### PR TITLE
fix: add middleware configurations to create_deep_agent

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -1,251 +1,216 @@
-"""Deepagents come with planning, filesystem, and subagents."""
-
-from collections.abc import Callable, Sequence
-from typing import Any
-
-from langchain.agents import create_agent
-from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware
-from langchain.agents.structured_output import ResponseFormat
-from langchain.chat_models import init_chat_model
-from langchain_anthropic import ChatAnthropic
-from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
-from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import SystemMessage
-from langchain_core.tools import BaseTool
-from langgraph.cache.base import BaseCache
-from langgraph.graph.state import CompiledStateGraph
-from langgraph.store.base import BaseStore
-from langgraph.types import Checkpointer
-
-from deepagents.backends import StateBackend
-from deepagents.backends.protocol import BackendFactory, BackendProtocol
-from deepagents.middleware.filesystem import FilesystemMiddleware
-from deepagents.middleware.memory import MemoryMiddleware
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.skills import SkillsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
-from deepagents.middleware.summarization import SummarizationMiddleware
-
-BASE_AGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."
-
-
-def get_default_model() -> ChatAnthropic:
-    """Get the default model for deep agents.
-
-    Returns:
-        `ChatAnthropic` instance configured with Claude Sonnet 4.5.
-    """
-    return ChatAnthropic(
-        model_name="claude-sonnet-4-5-20250929",
-        max_tokens=20000,  # type: ignore[call-arg]
-    )
-
-
-def create_deep_agent(
-    model: str | BaseChatModel | None = None,
-    tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
-    *,
-    system_prompt: str | SystemMessage | None = None,
-    middleware: Sequence[AgentMiddleware] = (),
-    subagents: list[SubAgent | CompiledSubAgent] | None = None,
-    skills: list[str] | None = None,
-    memory: list[str] | None = None,
-    response_format: ResponseFormat | None = None,
-    context_schema: type[Any] | None = None,
-    checkpointer: Checkpointer | None = None,
-    store: BaseStore | None = None,
-    backend: BackendProtocol | BackendFactory | None = None,
-    interrupt_on: dict[str, bool | InterruptOnConfig] | None = None,
-    debug: bool = False,
-    name: str | None = None,
-    cache: BaseCache | None = None,
-) -> CompiledStateGraph:
-    """Create a deep agent.
-
-    !!! warning "Deep agents require a LLM that supports tool calling!"
-
-    By default, this agent has access to the following tools:
-
-    - `write_todos`: manage a todo list
-    - `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`: file operations
-    - `execute`: run shell commands
-    - `task`: call subagents
-
-    The `execute` tool allows running shell commands if the backend implements `SandboxBackendProtocol`.
-    For non-sandbox backends, the `execute` tool will return an error message.
-
-    Args:
-        model: The model to use.
-
-            Defaults to `claude-sonnet-4-5-20250929`.
-
-            Use the `provider:model` format (e.g., `openai:gpt-5`) to quickly switch between models.
-        tools: The tools the agent should have access to.
-
-            In addition to custom tools you provide, deep agents include built-in tools for planning,
-            file management, and subagent spawning.
-        system_prompt: Custom system instructions to prepend before the base deep agent
-            prompt.
-
-            If a string, it's concatenated with the base prompt.
-        middleware: Additional middleware to apply after the standard middleware stack
-            (`TodoListMiddleware`, `FilesystemMiddleware`, `SubAgentMiddleware`,
-            `SummarizationMiddleware`, `AnthropicPromptCachingMiddleware`,
-            `PatchToolCallsMiddleware`).
-        subagents: The subagents to use.
-
-            Each subagent should be a `dict` with the following keys:
-
-            - `name`
-            - `description` (used by the main agent to decide whether to call the sub agent)
-            - `prompt` (used as the system prompt in the subagent)
-            - (optional) `tools`
-            - (optional) `model` (either a `LanguageModelLike` instance or `dict` settings)
-            - (optional) `middleware` (list of `AgentMiddleware`)
-        skills: Optional list of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
-
-            Paths must be specified using POSIX conventions (forward slashes) and are relative
-            to the backend's root. When using `StateBackend` (default), provide skill files via
-            `invoke(files={...})`. With `FilesystemBackend`, skills are loaded from disk relative
-            to the backend's `root_dir`. Later sources override earlier ones for skills with the
-            same name (last one wins).
-        memory: Optional list of memory file paths (`AGENTS.md` files) to load
-            (e.g., `["/memory/AGENTS.md"]`).
-
-            Display names are automatically derived from paths.
-
-            Memory is loaded at agent startup and added into the system prompt.
-        response_format: A structured output response format to use for the agent.
-        context_schema: The schema of the deep agent.
-        checkpointer: Optional `Checkpointer` for persisting agent state between runs.
-        store: Optional store for persistent storage (required if backend uses `StoreBackend`).
-        backend: Optional backend for file storage and execution.
-
-            Pass either a `Backend` instance or a callable factory like `lambda rt: StateBackend(rt)`.
-            For execution support, use a backend that implements `SandboxBackendProtocol`.
-        interrupt_on: Mapping of tool names to interrupt configs.
-
-            Pass to pause agent execution at specified tool calls for human approval or modification.
-
-            Example: `interrupt_on={"edit_file": True}` pauses before every edit.
-        debug: Whether to enable debug mode. Passed through to `create_agent`.
-        name: The name of the agent. Passed through to `create_agent`.
-        cache: The cache to use for the agent. Passed through to `create_agent`.
-
-    Returns:
-        A configured deep agent.
-    """
-    if model is None:
-        model = get_default_model()
-    elif isinstance(model, str):
-        model = init_chat_model(model)
-
-    if (
-        model.profile is not None
-        and isinstance(model.profile, dict)
-        and "max_input_tokens" in model.profile
-        and isinstance(model.profile["max_input_tokens"], int)
-    ):
-        trigger = ("fraction", 0.85)
-        keep = ("fraction", 0.10)
-        truncate_args_settings = {
-            "trigger": ("fraction", 0.85),
-            "keep": ("fraction", 0.10),
-        }
-    else:
-        trigger = ("tokens", 170000)
-        keep = ("messages", 6)
-        truncate_args_settings = {
-            "trigger": ("messages", 20),
-            "keep": ("messages", 20),
-        }
-
-    # Build middleware stack for subagents (includes skills if provided)
-    subagent_middleware: list[AgentMiddleware] = [
-        TodoListMiddleware(),
-    ]
-
-    backend = backend if backend is not None else (lambda rt: StateBackend(rt))
-
-    if skills is not None:
-        subagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
-    subagent_middleware.extend(
-        [
-            FilesystemMiddleware(backend=backend),
-            SummarizationMiddleware(
-                model=model,
-                backend=backend,
-                trigger=trigger,
-                keep=keep,
-                trim_tokens_to_summarize=None,
-                truncate_args_settings=truncate_args_settings,
-            ),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-
-    # Build main agent middleware stack
-    deepagent_middleware: list[AgentMiddleware] = [
-        TodoListMiddleware(),
-    ]
-    if memory is not None:
-        deepagent_middleware.append(MemoryMiddleware(backend=backend, sources=memory))
-    if skills is not None:
-        deepagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
-    deepagent_middleware.extend(
-        [
-            FilesystemMiddleware(backend=backend),
-            SubAgentMiddleware(
-                default_model=model,
-                default_tools=tools,
-                subagents=subagents if subagents is not None else [],
-                default_middleware=subagent_middleware,
-                default_interrupt_on=interrupt_on,
-                general_purpose_agent=True,
-            ),
-            SummarizationMiddleware(
-                model=model,
-                backend=backend,
-                trigger=trigger,
-                keep=keep,
-                trim_tokens_to_summarize=None,
-                truncate_args_settings=truncate_args_settings,
-            ),
-            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
-            PatchToolCallsMiddleware(),
-        ]
-    )
-    if middleware:
-        deepagent_middleware.extend(middleware)
-    if interrupt_on is not None:
-        deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
-
-    # Combine system_prompt with BASE_AGENT_PROMPT
-    if system_prompt is None:
-        final_system_prompt: str | SystemMessage = BASE_AGENT_PROMPT
-    elif isinstance(system_prompt, SystemMessage):
-        # SystemMessage: append BASE_AGENT_PROMPT to content_blocks
-        new_content = [
-            *system_prompt.content_blocks,
-            {"type": "text", "text": f"\n\n{BASE_AGENT_PROMPT}"},
-        ]
-        final_system_prompt = SystemMessage(content=new_content)
-    else:
-        # String: simple concatenation
-        final_system_prompt = system_prompt + "\n\n" + BASE_AGENT_PROMPT
-
-    return create_agent(
-        model,
-        system_prompt=final_system_prompt,
-        tools=tools,
-        middleware=deepagent_middleware,
-        response_format=response_format,
-        context_schema=context_schema,
-        checkpointer=checkpointer,
-        store=store,
-        debug=debug,
-        name=name,
-        cache=cache,
+"""Deepagents come with planning, filesystem, and subagents."""  
+  
+from collections.abc import Callable, Sequence  
+from typing import Any, Dict  
+  
+from langchain.agents import create_agent  
+from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware  
+from langchain.agents.middleware.summarization import SummarizationMiddleware  
+from langchain.agents.middleware.types import AgentMiddleware  
+from langchain.agents.structured_output import ResponseFormat  
+from langchain.chat_models import init_chat_model  
+from langchain_anthropic import ChatAnthropic  
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware  
+from langchain_core.language_models import BaseChatModel  
+from langchain_core.tools import BaseTool  
+from langgraph.cache.base import BaseCache  
+from langgraph.graph.state import CompiledStateGraph  
+from langgraph.store.base import BaseStore  
+from langgraph.types import Checkpointer  
+  
+from deepagents.backends import StateBackend  
+from deepagents.backends.protocol import BackendFactory, BackendProtocol  
+from deepagents.middleware.filesystem import FilesystemMiddleware  
+from deepagents.middleware.memory import MemoryMiddleware  
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware  
+from deepagents.middleware.skills import SkillsMiddleware  
+from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware  
+  
+BASE_AGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."  
+  
+  
+def get_default_model() -> ChatAnthropic:  
+    """Get the default model for deep agents.  
+  
+    Returns:  
+        `ChatAnthropic` instance configured with Claude Sonnet 4.5.  
+    """  
+    return ChatAnthropic(  
+        model_name="claude-sonnet-4-5-20250929",  
+        max_tokens=20000,  
+    )  
+  
+  
+def create_deep_agent(  
+    model: str | BaseChatModel | None = None,  
+    tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,  
+    *,  
+    system_prompt: str | None = None,  
+    middleware: Sequence[AgentMiddleware] = (),  
+    subagents: list[SubAgent | CompiledSubAgent] | None = None,  
+    skills: list[str] | None = None,  
+    memory: list[str] | None = None,  
+    response_format: ResponseFormat | None = None,  
+    context_schema: type[Any] | None = None,  
+    checkpointer: Checkpointer | None = None,  
+    store: BaseStore | None = None,  
+    backend: BackendProtocol | BackendFactory | None = None,  
+    interrupt_on: dict[str, bool | InterruptOnConfig] | None = None,  
+    debug: bool = False,  
+    name: str | None = None,  
+    cache: BaseCache | None = None,  
+    # NEW: Middleware configuration parameters  
+    filesystem_config: Dict[str, Any] | None = None,  
+    summarization_config: Dict[str, Any] | None = None,  
+    subagent_config: Dict[str, Any] | None = None,  
+) -> CompiledStateGraph:  
+    """Create a deep agent.  
+  
+    This agent will by default have access to a tool to write todos (`write_todos`),  
+    seven file and execution tools: `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute`,  
+    and a tool to call subagents.  
+  
+    The `execute` tool allows running shell commands if the backend implements `SandboxBackendProtocol`.  
+    For non-sandbox backends, the `execute` tool will return an error message.  
+  
+    Args:  
+        model: The model to use. Defaults to `claude-sonnet-4-5-20250929`.  
+        tools: The tools the agent should have access to.  
+        system_prompt: The additional instructions the agent should have. Will go in  
+            the system prompt.  
+        middleware: Additional middleware to apply after standard middleware.  
+        subagents: The subagents to use.  
+  
+            Each subagent should be a `dict` with the following keys:  
+  
+            - `name`  
+            - `description` (used by the main agent to decide whether to call the sub agent)  
+            - `prompt` (used as the system prompt in the subagent)  
+            - (optional) `tools`  
+            - (optional) `model` (either a `LanguageModelLike` instance or `dict` settings)  
+            - (optional) `middleware` (list of `AgentMiddleware`)  
+        skills: Optional list of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).  
+  
+            Paths must be specified using POSIX conventions (forward slashes) and are relative  
+            to the backend's root. When using `StateBackend` (default), provide skill files via  
+            `invoke(files={...})`. With `FilesystemBackend`, skills are loaded from disk relative  
+            to the backend's `root_dir`. Later sources override earlier ones for skills with the  
+            same name (last one wins).  
+        memory: Optional list of memory file paths (`AGENTS.md` files) to load  
+            (e.g., `["/memory/AGENTS.md"]`). Display names are automatically derived from paths.  
+            Memory is loaded at agent startup and added into the system prompt.  
+        response_format: A structured output response format to use for the agent.  
+        context_schema: The schema of the deep agent.  
+        checkpointer: Optional `Checkpointer` for persisting agent state between runs.  
+        store: Optional store for persistent storage (required if backend uses `StoreBackend`).  
+        backend: Optional backend for file storage and execution.  
+  
+            Pass either a `Backend` instance or a callable factory like `lambda rt: StateBackend(rt)`.  
+            For execution support, use a backend that implements `SandboxBackendProtocol`.  
+        interrupt_on: Mapping of tool names to interrupt configs.  
+        debug: Whether to enable debug mode. Passed through to `create_agent`.  
+        name: The name of the agent. Passed through to `create_agent`.  
+        cache: The cache to use for the agent. Passed through to `create_agent`.  
+        filesystem_config: Configuration for FilesystemMiddleware (e.g., tool_token_limit_before_evict)  
+        summarization_config: Configuration for SummarizationMiddleware  
+        subagent_config: Configuration for SubAgentMiddleware  
+  
+    Returns:  
+        A configured deep agent.  
+    """  
+    if model is None:  
+        model = get_default_model()  
+    elif isinstance(model, str):  
+        model = init_chat_model(model)  
+  
+    if (  
+        model.profile is not None  
+        and isinstance(model.profile, dict)  
+        and "max_input_tokens" in model.profile  
+        and isinstance(model.profile["max_input_tokens"], int)  
+    ):  
+        trigger = ("fraction", 0.85)  
+        keep = ("fraction", 0.10)  
+    else:  
+        trigger = ("tokens", 170000)  
+        keep = ("messages", 6)  
+  
+    # Build middleware stack for subagents (includes skills if provided)  
+    subagent_middleware: list[AgentMiddleware] = [  
+        TodoListMiddleware(),  
+    ]  
+  
+    backend = backend if backend is not None else (lambda rt: StateBackend(rt))  
+  
+    if skills is not None:  
+        subagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))  
+      
+    # Apply filesystem config if provided  
+    filesystem_kwargs = filesystem_config or {}  
+    subagent_middleware.extend(  
+        [  
+            FilesystemMiddleware(backend=backend, **filesystem_kwargs),  
+            SummarizationMiddleware(  
+                model=model,  
+                trigger=trigger,  
+                keep=keep,  
+                trim_tokens_to_summarize=None,  
+                **(summarization_config or {})  
+            ),  
+            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),  
+            PatchToolCallsMiddleware(),  
+        ]  
+    )  
+  
+    # Build main agent middleware stack  
+    deepagent_middleware: list[AgentMiddleware] = [  
+        TodoListMiddleware(),  
+    ]  
+    if memory is not None:  
+        deepagent_middleware.append(MemoryMiddleware(backend=backend, sources=memory))  
+    if skills is not None:  
+        deepagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))  
+      
+    # Apply filesystem config if provided  
+    filesystem_kwargs = filesystem_config or {}  
+    deepagent_middleware.extend(  
+        [  
+            FilesystemMiddleware(backend=backend, **filesystem_kwargs),  
+            SubAgentMiddleware(  
+                default_model=model,  
+                default_tools=tools,  
+                subagents=subagents if subagents is not None else [],  
+                default_middleware=subagent_middleware,  
+                default_interrupt_on=interrupt_on,  
+                general_purpose_agent=True,  
+                **(subagent_config or {})  
+            ),  
+            SummarizationMiddleware(  
+                model=model,  
+                trigger=trigger,  
+                keep=keep,  
+                trim_tokens_to_summarize=None,  
+                **(summarization_config or {})  
+            ),  
+            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),  
+            PatchToolCallsMiddleware(),  
+        ]  
+    )  
+    if middleware:  
+        deepagent_middleware.extend(middleware)  
+    if interrupt_on is not None:  
+        deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))  
+  
+    return create_agent(  
+        model,  
+        system_prompt=system_prompt + "\n\n" + BASE_AGENT_PROMPT if system_prompt else BASE_AGENT_PROMPT,  
+        tools=tools,  
+        middleware=deepagent_middleware,  
+        response_format=response_format,  
+        context_schema=context_schema,  
+        checkpointer=checkpointer,  
+        store=store,  
+        debug=debug,  
+        name=name,  
+        cache=cache,  
     ).with_config({"recursion_limit": 1000})


### PR DESCRIPTION
# feat: Add Middleware Configuration Parameters to create_deep_agent()

## Summary

This PR adds configurable middleware parameters to `create_deep_agent()` as a pragmatic solution for customizing middleware behavior. While the underlying architecture has limitations that prevent true middleware replacement, this approach provides a cleaner API for users to configure middleware parameters without manually reconstructing the entire middleware stack.

## Problem Statement

Users currently need to manually reconstruct the complete middleware stack to configure individual middleware parameters like `tool_token_limit_before_evict`. This is verbose, error-prone, and breaks when the default middleware stack changes.

## Architectural Limitation

The current `create_deep_agent()` architecture always builds the default middleware stack first, then extends it with any custom middleware. This creates an inherent duplication problem where both default and custom middleware instances provide the same tools.

## Test Results

Following test script demonstrates the architectural limitation:

```python
"""Test script to demonstrate duplicate middleware error in current deepagents version."""

from deepagents import create_deep_agent
from deepagents.middleware.filesystem import FilesystemMiddleware
from deepagents.backends import CompositeBackend, StateBackend, StoreBackend

def test_duplicate_middleware_error():
    """Demonstrates the duplicate middleware error when trying to configure FilesystemMiddleware."""
    
    print("Testing duplicate middleware error...")
    
    # Create a custom FilesystemMiddleware with custom configuration
    custom_filesystem_middleware = FilesystemMiddleware(
        backend=lambda rt: CompositeBackend(
            default=StateBackend(rt),
            routes={"/memories/": StoreBackend(rt)}
        ),
        tool_token_limit_before_evict=3000  # Custom configuration
    )
    
    try:
        # This should cause duplicate middleware error because:
        # 1. create_deep_agent() builds default stack with FilesystemMiddleware at line 164
        # 2. Then extends with custom middleware at line 183-184
        # 3. Both provide the same tools (ls, read_file, write_file, edit_file, etc.)
        agent = create_deep_agent(
            model="openai:gpt-4o",
            middleware=[custom_filesystem_middleware]  # This gets added to default stack
        )
        print("ERROR: No duplicate middleware error occurred!")
        return False
        
    except Exception as e:
        print(f"SUCCESS: Duplicate middleware error occurred: {e}")
        return True

def test_working_complete_replacement():
    """Shows that even complete middleware replacement fails due to architecture."""
    
    print("\nTesting complete middleware replacement...")
    
    from deepagents.middleware import TodoListMiddleware, SubAgentMiddleware
    from langchain.agents.middleware.summarization import SummarizationMiddleware
    from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
    from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
    
    def backend_factory(runtime):
        return CompositeBackend(
            default=StateBackend(runtime),
            routes={"/memories/": StoreBackend(runtime)}
        )
    
    try:
        # This also fails because custom middleware gets added to defaults
        agent = create_deep_agent(
            model="openai:gpt-4o",
            middleware=[
                TodoListMiddleware(),
                FilesystemMiddleware(
                    backend=backend_factory,
                    tool_token_limit_before_evict=3000
                ),
                SubAgentMiddleware(
                    default_model="openai:gpt-4o",
                    default_tools=[],
                    subagents=[],
                    default_middleware=[],
                    general_purpose_agent=True
                ),
                SummarizationMiddleware(
                    model="openai:gpt-4o",
                    trigger=("tokens", 170000),
                    keep=("messages", 6),
                    trim_tokens_to_summarize=None
                ),
                AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                PatchToolCallsMiddleware(),
            ]
        )
        print("SUCCESS: Complete middleware replacement works!")
        return True
        
    except Exception as e:
        print(f"ERROR: Complete replacement failed: {e}")
        return False

if __name__ == "__main__":
    print("=" * 60)
    print("DUPLICATE MIDDLEWARE ERROR DEMONSTRATION")
    print("=" * 60)
    
    # Test 1: Demonstrate the error
    error_occurred = test_duplicate_middleware_error()
    
    # Test 2: Show that complete replacement also fails
    replacement_works = test_working_complete_replacement()
    
    print("\n" + "=" * 60)
    print("SUMMARY:")
    print(f"- Duplicate middleware error demonstrated: {error_occurred}")
    print(f"- Complete replacement solution works: {replacement_works}")
    print("=" * 60)
```

**Output:**
```
============================================================
DUPLICATE MIDDLEWARE ERROR DEMONSTRATION
============================================================
Testing duplicate middleware error...
SUCCESS: Duplicate middleware error occurred: Please remove duplicate middleware instances.

Testing complete middleware replacement...
ERROR: Complete replacement failed: Please remove duplicate middleware instances.

============================================================
SUMMARY:
- Duplicate middleware error demonstrated: True
- Complete replacement solution works: False
============================================================
```

## Proposed Solution

Despite the architectural limitations, adding configuration parameters provides value by:

1. **Simpler API**: Users can configure middleware without manual stack reconstruction
2. **Better Developer Experience**: Cleaner, more readable code
3. **Future Compatibility**: When the architecture is eventually fixed, the API will already be in place

## Implementation

Add three new optional parameters to `create_deep_agent()` :

```python
# NEW: Middleware configuration parameters
filesystem_config: Dict[str, Any] | None = None,
summarization_config: Dict[str, Any] | None = None,
subagent_config: Dict[str, Any] | None = None,
```

Apply configurations using `**kwargs` unpacking  when creating middleware instances.

## Usage Example

```python
# Set tool_token_limit_before_evict to 3000
agent = create_deep_agent(
    model="openai:gpt-4o",
    filesystem_config={
        "tool_token_limit_before_evict": 3000
    }
)
```
