### PR TITLE
fix: normalize path separators in FilesystemBackend for cross-platform(OS:Window) compatibility

### DIFF
--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -21,9 +21,10 @@ def test_filesystem_backend_normal_mode(tmp_path: Path):
     # ls_info absolute path - should only list files in root, not subdirectories
     infos = be.ls_info(str(root))
     paths = {i["path"] for i in infos}
-    assert str(f1) in paths  # File in root should be listed
-    assert str(f2) not in paths  # File in subdirectory should NOT be listed
-    assert (str(root) + "/dir/") in paths  # Directory should be listed
+    # Normalize paths for cross-platform comparison
+    assert str(f1).replace("\\", "/") in paths  # File in root should be listed
+    assert str(f2).replace("\\", "/") not in paths  # File in subdirectory should NOT be listed
+    assert (str(root).replace("\\", "/") + "/dir/") in paths  # Directory should be listed
 
     # read, edit, write
     txt = be.read(str(f1))
@@ -39,7 +40,7 @@ def test_filesystem_backend_normal_mode(tmp_path: Path):
 
     # glob_info
     g = be.glob_info("*.py", path=str(root))
-    assert any(i["path"] == str(f2) for i in g)
+    assert any(i["path"] == str(f2).replace("\\", "/") for i in g)
 
 
 def test_filesystem_backend_virtual_mode(tmp_path: Path):
@@ -148,15 +149,16 @@ def test_filesystem_backend_ls_normal_mode_nested(tmp_path: Path):
     root_listing = be.ls_info(str(root))
     root_paths = [fi["path"] for fi in root_listing]
 
-    assert str(root / "file1.txt") in root_paths
-    assert str(root / "subdir") + "/" in root_paths
-    assert str(root / "subdir" / "file2.txt") not in root_paths
+    # Normalize paths for cross-platform comparison
+    assert str(root / "file1.txt").replace("\\", "/") in root_paths
+    assert str(root / "subdir").replace("\\", "/") + "/" in root_paths
+    assert str(root / "subdir" / "file2.txt").replace("\\", "/") not in root_paths
 
     subdir_listing = be.ls_info(str(root / "subdir"))
     subdir_paths = [fi["path"] for fi in subdir_listing]
-    assert str(root / "subdir" / "file2.txt") in subdir_paths
-    assert str(root / "subdir" / "nested") + "/" in subdir_paths
-    assert str(root / "subdir" / "nested" / "file3.txt") not in subdir_paths
+    assert str(root / "subdir" / "file2.txt").replace("\\", "/") in subdir_paths
+    assert str(root / "subdir" / "nested").replace("\\", "/") + "/" in subdir_paths
+    assert str(root / "subdir" / "nested" / "file3.txt").replace("\\", "/") not in subdir_paths
 
 
 def test_filesystem_backend_ls_trailing_slash(tmp_path: Path):


### PR DESCRIPTION
# PR Description

## Problem

On Windows, `FilesystemBackend` returns paths with mixed separators (e.g., `/\.circleci/`) causing display issues in agent tools.

**[AS-IS]**

<img width="543" height="1059" alt="image" src="https://github.com/user-attachments/assets/7d15fc7f-b69c-480b-beff-91ea8e1ef7c6" />

<img width="662" height="585" alt="image" src="https://github.com/user-attachments/assets/501860e4-741e-4206-bca0-6a9cdd726e9f" />

**[TO-BE]**

<img width="513" height="481" alt="image" src="https://github.com/user-attachments/assets/045c0d6e-9a0a-4d55-bdd9-30df1cd99c91" />

<img width="665" height="583" alt="image" src="https://github.com/user-attachments/assets/03439a7d-218a-4518-94ff-0cd5f955007f" />

## Why This Matters

DeepAgents provides essential filesystem capabilities for LangGraph-based agents, and cross-platform reliability is crucial for production deployments. Mixed path separators like `/\` can negatively impact agent performance in two ways:

1. **User Experience**: Inconsistent path displays reduce trust and usability, especially on Windows systems
2. **LLM Interpretation**: Language models rely on clean, consistent path formats to make accurate decisions about file operations

This fix ensures POSIX-style paths across all platforms, improving both the developer experience and agent reliability.

## Root Cause

There were two related but distinct issues affecting different modes:

### Issue 1: `virtual_mode=True` - Logic Bug (Functional Failure)

String slicing logic in `ls_info()` and `glob_info()` used raw string concatenation to construct virtual paths:

```python
# Problematic code
cwd_str = str(self.cwd)  # "C:\workspace"
if not cwd_str.endswith("/"):
    cwd_str += "/"  # "C:\workspace/" (mixed separators!)

abs_path = str(child_path)  # "C:\workspace\file.txt"
relative_path = abs_path[len(cwd_str):]  # Slicing fails - length mismatch!
virt_path = "/" + relative_path  # Result: "/\file.txt"
```

The string slicing failed because:
1. `cwd_str` used backslashes: `C:\workspace`
2. Adding `/` created mixed separators: `C:\workspace/`
3. `abs_path` used different separators: `C:\workspace\file.txt`
4. Length calculation was incorrect, producing: `/\.circleci/`

### Issue 2: `virtual_mode=False` - Display Bug (UX Issue)

In non-virtual mode, paths were functionally correct but displayed with Windows backslashes:

```python
abs_path = str(child_path)  # "C:\workspace\file.txt"
results.append({"path": abs_path, ...})  # Backslashes in output
```

This was purely a display inconsistency - functionality was correct, but output didn't match POSIX conventions.

## Solution

### For `virtual_mode=True` (Logic Fix):

Replace fragile string slicing with robust `pathlib` operations:

```python
# Fixed code
try:
    # Use pathlib for robust cross-platform path handling
    relative_path = Path(abs_path).resolve().relative_to(self.cwd).as_posix()
except ValueError:
    # Path is outside cwd - normalize to POSIX for error reporting
    relative_path = abs_path.replace("\\", "/")

# Ensure virtual path starts with /
virt_path = "/" + relative_path if not relative_path.startswith("/") else relative_path
```

**Key improvements:**
- `Path.relative_to()` correctly handles path differences
- `.as_posix()` ensures forward slashes on all platforms
- Security boundary (paths outside cwd) preserved for `_resolve_path()` validation

### For `virtual_mode=False` (Display Fix):

Simple normalization for consistent output:

```python
# Normalize path separators for cross-platform compatibility
normalized_path = abs_path.replace("\\", "/")
results.append({"path": normalized_path, ...})
```

### Test Updates:

Updated test assertions to use platform-independent comparison:

```python
# Before: assert str(f1) in paths
# After: assert str(f1).replace("\\", "/") in paths
```

## Testing

- ✅ All 6 backend unit tests pass on **Windows 10**
- ✅ All 6 backend unit tests pass on **Linux (WSL 2 Ubuntu 22.04)**
- ✅ Cross-platform compatibility verified: `pathlib.Path.as_posix()` works consistently across platforms
- ✅ Security: Paths outside cwd are properly caught by `_resolve_path()` validation
- ✅ Verified in production with `langgraph dev` on both Windows and WSL environments

**Test Results:**

<img width="1575" height="267" alt="image" src="https://github.com/user-attachments/assets/8a9d18cd-5358-4ca2-80ee-063c8eda5bd8" />

## Changes

- `libs/deepagents/deepagents/backends/filesystem.py`: Updated `ls_info()` and `glob_info()` methods to use `pathlib` for path normalization
- `libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py`: Updated test assertions for platform-independent path comparison

## Relationship to Issue #427

This PR and Issue #427 address **complementary** Windows path handling problems in different layers:

### This PR (Backend Layer - Output):
- **Scope**: `FilesystemBackend.ls_info()` / `glob_info()` - path **output** formatting
- **Problem**: Mixed separators (`/\`) in displayed paths
- **Impact**: Display issues, UX degradation, potential LLM confusion
- **Solution**: Normalize output to POSIX format

### PR #454 / Issue #427 (Middleware Layer - Input):
- **Scope**: `_validate_path()` - user **input** validation
- **Problem**: Windows absolute paths (`F:\git\...`) → invalid paths (`/F:/git/...`) → silent corruption
- **Impact**: Files saved to wrong locations without error
- **Solution**: Reject Windows absolute paths with clear error message
- **Link**: https://github.com/langchain-ai/deepagents/pull/454

**Both fixes are necessary** for robust Windows support:
1. This PR (#452) ensures clean path **display** (output normalization)
2. PR #454 prevents corrupt path **input** (input validation)

Together, they provide end-to-end Windows path handling in DeepAgents' filesystem layer.

