### PR TITLE
chore: update default model to claude-sonnet-4-5-20250929

### DIFF
--- a/src/deepagents/model.py
+++ b/src/deepagents/model.py
@@ -2,4 +2,4 @@ from langchain_anthropic import ChatAnthropic
 
 
 def get_default_model():
-    return ChatAnthropic(model_name="claude-sonnet-4-20250514", max_tokens=64000)
+    return ChatAnthropic(model_name="claude-sonnet-4-5-20250929", max_tokens=64000)


### PR DESCRIPTION
 ## Summary
  Updates the default model from `claude-sonnet-4-20250514` to `claude-sonnet-4-5-20250929` to use the latest Claude Sonnet 4.5 release.

  ## Changes
  - Updated `src/deepagents/model.py` with the new model ID