### PR TITLE
General Purpose sub task should get state schema

### DIFF
--- a/src/deepagents/sub_agent.py
+++ b/src/deepagents/sub_agent.py
@@ -44,6 +44,7 @@ def _get_agents(
             tools=tools,
             checkpointer=False,
             post_model_hook=post_model_hook,
+            state_schema=state_schema,
         )
     }
     tools_by_name = {}


### PR DESCRIPTION
The default general-purpose task needs to get the state schema so that it can pass back any updates to the files