### PR TITLE
feat: add agent name when creating subagents

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -251,7 +251,7 @@ def _get_subagents(
             system_prompt=DEFAULT_SUBAGENT_PROMPT,
             tools=default_tools,
             middleware=general_purpose_middleware,
-            name="subagent:general-purpose",
+            name="general-purpose",
         )
         agents["general-purpose"] = general_purpose_subagent
         subagent_descriptions.append(f"- general-purpose: {DEFAULT_GENERAL_PURPOSE_DESCRIPTION}")


### PR DESCRIPTION
before
<img width="329" height="104" alt="Screenshot 2026-01-13 at 5 09 38 PM" src="https://github.com/user-attachments/assets/04139663-0c0d-4d09-a379-948c71180eb6" />

after
<img width="327" height="160" alt="Screenshot 2026-01-13 at 5 08 41 PM" src="https://github.com/user-attachments/assets/400112d3-fd06-4de9-a717-e8d70f9f07af" />

should work w/ the LS team to make `weather` visible as an agent...