### PR TITLE
Fixed a typo for creating the subagents example code in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ class SubAgent(TypedDict):
 To use it looks like:
 
 ```python
-research_sub_agent = {
+research_subagent = {
     "name": "research-agent",
     "description": "Used to research more in depth questions",
     "prompt": sub_research_prompt,


### PR DESCRIPTION
The section 'Creating a custom deep agent' had a typo and inconsistency in the naming. 
When defining the `research_subagent` in the example Python code for creating subagents had an extra '_' between 'sub' and 'agent', which was inconsistent with the name when adding it to the list of subagents right after that.