### PR TITLE
feat: add option to start cli in interactive mode with arg as prompt

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/README.md
+++ b/libs/deepagents-cli/deepagents_cli/README.md
@@ -28,7 +28,9 @@ cli/
   - `cli_main()` - Console script entry point (called when you run `deepagents`)
   - `main()` - Async main function that orchestrates agent creation and CLI
   - `simple_cli()` - Main interactive loop handling user input
+    - Executes optional initial prompt before entering interactive mode
   - `parse_args()` - Command-line argument parsing
+    - Accepts optional positional `prompt` argument for piping prompts
   - `check_cli_dependencies()` - Validates required packages are installed
 
 ### `config.py` - Configuration & Constants
@@ -127,6 +129,18 @@ Display output via ui.py (TokenTracker, console)
 
 ## Key Features
 
+### Command-Line Prompt Execution
+Pass a prompt as a command-line argument to execute it and then enter interactive mode:
+```bash
+deepagents "create a hello.py file"
+deepagents --agent mybot "review the last commit"
+```
+
+This is useful for:
+- Quick tasks that you want to follow up on
+- Starting a session with initial context
+- Automating the first step of a workflow
+
 ### File Context Injection
 Type `@filename` and press Tab to autocomplete and inject file content into your prompt.
 
@@ -181,9 +195,13 @@ To modify the CLI:
 # From project root
 uv run python -m deepagents.cli
 
+# With initial prompt
+uv run python -m deepagents.cli "analyze this codebase"
+
 # Or install in editable mode
 uv pip install -e .
 deepagents
+deepagents "create a test file"
 ```
 
 ## Entry Point

--- a/libs/deepagents-cli/deepagents_cli/ui.py
+++ b/libs/deepagents-cli/deepagents_cli/ui.py
@@ -414,13 +414,13 @@ def show_help():
     console.print()
 
     console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
-    console.print("  deepagents [--agent NAME] [--auto-approve]     Start interactive session")
-    console.print("  deepagents list                                List all available agents")
-    console.print("  deepagents reset --agent AGENT                 Reset agent to default prompt")
+    console.print("  deepagents [--agent NAME] [--auto-approve] [PROMPT]  Start interactive session")
+    console.print("  deepagents list                                       List all available agents")
+    console.print("  deepagents reset --agent AGENT                        Reset agent to default prompt")
     console.print(
-        "  deepagents reset --agent AGENT --target SOURCE Reset agent to copy of another agent"
+        "  deepagents reset --agent AGENT --target SOURCE        Reset agent to copy of another agent"
     )
-    console.print("  deepagents help                                Show this help message")
+    console.print("  deepagents help                                       Show this help message")
     console.print()
 
     console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
@@ -433,6 +433,10 @@ def show_help():
     )
     console.print(
         "  deepagents --auto-approve               # Start with auto-approve enabled",
+        style=COLORS["dim"],
+    )
+    console.print(
+        '  deepagents "create hello.py"            # Execute prompt then enter interactive mode',
         style=COLORS["dim"],
     )
     console.print(


### PR DESCRIPTION
Add ability to pass a prompt as a command-line argument that executes on entering interactive mode.

Usage:
  deepagents "create hello.py"
  deepagents --agent mybot "review the last commit"
  deepagents --auto-approve "add a new unit test"

Changes:
- parse_args(): Detect if first positional arg is a prompt vs subcommand
- simple_cli(): Accept and execute initial_prompt parameter
- main(): Pass initial_prompt through
- cli_main(): Extract prompt from args and pass to main()
- ui.py: Update help text with [PROMPT] usage and example
- README.md: Document command-line prompt execution feature