### PR TITLE
fix(middleware): prevent silent corruption from Windows absolute paths (Issue #427)

### DIFF
--- a/libs/deepagents/tests/unit_tests/middleware/test_validate_path.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_validate_path.py
@@ -1,0 +1,69 @@
+"""Unit tests for _validate_path() function."""
+
+import pytest
+
+from deepagents.middleware.filesystem import _validate_path
+
+
+class TestValidatePath:
+    """Test cases for path validation and normalization."""
+
+    def test_relative_path_normalization(self):
+        """Test that relative paths get normalized with leading slash."""
+        assert _validate_path("foo/bar") == "/foo/bar"
+        assert _validate_path("relative/path.txt") == "/relative/path.txt"
+
+    def test_absolute_path_normalization(self):
+        """Test that absolute virtual paths are preserved."""
+        assert _validate_path("/workspace/file.txt") == "/workspace/file.txt"
+        assert _validate_path("/output/report.csv") == "/output/report.csv"
+
+    def test_path_normalization_removes_redundant_separators(self):
+        """Test that redundant path separators are normalized."""
+        assert _validate_path("/./foo//bar") == "/foo/bar"
+        assert _validate_path("foo/./bar") == "/foo/bar"
+
+    def test_path_traversal_rejected(self):
+        """Test that path traversal attempts are rejected."""
+        with pytest.raises(ValueError, match="Path traversal not allowed"):
+            _validate_path("../etc/passwd")
+
+        with pytest.raises(ValueError, match="Path traversal not allowed"):
+            _validate_path("foo/../../etc/passwd")
+
+    def test_home_directory_expansion_rejected(self):
+        """Test that home directory expansion is rejected."""
+        with pytest.raises(ValueError, match="Path traversal not allowed"):
+            _validate_path("~/secret.txt")
+
+    def test_windows_absolute_path_rejected_backslash(self):
+        """Test that Windows absolute paths with backslashes are rejected."""
+        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+            _validate_path("C:\\Users\\Documents\\file.txt")
+
+        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+            _validate_path("F:\\git\\project\\file.txt")
+
+    def test_windows_absolute_path_rejected_forward_slash(self):
+        """Test that Windows absolute paths with forward slashes are rejected."""
+        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+            _validate_path("C:/Users/Documents/file.txt")
+
+        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+            _validate_path("D:/data/output.csv")
+
+    def test_allowed_prefixes_enforcement(self):
+        """Test that allowed_prefixes parameter is enforced."""
+        # Should pass when prefix matches
+        result = _validate_path("/workspace/file.txt", allowed_prefixes=["/workspace/"])
+        assert result == "/workspace/file.txt"
+
+        # Should fail when prefix doesn't match
+        with pytest.raises(ValueError, match="Path must start with one of"):
+            _validate_path("/etc/file.txt", allowed_prefixes=["/workspace/"])
+
+    def test_backslash_normalization(self):
+        """Test that backslashes in relative paths are normalized to forward slashes."""
+        # Relative paths with backslashes should be normalized
+        assert _validate_path("foo\\bar\\baz") == "/foo/bar/baz"
+


### PR DESCRIPTION
# PR Description - Issue #427

## Problem

On Windows, when users pass absolute paths (e.g., `F:\git\project\file.txt`) to filesystem tools, `_validate_path()` creates invalid virtual paths by simply prefixing them with `/`, resulting in malformed paths like `/F:/git/project/file.txt`.

**Impact: Silent Data Corruption**

The malformed path `/F:/git/file.txt` is not recognized as an absolute path by Python's `pathlib` on Windows:
```python
Path('/F:/git/file.txt').is_absolute()  # False!
```

As a result, files are saved to unexpected locations (e.g., `{cwd}/F:/git/file.txt`) without any error message, causing silent data corruption that users may not notice until much later.

## Root Cause

The `_validate_path()` function was designed to normalize all paths to start with `/` for a virtual filesystem, but it didn't account for Windows absolute paths with drive letters:

```python
# Original code (master branch)
def _validate_path(path: str, ...) -> str:
    normalized = os.path.normpath(path)
    normalized = normalized.replace("\\", "/")
    
    if not normalized.startswith("/"):
        normalized = f"/{normalized}"  # Blindly prefixes / to Windows paths!
    
    return normalized
```

**Why this fails on Windows:**

1. **Input**: `F:\git\project\file.txt`
2. **After `os.path.normpath()`**: `F:\git\project\file.txt` (unchanged on Windows)
3. **After `.replace("\\", "/")`**: `F:/git/project/file.txt`
4. **Check**: `F:/git/...` doesn't start with `/` → adds prefix
5. **Output**: `/F:/git/project/file.txt` ❌

**Why Unix/Linux paths work fine:**

1. **Input**: `/home/user/file.txt`
2. **After normalization**: `/home/user/file.txt`
3. **Check**: Already starts with `/` → no prefix needed
4. **Output**: `/home/user/file.txt` ✅

The function inadvertently allows Unix absolute paths while breaking Windows absolute paths.

## Solution

Add explicit validation to reject Windows absolute paths before normalization:

```python
# Reject Windows absolute paths (e.g., C:\..., D:/...)
if re.match(r'^[a-zA-Z]:', path):
    msg = (
        f"Windows absolute paths are not supported: {path}. "
        f"Please use virtual paths starting with / (e.g., /workspace/file.txt)"
    )
    raise ValueError(msg)
```

This approach:
1. **Maintains consistency**: Enforces virtual filesystem paths across all platforms
2. **Prevents ambiguity**: Avoids mixing Windows absolute paths with virtual paths
3. **Provides clear feedback**: Error message guides users toward correct usage
4. **Preserves security**: All existing path traversal checks remain intact

## Testing

- ✅ All 9 new unit tests pass on **Windows 10**
- ✅ All tests pass on **Linux (WSL 2 Ubuntu 22.04)** - cross-platform verified
- ✅ Validates rejection of Windows absolute paths (both `\` and `/` separators)
- ✅ Confirms all existing functionality works (relative paths, path traversal, allowed_prefixes)
- ✅ Unix/Linux absolute paths continue to work (backward compatible)
- ✅ No regressions in existing codebase

**Test Coverage:**
```python
def test_windows_absolute_path_rejected_backslash(self):
    """Test that Windows absolute paths with backslashes are rejected."""
    with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
        _validate_path("C:\\Users\\Documents\\file.txt")

def test_windows_absolute_path_rejected_forward_slash(self):
    """Test that Windows absolute paths with forward slashes are rejected."""
    with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
        _validate_path("C:/Users/Documents/file.txt")
```

## Changes

- `libs/deepagents/deepagents/middleware/filesystem.py`: 
  - Added `import re` for Windows drive letter detection
  - Added explicit Windows absolute path validation
  - Updated docstring with clear examples
- `libs/deepagents/tests/unit_tests/middleware/test_validate_path.py`:
  - New comprehensive test suite (9 test cases)
  - Covers Windows paths, path traversal, normalization, and allowed_prefixes

## Relationship to Other Work

This PR complements the path normalization work in `FilesystemBackend` by addressing a different layer:

**This PR (Middleware - Input Validation):**
- Scope: `_validate_path()` in `middleware/filesystem.py`
- Purpose: Validate and reject invalid user inputs early
- Impact: Prevents silent corruption from Windows absolute paths

**PR #452 (Backend - Output Formatting):**
- Scope: `ls_info()` / `glob_info()` in `backends/filesystem.py`
- Purpose: Normalize path display for consistency
- Impact: Clean POSIX-style output across platforms
- Link: https://github.com/langchain-ai/deepagents/pull/452

**Design Philosophy:**

DeepAgents uses a virtual filesystem model where all paths should be:
- Virtual paths: `/workspace/file.txt`, `/memory/data.json` (Recommended)
- Relative paths: `data/file.txt` (Converted to `/data/file.txt`)
- Unix absolute paths: `/home/user/file.txt` (Allowed for backward compatibility)
- Windows absolute paths: `C:/Users/file.txt` (Rejected - incompatible with virtual FS)

For Windows users, the recommended approach is to use WSL or virtual paths as per the maintainer's guidance.

## Related Issues

Fixes #427

