### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🚀🧠 Deep Agents
 
+[![Run in Smithery](https://smithery.ai/badge/skills/langchain-ai)](https://smithery.ai/skills?ns=langchain-ai&utm_source=github&utm_medium=badge)
+
+
 Agents can increasingly tackle long-horizon tasks, [with agent task length doubling every 7 months](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/)! But, long horizon tasks often span dozens of tool calls, which present cost and reliability challenges. Popular agents such as [Claude Code](https://code.claude.com/docs) and [Manus](https://www.youtube.com/watch?v=6_BcCthVvb8) use some common principles to address these challenges, including **planning** (prior to task execution), **computer access** (giving the agent access to a shell and a filesystem), and **sub-agent delegation** (isolated task execution). `deepagents` is a simple agent harness that implements these tools, but is open source and easily extendable with your own custom tools and instructions.
 
 <img src=".github/images/deepagents_banner.png" alt="deep agent" width="100%"/>


### PR DESCRIPTION
## Add "Run in Smithery" Badge

Hi! We'd like to add a badge to your README that lets users instantly discover and try your Claude Skills in [Smithery](https://smithery.ai).

[![Run in Smithery](https://smithery.ai/badge/skills/langchain-ai)](https://smithery.ai/skills?ns=langchain-ai&utm_source=github&utm_medium=badge)

### What's Smithery?
Smithery is a platform for discovering and installing Claude Skills and MCP servers. Your 3 skills have been installed **17 times** by **17 users** in the last 30 days.

### Top Skills
- **arxiv-search** (16 activations, 16 users)
- **web-research** (1 activations, 1 users)
- **langgraph-docs** (0 activations, 0 users)

### What This PR Does
- Adds a badge to your README linking to your skills collection on Smithery
- Lets users browse and install your skills with one click
- Shows aggregate usage metrics across all your skills

### Suggested Placement
We recommend placing the badge at the top of your README, below the title or alongside other badges.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!