### PR TITLE
feat: add optional `system_prompt` to `SkillsMiddleware` init

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -502,17 +502,18 @@ class SkillsMiddleware(AgentMiddleware):
 
     state_schema = SkillsState
 
-    def __init__(self, *, backend: BACKEND_TYPES, sources: list[str]) -> None:
+    def __init__(self, *, backend: BACKEND_TYPES, sources: list[str], system_prompt: str | None = SKILLS_SYSTEM_PROMPT) -> None:
         """Initialize the skills middleware.
 
         Args:
             backend: Backend instance or factory function that takes runtime and returns a backend.
                      Use a factory for StateBackend: `lambda rt: StateBackend(rt)`
             sources: List of skill source paths (e.g., ["/skills/user/", "/skills/project/"]).
+            system_prompt: Optional custom system prompt override.
         """
         self._backend = backend
         self.sources = sources
-        self.system_prompt_template = SKILLS_SYSTEM_PROMPT
+        self.system_prompt_template = system_prompt
 
     def _get_backend(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> BackendProtocol:
         """Resolve backend from instance or factory.


### PR DESCRIPTION
## Summary

Add an optional `system_prompt` argument to `SkillsMiddleware.__init__` so callers can override the built-in skills system prompt.

## Problem

`SkillsMiddleware` always used the hardcoded `SKILLS_SYSTEM_PROMPT`. There was no way to:
- Customize the skills section (tone, layout, or extra instructions)

## Solution

- Add `system_prompt: str | None = SKILLS_SYSTEM_PROMPT` to `__init__`.
- Store it as `self.system_prompt_template` and use it in `modify_request` when formatting the skills section.
- Omit the argument to keep the existing default; passing a custom string overrides it.

## Changes

**File:** `libs/deepagents/deepagents/middleware/skills.py`

- **`__init__` (L505–516):**
  - New parameter: `system_prompt: str | None = SKILLS_SYSTEM_PROMPT`
  - Docstring: `system_prompt: Optional custom system prompt override.`
  - Assignment: `self.system_prompt_template = system_prompt`
- **`modify_request`:** Unchanged; it already uses `self.system_prompt_template.format(skills_locations=..., skills_list=...)`.

## Backward compatibility

- `system_prompt` is optional and defaults to `SKILLS_SYSTEM_PROMPT`.
- All existing `SkillsMiddleware(backend=..., sources=...)` call sites continue to work without changes.