### PR TITLE
feat: Add Ollama local model support

### DIFF
--- a/OLLAMA.md
+++ b/OLLAMA.md
@@ -1,0 +1,165 @@
+# Using Ollama with Deep Agents
+
+Deep Agents now supports running with local LLM models via [Ollama](https://ollama.ai/). This allows you to run Deep Agents completely offline using models like Llama, Mistral, Qwen, and many others.
+
+## Prerequisites
+
+1. **Install Ollama**: Download and install Ollama from [https://ollama.ai](https://ollama.ai)
+
+2. **Pull a model**: Download a model to use with Deep Agents
+   ```bash
+   # Example: Pull the qwen2.5-coder model (recommended for coding tasks)
+   ollama pull qwen2.5-coder:14b
+
+   # Or pull other models
+   ollama pull llama3.1:8b
+   ollama pull mistral:latest
+   ```
+
+3. **Verify Ollama is running**: Ollama should start automatically. You can verify it's running by checking:
+   ```bash
+   ollama list
+   ```
+
+## Configuration
+
+To use Ollama with the Deep Agents CLI, set the following environment variables:
+
+```bash
+# Required: The Ollama server URL
+export OLLAMA_BASE_URL=http://localhost:11434
+
+# Optional: The model to use (defaults to llama2)
+export OLLAMA_MODEL=qwen2.5-coder:14b
+```
+
+You can also add these to your `.env` file:
+```env
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen2.5-coder:14b
+```
+
+## Usage with the CLI
+
+Once configured, simply run the Deep Agents CLI as usual:
+
+```bash
+deepagents
+```
+
+The CLI will automatically detect your Ollama configuration and use it instead of OpenAI or Anthropic.
+
+## Usage in Python
+
+You can use Ollama models programmatically with Deep Agents:
+
+```python
+import os
+from langchain_ollama import ChatOllama
+from deepagents import create_deep_agent
+
+# Configure the Ollama model
+model = ChatOllama(
+    model="qwen2.5-coder:14b",
+    base_url="http://localhost:11434",
+    temperature=0.7,
+)
+
+# Create a deep agent with the Ollama model
+agent = create_deep_agent(
+    model=model,
+    tools=[...],  # Your tools here
+    system_prompt="Your custom instructions..."
+)
+
+# Use the agent
+result = agent.invoke({"messages": [{"role": "user", "content": "Your task here"}]})
+```
+
+## Recommended Models
+
+For coding tasks with Deep Agents:
+- **qwen2.5-coder:14b** - Excellent for coding tasks, good balance of speed and quality
+- **qwen2.5-coder:7b** - Faster, good for simpler tasks
+- **deepseek-coder:33b** - Very capable but requires more resources
+
+For general tasks:
+- **llama3.1:8b** - Fast and capable general-purpose model
+- **mistral:latest** - Good balance of speed and quality
+- **qwen3:14b** - Strong reasoning capabilities
+
+## Model Priority
+
+The Deep Agents CLI checks for model configurations in this order:
+1. **OpenAI** (if `OPENAI_API_KEY` is set)
+2. **Anthropic** (if `ANTHROPIC_API_KEY` is set)
+3. **Ollama** (if `OLLAMA_BASE_URL` is set)
+
+To ensure Ollama is used, make sure `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are not set.
+
+## Performance Tips
+
+1. **Use appropriate model sizes**: Larger models (14b+) provide better quality but require more RAM and are slower
+2. **Adjust temperature**: Lower temperatures (0.1-0.3) work better for deterministic tasks like coding
+3. **GPU acceleration**: If you have a GPU, Ollama will automatically use it for faster inference
+4. **Context length**: Be aware of your model's context window - some tasks may require models with larger context windows
+
+## Troubleshooting
+
+### Ollama not found
+```bash
+# Check if Ollama is installed
+which ollama
+
+# Check if Ollama service is running
+ollama list
+```
+
+### Model not available
+```bash
+# Pull the model
+ollama pull qwen2.5-coder:14b
+```
+
+### Connection refused
+Make sure Ollama is running and accessible at the configured base URL (default: http://localhost:11434)
+
+### Out of memory
+Try using a smaller model variant:
+```bash
+ollama pull qwen2.5-coder:7b
+export OLLAMA_MODEL=qwen2.5-coder:7b
+```
+
+## Example: Complete Setup
+
+```bash
+# 1. Install Ollama (visit https://ollama.ai)
+
+# 2. Pull a coding model
+ollama pull qwen2.5-coder:14b
+
+# 3. Configure environment
+export OLLAMA_BASE_URL=http://localhost:11434
+export OLLAMA_MODEL=qwen2.5-coder:14b
+
+# 4. Run Deep Agents CLI
+deepagents
+
+# You should see: "Using Ollama model: qwen2.5-coder:14b at http://localhost:11434"
+```
+
+## Benefits of Using Ollama
+
+- **Privacy**: Your code and data never leave your machine
+- **Cost**: No API costs, runs completely free on your hardware
+- **Offline**: Works without internet connection
+- **Customization**: Fine-tune models for your specific use cases
+- **Speed**: For small models, can be faster than API calls (no network latency)
+
+## Limitations
+
+- **Resource intensive**: Requires significant RAM (8GB+ for smaller models)
+- **Quality trade-offs**: Local models may not match the quality of GPT-4 or Claude for complex tasks
+- **Context windows**: Some local models have smaller context windows than cloud models
+- **Setup required**: Need to install and manage Ollama and models locally

--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ agent = create_deep_agent(
 )
 ```
 
+#### Using Local Models with Ollama
+
+Deep Agents supports local LLM models via [Ollama](https://ollama.ai/). See [OLLAMA.md](OLLAMA.md) for detailed setup instructions.
+
+```python
+from langchain_ollama import ChatOllama
+from deepagents import create_deep_agent
+
+model = ChatOllama(
+    model="qwen2.5-coder:14b",
+    base_url="http://localhost:11434",
+)
+agent = create_deep_agent(model=model)
+```
+
 ### `system_prompt`
 Deep Agents come with a built-in system prompt. This is relatively detailed prompt that is heavily based on and inspired by [attempts](https://github.com/kn1026/cc/blob/main/claudecode.md) to [replicate](https://github.com/asgeirtj/system_prompts_leaks/blob/main/Anthropic/claude-code.md)
 Claude Code's system prompt. It was made more general purpose than Claude Code's system prompt. The default prompt contains detailed instructions for how to use the built-in planning tool, file system tools, and sub agents.

--- a/libs/deepagents-cli/deepagents_cli/config.py
+++ b/libs/deepagents-cli/deepagents_cli/config.py
@@ -102,13 +102,14 @@ def create_model():
     """Create the appropriate model based on available API keys.
 
     Returns:
-        ChatModel instance (OpenAI or Anthropic)
+        ChatModel instance (OpenAI, Anthropic, or Ollama)
 
     Raises:
-        SystemExit if no API key is configured
+        SystemExit if no API key or Ollama configuration is set
     """
     openai_key = os.environ.get("OPENAI_API_KEY")
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    ollama_base_url = os.environ.get("OLLAMA_BASE_URL")
 
     if openai_key:
         from langchain_openai import ChatOpenAI
@@ -128,11 +129,27 @@ def create_model():
             model_name=model_name,
             max_tokens=20000,
         )
-    console.print("[bold red]Error:[/bold red] No API key configured.")
+    if ollama_base_url:
+        from langchain_ollama import ChatOllama
+
+        model_name = os.environ.get("OLLAMA_MODEL", "llama2")
+        console.print(f"[dim]Using Ollama model: {model_name} at {ollama_base_url}[/dim]")
+        return ChatOllama(
+            model=model_name,
+            base_url=ollama_base_url,
+            temperature=0.7,
+        )
+    console.print("[bold red]Error:[/bold red] No API key or Ollama configuration found.")
     console.print("\nPlease set one of the following environment variables:")
     console.print("  - OPENAI_API_KEY     (for OpenAI models like gpt-5-mini)")
     console.print("  - ANTHROPIC_API_KEY  (for Claude models)")
+    console.print("  - OLLAMA_BASE_URL    (for local Ollama models, e.g., http://localhost:11434)")
+    console.print("\nFor Ollama, also set:")
+    console.print("  - OLLAMA_MODEL       (optional, defaults to llama2)")
     console.print("\nExample:")
     console.print("  export OPENAI_API_KEY=your_api_key_here")
+    console.print("  # or for Ollama:")
+    console.print("  export OLLAMA_BASE_URL=http://localhost:11434")
+    console.print("  export OLLAMA_MODEL=qwen2.5-coder:14b")
     console.print("\nOr add it to your .env file.")
     sys.exit(1)

--- a/libs/deepagents-cli/pyproject.toml
+++ b/libs/deepagents-cli/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "rich>=13.0.0",
   "prompt-toolkit>=3.0.52",
   "langchain-openai>=0.1.0",
+  "langchain-ollama>=0.1.0",
   "tavily-python",
   "python-dotenv",
 ]

--- a/libs/deepagents-cli/tests/test_config.py
+++ b/libs/deepagents-cli/tests/test_config.py
@@ -1,0 +1,182 @@
+"""Tests for config.py model creation."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def test_create_model_with_ollama():
+    """Test that create_model returns ChatOllama when OLLAMA_BASE_URL is set."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "OLLAMA_BASE_URL": "http://localhost:11434",
+                "OLLAMA_MODEL": "qwen2.5-coder:14b",
+            },
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print") as mock_print,
+    ):
+        model = create_model()
+
+        # Verify we got a ChatOllama instance
+        assert model.__class__.__name__ == "ChatOllama"
+        assert model.model == "qwen2.5-coder:14b"
+        assert model.base_url == "http://localhost:11434"
+
+        # Verify console output
+        mock_print.assert_called_once()
+        call_args = mock_print.call_args[0][0]
+        assert "Ollama" in call_args
+        assert "qwen2.5-coder:14b" in call_args
+
+
+def test_create_model_with_ollama_default_model():
+    """Test that create_model uses default llama2 model when OLLAMA_MODEL is not set."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {"OLLAMA_BASE_URL": "http://localhost:11434"},
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert model.__class__.__name__ == "ChatOllama"
+        assert model.model == "llama2"  # Default model
+
+
+def test_create_model_with_openai():
+    """Test that create_model returns ChatOpenAI when OPENAI_API_KEY is set."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "test-key"},
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert model.__class__.__name__ == "ChatOpenAI"
+
+
+def test_create_model_with_anthropic():
+    """Test that create_model returns ChatAnthropic when ANTHROPIC_API_KEY is set."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {"ANTHROPIC_API_KEY": "test-key"},
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert model.__class__.__name__ == "ChatAnthropic"
+
+
+def test_create_model_priority_openai_over_anthropic():
+    """Test that OpenAI is prioritized when both API keys are set."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "openai-key",
+                "ANTHROPIC_API_KEY": "anthropic-key",
+            },
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert model.__class__.__name__ == "ChatOpenAI"
+
+
+def test_create_model_priority_openai_over_ollama():
+    """Test that OpenAI is prioritized when both OpenAI and Ollama are configured."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "openai-key",
+                "OLLAMA_BASE_URL": "http://localhost:11434",
+            },
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert model.__class__.__name__ == "ChatOpenAI"
+
+
+def test_create_model_priority_anthropic_over_ollama():
+    """Test that Anthropic is prioritized when both Anthropic and Ollama are configured."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_API_KEY": "anthropic-key",
+                "OLLAMA_BASE_URL": "http://localhost:11434",
+            },
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert model.__class__.__name__ == "ChatAnthropic"
+
+
+def test_create_model_exits_with_no_config():
+    """Test that create_model exits when no configuration is provided."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("deepagents_cli.config.console.print"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        create_model()
+
+    assert exc_info.value.code == 1
+
+
+def test_ollama_model_temperature():
+    """Test that Ollama model is created with correct temperature."""
+    from deepagents_cli.config import create_model
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "OLLAMA_BASE_URL": "http://localhost:11434",
+                "OLLAMA_MODEL": "qwen2.5-coder:14b",
+            },
+            clear=True,
+        ),
+        patch("deepagents_cli.config.console.print"),
+    ):
+        model = create_model()
+
+        assert hasattr(model, "temperature")
+        assert model.temperature == 0.7

--- a/test_ollama_integration.py
+++ b/test_ollama_integration.py
@@ -1,0 +1,33 @@
+"""Integration test for Ollama with qwen2.5-coder:14b."""
+
+import os
+
+# Set Ollama environment variables
+os.environ["OLLAMA_BASE_URL"] = "http://localhost:11434"
+os.environ["OLLAMA_MODEL"] = "qwen2.5-coder:14b"
+
+# Clear other model API keys to ensure Ollama is used
+os.environ.pop("OPENAI_API_KEY", None)
+os.environ.pop("ANTHROPIC_API_KEY", None)
+
+import sys
+sys.path.insert(0, "libs/deepagents-cli")
+
+from deepagents_cli.config import create_model
+
+print("Creating Ollama model...")
+model = create_model()
+
+print(f"\nModel type: {type(model).__name__}")
+print(f"Model name: {model.model}")
+print(f"Base URL: {model.base_url}")
+print(f"Temperature: {model.temperature}")
+
+print("\n✅ Model created successfully!")
+
+# Test a simple invocation
+print("\nTesting model invocation with a simple code question...")
+response = model.invoke("Write a Python function to calculate fibonacci numbers. Keep it very brief.")
+print(f"\nResponse: {response.content[:200]}...")
+
+print("\n✅ Integration test passed! Ollama with qwen2.5-coder:14b is working!")


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for running deepagents with local LLM models via Ollama, enabling:
- ✅ **Privacy**: Run models completely offline without sending data to cloud APIs
- ✅ **Cost**: No API costs for using local models
- ✅ **Flexibility**: Use any Ollama-supported model (Llama, Mistral, Qwen, etc.)

## Changes

### Core Implementation
- **config.py**: Added Ollama model provider detection and initialization
- **pyproject.toml**: Added `langchain-ollama>=0.1.0` dependency
- **Environment variables**: 
  - `OLLAMA_BASE_URL`: Ollama server URL (default: http://localhost:11434)
  - `OLLAMA_MODEL`: Model name (default: llama2)

### Testing
- **test_config.py**: Comprehensive unit tests (9 tests, all passing)
  - Model creation with Ollama
  - Default model fallback
  - Priority testing (OpenAI > Anthropic > Ollama)
  - Temperature configuration
- **test_ollama_integration.py**: End-to-end integration test
  - Validated with qwen2.5-coder:14b

### Documentation
- **OLLAMA.md**: Complete guide including:
  - Setup and installation instructions
  - Configuration examples
  - Model recommendations
  - Troubleshooting guide
  - Performance tips
- **README.md**: Added Ollama section with quick example

## Model Priority

The CLI checks for models in this order:
1. OpenAI (if `OPENAI_API_KEY` is set)
2. Anthropic (if `ANTHROPIC_API_KEY` is set)  
3. Ollama (if `OLLAMA_BASE_URL` is set)

## Test plan

- [x] All unit tests pass (9/9)
- [x] Integration test with qwen2.5-coder:14b passes
- [x] Model detection works correctly
- [x] Environment variable configuration works
- [x] Documentation is comprehensive
- [x] No breaking changes to existing functionality

## Example Usage

### CLI
```bash
export OLLAMA_BASE_URL=http://localhost:11434
export OLLAMA_MODEL=qwen2.5-coder:14b
deepagents
```

### Python
```python
from langchain_ollama import ChatOllama
from deepagents import create_deep_agent

model = ChatOllama(
    model="qwen2.5-coder:14b",
    base_url="http://localhost:11434",
)
agent = create_deep_agent(model=model)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)