### PR TITLE
Update parameter name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For complex cases, pass a pre-built LangGraph graph:
 ```python
 from deepagents import CompiledSubAgent, create_deep_agent
 
-custom_graph = create_agent(model=..., tools=..., prompt=...)
+custom_graph = create_agent(model=..., tools=..., system_prompt=...)
 
 agent = create_deep_agent(
     subagents=[CompiledSubAgent(


### PR DESCRIPTION
Update parameter name in README example for prebuilt LangGraph graph from `prompt` to `system_prompt`