### PR TITLE
update message.text() to .text

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/execution.py
+++ b/libs/deepagents-cli/deepagents_cli/execution.py
@@ -308,7 +308,7 @@ async def execute_task(
                     message, metadata = data
 
                     if isinstance(message, HumanMessage):
-                        content = message.text()
+                        content = message.text
                         if content:
                             flush_text_buffer(final=True)
                             if spinner_active:


### PR DESCRIPTION
Saw when running locally:
> LangChainDeprecationWarning: Calling .text() as a method is deprecated. Use .text as a property instead (e.g., message.text).