### PR TITLE
Fix: Replace 'prompt' with 'system_prompt' for langchain 1.0.0a12 

### DIFF
--- a/src/deepagents/graph.py
+++ b/src/deepagents/graph.py
@@ -50,7 +50,7 @@ def agent_builder(
 
     return create_agent(
         model,
-        prompt=instructions + "\n\n" + BASE_AGENT_PROMPT,
+        system_prompt=instructions + "\n\n" + BASE_AGENT_PROMPT,
         tools=tools,
         middleware=deepagent_middleware,
         context_schema=context_schema,

--- a/src/deepagents/middleware.py
+++ b/src/deepagents/middleware.py
@@ -82,7 +82,7 @@ def _get_agents(
     agents = {
         "general-purpose": create_agent(
             model,
-            prompt=BASE_AGENT_PROMPT,
+            system_prompt=BASE_AGENT_PROMPT,
             tools=default_subagent_tools,
             checkpointer=False,
             middleware=default_subagent_middleware
@@ -114,7 +114,7 @@ def _get_agents(
             _middleware = default_subagent_middleware
         agents[_agent["name"]] = create_agent(
             sub_model,
-            prompt=_agent["prompt"],
+            system_prompt=_agent["prompt"],
             tools=_tools,
             middleware=_middleware,
             checkpointer=False,


### PR DESCRIPTION
Small compatibility issue :) 
"prompt" input changed to "system_prompt" in the create agent call of langchain

referring to https://github.com/langchain-ai/deepagents/issues/152 