### PR TITLE
allow custom state to flow to subagent via task

### DIFF
--- a/src/deepagents/sub_agent.py
+++ b/src/deepagents/sub_agent.py
@@ -107,7 +107,7 @@ def _create_task_tool(
     async def task(
         description: str,
         subagent_type: str,
-        state: Annotated[DeepAgentState, InjectedState],
+        state: Annotated[dict, InjectedState],
         tool_call_id: Annotated[str, InjectedToolCallId],
     ):
         if subagent_type not in agents:


### PR DESCRIPTION
I have extended the state for my agent / sub-agents.
I need some of that state (other than messages) to flow down into my sub-agents.
However, although the state_schema is passed to the subagents, the create_task tool converts the injected state to the base DeepAgentState - thus losing the custom keys. 
By changing this to dict, the custom keys from the injected state are retained and my sub agent works as expected.