### PR TITLE
Fix CVE-2025-68664

### DIFF
--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "langchain-anthropic>=1.2.0,<2.0.0",
     "langchain-google-genai",
     "langchain>=1.1.0,<2.0.0",
-    "langchain-core>=1.1.0,<2.0.0",
+    "langchain-core>=1.2.5,<2.0.0",
     "wcmatch",
 ]
 


### PR DESCRIPTION
Fix Critical "LangGrinch" vulnerability:
https://cyata.ai/blog/langgrinch-langchain-core-cve-2025-68664/

sign-off-by: Ritesh Gomind <ritesh@cyberstorm.mu>
sign-off-by: Bhovanen Murday <bhovanen.murday@cyberstorm.mu>