### PR TITLE
configurable agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ build_agent = create_configurable_agent(
 ```
 You can now use `build_agent` in your `langgraph.json` and deploy it with `langgraph dev`
 
+For async tools, you can use `from deepagents import async_create_configurable_agent`
+
 
 ## Roadmap
 - [ ] Allow users to customize full system prompt

--- a/README.md
+++ b/README.md
@@ -316,6 +316,25 @@ async def main():
 asyncio.run(main())
 ```
 
+## Configurable Agent
+
+Configurable agents allow you to control the agent via a config passed in.
+
+```python
+from deepagents import create_configurable_agent
+
+agent_config = {"instructions": "foo", "subagents": []}
+
+build_agent = create_configurable_agent(
+    agent_config['instructions'],
+    agent_config['subagents'],
+    [],
+    agent_config={"recursion_limit": 1000}
+)
+```
+You can now use `build_agent` in your `langgraph.json` and deploy it with `langgraph dev`
+
+
 ## Roadmap
 - [ ] Allow users to customize full system prompt
 - [ ] Code cleanliness (type hinting, docstrings, formating)

--- a/src/deepagents/__init__.py
+++ b/src/deepagents/__init__.py
@@ -3,3 +3,4 @@ from deepagents.interrupt import ToolInterruptConfig
 from deepagents.state import DeepAgentState
 from deepagents.sub_agent import SubAgent
 from deepagents.model import get_default_model
+from deepagents.builder import create_configurable_agent

--- a/src/deepagents/__init__.py
+++ b/src/deepagents/__init__.py
@@ -3,4 +3,7 @@ from deepagents.interrupt import ToolInterruptConfig
 from deepagents.state import DeepAgentState
 from deepagents.sub_agent import SubAgent
 from deepagents.model import get_default_model
-from deepagents.builder import create_configurable_agent
+from deepagents.builder import (
+    create_configurable_agent,
+    async_create_configurable_agent,
+)

--- a/src/deepagents/builder.py
+++ b/src/deepagents/builder.py
@@ -1,4 +1,4 @@
-from deepagents import create_deep_agent, SubAgent
+from deepagents import create_deep_agent, async_create_deep_agent, SubAgent
 from pydantic import BaseModel
 from typing import Any, Optional
 from typing_extensions import TypedDict, NotRequired
@@ -12,14 +12,15 @@ class SerializableSubAgent(TypedDict):
     # Optional per-subagent model: can be either a model instance OR dict settings
     model: NotRequired[dict[str, Any]]
 
-def create_configurable_agent(
-        default_instructions: str,
-        default_sub_agents: list[SerializableSubAgent],
-        tools,
-        agent_config: Optional[dict]=None
-):
 
+def create_configurable_agent(
+    default_instructions: str,
+    default_sub_agents: list[SerializableSubAgent],
+    tools,
+    agent_config: Optional[dict] = None,
+):
     tool_names = [t.name for t in tools]
+
     class AgentConfig(BaseModel):
         instructions: str = default_instructions
         subagents: list[SerializableSubAgent] = default_sub_agents
@@ -38,7 +39,39 @@ def create_configurable_agent(
             instructions=config.instructions,
             tools=[t for t in tools if t.name in config.tools],
             subagents=config.subagents,
-            config_schema=AgentConfig
+            config_schema=AgentConfig,
+        ).with_config(agent_config or {})
+
+    return build_agent
+
+
+def async_create_configurable_agent(
+    default_instructions: str,
+    default_sub_agents: list[SerializableSubAgent],
+    tools,
+    agent_config: Optional[dict] = None,
+):
+    tool_names = [t.name for t in tools]
+
+    class AgentConfig(BaseModel):
+        instructions: str = default_instructions
+        subagents: list[SerializableSubAgent] = default_sub_agents
+        tools: list[str] = tool_names
+
+    def build_agent(config: Optional[dict] = None):
+        if config is not None:
+            config = config.get("configurable", {})
+        else:
+            config = {}
+        config_fields = {
+            k: v for k, v in config.items() if k in ["instructions", "subagents"]
+        }
+        config = AgentConfig(**config_fields)
+        return async_create_deep_agent(
+            instructions=config.instructions,
+            tools=[t for t in tools if t.name in config.tools],
+            subagents=config.subagents,
+            config_schema=AgentConfig,
         ).with_config(agent_config or {})
 
     return build_agent

--- a/src/deepagents/builder.py
+++ b/src/deepagents/builder.py
@@ -1,4 +1,5 @@
 from deepagents import create_deep_agent, async_create_deep_agent, SubAgent
+from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel
 from typing import Any, Optional
 from typing_extensions import TypedDict, NotRequired
@@ -18,7 +19,9 @@ def create_configurable_agent(
     default_sub_agents: list[SerializableSubAgent],
     tools,
     agent_config: Optional[dict] = None,
+    **kwargs,
 ):
+    tools = [t if isinstance(t, BaseTool) else tool(t) for t in tools]
     tool_names = [t.name for t in tools]
 
     class AgentConfig(BaseModel):
@@ -40,6 +43,7 @@ def create_configurable_agent(
             tools=[t for t in tools if t.name in config.tools],
             subagents=config.subagents,
             config_schema=AgentConfig,
+            **kwargs,
         ).with_config(agent_config or {})
 
     return build_agent
@@ -50,7 +54,9 @@ def async_create_configurable_agent(
     default_sub_agents: list[SerializableSubAgent],
     tools,
     agent_config: Optional[dict] = None,
+    **kwargs,
 ):
+    tools = [t if isinstance(t, BaseTool) else tool(t) for t in tools]
     tool_names = [t.name for t in tools]
 
     class AgentConfig(BaseModel):
@@ -72,6 +78,7 @@ def async_create_configurable_agent(
             tools=[t for t in tools if t.name in config.tools],
             subagents=config.subagents,
             config_schema=AgentConfig,
-        ).with_config(agent_config or {})
+            **kwargs,
+        ).with_config(agent_config or {"recursion_limit": 1000})
 
     return build_agent

--- a/src/deepagents/builder.py
+++ b/src/deepagents/builder.py
@@ -25,8 +25,11 @@ def create_configurable_agent(
         subagents: list[SerializableSubAgent] = default_sub_agents
         tools: list[str] = tool_names
 
-    def build_agent(config):
-        config = config.get("configurable", {})
+    def build_agent(config: Optional[dict] = None):
+        if config is not None:
+            config = config.get("configurable", {})
+        else:
+            config = {}
         config_fields = {
             k: v for k, v in config.items() if k in ["instructions", "subagents"]
         }

--- a/src/deepagents/builder.py
+++ b/src/deepagents/builder.py
@@ -33,7 +33,7 @@ def create_configurable_agent(
         config = AgentConfig(**config_fields)
         return create_deep_agent(
             instructions=config.instructions,
-            tools=tools,
+            tools=[t for t in tools if t.name in config.tools],
             subagents=config.subagents,
             config_schema=AgentConfig
         ).with_config(agent_config or {})

--- a/src/deepagents/builder.py
+++ b/src/deepagents/builder.py
@@ -1,0 +1,41 @@
+from deepagents import create_deep_agent, SubAgent
+from pydantic import BaseModel
+from typing import Any, Optional
+from typing_extensions import TypedDict, NotRequired
+
+
+class SerializableSubAgent(TypedDict):
+    name: str
+    description: str
+    prompt: str
+    tools: NotRequired[list[str]]
+    # Optional per-subagent model: can be either a model instance OR dict settings
+    model: NotRequired[dict[str, Any]]
+
+def create_configurable_agent(
+        default_instructions: str,
+        default_sub_agents: list[SerializableSubAgent],
+        tools,
+        agent_config: Optional[dict]=None
+):
+
+    tool_names = [t.name for t in tools]
+    class AgentConfig(BaseModel):
+        instructions: str = default_instructions
+        subagents: list[SerializableSubAgent] = default_sub_agents
+        tools: list[str] = tool_names
+
+    def build_agent(config):
+        config = config.get("configurable", {})
+        config_fields = {
+            k: v for k, v in config.items() if k in ["instructions", "subagents"]
+        }
+        config = AgentConfig(**config_fields)
+        return create_deep_agent(
+            instructions=config.instructions,
+            tools=tools,
+            subagents=config.subagents,
+            config_schema=AgentConfig
+        ).with_config(agent_config or {})
+
+    return build_agent

--- a/src/deepagents/graph.py
+++ b/src/deepagents/graph.py
@@ -146,7 +146,7 @@ def create_deep_agent(
         config_schema=config_schema,
         checkpointer=checkpointer,
         post_model_hook=post_model_hook,
-        is_async=False
+        is_async=False,
     )
 
 
@@ -198,5 +198,5 @@ def async_create_deep_agent(
         config_schema=config_schema,
         checkpointer=checkpointer,
         post_model_hook=post_model_hook,
-        is_async=True
+        is_async=True,
     )

--- a/src/deepagents/interrupt.py
+++ b/src/deepagents/interrupt.py
@@ -25,7 +25,7 @@ def create_interrupt_hook(
     # Right now we don't properly handle `ignore`
     for tool, interrupt_config in tool_configs.items():
         if isinstance(interrupt_config, dict):
-            if 'allow_ignore' in interrupt_config and interrupt_config['allow_ignore']:
+            if "allow_ignore" in interrupt_config and interrupt_config["allow_ignore"]:
                 raise ValueError(
                     f"For {tool} we get `allow_ignore = True` - we currently don't support `ignore`."
                 )
@@ -69,25 +69,30 @@ def create_interrupt_hook(
         tool_args = tool_call["args"]
         description = f"{message_prefix}\n\nTool: {tool_name}\nArgs: {tool_args}"
         tool_config = tool_configs[tool_name]
-        default_tool_config: HumanInterruptConfig = {"allow_accept": True, "allow_edit": True, "allow_respond": True, "allow_ignore": False}
+        default_tool_config: HumanInterruptConfig = {
+            "allow_accept": True,
+            "allow_edit": True,
+            "allow_respond": True,
+            "allow_ignore": False,
+        }
 
         request: HumanInterrupt = {
             "action_request": ActionRequest(
                 action=tool_name,
                 args=tool_args,
             ),
-            "config": tool_config if isinstance(tool_config, dict) else default_tool_config,
+            "config": tool_config
+            if isinstance(tool_config, dict)
+            else default_tool_config,
             "description": description,
         }
 
         responses: List[HumanResponse] = interrupt([request])
 
         if len(responses) != 1:
-            raise ValueError(
-                f"Expected a list of one response, got {responses}"
-            )
+            raise ValueError(f"Expected a list of one response, got {responses}")
         response = responses[0]
-            
+
         if response["type"] == "accept":
             approved_tool_calls.append(tool_call)
         elif response["type"] == "edit":
@@ -102,8 +107,8 @@ def create_interrupt_hook(
         elif response["type"] == "response":
             response_message = {
                 "type": "tool",
-                "tool_call_id": tool_call['id'],
-                "content": response['args']
+                "tool_call_id": tool_call["id"],
+                "content": response["args"],
             }
             return {"messages": [response_message]}
         else:


### PR DESCRIPTION
Things i dont like:

need to call it with

`build_agent({"configurable": {"insturctions": ...}})`

slightly cleaner if was able to just pass in without having to wrap in configurable?