### PR TITLE
fix(agent): improve system prompt for file paths

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/agent.py
+++ b/libs/deepagents-cli/deepagents_cli/agent.py
@@ -167,8 +167,6 @@ def create_agent_with_config(model, assistant_id: str, tools: list):
     long_term_backend = FilesystemBackend(root_dir=agent_dir, virtual_mode=True)
 
     # Composite backend: current working directory for default, agent directory for /memories/
-    # Default backend uses default settings (virtual_mode=False) to require absolute paths (like Claude Code)
-    # /memories/ backend uses virtual_mode=True for virtual path handling
     backend = CompositeBackend(
         default=FilesystemBackend(),
         routes={"/memories/": long_term_backend},


### PR DESCRIPTION
## Summary

Clarifies `deepagents-cli` file path handling by requiring absolute paths. 

## Problem

I noticed errors w/ `deepagents-cli` tool calls attempting to write files to root directory. 
 
e.g., `/hello_world.txt` rather than `{cwd}/hello_world.txt`

## How it works

When FilesystemBackend() is instantiated without parameters, it uses these defaults:
- root_dir=None → internally resolves to Path.cwd() (see https://github.com/langchain-ai/deepagents/blob/master/libs/deepagents/backends/filesystem.py#L48)
 virtual_mode=False → requires absolute paths, no sandboxing

This means FilesystemBackend() and FilesystemBackend(root_dir=Path.cwd(), virtual_mode=False) are functionally equivalent, but the former is cleaner and relies on documented default behavior.

## Changes

- Added <env> block containing the working directory (matching Claude Code format)
- Updated path handling instructions to explicitly require absolute paths
- Provided clear examples showing full absolute paths (e.g., /Users/name/project/file.txt)
- Clarified that /memories/ paths still work for persistent storage across sessions

##  Testing

  - ✅ All existing CLI tests pass
  - ✅ FilesystemBackend virtual_mode tests pass
  - ✅ Ready for local integration testing

  ---