### PR TITLE
relaxed version check for daytona to resolve daytona>=0.113.0's obsto…

### DIFF
--- a/libs/deepagents-cli/pyproject.toml
+++ b/libs/deepagents-cli/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "langchain-openai>=0.1.0",
   "tavily-python",
   "python-dotenv",
-  "daytona>=0.113.0",
+  "daytona",
   "modal>=0.65.0",
   "markdownify>=0.13.0",
   "langchain>=1.0.7",


### PR DESCRIPTION
Both daytona>=0.113.0 and deepagents==0.2.8 requires obstore package but daytona>=0.113.0 requires obstore>=0.7.0, <0.8.0 which is not available in Python 3.14.2 (has obstore==0.8.2)

To solve this we relax daytona's version number

Tested in Ubuntu 20.04, Python 3.14.2
