### PR TITLE
Using .ainvoke() to support async tools (e.g. tools retrieved via langchain-mcp-adapters) at subagent level

### DIFF
--- a/src/deepagents/sub_agent.py
+++ b/src/deepagents/sub_agent.py
@@ -44,7 +44,7 @@ def _create_task_tool(tools, instructions, subagents: list[SubAgent], model, sta
         description=TASK_DESCRIPTION_PREFIX.format(other_agents=other_agents_string)
         + TASK_DESCRIPTION_SUFFIX
     )
-    def task(
+    async def task(
         description: str,
         subagent_type: str,
         state: Annotated[DeepAgentState, InjectedState],
@@ -54,7 +54,7 @@ def _create_task_tool(tools, instructions, subagents: list[SubAgent], model, sta
             return f"Error: invoked agent of type {subagent_type}, the only allowed types are {[f'`{k}`' for k in agents]}"
         sub_agent = agents[subagent_type]
         state["messages"] = [{"role": "user", "content": description}]
-        result = sub_agent.invoke(state)
+        result = await sub_agent.ainvoke(state)
         return Command(
             update={
                 "files": result.get("files", {}),


### PR DESCRIPTION
I've realized that subagents don't handle async tools properly as they use non-async `.invoke` inside. This becomes problematic when you use langchain-mcp-adapters which [doesn't support sync tools](https://github.com/langchain-ai/langchain-mcp-adapters/issues/158#issuecomment-2894629847) (always returns async ones). What makes this issue particularly tricky is that the main agent works fine with async tools when you use `.ainvoke` so the problem only shows up when the main agent delegates a task involving async tools to one of subagents. 

This PR fixes the issue by updating the subagents to call `.ainvoke` instead. [Here's the reproduction](https://github.com/tnzk/deepagents-async-subagents-repro/blob/main/main.py).