### PR TITLE
Remove checkpointer=false from subagents

### DIFF
--- a/src/deepagents/middleware/subagents.py
+++ b/src/deepagents/middleware/subagents.py
@@ -273,7 +273,6 @@ def _get_subagents(
             system_prompt=agent_["system_prompt"],
             tools=_tools,
             middleware=_middleware,
-            checkpointer=False,
         )
     return agents, subagent_descriptions
 


### PR DESCRIPTION
This line was originally a patch for a quirk in langgraph, this is now fixed

When checkpointer=None for subagents, we will automatically use the main agent's checkpointer