### PR TITLE
fix: fix docstring formatting errors in backends

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -106,9 +106,11 @@ class CompositeBackend:
         """Read file content, routing to appropriate backend.
 
         Args:
-            file_path: Absolute file path
-            offset: Line offset to start reading from (0-indexed)
-            limit: Maximum number of lines to readReturns:
+            file_path: Absolute file path.
+            offset: Line offset to start reading from (0-indexed).
+            limit: Maximum number of lines to read.
+
+        Returns:
             Formatted file content with line numbers, or error message.
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
@@ -175,8 +177,10 @@ class CompositeBackend:
         """Create a new file, routing to appropriate backend.
 
         Args:
-            file_path: Absolute file path
-            content: File content as a stringReturns:
+            file_path: Absolute file path.
+            content: File content as a string.
+
+        Returns:
             Success message or Command object, or error if file already exists.
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
@@ -204,10 +208,12 @@ class CompositeBackend:
         """Edit a file, routing to appropriate backend.
 
         Args:
-            file_path: Absolute file path
-            old_string: String to find and replace
-            new_string: Replacement string
-            replace_all: If True, replace all occurrencesReturns:
+            file_path: Absolute file path.
+            old_string: String to find and replace.
+            new_string: Replacement string.
+            replace_all: If True, replace all occurrences.
+
+        Returns:
             Success message or Command object, or error message on failure.
         """
         backend, stripped_key = self._get_backend_and_key(file_path)

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -202,9 +202,11 @@ class FilesystemBackend(BackendProtocol):
         """Read file content with line numbers.
 
         Args:
-            file_path: Absolute or relative file path
-            offset: Line offset to start reading from (0-indexed)
-            limit: Maximum number of lines to readReturns:
+            file_path: Absolute or relative file path.
+            offset: Line offset to start reading from (0-indexed).
+            limit: Maximum number of lines to read.
+
+        Returns:
             Formatted file content with line numbers, or error message.
         """
         resolved_path = self._resolve_path(file_path)

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -99,9 +99,11 @@ class StateBackend(BackendProtocol):
         """Read file content with line numbers.
 
         Args:
-            file_path: Absolute file path
-            offset: Line offset to start reading from (0-indexed)
-            limit: Maximum number of lines to readReturns:
+            file_path: Absolute file path.
+            offset: Line offset to start reading from (0-indexed).
+            limit: Maximum number of lines to read.
+
+        Returns:
             Formatted file content with line numbers, or error message.
         """
         files = self.runtime.state.get("files", {})

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -38,17 +38,18 @@ class StoreBackend(BackendProtocol):
         """Initialize StoreBackend with runtime.
 
         Args:
+            runtime: The ToolRuntime instance providing store access and configuration.
         """
         self.runtime = runtime
 
     def _get_store(self) -> BaseStore:
         """Get the store instance.
 
-        Args:Returns:
-            BaseStore instance
+        Returns:
+            BaseStore instance from the runtime.
 
         Raises:
-            ValueError: If no store is available or runtime not provided
+            ValueError: If no store is available in the runtime.
         """
         store = self.runtime.store
         if store is None:
@@ -257,8 +258,9 @@ class StoreBackend(BackendProtocol):
         """Read file content with line numbers.
 
         Args:
-            file_path: Absolute file path
-            offset: Line offset to start reading from (0-indexed)limit: Maximum number of lines to read
+            file_path: Absolute file path.
+            offset: Line offset to start reading from (0-indexed).
+            limit: Maximum number of lines to read.
 
         Returns:
             Formatted file content with line numbers, or error message.


### PR DESCRIPTION
## Summary
Fix docstring formatting errors across backend files where parameters and Returns sections were incorrectly

## Changes
- Add missing Args description in `StoreBackend.__init__
- Fix merged `Args:Returns:` in `StoreBackend._get_store`
- Fix missing newlines between parameters and Returns section
- Add periods to parameter descriptions for 

## Files 
- `libs/deepagents/deepagents/backends/store.py`
- `libs/deepagents/deepagents/backends/composite.py`
- `libs/deepagents/deepagents/backends/state.py`
- `libs/deepagents/deepagents/backends/filesystem.py`
