### PR TITLE
feat: add agent name tag to `task` tool calls

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -356,7 +356,7 @@ def _create_task_tool(
         if rt := ls.get_current_run_tree():
             if not rt.tags:
                 rt.tags = []
-            rt.tags.insert(0, f"subagent_name:{subagent_type}")
+            rt.tags.insert(0, f"subagent:{subagent_type}")
         result = subagent.invoke(subagent_state, runtime.config)
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
@@ -375,7 +375,7 @@ def _create_task_tool(
         if rt := ls.get_current_run_tree():
             if not rt.tags:
                 rt.tags = []
-            rt.tags.insert(0, f"subagent_name:{subagent_type}")
+            rt.tags.insert(0, f"subagent:{subagent_type}")
         result = await subagent.ainvoke(subagent_state, runtime.config)
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"


### PR DESCRIPTION
This adds a `subagent:{subagent_name}` tag whenever the `task` tool is called.

before

<img width="1093" height="524" alt="Screenshot 2026-01-09 at 2 04 25 PM" src="https://github.com/user-attachments/assets/6541c5de-1137-42ee-8fd6-64bf4572a6e4" />

after

<img width="1080" height="544" alt="Screenshot 2026-01-09 at 2 04 57 PM" src="https://github.com/user-attachments/assets/168073fd-7708-4f50-bf1f-0a9a326e5a17" />