### PR TITLE
feat: Add --show-thinking flag to CLI (#311) and Show Tool Outputs in a Collapsible Pane #326

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/config.py
+++ b/libs/deepagents-cli/deepagents_cli/config.py
@@ -62,6 +62,7 @@ class SessionState:
     def __init__(self, auto_approve: bool = False, show_thinking: bool = False):
         self.auto_approve = auto_approve
         self.show_thinking = show_thinking
+        self.show_tool_outputs = False
         self.exit_hint_until: float | None = None
         self.exit_hint_handle = None
 
@@ -69,6 +70,11 @@ class SessionState:
         """Toggle auto-approve and return new state."""
         self.auto_approve = not self.auto_approve
         return self.auto_approve
+    
+    def toggle_tool_outputs(self) -> bool:
+        """Toggle tool output visibility and return new state."""
+        self.show_tool_outputs = not self.show_tool_outputs
+        return self.show_tool_outputs
 
 
 def get_default_coding_instructions() -> str:

--- a/libs/deepagents-cli/deepagents_cli/execution.py
+++ b/libs/deepagents-cli/deepagents_cli/execution.py
@@ -330,6 +330,14 @@ async def execute_task(
                         tool_content = format_tool_message_content(message.content)
                         record = file_op_tracker.complete_with_message(message)
 
+                        # Display tool output if toggle is enabled
+                        if session_state.show_tool_outputs and tool_content:
+                            if spinner_active:
+                                status.stop()
+                                spinner_active = False
+                            console.print(f"    ↳ {tool_content}", style="dim cyan", markup=False)
+                            console.print()
+
                         # Reset spinner message after tool completes
                         if spinner_active:
                             status.update(f"[bold {COLORS['thinking']}]Agent is thinking...")

--- a/libs/deepagents-cli/deepagents_cli/input.py
+++ b/libs/deepagents-cli/deepagents_cli/input.py
@@ -158,6 +158,13 @@ def get_bottom_toolbar(
 
         parts.append((base_class, base_msg))
 
+        # Show tool output toggle state
+        parts.append(("", " | "))
+        if session_state.show_tool_outputs:
+            parts.append(("class:toolbar-blue", "tool outputs ON (CTRL+O to toggle)"))
+        else:
+            parts.append(("class:toolbar-dim", "tool outputs off (CTRL+O to toggle)"))
+
         # Show exit confirmation hint if active
         hint_until = session_state.exit_hint_until
         if hint_until is not None:
@@ -227,6 +234,14 @@ def create_prompt_session(assistant_id: str, session_state: SessionState) -> Pro
         session_state.toggle_auto_approve()
         # Force UI refresh to update toolbar
         event.app.invalidate()
+    
+    # Bind Ctrl+O to toggle tool outputs
+    @kb.add("c-o")
+    def _(event):
+        """Toggle tool output visibility."""
+        session_state.toggle_tool_outputs()
+        # Force UI refresh to update toolbar
+        event.app.invalidate()
 
     # Bind regular Enter to submit (intuitive behavior)
     @kb.add("enter")
@@ -293,6 +308,8 @@ def create_prompt_session(assistant_id: str, session_state: SessionState) -> Pro
             "toolbar-green": "bg:#10b981 #000000",  # Green for auto-accept ON
             "toolbar-orange": "bg:#f59e0b #000000",  # Orange for manual accept
             "toolbar-exit": "bg:#2563eb #ffffff",  # Blue for exit hint
+            "toolbar-blue": "bg:#06b6d4 #000000",  # Cyan for tool outputs ON
+            "toolbar-dim": "bg:#6b7280 #000000",  # Gray for tool outputs off
         }
     )
 

--- a/libs/deepagents-cli/deepagents_cli/main.py
+++ b/libs/deepagents-cli/deepagents_cli/main.py
@@ -128,7 +128,7 @@ async def simple_cli(agent, assistant_id: str | None, session_state, baseline_to
         console.print()
 
     console.print(
-        "  Tips: Enter to submit, Alt+Enter for newline, Ctrl+E for editor, Ctrl+T to toggle auto-approve, Ctrl+C to interrupt",
+        "  Tips: Enter to submit, Alt+Enter for newline, Ctrl+E for editor, Ctrl+T to toggle auto-approve, Ctrl+O to toggle tool outputs, Ctrl+C to interrupt",
         style=f"dim {COLORS['dim']}",
     )
     console.print()

--- a/libs/deepagents-cli/deepagents_cli/ui.py
+++ b/libs/deepagents-cli/deepagents_cli/ui.py
@@ -499,6 +499,7 @@ def show_interactive_help():
         "  Ctrl+E          Open in external editor (nano by default)", style=COLORS["dim"]
     )
     console.print("  Ctrl+T          Toggle auto-approve mode", style=COLORS["dim"])
+    console.print("  Ctrl+O          Toggle tool output visibility", style=COLORS["dim"])
     console.print("  Arrow keys      Navigate input", style=COLORS["dim"])
     console.print("  Ctrl+C          Cancel input or interrupt agent mid-work", style=COLORS["dim"])
     console.print()
@@ -594,6 +595,7 @@ def show_help():
     )
     console.print("  Ctrl+J          Insert newline (alternative)", style=COLORS["dim"])
     console.print("  Ctrl+T          Toggle auto-approve mode", style=COLORS["dim"])
+    console.print("  Ctrl+O          Toggle tool output visibility", style=COLORS["dim"])
     console.print("  Arrow keys      Navigate input", style=COLORS["dim"])
     console.print(
         "  @filename       Type @ to auto-complete files and inject content", style=COLORS["dim"]


### PR DESCRIPTION
Add support for displaying agent reasoning/thinking process in the CLI.

Changes:
- Add --show-thinking command-line flag to main.py
- Extend SessionState with show_thinking field in config.py
- Display reasoning blocks in dim style when flag is enabled in execution.py
- Update help documentation and examples in ui.py

When enabled with --show-thinking, the agent's reasoning blocks from LangChain content blocks are displayed in real-time as dim text, providing transparency into the agent's thought process.

Resolves #311