### PR TITLE
feat: add delete_file tool to FilesystemMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ in the same way you would any LangGraph agent.
 
 **Context Management**
 
- File system tools (`ls`, `read_file`, `write_file`, `edit_file`) allow agents to offload large context to memory, preventing context window overflow and enabling work with variable-length tool results.
+ File system tools (`ls`, `read_file`, `write_file`, `edit_file`, `delete_file`) allow agents to offload large context to memory, preventing context window overflow and enabling work with variable-length tool results.
 
 **Subagent Spawning**
 
@@ -375,11 +375,12 @@ agent = create_agent(
 ### FilesystemMiddleware
 
 Context engineering is one of the main challenges in building effective agents. This can be particularly hard when using tools that can return variable length results (ex. web_search, rag), as long ToolResults can quickly fill up your context window.
-**FilesystemMiddleware** provides four tools to your agent to interact with both short-term and long-term memory.
+**FilesystemMiddleware** provides five tools to your agent to interact with both short-term and long-term memory.
 - **ls**: List the files in your filesystem
 - **read_file**: Read an entire file, or a certain number of lines from a file
 - **write_file**: Write a new file to your filesystem
 - **edit_file**: Edit an existing file in your filesystem
+- **delete_file**: Delete a file from your filesystem
 
 ```python
 from langchain.agents import create_agent


### PR DESCRIPTION
Added comprehensive delete_file functionality to the filesystem middleware:

- Implemented _delete_file_tool_generator with full support for both short-term (state) and long-term (store) memory
- Added DELETE_FILE_TOOL_DESCRIPTION and longterm memory supplement
- Updated FILESYSTEM_SYSTEM_PROMPT to include delete_file
- Added delete_file to TOOL_GENERATORS dictionary
- Updated FilesystemMiddleware docstring (four -> five tools)

Test coverage:
- test_delete_file_shortterm: Tests deletion from ephemeral state
- test_delete_file_longterm: Tests deletion from persistent store
- test_delete_file_not_found_shortterm: Error handling for missing files
- test_delete_file_not_found_longterm: Error handling in longterm memory
- Updated assert_longterm_mem_tools and assert_shortterm_mem_tools helpers

Documentation:
- Updated README.md to mention delete_file in Core Capabilities
- Updated FilesystemMiddleware section with new tool listing

The implementation follows existing patterns and provides feature parity with other filesystem tools including path validation, error handling, and support for custom descriptions.