### PR TITLE
fix: Don't error when "subagent" does not exist. And add test for truncation logic

### DIFF
--- a/libs/deepagents/middleware/subagents.py
+++ b/libs/deepagents/middleware/subagents.py
@@ -342,7 +342,7 @@ def _create_task_tool(
         runtime: ToolRuntime,
     ) -> str | Command:
         if subagent_type not in subagent_graphs:
-            allowed_types = ", ".join([f'`{k}`' for k in subagent_graphs])
+            allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
             return f"We cannot invoke subagent {subagent_type} because it does not exist, the only allowed types are {allowed_types}"
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
         result = subagent.invoke(subagent_state)
@@ -357,7 +357,7 @@ def _create_task_tool(
         runtime: ToolRuntime,
     ) -> str | Command:
         if subagent_type not in subagent_graphs:
-            allowed_types = ", ".join([f'`{k}`' for k in subagent_graphs])
+            allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
             return f"We cannot invoke subagent {subagent_type} because it does not exist, the only allowed types are {allowed_types}"
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
         result = await subagent.ainvoke(subagent_state)

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -932,7 +932,7 @@ class TestFilesystemMiddleware:
         line2 = "a" * 1500  # Long line that should be truncated
         line3 = "another short line"
         line4 = "b" * 2000  # Another long line
-        line5 = "c" * 500   # Short line
+        line5 = "c" * 500  # Short line
         large_content = f"{line1}\n{line2}\n{line3}\n{line4}\n{line5}\n" + ("x" * 1000)
 
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")


### PR DESCRIPTION
- Don't raise an error when an incorrect subagent is used, just tell the agent
- Add test for truncation logic 