### PR TITLE
feat: research example with open

### DIFF
--- a/examples/research_openai/README.md
+++ b/examples/research_openai/README.md
@@ -1,0 +1,78 @@
+### Deep Research Agent (OpenAI)
+
+This example mirrors the Anthropic-based research agent but uses OpenAI via LangChain's `init_chat_model`. It researches a topic using Tavily search, writes a structured report to a virtual filesystem, and can spawn sub-agents for deep research and critique.
+
+### Requirements
+
+- **Python**: 3.11+
+- **API keys**: `OPENAI_API_KEY`, `TAVILY_API_KEY`
+
+### Setup (macOS and Linux)
+
+1. Create and activate a virtual environment
+
+```bash
+cd examples/research_openai
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+2. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Create a `.env` file in this folder
+
+```dotenv
+OPENAI_API_KEY=your_openai_key
+TAVILY_API_KEY=your_tavily_key
+```
+
+### Running
+
+- Launch Studio (recommended):
+
+```bash
+uv run langgraph dev
+```
+
+### Files
+
+- `research_agent_openai.py`: Defines tools, sub-agents, and constructs the agent. Uses OpenAI via:
+
+```python
+from langchain.chat_models import init_chat_model
+model = init_chat_model(model="openai:gpt-4o-mini", temperature=0.2)
+```
+
+- `langgraph.json`: Wires the graph name `research_openai` to the `agent` object.
+- `requirements.txt`: Example-specific dependencies.
+
+### Customize the model
+
+Edit the `init_chat_model(...)` call in `research_agent_openai.py`. Examples:
+
+```python
+model = init_chat_model(model="openai:gpt-4o", temperature=0.2)
+# or a smaller model
+model = init_chat_model(model="openai:gpt-4o-mini", temperature=0)
+```
+
+Per-subagent overrides are also supported by the library if you add a `model_settings` dict to a sub-agent.
+
+### How it works
+
+- The agent uses built-in planning and a virtual filesystem (files are stored in state, not your disk). It commonly writes:
+  - `question.txt`: the original user query
+  - `final_report.md`: the final report in markdown
+- Sub-agents:
+  - `research-agent`: performs deep-dive research using `internet_search`
+  - `critique-agent`: reviews the report and suggests improvements (does not edit files itself)
+
+### Troubleshooting
+
+- Ensure `.env` contains valid `OPENAI_API_KEY` and `TAVILY_API_KEY`.
+- If you see OpenAI auth or model errors, verify your account has access to the requested model and the key is correct.
+- If `langgraph` CLI isn’t found, ensure the virtual environment is activated and dependencies installed.

--- a/examples/research_openai/langgraph.json
+++ b/examples/research_openai/langgraph.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": ["."],
+  "graphs": {
+    "research_openai": "./research_agent_openai.py:agent"
+  },
+  "env": ".env"
+}

--- a/examples/research_openai/requirements.txt
+++ b/examples/research_openai/requirements.txt
@@ -1,0 +1,7 @@
+deepagents
+langgraph-cli[inmem]
+tavily-python
+langchain
+langchain-openai
+
+

--- a/examples/research_openai/research_agent_openai.py
+++ b/examples/research_openai/research_agent_openai.py
@@ -1,0 +1,181 @@
+import os
+from typing import Literal
+
+from tavily import TavilyClient
+
+from langchain.chat_models import init_chat_model
+
+from deepagents import create_deep_agent, SubAgent
+
+# It's best practice to initialize the client once and reuse it.
+tavily_client = TavilyClient(api_key=os.environ["TAVILY_API_KEY"])
+
+
+# Search tool to use to do research
+def internet_search(
+    query: str,
+    max_results: int = 5,
+    topic: Literal["general", "news", "finance"] = "general",
+    include_raw_content: bool = False,
+):
+    """Run a web search"""
+    search_docs = tavily_client.search(
+        query,
+        max_results=max_results,
+        include_raw_content=include_raw_content,
+        topic=topic,
+    )
+    return search_docs
+
+
+sub_research_prompt = """You are a dedicated researcher. Your job is to conduct research based on the users questions.
+
+Conduct thorough research and then reply to the user with a detailed answer to their question
+
+only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!"""
+
+research_sub_agent: SubAgent = {
+    "name": "research-agent",
+    "description": "Used to research more in depth questions. Only give this researcher one topic at a time. Do not pass multiple sub questions to this researcher. Instead, you should break down a large topic into the necessary components, and then call multiple research agents in parallel, one for each sub question.",
+    "prompt": sub_research_prompt,
+    "tools": ["internet_search"],
+}
+
+
+sub_critique_prompt = """You are a dedicated editor. You are being tasked to critique a report.
+
+You can find the report at `final_report.md`.
+
+You can find the question/topic for this report at `question.txt`.
+
+The user may ask for specific areas to critique the report in. Respond to the user with a detailed critique of the report. Things that could be improved.
+
+You can use the search tool to search for information, if that will help you critique the report
+
+Do not write to the `final_report.md` yourself.
+
+Things to check:
+- Check that each section is appropriately named
+- Check that the report is written as you would find in an essay or a textbook - it should be text heavy, do not let it just be a list of bullet points!
+- Check that the report is comprehensive. If any paragraphs or sections are short, or missing important details, point it out.
+- Check that the article covers key areas of the industry, ensures overall understanding, and does not omit important parts.
+- Check that the article deeply analyzes causes, impacts, and trends, providing valuable insights
+- Check that the article closely follows the research topic and directly answers questions
+- Check that the article has a clear structure, fluent language, and is easy to understand.
+"""
+
+critique_sub_agent: SubAgent = {
+    "name": "critique-agent",
+    "description": "Used to critique the final report. Give this agent some infomration about how you want it to critique the report.",
+    "prompt": sub_critique_prompt,
+}
+
+
+# Prompt prefix to steer the agent to be an expert researcher
+research_instructions = """You are an expert researcher. Your job is to conduct thorough research, and then write a polished report.
+
+The first thing you should do is to write the original user question to `question.txt` so you have a record of it.
+
+Use the research-agent to conduct deep research. It will respond to your questions/topics with a detailed answer.
+
+When you think you enough information to write a final report, write it to `final_report.md`
+
+You can call the critique-agent to get a critique of the final report. After that (if needed) you can do more research and edit the `final_report.md`
+You can do this however many times you want until are you satisfied with the result.
+
+Only edit the file once at a time (if you call this tool in parallel, there may be conflicts).
+
+Here are instructions for writing the final report:
+
+<report_instructions>
+
+CRITICAL: Make sure the answer is written in the same language as the human messages! If you make a todo plan - you should note in the plan what language the report should be in so you dont forget!
+Note: the language the report should be in is the language the QUESTION is in, not the language/country that the question is ABOUT.
+
+Please create a detailed answer to the overall research brief that:
+1. Is well-organized with proper headings (# for title, ## for sections, ### for subsections)
+2. Includes specific facts and insights from the research
+3. References relevant sources using [Title](URL) format
+4. Provides a balanced, thorough analysis. Be as comprehensive as possible, and include all information that is relevant to the overall research question. People are using you for deep research and will expect detailed, comprehensive answers.
+5. Includes a "Sources" section at the end with all referenced links
+
+You can structure your report in a number of different ways. Here are some examples:
+
+To answer a question that asks you to compare two things, you might structure your report like this:
+1/ intro
+2/ overview of topic A
+3/ overview of topic B
+4/ comparison between A and B
+5/ conclusion
+
+To answer a question that asks you to return a list of things, you might only need a single section which is the entire list.
+1/ list of things or table of things
+Or, you could choose to make each item in the list a separate section in the report. When asked for lists, you don't need an introduction or conclusion.
+1/ item 1
+2/ item 2
+3/ item 3
+
+To answer a question that asks you to summarize a topic, give a report, or give an overview, you might structure your report like this:
+1/ overview of topic
+2/ concept 1
+3/ concept 2
+4/ concept 3
+5/ conclusion
+
+If you think you can answer the question with a single section, you can do that too!
+1/ answer
+
+REMEMBER: Section is a VERY fluid and loose concept. You can structure your report however you think is best, including in ways that are not listed above!
+Make sure that your sections are cohesive, and make sense for the reader.
+
+For each section of the report, do the following:
+- Use simple, clear language
+- Use ## for section title (Markdown format) for each section of the report
+- Do NOT ever refer to yourself as the writer of the report. This should be a professional report without any self-referential language. 
+- Do not say what you are doing in the report. Just write the report without any commentary from yourself.
+- Each section should be as long as necessary to deeply answer the question with the information you have gathered. It is expected that sections will be fairly long and verbose. You are writing a deep research report, and users will expect a thorough answer.
+- Use bullet points to list out information when appropriate, but by default, write in paragraph form.
+
+REMEMBER:
+The brief and research may be in English, but you need to translate this information to the right language when writing the final answer.
+Make sure the final answer report is in the SAME language as the human messages in the message history.
+
+Format the report in clear markdown with proper structure and include source references where appropriate.
+
+<Citation Rules>
+- Assign each unique URL a single citation number in your text
+- End with ### Sources that lists each source with corresponding numbers
+- IMPORTANT: Number sources sequentially without gaps (1,2,3,4...) in the final list regardless of which sources you choose
+- Each source should be a separate line item in a list, so that in markdown it is rendered as a list.
+- Example format:
+  [1] Source Title: URL
+  [2] Source Title: URL
+- Citations are extremely important. Make sure to include these, and pay a lot of attention to getting these right. Users will often use these citations to look into more information.
+</Citation Rules>
+</report_instructions>
+
+You have access to a few tools.
+
+## `internet_search`
+
+Use this to run an internet search for a given query. You can specify the number of results, the topic, and whether raw content should be included.
+"""
+
+
+# Initialize an OpenAI chat model via LangChain's init_chat_model
+# Requires OPENAI_API_KEY in the environment
+model = init_chat_model(
+    model="openai:gpt-4o-mini",
+    temperature=0.2,
+)
+
+
+# Create the agent
+agent = create_deep_agent(
+    [internet_search],
+    research_instructions,
+    model=model,
+    subagents=[critique_sub_agent, research_sub_agent],
+).with_config({"recursion_limit": 1000})
+
+


### PR DESCRIPTION
# Add OpenAI Research Agent Example

## What this PR does

Adds a new research agent example that mirrors the existing Anthropic-based research agent but uses OpenAI via LangChain's `init_chat_model`.

---

## Changes made

- **New example folder:** `examples/research_openai/`
- **New agent file:** `research_agent_openai.py` — OpenAI-powered research agent with same functionality as the Anthropic version
- **Configuration:** `langgraph.json` exposing the graph as `research_openai`
- **Dependencies:** `requirements.txt` including `langchain-openai`
- **Documentation:** Comprehensive `README.md` with setup instructions for macOS/Linux

---

## Key Features

- Uses **OpenAI GPT-4o-mini** instead of Claude Sonnet 4
- Maintains **identical research workflow**: planning, sub-agents (research + critique), virtual filesystem
- Same tools: **Tavily search**, file operations, todo management
- **Configurable model settings** via `init_chat_model`

---

## How to Test

1. Navigate to the example folder:
   ```bash
   cd examples/research_openai/
   ```

2. Set up your `.env` file with the following:
   ```env
   OPENAI_API_KEY=your_openai_api_key
   TAVILY_API_KEY=your_tavily_api_key
   ```

3. Install dependencies:
   ```bash
   pip install -r requirements.txt
   ```

4. Run the agent:
   ```bash
   langgraph dev
   # or
   langgraph run research_openai
   ```

---

## Why this is Useful

- Provides an **alternative model choice** for users who prefer OpenAI
- Demonstrates how to **customize** the DeepAgent framework with different LLM providers
- Maintains **feature parity** with the existing research example
- Shows the framework’s **flexibility** in model integration