### PR TITLE
fix: update download URLs to master branch

### DIFF
--- a/examples/downloading_agents/README.md
+++ b/examples/downloading_agents/README.md
@@ -21,7 +21,7 @@ uv tool install deepagents-cli==0.0.13a2
 mkdir my-project && cd my-project && git init
 
 # Download the agent
-curl -L https://raw.githubusercontent.com/langchain-ai/deepagents/agent-downloads/examples/downloading_agents/content-writer.zip -o agent.zip
+curl -L https://raw.githubusercontent.com/langchain-ai/deepagents/master/examples/downloading_agents/content-writer.zip -o agent.zip
 
 # Unzip to .deepagents
 unzip agent.zip -d .deepagents
@@ -43,5 +43,5 @@ deepagents
 ## One-Liner
 
 ```bash
-git init && curl -L https://raw.githubusercontent.com/langchain-ai/deepagents/agent-downloads/examples/downloading_agents/content-writer.zip -o agent.zip && unzip agent.zip -d .deepagents && rm agent.zip && deepagents
+git init && curl -L https://raw.githubusercontent.com/langchain-ai/deepagents/master/examples/downloading_agents/content-writer.zip -o agent.zip && unzip agent.zip -d .deepagents && rm agent.zip && deepagents
 ```


### PR DESCRIPTION
Updates the curl URLs in the downloading_agents example to point to master instead of the old agent-downloads branch.