### PR TITLE
feat(cli): add skill deletion command

### DIFF
--- a/libs/cli/deepagents_cli/skills/__init__.py
+++ b/libs/cli/deepagents_cli/skills/__init__.py
@@ -1,7 +1,7 @@
 """Skills module for deepagents CLI.
 
 Public API:
-- execute_skills_command: Execute skills subcommands (list/create/info)
+- execute_skills_command: Execute skills subcommands (list/create/info/delete)
 - setup_skills_parser: Setup argparse configuration for skills commands
 
 All other components are internal implementation details.

--- a/libs/cli/deepagents_cli/skills/load.py
+++ b/libs/cli/deepagents_cli/skills/load.py
@@ -1,6 +1,6 @@
 """Skill loader for CLI commands.
 
-This module provides filesystem-based skill loading for CLI operations
+This module provides filesystem-based skill discovery for CLI operations
 (list, create, info, delete). It wraps the prebuilt middleware functionality from
 deepagents.middleware.skills and adapts it for direct filesystem access
 needed by CLI commands.

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -68,7 +68,7 @@ def show_help() -> None:
         "  deepagents reset --agent AGENT [--target SRC]  Reset an agent's prompt"
     )
     console.print(
-        "  deepagents skills <list|create|info>           Manage agent skills"
+        "  deepagents skills <list|create|info|delete>    Manage agent skills"
     )
     console.print(
         "  deepagents threads <list|delete>               Manage conversation threads"


### PR DESCRIPTION
Add `deepagents skills delete <name>` to the CLI, with interactive confirmation, `--force` to skip it, and the same `--agent`/`--project` scoping as other skills subcommands. Also cleans up the skills help screen with common options, examples, and consistent formatting.