### PR TITLE
fix(cli): handle multiple concurrent interrupts in HITL workflow

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/execution.py
+++ b/libs/deepagents-cli/deepagents_cli/execution.py
@@ -545,7 +545,6 @@ async def execute_task(
                             raise
 
                 # Build response for all pending interrupts
-                all_responses: dict[str, HITLResponse] = {}
                 any_rejected = False
 
                 for interrupt_id, hitl_request in pending_interrupts.items():
@@ -565,7 +564,7 @@ async def execute_task(
 
                             decisions.append({"type": "approve"})
 
-                        all_responses[interrupt_id] = {"decisions": decisions}
+                        hitl_response[interrupt_id] = {"decisions": decisions}
 
                         # Restart spinner for continuation
                         if not spinner_active:
@@ -590,11 +589,8 @@ async def execute_task(
                         if any(decision.get("type") == "reject" for decision in decisions):
                             any_rejected = True
 
-                        all_responses[interrupt_id] = {"decisions": decisions}
+                        hitl_response[interrupt_id] = {"decisions": decisions}
 
-                # Always use dict format mapping interrupt_id -> response
-                # (works for both single and multiple interrupts)
-                hitl_response = all_responses
                 suppress_resumed_output = any_rejected
 
             if interrupt_occurred and hitl_response:


### PR DESCRIPTION
## Summary

Fixes `RuntimeError` when parallel subagents create multiple pending interrupts in the human-in-the-loop (HITL) workflow.

## Problem

I was testing multiple sub-agents, which are used in the [web-research skill](https://github.com/langchain-ai/deepagents/pull/315). When spawning multiple subagents in parallel that require HITL approval (e.g., 3 research subagents all calling `web_search`), LangGraph raises:
```
RuntimeError: When there are multiple pending interrupts, you must specify the interrupt id when resuming.
```

The previous code only handled one interrupt at a time and passed a simple response dict. LangGraph requires responses for **all** pending interrupts to be mapped by their interrupt IDs when multiple are present.

## Solution

**Changes to `execution.py`:**

1. **Collect all pending interrupts** - Changed from tracking a single `hitl_request` to a dict `pending_interrupts` keyed by interrupt ID
2. **Handle each interrupt** - Loop through all interrupts and collect responses (auto-approve or manual prompt)
3. **Build proper resume format**:
   - Single interrupt: pass response directly `{"decisions": [...]}`
   - Multiple interrupts: pass dict `{interrupt_id_1: {"decisions": [...]}, interrupt_id_2: {...}}`

## Test Plan

Tested all w/ `web-research skill`.

- [x] Test with single subagent (HITL) - should work as before
- [x] Test with 3 parallel subagents + `--auto-approve` - should auto-approve all
- [x] Test with 3 parallel subagents + manual HITL - should prompt for each and resume correctly