### PR TITLE
feat(cli): highlight file mentions and support CJK parsing

### DIFF
--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -15,9 +15,6 @@ from deepagents_cli.input import EMAIL_PREFIX_PATTERN, INPUT_HIGHLIGHT_PATTERN
 from deepagents_cli.ui import format_tool_display
 from deepagents_cli.widgets.diff import format_diff_textual
 
-_USER_HIGHLIGHT_PATTERN = INPUT_HIGHLIGHT_PATTERN
-"""Reuse the highlight pattern from input.py to avoid duplication."""
-
 if TYPE_CHECKING:
     from textual.app import ComposeResult
     from textual.events import Click
@@ -109,7 +106,7 @@ class UserMessage(Static):
         # Highlight @mentions and /commands in the content
         content = self._content
         last_end = 0
-        for match in _USER_HIGHLIGHT_PATTERN.finditer(content):
+        for match in INPUT_HIGHLIGHT_PATTERN.finditer(content):
             start, end = match.span()
             token = match.group()
 
@@ -123,14 +120,13 @@ class UserMessage(Static):
             if start > last_end:
                 text.append(content[last_end:start])
 
+            # The regex only matches tokens starting with / or @
             if token.startswith("/") and start == 0:
                 # /command at start - yellow/gold
                 text.append(token, style="bold #fbbf24")
             elif token.startswith("@"):
                 # @file mention - green
                 text.append(token, style="bold #10b981")
-            else:
-                text.append(token)
             last_end = end
 
         # Add remaining text after last match

--- a/libs/cli/tests/unit_tests/test_input_parsing.py
+++ b/libs/cli/tests/unit_tests/test_input_parsing.py
@@ -1,8 +1,16 @@
+"""Unit tests for input parsing utilities."""
+
+from pathlib import Path
+
+import pytest
+
 from deepagents_cli.input import parse_file_mentions
 
 
-def test_parse_file_mentions_with_chinese_sentence(tmp_path, monkeypatch):
-    """Ensure @file parsing stops before Chinese text or punctuation."""
+def test_parse_file_mentions_with_chinese_sentence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure `@file` parsing terminates at non-path characters such as CJK text."""
     file_path = tmp_path / "input.py"
     file_path.write_text("print('hello')")
 
@@ -14,8 +22,10 @@ def test_parse_file_mentions_with_chinese_sentence(tmp_path, monkeypatch):
     assert files == [file_path.resolve()]
 
 
-def test_parse_file_mentions_handles_multiple_mentions(tmp_path, monkeypatch):
-    """Ensure multiple @file mentions are extracted from a single input."""
+def test_parse_file_mentions_handles_multiple_mentions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure multiple `@file` mentions are extracted from a single input."""
     first = tmp_path / "a.txt"
     second = tmp_path / "b.txt"
     first.write_text("1")
@@ -29,7 +39,9 @@ def test_parse_file_mentions_handles_multiple_mentions(tmp_path, monkeypatch):
     assert files == [first.resolve(), second.resolve()]
 
 
-def test_parse_file_mentions_with_escaped_spaces(tmp_path, monkeypatch):
+def test_parse_file_mentions_with_escaped_spaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure escaped spaces in paths are handled correctly."""
     spaced_dir = tmp_path / "my folder"
     spaced_dir.mkdir()
@@ -42,7 +54,9 @@ def test_parse_file_mentions_with_escaped_spaces(tmp_path, monkeypatch):
     assert files == [file_path.resolve()]
 
 
-def test_parse_file_mentions_warns_for_nonexistent_file(tmp_path, monkeypatch, mocker):
+def test_parse_file_mentions_warns_for_nonexistent_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
     """Ensure non-existent files are excluded and warning is printed."""
     monkeypatch.chdir(tmp_path)
     mock_console = mocker.patch("deepagents_cli.input.console")
@@ -54,24 +68,31 @@ def test_parse_file_mentions_warns_for_nonexistent_file(tmp_path, monkeypatch, m
     assert "nonexistent.py" in mock_console.print.call_args[0][0]
 
 
-def test_parse_file_mentions_ignores_directories(tmp_path, monkeypatch):
+def test_parse_file_mentions_ignores_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
     """Ensure directories are not included in file list."""
     dir_path = tmp_path / "mydir"
     dir_path.mkdir()
     monkeypatch.chdir(tmp_path)
+    mock_console = mocker.patch("deepagents_cli.input.console")
 
     _, files = parse_file_mentions("@mydir")
 
     assert files == []
+    mock_console.print.assert_called_once()
+    assert "mydir" in mock_console.print.call_args[0][0]
 
 
-def test_parse_file_mentions_with_no_mentions():
+def test_parse_file_mentions_with_no_mentions() -> None:
     """Ensure text without mentions returns empty file list."""
     _, files = parse_file_mentions("just some text without mentions")
     assert files == []
 
 
-def test_parse_file_mentions_handles_path_traversal(tmp_path, monkeypatch):
+def test_parse_file_mentions_handles_path_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure path traversal sequences are resolved to actual paths."""
     subdir = tmp_path / "subdir"
     subdir.mkdir()
@@ -84,7 +105,7 @@ def test_parse_file_mentions_handles_path_traversal(tmp_path, monkeypatch):
     assert files == [file_path.resolve()]
 
 
-def test_parse_file_mentions_with_absolute_path(tmp_path):
+def test_parse_file_mentions_with_absolute_path(tmp_path: Path) -> None:
     """Ensure absolute paths are resolved correctly without cwd changes."""
     file_path = tmp_path / "test.py"
     file_path.write_text("content")
@@ -94,8 +115,10 @@ def test_parse_file_mentions_with_absolute_path(tmp_path):
     assert files == [file_path.resolve()]
 
 
-def test_parse_file_mentions_handles_multiple_in_sentence(tmp_path, monkeypatch):
-    """Ensure multiple @mentions with spaces are parsed as separate files."""
+def test_parse_file_mentions_handles_multiple_in_sentence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure multiple `@mentions` within a sentence are each parsed separately."""
     first = tmp_path / "a.py"
     second = tmp_path / "b.py"
     first.write_text("1")
@@ -107,8 +130,10 @@ def test_parse_file_mentions_handles_multiple_in_sentence(tmp_path, monkeypatch)
     assert files == [first.resolve(), second.resolve()]
 
 
-def test_parse_file_mentions_adjacent_looks_like_email(tmp_path, monkeypatch, mocker):
-    """Adjacent @mentions without space look like emails and are skipped.
+def test_parse_file_mentions_adjacent_looks_like_email(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    """Adjacent `@mentions` without space look like emails and are skipped.
 
     `@a.py@b.py` - the second `@` is preceded by `y` which looks like
     an email username, so `@b.py` is skipped. This is expected behavior
@@ -128,8 +153,10 @@ def test_parse_file_mentions_adjacent_looks_like_email(tmp_path, monkeypatch, mo
     mock_console.print.assert_not_called()
 
 
-def test_parse_file_mentions_handles_oserror(tmp_path, monkeypatch, mocker):
-    """Ensure OSError during path resolution is handled gracefully."""
+def test_parse_file_mentions_handles_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    """Ensure `OSError` during path resolution is handled gracefully."""
     monkeypatch.chdir(tmp_path)
     mock_console = mocker.patch("deepagents_cli.input.console")
     mocker.patch("pathlib.Path.resolve", side_effect=OSError("Permission denied"))
@@ -143,7 +170,9 @@ def test_parse_file_mentions_handles_oserror(tmp_path, monkeypatch, mocker):
     assert "Invalid path" in call_arg
 
 
-def test_parse_file_mentions_skips_email_addresses(tmp_path, monkeypatch, mocker):
+def test_parse_file_mentions_skips_email_addresses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
     """Ensure email addresses are not parsed as file mentions.
 
     Email addresses like `user@example.com` should be silently skipped
@@ -159,7 +188,9 @@ def test_parse_file_mentions_skips_email_addresses(tmp_path, monkeypatch, mocker
     mock_console.print.assert_not_called()
 
 
-def test_parse_file_mentions_skips_various_email_formats(tmp_path, monkeypatch, mocker):
+def test_parse_file_mentions_skips_various_email_formats(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
     """Ensure various email formats are all skipped."""
     monkeypatch.chdir(tmp_path)
     mock_console = mocker.patch("deepagents_cli.input.console")
@@ -179,8 +210,10 @@ def test_parse_file_mentions_skips_various_email_formats(tmp_path, monkeypatch, 
     mock_console.print.assert_not_called()
 
 
-def test_parse_file_mentions_works_after_cjk_text(tmp_path, monkeypatch, mocker):
-    """Ensure @file mentions work after CJK text (not email-like)."""
+def test_parse_file_mentions_works_after_cjk_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    """Ensure `@file` mentions work after CJK text (not email-like)."""
     file_path = tmp_path / "test.py"
     file_path.write_text("content")
     monkeypatch.chdir(tmp_path)
@@ -191,3 +224,22 @@ def test_parse_file_mentions_works_after_cjk_text(tmp_path, monkeypatch, mocker)
 
     assert files == [file_path.resolve()]
     mock_console.print.assert_not_called()
+
+
+def test_parse_file_mentions_handles_bad_tilde_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    """Ensure `~nonexistentuser` paths produce a warning instead of crashing.
+
+    `Path.expanduser()` raises `RuntimeError` when the username does not
+    exist. This must be caught gracefully rather than propagating up.
+    """
+    monkeypatch.chdir(tmp_path)
+    mock_console = mocker.patch("deepagents_cli.input.console")
+
+    _, files = parse_file_mentions("@~nonexistentuser12345/file.py")
+
+    assert files == []
+    mock_console.print.assert_called_once()
+    call_arg = mock_console.print.call_args[0][0]
+    assert "nonexistentuser12345" in call_arg

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -2,8 +2,8 @@
 
 import pytest
 
+from deepagents_cli.input import INPUT_HIGHLIGHT_PATTERN
 from deepagents_cli.widgets.messages import (
-    _USER_HIGHLIGHT_PATTERN,
     AppMessage,
     ErrorMessage,
     ToolCallMessage,
@@ -198,14 +198,14 @@ class TestUserMessageHighlighting:
     def test_at_mention_highlighted(self) -> None:
         """`@file` mentions should be styled in the output."""
         content = "look at @README.md please"
-        matches = list(_USER_HIGHLIGHT_PATTERN.finditer(content))
+        matches = list(INPUT_HIGHLIGHT_PATTERN.finditer(content))
         assert len(matches) == 1
         assert matches[0].group() == "@README.md"
 
     def test_slash_command_highlighted_at_start(self) -> None:
         """Slash commands at start should be detected."""
         content = "/help me with something"
-        matches = list(_USER_HIGHLIGHT_PATTERN.finditer(content))
+        matches = list(INPUT_HIGHLIGHT_PATTERN.finditer(content))
         assert len(matches) == 1
         assert matches[0].group() == "/help"
         assert matches[0].start() == 0
@@ -213,14 +213,14 @@ class TestUserMessageHighlighting:
     def test_slash_command_not_matched_mid_text(self) -> None:
         """Slash in middle of text should not match as command due to ^ anchor."""
         content = "check the /usr/bin path"
-        matches = list(_USER_HIGHLIGHT_PATTERN.finditer(content))
+        matches = list(INPUT_HIGHLIGHT_PATTERN.finditer(content))
         # The ^ anchor means /usr doesn't match when not at start of string
         assert len(matches) == 0
 
     def test_multiple_at_mentions(self) -> None:
         """Multiple `@mentions` should all be detected."""
         content = "compare @file1.py with @file2.py"
-        matches = list(_USER_HIGHLIGHT_PATTERN.finditer(content))
+        matches = list(INPUT_HIGHLIGHT_PATTERN.finditer(content))
         assert len(matches) == 2
         assert matches[0].group() == "@file1.py"
         assert matches[1].group() == "@file2.py"
@@ -228,12 +228,12 @@ class TestUserMessageHighlighting:
     def test_at_mention_with_path(self) -> None:
         """`@mentions` with paths should be fully captured."""
         content = "read @src/utils/helpers.py"
-        matches = list(_USER_HIGHLIGHT_PATTERN.finditer(content))
+        matches = list(INPUT_HIGHLIGHT_PATTERN.finditer(content))
         assert len(matches) == 1
         assert matches[0].group() == "@src/utils/helpers.py"
 
     def test_no_matches_in_plain_text(self) -> None:
         """Plain text without `@` or `/` should have no matches."""
         content = "just some normal text here"
-        matches = list(_USER_HIGHLIGHT_PATTERN.finditer(content))
+        matches = list(INPUT_HIGHLIGHT_PATTERN.finditer(content))
         assert len(matches) == 0


### PR DESCRIPTION
_(Description rewritten by @mdrxy, original preserved at footer)_

- Add syntax highlighting for `@file` mentions and `/commands` in messages
- Improve `@path` parsing to correctly handle CJK (Chinese, Japanese, Korean) text by tightening the allowed path character set

## Details

### Highlighting
Added `MentionHighlightLexer` that applies distinct styling to:
- `/commands` at the start of input (yellow/gold)
- `@file` mentions anywhere in input (green)

### CJK parsing fix
The previous `@path` regex used a greedy pattern that consumed trailing CJK characters. For example, in `请阅读@demo/test.txt并总结`, the parser would incorrectly include `并总结` as part of the path.

The fix defines an explicit `PATH_CHAR_CLASS` (`A-Za-z0-9._~/\\:-`) that stops at any character outside this set, including CJK punctuation and characters.

### Email address detection
Added `EMAIL_PREFIX_PATTERN` to skip `@mentions` that are likely part of email addresses (e.g., `user@example.com`).

---

<details>
  <summary>Original PR description</summary>
Title: Fix @path parsing when no whitespace follows

The previous implementation relied on a trailing space to detect the end of a path. In Chinese (and other languages with no mandatory whitespace), users often write sentences like "请阅读@demo/test.txt并总结", so the parser swallowed the trailing CJK text and produced a warning. The new tokenizer limits allowed path characters and treats multilingual punctuation as delimiters, so CJK inputs work without inserting artificial spaces.

1. Highlight file paths and commands in the prompt

Added a MentionHighlightLexer that colors /commands and @files as you type, matching the UX from tools like Gemini CLI and making file references easier to spot.

2. Docs to follow

If this PR is accepted, I'll submit a follow-up (or community can help) to refresh README/screenshots so this change doesn't bloat the diff.

3. Key changes

Unified regex/parser for completion and file injection, now CJK-aware.
Wired the lexer into PromptSession to render highlights.
Added unit tests for Chinese sentences and lexer output.
</details>