### PR TITLE
re-implement base sandbox without relying on python3

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -62,7 +62,7 @@ esac | while IFS=$'\\t' read -r fpath ftype; do
     escaped=$(printf '%s' "$fpath" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
 
     # Output JSON format matching the protocol
-    printf '{"path":"%s","is_dir":%s}\\n' "$escaped" "$is_dir"
+    printf '{{"path":"%s","is_dir":%s}}\\n' "$escaped" "$is_dir"
 done
 """
 
@@ -144,7 +144,7 @@ fi
 # Use awk to add line numbers and handle offset/limit
 awk -v offset={offset} -v limit={limit} '
     NR > offset && NR <= offset + limit {{
-        printf "%6d\\\\t%s\\\\n", NR, $0
+        printf "%6d\\t%s\\n", NR, $0
     }}
     NR > offset + limit {{ exit }}
 ' {file_path}


### PR DESCRIPTION
(not intended for merging) -- just testing whether we should do this. terminal-bench containers don't have python3 so issues w/ some of the file ops