### PR TITLE
fix(cli): resume should load previous thread messages

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/app.py
+++ b/libs/deepagents-cli/deepagents_cli/app.py
@@ -10,6 +10,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from textual.app import App
 from textual.binding import Binding, BindingType
 from textual.containers import Container, VerticalScroll
@@ -340,8 +341,11 @@ class DeepAgentsApp(App):
         # Size the spacer to fill remaining viewport below input
         self.call_after_refresh(self._size_initial_spacer)
 
-        # Auto-submit initial prompt if provided
-        if self._initial_prompt and self._initial_prompt.strip():
+        # Load thread history if resuming a session
+        if self._lc_thread_id and self._agent:
+            self.call_after_refresh(lambda: asyncio.create_task(self._load_thread_history()))
+        # Auto-submit initial prompt if provided (but not when resuming - let user see history first)
+        elif self._initial_prompt and self._initial_prompt.strip():
             # Use call_after_refresh to ensure UI is fully mounted before submitting
             self.call_after_refresh(
                 lambda: asyncio.create_task(self._handle_user_message(self._initial_prompt))
@@ -683,6 +687,100 @@ class DeepAgentsApp(App):
         # Ensure token display is restored (in case of early cancellation)
         if self._token_tracker:
             self._token_tracker.show()
+
+    async def _load_thread_history(self) -> None:
+        """Load and render message history when resuming a thread.
+
+        This retrieves the checkpoint state from the agent and converts
+        stored messages into UI widgets.
+        """
+        if not self._agent or not self._lc_thread_id:
+            return
+
+        config = {"configurable": {"thread_id": self._lc_thread_id}}
+
+        try:
+            # Get the state snapshot from the agent
+            state = await self._agent.aget_state(config)
+            if not state or not state.values:
+                return
+
+            messages = state.values.get("messages", [])
+            if not messages:
+                return
+
+            # Track tool calls from AIMessages to match with ToolMessages
+            pending_tool_calls: dict[str, dict] = {}
+
+            for msg in messages:
+                if isinstance(msg, HumanMessage):
+                    # Skip system messages that were auto-injected
+                    content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                    if content.startswith("[SYSTEM]"):
+                        continue
+                    await self._mount_message(UserMessage(content))
+
+                elif isinstance(msg, AIMessage):
+                    # Render text content if present
+                    content = msg.content
+                    if isinstance(content, str) and content.strip():
+                        widget = AssistantMessage(content)
+                        await self._mount_message(widget)
+                        await widget.write_initial_content()
+
+                    # Track tool calls for later matching with ToolMessages
+                    tool_calls = getattr(msg, "tool_calls", [])
+                    for tc in tool_calls:
+                        tc_id = tc.get("id")
+                        if tc_id:
+                            pending_tool_calls[tc_id] = {
+                                "name": tc.get("name", "unknown"),
+                                "args": tc.get("args", {}),
+                            }
+                            # Mount tool call widget
+                            tool_widget = ToolCallMessage(
+                                tc.get("name", "unknown"),
+                                tc.get("args", {}),
+                            )
+                            await self._mount_message(tool_widget)
+                            # Store widget reference for result matching
+                            pending_tool_calls[tc_id]["widget"] = tool_widget
+
+                elif isinstance(msg, ToolMessage):
+                    # Match with pending tool call and show result
+                    tc_id = getattr(msg, "tool_call_id", None)
+                    if tc_id and tc_id in pending_tool_calls:
+                        tool_info = pending_tool_calls.pop(tc_id)
+                        widget = tool_info.get("widget")
+                        if widget:
+                            status = getattr(msg, "status", "success")
+                            content = (
+                                msg.content if isinstance(msg.content, str) else str(msg.content)
+                            )
+                            if status == "success":
+                                widget.set_success(content)
+                            else:
+                                widget.set_error(content)
+
+            # Mark any unmatched tool calls as interrupted (no ToolMessage result)
+            for tool_info in pending_tool_calls.values():
+                widget = tool_info.get("widget")
+                if widget:
+                    widget.set_rejected()  # Shows as interrupted/rejected in UI
+
+            # Show system message indicating this is a resumed session
+            await self._mount_message(SystemMessage(f"Resumed session: {self._lc_thread_id}"))
+
+            # Scroll to bottom after UI renders
+            def scroll_to_end() -> None:
+                chat = self.query_one("#chat", VerticalScroll)
+                chat.scroll_end(animate=False)
+
+            self.call_after_refresh(scroll_to_end)
+
+        except Exception as e:
+            # Don't fail the app if history loading fails
+            await self._mount_message(SystemMessage(f"Could not load history: {e}"))
 
     async def _mount_message(self, widget: Static) -> None:
         """Mount a message widget to the messages area.


### PR DESCRIPTION
## Summary                                                                                                                                                                                                          
                                                                                                                                                                                                                      
  - Add thread history restoration when resuming a session with `-r`                                                                                                                                                  
  - Display previous messages, tool calls, and their results from the checkpoint                                                                                                                                      
  - Save accumulated assistant text and tool calls when user interrupts mid-stream                                                                                                                                    
  - Mark interrupted tool calls (no result) as rejected in the UI                                                                                                                                                     
  - Auto-scroll to bottom on resume so users see the most recent messages 