### PR TITLE
fix: move AgentMemoryMiddleware from CLI to core middleware package

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/agent.py
+++ b/libs/deepagents-cli/deepagents_cli/agent.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend
 from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.middleware.agent_memory import AgentMemoryMiddleware
 from deepagents.middleware.resumable_shell import ResumableShellToolMiddleware
 from langchain.agents.middleware import HostExecutionPolicy
 from langgraph.checkpoint.memory import InMemorySaver
 
-from .agent_memory import AgentMemoryMiddleware
 from .config import COLORS, config, console, get_default_coding_instructions
 
 

--- a/libs/deepagents-cli/deepagents_cli/token_utils.py
+++ b/libs/deepagents-cli/deepagents_cli/token_utils.py
@@ -58,6 +58,6 @@ def calculate_baseline_tokens(model, agent_dir: Path, system_prompt: str) -> int
 def get_memory_system_prompt() -> str:
     """Get the long-term memory system prompt text."""
     # Import from agent_memory middleware
-    from .agent_memory import LONGTERM_MEMORY_SYSTEM_PROMPT
+    from deepagents.middleware.agent_memory import LONGTERM_MEMORY_SYSTEM_PROMPT
 
     return LONGTERM_MEMORY_SYSTEM_PROMPT.format(memory_path="/memories/")

--- a/libs/deepagents/middleware/__init__.py
+++ b/libs/deepagents/middleware/__init__.py
@@ -1,10 +1,12 @@
 """Middleware for the DeepAgent."""
 
+from deepagents.middleware.agent_memory import AgentMemoryMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.resumable_shell import ResumableShellToolMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 
 __all__ = [
+    "AgentMemoryMiddleware",
     "CompiledSubAgent",
     "FilesystemMiddleware",
     "ResumableShellToolMiddleware",

--- a/libs/deepagents/middleware/agent_memory.py
+++ b/libs/deepagents/middleware/agent_memory.py
@@ -95,7 +95,7 @@ class AgentMemoryMiddleware(AgentMiddleware):
     Example:
         ```python
         from deepagents.middleware.agent_memory import AgentMemoryMiddleware
-        from deepagents.memory.backends import FilesystemBackend
+        from deepagents.backends.filesystem import FilesystemBackend
         from pathlib import Path
 
         # Set up backend pointing to agent's directory
@@ -103,7 +103,7 @@ class AgentMemoryMiddleware(AgentMiddleware):
         backend = FilesystemBackend(root_dir=agent_dir)
 
         # Create middleware
-        middleware = AgentMemoryMiddleware(backend=backend)
+        middleware = AgentMemoryMiddleware(backend=backend, memory_path="/memory/")
         ```
     """
 
@@ -120,6 +120,7 @@ class AgentMemoryMiddleware(AgentMiddleware):
 
         Args:
             backend: Backend to use for loading the agent memory file.
+            memory_path: Path prefix for memory files.
             system_prompt_template: Optional custom template for injecting
                 agent memory into system prompt.
         """
@@ -136,7 +137,7 @@ class AgentMemoryMiddleware(AgentMiddleware):
 
         Args:
             state: Current agent state.
-            handler: Handler function to call after loading memory.
+            runtime: Runtime context.
 
         Returns:
             Updated state with agent_memory populated.
@@ -155,7 +156,7 @@ class AgentMemoryMiddleware(AgentMiddleware):
 
         Args:
             state: Current agent state.
-            handler: Handler function to call after loading memory.
+            runtime: Runtime context.
 
         Returns:
             Updated state with agent_memory populated.
@@ -224,3 +225,4 @@ class AgentMemoryMiddleware(AgentMiddleware):
         )
 
         return await handler(request)
+


### PR DESCRIPTION
- Move AgentMemoryMiddleware from deepagents-cli to deepagents/middleware
- Update imports in CLI to reference the core package
- Export AgentMemoryMiddleware from deepagents.middleware module
- Fix incorrect import path shown in middleware docstring

This change fixes an architecture issue where a core middleware component was incorrectly placed in the CLI package. The middleware is now in the proper location alongside other middleware (FilesystemMiddleware, SubAgentMiddleware, etc.) and can be reused by any application using the deepagents library.

`AgentMemoryMiddleware` was incorrectly located in the `deepagents-cli` package but its documentation (line 97) showed an import from `deepagents.middleware.agent_memory`, which didn't exist. This created confusion and made the middleware unusable as documented.

## Solution

Move `AgentMemoryMiddleware` to `libs/deepagents/middleware/agent_memory.py` where it belongs, alongside other core middleware components (`FilesystemMiddleware`, `SubAgentMiddleware`, `ResumableShellToolMiddleware`).

## Why This Is Better

- ✅ **Correct architecture**: Core components in core package, CLI depends on core (not vice versa)
- ✅ **Reusability**: Any application can now use this middleware, not just the CLI
- ✅ **Documentation accuracy**: Example code in docstring now works as written
- ✅ **Consistency**: All middleware now follows the same organizational pattern

## Changes

- Moved `agent_memory.py` from `deepagents-cli` to `deepagents/middleware` (git detected as rename)
- Updated `libs/deepagents/middleware/__init__.py` to export `AgentMemoryMiddleware`
- Updated `libs/deepagents-cli/deepagents_cli/agent.py` to import from core package
- Updated `libs/deepagents-cli/deepagents_cli/token_utils.py` to import from core package

## Testing

✅ Verified imports work correctly:
```python
from deepagents.middleware.agent_memory import AgentMemoryMiddleware  # Works!
```

Closes #265 