### PR TITLE
fix(ci): use --test group only  to install test dependencies 

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: "📦 Install Test Dependencies"
         shell: bash
-        run: uv sync --all-groups
+        run: uv sync --group test
 
       - name: "🧪 Run Unit Tests"
         shell: bash


### PR DESCRIPTION
Resolve repeated test failures in https://github.com/langchain-ai/deepagents/pull/315 where responses (needed by test_tools.py) wasn't being installed during CI, causing:

```
ModuleNotFoundError: No module named 'responses'
```

<img width="1022" height="908" alt="image" src="https://github.com/user-attachments/assets/bad494c8-2dd2-4333-ab0f-e18ad1539526" />

Even though responses>=0.25.0 was listed in the test dependency group, the --group test --dev command wasn't successfully installing it in the CI environment. By using --all-groups, we ensure that every dependency group (including test) is fully resolved and installed, making the test suite work correctly.