### PR TITLE
Use .text instead of .content to return string content from subagent AIMessage

### DIFF
--- a/src/deepagents/middleware/subagents.py
+++ b/src/deepagents/middleware/subagents.py
@@ -319,7 +319,7 @@ def _create_task_tool(
         return Command(
             update={
                 **state_update,
-                "messages": [ToolMessage(result["messages"][-1].content, tool_call_id=tool_call_id)],
+                "messages": [ToolMessage(result["messages"][-1].text, tool_call_id=tool_call_id)],
             }
         )
 


### PR DESCRIPTION
Ensures that the returned content from a subagent is a string

Patches the malformed content raised in https://github.com/langchain-ai/deepagents/issues/28

Follow-up fix likely needed in langchain-aws to ensure consistent AIMessage and ToolMessage content
