### PR TITLE
fix(sdk): handle large payloads and headless container execution

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -46,13 +46,32 @@ for m in matches:
     print(json.dumps(result))
 " 2>/dev/null"""
 
-# Use heredoc to pass content via stdin to avoid ARG_MAX limits on large files
+# Use heredoc to pass content via stdin to avoid ARG_MAX limits on large files.
+# ARG_MAX limits the total size of command-line arguments.
+# Previously, base64-encoded content was interpolated directly into the command
+# string, which would fail for files larger than ~100KB after base64 expansion.
+# Heredocs bypass this by passing data through stdin rather than as arguments.
+# Stdin format: first line is base64-encoded file path, second line is base64-encoded content.
 _WRITE_COMMAND_TEMPLATE = """python3 -c "
 import os
 import sys
 import base64
+import json
 
-file_path = '{file_path}'
+# Read JSON payload from stdin containing file_path and content (both base64-encoded)
+payload_b64 = sys.stdin.read().strip()
+if not payload_b64:
+    print('Error: No payload received for write operation', file=sys.stderr)
+    sys.exit(1)
+
+try:
+    payload = base64.b64decode(payload_b64).decode('utf-8')
+    data = json.loads(payload)
+    file_path = data['path']
+    content = base64.b64decode(data['content']).decode('utf-8')
+except Exception as e:
+    print(f'Error: Failed to decode write payload: {e}', file=sys.stderr)
+    sys.exit(1)
 
 # Check if file already exists (atomic with write)
 if os.path.exists(file_path):
@@ -63,32 +82,45 @@ if os.path.exists(file_path):
 parent_dir = os.path.dirname(file_path) or '.'
 os.makedirs(parent_dir, exist_ok=True)
 
-# Read base64 content from stdin and decode
-content_b64 = sys.stdin.read().strip()
-content = base64.b64decode(content_b64).decode('utf-8')
 with open(file_path, 'w') as f:
     f.write(content)
 " <<'__DEEPAGENTS_EOF__'
-{content_b64}
+{payload_b64}
 __DEEPAGENTS_EOF__"""
 
-# Use heredoc to pass old/new strings via stdin to avoid ARG_MAX limits
-# Stdin format: base64-encoded JSON with {"old": str, "new": str}
+# Use heredoc to pass edit parameters via stdin to avoid ARG_MAX limits.
+# Stdin format: base64-encoded JSON with {"path": str, "old": str, "new": str}.
+# JSON bundles all parameters; base64 ensures safe transport of arbitrary content
+# (special chars, newlines, etc.) through the heredoc without escaping issues.
 _EDIT_COMMAND_TEMPLATE = """python3 -c "
 import sys
 import base64
 import json
-
-# Read file content
-with open('{file_path}', 'r') as f:
-    text = f.read()
+import os
 
 # Read and decode JSON payload from stdin
 payload_b64 = sys.stdin.read().strip()
-payload = base64.b64decode(payload_b64).decode('utf-8')
-data = json.loads(payload)
-old = data['old']
-new = data['new']
+if not payload_b64:
+    print('Error: No payload received for edit operation', file=sys.stderr)
+    sys.exit(4)
+
+try:
+    payload = base64.b64decode(payload_b64).decode('utf-8')
+    data = json.loads(payload)
+    file_path = data['path']
+    old = data['old']
+    new = data['new']
+except Exception as e:
+    print(f'Error: Failed to decode edit payload: {e}', file=sys.stderr)
+    sys.exit(4)
+
+# Check if file exists
+if not os.path.isfile(file_path):
+    sys.exit(3)  # File not found
+
+# Read file content
+with open(file_path, 'r') as f:
+    text = f.read()
 
 # Count occurrences
 count = text.count(old)
@@ -106,7 +138,7 @@ else:
     result = text.replace(old, new, 1)
 
 # Write back to file
-with open('{file_path}', 'w') as f:
+with open(file_path, 'w') as f:
     f.write(result)
 
 print(count)
@@ -233,11 +265,14 @@ except PermissionError:
         content: str,
     ) -> WriteResult:
         """Create a new file. Returns WriteResult; error populated on failure."""
-        # Encode content as base64 to avoid any escaping issues
+        # Create JSON payload with file path and base64-encoded content
+        # This avoids shell injection via file_path and ARG_MAX limits on content
         content_b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+        payload = json.dumps({"path": file_path, "content": content_b64})
+        payload_b64 = base64.b64encode(payload.encode("utf-8")).decode("ascii")
 
         # Single atomic check + write command
-        cmd = _WRITE_COMMAND_TEMPLATE.format(file_path=file_path, content_b64=content_b64)
+        cmd = _WRITE_COMMAND_TEMPLATE.format(payload_b64=payload_b64)
         result = self.execute(cmd)
 
         # Check for errors (exit code or error message in output)
@@ -256,23 +291,29 @@ except PermissionError:
         replace_all: bool = False,
     ) -> EditResult:
         """Edit a file by replacing string occurrences. Returns EditResult."""
-        # Create JSON payload with old and new strings
-        payload = json.dumps({"old": old_string, "new": new_string})
+        # Create JSON payload with file path, old string, and new string
+        # This avoids shell injection via file_path and ARG_MAX limits on strings
+        payload = json.dumps({"path": file_path, "old": old_string, "new": new_string})
         payload_b64 = base64.b64encode(payload.encode("utf-8")).decode("ascii")
 
         # Use template for string replacement
-        cmd = _EDIT_COMMAND_TEMPLATE.format(file_path=file_path, payload_b64=payload_b64, replace_all=replace_all)
+        cmd = _EDIT_COMMAND_TEMPLATE.format(payload_b64=payload_b64, replace_all=replace_all)
         result = self.execute(cmd)
 
         exit_code = result.exit_code
         output = result.output.strip()
 
-        if exit_code == 1:
-            return EditResult(error=f"Error: String not found in file: '{old_string}'")
-        if exit_code == 2:
-            return EditResult(error=f"Error: String '{old_string}' appears multiple times. Use replace_all=True to replace all occurrences.")
+        # Map exit codes to error messages
+        error_messages = {
+            1: f"Error: String not found in file: '{old_string}'",
+            2: f"Error: String '{old_string}' appears multiple times. Use replace_all=True to replace all occurrences.",
+            3: f"Error: File '{file_path}' not found",
+            4: f"Error: Failed to decode edit payload: {output}",
+        }
+        if exit_code in error_messages:
+            return EditResult(error=error_messages[exit_code])
         if exit_code != 0:
-            return EditResult(error=f"Error: File '{file_path}' not found")
+            return EditResult(error=f"Error editing file (exit code {exit_code}): {output or 'Unknown error'}")
 
         count = int(output)
         # External storage - no files_update needed

--- a/libs/harbor/deepagents_harbor/backend.py
+++ b/libs/harbor/deepagents_harbor/backend.py
@@ -16,7 +16,11 @@ from harbor.environments.base import BaseEnvironment
 
 
 class HarborSandbox(SandboxBackendProtocol):
-    """A sandbox implementation without assuming that python3 is available."""
+    """A sandbox implementation using shell commands.
+
+    Note: The edit operation requires python3 for JSON parsing. Other operations
+    (read, write, ls, grep, glob) use only standard shell utilities.
+    """
 
     def __init__(self, environment: BaseEnvironment) -> None:
         """Initialize HarborSandbox with the given environment."""
@@ -135,7 +139,9 @@ awk -v offset={offset} -v limit={limit} '
         content_b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
         safe_path = shlex.quote(file_path)
 
-        # Use heredoc to pass content via stdin to avoid ARG_MAX limits on large files
+        # Use heredoc to pass content via stdin to avoid ARG_MAX limits on large files.
+        # ARG_MAX limits the total size of command-line arguments.
+        # Heredocs bypass this by passing data through stdin rather than as arguments.
         cmd = f"""
 if [ -e {safe_path} ]; then
     echo "Error: File '{file_path}' already exists" >&2
@@ -143,9 +149,13 @@ if [ -e {safe_path} ]; then
 fi
 parent_dir=$(dirname {safe_path})
 mkdir -p "$parent_dir" 2>/dev/null
-base64 -d > {safe_path} <<'__DEEPAGENTS_EOF__'
+if ! base64 -d > {safe_path} <<'__DEEPAGENTS_EOF__'
 {content_b64}
 __DEEPAGENTS_EOF__
+then
+    echo "Error: Failed to decode content for file '{file_path}'" >&2
+    exit 1
+fi
 """
         result = await self.aexecute(cmd)
 
@@ -178,19 +188,37 @@ __DEEPAGENTS_EOF__
         replace_all_str = "true" if replace_all else "false"
 
         # Use heredoc to pass old/new strings via stdin to avoid ARG_MAX limits.
+        # ARG_MAX limits the total size of command-line arguments.
         # Format: base64-encoded JSON with {{"old": str, "new": str}}.
-        # The heredoc feeds into the brace group which contains the read commands.
+        # The heredoc feeds into the brace group { ... } which reads and processes stdin.
         cmd = f"""
 if [ ! -f {safe_path} ]; then
     exit 3
 fi
 
 {{
-    # Read and decode JSON payload from heredoc
-    read payload_b64
-    payload=$(echo "$payload_b64" | base64 -d)
-    old=$(echo "$payload" | python3 -c "import sys, json; print(json.load(sys.stdin)['old'], end='')")
-    new=$(echo "$payload" | python3 -c "import sys, json; print(json.load(sys.stdin)['new'], end='')")
+    # Read entire heredoc content using cat (read only gets first line)
+    payload_b64=$(cat)
+    if [ -z "$payload_b64" ]; then
+        echo "Error: No payload received for edit operation" >&2
+        exit 4
+    fi
+
+    # Decode base64 payload
+    payload=$(echo "$payload_b64" | base64 -d) || {{
+        echo "Error: Failed to decode payload" >&2
+        exit 4
+    }}
+
+    # Extract old and new strings from JSON using python3
+    old=$(echo "$payload" | python3 -c "import sys, json; print(json.load(sys.stdin)['old'], end='')") || {{
+        echo "Error: Failed to parse JSON payload" >&2
+        exit 4
+    }}
+    new=$(echo "$payload" | python3 -c "import sys, json; print(json.load(sys.stdin)['new'], end='')") || {{
+        echo "Error: Failed to parse JSON payload" >&2
+        exit 4
+    }}
 
     # Count occurrences using grep -F (fixed strings)
     count=$(grep -o -F "$old" {safe_path} | wc -l)
@@ -201,7 +229,9 @@ fi
         exit 2
     fi
 
-    # Use perl for reliable string replacement (handles special chars)
+    # Use perl for reliable string replacement (handles special chars).
+    # Note: \\Q...\\E escapes the search pattern. The replacement string is not
+    # escaped, so Perl special sequences (\\U, $1, etc.) in new will be interpreted.
     if [ "{replace_all_str}" = "true" ]; then
         perl -i -pe 's/\\Q'"$old"'\\E/'"$new"'/g' {safe_path}
     else
@@ -226,8 +256,12 @@ __DEEPAGENTS_EOF__
             )
         if exit_code == 3:
             return EditResult(error=f"Error: File '{file_path}' not found")
+        if exit_code == 4:
+            return EditResult(error=f"Error: Failed to decode edit payload: {output}")
         if exit_code != 0:
-            return EditResult(error=f"Error editing file: {output}")
+            return EditResult(
+                error=f"Error editing file (exit code {exit_code}): {output or 'Unknown error'}"
+            )
 
         try:
             count = int(output.split("\n")[0])


### PR DESCRIPTION
Conversation history offloading via `SummarizationMiddleware` was failing with `E2BIG` (Argument list too long) - Large conversations exceeded OS `ARG_MAX` limits when base64-encoded content was embedded directly in shell command strings passed to `execve()`.

`BaseSandbox.write()` and `edit()` embedded base64 payloads directly in Python one-liner commands.

This approach fails when `len(cmd)` exceeds `ARG_MAX`

We solve this by using `heredocs` for large payloads

Rewrote `_WRITE_COMMAND_TEMPLATE` and `_EDIT_COMMAND_TEMPLATE` to read base64 content from stdin via `heredoc`. Heredoc content is passed to the process as stdin, bypassing `execve()` argument limits.