### PR TITLE
fix(middleware): pass runtime.config to subagent invocations

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -345,7 +345,7 @@ def _create_task_tool(
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
             return f"We cannot invoke subagent {subagent_type} because it does not exist, the only allowed types are {allowed_types}"
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = subagent.invoke(subagent_state)
+        result = subagent.invoke(subagent_state, config=runtime.config)
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
@@ -360,7 +360,7 @@ def _create_task_tool(
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
             return f"We cannot invoke subagent {subagent_type} because it does not exist, the only allowed types are {allowed_types}"
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = await subagent.ainvoke(subagent_state)
+        result = await subagent.ainvoke(subagent_state, config=runtime.config)
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)


### PR DESCRIPTION
## Summary
This PR passes `runtime.config` to subagent invocations in `SubAgentMiddleware`, enabling proper `context_schema` support and callback continuity for pre-compiled subagents.

**Related to #569**

## Problem
When `SubAgentMiddleware` invokes subagents, it currently does not pass `runtime.config`

```python
result = subagent.invoke(subagent_state)  # No config
```

This causes issues for CompiledSubAgent runnables that have context_schema defined
- Tools with ToolRuntime[T] receive runtime.context as None
- Callbacks/tracing (e.g., LangSmith) are not propagated
- Other RunnableConfig properties are lost

## Solution
Pass runtime.config to subagent invocations:

```python
result = subagent.invoke(subagent_state, config=runtime.config)
result = await subagent.ainvoke(subagent_state, config=runtime.config)
```

This preserves the existing isolation model (filtered state, fresh messages) while enabling
- context_schema instantiation in subagent tools
- Callback/tracing continuity
- Proper RunnableConfig propagation

## Changes
- deepagents/middleware/subagents.py
  - Line 348: Added `config=runtime.config` to sync invocation
  - Line 363: Added `config=runtime.config` to async invocation


---
This change is backward compatible
- Subagents without context_schema are unaffected (config is simply passed through)
- Subagents with context_schema now work as expected
- No breaking changes to the public API

🍀