### PR TITLE
fix: Handle StructuredTool objects without __name__ attribute

### DIFF
--- a/src/deepagents/graph.py
+++ b/src/deepagents/graph.py
@@ -70,7 +70,7 @@ def create_deep_agent(
         # Only include built-in tools whose names are in the specified list
         built_in_tools = [
             tool for tool in all_builtin_tools 
-            if getattr(tool, 'name', tool.__name__) in builtin_tools
+            if getattr(tool, 'name', getattr(tool, '__name__', None)) in builtin_tools
         ]
     else:
         built_in_tools = all_builtin_tools


### PR DESCRIPTION
This PR fixes an AttributeError that occurs when using StructuredTool objects with the builtin_tools parameter. The fix ensures that the code gracefully handles tools that do not have a __name__ attribute.