### PR TITLE
fix: use `request.override` instead of direct attribute overrides

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/skills/middleware.py
+++ b/libs/deepagents-cli/deepagents_cli/skills/middleware.py
@@ -241,8 +241,8 @@ class SkillsMiddleware(AgentMiddleware):
 
         # Inject into system prompt
         if request.system_prompt:
-            request.system_prompt = request.system_prompt + "\n\n" + skills_section
+            system_prompt = request.system_prompt + "\n\n" + skills_section
         else:
-            request.system_prompt = skills_section
+            system_prompt = skills_section
 
-        return await handler(request)
+        return await handler(request.override(system_prompt=system_prompt))

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -468,7 +468,8 @@ class SubAgentMiddleware(AgentMiddleware):
     ) -> ModelResponse:
         """Update the system prompt to include instructions on using subagents."""
         if self.system_prompt is not None:
-            request.system_prompt = request.system_prompt + "\n\n" + self.system_prompt if request.system_prompt else self.system_prompt
+            system_prompt = request.system_prompt + "\n\n" + self.system_prompt if request.system_prompt else self.system_prompt
+            return handler(request.override(system_prompt=system_prompt))
         return handler(request)
 
     async def awrap_model_call(
@@ -478,5 +479,6 @@ class SubAgentMiddleware(AgentMiddleware):
     ) -> ModelResponse:
         """(async) Update the system prompt to include instructions on using subagents."""
         if self.system_prompt is not None:
-            request.system_prompt = request.system_prompt + "\n\n" + self.system_prompt if request.system_prompt else self.system_prompt
+            system_prompt = request.system_prompt + "\n\n" + self.system_prompt if request.system_prompt else self.system_prompt
+            return await handler(request.override(system_prompt=system_prompt))
         return await handler(request)


### PR DESCRIPTION
In preparation for `ModelCallRequest` and `ToolCallRequest` being frozen dataclasses