### PR TITLE
fix(cli): add explicit package inclusion for setuptools

### DIFF
--- a/libs/deepagents-cli/pyproject.toml
+++ b/libs/deepagents-cli/pyproject.toml
@@ -63,6 +63,9 @@ lint = [
 requires = ["setuptools>=73.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["deepagents_cli*"]
+
 [tool.setuptools.package-data]
 deepagents_cli = ["default_agent_prompt.md"]
 


### PR DESCRIPTION
makes the build declarative; it will always include exactly the specified packages regardless of what else exists in the directory.

this happened to me where the CLI created data directories during testing and subsequently failed to rebuild as a result