### PR TITLE
fix: added error catching for file operations without permissions

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -392,7 +392,10 @@ class FilesystemBackend(BackendProtocol):
         root = base_full if base_full.is_dir() else base_full.parent
 
         for fp in root.rglob("*"):
-            if not fp.is_file():
+            try:
+                if not fp.is_file():
+                    continue
+            except (PermissionError, OSError):
                 continue
             if include_glob and not wcglob.globmatch(fp.name, include_glob, flags=wcglob.BRACE):
                 continue
@@ -432,7 +435,7 @@ class FilesystemBackend(BackendProtocol):
             for matched_path in search_path.rglob(pattern):
                 try:
                     is_file = matched_path.is_file()
-                except OSError:
+                except (PermissionError, OSError):
                     continue
                 if not is_file:
                     continue


### PR DESCRIPTION
In its current state, file operations on protected files throws a PermissionError. this is not currently caught and rightfully propagates up to main and crashes the program. Here is a stack trace - can reproduce on DeepAgents 0.3.5.

```
» grep("target")                                                                           
  Traceback (most recent call last):                                                                                                  
  File "/home/localuser/project/.venv/bin/project", line 10, in <module>                                                            
  sys.exit(cli())                                                                                                                     
  ^^^^^                                                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/click/core.py", line 1485, in __call__                         
  return self.main(*args, **kwargs)                                                                                                   
  ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/click/core.py", line 1406, in main                             
  rv = self.invoke(ctx)                                                                                                               
  ^^^^^^^^^^^^^^^^                                                                                                                    
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/click/core.py", line 1873, in invoke                           
  return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                             
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                     
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/click/core.py", line 1269, in invoke                           
  return ctx.invoke(self.callback, **ctx.params)                                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/click/core.py", line 824, in invoke                            
  return callback(*args, **kwargs)                                                                                                    
  ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                           
  File "/home/localuser/project/src/project/cli/main.py", line 91, in run_command                                                   
  asyncio.run(_async_run(goal, agent, verbose, json_output))                                                                          
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 195, in      
  run                                                                                                                                 
  return runner.run(main)                                                                                                             
  ^^^^^^^^^^^^^^^^                                                                                                                    
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 118, in      
  run                                                                                                                                 
  return self._loop.run_until_complete(task)                                                                                          
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                 
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/base_events.py", line 691,     
  in run_until_complete                                                                                                               
  return future.result()                                                                                                              
  ^^^^^^^^^^^^^^^                                                                                                                     
  File "/home/localuser/project/src/project/cli/main.py", line 658, in _async_run                                                   
  final_state = await execute_autonomous_task(                                                                                        
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                      
  File "/home/localuser/project/src/project/display/execution.py", line 129, in execute_autonomous_task                             
  async for chunk in agent.astream(                                                                                                   
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/main.py", line 2974, in astream               
  async for _ in runner.atick(                                                                                                        
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/_runner.py", line 410, in atick               
  _panic_or_proceed(                                                                                                                  
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/_runner.py", line 520, in _panic_or_proceed   
  raise exc                                                                                                                           
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/_retry.py", line 138, in arun_with_retry      
  return await task.proc.ainvoke(task.input, config)                                                                                  
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                         
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/_internal/_runnable.py", line 705, in ainvoke        
  input = await asyncio.create_task(                                                                                                  
  ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/_internal/_runnable.py", line 473, in ainvoke        
  ret = await self.afunc(*args, **kwargs)                                                                                             
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                   
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 845, in _afunc          
  outputs = await asyncio.gather(*coros)                                                                                              
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1199, in _arun_one      
  content = _handle_tool_error(e, flag=self._handle_tool_errors)                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 429, in                 
  _handle_tool_error                                                                                                                  
  content = flag(e)  # type: ignore [assignment, call-arg]                                                                            
  ^^^^^^^                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 386, in                 
  _default_handle_tool_errors                                                                                                         
  raise e                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1190, in _arun_one      
  return await self._awrap_tool_call(tool_request, execute)                                                                           
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/middleware/filesystem.py", line 1143, in            
  awrap_tool_call                                                                                                                     
  tool_result = await handler(request)                                                                                                
  ^^^^^^^^^^^^^^^^^^^^^^                                                                                                              
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1181, in execute        
  return await self._execute_tool_async(req, input_type, config)                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1125, in                
  _execute_tool_async                                                                                                                 
  content = _handle_tool_error(e, flag=self._handle_tool_errors)                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 429, in                 
  _handle_tool_error                                                                                                                  
  content = flag(e)  # type: ignore [assignment, call-arg]                                                                            
  ^^^^^^^                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 386, in                 
  _default_handle_tool_errors                                                                                                         
  raise e                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1082, in                
  _execute_tool_async                                                                                                                 
  response = await tool.ainvoke(call_args, config)                                                                                    
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/structured.py", line 67, in ainvoke       
  return await super().ainvoke(input, config, **kwargs)                                                                               
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                      
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/base.py", line 642, in ainvoke            
  return await self.arun(tool_input, **kwargs)                                                                                        
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/base.py", line 1117, in arun              
  raise error_to_raise                                                                                                                
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/base.py", line 1083, in arun              
  response = await coro_with_context(coro, context)                                                                                   
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                              
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/structured.py", line 121, in _arun        
  return await self.coroutine(*args, **kwargs)                                                                                        
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/middleware/subagents.py", line 370, in atask        
  result = await subagent.ainvoke(subagent_state, runtime.config)                                                                     
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                              
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/main.py", line 3161, in ainvoke               
  async for chunk in self.astream(                                                                                                    
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/main.py", line 2974, in astream               
  async for _ in runner.atick(                                                                                                        
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/_runner.py", line 304, in atick               
  await arun_with_retry(                                                                                                              
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/pregel/_retry.py", line 138, in arun_with_retry      
  return await task.proc.ainvoke(task.input, config)                                                                                  
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                         
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/_internal/_runnable.py", line 705, in ainvoke        
  input = await asyncio.create_task(                                                                                                  
  ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/_internal/_runnable.py", line 473, in ainvoke        
  ret = await self.afunc(*args, **kwargs)                                                                                             
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                   
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 845, in _afunc          
  outputs = await asyncio.gather(*coros)                                                                                              
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1199, in _arun_one      
  content = _handle_tool_error(e, flag=self._handle_tool_errors)                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 429, in                 
  _handle_tool_error                                                                                                                  
  content = flag(e)  # type: ignore [assignment, call-arg]                                                                            
  ^^^^^^^                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 386, in                 
  _default_handle_tool_errors                                                                                                         
  raise e                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1190, in _arun_one      
  return await self._awrap_tool_call(tool_request, execute)                                                                           
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                  
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/middleware/filesystem.py", line 1141, in            
  awrap_tool_call                                                                                                                     
  return await handler(request)                                                                                                       
  ^^^^^^^^^^^^^^^^^^^^^^                                                                                                              
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1181, in execute        
  return await self._execute_tool_async(req, input_type, config)                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1125, in                
  _execute_tool_async                                                                                                                 
  content = _handle_tool_error(e, flag=self._handle_tool_errors)                                                                      
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 429, in                 
  _handle_tool_error                                                                                                                  
  content = flag(e)  # type: ignore [assignment, call-arg]                                                                            
  ^^^^^^^                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 386, in                 
  _default_handle_tool_errors                                                                                                         
  raise e                                                                                                                             
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langgraph/prebuilt/tool_node.py", line 1082, in                
  _execute_tool_async                                                                                                                 
  response = await tool.ainvoke(call_args, config)                                                                                    
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/structured.py", line 67, in ainvoke       
  return await super().ainvoke(input, config, **kwargs)                                                                               
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                      
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/base.py", line 642, in ainvoke            
  return await self.arun(tool_input, **kwargs)                                                                                        
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/base.py", line 1117, in arun              
  raise error_to_raise                                                                                                                
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/base.py", line 1083, in arun              
  response = await coro_with_context(coro, context)                                                                                   
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                              
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/langchain_core/tools/structured.py", line 121, in _arun        
  return await self.coroutine(*args, **kwargs)                                                                                        
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                               
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/middleware/filesystem.py", line 631, in             
  async_grep                                                                                                                          
  raw = await resolved_backend.agrep_raw(pattern, path=path, glob=glob)                                                               
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                     
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/backends/composite.py", line 300, in agrep_raw      
  raw_default = await self.default.agrep_raw(pattern, path, glob)  # type: ignore[attr-defined]                                       
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/backends/protocol.py", line 277, in agrep_raw       
  return await asyncio.to_thread(self.grep_raw, pattern, path, glob)                                                                  
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                         
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/threads.py", line 25, in       
  to_thread                                                                                                                           
  return await loop.run_in_executor(None, func_call)                                                                                  
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                         
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/concurrent/futures/thread.py", line    
  59, in run                                                                                                                          
  result = self.fn(*self.args, **self.kwargs)                                                                                         
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                  
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/backends/filesystem.py", line 332, in grep_raw      
  results = self._python_search(pattern, base_full, glob)                                                                             
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                       
  File "/home/localuser/project/.venv/lib/python3.12/site-packages/deepagents/backends/filesystem.py", line 395, in               
  _python_search                                                                                                                      
  if not fp.is_file():                                                                                                                
  ^^^^^^^^^^^^                                                                                                                        
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/pathlib.py", line 892, in is_file      
  return S_ISREG(self.stat().st_mode)                                                                                                 
  ^^^^^^^^^^^                                                                                                                         
  File "/home/localuser/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/pathlib.py", line 840, in stat         
  return os.stat(self, follow_symlinks=follow_symlinks)                                                                               
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                      
  PermissionError: [Errno 13] Permission denied: '/proc/1/cwd'                                                                        
  During task with name 'tools' and id '81c59826-dc45-34dd-0313-ce0587d154cc'                                                         
  During task with name 'tools' and id '1e631187-dfcd-f8aa-d252-0243e039455c'                                                         
```