### PR TITLE
chore(deepagents): make memory strict if AGENTS.md not found

### DIFF
--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -216,11 +216,6 @@ class MemoryMiddleware(AgentMiddleware):
         response = results[0]
 
         if response.error is not None:
-            # For now, memory files are treated as optional. file_not_found is expected
-            # and we skip silently to allow graceful degradation.
-            if response.error == "file_not_found":
-                return None
-            # Other errors should be raised
             raise ValueError(f"Failed to download {path}: {response.error}")
 
         if response.content is not None:
@@ -249,11 +244,6 @@ class MemoryMiddleware(AgentMiddleware):
         response = results[0]
 
         if response.error is not None:
-            # For now, memory files are treated as optional. file_not_found is expected
-            # and we skip silently to allow graceful degradation.
-            if response.error == "file_not_found":
-                return None
-            # Other errors should be raised
             raise ValueError(f"Failed to download {path}: {response.error}")
 
         if response.content is not None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
@@ -240,7 +241,7 @@ def test_load_memory_from_backend_multiple_sources(tmp_path: Path) -> None:
 
 
 def test_load_memory_handles_missing_file(tmp_path: Path) -> None:
-    """Test that missing files are handled gracefully."""
+    """Test that missing files raise an error."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create only one of two memory files
@@ -257,16 +258,9 @@ def test_load_memory_handles_missing_file(tmp_path: Path) -> None:
     ]
     middleware = MemoryMiddleware(backend=backend, sources=sources)
 
-    # Test before_agent loads only existing memory
-    result = middleware.before_agent({}, None, {})  # type: ignore
-
-    assert result is not None
-    assert "memory_contents" in result
-    # Missing file should not be in contents
-    assert missing_path not in result["memory_contents"]
-    # Existing file should be loaded
-    assert user_path in result["memory_contents"]
-    assert "Be helpful" in result["memory_contents"][user_path]
+    # Test before_agent raises error for missing file
+    with pytest.raises(ValueError, match="Failed to download.*file_not_found"):
+        middleware.before_agent({}, None, {})  # type: ignore
 
 
 def test_before_agent_skips_if_already_loaded(tmp_path: Path) -> None:
@@ -626,11 +620,10 @@ def test_memory_middleware_with_store_backend_assistant_id() -> None:
     assert "Context for assistant 1" in result_1["memory_contents"]["/memory/AGENTS.md"]
 
     # Test: assistant-456 cannot see assistant-123's memory (different namespace)
+    # and raises error because no memory exists yet
     config_2 = {"metadata": {"assistant_id": "assistant-456"}}
-    result_2 = middleware.before_agent({}, runtime, config_2)  # type: ignore
-
-    assert result_2 is not None
-    assert len(result_2["memory_contents"]) == 0  # No memory in assistant-456's namespace yet
+    with pytest.raises(ValueError, match="Failed to download.*file_not_found"):
+        middleware.before_agent({}, runtime, config_2)  # type: ignore
 
     # Add memory for assistant-456 with namespace (assistant-456, filesystem)
     assistant_2_content = make_memory_content("Assistant 2", "- Context for assistant 2")
@@ -716,7 +709,7 @@ def test_create_deep_agent_with_memory_and_filesystem_backend(tmp_path: Path) ->
 
 
 def test_create_deep_agent_with_memory_missing_files(tmp_path: Path) -> None:
-    """Test that memory works gracefully when files don't exist."""
+    """Test that memory raises an error when files don't exist."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create agent with non-existent memory files
@@ -726,12 +719,9 @@ def test_create_deep_agent_with_memory_missing_files(tmp_path: Path) -> None:
         model=GenericFakeChatModel(messages=iter([AIMessage(content="No memory, but that's okay.")])),
     )
 
-    # Invoke agent
-    result = agent.invoke({"messages": [HumanMessage(content="Hello")]})
-
-    # Verify invocation succeeded even without memory
-    assert "messages" in result
-    assert len(result["messages"]) > 0
+    # Invoke agent - should raise error for missing memory file
+    with pytest.raises(ValueError, match="Failed to download.*file_not_found"):
+        agent.invoke({"messages": [HumanMessage(content="Hello")]})
 
 
 def test_create_deep_agent_with_memory_default_backend() -> None:


### PR DESCRIPTION
Changing semantics prior to release of deepagents memory support.

If AGENTS.md is not found, we'll raise an exception.