### PR TITLE
fix(deepagents): Pass through runtime config to subagents

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -350,7 +350,7 @@ def _create_task_tool(
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
             return f"We cannot invoke subagent {subagent_type} because it does not exist, the only allowed types are {allowed_types}"
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = subagent.invoke(input=subagent_state, config=runtime.config)
+        result = subagent.invoke(subagent_state, runtime.config)
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
@@ -365,7 +365,7 @@ def _create_task_tool(
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
             return f"We cannot invoke subagent {subagent_type} because it does not exist, the only allowed types are {allowed_types}"
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = await subagent.ainvoke(input=subagent_state, config=runtime.config)
+        result = await subagent.ainvoke(subagent_state, runtime.config)
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)


### PR DESCRIPTION
Needed when passing along config properties etc. 

Currently a pretty ugly hack is needed to make this work (obviously not my actual code):
```python
  # hack! Store config in state, workers extract it
  # 1. Add config field to agent state:
  class GenericAgentState(StateT):
      runnable_config: RunnableConfig | None  # NEW

  # 2. Inject config into state when building graph
  def agent_node_process(state: StateT, config) -> dict:
      # HACK: Inject config into state so workers can access it
      state_with_config = dict(state)
      state_with_config["runnable_config"] = config

      # orchestrator invocation
      result = asyncio.run(agent.ainvoke(input=state_with_config, runnable_config=config))

  # 3. Workers extract and use config:
  class GenericWorkerImpl(Runnable[InputType, GenericAgentState]):
      async def ainvoke(self, input: GenericAgentState, config: RunnableConfig | None = None):
          # Extract parent config if available
          config = config or input.get("runnable_config")

      # ... remaining implementation
```

I see no PR template added when I create my PR? what do i need to add?

