### PR TITLE
fix(deepagents): add character-based truncation to read_file

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -27,7 +27,7 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     check_empty_content,
-    format_content_with_line_numbers,
+    format_lines_with_truncation,
     perform_string_replacement,
 )
 
@@ -225,14 +225,7 @@ class FilesystemBackend(BackendProtocol):
                 return empty_msg
 
             lines = content.splitlines()
-            start_idx = offset
-            end_idx = min(start_idx + limit, len(lines))
-
-            if start_idx >= len(lines):
-                return f"Error: Line offset {offset} exceeds file length ({len(lines)} lines)"
-
-            selected_lines = lines[start_idx:end_idx]
-            return format_content_with_line_numbers(selected_lines, start_line=start_idx + 1)
+            return format_lines_with_truncation(lines, offset, limit)
         except (OSError, UnicodeDecodeError) as e:
             return f"Error reading file '{file_path}': {e}"
 


### PR DESCRIPTION
Closes #553

## Summary
- Add `_format_lines_with_truncation` helper to enforce a character cap (TOOL_RESULT_TOKEN_LIMIT * 4 ≈ 80K chars) on `read_file` output.
- Refactor `format_read_response` to use the helper and simplify `FilesystemBackend.read()`.
- When truncation occurs, return partial content plus a clear message showing shown/total lines and chars, with guidance to use smaller `limit`/`offset`.

## Problem
`read_file` only limited line count (default 2000) and per-line length (10k). Minified JS/JSON or many long lines could exceed 20M chars (~5M tokens), leading to “input is too long” on subsequent model calls.

## Solution
Apply character-based truncation using the existing TOOL_RESULT_TOKEN_LIMIT (20K tokens ≈ 80K chars), centralized in `_format_lines_with_truncation`, reused by both `format_read_response` and `FilesystemBackend.read`.

## Changes
1. `deepagents/backends/utils.py`: add `_format_lines_with_truncation`; refactor `format_read_response`.
2. `deepagents/backends/filesystem.py`: call the helper in `read`.
3. `tests/unit_tests/test_middleware.py`: add `TestReadFileTruncation` cases.

## Testing
### Full Middleware Test Suite: ✅ All Passing
```
pytest libs/deepagents/tests/unit_tests/test_middleware.py -v

Results: 67 passed in 2.70s
- Existing tests: 61/61 PASSED (no regressions)
- New read-file truncation tests: 6/6 PASSED
```
### Truncation Output Example

When reading a minified JSON file (300 lines × ~1900 chars/line = 570K chars):

**Input**: Minified JSON with large payloads
```json
{"id": 0, "user": "user_0", "data": "xxx...xxx", "metadata": {"timestamp": "2025-12-27T12:00:00Z", "tags": [...]}}
{"id": 1, "user": "user_1", "data": "xxx...xxx", "metadata": {"timestamp": "2025-12-27T12:00:00Z", "tags": [...]}}
...
```

**Output** (80K character limit enforced):
```
     1  {"id": 0, "user": "user_0", "data": "xxxxxxxxxxxxxxxxxxxxxxxxx...
     2  {"id": 1, "user": "user_1", "data": "xxxxxxxxxxxxxxxxxxxxxxxxx...
...
    19  {"id": 18, "user": "user_18", "data": "xxxxxxxxxxxxxxxxxxxxxxxxx...
[Result truncated: showing 19/300 lines (79818/570000 chars). Use smaller limit or offset to read more.]
```

**Result**: 
- Input: 570,000 chars (≈142K tokens)
- Output: 80,076 chars (≈20K tokens) ✅


## Impact / Notes
- StateBackend and StoreBackend benefit automatically (they use `format_read_response`); Composite routes through them.
- Sandbox backend unchanged (remote shell path).
- Backward compatible; large outputs now truncate with guidance.