### PR TITLE
Handle read_file offset exceeding file length by returning all lines (issue #559)

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/file_ops.py
+++ b/libs/deepagents-cli/deepagents_cli/file_ops.py
@@ -344,6 +344,8 @@ class FileOpTracker:
             offset = record.args.get("offset")
             limit = record.args.get("limit")
             if isinstance(offset, int):
+                if offset > lines:
+                    offset = 0
                 record.metrics.start_line = offset + 1
                 if lines:
                     record.metrics.end_line = offset + lines


### PR DESCRIPTION
This is meant to address [issue #559](https://github.com/langchain-ai/deepagents/issues/559) and does so by updating the read_file behavior so that if the offset is larger than the number of lines in the file, it returns all lines starting from the first line instead of throwing an error. This is as-described in the referenced issue.

This is my first contribution to an open source project, so I appreciate any and all feedback.