### PR TITLE
fix(deepagents): filter `runtime` parameter from JSON schema in middleware tools

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -348,6 +348,7 @@ def _ls_tool_generator(
         description=tool_description,
         func=sync_ls,
         coroutine=async_ls,
+        filter_args=["runtime"],
     )
 
 
@@ -393,6 +394,7 @@ def _read_file_tool_generator(
         description=tool_description,
         func=sync_read_file,
         coroutine=async_read_file,
+        filter_args=["runtime"],
     )
 
 
@@ -468,6 +470,7 @@ def _write_file_tool_generator(
         description=tool_description,
         func=sync_write_file,
         coroutine=async_write_file,
+        filter_args=["runtime"],
     )
 
 
@@ -547,6 +550,7 @@ def _edit_file_tool_generator(
         description=tool_description,
         func=sync_edit_file,
         coroutine=async_edit_file,
+        filter_args=["runtime"],
     )
 
 
@@ -586,6 +590,7 @@ def _glob_tool_generator(
         description=tool_description,
         func=sync_glob,
         coroutine=async_glob,
+        filter_args=["runtime"],
     )
 
 
@@ -639,6 +644,7 @@ def _grep_tool_generator(
         description=tool_description,
         func=sync_grep,
         coroutine=async_grep,
+        filter_args=["runtime"],
     )
 
 
@@ -751,6 +757,7 @@ def _execute_tool_generator(
         description=tool_description,
         func=sync_execute,
         coroutine=async_execute,
+        filter_args=["runtime"],
     )
 
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -378,6 +378,7 @@ def _create_task_tool(
         func=task,
         coroutine=atask,
         description=task_description,
+        filter_args=["runtime"],
     )
 
 


### PR DESCRIPTION
## Issue
#620 

## **Problem**

8 tools across `filesystem.py` and `subagents.py` use `StructuredTool.from_function()` with a `runtime: ToolRuntime` parameter. When generating JSON schema, Pydantic attempts to serialize `ToolRuntime`, which fails because

1. `ToolRuntime` inherits from `_DirectlyInjectedToolArg`
2. `StructuredTool.from_function()` uses `_filter_schema_args()` which only calls `_is_injected_arg_type()`
3. `_is_injected_arg_type()` only detects `Annotated[T, InjectedToolArg]` patterns, not direct inheritance
4. Pydantic cannot serialize `ToolRuntime` to JSON schema

## **Solution**

Add `filter_args=["runtime"]` to all 8 `StructuredTool.from_function()` calls.

## **Changes**

```diff
# deepagents/middleware/filesystem.py

# _ls_tool_generator (line 346)
return StructuredTool.from_function(
    name="ls",
    description=tool_description,
    func=sync_ls,
    coroutine=async_ls,
+   filter_args=["runtime"],
)

# _read_file_tool_generator (line 391)
return StructuredTool.from_function(
    name="read_file",
    description=tool_description,
    func=sync_read_file,
    coroutine=async_read_file,
+   filter_args=["runtime"],
)

# _write_file_tool_generator (line 466)
return StructuredTool.from_function(
    name="write_file",
    description=tool_description,
    func=sync_write_file,
    coroutine=async_write_file,
+   filter_args=["runtime"],
)

# _edit_file_tool_generator (line 545)
return StructuredTool.from_function(
    name="edit_file",
    description=tool_description,
    func=sync_edit_file,
    coroutine=async_edit_file,
+   filter_args=["runtime"],
)

# _glob_tool_generator (line 584)
return StructuredTool.from_function(
    name="glob",
    description=tool_description,
    func=sync_glob,
    coroutine=async_glob,
+   filter_args=["runtime"],
)

# _grep_tool_generator (line 637)
return StructuredTool.from_function(
    name="grep",
    description=tool_description,
    func=sync_grep,
    coroutine=async_grep,
+   filter_args=["runtime"],
)

# _execute_tool_generator (line 749)
return StructuredTool.from_function(
    name="execute",
    description=tool_description,
    func=sync_execute,
    coroutine=async_execute,
+   filter_args=["runtime"],
)
```

```diff
# deepagents/middleware/subagents.py

# _create_task_tool (line 376)
return StructuredTool.from_function(
    name="task",
    func=task,
    coroutine=atask,
    description=task_description,
+   filter_args=["runtime"],
)
```

## **Why This Works**

- `filter_args` is passed to `create_schema_from_function()` which excludes the specified parameters from the Pydantic model
- The `runtime` parameter is still available at function call time (injected by LangGraph's `ToolNode`)
- Only the JSON schema (used by LLM for tool calling) excludes `runtime`