### PR TITLE
Propagate local state from sub-assistants

### DIFF
--- a/src/deepagents/sub_agent.py
+++ b/src/deepagents/sub_agent.py
@@ -86,16 +86,7 @@ def _create_task_tool(
         sub_agent = agents[subagent_type]
         state["messages"] = [{"role": "user", "content": description}]
         result = await sub_agent.ainvoke(state)
-        return Command(
-            update={
-                "files": result.get("files", {}),
-                "messages": [
-                    ToolMessage(
-                        result["messages"][-1].content, tool_call_id=tool_call_id
-                    )
-                ],
-            }
-        )
+        return Command(update=result)
 
     return task
 
@@ -121,15 +112,6 @@ def _create_sync_task_tool(
         sub_agent = agents[subagent_type]
         state["messages"] = [{"role": "user", "content": description}]
         result = sub_agent.invoke(state)
-        return Command(
-            update={
-                "files": result.get("files", {}),
-                "messages": [
-                    ToolMessage(
-                        result["messages"][-1].content, tool_call_id=tool_call_id
-                    )
-                ],
-            }
-        )
+        return Command(update=result)
 
     return task


### PR DESCRIPTION
Simplifies the way the `Command` object is constructed in both the asynchronous and synchronous `task` functions in `src/deepagents/sub_agent.py`. Instead of manually extracting and formatting the `files` and `messages` from the sub-agent's result, the entire result is now passed directly to the `Command`'s `update` field.
