### PR TITLE
Fix default_agent_prompt.md: Replace /memories/ with generic memory r…

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/default_agent_prompt.md
+++ b/libs/deepagents-cli/deepagents_cli/default_agent_prompt.md
@@ -7,20 +7,20 @@ Your core role and behavior may be updated based on user feedback and instructio
 You have access to a persistent memory system. ALWAYS follow this protocol:
 
 **At session start:**
-- Check `ls /memories/` to see what knowledge you have stored
-- If your role description references specific topics, check /memories/ for relevant guides
+- Check your memory directories to see what knowledge you have stored (see system prompt for exact paths)
+- If your role description references specific topics, check memory directories for relevant guides
 
 **Before answering questions:**
-- If asked "what do you know about X?" or "how do I do Y?" → Check `ls /memories/` FIRST
+- If asked "what do you know about X?" or "how do I do Y?" → Check memory directories FIRST
 - If relevant memory files exist → Read them and base your answer on saved knowledge
 - Prefer saved knowledge over general knowledge when available
 
 **When learning new information:**
-- If user teaches you something or asks you to remember → Save to `/memories/[topic].md`
-- Use descriptive filenames: `/memories/deep-agents-guide.md` not `/memories/notes.md`
+- If user teaches you something or asks you to remember → Save to appropriate memory location (see system prompt for paths)
+- Use descriptive filenames for memory files
 - After saving, verify by reading back the key points
 
-**Important:** Your memories persist across sessions. Information stored in /memories/ is more reliable than general knowledge for topics you've specifically studied.
+**Important:** Your memories persist across sessions. Information stored in memory files is more reliable than general knowledge for topics you've specifically studied. See your system prompt for detailed memory location paths and usage instructions.
 
 # Tone and Style
 Be concise and direct. Answer in fewer than 4 lines unless the user asks for detail.


### PR DESCRIPTION
# Fix default_agent_prompt.md: Replace /memories/ with generic memory references

Fixes #522

## Problem

The `default_agent_prompt.md` template referenced a `/memories/` directory that doesn't exist in the CLI implementation. The CLI uses a filesystem-based memory system with `.deepagents/` directories instead of the `/memories/` virtual route.


## Solution

Updated `default_agent_prompt.md` to use generic memory references that:
- Reference the system prompt for exact paths (which are provided by `LONGTERM_MEMORY_SYSTEM_PROMPT`)
- Work with the current filesystem-based implementation
- Would also work if `/memories/` route is configured in the future
- Avoid duplication since detailed paths are already in the system prompt

## Changes

- Replaced `/memories/` directory references with generic "memory directories"
- Updated instructions to reference system prompt for exact paths
- Made the template more flexible and implementation-agnostic

## Technical Details

The `AgentMemoryMiddleware` builds the system prompt by combining:
1. Memory content from `agent.md` (created from `default_agent_prompt.md` template)
2. Base system prompt
3. `LONGTERM_MEMORY_SYSTEM_PROMPT` with exact paths (e.g., `{agent_dir_absolute}`, `{project_deepagents_dir}`)

So the agent receives both:
- Generic memory protocol instructions (from template)
- Detailed path information (from `LONGTERM_MEMORY_SYSTEM_PROMPT`)

## Testing

- Verified that the generic instructions work with the current filesystem-based memory system
- Confirmed that `LONGTERM_MEMORY_SYSTEM_PROMPT` provides the necessary path details
- No breaking changes - this is a template fix only

