### PR TITLE
fix(deepagents): lower threshold for summarization

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -104,7 +104,7 @@ def create_deep_agent(
         and "max_input_tokens" in model.profile
         and isinstance(model.profile["max_input_tokens"], int)
     ):
-        trigger = ("fraction", 0.85)
+        trigger = ("fraction", 0.70)
         keep = ("fraction", 0.10)
     else:
         trigger = ("tokens", 170000)


### PR DESCRIPTION
We use `count_tokens_approximately` to measure context lengths in SummarizationMiddleware.

This appears to under-estimate Anthropic token counts by 22%.

Assuming Claude Sonnet 4.5, we are triggering summarization at 170,000 tokens, but this is actually more like 207,000 Anthropic tokens, which is above its max input size of 200,000.

Here we compensate by adjusting the trigger down to 70%, or 140,000 tokens as measured by `count_tokens_approximately`, which is about the desired 170,000 tokens.