### PR TITLE
feat(cli): add interactive step-into mode for subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,54 @@ agent = create_deep_agent(
 
 See the [subagents documentation](https://docs.langchain.com/oss/python/deepagents/subagents) for more details.
 
+### Step-Into Mode for Subagents
+
+Traditional subagent delegation is fire-and-forget: you send a task, wait for results, and hope it explored the right direction. **Step-into mode** changes this by letting you enter an interactive session with the subagent while maintaining context isolation.
+
+When using the CLI with human-in-the-loop enabled, subagent invocations present a new option:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🤖 Task: Subagent Invocation                                │
+│                                                             │
+│ [Approve]  [Reject]  [Step into]  [Auto-accept all]         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Selecting **Step into** opens an interactive session where you can:
+
+- **Guide exploration in real-time** - redirect the subagent mid-task instead of starting over
+- **Ask follow-up questions** - dig deeper into findings within the isolated context
+- **Curate the summary** - decide what information returns to the parent context
+
+```
+You: Research the authentication system
+
+Agent: I'll delegate this to a subagent.
+
+[Select "Step into"]
+
+[general-purpose:1] > Agent finds 3 auth methods...
+
+[general-purpose:1] > Focus on JWT only.
+
+[general-purpose:1] > Agent explores JWT, finds issues...
+
+[general-purpose:1] > /return   ← exit with curated summary
+```
+
+Key commands in step-into mode:
+
+| Command | Description |
+|---------|-------------|
+| `/return` | Exit subagent and send summary to parent |
+| `/summary` | View or edit the summary file |
+| `/context` | Show your position in the context stack |
+
+Step-into supports nesting - you can step into subagents spawned by subagents, with `/return` unwinding one level at a time.
+
+See the [step-into documentation](libs/deepagents-cli/STEP_INTO.md) for the full guide.
+
 ### `interrupt_on`
 
 Some tools may be sensitive and require human approval before execution. Deepagents supports human-in-the-loop workflows through LangGraph’s interrupt capabilities. You can configure which tools require approval using a checkpointer.

--- a/libs/deepagents-cli/STEP_INTO.md
+++ b/libs/deepagents-cli/STEP_INTO.md
@@ -1,0 +1,252 @@
+# Step-Into Subagents: Interactive Context Branching
+
+## Manifesto: Reclaiming Control in Agentic Systems
+
+### The False Equivalence
+
+The current paradigm of AI agent delegation rests on a flawed assumption: that **context isolation requires surrendering control**.
+
+When we delegate to a subagent today, we fire a task into the void and wait for results. We call this "autonomy." But autonomy without oversight is abandonment. We've confused giving agents space to work with cutting the communication channel entirely.
+
+**Context isolation** is a technical constraint. Tokens are finite. Verbose exploration pollutes focused conversation. Memory has boundaries.
+
+**Control** is a human need. We steer. We course-correct. We say "not that direction" and "dig deeper here." We are not task-specifiers; we are collaborators.
+
+These are orthogonal concerns. The industry has collapsed them into one.
+
+### The Batch Processing Trap
+
+Current subagent architectures are batch jobs wearing agent costumes:
+
+```
+INPUT → [BLACK BOX] → OUTPUT
+```
+
+You specify everything upfront. The agent runs. You receive results. If the results are wrong, you start over with better instructions.
+
+This is 1960s computing with better marketing.
+
+True collaboration looks different:
+
+```
+HUMAN ←→ AGENT ←→ HUMAN ←→ AGENT
+         ↓
+    [isolated context]
+         ↓
+      summary
+```
+
+The context can be isolated. The channel should not be.
+
+### Principles
+
+**1. Isolation is Memory, Not Communication**
+
+Context isolation means: "Your working memory is separate from mine."
+It does not mean: "We cannot speak."
+
+A subagent should have its own context window, its own scratchpad, its own exploration space. But messages should flow. Questions should be askable. Guidance should be givable.
+
+**2. Delegation is Not Abdication**
+
+When you delegate to a human colleague, you don't seal them in a room and wait for a report. You check in. You redirect. You say "actually, focus on X instead."
+
+Agents deserve the same interactive relationship. Delegation should be a tether, not a severance.
+
+**3. Summarization is Export, Not the Only Exit**
+
+The current model forces all subagent work through a summarization bottleneck. Everything must be compressed to return to the parent context.
+
+But sometimes you want to *enter* the subagent's context. Explore what it found. Ask follow-up questions in its space. Then return with what *you* decide is relevant.
+
+The summary should be one option, not the only option.
+
+**4. Control Has Granularity**
+
+Not all tasks need the same level of oversight:
+
+- **Fire-and-forget**: "Search for X and summarize" - current model works fine
+- **Checkpoint-based**: "Explore, but check with me before making decisions"
+- **Interactive**: "Let's explore this together in a separate context"
+- **Supervised**: "Do this, but stream your reasoning so I can interrupt"
+
+One interaction model cannot serve all needs.
+
+---
+
+*Context isolation is about memory.*
+*Control is about agency.*
+*They were never the same thing.*
+
+---
+
+## How It Works
+
+When the agent invokes the `task` tool to delegate work to a subagent, you now see a new option:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🤖 Task: Subagent Invocation                                │
+│                                                             │
+│ Subagent Type: general-purpose                              │
+│                                                             │
+│ Task Instructions:                                          │
+│ ────────────────────────────────────────                    │
+│ Research how JWT refresh tokens work in this codebase...    │
+│ ────────────────────────────────────────                    │
+│                                                             │
+│ [Approve]  [Reject]  [Step into]  [Auto-accept all]         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+| Option | Behavior |
+|--------|----------|
+| **Approve** | Fire-and-forget (existing behavior) |
+| **Reject** | Don't run the subagent |
+| **Step into** | Enter the subagent conversation interactively |
+| **Auto-accept all** | Approve all future tool calls |
+
+## Usage
+
+### Stepping Into a Subagent
+
+1. When the agent wants to delegate, select **"Step into"** (press `S` or arrow down)
+2. You enter an interactive session with the subagent
+3. The prompt changes to show your depth: `[general-purpose:1] >`
+4. Work with the subagent as you would normally
+5. A summary file is created at `~/.deepagents/{agent}/branches/{id}/summary.md`
+
+### New Commands
+
+| Command | Description |
+|---------|-------------|
+| `/return` | Exit subagent, send summary to parent, return to previous context |
+| `/summary` | View or edit the summary file (opens in `$EDITOR` if set) |
+| `/context` | Show your current position in the context stack |
+
+### Example Session
+
+```
+You: Research the authentication system in this codebase
+
+Agent: I'll delegate this to a subagent for focused exploration.
+
+[HITL prompt appears - select "Step into"]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Stepped into: general-purpose subagent
+Summary file: ~/.deepagents/agent/branches/abc123/summary.md
+Type /return to exit, /summary to edit summary, /context to see stack
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+[general-purpose:1] > The agent starts working...
+
+Agent: Found 3 auth approaches - JWT, session-based, and OAuth.
+       Which should I focus on?
+
+[general-purpose:1] > JWT. Ignore the others.
+
+Agent: JWT implementation spans 4 files. The token refresh logic
+       looks suspicious. Want me to dig into that?
+
+[general-purpose:1] > Yes, and check if there are tests for it.
+
+Agent: [explores, finds issues, reports back]
+
+[general-purpose:1] > Add your findings to the summary.
+
+Agent: [edits summary.md]
+
+[general-purpose:1] > /return
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✓ Returned to root
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Agent: Based on the subagent's findings, the JWT implementation has...
+       [continues with the summary you helped craft]
+```
+
+### Viewing Context Stack
+
+```
+> /context
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Context Stack:
+  [0] root (main conversation)
+  [1] general-purpose ← current
+      task: "Research authentication system"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Summary: ~/.deepagents/agent/branches/abc123/summary.md
+```
+
+### Nested Step-Into
+
+You can step into subagents from within subagents:
+
+```
+[general-purpose:1] Agent: I'll delegate the OAuth part to another subagent.
+
+[Select "Step into" again]
+
+[general-purpose:2] > Now you're two levels deep
+
+[general-purpose:2] > /return  ← returns to depth 1
+
+[general-purpose:1] > /return  ← returns to root
+```
+
+## Summary File
+
+When you step into a subagent, a summary file is created:
+
+**Location:** `~/.deepagents/{agent}/branches/{branch_id}/summary.md`
+
+**Template:**
+```markdown
+# Branch Summary: general-purpose
+
+## Task
+[Original task description from parent]
+
+## Findings
+
+<!-- Add your findings here -->
+
+## Conclusion
+
+<!-- Summary for parent context -->
+```
+
+You can:
+- Ask the agent to update it: "Add this to the summary"
+- Edit it directly: `/summary` opens it in your `$EDITOR`
+- View it: `/summary` displays contents if no editor is set
+
+When you `/return`, this file's contents are sent to the parent agent.
+
+## Comparison
+
+| Aspect | Fire-and-Forget | Step Into |
+|--------|-----------------|-----------|
+| **Control** | None - wait for result | Full - guide the exploration |
+| **Visibility** | Black box | See every step |
+| **Course correction** | Start over with new prompt | Redirect mid-task |
+| **Summary quality** | Agent decides what's important | You decide together |
+| **Context isolation** | Yes | Yes |
+| **Token efficiency** | Yes | Yes |
+
+## Design Decisions
+
+| Aspect | Decision |
+|--------|----------|
+| **Persistence** | Ephemeral - branches exist only in current session |
+| **Inheritance** | Full - subagent has same tools/middleware as parent |
+| **`/clear` behavior** | Resets all contexts back to root |
+
+## Technical Details
+
+- Uses LangGraph's thread-based checkpointing for context isolation
+- Context stack tracks nested conversations
+- Summary injection uses `agent.aupdate_state()` on return
+- Same agent instance, different thread IDs per context

--- a/libs/deepagents-cli/deepagents_cli/commands.py
+++ b/libs/deepagents-cli/deepagents_cli/commands.py
@@ -1,15 +1,28 @@
 """Command handlers for slash commands and bash execution."""
 
+import os
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 from langgraph.checkpoint.memory import InMemorySaver
 
-from .config import COLORS, DEEP_AGENTS_ASCII, console
+from .config import COLORS, DEEP_AGENTS_ASCII, SessionState, console
 from .ui import TokenTracker, show_interactive_help
 
 
-def handle_command(command: str, agent, token_tracker: TokenTracker) -> str | bool:
+@dataclass
+class CommandResult:
+    """Result of a command handler."""
+
+    handled: bool = True
+    exit: bool = False
+    return_to_parent: bool = False  # Signals main loop to inject summary and switch context
+
+
+def handle_command(
+    command: str, agent, token_tracker: TokenTracker, session_state: SessionState
+) -> CommandResult | str | bool:
     """Handle slash commands. Returns 'exit' to exit, True if handled, False to pass to agent."""
     cmd = command.lower().strip().lstrip("/")
 
@@ -19,6 +32,9 @@ def handle_command(command: str, agent, token_tracker: TokenTracker) -> str | bo
     if cmd == "clear":
         # Reset agent conversation state
         agent.checkpointer = InMemorySaver()
+
+        # Reset context stack to fresh root
+        session_state.reset_to_root()
 
         # Reset token tracking to baseline
         token_tracker.reset()
@@ -41,13 +57,20 @@ def handle_command(command: str, agent, token_tracker: TokenTracker) -> str | bo
         token_tracker.display_session()
         return True
 
+    if cmd == "return":
+        return _handle_return_command(session_state)
+
+    if cmd == "summary":
+        return _handle_summary_command(session_state)
+
+    if cmd == "context":
+        return _handle_context_command(session_state)
+
     console.print()
     console.print(f"[yellow]Unknown command: /{cmd}[/yellow]")
     console.print("[dim]Type /help for available commands.[/dim]")
     console.print()
     return True
-
-    return False
 
 
 def execute_bash_command(command: str) -> bool:
@@ -87,3 +110,121 @@ def execute_bash_command(command: str) -> bool:
         console.print(f"[red]Error executing command: {e}[/red]")
         console.print()
         return True
+
+
+def _handle_return_command(session_state: SessionState) -> CommandResult | bool:
+    """Handle /return command to exit from a stepped-into subagent.
+
+    Returns CommandResult with return_to_parent=True to signal main loop to inject summary.
+    """
+    if session_state.depth == 0:
+        console.print()
+        console.print("[yellow]Already at root context - nothing to return from.[/yellow]")
+        console.print()
+        return True
+
+    ctx = session_state.current_context
+    console.print()
+    console.print("━" * 60)
+    console.print(f"[bold cyan]Returning from: {ctx.subagent_type}[/bold cyan]")
+
+    # Read summary file if it exists
+    summary_content = ""
+    if ctx.summary_path and ctx.summary_path.exists():
+        summary_content = ctx.summary_path.read_text()
+        console.print(f"[dim]Summary loaded from: {ctx.summary_path}[/dim]")
+    else:
+        console.print("[yellow]No summary file found - returning with empty summary.[/yellow]")
+
+    console.print("━" * 60)
+    console.print()
+
+    # Store summary content in context before returning
+    # The main loop will handle popping and injecting
+    ctx.summary_content = summary_content  # type: ignore[attr-defined]
+
+    return CommandResult(handled=True, return_to_parent=True)
+
+
+def _handle_summary_command(session_state: SessionState) -> bool:
+    """Handle /summary command to view/edit the summary file."""
+    if session_state.depth == 0:
+        console.print()
+        console.print("[yellow]Not in a subagent context - no summary file.[/yellow]")
+        console.print()
+        return True
+
+    ctx = session_state.current_context
+    if not ctx.summary_path:
+        console.print()
+        console.print("[yellow]No summary file for this context.[/yellow]")
+        console.print()
+        return True
+
+    console.print()
+    console.print(f"[bold]Summary file:[/bold] {ctx.summary_path}")
+    console.print()
+
+    # Check if $EDITOR is set
+    editor = os.environ.get("EDITOR")
+    if editor:
+        console.print(f"[dim]Opening in {editor}...[/dim]")
+        console.print()
+        try:
+            subprocess.run([editor, str(ctx.summary_path)], check=False)
+        except Exception as e:
+            console.print(f"[red]Error opening editor: {e}[/red]")
+            console.print("[dim]Displaying file contents instead:[/dim]")
+            console.print()
+            _display_summary_file(ctx.summary_path)
+    else:
+        console.print("[dim]Set $EDITOR to open in your preferred editor.[/dim]")
+        console.print("[dim]Displaying current contents:[/dim]")
+        console.print()
+        _display_summary_file(ctx.summary_path)
+
+    console.print()
+    return True
+
+
+def _display_summary_file(path: Path) -> None:
+    """Display the contents of a summary file."""
+    if path.exists():
+        content = path.read_text()
+        console.print("─" * 40)
+        console.print(content, markup=False)
+        console.print("─" * 40)
+    else:
+        console.print("[yellow]File does not exist yet.[/yellow]")
+
+
+def _handle_context_command(session_state: SessionState) -> bool:
+    """Handle /context command to show the conversation stack."""
+    console.print()
+    console.print("━" * 40)
+    console.print("[bold]Context Stack:[/bold]")
+    console.print()
+
+    for i, ctx in enumerate(session_state.context_stack):
+        is_current = i == len(session_state.context_stack) - 1
+        marker = " ← current" if is_current else ""
+
+        if ctx.subagent_type == "root":
+            console.print(f"  [{i}] root (main conversation){marker}")
+        else:
+            task_preview = ctx.task_description[:40] + "..." if len(ctx.task_description) > 40 else ctx.task_description
+            console.print(f"  [{i}] {ctx.subagent_type}{marker}")
+            if task_preview:
+                console.print(f"      [dim]task: \"{task_preview}\"[/dim]")
+
+    console.print()
+    console.print("━" * 40)
+
+    # Show summary path if in subagent
+    if session_state.depth > 0:
+        ctx = session_state.current_context
+        if ctx.summary_path:
+            console.print(f"[dim]Summary: {ctx.summary_path}[/dim]")
+
+    console.print()
+    return True

--- a/libs/deepagents-cli/deepagents_cli/input.py
+++ b/libs/deepagents-cli/deepagents_cli/input.py
@@ -184,6 +184,12 @@ def get_bottom_toolbar(
     def toolbar() -> list[tuple[str, str]]:
         parts = []
 
+        # Show subagent context indicator
+        if session_state.depth > 0:
+            ctx = session_state.current_context
+            parts.append(("bg:#7c3aed fg:#ffffff bold", f" {ctx.subagent_type}:{session_state.depth} "))
+            parts.append(("", " | "))
+
         # Check if we're in BASH mode (input starts with !)
         try:
             session = session_ref.get("session")
@@ -405,9 +411,20 @@ def create_prompt_session(
     # Create session reference dict for toolbar to access session
     session_ref = {}
 
+    # Dynamic prompt that shows depth indicator when in subagent context
+    def get_prompt_message() -> HTML:
+        if session_state.depth > 0:
+            ctx = session_state.current_context
+            # Show [subagent_type:depth] > when in a subagent
+            return HTML(
+                f'<style fg="#fbbf24">[{ctx.subagent_type}:{session_state.depth}]</style> '
+                f'<style fg="{COLORS["user"]}">></style> '
+            )
+        return HTML(f'<style fg="{COLORS["user"]}">></style> ')
+
     # Create the session
     session = PromptSession(
-        message=HTML(f'<style fg="{COLORS["user"]}">></style> '),
+        message=get_prompt_message,
         multiline=True,  # Keep multiline support but Enter submits
         key_bindings=kb,
         completer=merge_completers([CommandCompleter(), FilePathCompleter()]),


### PR DESCRIPTION
## Problem

Subagent delegation is currently fire-and-forget. You specify a task, the agent runs in isolation, and you get a summary back. If the results are wrong, you start over.

This works for simple tasks but fails for anything requiring nuance. The user can't:
- Course-correct mid-exploration
- Say "not that direction, focus here"
- Guide what ends up in the summary

**Context isolation was conflated with loss of control.** They're orthogonal concerns.

## Solution

Add a "Step into" option to the HITL prompt when the agent invokes the `task` tool:

```
[Approve]  [Reject]  [Step into]  [Auto-accept all]
```

- **Approve** = fire-and-forget (existing behavior)
- **Step into** = enter the subagent conversation interactively

When stepping in:
- User enters an interactive session with the subagent
- Prompt shows depth: `[general-purpose:1] >`
- Summary file created at `~/.deepagents/{agent}/branches/{id}/summary.md`
- `/return` exits and sends summary to parent context
- `/summary` edits the summary file
- `/context` shows position in context stack

Context stays isolated. User stays in control. Both concerns addressed.

## Changes

- `config.py`: Add `ConversationContext`, refactor `SessionState` to use context stack
- `execution.py`: Add "Step into" to HITL, create branch context
- `main.py`: Context routing, step-in/return handling  
- `commands.py`: Add `/return`, `/summary`, `/context` commands
- `input.py`: Dynamic prompt with depth indicator
- `STEP_INTO.md`: Documentation

## Example

```
You: Research the auth system

Agent: I'll delegate this to a subagent.

[Select "Step into"]

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Stepped into: general-purpose subagent
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[general-purpose:1] Agent: Found 3 auth approaches. Which to focus on?

[general-purpose:1] You: JWT only.

[general-purpose:1] Agent: [explores JWT, reports findings]

[general-purpose:1] You: Add that to the summary.

[general-purpose:1] You: /return

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
✓ Returned to root
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Agent: Based on the findings... [uses summary you helped craft]
```

See `STEP_INTO.md` for full documentation and the philosophy behind this change.