### PR TITLE
fix(middleware): handle missing system_prompt in SubAgentMiddleware

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -3,7 +3,11 @@
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
+from deepagents.middleware.subagents import (
+    CompiledSubAgent,
+    SubAgent,
+    SubAgentMiddleware,
+)
 
 __all__ = [
     "CompiledSubAgent",

--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -73,7 +73,9 @@ class CompositeBackend(BackendProtocol):
         self.routes = routes
 
         # Sort routes by length (longest first) for correct prefix matching
-        self.sorted_routes = sorted(routes.items(), key=lambda x: len(x[0]), reverse=True)
+        self.sorted_routes = sorted(
+            routes.items(), key=lambda x: len(x[0]), reverse=True
+        )
 
     def _get_backend_and_key(self, key: str) -> tuple[BackendProtocol, str]:
         """Get backend for path and strip route prefix.
@@ -248,7 +250,9 @@ class CompositeBackend(BackendProtocol):
         for route_prefix, backend in self.sorted_routes:
             if path is not None and path.startswith(route_prefix.rstrip("/")):
                 search_path = path[len(route_prefix) - 1 :]
-                raw = backend.grep_raw(pattern, search_path if search_path else "/", glob)
+                raw = backend.grep_raw(
+                    pattern, search_path if search_path else "/", glob
+                )
                 if isinstance(raw, str):
                     return raw
                 return [{**m, "path": f"{route_prefix[:-1]}{m['path']}"} for m in raw]
@@ -268,7 +272,9 @@ class CompositeBackend(BackendProtocol):
                 if isinstance(raw, str):
                     # This happens if error occurs
                     return raw
-                all_matches.extend({**m, "path": f"{route_prefix[:-1]}{m['path']}"} for m in raw)
+                all_matches.extend(
+                    {**m, "path": f"{route_prefix[:-1]}{m['path']}"} for m in raw
+                )
 
             return all_matches
         # Path specified but doesn't match a route - search only default
@@ -288,7 +294,9 @@ class CompositeBackend(BackendProtocol):
         for route_prefix, backend in self.sorted_routes:
             if path is not None and path.startswith(route_prefix.rstrip("/")):
                 search_path = path[len(route_prefix) - 1 :]
-                raw = await backend.agrep_raw(pattern, search_path if search_path else "/", glob)
+                raw = await backend.agrep_raw(
+                    pattern, search_path if search_path else "/", glob
+                )
                 if isinstance(raw, str):
                     return raw
                 return [{**m, "path": f"{route_prefix[:-1]}{m['path']}"} for m in raw]
@@ -308,7 +316,9 @@ class CompositeBackend(BackendProtocol):
                 if isinstance(raw, str):
                     # This happens if error occurs
                     return raw
-                all_matches.extend({**m, "path": f"{route_prefix[:-1]}{m['path']}"} for m in raw)
+                all_matches.extend(
+                    {**m, "path": f"{route_prefix[:-1]}{m['path']}"} for m in raw
+                )
 
             return all_matches
         # Path specified but doesn't match a route - search only default
@@ -322,14 +332,18 @@ class CompositeBackend(BackendProtocol):
             if path.startswith(route_prefix.rstrip("/")):
                 search_path = path[len(route_prefix) - 1 :]
                 infos = backend.glob_info(pattern, search_path if search_path else "/")
-                return [{**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos]
+                return [
+                    {**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos
+                ]
 
         # Path doesn't match any specific route - search default backend AND all routed backends
         results.extend(self.default.glob_info(pattern, path))
 
         for route_prefix, backend in self.routes.items():
             infos = backend.glob_info(pattern, "/")
-            results.extend({**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos)
+            results.extend(
+                {**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos
+            )
 
         # Deterministic ordering
         results.sort(key=lambda x: x.get("path", ""))
@@ -343,15 +357,21 @@ class CompositeBackend(BackendProtocol):
         for route_prefix, backend in self.sorted_routes:
             if path.startswith(route_prefix.rstrip("/")):
                 search_path = path[len(route_prefix) - 1 :]
-                infos = await backend.aglob_info(pattern, search_path if search_path else "/")
-                return [{**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos]
+                infos = await backend.aglob_info(
+                    pattern, search_path if search_path else "/"
+                )
+                return [
+                    {**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos
+                ]
 
         # Path doesn't match any specific route - search default backend AND all routed backends
         results.extend(await self.default.aglob_info(pattern, path))
 
         for route_prefix, backend in self.routes.items():
             infos = await backend.aglob_info(pattern, "/")
-            results.extend({**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos)
+            results.extend(
+                {**fi, "path": f"{route_prefix[:-1]}{fi['path']}"} for fi in infos
+            )
 
         # Deterministic ordering
         results.sort(key=lambda x: x.get("path", ""))
@@ -426,7 +446,9 @@ class CompositeBackend(BackendProtocol):
             Success message or Command object, or error message on failure.
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
-        res = backend.edit(stripped_key, old_string, new_string, replace_all=replace_all)
+        res = backend.edit(
+            stripped_key, old_string, new_string, replace_all=replace_all
+        )
         if res.files_update:
             try:
                 runtime = getattr(self.default, "runtime", None)
@@ -448,7 +470,9 @@ class CompositeBackend(BackendProtocol):
     ) -> EditResult:
         """Async version of edit."""
         backend, stripped_key = self._get_backend_and_key(file_path)
-        res = await backend.aedit(stripped_key, old_string, new_string, replace_all=replace_all)
+        res = await backend.aedit(
+            stripped_key, old_string, new_string, replace_all=replace_all
+        )
         if res.files_update:
             try:
                 runtime = getattr(self.default, "runtime", None)
@@ -527,7 +551,9 @@ class CompositeBackend(BackendProtocol):
         # Group files by backend, tracking original indices
         from collections import defaultdict
 
-        backend_batches: dict[BackendProtocol, list[tuple[int, str, bytes]]] = defaultdict(list)
+        backend_batches: dict[BackendProtocol, list[tuple[int, str, bytes]]] = (
+            defaultdict(list)
+        )
 
         for idx, (path, content) in enumerate(files):
             backend, stripped_path = self._get_backend_and_key(path)
@@ -546,18 +572,24 @@ class CompositeBackend(BackendProtocol):
             for i, orig_idx in enumerate(indices):
                 results[orig_idx] = FileUploadResponse(
                     path=files[orig_idx][0],  # Original path
-                    error=batch_responses[i].error if i < len(batch_responses) else None,
+                    error=(
+                        batch_responses[i].error if i < len(batch_responses) else None
+                    ),
                 )
 
         return results  # type: ignore[return-value]
 
-    async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+    async def aupload_files(
+        self, files: list[tuple[str, bytes]]
+    ) -> list[FileUploadResponse]:
         """Async version of upload_files."""
         # Pre-allocate result list
         results: list[FileUploadResponse | None] = [None] * len(files)
 
         # Group files by backend, tracking original indices
-        backend_batches: dict[BackendProtocol, list[tuple[int, str, bytes]]] = defaultdict(list)
+        backend_batches: dict[BackendProtocol, list[tuple[int, str, bytes]]] = (
+            defaultdict(list)
+        )
 
         for idx, (path, content) in enumerate(files):
             backend, stripped_path = self._get_backend_and_key(path)
@@ -576,7 +608,9 @@ class CompositeBackend(BackendProtocol):
             for i, orig_idx in enumerate(indices):
                 results[orig_idx] = FileUploadResponse(
                     path=files[orig_idx][0],  # Original path
-                    error=batch_responses[i].error if i < len(batch_responses) else None,
+                    error=(
+                        batch_responses[i].error if i < len(batch_responses) else None
+                    ),
                 )
 
         return results  # type: ignore[return-value]
@@ -597,7 +631,9 @@ class CompositeBackend(BackendProtocol):
         # Pre-allocate result list
         results: list[FileDownloadResponse | None] = [None] * len(paths)
 
-        backend_batches: dict[BackendProtocol, list[tuple[int, str]]] = defaultdict(list)
+        backend_batches: dict[BackendProtocol, list[tuple[int, str]]] = defaultdict(
+            list
+        )
 
         for idx, path in enumerate(paths):
             backend, stripped_path = self._get_backend_and_key(path)
@@ -615,8 +651,12 @@ class CompositeBackend(BackendProtocol):
             for i, orig_idx in enumerate(indices):
                 results[orig_idx] = FileDownloadResponse(
                     path=paths[orig_idx],  # Original path
-                    content=batch_responses[i].content if i < len(batch_responses) else None,
-                    error=batch_responses[i].error if i < len(batch_responses) else None,
+                    content=(
+                        batch_responses[i].content if i < len(batch_responses) else None
+                    ),
+                    error=(
+                        batch_responses[i].error if i < len(batch_responses) else None
+                    ),
                 )
 
         return results  # type: ignore[return-value]
@@ -626,7 +666,9 @@ class CompositeBackend(BackendProtocol):
         # Pre-allocate result list
         results: list[FileDownloadResponse | None] = [None] * len(paths)
 
-        backend_batches: dict[BackendProtocol, list[tuple[int, str]]] = defaultdict(list)
+        backend_batches: dict[BackendProtocol, list[tuple[int, str]]] = defaultdict(
+            list
+        )
 
         for idx, path in enumerate(paths):
             backend, stripped_path = self._get_backend_and_key(path)
@@ -644,8 +686,12 @@ class CompositeBackend(BackendProtocol):
             for i, orig_idx in enumerate(indices):
                 results[orig_idx] = FileDownloadResponse(
                     path=paths[orig_idx],  # Original path
-                    content=batch_responses[i].content if i < len(batch_responses) else None,
-                    error=batch_responses[i].error if i < len(batch_responses) else None,
+                    content=(
+                        batch_responses[i].content if i < len(batch_responses) else None
+                    ),
+                    error=(
+                        batch_responses[i].error if i < len(batch_responses) else None
+                    ),
                 )
 
         return results  # type: ignore[return-value]

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -79,7 +79,9 @@ class FilesystemBackend(BackendProtocol):
             try:
                 full.relative_to(self.cwd)
             except ValueError:
-                raise ValueError(f"Path:{full} outside root directory: {self.cwd}") from None
+                raise ValueError(
+                    f"Path:{full} outside root directory: {self.cwd}"
+                ) from None
             return full
 
         path = Path(key)
@@ -129,7 +131,9 @@ class FilesystemBackend(BackendProtocol):
                                     "path": abs_path,
                                     "is_dir": False,
                                     "size": int(st.st_size),
-                                    "modified_at": datetime.fromtimestamp(st.st_mtime).isoformat(),
+                                    "modified_at": datetime.fromtimestamp(
+                                        st.st_mtime
+                                    ).isoformat(),
                                 }
                             )
                         except OSError:
@@ -142,7 +146,9 @@ class FilesystemBackend(BackendProtocol):
                                     "path": abs_path + "/",
                                     "is_dir": True,
                                     "size": 0,
-                                    "modified_at": datetime.fromtimestamp(st.st_mtime).isoformat(),
+                                    "modified_at": datetime.fromtimestamp(
+                                        st.st_mtime
+                                    ).isoformat(),
                                 }
                             )
                         except OSError:
@@ -168,7 +174,9 @@ class FilesystemBackend(BackendProtocol):
                                     "path": virt_path,
                                     "is_dir": False,
                                     "size": int(st.st_size),
-                                    "modified_at": datetime.fromtimestamp(st.st_mtime).isoformat(),
+                                    "modified_at": datetime.fromtimestamp(
+                                        st.st_mtime
+                                    ).isoformat(),
                                 }
                             )
                         except OSError:
@@ -181,7 +189,9 @@ class FilesystemBackend(BackendProtocol):
                                     "path": virt_path + "/",
                                     "is_dir": True,
                                     "size": 0,
-                                    "modified_at": datetime.fromtimestamp(st.st_mtime).isoformat(),
+                                    "modified_at": datetime.fromtimestamp(
+                                        st.st_mtime
+                                    ).isoformat(),
                                 }
                             )
                         except OSError:
@@ -232,7 +242,9 @@ class FilesystemBackend(BackendProtocol):
                 return f"Error: Line offset {offset} exceeds file length ({len(lines)} lines)"
 
             selected_lines = lines[start_idx:end_idx]
-            return format_content_with_line_numbers(selected_lines, start_line=start_idx + 1)
+            return format_content_with_line_numbers(
+                selected_lines, start_line=start_idx + 1
+            )
         except (OSError, UnicodeDecodeError) as e:
             return f"Error reading file '{file_path}': {e}"
 
@@ -247,7 +259,9 @@ class FilesystemBackend(BackendProtocol):
         resolved_path = self._resolve_path(file_path)
 
         if resolved_path.exists():
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
+            return WriteResult(
+                error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
+            )
 
         try:
             # Create parent directories if needed
@@ -286,7 +300,9 @@ class FilesystemBackend(BackendProtocol):
             with os.fdopen(fd, "r", encoding="utf-8") as f:
                 content = f.read()
 
-            result = perform_string_replacement(content, old_string, new_string, replace_all)
+            result = perform_string_replacement(
+                content, old_string, new_string, replace_all
+            )
 
             if isinstance(result, str):
                 return EditResult(error=result)
@@ -301,7 +317,9 @@ class FilesystemBackend(BackendProtocol):
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(new_content)
 
-            return EditResult(path=file_path, files_update=None, occurrences=int(occurrences))
+            return EditResult(
+                path=file_path, files_update=None, occurrences=int(occurrences)
+            )
         except (OSError, UnicodeDecodeError, UnicodeEncodeError) as e:
             return EditResult(error=f"Error editing file '{file_path}': {e}")
 
@@ -334,10 +352,14 @@ class FilesystemBackend(BackendProtocol):
         matches: list[GrepMatch] = []
         for fpath, items in results.items():
             for line_num, line_text in items:
-                matches.append({"path": fpath, "line": int(line_num), "text": line_text})
+                matches.append(
+                    {"path": fpath, "line": int(line_num), "text": line_text}
+                )
         return matches
 
-    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:
+    def _ripgrep_search(
+        self, pattern: str, base_full: Path, include_glob: str | None
+    ) -> dict[str, list[tuple[int, str]]] | None:
         cmd = ["rg", "--json"]
         if include_glob:
             cmd.extend(["--glob", include_glob])
@@ -382,7 +404,9 @@ class FilesystemBackend(BackendProtocol):
 
         return results
 
-    def _python_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]]:
+    def _python_search(
+        self, pattern: str, base_full: Path, include_glob: str | None
+    ) -> dict[str, list[tuple[int, str]]]:
         try:
             regex = re.compile(pattern)
         except re.error:
@@ -394,7 +418,9 @@ class FilesystemBackend(BackendProtocol):
         for fp in root.rglob("*"):
             if not fp.is_file():
                 continue
-            if include_glob and not wcglob.globmatch(fp.name, include_glob, flags=wcglob.BRACE):
+            if include_glob and not wcglob.globmatch(
+                fp.name, include_glob, flags=wcglob.BRACE
+            ):
                 continue
             try:
                 if fp.stat().st_size > self.max_file_size_bytes:
@@ -445,7 +471,9 @@ class FilesystemBackend(BackendProtocol):
                                 "path": abs_path,
                                 "is_dir": False,
                                 "size": int(st.st_size),
-                                "modified_at": datetime.fromtimestamp(st.st_mtime).isoformat(),
+                                "modified_at": datetime.fromtimestamp(
+                                    st.st_mtime
+                                ).isoformat(),
                             }
                         )
                     except OSError:
@@ -468,7 +496,9 @@ class FilesystemBackend(BackendProtocol):
                                 "path": virt,
                                 "is_dir": False,
                                 "size": int(st.st_size),
-                                "modified_at": datetime.fromtimestamp(st.st_mtime).isoformat(),
+                                "modified_at": datetime.fromtimestamp(
+                                    st.st_mtime
+                                ).isoformat(),
                             }
                         )
                     except OSError:
@@ -508,14 +538,20 @@ class FilesystemBackend(BackendProtocol):
             except FileNotFoundError:
                 responses.append(FileUploadResponse(path=path, error="file_not_found"))
             except PermissionError:
-                responses.append(FileUploadResponse(path=path, error="permission_denied"))
+                responses.append(
+                    FileUploadResponse(path=path, error="permission_denied")
+                )
             except (ValueError, OSError) as e:
                 # ValueError from _resolve_path for path traversal, OSError for other file errors
                 if isinstance(e, ValueError) or "invalid" in str(e).lower():
-                    responses.append(FileUploadResponse(path=path, error="invalid_path"))
+                    responses.append(
+                        FileUploadResponse(path=path, error="invalid_path")
+                    )
                 else:
                     # Generic error fallback
-                    responses.append(FileUploadResponse(path=path, error="invalid_path"))
+                    responses.append(
+                        FileUploadResponse(path=path, error="invalid_path")
+                    )
 
         return responses
 
@@ -537,14 +573,28 @@ class FilesystemBackend(BackendProtocol):
                 fd = os.open(resolved_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
                 with os.fdopen(fd, "rb") as f:
                     content = f.read()
-                responses.append(FileDownloadResponse(path=path, content=content, error=None))
+                responses.append(
+                    FileDownloadResponse(path=path, content=content, error=None)
+                )
             except FileNotFoundError:
-                responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+                responses.append(
+                    FileDownloadResponse(
+                        path=path, content=None, error="file_not_found"
+                    )
+                )
             except PermissionError:
-                responses.append(FileDownloadResponse(path=path, content=None, error="permission_denied"))
+                responses.append(
+                    FileDownloadResponse(
+                        path=path, content=None, error="permission_denied"
+                    )
+                )
             except IsADirectoryError:
-                responses.append(FileDownloadResponse(path=path, content=None, error="is_directory"))
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error="is_directory")
+                )
             except ValueError:
-                responses.append(FileDownloadResponse(path=path, content=None, error="invalid_path"))
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error="invalid_path")
+                )
             # Let other errors propagate
         return responses

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -352,7 +352,9 @@ class BackendProtocol(abc.ABC):
         replace_all: bool = False,
     ) -> EditResult:
         """Async version of edit."""
-        return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
+        return await asyncio.to_thread(
+            self.edit, file_path, old_string, new_string, replace_all
+        )
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files to the sandbox.
@@ -379,7 +381,9 @@ class BackendProtocol(abc.ABC):
             ```
         """
 
-    async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+    async def aupload_files(
+        self, files: list[tuple[str, bytes]]
+    ) -> list[FileUploadResponse]:
         """Async version of upload_files."""
         return await asyncio.to_thread(self.upload_files, files)
 

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -204,7 +204,9 @@ except PermissionError:
     ) -> str:
         """Read file content with line numbers using a single shell command."""
         # Use template for reading file with offset and limit
-        cmd = _READ_COMMAND_TEMPLATE.format(file_path=file_path, offset=offset, limit=limit)
+        cmd = _READ_COMMAND_TEMPLATE.format(
+            file_path=file_path, offset=offset, limit=limit
+        )
         result = self.execute(cmd)
 
         output = result.output.rstrip()
@@ -225,7 +227,9 @@ except PermissionError:
         content_b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
 
         # Single atomic check + write command
-        cmd = _WRITE_COMMAND_TEMPLATE.format(file_path=file_path, content_b64=content_b64)
+        cmd = _WRITE_COMMAND_TEMPLATE.format(
+            file_path=file_path, content_b64=content_b64
+        )
         result = self.execute(cmd)
 
         # Check for errors (exit code or error message in output)
@@ -249,7 +253,12 @@ except PermissionError:
         new_b64 = base64.b64encode(new_string.encode("utf-8")).decode("ascii")
 
         # Use template for string replacement
-        cmd = _EDIT_COMMAND_TEMPLATE.format(file_path=file_path, old_b64=old_b64, new_b64=new_b64, replace_all=replace_all)
+        cmd = _EDIT_COMMAND_TEMPLATE.format(
+            file_path=file_path,
+            old_b64=old_b64,
+            new_b64=new_b64,
+            replace_all=replace_all,
+        )
         result = self.execute(cmd)
 
         exit_code = result.exit_code
@@ -258,7 +267,9 @@ except PermissionError:
         if exit_code == 1:
             return EditResult(error=f"Error: String not found in file: '{old_string}'")
         if exit_code == 2:
-            return EditResult(error=f"Error: String '{old_string}' appears multiple times. Use replace_all=True to replace all occurrences.")
+            return EditResult(
+                error=f"Error: String '{old_string}' appears multiple times. Use replace_all=True to replace all occurrences."
+            )
         if exit_code != 0:
             return EditResult(error=f"Error: File '{file_path}' not found")
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -133,7 +133,9 @@ class StateBackend(BackendProtocol):
         files = self.runtime.state.get("files", {})
 
         if file_path in files:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
+            return WriteResult(
+                error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
+            )
 
         new_file_data = create_file_data(content)
         return WriteResult(path=file_path, files_update={file_path: new_file_data})
@@ -155,14 +157,20 @@ class StateBackend(BackendProtocol):
             return EditResult(error=f"Error: File '{file_path}' not found")
 
         content = file_data_to_string(file_data)
-        result = perform_string_replacement(content, old_string, new_string, replace_all)
+        result = perform_string_replacement(
+            content, old_string, new_string, replace_all
+        )
 
         if isinstance(result, str):
             return EditResult(error=result)
 
         new_content, occurrences = result
         new_file_data = update_file_data(file_data, new_content)
-        return EditResult(path=file_path, files_update={file_path: new_file_data}, occurrences=int(occurrences))
+        return EditResult(
+            path=file_path,
+            files_update={file_path: new_file_data},
+            occurrences=int(occurrences),
+        )
 
     def grep_raw(
         self,
@@ -224,13 +232,19 @@ class StateBackend(BackendProtocol):
             file_data = state_files.get(path)
 
             if file_data is None:
-                responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+                responses.append(
+                    FileDownloadResponse(
+                        path=path, content=None, error="file_not_found"
+                    )
+                )
                 continue
 
             # Convert file data to bytes
             content_str = file_data_to_string(file_data)
             content_bytes = content_str.encode("utf-8")
 
-            responses.append(FileDownloadResponse(path=path, content=content_bytes, error=None))
+            responses.append(
+                FileDownloadResponse(path=path, content=content_bytes, error=None)
+            )
 
         return responses

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -106,13 +106,19 @@ class StoreBackend(BackendProtocol):
         Raises:
             ValueError: If required fields are missing or have incorrect types.
         """
-        if "content" not in store_item.value or not isinstance(store_item.value["content"], list):
+        if "content" not in store_item.value or not isinstance(
+            store_item.value["content"], list
+        ):
             msg = f"Store item does not contain valid content field. Got: {store_item.value.keys()}"
             raise ValueError(msg)
-        if "created_at" not in store_item.value or not isinstance(store_item.value["created_at"], str):
+        if "created_at" not in store_item.value or not isinstance(
+            store_item.value["created_at"], str
+        ):
             msg = f"Store item does not contain valid created_at field. Got: {store_item.value.keys()}"
             raise ValueError(msg)
-        if "modified_at" not in store_item.value or not isinstance(store_item.value["modified_at"], str):
+        if "modified_at" not in store_item.value or not isinstance(
+            store_item.value["modified_at"], str
+        ):
             msg = f"Store item does not contain valid modified_at field. Got: {store_item.value.keys()}"
             raise ValueError(msg)
         return {
@@ -121,7 +127,9 @@ class StoreBackend(BackendProtocol):
             "modified_at": store_item.value["modified_at"],
         }
 
-    def _convert_file_data_to_store_value(self, file_data: dict[str, Any]) -> dict[str, Any]:
+    def _convert_file_data_to_store_value(
+        self, file_data: dict[str, Any]
+    ) -> dict[str, Any]:
         """Convert FileData to a dict suitable for store.put().
 
         Args:
@@ -293,7 +301,9 @@ class StoreBackend(BackendProtocol):
         # Check if file exists
         existing = store.get(namespace, file_path)
         if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
+            return WriteResult(
+                error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
+            )
 
         # Create new file
         file_data = create_file_data(content)
@@ -325,7 +335,9 @@ class StoreBackend(BackendProtocol):
             return EditResult(error=f"Error: {e}")
 
         content = file_data_to_string(file_data)
-        result = perform_string_replacement(content, old_string, new_string, replace_all)
+        result = perform_string_replacement(
+            content, old_string, new_string, replace_all
+        )
 
         if isinstance(result, str):
             return EditResult(error=result)
@@ -336,7 +348,9 @@ class StoreBackend(BackendProtocol):
         # Update file in store
         store_value = self._convert_file_data_to_store_value(new_file_data)
         store.put(namespace, file_path, store_value)
-        return EditResult(path=file_path, files_update=None, occurrences=int(occurrences))
+        return EditResult(
+            path=file_path, files_update=None, occurrences=int(occurrences)
+        )
 
     # Removed legacy grep() convenience to keep lean surface
 
@@ -429,7 +443,11 @@ class StoreBackend(BackendProtocol):
             item = store.get(namespace, path)
 
             if item is None:
-                responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+                responses.append(
+                    FileDownloadResponse(
+                        path=path, content=None, error="file_not_found"
+                    )
+                )
                 continue
 
             file_data = self._convert_store_item_to_file_data(item)
@@ -437,6 +455,8 @@ class StoreBackend(BackendProtocol):
             content_str = file_data_to_string(file_data)
             content_bytes = content_str.encode("utf-8")
 
-            responses.append(FileDownloadResponse(path=path, content=content_bytes, error=None))
+            responses.append(
+                FileDownloadResponse(path=path, content=content_bytes, error=None)
+            )
 
         return responses

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -19,7 +19,9 @@ EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
 MAX_LINE_LENGTH = 10000
 LINE_NUMBER_WIDTH = 6
 TOOL_RESULT_TOKEN_LIMIT = 20000  # Same threshold as eviction
-TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your parameters]"
+TRUNCATION_GUIDANCE = (
+    "... [results truncated, try being more specific with your parameters]"
+)
 
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
@@ -76,7 +78,9 @@ def format_content_with_line_numbers(
                 else:
                     # Continuation chunks: use decimal notation (e.g., 5.1, 5.2)
                     continuation_marker = f"{line_num}.{chunk_idx}"
-                    result_lines.append(f"{continuation_marker:>{LINE_NUMBER_WIDTH}}\t{chunk}")
+                    result_lines.append(
+                        f"{continuation_marker:>{LINE_NUMBER_WIDTH}}\t{chunk}"
+                    )
 
     return "\n".join(result_lines)
 
@@ -212,7 +216,9 @@ def truncate_if_too_long(result: list[str] | str) -> list[str] | str:
     if isinstance(result, list):
         total_chars = sum(len(item) for item in result)
         if total_chars > TOOL_RESULT_TOKEN_LIMIT * 4:
-            return result[: len(result) * TOOL_RESULT_TOKEN_LIMIT * 4 // total_chars] + [TRUNCATION_GUIDANCE]
+            return result[
+                : len(result) * TOOL_RESULT_TOKEN_LIMIT * 4 // total_chars
+            ] + [TRUNCATION_GUIDANCE]
         return result
     # string
     if len(result) > TOOL_RESULT_TOKEN_LIMIT * 4:
@@ -286,7 +292,9 @@ def _glob_search_files(
         if not relative:
             relative = file_path.split("/")[-1]
 
-        if wcglob.globmatch(relative, effective_pattern, flags=wcglob.BRACE | wcglob.GLOBSTAR):
+        if wcglob.globmatch(
+            relative, effective_pattern, flags=wcglob.BRACE | wcglob.GLOBSTAR
+        ):
             matches.append((file_path, file_data["modified_at"]))
 
     matches.sort(key=lambda x: x[1], reverse=True)
@@ -331,7 +339,9 @@ def _grep_search_files(
     pattern: str,
     path: str | None = None,
     glob: str | None = None,
-    output_mode: Literal["files_with_matches", "content", "count"] = "files_with_matches",
+    output_mode: Literal[
+        "files_with_matches", "content", "count"
+    ] = "files_with_matches",
 ) -> str:
     """Search file contents for regex pattern.
 
@@ -365,7 +375,11 @@ def _grep_search_files(
     filtered = {fp: fd for fp, fd in files.items() if fp.startswith(normalized_path)}
 
     if glob:
-        filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
+        filtered = {
+            fp: fd
+            for fp, fd in filtered.items()
+            if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)
+        }
 
     results: dict[str, list[tuple[int, str]]] = {}
     for file_path, file_data in filtered.items():
@@ -408,7 +422,11 @@ def grep_matches_from_files(
     filtered = {fp: fd for fp, fd in files.items() if fp.startswith(normalized_path)}
 
     if glob:
-        filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
+        filtered = {
+            fp: fd
+            for fp, fd in filtered.items()
+            if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)
+        }
 
     matches: list[GrepMatch] = []
     for file_path, file_data in filtered.items():
@@ -418,7 +436,9 @@ def grep_matches_from_files(
     return matches
 
 
-def build_grep_results_dict(matches: list[GrepMatch]) -> dict[str, list[tuple[int, str]]]:
+def build_grep_results_dict(
+    matches: list[GrepMatch],
+) -> dict[str, list[tuple[int, str]]]:
     """Group structured matches into the legacy dict form used by formatters."""
     grouped: dict[str, list[tuple[int, str]]] = {}
     for m in matches:

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -4,7 +4,11 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 from langchain.agents import create_agent
-from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
+from langchain.agents.middleware import (
+    HumanInTheLoopMiddleware,
+    InterruptOnConfig,
+    TodoListMiddleware,
+)
 from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import ResponseFormat
@@ -24,7 +28,11 @@ from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
+from deepagents.middleware.subagents import (
+    CompiledSubAgent,
+    SubAgent,
+    SubAgentMiddleware,
+)
 
 BASE_AGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."
 
@@ -187,7 +195,11 @@ def create_deep_agent(
 
     return create_agent(
         model,
-        system_prompt=system_prompt + "\n\n" + BASE_AGENT_PROMPT if system_prompt else BASE_AGENT_PROMPT,
+        system_prompt=(
+            system_prompt + "\n\n" + BASE_AGENT_PROMPT
+            if system_prompt
+            else BASE_AGENT_PROMPT
+        ),
         tools=tools,
         middleware=deepagent_middleware,
         response_format=response_format,

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -3,7 +3,11 @@
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
+from deepagents.middleware.subagents import (
+    CompiledSubAgent,
+    SubAgent,
+    SubAgentMiddleware,
+)
 
 __all__ = [
     "CompiledSubAgent",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1,4 +1,5 @@
 """Middleware for providing filesystem tools to an agent."""
+
 # ruff: noqa: E501
 
 import os
@@ -56,7 +57,9 @@ class FileData(TypedDict):
     """ISO 8601 timestamp of last modification."""
 
 
-def _file_data_reducer(left: dict[str, FileData] | None, right: dict[str, FileData | None]) -> dict[str, FileData]:
+def _file_data_reducer(
+    left: dict[str, FileData] | None, right: dict[str, FileData | None]
+) -> dict[str, FileData]:
     """Merge file updates with support for deletions.
 
     This reducer enables file deletion by treating `None` values in the right
@@ -142,7 +145,9 @@ def _validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) 
     if not normalized.startswith("/"):
         normalized = f"/{normalized}"
 
-    if allowed_prefixes is not None and not any(normalized.startswith(prefix) for prefix in allowed_prefixes):
+    if allowed_prefixes is not None and not any(
+        normalized.startswith(prefix) for prefix in allowed_prefixes
+    ):
         msg = f"Path must start with one of {allowed_prefixes}: {path}"
         raise ValueError(msg)
 
@@ -497,7 +502,9 @@ def _edit_file_tool_generator(
         """Synchronous wrapper for edit_file tool."""
         resolved_backend = _get_backend(backend, runtime)
         file_path = _validate_path(file_path)
-        res: EditResult = resolved_backend.edit(file_path, old_string, new_string, replace_all=replace_all)
+        res: EditResult = resolved_backend.edit(
+            file_path, old_string, new_string, replace_all=replace_all
+        )
         if res.error:
             return res.error
         if res.files_update is not None:
@@ -525,7 +532,9 @@ def _edit_file_tool_generator(
         """Asynchronous wrapper for edit_file tool."""
         resolved_backend = _get_backend(backend, runtime)
         file_path = _validate_path(file_path)
-        res: EditResult = await resolved_backend.aedit(file_path, old_string, new_string, replace_all=replace_all)
+        res: EditResult = await resolved_backend.aedit(
+            file_path, old_string, new_string, replace_all=replace_all
+        )
         if res.error:
             return res.error
         if res.files_update is not None:
@@ -565,7 +574,9 @@ def _glob_tool_generator(
     """
     tool_description = custom_description or GLOB_TOOL_DESCRIPTION
 
-    def sync_glob(pattern: str, runtime: ToolRuntime[None, FilesystemState], path: str = "/") -> str:
+    def sync_glob(
+        pattern: str, runtime: ToolRuntime[None, FilesystemState], path: str = "/"
+    ) -> str:
         """Synchronous wrapper for glob tool."""
         resolved_backend = _get_backend(backend, runtime)
         infos = resolved_backend.glob_info(pattern, path=path)
@@ -573,7 +584,9 @@ def _glob_tool_generator(
         result = truncate_if_too_long(paths)
         return str(result)
 
-    async def async_glob(pattern: str, runtime: ToolRuntime[None, FilesystemState], path: str = "/") -> str:
+    async def async_glob(
+        pattern: str, runtime: ToolRuntime[None, FilesystemState], path: str = "/"
+    ) -> str:
         """Asynchronous wrapper for glob tool."""
         resolved_backend = _get_backend(backend, runtime)
         infos = await resolved_backend.aglob_info(pattern, path=path)
@@ -609,7 +622,9 @@ def _grep_tool_generator(
         runtime: ToolRuntime[None, FilesystemState],
         path: str | None = None,
         glob: str | None = None,
-        output_mode: Literal["files_with_matches", "content", "count"] = "files_with_matches",
+        output_mode: Literal[
+            "files_with_matches", "content", "count"
+        ] = "files_with_matches",
     ) -> str:
         """Synchronous wrapper for grep tool."""
         resolved_backend = _get_backend(backend, runtime)
@@ -624,7 +639,9 @@ def _grep_tool_generator(
         runtime: ToolRuntime[None, FilesystemState],
         path: str | None = None,
         glob: str | None = None,
-        output_mode: Literal["files_with_matches", "content", "count"] = "files_with_matches",
+        output_mode: Literal[
+            "files_with_matches", "content", "count"
+        ] = "files_with_matches",
     ) -> str:
         """Asynchronous wrapper for grep tool."""
         resolved_backend = _get_backend(backend, runtime)
@@ -895,7 +912,10 @@ class FilesystemMiddleware(AgentMiddleware):
             The model response from the handler.
         """
         # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
+        has_execute_tool = any(
+            (tool.name if hasattr(tool, "name") else tool.get("name")) == "execute"
+            for tool in request.tools
+        )
 
         backend_supports_execution = False
         if has_execute_tool:
@@ -905,7 +925,12 @@ class FilesystemMiddleware(AgentMiddleware):
 
             # If execute tool exists but backend doesn't support it, filter it out
             if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
+                filtered_tools = [
+                    tool
+                    for tool in request.tools
+                    if (tool.name if hasattr(tool, "name") else tool.get("name"))
+                    != "execute"
+                ]
                 request = request.override(tools=filtered_tools)
                 has_execute_tool = False
 
@@ -923,7 +948,13 @@ class FilesystemMiddleware(AgentMiddleware):
             system_prompt = "\n\n".join(prompt_parts)
 
         if system_prompt:
-            request = request.override(system_prompt=request.system_prompt + "\n\n" + system_prompt if request.system_prompt else system_prompt)
+            request = request.override(
+                system_prompt=(
+                    request.system_prompt + "\n\n" + system_prompt
+                    if request.system_prompt
+                    else system_prompt
+                )
+            )
 
         return handler(request)
 
@@ -942,7 +973,10 @@ class FilesystemMiddleware(AgentMiddleware):
             The model response from the handler.
         """
         # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
+        has_execute_tool = any(
+            (tool.name if hasattr(tool, "name") else tool.get("name")) == "execute"
+            for tool in request.tools
+        )
 
         backend_supports_execution = False
         if has_execute_tool:
@@ -952,7 +986,12 @@ class FilesystemMiddleware(AgentMiddleware):
 
             # If execute tool exists but backend doesn't support it, filter it out
             if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
+                filtered_tools = [
+                    tool
+                    for tool in request.tools
+                    if (tool.name if hasattr(tool, "name") else tool.get("name"))
+                    != "execute"
+                ]
                 request = request.override(tools=filtered_tools)
                 has_execute_tool = False
 
@@ -970,7 +1009,13 @@ class FilesystemMiddleware(AgentMiddleware):
             system_prompt = "\n\n".join(prompt_parts)
 
         if system_prompt:
-            request = request.override(system_prompt=request.system_prompt + "\n\n" + system_prompt if request.system_prompt else system_prompt)
+            request = request.override(
+                system_prompt=(
+                    request.system_prompt + "\n\n" + system_prompt
+                    if request.system_prompt
+                    else system_prompt
+                )
+            )
 
         return await handler(request)
 
@@ -1033,7 +1078,9 @@ class FilesystemMiddleware(AgentMiddleware):
             return message, None
 
         # Create truncated preview for the replacement message
-        content_sample = format_content_with_line_numbers([line[:1000] for line in content_str.splitlines()[:10]], start_line=1)
+        content_sample = format_content_with_line_numbers(
+            [line[:1000] for line in content_str.splitlines()[:10]], start_line=1
+        )
         replacement_text = TOO_LARGE_TOOL_MSG.format(
             tool_call_id=message.tool_call_id,
             file_path=file_path,
@@ -1047,7 +1094,9 @@ class FilesystemMiddleware(AgentMiddleware):
         )
         return processed_message, result.files_update
 
-    def _intercept_large_tool_result(self, tool_result: ToolMessage | Command, runtime: ToolRuntime) -> ToolMessage | Command:
+    def _intercept_large_tool_result(
+        self, tool_result: ToolMessage | Command, runtime: ToolRuntime
+    ) -> ToolMessage | Command:
         """Intercept and process large tool results before they're added to state.
 
         Args:
@@ -1100,8 +1149,16 @@ class FilesystemMiddleware(AgentMiddleware):
                 processed_messages.append(processed_message)
                 if files_update is not None:
                     accumulated_file_updates.update(files_update)
-            return Command(update={**update, "messages": processed_messages, "files": accumulated_file_updates})
-        raise AssertionError(f"Unreachable code reached in _intercept_large_tool_result: for tool_result of type {type(tool_result)}")
+            return Command(
+                update={
+                    **update,
+                    "messages": processed_messages,
+                    "files": accumulated_file_updates,
+                }
+            )
+        raise AssertionError(
+            f"Unreachable code reached in _intercept_large_tool_result: for tool_result of type {type(tool_result)}"
+        )
 
     def wrap_tool_call(
         self,
@@ -1117,7 +1174,10 @@ class FilesystemMiddleware(AgentMiddleware):
         Returns:
             The raw ToolMessage, or a pseudo tool message with the ToolResult in state.
         """
-        if self.tool_token_limit_before_evict is None or request.tool_call["name"] in TOOL_GENERATORS:
+        if (
+            self.tool_token_limit_before_evict is None
+            or request.tool_call["name"] in TOOL_GENERATORS
+        ):
             return handler(request)
 
         tool_result = handler(request)
@@ -1137,7 +1197,10 @@ class FilesystemMiddleware(AgentMiddleware):
         Returns:
             The raw ToolMessage, or a pseudo tool message with the ToolResult in state.
         """
-        if self.tool_token_limit_before_evict is None or request.tool_call["name"] in TOOL_GENERATORS:
+        if (
+            self.tool_token_limit_before_evict is None
+            or request.tool_call["name"] in TOOL_GENERATORS
+        ):
             return await handler(request)
 
         tool_result = await handler(request)

--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -182,7 +182,9 @@ class MemoryMiddleware(AgentMiddleware):
         self._backend = backend
         self.sources = sources
 
-    def _get_backend(self, state: MemoryState, runtime: Runtime, config: RunnableConfig) -> BackendProtocol:
+    def _get_backend(
+        self, state: MemoryState, runtime: Runtime, config: RunnableConfig
+    ) -> BackendProtocol:
         """Resolve backend from instance or factory.
 
         Args:
@@ -246,7 +248,9 @@ class MemoryMiddleware(AgentMiddleware):
         results = await backend.adownload_files([path])
         # Should get exactly one response for one path
         if len(results) != 1:
-            raise AssertionError(f"Expected 1 response for path {path}, got {len(results)}")
+            raise AssertionError(
+                f"Expected 1 response for path {path}, got {len(results)}"
+            )
         response = results[0]
 
         if response.error is not None:
@@ -279,7 +283,9 @@ class MemoryMiddleware(AgentMiddleware):
         results = backend.download_files([path])
         # Should get exactly one response for one path
         if len(results) != 1:
-            raise AssertionError(f"Expected 1 response for path {path}, got {len(results)}")
+            raise AssertionError(
+                f"Expected 1 response for path {path}, got {len(results)}"
+            )
         response = results[0]
 
         if response.error is not None:
@@ -295,7 +301,9 @@ class MemoryMiddleware(AgentMiddleware):
 
         return None
 
-    def before_agent(self, state: MemoryState, runtime: Runtime, config: RunnableConfig) -> MemoryStateUpdate | None:
+    def before_agent(
+        self, state: MemoryState, runtime: Runtime, config: RunnableConfig
+    ) -> MemoryStateUpdate | None:
         """Load memory content before agent execution (synchronous).
 
         Loads memory from all configured sources and stores in state.
@@ -324,7 +332,9 @@ class MemoryMiddleware(AgentMiddleware):
 
         return MemoryStateUpdate(memory_contents=contents)
 
-    async def abefore_agent(self, state: MemoryState, runtime: Runtime, config: RunnableConfig) -> MemoryStateUpdate | None:
+    async def abefore_agent(
+        self, state: MemoryState, runtime: Runtime, config: RunnableConfig
+    ) -> MemoryStateUpdate | None:
         """Load memory content before agent execution.
 
         Loads memory from all configured sources and stores in state.

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -11,7 +11,9 @@ from langgraph.types import Overwrite
 class PatchToolCallsMiddleware(AgentMiddleware):
     """Middleware to patch dangling tool calls in the messages history."""
 
-    def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
+    def before_agent(
+        self, state: AgentState, runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:  # noqa: ARG002
         """Before the agent runs, handle dangling tool calls from any AIMessage."""
         messages = state["messages"]
         if not messages or len(messages) == 0:
@@ -24,7 +26,12 @@ class PatchToolCallsMiddleware(AgentMiddleware):
             if msg.type == "ai" and msg.tool_calls:
                 for tool_call in msg.tool_calls:
                     corresponding_tool_msg = next(
-                        (msg for msg in messages[i:] if msg.type == "tool" and msg.tool_call_id == tool_call["id"]),
+                        (
+                            msg
+                            for msg in messages[i:]
+                            if msg.type == "tool"
+                            and msg.tool_call_id == tool_call["id"]
+                        ),
                         None,
                     )
                     if corresponding_tool_msg is None:

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -211,7 +211,9 @@ def _parse_skill_metadata(
         SkillMetadata if parsing succeeds, None if parsing fails or validation errors occur
     """
     if len(content) > MAX_SKILL_FILE_SIZE:
-        logger.warning("Skipping %s: content too large (%d bytes)", skill_path, len(content))
+        logger.warning(
+            "Skipping %s: content too large (%d bytes)", skill_path, len(content)
+        )
         return None
 
     # Match YAML frontmatter between --- delimiters
@@ -240,7 +242,9 @@ def _parse_skill_metadata(
     description = frontmatter_data.get("description")
 
     if not name or not description:
-        logger.warning("Skipping %s: missing required 'name' or 'description'", skill_path)
+        logger.warning(
+            "Skipping %s: missing required 'name' or 'description'", skill_path
+        )
         return None
 
     # Validate name format per spec (warn but continue loading for backwards compatibility)
@@ -324,7 +328,9 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
     responses = backend.download_files(paths_to_download)
 
     # Parse each downloaded SKILL.md
-    for (skill_dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
+    for (skill_dir_path, skill_md_path), response in zip(
+        skill_md_paths, responses, strict=True
+    ):
         if response.error:
             # Skill doesn't have a SKILL.md, skip it
             continue
@@ -354,7 +360,9 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
     return skills
 
 
-async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetadata]:
+async def _alist_skills(
+    backend: BackendProtocol, source_path: str
+) -> list[SkillMetadata]:
     """List all skills from a backend source (async version).
 
     Scans backend for subdirectories containing SKILL.md files, downloads their content,
@@ -399,7 +407,9 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
     responses = await backend.adownload_files(paths_to_download)
 
     # Parse each downloaded SKILL.md
-    for (skill_dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
+    for (skill_dir_path, skill_md_path), response in zip(
+        skill_md_paths, responses, strict=True
+    ):
         if response.error:
             # Skill doesn't have a SKILL.md, skip it
             continue
@@ -512,7 +522,9 @@ class SkillsMiddleware(AgentMiddleware):
         self.sources = sources
         self.system_prompt_template = SKILLS_SYSTEM_PROMPT
 
-    def _get_backend(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> BackendProtocol:
+    def _get_backend(
+        self, state: SkillsState, runtime: Runtime, config: RunnableConfig
+    ) -> BackendProtocol:
         """Resolve backend from instance or factory.
 
         Args:
@@ -535,7 +547,9 @@ class SkillsMiddleware(AgentMiddleware):
             )
             backend = self._backend(tool_runtime)
             if backend is None:
-                raise AssertionError("SkillsMiddleware requires a valid backend instance")
+                raise AssertionError(
+                    "SkillsMiddleware requires a valid backend instance"
+                )
             return backend
 
         return self._backend
@@ -587,7 +601,9 @@ class SkillsMiddleware(AgentMiddleware):
 
         return request.override(system_prompt=system_prompt)
 
-    def before_agent(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> SkillsStateUpdate | None:
+    def before_agent(
+        self, state: SkillsState, runtime: Runtime, config: RunnableConfig
+    ) -> SkillsStateUpdate | None:
         """Load skills metadata before agent execution (synchronous).
 
         Runs before each agent interaction to discover available skills from all
@@ -622,7 +638,9 @@ class SkillsMiddleware(AgentMiddleware):
         skills = list(all_skills.values())
         return SkillsStateUpdate(skills_metadata=skills)
 
-    async def abefore_agent(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> SkillsStateUpdate | None:
+    async def abefore_agent(
+        self, state: SkillsState, runtime: Runtime, config: RunnableConfig
+    ) -> SkillsStateUpdate | None:
         """Load skills metadata before agent execution (async).
 
         Runs before each agent interaction to discover available skills from all

--- a/libs/deepagents/tests/integration_tests/test_deepagents.py
+++ b/libs/deepagents/tests/integration_tests/test_deepagents.py
@@ -57,10 +57,20 @@ class TestDeepAgents:
         ]
         agent = create_deep_agent(tools=[sample_tool], subagents=subagents)
         assert_all_deepagent_qualities(agent)
-        result = agent.invoke({"messages": [HumanMessage(content="What is the weather in Tokyo?")]})
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="What is the weather in Tokyo?")]}
+        )
         agent_messages = [msg for msg in result.get("messages", []) if msg.type == "ai"]
-        tool_calls = [tool_call for msg in agent_messages for tool_call in msg.tool_calls]
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "weather_agent" for tool_call in tool_calls])
+        tool_calls = [
+            tool_call for msg in agent_messages for tool_call in msg.tool_calls
+        ]
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "weather_agent"
+                for tool_call in tool_calls
+            ]
+        )
 
     def test_deep_agent_with_subagents_gen_purpose(self):
         subagents = [
@@ -74,10 +84,26 @@ class TestDeepAgents:
         ]
         agent = create_deep_agent(tools=[sample_tool], subagents=subagents)
         assert_all_deepagent_qualities(agent)
-        result = agent.invoke({"messages": [HumanMessage(content="Use the general purpose subagent to call the sample tool")]})
+        result = agent.invoke(
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Use the general purpose subagent to call the sample tool"
+                    )
+                ]
+            }
+        )
         agent_messages = [msg for msg in result.get("messages", []) if msg.type == "ai"]
-        tool_calls = [tool_call for msg in agent_messages for tool_call in msg.tool_calls]
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "general-purpose" for tool_call in tool_calls])
+        tool_calls = [
+            tool_call for msg in agent_messages for tool_call in msg.tool_calls
+        ]
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "general-purpose"
+                for tool_call in tool_calls
+            ]
+        )
 
     def test_deep_agent_with_subagents_with_middleware(self):
         subagents = [
@@ -92,10 +118,20 @@ class TestDeepAgents:
         ]
         agent = create_deep_agent(tools=[sample_tool], subagents=subagents)
         assert_all_deepagent_qualities(agent)
-        result = agent.invoke({"messages": [HumanMessage(content="What is the weather in Tokyo?")]})
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="What is the weather in Tokyo?")]}
+        )
         agent_messages = [msg for msg in result.get("messages", []) if msg.type == "ai"]
-        tool_calls = [tool_call for msg in agent_messages for tool_call in msg.tool_calls]
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "weather_agent" for tool_call in tool_calls])
+        tool_calls = [
+            tool_call for msg in agent_messages for tool_call in msg.tool_calls
+        ]
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "weather_agent"
+                for tool_call in tool_calls
+            ]
+        )
 
     def test_deep_agent_with_custom_subagents(self):
         subagents = [
@@ -118,11 +154,33 @@ class TestDeepAgents:
         ]
         agent = create_deep_agent(tools=[sample_tool], subagents=subagents)
         assert_all_deepagent_qualities(agent)
-        result = agent.invoke({"messages": [HumanMessage(content="Look up the weather in Tokyo, and the latest scores for Manchester City!")]})
+        result = agent.invoke(
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Look up the weather in Tokyo, and the latest scores for Manchester City!"
+                    )
+                ]
+            }
+        )
         agent_messages = [msg for msg in result.get("messages", []) if msg.type == "ai"]
-        tool_calls = [tool_call for msg in agent_messages for tool_call in msg.tool_calls]
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "weather_agent" for tool_call in tool_calls])
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "soccer_agent" for tool_call in tool_calls])
+        tool_calls = [
+            tool_call for msg in agent_messages for tool_call in msg.tool_calls
+        ]
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "weather_agent"
+                for tool_call in tool_calls
+            ]
+        )
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "soccer_agent"
+                for tool_call in tool_calls
+            ]
+        )
 
     def test_deep_agent_with_extended_state_and_subagents(self):
         subagents = [
@@ -133,13 +191,30 @@ class TestDeepAgents:
                 "middleware": [ResearchMiddlewareWithTools()],
             }
         ]
-        agent = create_deep_agent(tools=[sample_tool], subagents=subagents, middleware=[ResearchMiddleware()])
+        agent = create_deep_agent(
+            tools=[sample_tool], subagents=subagents, middleware=[ResearchMiddleware()]
+        )
         assert_all_deepagent_qualities(agent)
         assert "research" in agent.stream_channels
-        result = agent.invoke({"messages": [HumanMessage(content="Get surface level info on lebron james")]}, config={"recursion_limit": 100})
+        result = agent.invoke(
+            {
+                "messages": [
+                    HumanMessage(content="Get surface level info on lebron james")
+                ]
+            },
+            config={"recursion_limit": 100},
+        )
         agent_messages = [msg for msg in result.get("messages", []) if msg.type == "ai"]
-        tool_calls = [tool_call for msg in agent_messages for tool_call in msg.tool_calls]
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "basketball_info_agent" for tool_call in tool_calls])
+        tool_calls = [
+            tool_call for msg in agent_messages for tool_call in msg.tool_calls
+        ]
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "basketball_info_agent"
+                for tool_call in tool_calls
+            ]
+        )
         assert TOY_BASKETBALL_RESEARCH in result["research"]
 
     def test_deep_agent_with_subagents_no_tools(self):
@@ -153,18 +228,39 @@ class TestDeepAgents:
         agent = create_deep_agent(tools=[sample_tool], subagents=subagents)
         assert_all_deepagent_qualities(agent)
         result = agent.invoke(
-            {"messages": [HumanMessage(content="Use the basketball info subagent to call the sample tool")]}, config={"recursion_limit": 100}
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Use the basketball info subagent to call the sample tool"
+                    )
+                ]
+            },
+            config={"recursion_limit": 100},
         )
         agent_messages = [msg for msg in result.get("messages", []) if msg.type == "ai"]
-        tool_calls = [tool_call for msg in agent_messages for tool_call in msg.tool_calls]
-        assert any([tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "basketball_info_agent" for tool_call in tool_calls])
+        tool_calls = [
+            tool_call for msg in agent_messages for tool_call in msg.tool_calls
+        ]
+        assert any(
+            [
+                tool_call["name"] == "task"
+                and tool_call["args"].get("subagent_type") == "basketball_info_agent"
+                for tool_call in tool_calls
+            ]
+        )
 
     def test_response_format_tool_strategy(self):
         class StructuredOutput(BaseModel):
             pokemon: list[str]
 
         agent = create_deep_agent(response_format=ToolStrategy(schema=StructuredOutput))
-        response = agent.invoke({"messages": [{"role": "user", "content": "Who are all of the Kanto starters?"}]})
+        response = agent.invoke(
+            {
+                "messages": [
+                    {"role": "user", "content": "Who are all of the Kanto starters?"}
+                ]
+            }
+        )
         structured_output = response["structured_response"]
         assert len(structured_output.pokemon) == 3
 
@@ -192,5 +288,7 @@ class TestDeepAgents:
             store=store,
         )
         assert_all_deepagent_qualities(agent)
-        result = await agent.ainvoke({"messages": [HumanMessage(content="What is your name?")]})
+        result = await agent.ainvoke(
+            {"messages": [HumanMessage(content="What is your name?")]}
+        )
         assert "Jackson" in result["messages"][-1].content

--- a/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
@@ -16,7 +16,13 @@ from deepagents.middleware.filesystem import (
     FilesystemMiddleware,
 )
 
-from ..utils import ResearchMiddleware, get_la_liga_standings, get_nba_standings, get_nfl_standings, get_premier_league_standings
+from ..utils import (
+    ResearchMiddleware,
+    get_la_liga_standings,
+    get_nba_standings,
+    get_nfl_standings,
+    get_premier_league_standings,
+)
 
 
 def build_composite_state_backend(runtime, *, routes):
@@ -42,11 +48,15 @@ class TestFilesystem:
                 )
             ],
         )
-        response = agent.invoke({"messages": [HumanMessage(content="What do you like?")]})
+        response = agent.invoke(
+            {"messages": [HumanMessage(content="What do you like?")]}
+        )
         assert "pokemon" in response["messages"][1].text.lower()
 
     def test_filesystem_system_prompt_override_with_composite_backend(self):
-        backend = lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})
+        backend = lambda rt: build_composite_state_backend(
+            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+        )
         agent = create_agent(
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
@@ -57,7 +67,9 @@ class TestFilesystem:
             ],
             store=InMemoryStore(),
         )
-        response = agent.invoke({"messages": [HumanMessage(content="What do you like?")]})
+        response = agent.invoke(
+            {"messages": [HumanMessage(content="What do you like?")]}
+        )
         assert "pizza" in response["messages"][1].text.lower()
 
     def test_filesystem_tool_prompt_override(self):
@@ -89,7 +101,11 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=(lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})),
+                    backend=(
+                        lambda rt: build_composite_state_backend(
+                            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                        )
+                    ),
                     custom_tool_descriptions={
                         "ls": "Charmander",
                         "read_file": "Bulbasaur",
@@ -134,7 +150,11 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=(lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})),
+                    backend=(
+                        lambda rt: build_composite_state_backend(
+                            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                        )
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -160,7 +180,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        ls_message = next(message for message in messages if message.type == "tool" and message.name == "ls")
+        ls_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "ls"
+        )
         assert "/pizza.txt" in ls_message.text
         assert "/pokemon/squirtle.txt" not in ls_message.text
         assert "/memories/test.txt" not in ls_message.text
@@ -194,7 +218,11 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=(lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})),
+                    backend=(
+                        lambda rt: build_composite_state_backend(
+                            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                        )
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -203,7 +231,11 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="List all of your files in the /pokemon directory")],
+                "messages": [
+                    HumanMessage(
+                        content="List all of your files in the /pokemon directory"
+                    )
+                ],
                 "files": {
                     "/pizza.txt": FileData(
                         content=["Hello world"],
@@ -220,7 +252,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        ls_message = next(message for message in messages if message.type == "tool" and message.name == "ls")
+        ls_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "ls"
+        )
         assert "/pokemon/squirtle.txt" in ls_message.text
         assert "/memories/pokemon/charmander.txt" not in ls_message.text
 
@@ -240,7 +276,11 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=(lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})),
+                    backend=(
+                        lambda rt: build_composite_state_backend(
+                            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                        )
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -249,7 +289,9 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Read test.txt from the local filesystem")],
+                "messages": [
+                    HumanMessage(content="Read test.txt from the local filesystem")
+                ],
                 "files": {
                     "/test.txt": FileData(
                         content=["Goodbye world"],
@@ -261,7 +303,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        read_file_message = next(message for message in messages if message.type == "tool" and message.name == "read_file")
+        read_file_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "read_file"
+        )
         assert read_file_message is not None
         assert "Goodbye world" in read_file_message.content
 
@@ -281,7 +327,11 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=(lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})),
+                    backend=(
+                        lambda rt: build_composite_state_backend(
+                            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                        )
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -290,7 +340,9 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Read test.txt from the memories directory")],
+                "messages": [
+                    HumanMessage(content="Read test.txt from the memories directory")
+                ],
                 "files": {
                     "/test.txt": FileData(
                         content=["Goodbye world"],
@@ -302,7 +354,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        read_file_message = next(message for message in messages if message.type == "tool" and message.name == "read_file")
+        read_file_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "read_file"
+        )
         assert read_file_message is not None
         assert "Hello world" in read_file_message.content
 
@@ -331,7 +387,11 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=(lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})),
+                    backend=(
+                        lambda rt: build_composite_state_backend(
+                            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                        )
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -340,7 +400,11 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Read the contents of the file about charmander from the memories directory.")],
+                "messages": [
+                    HumanMessage(
+                        content="Read the contents of the file about charmander from the memories directory."
+                    )
+                ],
                 "files": {},
             },
             config=config,
@@ -350,7 +414,11 @@ class TestFilesystem:
             message
             for message in messages
             if message.type == "ai"
-            and any(tc["name"] == "read_file" and tc["args"]["file_path"] == "/memories/pokemon/charmander.txt" for tc in message.tool_calls)
+            and any(
+                tc["name"] == "read_file"
+                and tc["args"]["file_path"] == "/memories/pokemon/charmander.txt"
+                for tc in message.tool_calls
+            )
         )
         assert ai_msg_w_toolcall is not None
 
@@ -361,7 +429,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -371,18 +441,26 @@ class TestFilesystem:
         response = agent.invoke(
             {
                 "messages": [
-                    HumanMessage(content="Write a haiku about Charmander to the memories directory in /charmander.txt, use the word 'fiery'")
+                    HumanMessage(
+                        content="Write a haiku about Charmander to the memories directory in /charmander.txt, use the word 'fiery'"
+                    )
                 ],
                 "files": {},
             },
             config=config,
         )
         messages = response["messages"]
-        write_file_message = next(message for message in messages if message.type == "tool" and message.name == "write_file")
+        write_file_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "write_file"
+        )
         assert write_file_message is not None
         file_item = store.get(("filesystem",), "/charmander.txt")
         assert file_item is not None
-        assert any("fiery" in c for c in file_item.value["content"]) or any("Fiery" in c for c in file_item.value["content"])
+        assert any("fiery" in c for c in file_item.value["content"]) or any(
+            "Fiery" in c for c in file_item.value["content"]
+        )
 
     def test_write_file_fail_already_exists_in_store(self):
         checkpointer = MemorySaver()
@@ -400,7 +478,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -409,13 +489,21 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Write a haiku about Charmander to /memories/charmander.txt, use the word 'fiery'")],
+                "messages": [
+                    HumanMessage(
+                        content="Write a haiku about Charmander to /memories/charmander.txt, use the word 'fiery'"
+                    )
+                ],
                 "files": {},
             },
             config=config,
         )
         messages = response["messages"]
-        write_file_message = next(message for message in messages if message.type == "tool" and message.name == "write_file")
+        write_file_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "write_file"
+        )
         assert write_file_message is not None
         assert "Cannot write" in write_file_message.content
 
@@ -426,7 +514,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -435,7 +525,11 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Write a haiku about Charmander to /charmander.txt, use the word 'fiery'")],
+                "messages": [
+                    HumanMessage(
+                        content="Write a haiku about Charmander to /charmander.txt, use the word 'fiery'"
+                    )
+                ],
                 "files": {
                     "/charmander.txt": FileData(
                         content=["Hello world"],
@@ -447,7 +541,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        write_file_message = next(message for message in messages if message.type == "tool" and message.name == "write_file")
+        write_file_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "write_file"
+        )
         assert write_file_message is not None
         assert "Cannot write" in write_file_message.content
 
@@ -467,7 +565,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -486,9 +586,15 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        edit_file_message = next(message for message in messages if message.type == "tool" and message.name == "edit_file")
+        edit_file_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "edit_file"
+        )
         assert edit_file_message is not None
-        assert store.get(("filesystem",), "/charmander.txt").value["content"] == ["The embers burns brightly. The embers burns hot."]
+        assert store.get(("filesystem",), "/charmander.txt").value["content"] == [
+            "The embers burns brightly. The embers burns hot."
+        ]
 
     def test_longterm_memory_multiple_tools(self):
         checkpointer = MemorySaver()
@@ -497,7 +603,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -508,14 +616,20 @@ class TestFilesystem:
     def test_longterm_memory_multiple_tools_deepagent(self):
         checkpointer = MemorySaver()
         store = InMemoryStore()
-        backend = lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})
-        agent = create_deep_agent(backend=backend, checkpointer=checkpointer, store=store)
+        backend = lambda rt: build_composite_state_backend(
+            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+        )
+        agent = create_deep_agent(
+            backend=backend, checkpointer=checkpointer, store=store
+        )
         assert_longterm_mem_tools(agent, store)
 
     def test_shortterm_memory_multiple_tools_deepagent(self):
         checkpointer = MemorySaver()
         store = InMemoryStore()
-        agent = create_deep_agent(backend=lambda rt: StateBackend(rt), checkpointer=checkpointer, store=store)
+        agent = create_deep_agent(
+            backend=lambda rt: StateBackend(rt), checkpointer=checkpointer, store=store
+        )
         assert_shortterm_mem_tools(agent)
 
     def test_tool_call_with_tokens_exceeding_limit(self):
@@ -529,7 +643,13 @@ class TestFilesystem:
             ],
         )
         response = agent.invoke(
-            {"messages": [HumanMessage(content="Get the NBA standings using your tool. If the tool returns bad results, tell the user.")]}
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Get the NBA standings using your tool. If the tool returns bad results, tell the user."
+                    )
+                ]
+            }
         )
         assert response["messages"][2].type == "tool"
         assert len(response["messages"][2].content) < 10000
@@ -548,7 +668,13 @@ class TestFilesystem:
             ],
         )
         response = agent.invoke(
-            {"messages": [HumanMessage(content="Get the NFL standings using your tool. If the tool returns bad results, tell the user.")]}
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Get the NFL standings using your tool. If the tool returns bad results, tell the user."
+                    )
+                ]
+            }
         )
         assert response["messages"][2].type == "tool"
         assert len(response["messages"][2].content) < 1500
@@ -567,7 +693,13 @@ class TestFilesystem:
             ],
         )
         response = agent.invoke(
-            {"messages": [HumanMessage(content="Get the la liga standings using your tool. If the tool returns bad results, tell the user.")]}
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Get the la liga standings using your tool. If the tool returns bad results, tell the user."
+                    )
+                ]
+            }
         )
         assert response["messages"][2].type == "tool"
         assert len(response["messages"][2].content) < 1500
@@ -589,7 +721,9 @@ class TestFilesystem:
         response = agent.invoke(
             {
                 "messages": [
-                    HumanMessage(content="Get the premier league standings using your tool. If the tool returns bad results, tell the user.")
+                    HumanMessage(
+                        content="Get the premier league standings using your tool. If the tool returns bad results, tell the user."
+                    )
                 ],
             }
         )
@@ -636,7 +770,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        glob_message = next(message for message in messages if message.type == "tool" and message.name == "glob")
+        glob_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "glob"
+        )
         assert "/test.py" in glob_message.content
         assert "/main.py" in glob_message.content
         assert "/readme.txt" not in glob_message.content
@@ -675,7 +813,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -684,13 +824,21 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Use glob to find all Python files in /memories")],
+                "messages": [
+                    HumanMessage(
+                        content="Use glob to find all Python files in /memories"
+                    )
+                ],
                 "files": {},
             },
             config=config,
         )
         messages = response["messages"]
-        glob_message = next(message for message in messages if message.type == "tool" and message.name == "glob")
+        glob_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "glob"
+        )
         assert "/memories/config.py" in glob_message.content
         assert "/memories/settings.py" in glob_message.content
         assert "/memories/notes.txt" not in glob_message.content
@@ -720,7 +868,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -746,7 +896,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        glob_message = next(message for message in messages if message.type == "tool" and message.name == "glob")
+        glob_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "glob"
+        )
         assert "/shortterm.py" in glob_message.content
         assert "/memories/longterm.py" in glob_message.content
         assert "/shortterm.txt" not in glob_message.content
@@ -766,7 +920,11 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Use grep to find all files containing the word 'import'")],
+                "messages": [
+                    HumanMessage(
+                        content="Use grep to find all files containing the word 'import'"
+                    )
+                ],
                 "files": {
                     "/test.py": FileData(
                         content=["import os", "import sys"],
@@ -788,7 +946,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        grep_message = next(message for message in messages if message.type == "tool" and message.name == "grep")
+        grep_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "grep"
+        )
         assert "/test.py" in grep_message.content
         assert "/helper.py" in grep_message.content
         assert "/main.py" not in grep_message.content
@@ -827,7 +989,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -836,13 +1000,21 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Use grep to find all files in the memories directory containing the word 'fire'")],
+                "messages": [
+                    HumanMessage(
+                        content="Use grep to find all files in the memories directory containing the word 'fire'"
+                    )
+                ],
                 "files": {},
             },
             config=config,
         )
         messages = response["messages"]
-        grep_message = next(message for message in messages if message.type == "tool" and message.name == "grep")
+        grep_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "grep"
+        )
         assert "/memories/pokemon/charmander.txt" in grep_message.content
         assert "/memories/pokemon/squirtle.txt" not in grep_message.content
         assert "/memories/pokemon/bulbasaur.txt" not in grep_message.content
@@ -872,7 +1044,9 @@ class TestFilesystem:
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
             middleware=[
                 FilesystemMiddleware(
-                    backend=lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))}),
+                    backend=lambda rt: build_composite_state_backend(
+                        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+                    ),
                 )
             ],
             checkpointer=checkpointer,
@@ -881,7 +1055,11 @@ class TestFilesystem:
         config = {"configurable": {"thread_id": uuid.uuid4()}}
         response = agent.invoke(
             {
-                "messages": [HumanMessage(content="Use grep to find all files containing 'DEBUG'")],
+                "messages": [
+                    HumanMessage(
+                        content="Use grep to find all files containing 'DEBUG'"
+                    )
+                ],
                 "files": {
                     "/shortterm_config.py": FileData(
                         content=["DEBUG = False", "VERBOSE = True"],
@@ -898,7 +1076,11 @@ class TestFilesystem:
             config=config,
         )
         messages = response["messages"]
-        grep_message = next(message for message in messages if message.type == "tool" and message.name == "grep")
+        grep_message = next(
+            message
+            for message in messages
+            if message.type == "tool" and message.name == "grep"
+        )
         print(grep_message.content)
         assert "/shortterm_config.py" in grep_message.content
         assert "/memories/longterm_config.py" in grep_message.content
@@ -909,9 +1091,7 @@ class TestFilesystem:
         checkpointer = MemorySaver()
         agent = create_agent(
             model=ChatAnthropic(model="claude-sonnet-4-20250514"),
-            middleware=[
-                FilesystemMiddleware()  # No backend specified
-            ],
+            middleware=[FilesystemMiddleware()],  # No backend specified
             checkpointer=checkpointer,
         )
         config = {"configurable": {"thread_id": uuid.uuid4()}}
@@ -922,14 +1102,18 @@ class TestFilesystem:
         )
 
         assert "/test.txt" in response["files"]
-        assert any("Hello World" in line for line in response["files"]["/test.txt"]["content"])
+        assert any(
+            "Hello World" in line for line in response["files"]["/test.txt"]["content"]
+        )
 
         response = agent.invoke(
             {"messages": [HumanMessage(content="Read /test.txt")]},
             config=config,
         )
         messages = response["messages"]
-        read_message = next(msg for msg in messages if msg.type == "tool" and msg.name == "read_file")
+        read_message = next(
+            msg for msg in messages if msg.type == "tool" and msg.name == "read_file"
+        )
         assert "Hello World" in read_message.content
 
     def test_execute_tool_filtered_for_non_sandbox_backend(self):
@@ -945,7 +1129,12 @@ class TestFilesystem:
             def wrap_model_call(self, request, handler):
                 # Capture tool names
                 captured_tools.clear()
-                captured_tools.extend([tool.name if hasattr(tool, "name") else tool.get("name") for tool in request.tools])
+                captured_tools.extend(
+                    [
+                        tool.name if hasattr(tool, "name") else tool.get("name")
+                        for tool in request.tools
+                    ]
+                )
                 return handler(request)
 
         # Test with StateBackend (no execution support)
@@ -1078,7 +1267,13 @@ def assert_longterm_mem_tools(agent, store):
     # Write a longterm memory file
     config = {"configurable": {"thread_id": uuid.uuid4()}}
     agent.invoke(
-        {"messages": [HumanMessage(content="Write a haiku about Charmander to /memories/charmander.txt, use the word 'fiery'")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Write a haiku about Charmander to /memories/charmander.txt, use the word 'fiery'"
+                )
+            ]
+        },
         config=config,
     )
     namespaces = store.list_namespaces()
@@ -1091,42 +1286,80 @@ def assert_longterm_mem_tools(agent, store):
     # Read the longterm memory file
     config2 = {"configurable": {"thread_id": uuid.uuid4()}}
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Read the haiku about Charmander from /memories/charmander.txt")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Read the haiku about Charmander from /memories/charmander.txt"
+                )
+            ]
+        },
         config=config2,
     )
     messages = response["messages"]
-    read_file_message = next(message for message in messages if message.type == "tool" and message.name == "read_file")
+    read_file_message = next(
+        message
+        for message in messages
+        if message.type == "tool" and message.name == "read_file"
+    )
     assert "fiery" in read_file_message.content or "Fiery" in read_file_message.content
 
     # List all of the files in longterm memory
     config3 = {"configurable": {"thread_id": uuid.uuid4()}}
     response = agent.invoke(
-        {"messages": [HumanMessage(content="List all of the files in the memories directory at /memories")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="List all of the files in the memories directory at /memories"
+                )
+            ]
+        },
         config=config3,
     )
     messages = response["messages"]
-    ls_message = next(message for message in messages if message.type == "tool" and message.name == "ls")
+    ls_message = next(
+        message
+        for message in messages
+        if message.type == "tool" and message.name == "ls"
+    )
     assert "/memories/charmander.txt" in ls_message.content
 
     # Edit the longterm memory file
     config4 = {"configurable": {"thread_id": uuid.uuid4()}}
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Edit the haiku about Charmander at /memories/charmander.txt to use the word 'ember'")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Edit the haiku about Charmander at /memories/charmander.txt to use the word 'ember'"
+                )
+            ]
+        },
         config=config4,
     )
     file_item = store.get(("filesystem",), "/charmander.txt")
     assert file_item is not None
     assert file_item.key == "/charmander.txt"
-    assert any("ember" in c for c in file_item.value["content"]) or any("Ember" in c for c in file_item.value["content"])
+    assert any("ember" in c for c in file_item.value["content"]) or any(
+        "Ember" in c for c in file_item.value["content"]
+    )
 
     # Read the longterm memory file
     config5 = {"configurable": {"thread_id": uuid.uuid4()}}
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Read the haiku about Charmander at /memories/charmander.txt")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Read the haiku about Charmander at /memories/charmander.txt"
+                )
+            ]
+        },
         config=config5,
     )
     messages = response["messages"]
-    read_file_message = next(message for message in messages if message.type == "tool" and message.name == "read_file")
+    read_file_message = next(
+        message
+        for message in messages
+        if message.type == "tool" and message.name == "read_file"
+    )
     assert "ember" in read_file_message.content or "Ember" in read_file_message.content
 
 
@@ -1134,7 +1367,13 @@ def assert_shortterm_mem_tools(agent):
     # Write a shortterm memory file
     config = {"configurable": {"thread_id": uuid.uuid4()}}
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Write a haiku about Charmander to /charmander.txt, use the word 'fiery'")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Write a haiku about Charmander to /charmander.txt, use the word 'fiery'"
+                )
+            ]
+        },
         config=config,
     )
     files = response["files"]
@@ -1142,36 +1381,72 @@ def assert_shortterm_mem_tools(agent):
 
     # Read the shortterm memory file
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Read the haiku about Charmander from /charmander.txt")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Read the haiku about Charmander from /charmander.txt"
+                )
+            ]
+        },
         config=config,
     )
     messages = response["messages"]
-    read_file_message = next(message for message in reversed(messages) if message.type == "tool" and message.name == "read_file")
+    read_file_message = next(
+        message
+        for message in reversed(messages)
+        if message.type == "tool" and message.name == "read_file"
+    )
     assert "fiery" in read_file_message.content or "Fiery" in read_file_message.content
 
     # List all of the files in shortterm memory
     response = agent.invoke(
-        {"messages": [HumanMessage(content="List all of the files in your filesystem")]},
+        {
+            "messages": [
+                HumanMessage(content="List all of the files in your filesystem")
+            ]
+        },
         config=config,
     )
     messages = response["messages"]
-    ls_message = next(message for message in messages if message.type == "tool" and message.name == "ls")
+    ls_message = next(
+        message
+        for message in messages
+        if message.type == "tool" and message.name == "ls"
+    )
     assert "/charmander.txt" in ls_message.content
 
     # Edit the shortterm memory file
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Edit the haiku about Charmander to use the word 'ember'")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Edit the haiku about Charmander to use the word 'ember'"
+                )
+            ]
+        },
         config=config,
     )
     files = response["files"]
     assert "/charmander.txt" in files
-    assert any("ember" in c for c in files["/charmander.txt"]["content"]) or any("Ember" in c for c in files["/charmander.txt"]["content"])
+    assert any("ember" in c for c in files["/charmander.txt"]["content"]) or any(
+        "Ember" in c for c in files["/charmander.txt"]["content"]
+    )
 
     # Read the shortterm memory file
     response = agent.invoke(
-        {"messages": [HumanMessage(content="Read the haiku about Charmander at /charmander.txt")]},
+        {
+            "messages": [
+                HumanMessage(
+                    content="Read the haiku about Charmander at /charmander.txt"
+                )
+            ]
+        },
         config=config,
     )
     messages = response["messages"]
-    read_file_message = next(message for message in reversed(messages) if message.type == "tool" and message.name == "read_file")
+    read_file_message = next(
+        message
+        for message in reversed(messages)
+        if message.type == "tool" and message.name == "read_file"
+    )
     assert "ember" in read_file_message.content or "Ember" in read_file_message.content

--- a/libs/deepagents/tests/integration_tests/test_subagent_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_subagent_middleware.py
@@ -36,10 +36,16 @@ def assert_expected_subgraph_actions(expected_tool_calls, agent, inputs):
             for tool_call in tool_calls:
                 if tool_call["name"] == expected_tool_calls[current_idx]["name"]:
                     if "model" in expected_tool_calls[current_idx]:
-                        assert ai_message.response_metadata["model_name"] == expected_tool_calls[current_idx]["model"]
+                        assert (
+                            ai_message.response_metadata["model_name"]
+                            == expected_tool_calls[current_idx]["model"]
+                        )
                     for arg in expected_tool_calls[current_idx]["args"]:
                         assert arg in tool_call["args"]
-                        assert tool_call["args"][arg] == expected_tool_calls[current_idx]["args"][arg]
+                        assert (
+                            tool_call["args"][arg]
+                            == expected_tool_calls[current_idx]["args"][arg]
+                        )
                     current_idx += 1
     assert current_idx == len(expected_tool_calls)
 
@@ -60,9 +66,14 @@ class TestSubagentMiddleware:
             ],
         )
         assert "task" in agent.nodes["tools"].bound._tools_by_name.keys()
-        response = agent.invoke({"messages": [HumanMessage(content="What is the weather in Tokyo?")]})
+        response = agent.invoke(
+            {"messages": [HumanMessage(content="What is the weather in Tokyo?")]}
+        )
         assert response["messages"][1].tool_calls[0]["name"] == "task"
-        assert response["messages"][1].tool_calls[0]["args"]["subagent_type"] == "general-purpose"
+        assert (
+            response["messages"][1].tool_calls[0]["args"]["subagent_type"]
+            == "general-purpose"
+        )
 
     def test_defined_subagent(self):
         agent = create_agent(
@@ -84,9 +95,13 @@ class TestSubagentMiddleware:
             ],
         )
         assert "task" in agent.nodes["tools"].bound._tools_by_name.keys()
-        response = agent.invoke({"messages": [HumanMessage(content="What is the weather in Tokyo?")]})
+        response = agent.invoke(
+            {"messages": [HumanMessage(content="What is the weather in Tokyo?")]}
+        )
         assert response["messages"][1].tool_calls[0]["name"] == "task"
-        assert response["messages"][1].tool_calls[0]["args"]["subagent_type"] == "weather"
+        assert (
+            response["messages"][1].tool_calls[0]["args"]["subagent_type"] == "weather"
+        )
 
     def test_defined_subagent_tool_calls(self):
         agent = create_agent(
@@ -262,7 +277,9 @@ class TestSubagentMiddleware:
         assert middleware.system_prompt is TASK_SYSTEM_PROMPT
         assert len(middleware.tools) == 1
         assert middleware.tools[0].name == "task"
-        expected_desc = TASK_TOOL_DESCRIPTION.format(available_agents=f"- general-purpose: {DEFAULT_GENERAL_PURPOSE_DESCRIPTION}")
+        expected_desc = TASK_TOOL_DESCRIPTION.format(
+            available_agents=f"- general-purpose: {DEFAULT_GENERAL_PURPOSE_DESCRIPTION}"
+        )
         assert middleware.tools[0].description == expected_desc
 
     def test_default_subagent_with_tools(self):

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -67,7 +67,9 @@ class MockSandboxBackend(SandboxBackendProtocol, StateBackend):
 async def test_composite_state_backend_routes_and_search_async(tmp_path: Path):
     """Test async operations with composite backend routing."""
     rt = make_runtime("t3")
-    be = build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})
+    be = build_composite_state_backend(
+        rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+    )
 
     # write to default (state)
     res = await be.awrite("/file.txt", "alpha")
@@ -75,7 +77,9 @@ async def test_composite_state_backend_routes_and_search_async(tmp_path: Path):
 
     # write to routed (store)
     msg = await be.awrite("/memories/readme.md", "beta")
-    assert isinstance(msg, WriteResult) and msg.error is None and msg.files_update is None
+    assert (
+        isinstance(msg, WriteResult) and msg.error is None and msg.files_update is None
+    )
 
     # als_info at root returns both
     infos = await be.als_info("/")
@@ -132,15 +136,25 @@ async def test_composite_backend_store_to_store_async():
     default_store = StoreBackend(rt)
     memories_store = StoreBackend(rt)
 
-    comp = CompositeBackend(default=default_store, routes={"/memories/": memories_store})
+    comp = CompositeBackend(
+        default=default_store, routes={"/memories/": memories_store}
+    )
 
     # Write to default store
     res1 = await comp.awrite("/notes.txt", "default store content")
-    assert isinstance(res1, WriteResult) and res1.error is None and res1.path == "/notes.txt"
+    assert (
+        isinstance(res1, WriteResult)
+        and res1.error is None
+        and res1.path == "/notes.txt"
+    )
 
     # Write to routed store
     res2 = await comp.awrite("/memories/important.txt", "routed store content")
-    assert isinstance(res2, WriteResult) and res2.error is None and res2.path == "/important.txt"
+    assert (
+        isinstance(res2, WriteResult)
+        and res2.error is None
+        and res2.path == "/important.txt"
+    )
 
     # Read from both
     content1 = await comp.aread("/notes.txt")
@@ -224,7 +238,9 @@ async def test_composite_backend_multiple_routes_async():
     assert any(i["path"] == "/memories/important.md" for i in glob_results)
 
     # Edit in routed backend
-    edit_res = await comp.aedit("/memories/important.md", "long-term", "persistent", replace_all=False)
+    edit_res = await comp.aedit(
+        "/memories/important.md", "long-term", "persistent", replace_all=False
+    )
     assert edit_res.error is None
     assert edit_res.occurrences == 1
 
@@ -544,7 +560,9 @@ async def test_composite_aupload_download_multiple_routes_async(tmp_path: Path):
     store1 = StoreBackend(rt)
     store2 = StoreBackend(rt)
 
-    comp = CompositeBackend(default=fs, routes={"/memories/": store1, "/archive/": store2})
+    comp = CompositeBackend(
+        default=fs, routes={"/memories/": store1, "/archive/": store2}
+    )
 
     # Upload to different backends
     files = [
@@ -646,7 +664,9 @@ async def test_composite_agrep_with_glob_filter_async(tmp_path: Path) -> None:
     assert not any(".md" in p for p in match_paths)
 
 
-async def test_composite_agrep_with_glob_in_specific_route_async(tmp_path: Path) -> None:
+async def test_composite_agrep_with_glob_in_specific_route_async(
+    tmp_path: Path,
+) -> None:
     """Test async grep with glob parameter targeting a specific route."""
     rt = make_runtime("t_agrep3")
     root = tmp_path
@@ -832,7 +852,9 @@ async def test_composite_agrep_multiple_matches_per_file_async(tmp_path: Path) -
     "causing files written to one route to appear in all routes that use the same backend instance. "
     "This violates the expected isolation between routes."
 )
-async def test_composite_agrep_multiple_routes_aggregation_async(tmp_path: Path) -> None:
+async def test_composite_agrep_multiple_routes_aggregation_async(
+    tmp_path: Path,
+) -> None:
     """Test async grep aggregates results from multiple routed backends with expected isolation.
 
     This test represents the intuitive expected behavior: files written to /memories/
@@ -848,7 +870,9 @@ async def test_composite_agrep_multiple_routes_aggregation_async(tmp_path: Path)
     store1 = StoreBackend(rt)
     store2 = StoreBackend(rt)
 
-    comp = CompositeBackend(default=fs, routes={"/memories/": store1, "/archive/": store2})
+    comp = CompositeBackend(
+        default=fs, routes={"/memories/": store1, "/archive/": store2}
+    )
 
     # Write to each route
     await comp.awrite("/memories/mem.txt", "memory findme")
@@ -876,7 +900,9 @@ async def test_composite_agrep_error_in_routed_backend_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        async def agrep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep_raw(
+            self, pattern: str, path: str | None = None, glob: str | None = None
+        ):
             return "Invalid regex pattern error"
 
     error_backend = ErrorBackend(rt)
@@ -895,7 +921,9 @@ async def test_composite_agrep_error_in_routed_backend_at_root_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        async def agrep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep_raw(
+            self, pattern: str, path: str | None = None, glob: str | None = None
+        ):
             return "Backend error occurred"
 
     error_backend = ErrorBackend(rt)
@@ -914,7 +942,9 @@ async def test_composite_agrep_error_in_default_backend_at_root_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorDefaultBackend(StateBackend):
-        async def agrep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep_raw(
+            self, pattern: str, path: str | None = None, glob: str | None = None
+        ):
             return "Default backend error"
 
     error_default = ErrorDefaultBackend(rt)
@@ -927,7 +957,9 @@ async def test_composite_agrep_error_in_default_backend_at_root_async() -> None:
     assert result == "Default backend error"
 
 
-async def test_composite_agrep_non_root_path_on_default_backend_async(tmp_path: Path) -> None:
+async def test_composite_agrep_non_root_path_on_default_backend_async(
+    tmp_path: Path,
+) -> None:
     """Test async grep with non-root path on default backend."""
     rt = make_runtime("t_agrep_default")
     root = tmp_path

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -31,11 +31,17 @@ def test_filesystem_backend_normal_mode(tmp_path: Path):
     msg = be.edit(str(f1), "fs", "filesystem", replace_all=False)
     assert isinstance(msg, EditResult) and msg.error is None and msg.occurrences == 1
     msg2 = be.write(str(root / "new.txt"), "new content")
-    assert isinstance(msg2, WriteResult) and msg2.error is None and msg2.path.endswith("new.txt")
+    assert (
+        isinstance(msg2, WriteResult)
+        and msg2.error is None
+        and msg2.path.endswith("new.txt")
+    )
 
     # grep_raw
     matches = be.grep_raw("hello", path=str(root))
-    assert isinstance(matches, list) and any(m["path"].endswith("a.txt") for m in matches)
+    assert isinstance(matches, list) and any(
+        m["path"].endswith("a.txt") for m in matches
+    )
 
     # glob_info
     g = be.glob_info("*.py", path=str(root))
@@ -206,7 +212,10 @@ def test_filesystem_backend_intercept_large_tool_result(tmp_path: Path):
         config={},
     )
 
-    middleware = FilesystemMiddleware(backend=lambda r: FilesystemBackend(root_dir=str(root), virtual_mode=True), tool_token_limit_before_evict=1000)
+    middleware = FilesystemMiddleware(
+        backend=lambda r: FilesystemBackend(root_dir=str(root), virtual_mode=True),
+        tool_token_limit_before_evict=1000,
+    )
 
     large_content = "f" * 5000
     tool_message = ToolMessage(content=large_content, tool_call_id="test_fs_123")

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend_async.py
@@ -36,11 +36,17 @@ async def test_filesystem_backend_async_normal_mode(tmp_path: Path):
     msg = await be.aedit(str(f1), "fs", "filesystem", replace_all=False)
     assert isinstance(msg, EditResult) and msg.error is None and msg.occurrences == 1
     msg2 = await be.awrite(str(root / "new.txt"), "new content")
-    assert isinstance(msg2, WriteResult) and msg2.error is None and msg2.path.endswith("new.txt")
+    assert (
+        isinstance(msg2, WriteResult)
+        and msg2.error is None
+        and msg2.path.endswith("new.txt")
+    )
 
     # agrep_raw
     matches = await be.agrep_raw("hello", path=str(root))
-    assert isinstance(matches, list) and any(m["path"].endswith("a.txt") for m in matches)
+    assert isinstance(matches, list) and any(
+        m["path"].endswith("a.txt") for m in matches
+    )
 
     # aglob_info
     g = await be.aglob_info("*.py", path=str(root))
@@ -210,7 +216,10 @@ async def test_filesystem_backend_intercept_large_tool_result_async(tmp_path: Pa
         config={},
     )
 
-    middleware = FilesystemMiddleware(backend=lambda r: FilesystemBackend(root_dir=str(root), virtual_mode=True), tool_token_limit_before_evict=1000)
+    middleware = FilesystemMiddleware(
+        backend=lambda r: FilesystemBackend(root_dir=str(root), virtual_mode=True),
+        tool_token_limit_before_evict=1000,
+    )
 
     large_content = "f" * 5000
     tool_message = ToolMessage(content=large_content, tool_call_id="test_fs_123")

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -73,7 +73,11 @@ def test_state_backend_errors():
     assert isinstance(res, WriteResult) and res.files_update is not None
     rt.state["files"].update(res.files_update)
     dup_err = be.write("/dup.txt", "y")
-    assert isinstance(dup_err, WriteResult) and dup_err.error and "already exists" in dup_err.error
+    assert (
+        isinstance(dup_err, WriteResult)
+        and dup_err.error
+        and "already exists" in dup_err.error
+    )
 
 
 def test_state_backend_ls_nested_directories():
@@ -149,7 +153,9 @@ def test_state_backend_intercept_large_tool_result():
     from deepagents.middleware.filesystem import FilesystemMiddleware
 
     rt = make_runtime()
-    middleware = FilesystemMiddleware(backend=lambda r: StateBackend(r), tool_token_limit_before_evict=1000)
+    middleware = FilesystemMiddleware(
+        backend=lambda r: StateBackend(r), tool_token_limit_before_evict=1000
+    )
 
     large_content = "x" * 5000
     tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
@@ -157,5 +163,7 @@ def test_state_backend_intercept_large_tool_result():
 
     assert isinstance(result, Command)
     assert "/large_tool_results/test_123" in result.update["files"]
-    assert result.update["files"]["/large_tool_results/test_123"]["content"] == [large_content]
+    assert result.update["files"]["/large_tool_results/test_123"]["content"] == [
+        large_content
+    ]
     assert "Tool result too large" in result.update["messages"][0].content

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend_async.py
@@ -77,7 +77,11 @@ async def test_state_backend_async_errors():
     assert isinstance(res, WriteResult) and res.files_update is not None
     rt.state["files"].update(res.files_update)
     dup_err = await be.awrite("/dup.txt", "y")
-    assert isinstance(dup_err, WriteResult) and dup_err.error and "already exists" in dup_err.error
+    assert (
+        isinstance(dup_err, WriteResult)
+        and dup_err.error
+        and "already exists" in dup_err.error
+    )
 
 
 async def test_state_backend_als_nested_directories():
@@ -262,7 +266,9 @@ async def test_state_backend_intercept_large_tool_result_async():
     from deepagents.middleware.filesystem import FilesystemMiddleware
 
     rt = make_runtime()
-    middleware = FilesystemMiddleware(backend=lambda r: StateBackend(r), tool_token_limit_before_evict=1000)
+    middleware = FilesystemMiddleware(
+        backend=lambda r: StateBackend(r), tool_token_limit_before_evict=1000
+    )
 
     large_content = "x" * 5000
     tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
@@ -270,5 +276,7 @@ async def test_state_backend_intercept_large_tool_result_async():
 
     assert isinstance(result, Command)
     assert "/large_tool_results/test_123" in result.update["files"]
-    assert result.update["files"]["/large_tool_results/test_123"]["content"] == [large_content]
+    assert result.update["files"]["/large_tool_results/test_123"]["content"] == [
+        large_content
+    ]
     assert "Tool result too large" in result.update["messages"][0].content

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -22,7 +22,11 @@ def test_store_backend_crud_and_search():
 
     # write new file
     msg = be.write("/docs/readme.md", "hello store")
-    assert isinstance(msg, WriteResult) and msg.error is None and msg.path == "/docs/readme.md"
+    assert (
+        isinstance(msg, WriteResult)
+        and msg.error is None
+        and msg.path == "/docs/readme.md"
+    )
 
     # read
     txt = be.read("/docs/readme.md")
@@ -38,7 +42,9 @@ def test_store_backend_crud_and_search():
 
     # grep_raw
     matches = be.grep_raw("hi", path="/")
-    assert isinstance(matches, list) and any(m["path"] == "/docs/readme.md" for m in matches)
+    assert isinstance(matches, list) and any(
+        m["path"] == "/docs/readme.md" for m in matches
+    )
 
     # glob_info
     g = be.glob_info("*.md", path="/")
@@ -120,7 +126,9 @@ def test_store_backend_intercept_large_tool_result():
     from deepagents.middleware.filesystem import FilesystemMiddleware
 
     rt = make_runtime()
-    middleware = FilesystemMiddleware(backend=lambda r: StoreBackend(r), tool_token_limit_before_evict=1000)
+    middleware = FilesystemMiddleware(
+        backend=lambda r: StoreBackend(r), tool_token_limit_before_evict=1000
+    )
 
     large_content = "y" * 5000
     tool_message = ToolMessage(content=large_content, tool_call_id="test_456")

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -25,7 +25,11 @@ async def test_store_backend_async_crud_and_search():
 
     # awrite new file
     msg = await be.awrite("/docs/readme.md", "hello store")
-    assert isinstance(msg, WriteResult) and msg.error is None and msg.path == "/docs/readme.md"
+    assert (
+        isinstance(msg, WriteResult)
+        and msg.error is None
+        and msg.path == "/docs/readme.md"
+    )
 
     # aread
     txt = await be.aread("/docs/readme.md")
@@ -41,7 +45,9 @@ async def test_store_backend_async_crud_and_search():
 
     # agrep_raw
     matches = await be.agrep_raw("hi", path="/")
-    assert isinstance(matches, list) and any(m["path"] == "/docs/readme.md" for m in matches)
+    assert isinstance(matches, list) and any(
+        m["path"] == "/docs/readme.md" for m in matches
+    )
 
     # aglob_info
     g = await be.aglob_info("*.md", path="/")
@@ -281,7 +287,9 @@ async def test_store_backend_intercept_large_tool_result_async():
     from deepagents.middleware.filesystem import FilesystemMiddleware
 
     rt = make_runtime()
-    middleware = FilesystemMiddleware(backend=lambda r: StoreBackend(r), tool_token_limit_before_evict=1000)
+    middleware = FilesystemMiddleware(
+        backend=lambda r: StoreBackend(r), tool_token_limit_before_evict=1000
+    )
 
     large_content = "y" * 5000
     tool_message = ToolMessage(content=large_content, tool_call_id="test_456")

--- a/libs/deepagents/tests/unit_tests/chat_model.py
+++ b/libs/deepagents/tests/unit_tests/chat_model.py
@@ -4,9 +4,7 @@ import re
 from collections.abc import Callable, Iterator, Sequence
 from typing import Any, cast
 
-from langchain_core.callbacks import (
-    CallbackManagerForLLMRun,
-)
+from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
@@ -125,7 +123,9 @@ class GenericFakeChatModel(BaseChatModel):
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> Iterator[ChatGenerationChunk]:
-        chat_result = self._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        chat_result = self._generate(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        )
         if not isinstance(chat_result, ChatResult):
             msg = f"Expected generate to return a ChatResult, but got {type(chat_result)} instead."
             raise ValueError(msg)  # noqa: TRY004
@@ -151,7 +151,9 @@ class GenericFakeChatModel(BaseChatModel):
             else:
                 # Split content using the delimiter
                 # Use re.split to support both string and regex patterns
-                content_chunks = cast("list[str]", re.split(self.stream_delimiter, content))
+                content_chunks = cast(
+                    "list[str]", re.split(self.stream_delimiter, content)
+                )
                 # Remove empty strings that can result from splitting
                 content_chunks = [chunk for chunk in content_chunks if chunk]
 
@@ -167,7 +169,11 @@ class GenericFakeChatModel(BaseChatModel):
                         tool_calls=chunk_tool_calls,
                     )
                 )
-                if is_last and isinstance(chunk.message, AIMessageChunk) and not message.additional_kwargs:
+                if (
+                    is_last
+                    and isinstance(chunk.message, AIMessageChunk)
+                    and not message.additional_kwargs
+                ):
                     chunk.message.chunk_position = "last"
                 if run_manager:
                     run_manager.on_llm_new_token(token, chunk=chunk)
@@ -200,7 +206,9 @@ class GenericFakeChatModel(BaseChatModel):
                                     message=AIMessageChunk(
                                         id=message.id,
                                         content="",
-                                        additional_kwargs={"function_call": {fkey: fvalue_chunk}},
+                                        additional_kwargs={
+                                            "function_call": {fkey: fvalue_chunk}
+                                        },
                                     )
                                 )
                                 if run_manager:
@@ -224,7 +232,11 @@ class GenericFakeChatModel(BaseChatModel):
                                 )
                             yield chunk
                 else:
-                    chunk = ChatGenerationChunk(message=AIMessageChunk(id=message.id, content="", additional_kwargs={key: value}))
+                    chunk = ChatGenerationChunk(
+                        message=AIMessageChunk(
+                            id=message.id, content="", additional_kwargs={key: value}
+                        )
+                    )
                     if run_manager:
                         run_manager.on_llm_new_token(
                             "",

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
@@ -136,7 +136,10 @@ def test_format_agent_memory_preserves_order() -> None:
         ],
     )
     # Dict order doesn't match sources order
-    contents = {"/second/AGENTS.md": "Second content", "/first/AGENTS.md": "First content"}
+    contents = {
+        "/second/AGENTS.md": "Second content",
+        "/first/AGENTS.md": "First content",
+    }
     result = middleware._format_agent_memory(contents)
 
     # First should appear before second (based on sources order, not dict order)
@@ -231,8 +234,12 @@ def test_load_memory_from_backend_multiple_sources(tmp_path: Path) -> None:
     user_path = str(tmp_path / "user" / "AGENTS.md")
     project_path = str(tmp_path / "project" / "AGENTS.md")
 
-    user_content = make_memory_content("User Preferences", "- Use Python 3.11+\n- Follow PEP 8")
-    project_content = make_memory_content("Project Guidelines", "## Architecture\nThis is a FastAPI project.")
+    user_content = make_memory_content(
+        "User Preferences", "- Use Python 3.11+\n- Follow PEP 8"
+    )
+    project_content = make_memory_content(
+        "Project Guidelines", "## Architecture\nThis is a FastAPI project."
+    )
 
     responses = backend.upload_files(
         [
@@ -415,7 +422,9 @@ def test_agent_with_memory_middleware_system_prompt(tmp_path: Path) -> None:
     assert responses[0].error is None
 
     # Create a fake chat model that we can inspect
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="I understand your preferences.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="I understand your preferences.")])
+    )
 
     # Create middleware
     sources: list[str] = [memory_path]
@@ -435,7 +444,9 @@ def test_agent_with_memory_middleware_system_prompt(tmp_path: Path) -> None:
     assert len(result["messages"]) > 0
 
     # Inspect the call history to verify system prompt was injected
-    assert len(fake_model.call_history) > 0, "Model should have been called at least once"
+    assert (
+        len(fake_model.call_history) > 0
+    ), "Model should have been called at least once"
 
     # Get the first call
     first_call = fake_model.call_history[0]
@@ -444,7 +455,9 @@ def test_agent_with_memory_middleware_system_prompt(tmp_path: Path) -> None:
     system_message = messages[0]
     assert system_message.type == "system", "First message should be system prompt"
     content = system_message.text
-    assert "<agent_memory>" in content, "System prompt should contain <agent_memory> tags"
+    assert (
+        "<agent_memory>" in content
+    ), "System prompt should contain <agent_memory> tags"
     assert memory_path in content, "System prompt should contain memory path"
     assert "type hints" in content, "System prompt should mention memory content"
     assert "functional programming" in content
@@ -470,7 +483,9 @@ def test_agent_with_memory_middleware_multiple_sources(tmp_path: Path) -> None:
     assert all(r.error is None for r in responses)
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="I see both user and project preferences.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="I see both user and project preferences.")])
+    )
 
     # Create middleware with multiple sources
     sources: list[str] = [
@@ -505,7 +520,9 @@ def test_agent_with_memory_middleware_empty_sources(tmp_path: Path) -> None:
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Working without memory.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="Working without memory.")])
+    )
 
     # Create middleware with empty sources
     middleware = MemoryMiddleware(backend=backend, sources=[])
@@ -539,7 +556,9 @@ async def test_agent_with_memory_middleware_async(tmp_path: Path) -> None:
     assert responses[0].error is None
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Async invocation successful.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="Async invocation successful.")])
+    )
 
     # Create middleware
     sources: list[str] = [memory_path]
@@ -631,7 +650,9 @@ def test_memory_middleware_with_store_backend_assistant_id() -> None:
     runtime = SimpleNamespace(context=None, store=store, stream_writer=lambda _: None)
 
     # Add memory for assistant-123 with namespace (assistant-123, filesystem)
-    assistant_1_content = make_memory_content("Assistant 1", "- Context for assistant 1")
+    assistant_1_content = make_memory_content(
+        "Assistant 1", "- Context for assistant 1"
+    )
     store.put(
         ("assistant-123", "filesystem"),
         "/memory/AGENTS.md",
@@ -653,7 +674,9 @@ def test_memory_middleware_with_store_backend_assistant_id() -> None:
     assert len(result_2["memory_contents"]) == 0
 
     # Add memory for assistant-456 with namespace (assistant-456, filesystem)
-    assistant_2_content = make_memory_content("Assistant 2", "- Context for assistant 2")
+    assistant_2_content = make_memory_content(
+        "Assistant 2", "- Context for assistant 2"
+    )
     store.put(
         ("assistant-456", "filesystem"),
         "/memory/AGENTS.md",
@@ -666,7 +689,10 @@ def test_memory_middleware_with_store_backend_assistant_id() -> None:
     assert result_3 is not None
     assert "/memory/AGENTS.md" in result_3["memory_contents"]
     assert "Context for assistant 2" in result_3["memory_contents"]["/memory/AGENTS.md"]
-    assert "Context for assistant 1" not in result_3["memory_contents"]["/memory/AGENTS.md"]
+    assert (
+        "Context for assistant 1"
+        not in result_3["memory_contents"]["/memory/AGENTS.md"]
+    )
 
     # Test: assistant-123 still only sees its own memory (no cross-contamination)
     result_4 = middleware.before_agent({}, runtime, config_1)  # type: ignore
@@ -674,7 +700,10 @@ def test_memory_middleware_with_store_backend_assistant_id() -> None:
     assert result_4 is not None
     assert "/memory/AGENTS.md" in result_4["memory_contents"]
     assert "Context for assistant 1" in result_4["memory_contents"]["/memory/AGENTS.md"]
-    assert "Context for assistant 2" not in result_4["memory_contents"]["/memory/AGENTS.md"]
+    assert (
+        "Context for assistant 2"
+        not in result_4["memory_contents"]["/memory/AGENTS.md"]
+    )
 
 
 def test_memory_middleware_with_store_backend_no_assistant_id() -> None:
@@ -700,7 +729,9 @@ def test_memory_middleware_with_store_backend_no_assistant_id() -> None:
 
     assert result_1 is not None
     assert "/memory/AGENTS.md" in result_1["memory_contents"]
-    assert "Default namespace context" in result_1["memory_contents"]["/memory/AGENTS.md"]
+    assert (
+        "Default namespace context" in result_1["memory_contents"]["/memory/AGENTS.md"]
+    )
 
     # Test: config with metadata but no assistant_id also uses default namespace
     config_with_other_metadata = {"metadata": {"some_other_key": "value"}}
@@ -708,7 +739,9 @@ def test_memory_middleware_with_store_backend_no_assistant_id() -> None:
 
     assert result_2 is not None
     assert "/memory/AGENTS.md" in result_2["memory_contents"]
-    assert "Default namespace context" in result_2["memory_contents"]["/memory/AGENTS.md"]
+    assert (
+        "Default namespace context" in result_2["memory_contents"]["/memory/AGENTS.md"]
+    )
 
 
 def test_create_deep_agent_with_memory_and_filesystem_backend(tmp_path: Path) -> None:
@@ -724,7 +757,9 @@ def test_create_deep_agent_with_memory_and_filesystem_backend(tmp_path: Path) ->
     agent = create_deep_agent(
         backend=backend,
         memory=[memory_path],
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="Memory loaded successfully.")])),
+        model=GenericFakeChatModel(
+            messages=iter([AIMessage(content="Memory loaded successfully.")])
+        ),
     )
 
     # Invoke agent
@@ -743,7 +778,9 @@ def test_create_deep_agent_with_memory_missing_files(tmp_path: Path) -> None:
     agent = create_deep_agent(
         backend=backend,
         memory=[str(tmp_path / "nonexistent" / "AGENTS.md")],
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="No memory, but that's okay.")])),
+        model=GenericFakeChatModel(
+            messages=iter([AIMessage(content="No memory, but that's okay.")])
+        ),
     )
 
     # Invoke agent - should succeed even without memory file
@@ -760,7 +797,9 @@ def test_create_deep_agent_with_memory_default_backend() -> None:
     checkpointer = InMemorySaver()
     agent = create_deep_agent(
         memory=["/user/.deepagents/AGENTS.md"],
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="Working with default backend.")])),
+        model=GenericFakeChatModel(
+            messages=iter([AIMessage(content="Working with default backend.")])
+        ),
         checkpointer=checkpointer,
     )
 
@@ -794,7 +833,9 @@ def test_create_deep_agent_with_memory_default_backend() -> None:
     checkpoint = agent.checkpointer.get(config)
     assert "/user/.deepagents/AGENTS.md" in checkpoint["channel_values"]["files"]
     assert "memory_contents" in checkpoint["channel_values"]
-    assert "/user/.deepagents/AGENTS.md" in checkpoint["channel_values"]["memory_contents"]
+    assert (
+        "/user/.deepagents/AGENTS.md" in checkpoint["channel_values"]["memory_contents"]
+    )
 
 
 def test_memory_middleware_order_matters(tmp_path: Path) -> None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware_async.py
@@ -68,8 +68,12 @@ async def test_load_memory_from_backend_multiple_sources_async(tmp_path: Path) -
     user_path = str(tmp_path / "user" / "AGENTS.md")
     project_path = str(tmp_path / "project" / "AGENTS.md")
 
-    user_content = make_memory_content("User Preferences", "- Use Python 3.11+\n- Follow PEP 8")
-    project_content = make_memory_content("Project Guidelines", "## Architecture\nThis is a FastAPI project.")
+    user_content = make_memory_content(
+        "User Preferences", "- Use Python 3.11+\n- Follow PEP 8"
+    )
+    project_content = make_memory_content(
+        "Project Guidelines", "## Architecture\nThis is a FastAPI project."
+    )
 
     responses = backend.upload_files(
         [
@@ -236,7 +240,9 @@ async def test_memory_content_with_large_file_async(tmp_path: Path) -> None:
     assert content.count("Line of content") == 500
 
 
-async def test_agent_with_memory_middleware_multiple_sources_async(tmp_path: Path) -> None:
+async def test_agent_with_memory_middleware_multiple_sources_async(
+    tmp_path: Path,
+) -> None:
     """Test agent with memory from multiple sources (async)."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
@@ -256,7 +262,9 @@ async def test_agent_with_memory_middleware_multiple_sources_async(tmp_path: Pat
     assert all(r.error is None for r in responses)
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="I see both user and project preferences.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="I see both user and project preferences.")])
+    )
 
     # Create middleware with multiple sources
     sources: list[str] = [
@@ -291,7 +299,9 @@ async def test_agent_with_memory_middleware_empty_sources_async(tmp_path: Path) 
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Working without memory.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="Working without memory.")])
+    )
 
     # Create middleware with empty sources
     middleware = MemoryMiddleware(backend=backend, sources=[])

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -155,7 +155,9 @@ description: Minimal skill
 # Minimal Skill
 """
 
-    result = _parse_skill_metadata(content, "/skills/minimal-skill/SKILL.md", "minimal-skill")
+    result = _parse_skill_metadata(
+        content, "/skills/minimal-skill/SKILL.md", "minimal-skill"
+    )
 
     assert result == {
         "name": "minimal-skill",
@@ -240,7 +242,9 @@ name: test-skill
 description: Test
 ---
 
-""" + ("X" * MAX_SKILL_FILE_SIZE)
+""" + (
+        "X" * MAX_SKILL_FILE_SIZE
+    )
 
     result = _parse_skill_metadata(large_content, "/skills/test/SKILL.md", "test-skill")
     assert result is None
@@ -706,7 +710,9 @@ def test_agent_with_skills_middleware_system_prompt(tmp_path: Path) -> None:
     fake_model = GenericFakeChatModel(
         messages=iter(
             [
-                AIMessage(content="I have processed your request using the test-skill."),
+                AIMessage(
+                    content="I have processed your request using the test-skill."
+                ),
             ]
         )
     )
@@ -725,14 +731,18 @@ def test_agent_with_skills_middleware_system_prompt(tmp_path: Path) -> None:
     )
 
     # Invoke the agent
-    result = agent.invoke({"messages": [HumanMessage(content="Hello, please help me.")]})
+    result = agent.invoke(
+        {"messages": [HumanMessage(content="Hello, please help me.")]}
+    )
 
     # Verify the agent was invoked
     assert "messages" in result
     assert len(result["messages"]) > 0
 
     # Inspect the call history to verify system prompt was injected
-    assert len(fake_model.call_history) > 0, "Model should have been called at least once"
+    assert (
+        len(fake_model.call_history) > 0
+    ), "Model should have been called at least once"
 
     # Get the first call
     first_call = fake_model.call_history[0]
@@ -741,7 +751,9 @@ def test_agent_with_skills_middleware_system_prompt(tmp_path: Path) -> None:
     system_message = messages[0]
     assert system_message.type == "system", "First message should be system prompt"
     content = system_message.text
-    assert "Skills System" in content, "System prompt should contain 'Skills System' section"
+    assert (
+        "Skills System" in content
+    ), "System prompt should contain 'Skills System' section"
     assert "test-skill" in content, "System prompt should mention the skill name"
 
 
@@ -821,7 +833,9 @@ async def test_agent_with_skills_middleware_async(tmp_path: Path) -> None:
     fake_model = GenericFakeChatModel(
         messages=iter(
             [
-                AIMessage(content="I have processed your async request using the async-skill."),
+                AIMessage(
+                    content="I have processed your async request using the async-skill."
+                ),
             ]
         )
     )
@@ -840,17 +854,23 @@ async def test_agent_with_skills_middleware_async(tmp_path: Path) -> None:
     )
 
     # Invoke the agent asynchronously
-    result = await agent.ainvoke({"messages": [HumanMessage(content="Hello, please help me.")]})
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage(content="Hello, please help me.")]}
+    )
 
     # Verify the agent was invoked
     assert "messages" in result
     assert len(result["messages"]) > 0
 
     # Verify skills_metadata is NOT in final state (it's a PrivateStateAttr)
-    assert "skills_metadata" not in result, "skills_metadata should be private and not in final state"
+    assert (
+        "skills_metadata" not in result
+    ), "skills_metadata should be private and not in final state"
 
     # Inspect the call history to verify system prompt was injected
-    assert len(fake_model.call_history) > 0, "Model should have been called at least once"
+    assert (
+        len(fake_model.call_history) > 0
+    ), "Model should have been called at least once"
 
     # Get the first call
     first_call = fake_model.call_history[0]
@@ -859,11 +879,15 @@ async def test_agent_with_skills_middleware_async(tmp_path: Path) -> None:
     system_message = messages[0]
     assert system_message.type == "system", "First message should be system prompt"
     content = system_message.text
-    assert "Skills System" in content, "System prompt should contain 'Skills System' section"
+    assert (
+        "Skills System" in content
+    ), "System prompt should contain 'Skills System' section"
     assert "async-skill" in content, "System prompt should mention the skill name"
 
 
-def test_agent_with_skills_middleware_multiple_registries_override(tmp_path: Path) -> None:
+def test_agent_with_skills_middleware_multiple_registries_override(
+    tmp_path: Path,
+) -> None:
     """Test skills middleware with multiple sources where later sources override earlier ones."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
@@ -875,7 +899,9 @@ def test_agent_with_skills_middleware_multiple_registries_override(tmp_path: Pat
     user_skill_path = str(user_dir / "shared-skill" / "SKILL.md")
 
     base_content = make_skill_content("shared-skill", "Base registry description")
-    user_content = make_skill_content("shared-skill", "User registry description - should win")
+    user_content = make_skill_content(
+        "shared-skill", "User registry description - should win"
+    )
 
     responses = backend.upload_files(
         [
@@ -911,17 +937,23 @@ def test_agent_with_skills_middleware_multiple_registries_override(tmp_path: Pat
     )
 
     # Invoke the agent
-    result = agent.invoke({"messages": [HumanMessage(content="Hello, please help me.")]})
+    result = agent.invoke(
+        {"messages": [HumanMessage(content="Hello, please help me.")]}
+    )
 
     # Verify the agent was invoked
     assert "messages" in result
     assert len(result["messages"]) > 0
 
     # Verify skills_metadata is NOT in final state (it's a PrivateStateAttr)
-    assert "skills_metadata" not in result, "skills_metadata should be private and not in final state"
+    assert (
+        "skills_metadata" not in result
+    ), "skills_metadata should be private and not in final state"
 
     # Inspect the call history to verify system prompt was injected with USER version
-    assert len(fake_model.call_history) > 0, "Model should have been called at least once"
+    assert (
+        len(fake_model.call_history) > 0
+    ), "Model should have been called at least once"
 
     # Get the first call
     first_call = fake_model.call_history[0]
@@ -930,10 +962,16 @@ def test_agent_with_skills_middleware_multiple_registries_override(tmp_path: Pat
     system_message = messages[0]
     assert system_message.type == "system", "First message should be system prompt"
     content = system_message.text
-    assert "Skills System" in content, "System prompt should contain 'Skills System' section"
+    assert (
+        "Skills System" in content
+    ), "System prompt should contain 'Skills System' section"
     assert "shared-skill" in content, "System prompt should mention the skill name"
-    assert "User registry description - should win" in content, "Should use user source description"
-    assert "Base registry description" not in content, "Should not contain base source description"
+    assert (
+        "User registry description - should win" in content
+    ), "Should use user source description"
+    assert (
+        "Base registry description" not in content
+    ), "Should not contain base source description"
 
 
 def test_before_agent_skips_loading_if_metadata_present(tmp_path: Path) -> None:
@@ -1003,11 +1041,17 @@ def test_create_deep_agent_with_skills_and_filesystem_backend(tmp_path: Path) ->
     agent = create_deep_agent(
         backend=backend,
         skills=[str(skills_dir)],
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="I see the test-skill in the system prompt.")])),
+        model=GenericFakeChatModel(
+            messages=iter(
+                [AIMessage(content="I see the test-skill in the system prompt.")]
+            )
+        ),
     )
 
     # Invoke agent
-    result = agent.invoke({"messages": [HumanMessage(content="What skills are available?")]})
+    result = agent.invoke(
+        {"messages": [HumanMessage(content="What skills are available?")]}
+    )
 
     # Verify invocation succeeded
     assert "messages" in result
@@ -1025,11 +1069,15 @@ def test_create_deep_agent_with_skills_empty_directory(tmp_path: Path) -> None:
     agent = create_deep_agent(
         backend=backend,
         skills=[str(skills_dir)],
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="No skills found, but that's okay.")])),
+        model=GenericFakeChatModel(
+            messages=iter([AIMessage(content="No skills found, but that's okay.")])
+        ),
     )
 
     # Invoke agent
-    result = agent.invoke({"messages": [HumanMessage(content="What skills are available?")]})
+    result = agent.invoke(
+        {"messages": [HumanMessage(content="What skills are available?")]}
+    )
 
     # Verify invocation succeeded even without skills
     assert "messages" in result
@@ -1047,7 +1095,9 @@ def test_create_deep_agent_with_skills_default_backend() -> None:
     checkpointer = InMemorySaver()
     agent = create_deep_agent(
         skills=["/skills/user"],
-        model=GenericFakeChatModel(messages=iter([AIMessage(content="Working with default backend.")])),
+        model=GenericFakeChatModel(
+            messages=iter([AIMessage(content="Working with default backend.")])
+        ),
         checkpointer=checkpointer,
     )
 
@@ -1143,7 +1193,9 @@ def test_skills_middleware_with_store_backend_assistant_id() -> None:
     result_2 = middleware.before_agent({}, runtime, config_2)  # type: ignore
 
     assert result_2 is not None
-    assert len(result_2["skills_metadata"]) == 0  # No skills in assistant-456's namespace yet
+    assert (
+        len(result_2["skills_metadata"]) == 0
+    )  # No skills in assistant-456's namespace yet
 
     # Add skill for assistant-456 with namespace (assistant-456, filesystem)
     assistant_2_skill = make_skill_content("skill-two", "Skill for assistant 2")
@@ -1215,7 +1267,9 @@ async def test_skills_middleware_with_store_backend_assistant_id_async() -> None
     runtime = SimpleNamespace(context=None, store=store, stream_writer=lambda _: None)
 
     # Add skill for assistant-123 with namespace (assistant-123, filesystem)
-    assistant_1_skill = make_skill_content("async-skill-one", "Async skill for assistant 1")
+    assistant_1_skill = make_skill_content(
+        "async-skill-one", "Async skill for assistant 1"
+    )
     store.put(
         ("assistant-123", "filesystem"),
         "/skills/user/async-skill-one/SKILL.md",
@@ -1229,17 +1283,23 @@ async def test_skills_middleware_with_store_backend_assistant_id_async() -> None
     assert result_1 is not None
     assert len(result_1["skills_metadata"]) == 1
     assert result_1["skills_metadata"][0]["name"] == "async-skill-one"
-    assert result_1["skills_metadata"][0]["description"] == "Async skill for assistant 1"
+    assert (
+        result_1["skills_metadata"][0]["description"] == "Async skill for assistant 1"
+    )
 
     # Test: assistant-456 cannot see assistant-123's skill (different namespace)
     config_2 = {"metadata": {"assistant_id": "assistant-456"}}
     result_2 = await middleware.abefore_agent({}, runtime, config_2)  # type: ignore
 
     assert result_2 is not None
-    assert len(result_2["skills_metadata"]) == 0  # No skills in assistant-456's namespace yet
+    assert (
+        len(result_2["skills_metadata"]) == 0
+    )  # No skills in assistant-456's namespace yet
 
     # Add skill for assistant-456 with namespace (assistant-456, filesystem)
-    assistant_2_skill = make_skill_content("async-skill-two", "Async skill for assistant 2")
+    assistant_2_skill = make_skill_content(
+        "async-skill-two", "Async skill for assistant 2"
+    )
     store.put(
         ("assistant-456", "filesystem"),
         "/skills/user/async-skill-two/SKILL.md",
@@ -1252,7 +1312,9 @@ async def test_skills_middleware_with_store_backend_assistant_id_async() -> None
     assert result_3 is not None
     assert len(result_3["skills_metadata"]) == 1
     assert result_3["skills_metadata"][0]["name"] == "async-skill-two"
-    assert result_3["skills_metadata"][0]["description"] == "Async skill for assistant 2"
+    assert (
+        result_3["skills_metadata"][0]["description"] == "Async skill for assistant 2"
+    )
 
     # Test: assistant-123 still only sees its own skill (no cross-contamination)
     result_4 = await middleware.abefore_agent({}, runtime, config_1)  # type: ignore
@@ -1260,4 +1322,6 @@ async def test_skills_middleware_with_store_backend_assistant_id_async() -> None
     assert result_4 is not None
     assert len(result_4["skills_metadata"]) == 1
     assert result_4["skills_metadata"][0]["name"] == "async-skill-one"
-    assert result_4["skills_metadata"][0]["description"] == "Async skill for assistant 1"
+    assert (
+        result_4["skills_metadata"][0]["description"] == "Async skill for assistant 1"
+    )

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
@@ -321,7 +321,9 @@ async def test_abefore_agent_skips_loading_if_metadata_present(tmp_path: Path) -
     assert result is None
 
 
-async def test_agent_with_skills_middleware_multiple_sources_async(tmp_path: Path) -> None:
+async def test_agent_with_skills_middleware_multiple_sources_async(
+    tmp_path: Path,
+) -> None:
     """Test agent with skills from multiple sources (async)."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
@@ -344,7 +346,9 @@ async def test_agent_with_skills_middleware_multiple_sources_async(tmp_path: Pat
     assert all(r.error is None for r in responses)
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="I see both skills.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="I see both skills.")])
+    )
 
     # Create middleware with multiple sources
     sources = [
@@ -383,7 +387,9 @@ async def test_agent_with_skills_middleware_empty_sources_async(tmp_path: Path) 
     skills_dir.mkdir()
 
     # Create fake model
-    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Working without skills.")]))
+    fake_model = GenericFakeChatModel(
+        messages=iter([AIMessage(content="Working without skills.")])
+    )
 
     # Create middleware with empty directory
     middleware = SkillsMiddleware(backend=backend, sources=[str(skills_dir)])

--- a/libs/deepagents/tests/unit_tests/middleware/test_validate_path.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_validate_path.py
@@ -38,18 +38,26 @@ class TestValidatePath:
 
     def test_windows_absolute_path_rejected_backslash(self):
         """Test that Windows absolute paths with backslashes are rejected."""
-        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+        with pytest.raises(
+            ValueError, match="Windows absolute paths are not supported"
+        ):
             _validate_path("C:\\Users\\Documents\\file.txt")
 
-        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+        with pytest.raises(
+            ValueError, match="Windows absolute paths are not supported"
+        ):
             _validate_path("F:\\git\\project\\file.txt")
 
     def test_windows_absolute_path_rejected_forward_slash(self):
         """Test that Windows absolute paths with forward slashes are rejected."""
-        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+        with pytest.raises(
+            ValueError, match="Windows absolute paths are not supported"
+        ):
             _validate_path("C:/Users/Documents/file.txt")
 
-        with pytest.raises(ValueError, match="Windows absolute paths are not supported"):
+        with pytest.raises(
+            ValueError, match="Windows absolute paths are not supported"
+        ):
             _validate_path("D:/data/output.csv")
 
     def test_allowed_prefixes_enforcement(self):

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -114,7 +114,9 @@ class TestDeepAgentEndToEnd:
         agent = create_deep_agent(model=model, tools=[sample_tool])
 
         # Invoke the agent
-        result = agent.invoke({"messages": [HumanMessage(content="Use the sample tool")]})
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="Use the sample tool")]}
+        )
 
         # Verify the agent executed correctly
         assert "messages" in result
@@ -210,7 +212,9 @@ class TestDeepAgentEndToEnd:
         agent = create_deep_agent(model=model, tools=[sample_tool])
 
         # Invoke the agent
-        result = agent.invoke({"messages": [HumanMessage(content="Use sample tool twice")]})
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="Use sample tool twice")]}
+        )
 
         # Verify the agent executed correctly
         assert "messages" in result
@@ -244,7 +248,9 @@ class TestDeepAgentEndToEnd:
 
         with patch("deepagents.graph.init_chat_model", return_value=fake_model):
             # This should not raise AttributeError: 'str' object has no attribute 'profile'
-            agent = create_deep_agent(model="claude-sonnet-4-5-20250929", tools=[sample_tool])
+            agent = create_deep_agent(
+                model="claude-sonnet-4-5-20250929", tools=[sample_tool]
+            )
 
             # Verify agent was created successfully
             assert agent is not None

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -12,8 +12,16 @@ from langgraph.types import Overwrite
 
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
-from deepagents.backends.utils import create_file_data, truncate_if_too_long, update_file_data
-from deepagents.middleware.filesystem import FileData, FilesystemMiddleware, FilesystemState
+from deepagents.backends.utils import (
+    create_file_data,
+    truncate_if_too_long,
+    update_file_data,
+)
+from deepagents.middleware.filesystem import (
+    FileData,
+    FilesystemMiddleware,
+    FilesystemState,
+)
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.subagents import SubAgentMiddleware
 
@@ -32,7 +40,9 @@ def build_composite_state_backend(runtime: ToolRuntime, *, routes):
 class TestAddMiddleware:
     def test_filesystem_middleware(self):
         middleware = [FilesystemMiddleware()]
-        agent = create_agent(model="claude-sonnet-4-20250514", middleware=middleware, tools=[])
+        agent = create_agent(
+            model="claude-sonnet-4-20250514", middleware=middleware, tools=[]
+        )
         assert "files" in agent.stream_channels
         agent_tools = agent.nodes["tools"].bound._tools_by_name.keys()
         assert "ls" in agent_tools
@@ -43,13 +53,26 @@ class TestAddMiddleware:
         assert "grep" in agent_tools
 
     def test_subagent_middleware(self):
-        middleware = [SubAgentMiddleware(default_tools=[], subagents=[], default_model="claude-sonnet-4-20250514")]
-        agent = create_agent(model="claude-sonnet-4-20250514", middleware=middleware, tools=[])
+        middleware = [
+            SubAgentMiddleware(
+                default_tools=[], subagents=[], default_model="claude-sonnet-4-20250514"
+            )
+        ]
+        agent = create_agent(
+            model="claude-sonnet-4-20250514", middleware=middleware, tools=[]
+        )
         assert "task" in agent.nodes["tools"].bound._tools_by_name.keys()
 
     def test_multiple_middleware(self):
-        middleware = [FilesystemMiddleware(), SubAgentMiddleware(default_tools=[], subagents=[], default_model="claude-sonnet-4-20250514")]
-        agent = create_agent(model="claude-sonnet-4-20250514", middleware=middleware, tools=[])
+        middleware = [
+            FilesystemMiddleware(),
+            SubAgentMiddleware(
+                default_tools=[], subagents=[], default_model="claude-sonnet-4-20250514"
+            ),
+        ]
+        agent = create_agent(
+            model="claude-sonnet-4-20250514", middleware=middleware, tools=[]
+        )
         assert "files" in agent.stream_channels
         agent_tools = agent.nodes["tools"].bound._tools_by_name.keys()
         assert "ls" in agent_tools
@@ -69,7 +92,9 @@ class TestFilesystemMiddleware:
         assert len(middleware.tools) == 7  # All tools including execute
 
     def test_init_with_composite_backend(self):
-        backend_factory = lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})
+        backend_factory = lambda rt: build_composite_state_backend(
+            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+        )
         middleware = FilesystemMiddleware(backend=backend_factory)
         assert callable(middleware.backend)
         assert middleware._custom_system_prompt is None
@@ -82,22 +107,33 @@ class TestFilesystemMiddleware:
         assert len(middleware.tools) == 7  # All tools including execute
 
     def test_init_custom_system_prompt_with_composite(self):
-        backend_factory = lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})
-        middleware = FilesystemMiddleware(backend=backend_factory, system_prompt="Custom system prompt")
+        backend_factory = lambda rt: build_composite_state_backend(
+            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+        )
+        middleware = FilesystemMiddleware(
+            backend=backend_factory, system_prompt="Custom system prompt"
+        )
         assert callable(middleware.backend)
         assert middleware._custom_system_prompt == "Custom system prompt"
         assert len(middleware.tools) == 7  # All tools including execute
 
     def test_init_custom_tool_descriptions_default(self):
-        middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})
+        middleware = FilesystemMiddleware(
+            custom_tool_descriptions={"ls": "Custom ls tool description"}
+        )
         assert callable(middleware.backend)
         assert middleware._custom_system_prompt is None
         ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
         assert ls_tool.description == "Custom ls tool description"
 
     def test_init_custom_tool_descriptions_with_composite(self):
-        backend_factory = lambda rt: build_composite_state_backend(rt, routes={"/memories/": (lambda r: StoreBackend(r))})
-        middleware = FilesystemMiddleware(backend=backend_factory, custom_tool_descriptions={"ls": "Custom ls tool description"})
+        backend_factory = lambda rt: build_composite_state_backend(
+            rt, routes={"/memories/": (lambda r: StoreBackend(r))}
+        )
+        middleware = FilesystemMiddleware(
+            backend=backend_factory,
+            custom_tool_descriptions={"ls": "Custom ls tool description"},
+        )
         assert callable(middleware.backend)
         assert middleware._custom_system_prompt is None
         ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
@@ -122,7 +158,17 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
         result = ls_tool.invoke(
-            {"runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}), "path": "/"}
+            {
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
+                "path": "/",
+            }
         )
         assert result == str(["/test.txt", "/test2.txt"])
 
@@ -157,14 +203,23 @@ class TestFilesystemMiddleware:
         result_raw = ls_tool.invoke(
             {
                 "path": "/pokemon/",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         result = result_raw
         # ls should only return files directly in /pokemon/, not in subdirectories
         assert "/pokemon/test2.txt" in result
         assert "/pokemon/charmander.txt" in result
-        assert "/pokemon/water/squirtle.txt" not in result  # In subdirectory, should NOT be listed
+        assert (
+            "/pokemon/water/squirtle.txt" not in result
+        )  # In subdirectory, should NOT be listed
         # ls should also list subdirectories with trailing /
         assert "/pokemon/water/" in result
 
@@ -200,7 +255,14 @@ class TestFilesystemMiddleware:
         result_raw = ls_tool.invoke(
             {
                 "path": "/",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         result = result_raw
@@ -239,12 +301,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         print(glob_search_tool)
         result_raw = glob_search_tool.invoke(
             {
                 "pattern": "*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         result = result_raw
@@ -273,11 +344,20 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result_raw = glob_search_tool.invoke(
             {
                 "pattern": "**/*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         result = result_raw
@@ -307,12 +387,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result_raw = glob_search_tool.invoke(
             {
                 "pattern": "*.py",
                 "path": "/src",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         result = result_raw
@@ -342,11 +431,20 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result_raw = glob_search_tool.invoke(
             {
                 "pattern": "*.{py,pyi}",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         result = result_raw
@@ -366,11 +464,20 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result = glob_search_tool.invoke(
             {
                 "pattern": "*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         print(glob_search_tool)
@@ -393,11 +500,20 @@ class TestFilesystemMiddleware:
 
         state = FilesystemState(messages=[], files=files)
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result_raw = glob_search_tool.invoke(
             {
                 "pattern": "*.txt",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
 
@@ -433,11 +549,20 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "import",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py" in result
@@ -456,12 +581,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "import",
                 "output_mode": "content",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "1: import os" in result
@@ -485,12 +619,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "import",
                 "output_mode": "count",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py:2" in result or "/test.py: 2" in result
@@ -513,12 +656,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "import",
                 "glob": "*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py" in result
@@ -541,12 +693,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "import",
                 "path": "/src",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/src/main.py" in result
@@ -564,12 +725,21 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": r"def \w+\(",
                 "output_mode": "content",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         print(result)
@@ -589,11 +759,20 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "import",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert result == "No matches found"
@@ -610,11 +789,20 @@ class TestFilesystemMiddleware:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = grep_search_tool.invoke(
             {
                 "pattern": "[invalid",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "Invalid regex pattern" in result
@@ -639,7 +827,9 @@ class TestFilesystemMiddleware:
                 },
             )
 
-        result = StoreBackend._search_store_paginated(self, store, ("filesystem",), page_size=10)
+        result = StoreBackend._search_store_paginated(
+            self, store, ("filesystem",), page_size=10
+        )
         assert len(result) == 5
         # Check that all files are present (order may vary)
         keys = {item.key for item in result}
@@ -659,7 +849,9 @@ class TestFilesystemMiddleware:
                 },
             )
 
-        result = StoreBackend._search_store_paginated(self, store, ("filesystem",), page_size=10)
+        result = StoreBackend._search_store_paginated(
+            self, store, ("filesystem",), page_size=10
+        )
         assert len(result) == 10
         keys = {item.key for item in result}
         assert keys == {f"/file{i}.txt" for i in range(10)}
@@ -678,7 +870,9 @@ class TestFilesystemMiddleware:
                 },
             )
 
-        result = StoreBackend._search_store_paginated(self, store, ("filesystem",), page_size=100)
+        result = StoreBackend._search_store_paginated(
+            self, store, ("filesystem",), page_size=100
+        )
         assert len(result) == 250
         keys = {item.key for item in result}
         assert keys == {f"/file{i}.txt" for i in range(250)}
@@ -699,7 +893,9 @@ class TestFilesystemMiddleware:
             )
 
         # Filter for type="test" (every other item, so 10 items)
-        result = StoreBackend._search_store_paginated(self, store, ("filesystem",), filter={"type": "test"}, page_size=5)
+        result = StoreBackend._search_store_paginated(
+            self, store, ("filesystem",), filter={"type": "test"}, page_size=5
+        )
         assert len(result) == 10
         # Verify all returned items have type="test"
         for item in result:
@@ -720,7 +916,9 @@ class TestFilesystemMiddleware:
                 },
             )
 
-        result = StoreBackend._search_store_paginated(self, store, ("filesystem",), page_size=20)
+        result = StoreBackend._search_store_paginated(
+            self, store, ("filesystem",), page_size=20
+        )
         # Should make 3 calls: 20, 20, 15
         assert len(result) == 55
         keys = {item.key for item in result}
@@ -858,7 +1056,14 @@ class TestFilesystemMiddleware:
         """Test that small ToolMessages pass through unchanged."""
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         small_content = "x" * 1000
         tool_message = ToolMessage(content=small_content, tool_call_id="test_123")
@@ -872,7 +1077,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         large_content = "x" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
@@ -888,7 +1100,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         small_content = "x" * 1000
         tool_message = ToolMessage(content=small_content, tool_call_id="test_123")
@@ -904,7 +1123,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         large_content = "y" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
@@ -921,12 +1147,27 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         large_content = "z" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
-        existing_file = FileData(content=["existing"], created_at="2021-01-01", modified_at="2021-01-01")
-        command = Command(update={"messages": [tool_message], "files": {"/existing.txt": existing_file}, "custom_key": "custom_value"})
+        existing_file = FileData(
+            content=["existing"], created_at="2021-01-01", modified_at="2021-01-01"
+        )
+        command = Command(
+            update={
+                "messages": [tool_message],
+                "files": {"/existing.txt": existing_file},
+                "custom_key": "custom_value",
+            }
+        )
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
@@ -948,7 +1189,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         large_content = "x" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test/call.id")
@@ -963,7 +1211,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=100)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_cb", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_cb",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create list with content block with large text
         content_blocks = [{"type": "text", "text": "x" * 5000}]
@@ -981,7 +1236,14 @@ class TestFilesystemMiddleware:
         """Test that content blocks with small text are not evicted."""
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_small_cb", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_small_cb",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create list with content block with small text
         content_blocks = [{"type": "text", "text": "small text"}]
@@ -998,7 +1260,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=100)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_other", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_other",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create list with content block with different type that's large when stringified
         content_blocks = [{"type": "image", "data": "x" * 5000}]
@@ -1015,7 +1284,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=100)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_list", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_list",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create list content that's large when stringified
         list_content = [{"key": "x" * 1000} for _ in range(50)]
@@ -1032,7 +1308,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=100)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_single", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_single",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create single text block with large text
         content_blocks = [{"type": "text", "text": "Hello world! " * 1000}]
@@ -1041,7 +1324,9 @@ class TestFilesystemMiddleware:
 
         assert isinstance(result, Command)
         # Check that the file contains actual text, not stringified dict
-        file_content = result.update["files"]["/large_tool_results/test_single"]["content"]
+        file_content = result.update["files"]["/large_tool_results/test_single"][
+            "content"
+        ]
         file_text = "\n".join(file_content)
         # Should start with the actual text, not with "[{" which would indicate stringified dict
         assert file_text.startswith("Hello world!")
@@ -1053,7 +1338,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=100)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_multi", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_multi",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create multiple text blocks
         content_blocks = [
@@ -1065,7 +1357,9 @@ class TestFilesystemMiddleware:
 
         assert isinstance(result, Command)
         # Check that the file contains stringified structure (starts with "[")
-        file_content = result.update["files"]["/large_tool_results/test_multi"]["content"]
+        file_content = result.update["files"]["/large_tool_results/test_multi"][
+            "content"
+        ]
         file_text = "\n".join(file_content)
         # Should be stringified list of dicts
         assert file_text.startswith("[{")
@@ -1076,7 +1370,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=100)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_mixed", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_mixed",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create mixed content blocks
         content_blocks = [
@@ -1088,7 +1389,9 @@ class TestFilesystemMiddleware:
 
         assert isinstance(result, Command)
         # Check that the file contains stringified structure
-        file_content = result.update["files"]["/large_tool_results/test_mixed"]["content"]
+        file_content = result.update["files"]["/large_tool_results/test_mixed"][
+            "content"
+        ]
         file_text = "\n".join(file_content)
         assert file_text.startswith("[{")
         # Should contain both blocks in the stringified output
@@ -1098,7 +1401,9 @@ class TestFilesystemMiddleware:
     def test_execute_tool_returns_error_when_backend_doesnt_support(self):
         """Test that execute tool returns friendly error instead of raising exception."""
         state = FilesystemState(messages=[], files={})
-        middleware = FilesystemMiddleware()  # Default StateBackend doesn't support execution
+        middleware = (
+            FilesystemMiddleware()
+        )  # Default StateBackend doesn't support execution
 
         # Find the execute tool
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
@@ -1272,7 +1577,14 @@ class TestFilesystemMiddleware:
 
         middleware = FilesystemMiddleware(tool_token_limit_before_evict=1000)
         state = FilesystemState(messages=[], files={})
-        runtime = ToolRuntime(state=state, context=None, tool_call_id="test_123", store=None, stream_writer=lambda _: None, config={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="test_123",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
 
         # Create content with multiple lines, some longer than 1000 chars
         line1 = "short line"
@@ -1309,7 +1621,9 @@ class TestFilesystemMiddleware:
         for i in range(sample_start_idx, len(lines)):
             line = lines[i]
             if line.strip():  # Skip empty lines
-                assert len(line) <= 1010, f"Line {i} exceeds 1000 chars: {len(line)} chars"
+                assert (
+                    len(line) <= 1010
+                ), f"Line {i} exceeds 1000 chars: {len(line)} chars"
 
 
 class TestPatchToolCallsMiddleware:
@@ -1336,7 +1650,13 @@ class TestPatchToolCallsMiddleware:
             HumanMessage(content="Hello, how are you?", id="2"),
             AIMessage(
                 content="I'm doing well, thank you!",
-                tool_calls=[ToolCall(id="123", name="get_events_for_days", args={"date_str": "2025-01-01"})],
+                tool_calls=[
+                    ToolCall(
+                        id="123",
+                        name="get_events_for_days",
+                        args={"date_str": "2025-01-01"},
+                    )
+                ],
                 id="3",
             ),
             HumanMessage(content="What is the weather in Tokyo?", id="4"),
@@ -1368,10 +1688,18 @@ class TestPatchToolCallsMiddleware:
             HumanMessage(content="Hello, how are you?", id="2"),
             AIMessage(
                 content="I'm doing well, thank you!",
-                tool_calls=[ToolCall(id="123", name="get_events_for_days", args={"date_str": "2025-01-01"})],
+                tool_calls=[
+                    ToolCall(
+                        id="123",
+                        name="get_events_for_days",
+                        args={"date_str": "2025-01-01"},
+                    )
+                ],
                 id="3",
             ),
-            ToolMessage(content="I have no events for that date.", tool_call_id="123", id="4"),
+            ToolMessage(
+                content="I have no events for that date.", tool_call_id="123", id="4"
+            ),
             HumanMessage(content="What is the weather in Tokyo?", id="5"),
         ]
         middleware = PatchToolCallsMiddleware()
@@ -1400,13 +1728,25 @@ class TestPatchToolCallsMiddleware:
             HumanMessage(content="Hello, how are you?", id="2"),
             AIMessage(
                 content="I'm doing well, thank you!",
-                tool_calls=[ToolCall(id="123", name="get_events_for_days", args={"date_str": "2025-01-01"})],
+                tool_calls=[
+                    ToolCall(
+                        id="123",
+                        name="get_events_for_days",
+                        args={"date_str": "2025-01-01"},
+                    )
+                ],
                 id="3",
             ),
             HumanMessage(content="What is the weather in Tokyo?", id="4"),
             AIMessage(
                 content="I'm doing well, thank you!",
-                tool_calls=[ToolCall(id="456", name="get_events_for_days", args={"date_str": "2025-01-01"})],
+                tool_calls=[
+                    ToolCall(
+                        id="456",
+                        name="get_events_for_days",
+                        args={"date_str": "2025-01-01"},
+                    )
+                ],
                 id="5",
             ),
             HumanMessage(content="What is the weather in Tokyo?", id="6"),

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -6,7 +6,11 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import CompositeBackend, StateBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
-from deepagents.middleware.filesystem import FileData, FilesystemMiddleware, FilesystemState
+from deepagents.middleware.filesystem import (
+    FileData,
+    FilesystemMiddleware,
+    FilesystemState,
+)
 
 
 def build_composite_state_backend(runtime: ToolRuntime, *, routes):
@@ -44,7 +48,17 @@ class TestFilesystemMiddlewareAsync:
         middleware = FilesystemMiddleware()
         ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
         result = await ls_tool.ainvoke(
-            {"runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}), "path": "/"}
+            {
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
+                "path": "/",
+            }
         )
         assert result == str(["/test.txt", "/test2.txt"])
 
@@ -81,7 +95,14 @@ class TestFilesystemMiddlewareAsync:
         result = await ls_tool.ainvoke(
             {
                 "path": "/pokemon/",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         # ls should only return files directly in /pokemon/, not in subdirectories
@@ -123,7 +144,14 @@ class TestFilesystemMiddlewareAsync:
         result = await ls_tool.ainvoke(
             {
                 "path": "/",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         # ls should list both files and directories at root level
@@ -163,11 +191,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result = await glob_search_tool.ainvoke(
             {
                 "pattern": "*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         # Standard glob: *.py only matches files in root directory, not subdirectories
@@ -197,11 +234,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result = await glob_search_tool.ainvoke(
             {
                 "pattern": "**/*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/src/main.py" in result
@@ -232,12 +278,21 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result = await glob_search_tool.ainvoke(
             {
                 "pattern": "*.py",
                 "path": "/src",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/src/main.py" in result
@@ -268,11 +323,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result = await glob_search_tool.ainvoke(
             {
                 "pattern": "*.{py,pyi}",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py" in result
@@ -293,11 +357,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        glob_search_tool = next(tool for tool in middleware.tools if tool.name == "glob")
+        glob_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "glob"
+        )
         result = await glob_search_tool.ainvoke(
             {
                 "pattern": "*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert result == str([])
@@ -326,11 +399,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "import",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py" in result
@@ -351,12 +433,21 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "import",
                 "output_mode": "content",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "1: import os" in result
@@ -382,12 +473,21 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "import",
                 "output_mode": "count",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py:2" in result or "/test.py: 2" in result
@@ -412,12 +512,21 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "import",
                 "glob": "*.py",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/test.py" in result
@@ -442,12 +551,21 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "import",
                 "path": "/src",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "/src/main.py" in result
@@ -467,12 +585,21 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": r"def \w+\(",
                 "output_mode": "content",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "1: def hello():" in result
@@ -493,11 +620,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "import",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert result == "No matches found"
@@ -516,11 +652,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        grep_search_tool = next(tool for tool in middleware.tools if tool.name == "grep")
+        grep_search_tool = next(
+            tool for tool in middleware.tools if tool.name == "grep"
+        )
         result = await grep_search_tool.ainvoke(
             {
                 "pattern": "[invalid",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "Invalid regex pattern" in result
@@ -539,11 +684,20 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        read_file_tool = next(
+            tool for tool in middleware.tools if tool.name == "read_file"
+        )
         result = await read_file_tool.ainvoke(
             {
                 "file_path": "/test.txt",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "Hello world" in result
@@ -564,13 +718,22 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        read_file_tool = next(
+            tool for tool in middleware.tools if tool.name == "read_file"
+        )
         result = await read_file_tool.ainvoke(
             {
                 "file_path": "/test.txt",
                 "offset": 1,
                 "limit": 2,
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert "Line 2" in result
@@ -585,12 +748,21 @@ class TestFilesystemMiddlewareAsync:
 
         state = FilesystemState(messages=[], files={})
         middleware = FilesystemMiddleware()
-        write_file_tool = next(tool for tool in middleware.tools if tool.name == "write_file")
+        write_file_tool = next(
+            tool for tool in middleware.tools if tool.name == "write_file"
+        )
         result = await write_file_tool.ainvoke(
             {
                 "file_path": "/test.txt",
                 "content": "Hello world",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="tc1", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="tc1",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         # StateBackend returns a Command with files_update
@@ -613,13 +785,22 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        edit_file_tool = next(tool for tool in middleware.tools if tool.name == "edit_file")
+        edit_file_tool = next(
+            tool for tool in middleware.tools if tool.name == "edit_file"
+        )
         result = await edit_file_tool.ainvoke(
             {
                 "file_path": "/test.txt",
                 "old_string": "Hello",
                 "new_string": "Hi",
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="tc2", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="tc2",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         # StateBackend returns a Command with files_update
@@ -642,14 +823,23 @@ class TestFilesystemMiddlewareAsync:
             },
         )
         middleware = FilesystemMiddleware()
-        edit_file_tool = next(tool for tool in middleware.tools if tool.name == "edit_file")
+        edit_file_tool = next(
+            tool for tool in middleware.tools if tool.name == "edit_file"
+        )
         result = await edit_file_tool.ainvoke(
             {
                 "file_path": "/test.txt",
                 "old_string": "Hello",
                 "new_string": "Hi",
                 "replace_all": True,
-                "runtime": ToolRuntime(state=state, context=None, tool_call_id="tc3", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(
+                    state=state,
+                    context=None,
+                    tool_call_id="tc3",
+                    store=None,
+                    stream_writer=lambda _: None,
+                    config={},
+                ),
             }
         )
         assert isinstance(result, Command)
@@ -659,7 +849,9 @@ class TestFilesystemMiddlewareAsync:
     async def test_aexecute_tool_returns_error_when_backend_doesnt_support(self):
         """Test async execute tool returns friendly error instead of raising exception."""
         state = FilesystemState(messages=[], files={})
-        middleware = FilesystemMiddleware()  # Default StateBackend doesn't support execution
+        middleware = (
+            FilesystemMiddleware()
+        )  # Default StateBackend doesn't support execution
 
         # Find the execute tool
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
@@ -807,7 +999,9 @@ class TestFilesystemMiddlewareAsync:
         middleware = FilesystemMiddleware(backend=backend)
 
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
-        result = await execute_tool.ainvoke({"command": "cat large_file", "runtime": rt})
+        result = await execute_tool.ainvoke(
+            {"command": "cat large_file", "runtime": rt}
+        )
 
         assert "Async Very long output..." in result
         assert "truncated" in result

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -97,11 +97,15 @@ class TestSubAgentInvocation:
 
         # Find the ToolMessage that contains the subagent's response
         tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
-        assert len(tool_messages) > 0, "Should have at least one ToolMessage from subagent"
+        assert (
+            len(tool_messages) > 0
+        ), "Should have at least one ToolMessage from subagent"
 
         # Verify the ToolMessage contains the subagent's final response
         subagent_tool_message = tool_messages[0]
-        assert "The sum of 2 and 3 is 5." in subagent_tool_message.content, "ToolMessage should contain subagent's final message content"
+        assert (
+            "The sum of 2 and 3 is 5." in subagent_tool_message.content
+        ), "ToolMessage should contain subagent's final message content"
 
     def test_multiple_subagents_invoked_in_parallel(self) -> None:
         """Test that multiple different subagents can be launched in parallel.
@@ -202,25 +206,31 @@ class TestSubAgentInvocation:
 
         # Find all ToolMessages - should have one for each subagent invocation
         tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
-        assert len(tool_messages) == 2, f"Should have exactly 2 ToolMessages (one per subagent), but got {len(tool_messages)}"
+        assert (
+            len(tool_messages) == 2
+        ), f"Should have exactly 2 ToolMessages (one per subagent), but got {len(tool_messages)}"
 
         # Create a lookup map from tool_call_id to ToolMessage for precise verification
         tool_messages_by_id = {msg.tool_call_id: msg for msg in tool_messages}
 
         # Verify we have both expected tool call IDs
-        assert "call_addition" in tool_messages_by_id, "Should have response from addition subagent"
-        assert "call_multiplication" in tool_messages_by_id, "Should have response from multiplication subagent"
+        assert (
+            "call_addition" in tool_messages_by_id
+        ), "Should have response from addition subagent"
+        assert (
+            "call_multiplication" in tool_messages_by_id
+        ), "Should have response from multiplication subagent"
 
         # Verify the exact content of each response by looking up the specific tool message
         addition_tool_message = tool_messages_by_id["call_addition"]
-        assert addition_tool_message.content == "The sum of 5 and 7 is 12.", (
-            f"Addition subagent should return exact message, got: {addition_tool_message.content}"
-        )
+        assert (
+            addition_tool_message.content == "The sum of 5 and 7 is 12."
+        ), f"Addition subagent should return exact message, got: {addition_tool_message.content}"
 
         multiplication_tool_message = tool_messages_by_id["call_multiplication"]
-        assert multiplication_tool_message.content == "The product of 4 and 6 is 24.", (
-            f"Multiplication subagent should return exact message, got: {multiplication_tool_message.content}"
-        )
+        assert (
+            multiplication_tool_message.content == "The product of 4 and 6 is 24."
+        ), f"Multiplication subagent should return exact message, got: {multiplication_tool_message.content}"
 
 
 class TestStructuredOutput:
@@ -244,7 +254,9 @@ class TestStructuredOutput:
         class WeatherReport(BaseModel):
             """Structured weather information."""
 
-            location: str = Field(description="The city or location for the weather report")
+            location: str = Field(
+                description="The city or location for the weather report"
+            )
             temperature: float = Field(description="Temperature in Celsius")
             condition: str = Field(description="Weather condition (e.g., sunny, rainy)")
 
@@ -279,18 +291,28 @@ class TestStructuredOutput:
         )
 
         # Invoke the agent
-        result = agent.invoke({"messages": [HumanMessage(content="What's the weather in San Francisco?")]})
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="What's the weather in San Francisco?")]}
+        )
 
         # Verify the structured_response key exists in the result
-        assert "structured_response" in result, "Result should contain structured_response key"
+        assert (
+            "structured_response" in result
+        ), "Result should contain structured_response key"
 
         # Verify the structured response is the correct type
         structured_response = result["structured_response"]
-        assert isinstance(structured_response, WeatherReport), f"Expected WeatherReport instance, got {type(structured_response)}"
+        assert isinstance(
+            structured_response, WeatherReport
+        ), f"Expected WeatherReport instance, got {type(structured_response)}"
 
         # Verify the structured response has the correct values
-        expected_response = WeatherReport(location="San Francisco", temperature=18.5, condition="sunny")
-        assert structured_response == expected_response, f"Expected {expected_response}, got {structured_response}"
+        expected_response = WeatherReport(
+            location="San Francisco", temperature=18.5, condition="sunny"
+        )
+        assert (
+            structured_response == expected_response
+        ), f"Expected {expected_response}, got {structured_response}"
 
 
 class TestSubAgentTodoList:
@@ -359,7 +381,11 @@ class TestSubAgentTodoList:
                                             "status": "in_progress",
                                             "activeForm": "Searching for Python history",
                                         },
-                                        {"content": "Summarize findings", "status": "pending", "activeForm": "Summarizing findings"},
+                                        {
+                                            "content": "Summarize findings",
+                                            "status": "pending",
+                                            "activeForm": "Summarizing findings",
+                                        },
                                     ]
                                 },
                                 "id": "call_write_todos_python_1",
@@ -375,8 +401,16 @@ class TestSubAgentTodoList:
                                 "name": "write_todos",
                                 "args": {
                                     "todos": [
-                                        {"content": "Search for Python history", "status": "completed", "activeForm": "Searching for Python history"},
-                                        {"content": "Summarize findings", "status": "completed", "activeForm": "Summarizing findings"},
+                                        {
+                                            "content": "Search for Python history",
+                                            "status": "completed",
+                                            "activeForm": "Searching for Python history",
+                                        },
+                                        {
+                                            "content": "Summarize findings",
+                                            "status": "completed",
+                                            "activeForm": "Summarizing findings",
+                                        },
                                     ]
                                 },
                                 "id": "call_write_todos_python_2",
@@ -385,7 +419,9 @@ class TestSubAgentTodoList:
                         ],
                     ),
                     # Final result message
-                    AIMessage(content="Python was created by Guido van Rossum and released in 1991."),
+                    AIMessage(
+                        content="Python was created by Guido van Rossum and released in 1991."
+                    ),
                 ]
             )
         )
@@ -407,7 +443,11 @@ class TestSubAgentTodoList:
                                             "status": "in_progress",
                                             "activeForm": "Searching for JavaScript history",
                                         },
-                                        {"content": "Compile summary", "status": "pending", "activeForm": "Compiling summary"},
+                                        {
+                                            "content": "Compile summary",
+                                            "status": "pending",
+                                            "activeForm": "Compiling summary",
+                                        },
                                     ]
                                 },
                                 "id": "call_write_todos_js_1",
@@ -428,7 +468,11 @@ class TestSubAgentTodoList:
                                             "status": "completed",
                                             "activeForm": "Searching for JavaScript history",
                                         },
-                                        {"content": "Compile summary", "status": "completed", "activeForm": "Compiling summary"},
+                                        {
+                                            "content": "Compile summary",
+                                            "status": "completed",
+                                            "activeForm": "Compiling summary",
+                                        },
                                     ]
                                 },
                                 "id": "call_write_todos_js_2",
@@ -437,7 +481,9 @@ class TestSubAgentTodoList:
                         ],
                     ),
                     # Final result message
-                    AIMessage(content="JavaScript was created by Brendan Eich at Netscape in 1995."),
+                    AIMessage(
+                        content="JavaScript was created by Brendan Eich at Netscape in 1995."
+                    ),
                 ]
             )
         )
@@ -472,7 +518,11 @@ class TestSubAgentTodoList:
 
         # Invoke the parent agent
         result = parent_agent.invoke(
-            {"messages": [HumanMessage(content="Research Python and JavaScript history")]},
+            {
+                "messages": [
+                    HumanMessage(content="Research Python and JavaScript history")
+                ]
+            },
             config={"configurable": {"thread_id": "test_thread_todos"}},
         )
 
@@ -481,29 +531,37 @@ class TestSubAgentTodoList:
 
         # Find all ToolMessages from the subagents
         tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
-        assert len(tool_messages) == 2, f"Should have exactly 2 ToolMessages, got {len(tool_messages)}"
+        assert (
+            len(tool_messages) == 2
+        ), f"Should have exactly 2 ToolMessages, got {len(tool_messages)}"
 
         # Create lookup map by tool_call_id
         tool_messages_by_id = {msg.tool_call_id: msg for msg in tool_messages}
 
         # Verify both expected tool call IDs are present
-        assert "call_research_python" in tool_messages_by_id, "Should have response from Python researcher"
-        assert "call_research_javascript" in tool_messages_by_id, "Should have response from JavaScript researcher"
+        assert (
+            "call_research_python" in tool_messages_by_id
+        ), "Should have response from Python researcher"
+        assert (
+            "call_research_javascript" in tool_messages_by_id
+        ), "Should have response from JavaScript researcher"
 
         # Verify that todos are NOT in the parent agent's final state
         # (they should be excluded per _EXCLUDED_STATE_KEYS)
-        assert "todos" not in result, "Parent agent state should not contain todos key (it should be excluded per _EXCLUDED_STATE_KEYS)"
+        assert (
+            "todos" not in result
+        ), "Parent agent state should not contain todos key (it should be excluded per _EXCLUDED_STATE_KEYS)"
 
         # Verify the final messages contain the research results
         python_tool_message = tool_messages_by_id["call_research_python"]
-        assert "Python was created by Guido van Rossum" in python_tool_message.content, (
-            f"Expected Python research result in message, got: {python_tool_message.content}"
-        )
+        assert (
+            "Python was created by Guido van Rossum" in python_tool_message.content
+        ), f"Expected Python research result in message, got: {python_tool_message.content}"
 
         javascript_tool_message = tool_messages_by_id["call_research_javascript"]
-        assert "JavaScript was created by Brendan Eich" in javascript_tool_message.content, (
-            f"Expected JavaScript research result in message, got: {javascript_tool_message.content}"
-        )
+        assert (
+            "JavaScript was created by Brendan Eich" in javascript_tool_message.content
+        ), f"Expected JavaScript research result in message, got: {javascript_tool_message.content}"
 
 
 class TestSubAgentsWithStructuredOutput:
@@ -536,7 +594,9 @@ class TestSubAgentsWithStructuredOutput:
 
             city: str = Field(description="Name of the city")
             population: int = Field(description="Total population")
-            metro_area_population: int = Field(description="Metropolitan area population")
+            metro_area_population: int = Field(
+                description="Metropolitan area population"
+            )
 
         # Create parent agent's chat model that calls both subagents in parallel
         parent_chat_model = GenericFakeChatModel(
@@ -567,7 +627,9 @@ class TestSubAgentsWithStructuredOutput:
                         ],
                     ),
                     # Second response: acknowledge both results
-                    AIMessage(content="I've gathered weather and population data for Tokyo."),
+                    AIMessage(
+                        content="I've gathered weather and population data for Tokyo."
+                    ),
                 ]
             )
         )
@@ -648,7 +710,11 @@ class TestSubAgentsWithStructuredOutput:
 
         # Invoke the parent agent
         result = parent_agent.invoke(
-            {"messages": [HumanMessage(content="Tell me about Tokyo's weather and population")]},
+            {
+                "messages": [
+                    HumanMessage(content="Tell me about Tokyo's weather and population")
+                ]
+            },
             config={"configurable": {"thread_id": "test_thread_structured"}},
         )
 
@@ -657,32 +723,38 @@ class TestSubAgentsWithStructuredOutput:
 
         # Find all ToolMessages from the subagents
         tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
-        assert len(tool_messages) == 2, f"Should have exactly 2 ToolMessages, got {len(tool_messages)}"
+        assert (
+            len(tool_messages) == 2
+        ), f"Should have exactly 2 ToolMessages, got {len(tool_messages)}"
 
         # Create lookup map by tool_call_id
         tool_messages_by_id = {msg.tool_call_id: msg for msg in tool_messages}
 
         # Verify both expected tool call IDs are present
-        assert "call_weather" in tool_messages_by_id, "Should have response from weather subagent"
-        assert "call_population" in tool_messages_by_id, "Should have response from population subagent"
+        assert (
+            "call_weather" in tool_messages_by_id
+        ), "Should have response from weather subagent"
+        assert (
+            "call_population" in tool_messages_by_id
+        ), "Should have response from population subagent"
 
         # Verify that structured_response is NOT in the parent agent's final state
         # (it should be excluded per _EXCLUDED_STATE_KEYS)
-        assert "structured_response" not in result, (
-            "Parent agent state should not contain structured_response key (it should be excluded per _EXCLUDED_STATE_KEYS)"
-        )
+        assert (
+            "structured_response" not in result
+        ), "Parent agent state should not contain structured_response key (it should be excluded per _EXCLUDED_STATE_KEYS)"
 
         # Verify the exact content of the ToolMessages
         # When a subagent uses ToolStrategy for structured output, the default tool message
         # content shows the structured response using the Pydantic model's string representation
         weather_tool_message = tool_messages_by_id["call_weather"]
         expected_weather_content = "Returning structured response: city='Tokyo' temperature_celsius=22.5 humidity_percent=65"
-        assert weather_tool_message.content == expected_weather_content, (
-            f"Expected weather ToolMessage content:\n{expected_weather_content}\nGot:\n{weather_tool_message.content}"
-        )
+        assert (
+            weather_tool_message.content == expected_weather_content
+        ), f"Expected weather ToolMessage content:\n{expected_weather_content}\nGot:\n{weather_tool_message.content}"
 
         population_tool_message = tool_messages_by_id["call_population"]
         expected_population_content = "Returning structured response: city='Tokyo' population=14000000 metro_area_population=37400000"
-        assert population_tool_message.content == expected_population_content, (
-            f"Expected population ToolMessage content:\n{expected_population_content}\nGot:\n{population_tool_message.content}"
-        )
+        assert (
+            population_tool_message.content == expected_population_content
+        ), f"Expected population ToolMessage content:\n{expected_population_content}\nGot:\n{population_tool_message.content}"

--- a/libs/deepagents/tests/unit_tests/test_todo_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_todo_middleware.py
@@ -87,13 +87,21 @@ class TestTodoMiddleware:
 
         # The middleware should return error messages for both parallel write_todos calls
         tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
-        assert len(tool_messages) == 2, f"Expected 2 error messages, got {len(tool_messages)}"
+        assert (
+            len(tool_messages) == 2
+        ), f"Expected 2 error messages, got {len(tool_messages)}"
 
         # Verify exact error content and status for both tool messages
         expected_error = "Error: The `write_todos` tool should never be called multiple times in parallel. Please call it only once per model invocation to update the todo list."
         for tool_msg in tool_messages:
-            assert tool_msg.content == expected_error, f"Expected exact error message, got: {tool_msg.content}"
-            assert tool_msg.status == "error", f"Tool message status should be 'error', got: {tool_msg.status}"
+            assert (
+                tool_msg.content == expected_error
+            ), f"Expected exact error message, got: {tool_msg.content}"
+            assert (
+                tool_msg.status == "error"
+            ), f"Tool message status should be 'error', got: {tool_msg.status}"
 
         # No todos should be written since both calls were rejected
-        assert result.get("todos", []) == [], "Todos should be empty when parallel writes are rejected"
+        assert (
+            result.get("todos", []) == []
+        ), "Todos should be empty when parallel writes are rejected"

--- a/libs/deepagents/tests/utils.py
+++ b/libs/deepagents/tests/utils.py
@@ -25,11 +25,21 @@ SAMPLE_MODEL = "claude-sonnet-4-20250514"
 
 @tool(description="Use this tool to get premier league standings")
 def get_premier_league_standings(runtime: ToolRuntime):
-    long_tool_msg = "This is a long tool message that should be evicted to the filesystem.\n" * 300
+    long_tool_msg = (
+        "This is a long tool message that should be evicted to the filesystem.\n" * 300
+    )
     return Command(
         update={
-            "messages": [ToolMessage(content=long_tool_msg, tool_call_id=runtime.tool_call_id)],
-            "files": {"/test.txt": {"content": ["Goodbye world"], "created_at": "2021-01-01", "modified_at": "2021-01-01"}},
+            "messages": [
+                ToolMessage(content=long_tool_msg, tool_call_id=runtime.tool_call_id)
+            ],
+            "files": {
+                "/test.txt": {
+                    "content": ["Goodbye world"],
+                    "created_at": "2021-01-01",
+                    "modified_at": "2021-01-01",
+                }
+            },
             "research": "extra_value",
         }
     )
@@ -37,10 +47,14 @@ def get_premier_league_standings(runtime: ToolRuntime):
 
 @tool(description="Use this tool to get la liga standings")
 def get_la_liga_standings(runtime: ToolRuntime):
-    long_tool_msg = "This is a long tool message that should be evicted to the filesystem.\n" * 300
+    long_tool_msg = (
+        "This is a long tool message that should be evicted to the filesystem.\n" * 300
+    )
     return Command(
         update={
-            "messages": [ToolMessage(content=long_tool_msg, tool_call_id=runtime.tool_call_id)],
+            "messages": [
+                ToolMessage(content=long_tool_msg, tool_call_id=runtime.tool_call_id)
+            ],
         }
     )
 
@@ -78,11 +92,18 @@ def sample_tool_with_injected_state(sample_input: str, runtime: ToolRuntime):
 TOY_BASKETBALL_RESEARCH = "Lebron James is the best basketball player of all time with over 40k points and 21 seasons in the NBA."
 
 
-@tool(description="Use this tool to conduct research into basketball and save it to state")
+@tool(
+    description="Use this tool to conduct research into basketball and save it to state"
+)
 def research_basketball(topic: str, runtime: ToolRuntime):
     current_research = runtime.state.get("research", "")
     research = f"{current_research}\n\nResearching on {topic}... Done! {TOY_BASKETBALL_RESEARCH}"
-    return Command(update={"research": research, "messages": [ToolMessage(research, tool_call_id=runtime.tool_call_id)]})
+    return Command(
+        update={
+            "research": research,
+            "messages": [ToolMessage(research, tool_call_id=runtime.tool_call_id)],
+        }
+    )
 
 
 class ResearchState(AgentState):


### PR DESCRIPTION
Description:

Related Issue: Closes #716

Description: This PR fixes a KeyError: 'system_prompt' that occurs when using create_deep_agent with certain custom LLM configurations. The SubAgentMiddleware previously assumed the system_prompt key would always be present in the state.

Changes:

Updated SubAgentMiddleware to use .get() for system_prompt access.

Added robustness to wrap_model_call for missing request attributes.

Verified with a reproduction script using mock LLMs (handles missing keys and aliases).

Validation:

[x] Reproduction script passed.

[x] pytest tests/unit_tests/test_subagents.py passed.

[x] pytest tests/unit_tests/test_middleware.py passed.