### PR TITLE
fix(deepagents): strip trailing whitespace from subagent messages to prevent Anthropic API errors

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -314,10 +314,12 @@ def _create_task_tool(
 
     def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
         state_update = {k: v for k, v in result.items() if k not in _EXCLUDED_STATE_KEYS}
+        # Strip trailing whitespace to prevent API errors with Anthropic
+        message_text = result["messages"][-1].text.rstrip() if result["messages"][-1].text else ""
         return Command(
             update={
                 **state_update,
-                "messages": [ToolMessage(result["messages"][-1].text, tool_call_id=tool_call_id)],
+                "messages": [ToolMessage(message_text, tool_call_id=tool_call_id)],
             }
         )
 


### PR DESCRIPTION
## Summary

  Fixes an issue where subagent responses with trailing whitespace caused Anthropic API errors when the ToolMessage became the final assistant message in a conversation.

  ## Problem

  The middleware was creating ToolMessages from subagent responses without sanitizing the message text. When these messages ended with trailing whitespace and became the final assistant message, the Anthropic API would reject them with:

  messages: final assistant content cannot end with trailing whitespace
```
Traceback (most recent call last):
  File "/home/path/to/project/wiki/backend/wikis/agents/gen_page_agent.py", line 208, in create_page_content
    result = await self.agent.ainvoke(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langgraph/pregel/main.py", line 3158, in ainvoke
    async for chunk in self.astream(
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langgraph/pregel/main.py", line 2971, in astream
    async for _ in runner.atick(
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langgraph/pregel/_runner.py", line 304, in atick
    await arun_with_retry(
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langgraph/pregel/_retry.py", line 137, in arun_with_retry
    return await task.proc.ainvoke(task.input, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langgraph/_internal/_runnable.py", line 705, in ainvoke
    input = await asyncio.create_task(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langgraph/_internal/_runnable.py", line 473, in ainvoke
    ret = await self.afunc(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 1189, in amodel_node
    response = await awrap_model_call_handler(request, _execute_model_async)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 277, in final_normalized
    final_result = await result(request, handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 261, in composed
    outer_result = await outer(request, inner_handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/middleware/todo.py", line 225, in awrap_model_call
    return await handler(request.override(system_message=new_system_message))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 257, in inner_handler
    inner_result = await inner(req, handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 261, in composed
    outer_result = await outer(request, inner_handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/deepagents/middleware/filesystem.py", line 975, in awrap_model_call
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 257, in inner_handler
    inner_result = await inner(req, handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 261, in composed
    outer_result = await outer(request, inner_handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/deepagents/middleware/subagents.py", line 483, in awrap_model_call
    if self.system_prompt is not None:
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 257, in inner_handler
    inner_result = await inner(req, handler)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_anthropic/middleware/prompt_caching.py", line 140, in awrap_model_call
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain/agents/factory.py", line 1157, in _execute_model_async
    output = await model_.ainvoke(messages)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 5561, in ainvoke
    return await self.bound.ainvoke(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 421, in ainvoke
    llm_result = await self.agenerate_prompt(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 1128, in agenerate_prompt
    return await self.agenerate(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 1086, in agenerate
    raise exceptions[0]
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 1339, in _agenerate_with_cache
    result = await self._agenerate(
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_openai/chat_models/base.py", line 1630, in _agenerate
    raise e
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/langchain_openai/chat_models/base.py", line 1623, in _agenerate
    raw_response = await self.async_client.with_raw_response.create(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/openai/_legacy_response.py", line 381, in wrapped
    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 2678, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1797, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/path/to/project/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1597, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'code': 400, 'message': '{"type":"error","error":{"type":"invalid_request_error","message":"messages: final assistant content cannot end with trailing whitespace"},"request_id":"req_vrtx_011CWDrA1NU25Yz8wL4s5b3s"}', 'status': 'INVALID_ARGUMENT'}}
During task with name 'model' and id 'd63ab56b-aa71-091e-fd88-6ed4ddc6cf21'
```

  ## Solution

  Modified `_return_command_with_state_update` in `deepagents/middleware/subagents.py` to strip trailing whitespace from subagent message text using `.rstrip()` before creating the ToolMessage. The fix also safely handles cases where the message text might be `None`.

  ## Changes

  - Added whitespace stripping to line 318 in `subagents.py`
  - Added null-safety check for message text
  - Added comment documenting the fix

  ## Test Plan

  - [x] Run existing subagent tests to ensure no regressions
  - [x] Verify that subagent responses with trailing whitespace no longer cause API errors
  - [x] Confirm that normal subagent responses continue to work as expected