### PR TITLE
fix(sdk):  FilesystemMiddleware forward 'name' attribute in large_tool_result from the original tool msg

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1128,6 +1128,7 @@ class FilesystemMiddleware(AgentMiddleware):
         processed_message = ToolMessage(
             content=replacement_text,
             tool_call_id=message.tool_call_id,
+            name=message.name,
         )
         return processed_message, result.files_update
 

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -300,7 +300,7 @@ async def test_store_backend_aintercept_large_tool_result_async():
     middleware = FilesystemMiddleware(backend=lambda r: StoreBackend(r), tool_token_limit_before_evict=1000)
 
     large_content = "z" * 5000
-    tool_message = ToolMessage(content=large_content, tool_call_id="test_async_789")
+    tool_message = ToolMessage(content=large_content, tool_call_id="test_async_789", name="example_tool")
 
     # Use the async intercept path (what awrap_tool_call uses)
     result = await middleware._aintercept_large_tool_result(tool_message, rt)
@@ -308,6 +308,7 @@ async def test_store_backend_aintercept_large_tool_result_async():
     assert isinstance(result, ToolMessage)
     assert "Tool result too large" in result.content
     assert "/large_tool_results/test_async_789" in result.content
+    assert result.name == "example_tool"
 
     # Verify content was stored via async path
     stored_content = await rt.store.aget(("filesystem",), "/large_tool_results/test_async_789")


### PR DESCRIPTION
Currently 'name' property from the original tool call is lost when `_process_large_message()` is called when `tool_token_limit_before_evict` is reached.

In our case this affects some front end libraries which want to display the name of the tool (including LangSmith Studio).

Regarding tests: I couldn't see any tests on `_aintercept_large_tool_result()` in `test_middleware.py` so added I added it to `test_store_backend_async.py` for now. Let me know if this needs to be changed. 