### PR TITLE
Fix invalid YAML in skill-creator SKILL.md frontmatter

### DIFF
--- a/libs/deepagents-cli/examples/skills/skill-creator/SKILL.md
+++ b/libs/deepagents-cli/examples/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills that extend agent capabilities with specialized knowledge, workflows, or tool integrations. Use this skill when the user asks to: (1) create a new skill, (2) make a skill, (3) build a skill, (4) set up a skill, (5) initialize a skill, (6) scaffold a skill, (7) update or modify an existing skill, (8) validate a skill, (9) learn about skill structure, (10) understand how skills work, or (11) get guidance on skill design patterns. Trigger on phrases like "create a skill", "new skill", "make a skill", "skill for X", "how do I create a skill", or "help me build a skill".
+description: "Guide for creating effective skills that extend agent capabilities with specialized knowledge, workflows, or tool integrations. Use this skill when the user asks to: (1) create a new skill, (2) make a skill, (3) build a skill, (4) set up a skill, (5) initialize a skill, (6) scaffold a skill, (7) update or modify an existing skill, (8) validate a skill, (9) learn about skill structure, (10) understand how skills work, or (11) get guidance on skill design patterns. Trigger on phrases like \"create a skill\", \"new skill\", \"make a skill\", \"skill for X\", \"how do I create a skill\", or \"help me build a skill\"."
 ---
 
 # Skill Creator


### PR DESCRIPTION
Fixes #657

The colon in "Use this skill when the user asks to:" was causing the YAML frontmatter to be invalid.

## Changes
- Wrapped the `description` field in double quotes to properly escape colons
- Escaped internal quotes within the description

## Testing
- Verified YAML parses correctly with Python's yaml.safe_load()
- Validated all other SKILL.md files still parse correctly