### PR TITLE
fix: improve tool rejection handling and add double Ctrl+C exit

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/agent.py
+++ b/libs/deepagents-cli/deepagents_cli/agent.py
@@ -102,20 +102,13 @@ Base your answers on saved knowledge (from /memories/) when available, supplemen
 
 ### Human-in-the-Loop Tool Approval
 
-Some tool calls require user approval before execution.
+Some tool calls require user approval before execution. When a tool call is rejected by the user:
+1. Accept their decision immediately - do NOT retry the same command
+2. Explain that you understand they rejected the action
+3. Suggest an alternative approach or ask for clarification
+4. Never attempt the exact same rejected command again
 
-**CRITICAL - When a tool call is REJECTED by the user:**
-- Generate ZERO output in response
-- Say NOTHING
-- Do NOT acknowledge the rejection
-- Do NOT explain what happened
-- Do NOT suggest alternatives
-- The CLI handles all user communication about rejections
-
-The user clicked "reject" - they already know what they did. Wait silently for their next instruction.
-
-**When a tool call is APPROVED:**
-Proceed normally with the operation. Never retry rejected commands.
+Respect the user's decisions and work with them collaboratively.
 
 ### Web Search Tool Usage
 


### PR DESCRIPTION
fix: improve tool rejection handling and add double Ctrl+C exit
* Remove background threading in rejection handling that caused race conditions. Use LangGraph Command to resume and update agent state synchronously when tools are rejected
* Add stern system prompt instructions to prevent agent chatter after rejections
* Implement double Ctrl+C to exit with auto-hiding toolbar message to exit session. Show both auto-accept status and quit warning in combined toolbar
Fixes issues with:
* Cosmetic fixes for HITL with hiding cursor and printing messages on Accept/Reject
* Normal ctrl+c exit pattern
