### PR TITLE
Support `create_react_agent`'s `pre_model_hook` arg

### DIFF
--- a/src/deepagents/graph.py
+++ b/src/deepagents/graph.py
@@ -3,6 +3,7 @@ from deepagents.model import get_default_model
 from deepagents.tools import write_todos, write_file, read_file, ls, edit_file
 from deepagents.state import DeepAgentState
 from typing import Sequence, Union, Callable, Any, TypeVar, Type, Optional
+from langchain_core.runnables.base import RunnableLike
 from langchain_core.tools import BaseTool, tool
 from langchain_core.language_models import LanguageModelLike
 from deepagents.interrupt import create_interrupt_hook, ToolInterruptConfig
@@ -35,6 +36,7 @@ def _agent_builder(
     interrupt_config: Optional[ToolInterruptConfig] = None,
     config_schema: Optional[Type[Any]] = None,
     checkpointer: Optional[Checkpointer] = None,
+    pre_model_hook: Optional[RunnableLike] = None,
     post_model_hook: Optional[Callable] = None,
     is_async: bool = False,
 ):
@@ -77,6 +79,7 @@ def _agent_builder(
             subagents or [],
             model,
             state_schema,
+            pre_model_hook,
             selected_post_model_hook,
         )
     else:
@@ -86,6 +89,7 @@ def _agent_builder(
             subagents or [],
             model,
             state_schema,
+            pre_model_hook,
             selected_post_model_hook,
         )
     all_tools = built_in_tools + list(tools) + [task_tool]
@@ -95,6 +99,7 @@ def _agent_builder(
         prompt=prompt,
         tools=all_tools,
         state_schema=state_schema,
+        pre_model_hook=pre_model_hook,
         post_model_hook=selected_post_model_hook,
         config_schema=config_schema,
         checkpointer=checkpointer,
@@ -111,6 +116,7 @@ def create_deep_agent(
     interrupt_config: Optional[ToolInterruptConfig] = None,
     config_schema: Optional[Type[Any]] = None,
     checkpointer: Optional[Checkpointer] = None,
+    pre_model_hook: Optional[RunnableLike] = None,
     post_model_hook: Optional[Callable] = None,
 ):
     """Create a deep agent.
@@ -135,6 +141,7 @@ def create_deep_agent(
             only the specified built-in tools are included.
         interrupt_config: Optional Dict[str, HumanInterruptConfig] mapping tool names to interrupt configs.
         config_schema: The schema of the deep agent.
+        pre_model_hook: Custom pre model hook
         post_model_hook: Custom post model hook
         checkpointer: Optional checkpointer for persisting agent state between runs.
     """
@@ -148,6 +155,7 @@ def create_deep_agent(
         interrupt_config=interrupt_config,
         config_schema=config_schema,
         checkpointer=checkpointer,
+        pre_model_hook=pre_model_hook,
         post_model_hook=post_model_hook,
         is_async=False,
     )
@@ -163,6 +171,7 @@ def async_create_deep_agent(
     interrupt_config: Optional[ToolInterruptConfig] = None,
     config_schema: Optional[Type[Any]] = None,
     checkpointer: Optional[Checkpointer] = None,
+    pre_model_hook: Optional[RunnableLike] = None,
     post_model_hook: Optional[Callable] = None,
 ):
     """Create a deep agent.
@@ -187,6 +196,7 @@ def async_create_deep_agent(
             only the specified built-in tools are included.
         interrupt_config: Optional Dict[str, HumanInterruptConfig] mapping tool names to interrupt configs.
         config_schema: The schema of the deep agent.
+        pre_model_hook: Custom pre model hook
         post_model_hook: Custom post model hook
         checkpointer: Optional checkpointer for persisting agent state between runs.
     """
@@ -200,6 +210,7 @@ def async_create_deep_agent(
         interrupt_config=interrupt_config,
         config_schema=config_schema,
         checkpointer=checkpointer,
+        pre_model_hook=pre_model_hook,
         post_model_hook=post_model_hook,
         is_async=True,
     )

--- a/src/deepagents/sub_agent.py
+++ b/src/deepagents/sub_agent.py
@@ -1,5 +1,6 @@
 from deepagents.prompts import TASK_DESCRIPTION_PREFIX, TASK_DESCRIPTION_SUFFIX
 from deepagents.state import DeepAgentState
+from langchain_core.runnables.base import RunnableLike
 from langgraph.prebuilt import create_react_agent
 from langchain_core.tools import BaseTool
 from typing_extensions import TypedDict
@@ -22,10 +23,10 @@ class SubAgent(TypedDict):
     model: NotRequired[Union[LanguageModelLike, dict[str, Any]]]
 
 
-def _get_agents(tools, instructions, subagents: list[SubAgent], model, state_schema, post_model_hook: Optional[Callable] = None):
+def _get_agents(tools, instructions, subagents: list[SubAgent], model, state_schema, pre_model_hook: Optional[RunnableLike] = None, post_model_hook: Optional[Callable] = None):
     agents = {
         "general-purpose": create_react_agent(
-            model, prompt=instructions, tools=tools, checkpointer=False, post_model_hook=post_model_hook
+            model, prompt=instructions, tools=tools, checkpointer=False, pre_model_hook=pre_model_hook, post_model_hook=post_model_hook
         )
     }
     tools_by_name = {}
@@ -56,6 +57,7 @@ def _get_agents(tools, instructions, subagents: list[SubAgent], model, state_sch
             tools=_tools,
             state_schema=state_schema,
             checkpointer=False,
+            pre_model_hook=pre_model_hook,
             post_model_hook=post_model_hook,
         )
     return agents
@@ -66,9 +68,9 @@ def _get_subagent_description(subagents):
 
 
 def _create_task_tool(
-    tools, instructions, subagents: list[SubAgent], model, state_schema, post_model_hook: Optional[Callable] = None
+    tools, instructions, subagents: list[SubAgent], model, state_schema, pre_model_hook: Optional[RunnableLike] = None, post_model_hook: Optional[Callable] = None
 ):
-    agents = _get_agents(tools, instructions, subagents, model, state_schema, post_model_hook)
+    agents = _get_agents(tools, instructions, subagents, model, state_schema, pre_model_hook, post_model_hook)
     other_agents_string = _get_subagent_description(subagents)
 
     @tool(
@@ -101,9 +103,9 @@ def _create_task_tool(
 
 
 def _create_sync_task_tool(
-    tools, instructions, subagents: list[SubAgent], model, state_schema, post_model_hook: Optional[Callable] = None
+    tools, instructions, subagents: list[SubAgent], model, state_schema, pre_model_hook: Optional[RunnableLike] = None, post_model_hook: Optional[Callable] = None
 ):
-    agents = _get_agents(tools, instructions, subagents, model, state_schema, post_model_hook)
+    agents = _get_agents(tools, instructions, subagents, model, state_schema, pre_model_hook, post_model_hook)
     other_agents_string = _get_subagent_description(subagents)
 
     @tool(


### PR DESCRIPTION
Regarding the type - I chose to stick to the original `RunnableLike` type of `create_react_agent` even though we used the partial `Callable` for `post_model_hook` - I do think these passthrough args should stick to the original type but if you guys prefer simplicity and uniformness that's fine