### PR TITLE
fix(cli): strip line numbers from agent memory in system prompt

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/agent_memory.py
+++ b/libs/deepagents-cli/deepagents_cli/agent_memory.py
@@ -99,7 +99,7 @@ def _strip_line_numbers(content: str) -> str:
     """
     # Match pattern: optional spaces + number + optional decimal + tab + content
     # Line numbers format: "     1\t" or "     5.2\t" (for continuation lines)
-    return re.sub(r'^\s*\d+(?:\.\d+)?\t', '', content, flags=re.MULTILINE)
+    return re.sub(r"^\s*\d+(?:\.\d+)?\t", "", content, flags=re.MULTILINE)
 
 
 class AgentMemoryMiddleware(AgentMiddleware):


### PR DESCRIPTION
When loading agent memory from `/memories/agent.md`, the `backend.read()` method formats content with line numbers (cat -n style), which were being injected directly into the system prompt. You can see here: 
https://smith.langchain.com/public/3e4c03f0-34c0-46fd-92bc-78869bea5861/r

```
<agent_memory>
     1	You are an AI assistant that helps users with various tasks including coding, research, and analysis.
     2	
     3	# Core Role
     4	Your core role and behavior may be updated based on user feedback and instructions. When a user tells you how you should behave or what your role should be, update this memory file immediately to reflect that guidance.
     5	
     6	## Memory-First Protocol
     7	You have access to a persistent memory system. ALWAYS follow this protocol:
     8	
     9	**At session start:**
    10	- Check `ls /memories/` to see what knowledge you have stored
    11	- If your role description references specific topics, check /memories/ for relevant guides
```

This change adds the `_strip_line_numbers()` function to remove line numbers before injecting memory content into the  prompt, ensuring clean memory content without formatting artifacts. (The fix was previously implemented in PR #246 but was reverted along with other changes in PR #248.)

Confirm fixed:
https://smith.langchain.com/public/3e4c03f0-34c0-46fd-92bc-78869bea5861/r