### PR TITLE
fix(cli): scrolling wrapping on input/resume, running tool spinner

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/app.py
+++ b/libs/deepagents-cli/deepagents_cli/app.py
@@ -14,7 +14,7 @@ from textual.app import App
 from textual.binding import Binding, BindingType
 from textual.containers import Container, VerticalScroll
 from textual.css.query import NoMatches
-from textual.events import Click, MouseUp
+from textual.events import Click, MouseUp, Resize
 from textual.widgets import Static
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
     from langgraph.pregel import Pregel
     from textual.app import ComposeResult
     from textual.worker import Worker
+
+
 
 
 class TextualTokenTracker:
@@ -218,9 +220,8 @@ class DeepAgentsApp(App):
     CSS_PATH = "app.tcss"
     ENABLE_COMMAND_PALETTE = False
 
-    # Slow down scroll speed (default is 3 lines per scroll event)
-    # Using 0.25 to require 4 scroll events per line - very smooth
-    SCROLL_SENSITIVITY_Y = 0.25
+    # Scroll speed (default is 3 lines per scroll event)
+    SCROLL_SENSITIVITY_Y = 1.0
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "interrupt", "Interrupt", show=False, priority=True),
@@ -293,7 +294,7 @@ class DeepAgentsApp(App):
     def compose(self) -> ComposeResult:
         """Compose the application layout."""
         # Main chat area with scrollable messages
-        # Input is inside scroll so it appears right below content initially
+        # VerticalScroll tracks user scroll intent for better auto-scroll behavior
         with VerticalScroll(id="chat"):
             yield WelcomeBanner(id="welcome-banner")
             yield Container(id="messages")
@@ -351,6 +352,15 @@ class DeepAgentsApp(App):
                 lambda: asyncio.create_task(self._handle_user_message(self._initial_prompt))
             )
 
+    def on_resize(self, _event: Resize) -> None:
+        """Handle terminal resize to recalculate layout."""
+        try:
+            self.query_one("#chat-spacer", Static)
+            # Spacer exists, recalculate its height
+            self.call_after_refresh(self._size_initial_spacer)
+        except NoMatches:
+            pass  # Spacer already removed, no action needed
+
     def _update_status(self, message: str) -> None:
         """Update the status bar with a message."""
         if self._status_bar:
@@ -367,14 +377,22 @@ class DeepAgentsApp(App):
             self._status_bar.hide_tokens()
 
     def _scroll_chat_to_bottom(self) -> None:
-        """Scroll the chat area to the bottom.
+        """Scroll chat to bottom using sticky scroll pattern.
 
-        Uses anchor() for smoother streaming - keeps scroll locked to bottom
-        as new content is added without causing visual jumps.
+        Only scrolls if user is already at/near the bottom.
+        This prevents dragging the user back if they've scrolled up to read.
         """
         chat = self.query_one("#chat", VerticalScroll)
-        if chat.virtual_size.height > chat.size.height:
-            chat.anchor()
+
+        # Nothing to scroll if content fits in viewport
+        if chat.max_scroll_y <= 0:
+            return
+
+        # Sticky scroll: only scroll to bottom if user is near the bottom
+        # "Near" means within 100 pixels of the bottom (about 6-7 lines)
+        distance_from_bottom = chat.max_scroll_y - chat.scroll_y
+        if distance_from_bottom < 100:
+            chat.scroll_end(animate=False)
 
     async def _show_thinking(self) -> None:
         """Show or reposition the thinking spinner at the bottom of messages."""
@@ -385,7 +403,8 @@ class DeepAgentsApp(App):
         self._loading_widget = LoadingWidget("Thinking")
         messages = self.query_one("#messages", Container)
         await messages.mount(self._loading_widget)
-        self._scroll_chat_to_bottom()
+        # NOTE: Don't call _scroll_chat_to_bottom() here - it would re-anchor
+        # and drag user back to bottom if they've scrolled away during streaming
 
     async def _hide_thinking(self) -> None:
         """Hide the thinking spinner."""
@@ -395,14 +414,17 @@ class DeepAgentsApp(App):
 
     def _size_initial_spacer(self) -> None:
         """Size the spacer to fill remaining viewport below input."""
-        chat = self.query_one("#chat", VerticalScroll)
-        welcome = self.query_one("#welcome-banner", WelcomeBanner)
-        input_container = self.query_one("#bottom-app-container", Container)
-        spacer = self.query_one("#chat-spacer", Static)
-        content_height = welcome.size.height + input_container.size.height + 4
-        spacer_height = chat.size.height - content_height
-        if spacer_height > 0:
-            spacer.styles.height = spacer_height
+        try:
+            chat = self.query_one("#chat", VerticalScroll)
+            welcome = self.query_one("#welcome-banner", WelcomeBanner)
+            input_container = self.query_one("#bottom-app-container", Container)
+            spacer = self.query_one("#chat-spacer", Static)
+            content_height = welcome.size.height + input_container.size.height + 4
+            spacer_height = chat.size.height - content_height
+            spacer.styles.height = max(0, spacer_height)
+        except NoMatches:
+            # Spacer may have been removed already (e.g., when resuming a session)
+            pass
 
     async def _remove_spacer(self) -> None:
         """Remove the initial spacer when first message is sent."""
@@ -445,7 +467,8 @@ class DeepAgentsApp(App):
         try:
             messages = self.query_one("#messages", Container)
             await messages.mount(menu)
-            self._scroll_chat_to_bottom()
+            # Scroll to make approval visible (but don't re-anchor)
+            self.call_after_refresh(menu.scroll_visible)
             # Focus approval menu
             self.call_after_refresh(menu.focus)
         except Exception as e:
@@ -536,8 +559,9 @@ class DeepAgentsApp(App):
             if result.returncode != 0:
                 await self._mount_message(ErrorMessage(f"Exit code: {result.returncode}"))
 
-            # Scroll to show the output
-            self._scroll_chat_to_bottom()
+            # Scroll to show the output (user-initiated command, so scroll is expected)
+            chat = self.query_one("#chat", VerticalScroll)
+            chat.scroll_end(animate=False)
 
         except subprocess.TimeoutExpired:
             await self._mount_message(ErrorMessage("Command timed out (60s limit)"))
@@ -627,6 +651,11 @@ class DeepAgentsApp(App):
         """
         # Mount the user message
         await self._mount_message(UserMessage(message))
+
+        # Scroll to bottom when user sends a new message
+        chat = self.query_one("#chat", VerticalScroll)
+        if chat.max_scroll_y > 0:
+            chat.scroll_end(animate=False)
 
         # Check if agent is available
         if self._agent and self._ui_adapter and self._session_state:
@@ -720,8 +749,21 @@ class DeepAgentsApp(App):
                 elif isinstance(msg, AIMessage):
                     # Render text content if present
                     content = msg.content
-                    if isinstance(content, str) and content.strip():
-                        widget = AssistantMessage(content)
+                    # Handle both string content and list of content blocks
+                    text_content = ""
+                    if isinstance(content, str):
+                        text_content = content.strip()
+                    elif isinstance(content, list):
+                        # Extract text from content blocks
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                text_content += block.get("text", "")
+                            elif isinstance(block, str):
+                                text_content += block
+                        text_content = text_content.strip()
+
+                    if text_content:
+                        widget = AssistantMessage(text_content)
                         await self._mount_message(widget)
                         await widget.write_initial_content()
 
@@ -768,12 +810,13 @@ class DeepAgentsApp(App):
             # Show system message indicating this is a resumed session
             await self._mount_message(SystemMessage(f"Resumed session: {self._lc_thread_id}"))
 
-            # Scroll to bottom after UI renders
+            # Scroll to bottom after UI fully renders
+            # Use set_timer to ensure layout is complete (Markdown rendering is async)
             def scroll_to_end() -> None:
                 chat = self.query_one("#chat", VerticalScroll)
-                chat.scroll_end(animate=False)
+                chat.scroll_end(animate=False, immediate=True)
 
-            self.call_after_refresh(scroll_to_end)
+            self.set_timer(0.1, scroll_to_end)
 
         except Exception as e:
             # Don't fail the app if history loading fails
@@ -921,7 +964,9 @@ class DeepAgentsApp(App):
         """Handle clicks anywhere in the terminal to focus on the command line."""
         if not self._chat_input:
             return
-
+        # Don't steal focus from approval widget
+        if self._pending_approval_widget:
+            return
         self.call_after_refresh(self._chat_input.focus_input)
 
     def on_mouse_up(self, event: MouseUp) -> None:  # noqa: ARG002

--- a/libs/deepagents-cli/deepagents_cli/app.py
+++ b/libs/deepagents-cli/deepagents_cli/app.py
@@ -38,8 +38,6 @@ if TYPE_CHECKING:
     from textual.worker import Worker
 
 
-
-
 class TextualTokenTracker:
     """Token tracker that updates the status bar."""
 

--- a/libs/deepagents-cli/deepagents_cli/textual_adapter.py
+++ b/libs/deepagents-cli/deepagents_cli/textual_adapter.py
@@ -10,7 +10,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.human_in_the_loop import (
-    ActionRequest,
     HITLRequest,
     HITLResponse,
 )

--- a/libs/deepagents-cli/deepagents_cli/textual_adapter.py
+++ b/libs/deepagents-cli/deepagents_cli/textual_adapter.py
@@ -386,14 +386,15 @@ async def execute_task_textual(
                                     current_msg = AssistantMessage()
                                     await adapter._mount_message(current_msg)
                                     assistant_message_by_namespace[ns_key] = current_msg
-                                    # Anchor scroll once when message is created
-                                    # anchor() keeps scroll locked to bottom as content grows
-                                    if adapter._scroll_to_bottom:
-                                        adapter._scroll_to_bottom()
 
                                 # Append just the new text chunk for smoother streaming
                                 # (uses MarkdownStream internally for better performance)
                                 await current_msg.append_content(text)
+
+                                # Sticky scroll: scroll to bottom only if user is near bottom
+                                # This lets users scroll away and stay where they are
+                                if adapter._scroll_to_bottom:
+                                    adapter._scroll_to_bottom()
 
                         elif block_type in ("tool_call_chunk", "tool_call"):
                             chunk_name = block.get("name")
@@ -472,6 +473,10 @@ async def execute_task_textual(
                                 await adapter._mount_message(tool_msg)
                                 adapter._current_tool_messages[buffer_id] = tool_msg
 
+                                # Sticky scroll after tool call is shown
+                                if adapter._scroll_to_bottom:
+                                    adapter._scroll_to_bottom()
+
                             tool_call_buffers.pop(buffer_key, None)
 
                     if getattr(message, "chunk_position", None) == "last":
@@ -497,89 +502,70 @@ async def execute_task_textual(
                 any_rejected = False
 
                 for interrupt_id, hitl_request in pending_interrupts.items():
+                    action_requests = hitl_request["action_requests"]
+
                     if session_state.auto_approve:
-                        # Auto-approve silently (user sees tool calls already)
-                        decisions = [{"type": "approve"} for _ in hitl_request["action_requests"]]
+                        # Auto-approve silently - start running animation
+                        decisions = [{"type": "approve"} for _ in action_requests]
                         hitl_response[interrupt_id] = {"decisions": decisions}
+                        # Mark all tools as running
+                        for tool_msg in adapter._current_tool_messages.values():
+                            tool_msg.set_running()
                     else:
-                        # Request approval via adapter
-                        decisions = []
+                        # Batch approval - one dialog for all parallel tool calls
+                        future = await adapter._request_approval(action_requests, assistant_id)
+                        decision = await future
 
-                        def mark_hitl_approved(action_request: ActionRequest) -> None:
-                            tool_name = action_request.get("name")
-                            if tool_name not in {"write_file", "edit_file"}:
-                                return
-                            args = action_request.get("args", {})
-                            if isinstance(args, dict):
-                                file_op_tracker.mark_hitl_approved(tool_name, args)
+                        # Handle the batch decision
+                        if isinstance(decision, dict):
+                            decision_type = decision.get("type")
 
-                        for action_request in hitl_request["action_requests"]:
-                            future = await adapter._request_approval(action_request, assistant_id)
-                            decision = await future
-
-                            # Check for auto-approve-all
-                            if (
-                                isinstance(decision, dict)
-                                and decision.get("type") == "auto_approve_all"
-                            ):
+                            if decision_type == "auto_approve_all":
+                                # Enable auto-approve for session
                                 session_state.auto_approve = True
                                 if adapter._on_auto_approve_enabled:
                                     adapter._on_auto_approve_enabled()
-                                decisions.append({"type": "approve"})
-                                mark_hitl_approved(action_request)
-                                # Approve remaining actions
-                                for _ in hitl_request["action_requests"][len(decisions) :]:
-                                    decisions.append({"type": "approve"})
-                                break
+                                # Approve all
+                                decisions = [{"type": "approve"} for _ in action_requests]
+                                for tool_msg in adapter._current_tool_messages.values():
+                                    tool_msg.set_running()
+                                # Mark file ops as approved
+                                for action_request in action_requests:
+                                    tool_name = action_request.get("name")
+                                    if tool_name in {"write_file", "edit_file"}:
+                                        args = action_request.get("args", {})
+                                        if isinstance(args, dict):
+                                            file_op_tracker.mark_hitl_approved(tool_name, args)
 
-                            decisions.append(decision)
-                            # Try multiple keys for tool call id
-                            tool_id = (
-                                action_request.get("id")
-                                or action_request.get("tool_call_id")
-                                or action_request.get("call_id")
-                            )
-                            tool_name = action_request.get("name", "")
+                            elif decision_type == "approve":
+                                # Approve all
+                                decisions = [{"type": "approve"} for _ in action_requests]
+                                for tool_msg in adapter._current_tool_messages.values():
+                                    tool_msg.set_running()
+                                # Mark file ops as approved
+                                for action_request in action_requests:
+                                    tool_name = action_request.get("name")
+                                    if tool_name in {"write_file", "edit_file"}:
+                                        args = action_request.get("args", {})
+                                        if isinstance(args, dict):
+                                            file_op_tracker.mark_hitl_approved(tool_name, args)
 
-                            # Find matching tool message - by id or by name as fallback
-                            tool_msg = None
-                            tool_msg_key = None  # Track key for cleanup
-                            if tool_id and tool_id in adapter._current_tool_messages:
-                                tool_msg = adapter._current_tool_messages[tool_id]
-                                tool_msg_key = tool_id
-                            elif tool_name:
-                                # Fallback: find last tool message with matching name
-                                for key, msg in reversed(
-                                    list(adapter._current_tool_messages.items())
-                                ):
-                                    if msg._tool_name == tool_name:
-                                        tool_msg = msg
-                                        tool_msg_key = key
-                                        break
-
-                            if isinstance(decision, dict) and decision.get("type") == "approve":
-                                mark_hitl_approved(action_request)
-                                # Don't call set_success here - wait for actual tool output
-                                # The ToolMessage handler will update with real results
-                            elif isinstance(decision, dict) and decision.get("type") == "reject":
-                                if tool_msg:
+                            elif decision_type == "reject":
+                                # Reject all
+                                decisions = [{"type": "reject"} for _ in action_requests]
+                                for tool_msg in adapter._current_tool_messages.values():
                                     tool_msg.set_rejected()
-                                # Only remove from tracking on reject (approved tools need output update)
-                                if tool_msg_key and tool_msg_key in adapter._current_tool_messages:
-                                    del adapter._current_tool_messages[tool_msg_key]
-                                # Mark remaining pending tools as skipped and return immediately
-                                for remaining_msg in list(adapter._current_tool_messages.values()):
-                                    remaining_msg.set_skipped()
                                 adapter._current_tool_messages.clear()
                                 any_rejected = True
-                                break  # Exit approval loop immediately
-
-                        if any(d.get("type") == "reject" for d in decisions):
+                            else:
+                                decisions = [{"type": "reject"} for _ in action_requests]
+                                any_rejected = True
+                        else:
+                            decisions = [{"type": "reject"} for _ in action_requests]
                             any_rejected = True
 
                         hitl_response[interrupt_id] = {"decisions": decisions}
 
-                        # If rejected, break out of outer loop too
                         if any_rejected:
                             break
 

--- a/libs/deepagents-cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/deepagents-cli/deepagents_cli/widgets/chat_input.py
@@ -358,6 +358,9 @@ class ChatInput(Vertical):
             cursor_offset = self._get_cursor_offset()
             self._completion_manager.on_text_changed(text, cursor_offset)
 
+        # Scroll input into view when content changes (handles text wrap)
+        self.scroll_visible()
+
     def on_chat_text_area_submitted(self, event: ChatTextArea.Submitted) -> None:
         """Handle text submission."""
         if not self._submit_enabled:

--- a/libs/deepagents-cli/deepagents_cli/widgets/messages.py
+++ b/libs/deepagents-cli/deepagents_cli/widgets/messages.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from rich.text import Text
 from textual.containers import Vertical
+from textual.events import Click
 from textual.timer import Timer
 from textual.widgets import Markdown, Static
 from textual.widgets._markdown import MarkdownStream
@@ -393,7 +394,7 @@ class ToolCallMessage(Vertical):
         self._expanded = not self._expanded
         self._update_output_display()
 
-    def on_click(self, event: Any) -> None:
+    def on_click(self, event: Click) -> None:
         """Handle click to toggle output expansion."""
         event.stop()  # Prevent click from bubbling up and scrolling
         self.toggle_output()

--- a/libs/deepagents-cli/deepagents_cli/widgets/messages.py
+++ b/libs/deepagents-cli/deepagents_cli/widgets/messages.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from time import time
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from rich.text import Text
 from textual.containers import Vertical
+from textual.timer import Timer
 from textual.widgets import Markdown, Static
 from textual.widgets._markdown import MarkdownStream
 
@@ -158,6 +160,7 @@ class ToolCallMessage(Vertical):
 
     Tool outputs are shown as a 3-line preview by default.
     Press Ctrl+O to expand/collapse the full output.
+    Shows an animated "Running..." indicator while the tool is executing.
     """
 
     DEFAULT_CSS = """
@@ -205,8 +208,7 @@ class ToolCallMessage(Vertical):
         padding: 1;
         background: $surface-darken-1;
         color: $text-muted;
-        max-height: 20;
-        overflow-y: auto;
+        height: auto;
     }
 
     ToolCallMessage .tool-output-preview {
@@ -224,6 +226,9 @@ class ToolCallMessage(Vertical):
         background: $surface-lighten-1;
     }
     """
+
+    # Spinner frames for running animation
+    _SPINNER_FRAMES: ClassVar[tuple[str, ...]] = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
     # Max lines/chars to show in preview mode
     _PREVIEW_LINES = 3
@@ -245,7 +250,7 @@ class ToolCallMessage(Vertical):
         super().__init__(**kwargs)
         self._tool_name = tool_name
         self._args = args or {}
-        self._status = "pending"
+        self._status = "pending"  # Waiting for approval or auto-approve
         self._output: str = ""
         self._expanded: bool = False
         # Widget references (set in on_mount)
@@ -253,6 +258,10 @@ class ToolCallMessage(Vertical):
         self._preview_widget: Static | None = None
         self._hint_widget: Static | None = None
         self._full_widget: Static | None = None
+        # Animation state
+        self._spinner_position = 0
+        self._start_time: float | None = None
+        self._animation_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the tool call message layout."""
@@ -267,7 +276,7 @@ class ToolCallMessage(Vertical):
             if len(args) > _MAX_INLINE_ARGS:
                 args_str += ", ..."
             yield Static(f"({args_str})", classes="tool-args")
-        # Status - hidden by default, only shown for errors/rejections
+        # Status - shows running animation while pending, then final status
         yield Static("", classes="tool-status", id="status")
         # Output area - hidden initially, shown when output is set
         # Use markup=False for output content to prevent Rich markup injection
@@ -276,15 +285,53 @@ class ToolCallMessage(Vertical):
         yield Static("", classes="tool-output", id="output-full", markup=False)
 
     def on_mount(self) -> None:
-        """Cache widget references and hide status/output areas initially."""
+        """Cache widget references and hide all status/output areas initially."""
         self._status_widget = self.query_one("#status", Static)
         self._preview_widget = self.query_one("#output-preview", Static)
         self._hint_widget = self.query_one("#output-hint", Static)
         self._full_widget = self.query_one("#output-full", Static)
+        # Hide everything initially - status only shown when running or on error/reject
         self._status_widget.display = False
         self._preview_widget.display = False
         self._hint_widget.display = False
         self._full_widget.display = False
+
+    def set_running(self) -> None:
+        """Mark the tool as running (approved and executing).
+
+        Call this when approval is granted to start the running animation.
+        """
+        if self._status == "running":
+            return  # Already running
+
+        self._status = "running"
+        self._start_time = time()
+        if self._status_widget:
+            self._status_widget.add_class("pending")
+            self._status_widget.display = True
+        self._update_running_animation()
+        self._animation_timer = self.set_interval(0.1, self._update_running_animation)
+
+    def _update_running_animation(self) -> None:
+        """Update the running spinner animation."""
+        if self._status != "running" or self._status_widget is None:
+            return
+
+        frame = self._SPINNER_FRAMES[self._spinner_position]
+        self._spinner_position = (self._spinner_position + 1) % len(self._SPINNER_FRAMES)
+
+        elapsed = ""
+        if self._start_time is not None:
+            elapsed_secs = int(time() - self._start_time)
+            elapsed = f" ({elapsed_secs}s)"
+
+        self._status_widget.update(f"[yellow]{frame} Running...{elapsed}[/yellow]")
+
+    def _stop_animation(self) -> None:
+        """Stop the running animation."""
+        if self._animation_timer is not None:
+            self._animation_timer.stop()
+            self._animation_timer = None
 
     def set_success(self, result: str = "") -> None:
         """Mark the tool call as successful.
@@ -292,9 +339,13 @@ class ToolCallMessage(Vertical):
         Args:
             result: Tool output/result to display
         """
+        self._stop_animation()
         self._status = "success"
         self._output = result
-        # No status label for success - just show output
+        if self._status_widget:
+            self._status_widget.remove_class("pending")
+            # Hide status on success - output speaks for itself
+            self._status_widget.display = False
         self._update_output_display()
 
     def set_error(self, error: str) -> None:
@@ -303,9 +354,11 @@ class ToolCallMessage(Vertical):
         Args:
             error: Error message
         """
+        self._stop_animation()
         self._status = "error"
         self._output = error
         if self._status_widget:
+            self._status_widget.remove_class("pending")
             self._status_widget.add_class("error")
             self._status_widget.update("[red]✗ Error[/red]")
             self._status_widget.display = True
@@ -315,16 +368,20 @@ class ToolCallMessage(Vertical):
 
     def set_rejected(self) -> None:
         """Mark the tool call as rejected by user."""
+        self._stop_animation()
         self._status = "rejected"
         if self._status_widget:
+            self._status_widget.remove_class("pending")
             self._status_widget.add_class("rejected")
             self._status_widget.update("[yellow]✗ Rejected[/yellow]")
             self._status_widget.display = True
 
     def set_skipped(self) -> None:
         """Mark the tool call as skipped (due to another rejection)."""
+        self._stop_animation()
         self._status = "skipped"
         if self._status_widget:
+            self._status_widget.remove_class("pending")
             self._status_widget.add_class("rejected")  # Use same styling as rejected
             self._status_widget.update("[dim]- Skipped[/dim]")
             self._status_widget.display = True
@@ -336,8 +393,9 @@ class ToolCallMessage(Vertical):
         self._expanded = not self._expanded
         self._update_output_display()
 
-    def on_click(self) -> None:
+    def on_click(self, event: Any) -> None:
         """Handle click to toggle output expansion."""
+        event.stop()  # Prevent click from bubbling up and scrolling
         self.toggle_output()
 
     def _update_output_display(self) -> None:


### PR DESCRIPTION
  Changes                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  - Scroll: scroll down on input new line and resume                                                                                       
  - Batch approval: Parallel tool calls now show a single approval dialog ("Approve all 4 / Reject all 4") instead of one-by-one                                                                                 
  - Tool status indicators: Shows animated "Running..." spinner with elapsed time while tools execute                                                                                                                                                                                                                                                                                                                                                         