### PR TITLE
fix-cli(ui): show tool call running in spinner instead of hanging cursor

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/execution.py
+++ b/libs/deepagents-cli/deepagents_cli/execution.py
@@ -353,6 +353,10 @@ def execute_task(
                         tool_content = format_tool_message_content(message.content)
                         record = file_op_tracker.complete_with_message(message)
 
+                        # Reset spinner message after tool completes
+                        if spinner_active:
+                            status.update(f"[bold {COLORS['thinking']}]Agent is thinking...")
+
                         if tool_name == "shell" and tool_status != "success":
                             flush_summary_buffer()
                             flush_text_buffer(final=True)
@@ -525,9 +529,10 @@ def execute_task(
                                 markup=False,
                             )
 
-                            if not spinner_active:
-                                status.start()
-                                spinner_active = True
+                            # Restart spinner with context about which tool is executing
+                            status.update(f"[bold {COLORS['thinking']}]Executing {display_str}...")
+                            status.start()
+                            spinner_active = True
 
                     if getattr(message, "chunk_position", None) == "last":
                         flush_summary_buffer()


### PR DESCRIPTION
hanging cursor can look like agent froze, so show message executing tool call