### PR TITLE
feat(cli): format file tree with markdown

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/local_context.py
+++ b/libs/deepagents-cli/deepagents_cli/local_context.py
@@ -493,7 +493,9 @@ class LocalContextMiddleware(AgentMiddleware):
         tree = self._get_directory_tree()
         if tree:
             sections.append("**Tree** (3 levels):")
+            sections.append("```text")
             sections.append(tree)
+            sections.append("```")
             sections.append("")
 
         # Makefile preview


### PR DESCRIPTION
for better rendering (e.g. in langsmith)