### PR TITLE
refactor(subagents): use `task` for clarity and remove dead code

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/agent.py
+++ b/libs/deepagents-cli/deepagents_cli/agent.py
@@ -210,19 +210,12 @@ def create_agent_with_config(model, assistant_id: str, tools: list):
     def format_task_description(tool_call: dict) -> str:
         """Format task (subagent) tool call for approval prompt."""
         args = tool_call.get("args", {})
-        description = args.get("description", "unknown")
-        prompt = args.get("prompt", "")
-
-        # Truncate prompt if too long
-        prompt_preview = prompt[:300]
-        if len(prompt) > 300:
-            prompt_preview += "..."
+        task = args.get("task", "unknown")
 
         return (
-            f"Task: {description}\n\n"
+            f"Task: {task}\n\n"
             f"Instructions to subagent:\n"
             f"{'─' * 40}\n"
-            f"{prompt_preview}\n"
             f"{'─' * 40}\n\n"
             f"⚠️  Subagent will have access to file operations and shell commands"
         )

--- a/libs/deepagents-cli/deepagents_cli/ui.py
+++ b/libs/deepagents-cli/deepagents_cli/ui.py
@@ -126,10 +126,10 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
 
     elif tool_name == "task":
         # Task: show the task description
-        if "description" in tool_args:
-            desc = str(tool_args["description"])
-            desc = truncate_value(desc, 100)
-            return f'{tool_name}("{desc}")'
+        if "task" in tool_args:
+            task = str(tool_args["task"])
+            task = truncate_value(task, 100)
+            return f'{tool_name}("{task}")'
 
     elif tool_name == "write_todos":
         # Todos: show count of items


### PR DESCRIPTION
## Why this PR?

While analyzing `SubAgentMiddleware`, I realized its main role is to generate a structured tool for specifying subagents and passing tasks to them. However, the variable names used in this module are not intuitive and can make interpretation and extension difficult.

### 1. `task_description` → `task_tool_description`  
**Files:**
- `src/deepagents/middleware/subagents.py`

The variable `task_description` superficially suggests it contains the actual task content, but in reality, it is the description visible at a higher level for the task tool itself. Because this is frequently formatted from the constant prompt `TASK_TOOL_DESCRIPTION`, renaming the variable for clarity is appropriate.

### 2. Function param: `description` → `task`  
**Files:**
- `src/deepagents/middleware/subagents.py`
- `libs/deepagents-cli/deepagents_cli/agent.py`
- `libs/deepagents-cli/deepagents_cli/ui.py`

In `def task()` and `async def atask()`, the parameter `description` was used. However, “description” throughout the codebase refers to documentation for a tool/model/function, which creates confusion. Here, the parameter is actually the *prompt or instruction* for the subagent—the specific task to perform from the LLM's or agent's perspective. Therefore, I changed it to `task: str`, and updated all usages (including UI and agent display logic) for clarity and consistency.

### 3. Dead code removal in `format_task_description`  
**File:**
- `libs/deepagents-cli/deepagents_cli/agent.py`

Previously, the function `format_task_description` attempted to extract `prompt = args.get("prompt", "")` from tool call arguments, but this value was never actually passed, making the code unreachable. All related lines (from line 214 onward) were removed.