### PR TITLE
feat: show allowed tools for each skill in skill list

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -560,6 +560,8 @@ class SkillsMiddleware(AgentMiddleware):
         lines = []
         for skill in skills:
             lines.append(f"- **{skill['name']}**: {skill['description']}")
+            if skill["allowed_tools"]:
+                lines.append(f"  -> Allowed tools: {', '.join(skill['allowed_tools'])}")
             lines.append(f"  -> Read `{skill['path']}` for full instructions")
 
         return "\n".join(lines)


### PR DESCRIPTION
### Problem

Skill discovery relied only on name + description.  
The agent couldn’t see which tools a skill is allowed to use, so it had to guess or open the SKILL.md to infer capabilities:

- Harder for the LLM to choose the right skill for a task
- Easy to misuse skills with restricted tool sets
- Extra reads of SKILL.md just to understand tool scope

### Solution

Added display of allowed tools for each skill in the formatted skill list output. This provides more visibility into which tools are permitted for each skill.

- When a skill defines `allowed-tools` in its frontmatter, the skills list now shows a concise “Allowed tools” line
- If `allowed_tools` is empty, the output is unchanged (no extra line)

### Changes

- **`libs/deepagents/deepagents/middleware/skills.py`**
  - At `skills.py:563–564`, append a formatted “Allowed tools” line to the skills list output when `skill["allowed_tools"]` is present:
    - `-> Allowed tools: tool_a, tool_b, ...`

### Example

Before:

- `web-research`: Structured approach to conducting thorough web research

After:

- `web-research`: Structured approach to conducting thorough web research  
  `-> Allowed tools: http_request, web_search`

### Test

Before adding `allowed-tools`, the model would never load this skill under any circumstances; after adding it, it would load immediately.

<img width="1268" height="170" alt="image" src="https://github.com/user-attachments/assets/9fa66dbd-47b9-45a0-b152-19309449ea8b" />
