### PR TITLE
feat(cli): add custom subagent support via filesystem

### DIFF
--- a/libs/deepagents-cli/deepagents_cli/agent.py
+++ b/libs/deepagents-cli/deepagents_cli/agent.py
@@ -26,6 +26,7 @@ from deepagents_cli.config import COLORS, config, console, get_default_coding_in
 from deepagents_cli.integrations.sandbox_factory import get_default_working_dir
 from deepagents_cli.local_context import LocalContextMiddleware
 from deepagents_cli.shell import ShellMiddleware
+from deepagents_cli.subagents import list_subagents
 
 
 def list_agents() -> None:
@@ -380,6 +381,24 @@ def create_cli_agent(
         skills_dir = settings.ensure_user_skills_dir(assistant_id)
         project_skills_dir = settings.get_project_skills_dir()
 
+    # Load custom subagents from filesystem
+    custom_subagents: list[dict] = []
+    user_agents_dir = settings.get_user_agents_dir(assistant_id)
+    project_agents_dir = settings.get_project_agents_dir()
+
+    for subagent_meta in list_subagents(
+        user_agents_dir=user_agents_dir,
+        project_agents_dir=project_agents_dir,
+    ):
+        subagent: dict = {
+            "name": subagent_meta["name"],
+            "description": subagent_meta["description"],
+            "system_prompt": subagent_meta["system_prompt"],
+        }
+        if subagent_meta["model"]:
+            subagent["model"] = subagent_meta["model"]
+        custom_subagents.append(subagent)
+
     # Build middleware stack based on enabled features
     agent_middleware = []
 
@@ -484,5 +503,6 @@ def create_cli_agent(
         middleware=agent_middleware,
         interrupt_on=interrupt_on,
         checkpointer=final_checkpointer,
+        subagents=custom_subagents if custom_subagents else None,
     ).with_config(config)
     return agent, composite_backend

--- a/libs/deepagents-cli/deepagents_cli/config.py
+++ b/libs/deepagents-cli/deepagents_cli/config.py
@@ -384,6 +384,27 @@ class Settings:
         skills_dir.mkdir(parents=True, exist_ok=True)
         return skills_dir
 
+    def get_user_agents_dir(self, agent_name: str) -> Path:
+        """Get user-level agents directory path for custom subagent definitions.
+
+        Args:
+            agent_name: Name of the CLI agent (e.g., "deepagents")
+
+        Returns:
+            Path to ~/.deepagents/{agent_name}/agents/
+        """
+        return self.get_agent_dir(agent_name) / "agents"
+
+    def get_project_agents_dir(self) -> Path | None:
+        """Get project-level agents directory path for custom subagent definitions.
+
+        Returns:
+            Path to {project_root}/.deepagents/agents/, or None if not in a project
+        """
+        if not self.project_root:
+            return None
+        return self.project_root / ".deepagents" / "agents"
+
 
 # Global settings instance (initialized once)
 settings = Settings.from_environment()

--- a/libs/deepagents-cli/deepagents_cli/subagents.py
+++ b/libs/deepagents-cli/deepagents_cli/subagents.py
@@ -1,0 +1,171 @@
+"""Subagent loader for CLI.
+
+Loads custom subagent definitions from the filesystem. Subagents are defined
+as markdown files with YAML frontmatter in the agents/ directory.
+
+Directory structure:
+    .deepagents/agents/{agent_name}/{agent_name}.md
+
+Example file (researcher/researcher.md):
+    ---
+    name: researcher
+    description: Research topics on the web before writing content
+    model: anthropic:claude-haiku-4-5-20251001
+    ---
+
+    You are a research assistant with access to web search.
+
+    ## Your Process
+    1. Search for relevant information
+    2. Summarize findings clearly
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, TypedDict
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class SubagentMetadata(TypedDict):
+    """Metadata for a custom subagent loaded from filesystem."""
+
+    name: str
+    """Unique identifier for the subagent, used with the task tool."""
+
+    description: str
+    """What this subagent does. Main agent uses this to decide when to delegate."""
+
+    system_prompt: str
+    """Instructions for the subagent (body of the markdown file)."""
+
+    model: str | None
+    """Optional model override in 'provider:model-name' format."""
+
+    source: str
+    """Where this subagent was loaded from ('user' or 'project')."""
+
+    path: str
+    """Absolute path to the subagent definition file."""
+
+
+def _parse_subagent_file(file_path: Path) -> SubagentMetadata | None:
+    """Parse a subagent markdown file with YAML frontmatter.
+
+    The file must have YAML frontmatter (delimited by ---) containing at minimum
+    'name' and 'description' fields. The body of the file becomes the system_prompt.
+
+    Args:
+        file_path: Path to the markdown file.
+
+    Returns:
+        SubagentMetadata if parsing succeeds, None otherwise.
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    # Extract YAML frontmatter (--- delimited)
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
+    if not match:
+        return None
+
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return None
+
+    # Validate frontmatter structure and required fields
+    if not isinstance(frontmatter, dict):
+        return None
+
+    name = frontmatter.get("name")
+    description = frontmatter.get("description")
+    model = frontmatter.get("model")
+
+    # Validate types: name and description must be non-empty strings
+    # model is optional but must be string if present
+    name_valid = isinstance(name, str) and name
+    description_valid = isinstance(description, str) and description
+    model_valid = model is None or isinstance(model, str)
+
+    if not (name_valid and description_valid and model_valid):
+        return None
+
+    return {
+        "name": name,
+        "description": description,
+        "system_prompt": match.group(2).strip(),
+        "model": model,
+        "source": "",  # Set by caller
+        "path": str(file_path),
+    }
+
+
+def _load_subagents_from_dir(agents_dir: Path, source: str) -> dict[str, SubagentMetadata]:
+    """Load subagents from a directory.
+
+    Expects structure: agents_dir/{subagent_name}/{subagent_name}.md
+
+    Args:
+        agents_dir: Directory containing subagent folders.
+        source: Source identifier ('user' or 'project').
+
+    Returns:
+        Dict mapping subagent name to metadata.
+    """
+    subagents: dict[str, SubagentMetadata] = {}
+
+    if not agents_dir.exists() or not agents_dir.is_dir():
+        return subagents
+
+    for folder in agents_dir.iterdir():
+        if not folder.is_dir():
+            continue
+
+        # Look for {folder_name}/{folder_name}.md
+        subagent_file = folder / f"{folder.name}.md"
+        if not subagent_file.exists():
+            continue
+
+        subagent = _parse_subagent_file(subagent_file)
+        if subagent:
+            subagent["source"] = source
+            subagents[subagent["name"]] = subagent
+
+    return subagents
+
+
+def list_subagents(
+    *,
+    user_agents_dir: Path | None = None,
+    project_agents_dir: Path | None = None,
+) -> list[SubagentMetadata]:
+    """List subagents from user and/or project directories.
+
+    Scans for subagent definitions in the provided directories.
+    Project subagents override user subagents with the same name.
+
+    Args:
+        user_agents_dir: Path to user-level agents directory.
+        project_agents_dir: Path to project-level agents directory.
+
+    Returns:
+        List of subagent metadata, with project subagents taking precedence.
+    """
+    all_subagents: dict[str, SubagentMetadata] = {}
+
+    # Load user subagents first (lower priority)
+    if user_agents_dir is not None:
+        all_subagents.update(_load_subagents_from_dir(user_agents_dir, "user"))
+
+    # Load project subagents second (override user)
+    if project_agents_dir is not None:
+        all_subagents.update(_load_subagents_from_dir(project_agents_dir, "project"))
+
+    return list(all_subagents.values())

--- a/libs/deepagents-cli/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents-cli/tests/unit_tests/test_subagents.py
@@ -1,0 +1,428 @@
+"""Unit tests for subagent loading functionality."""
+
+from pathlib import Path
+
+from deepagents_cli.subagents import (
+    _load_subagents_from_dir,
+    _parse_subagent_file,
+    list_subagents,
+)
+
+
+def make_subagent_content(
+    name: str,
+    description: str,
+    model: str | None = None,
+    system_prompt: str | None = None,
+) -> str:
+    """Create subagent markdown content with YAML frontmatter."""
+    model_line = f"model: {model}\n" if model else ""
+    prompt = system_prompt or f"You are a {name} assistant.\n\n## Instructions\nDo your job well."
+    return f"""---
+name: {name}
+description: {description}
+{model_line}---
+
+{prompt}
+"""
+
+
+class TestParseSubagentFile:
+    """Test _parse_subagent_file function."""
+
+    def test_parse_valid_subagent_with_all_fields(self, tmp_path: Path) -> None:
+        """Test parsing a valid subagent file with all fields."""
+        subagent_file = tmp_path / "researcher.md"
+        subagent_file.write_text(
+            make_subagent_content(
+                "researcher",
+                "Research topics on the web",
+                model="anthropic:claude-haiku-4-5-20251001",
+            )
+        )
+
+        result = _parse_subagent_file(subagent_file)
+
+        assert result is not None
+        assert result["name"] == "researcher"
+        assert result["description"] == "Research topics on the web"
+        assert result["model"] == "anthropic:claude-haiku-4-5-20251001"
+        assert "researcher assistant" in result["system_prompt"]
+        assert "## Instructions" in result["system_prompt"]
+        assert result["path"] == str(subagent_file)
+
+    def test_parse_subagent_without_model(self, tmp_path: Path) -> None:
+        """Test parsing subagent without optional model field."""
+        subagent_file = tmp_path / "helper.md"
+        subagent_file.write_text(make_subagent_content("helper", "A helpful assistant"))
+
+        result = _parse_subagent_file(subagent_file)
+
+        assert result is not None
+        assert result["name"] == "helper"
+        assert result["description"] == "A helpful assistant"
+        assert result["model"] is None
+
+    def test_parse_subagent_with_multiline_system_prompt(self, tmp_path: Path) -> None:
+        """Test parsing subagent with complex multiline system prompt."""
+        subagent_file = tmp_path / "writer.md"
+        content = """---
+name: writer
+description: Write content
+---
+
+You are a skilled writer.
+
+## Guidelines
+
+1. Write clearly
+2. Use proper grammar
+3. Be concise
+
+## Output Format
+
+Always structure your response with headings.
+"""
+        subagent_file.write_text(content)
+
+        result = _parse_subagent_file(subagent_file)
+
+        assert result is not None
+        assert "## Guidelines" in result["system_prompt"]
+        assert "## Output Format" in result["system_prompt"]
+        assert "1. Write clearly" in result["system_prompt"]
+
+    def test_parse_subagent_missing_name(self, tmp_path: Path) -> None:
+        """Test that subagent without name is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+description: Missing name field
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_missing_description(self, tmp_path: Path) -> None:
+        """Test that subagent without description is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+name: invalid
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_no_frontmatter(self, tmp_path: Path) -> None:
+        """Test that file without frontmatter is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("# Just markdown\n\nNo frontmatter.")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_invalid_yaml(self, tmp_path: Path) -> None:
+        """Test that invalid YAML is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+name: [unclosed
+description: test
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_empty_name(self, tmp_path: Path) -> None:
+        """Test that empty name is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+name: ""
+description: Has empty name
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_non_string_name(self, tmp_path: Path) -> None:
+        """Test that non-string name is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+name: 123
+description: Has numeric name
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_non_string_model(self, tmp_path: Path) -> None:
+        """Test that non-string model is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+name: test
+description: Test
+model: 123
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test that nonexistent file returns None."""
+        subagent_file = tmp_path / "nonexistent.md"
+
+        assert _parse_subagent_file(subagent_file) is None
+
+    def test_parse_subagent_frontmatter_not_dict(self, tmp_path: Path) -> None:
+        """Test that non-dict frontmatter is rejected."""
+        subagent_file = tmp_path / "invalid.md"
+        subagent_file.write_text("""---
+- item1
+- item2
+---
+
+Content
+""")
+
+        assert _parse_subagent_file(subagent_file) is None
+
+
+class TestLoadSubagentsFromDir:
+    """Test _load_subagents_from_dir function."""
+
+    def test_load_from_empty_directory(self, tmp_path: Path) -> None:
+        """Test loading from empty directory."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+
+        result = _load_subagents_from_dir(agents_dir, "user")
+        assert result == {}
+
+    def test_load_single_subagent(self, tmp_path: Path) -> None:
+        """Test loading a single subagent."""
+        agents_dir = tmp_path / "agents"
+        folder = agents_dir / "researcher"
+        folder.mkdir(parents=True)
+        (folder / "researcher.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+
+        result = _load_subagents_from_dir(agents_dir, "user")
+
+        assert len(result) == 1
+        assert "researcher" in result
+        assert result["researcher"]["source"] == "user"
+
+    def test_load_multiple_subagents(self, tmp_path: Path) -> None:
+        """Test loading multiple subagents."""
+        agents_dir = tmp_path / "agents"
+
+        for name in ["researcher", "writer", "reviewer"]:
+            folder = agents_dir / name
+            folder.mkdir(parents=True)
+            (folder / f"{name}.md").write_text(
+                make_subagent_content(name, f"{name.title()} assistant")
+            )
+
+        result = _load_subagents_from_dir(agents_dir, "project")
+
+        assert len(result) == 3
+        assert all(s["source"] == "project" for s in result.values())
+
+    def test_load_skips_misnamed_files(self, tmp_path: Path) -> None:
+        """Test that files not matching folder name are skipped."""
+        agents_dir = tmp_path / "agents"
+        folder = agents_dir / "researcher"
+        folder.mkdir(parents=True)
+        # Wrong filename - should be researcher.md
+        (folder / "agent.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+
+        result = _load_subagents_from_dir(agents_dir, "user")
+        assert result == {}
+
+    def test_load_skips_invalid_subagents(self, tmp_path: Path) -> None:
+        """Test that invalid subagents are skipped."""
+        agents_dir = tmp_path / "agents"
+
+        # Valid subagent
+        valid_folder = agents_dir / "valid"
+        valid_folder.mkdir(parents=True)
+        (valid_folder / "valid.md").write_text(
+            make_subagent_content("valid", "Valid assistant")
+        )
+
+        # Invalid subagent (missing description)
+        invalid_folder = agents_dir / "invalid"
+        invalid_folder.mkdir(parents=True)
+        (invalid_folder / "invalid.md").write_text("""---
+name: invalid
+---
+Content
+""")
+
+        result = _load_subagents_from_dir(agents_dir, "user")
+
+        assert len(result) == 1
+        assert "valid" in result
+
+    def test_load_skips_files_in_root(self, tmp_path: Path) -> None:
+        """Test that files directly in agents dir (not in subfolders) are skipped."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "stray.md").write_text(
+            make_subagent_content("stray", "Stray file")
+        )
+
+        result = _load_subagents_from_dir(agents_dir, "user")
+        assert result == {}
+
+    def test_load_nonexistent_directory(self, tmp_path: Path) -> None:
+        """Test loading from nonexistent directory."""
+        result = _load_subagents_from_dir(tmp_path / "nonexistent", "user")
+        assert result == {}
+
+
+class TestListSubagents:
+    """Test list_subagents function."""
+
+    def test_list_no_directories(self) -> None:
+        """Test listing with no directories specified."""
+        result = list_subagents()
+        assert result == []
+
+    def test_list_user_only(self, tmp_path: Path) -> None:
+        """Test listing from user directory only."""
+        user_dir = tmp_path / "user_agents"
+        folder = user_dir / "researcher"
+        folder.mkdir(parents=True)
+        (folder / "researcher.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+
+        result = list_subagents(user_agents_dir=user_dir)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "researcher"
+        assert result[0]["source"] == "user"
+
+    def test_list_project_only(self, tmp_path: Path) -> None:
+        """Test listing from project directory only."""
+        project_dir = tmp_path / "project_agents"
+        folder = project_dir / "reviewer"
+        folder.mkdir(parents=True)
+        (folder / "reviewer.md").write_text(
+            make_subagent_content("reviewer", "Code reviewer")
+        )
+
+        result = list_subagents(project_agents_dir=project_dir)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "reviewer"
+        assert result[0]["source"] == "project"
+
+    def test_list_both_sources(self, tmp_path: Path) -> None:
+        """Test listing from both user and project directories."""
+        user_dir = tmp_path / "user_agents"
+        project_dir = tmp_path / "project_agents"
+
+        # User subagent
+        user_folder = user_dir / "researcher"
+        user_folder.mkdir(parents=True)
+        (user_folder / "researcher.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+
+        # Project subagent
+        project_folder = project_dir / "reviewer"
+        project_folder.mkdir(parents=True)
+        (project_folder / "reviewer.md").write_text(
+            make_subagent_content("reviewer", "Code reviewer")
+        )
+
+        result = list_subagents(
+            user_agents_dir=user_dir,
+            project_agents_dir=project_dir,
+        )
+
+        assert len(result) == 2
+        names = {s["name"] for s in result}
+        assert names == {"researcher", "reviewer"}
+
+    def test_list_project_overrides_user(self, tmp_path: Path) -> None:
+        """Test that project subagents override user subagents with same name."""
+        user_dir = tmp_path / "user_agents"
+        project_dir = tmp_path / "project_agents"
+
+        # User version
+        user_folder = user_dir / "shared"
+        user_folder.mkdir(parents=True)
+        (user_folder / "shared.md").write_text(
+            make_subagent_content("shared", "User version")
+        )
+
+        # Project version (same name)
+        project_folder = project_dir / "shared"
+        project_folder.mkdir(parents=True)
+        (project_folder / "shared.md").write_text(
+            make_subagent_content("shared", "Project version")
+        )
+
+        result = list_subagents(
+            user_agents_dir=user_dir,
+            project_agents_dir=project_dir,
+        )
+
+        assert len(result) == 1
+        assert result[0]["name"] == "shared"
+        assert result[0]["description"] == "Project version"
+        assert result[0]["source"] == "project"
+
+    def test_list_empty_directories(self, tmp_path: Path) -> None:
+        """Test listing from empty directories."""
+        user_dir = tmp_path / "user_agents"
+        project_dir = tmp_path / "project_agents"
+        user_dir.mkdir()
+        project_dir.mkdir()
+
+        result = list_subagents(
+            user_agents_dir=user_dir,
+            project_agents_dir=project_dir,
+        )
+        assert result == []
+
+    def test_list_nonexistent_directories(self, tmp_path: Path) -> None:
+        """Test listing from nonexistent directories."""
+        result = list_subagents(
+            user_agents_dir=tmp_path / "nonexistent_user",
+            project_agents_dir=tmp_path / "nonexistent_project",
+        )
+        assert result == []
+
+    def test_list_with_model_field(self, tmp_path: Path) -> None:
+        """Test that model field is correctly loaded."""
+        user_dir = tmp_path / "agents"
+        folder = user_dir / "fast-researcher"
+        folder.mkdir(parents=True)
+        (folder / "fast-researcher.md").write_text(
+            make_subagent_content(
+                "fast-researcher",
+                "Fast research using Haiku",
+                model="anthropic:claude-haiku-4-5-20251001",
+            )
+        )
+
+        result = list_subagents(user_agents_dir=user_dir)
+
+        assert len(result) == 1
+        assert result[0]["model"] == "anthropic:claude-haiku-4-5-20251001"

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -34,11 +34,11 @@ class SubAgent(TypedDict):
         system_prompt: Instructions for the subagent.
 
             Include tool usage guidance and output format requirements.
-        tools: Tools the subagent can use.
-
-            Keep this minimal and include only what's needed.
 
     Optional fields:
+        tools: Tools the subagent can use.
+
+            If not specified, inherits tools from the main agent via `default_tools`.
         model: Override the main agent's model.
 
             Use the format `'provider:model-name'` (e.g., `'openai:gpt-4o'`).
@@ -57,8 +57,8 @@ class SubAgent(TypedDict):
     system_prompt: str
     """Instructions for the subagent."""
 
-    tools: Sequence[BaseTool | Callable | dict[str, Any]]
-    """Tools the subagent can use."""
+    tools: NotRequired[Sequence[BaseTool | Callable | dict[str, Any]]]
+    """Tools the subagent can use. If not specified, inherits from main agent."""
 
     model: NotRequired[str | BaseChatModel]
     """Override the main agent's model. Use `'provider:model-name'` format."""
@@ -523,7 +523,21 @@ class SubAgentMiddleware(AgentMiddleware):
     ) -> None:
         """Initialize the `SubAgentMiddleware`."""
         super().__init__()
-        self.system_prompt = system_prompt
+
+        # Build list of available agents for system prompt
+        subagent_descriptions = []
+        if general_purpose_agent:
+            subagent_descriptions.append(f"- general-purpose: {DEFAULT_GENERAL_PURPOSE_DESCRIPTION}")
+        for agent_ in subagents or []:
+            subagent_descriptions.append(f"- {agent_['name']}: {agent_['description']}")
+
+        # Append available agents to system prompt if we have any
+        if system_prompt is not None and subagent_descriptions:
+            agents_section = "\n\nAvailable subagent types:\n" + "\n".join(subagent_descriptions)
+            self.system_prompt = system_prompt + agents_section
+        else:
+            self.system_prompt = system_prompt
+
         task_tool = _create_task_tool(
             default_model=default_model,
             default_tools=default_tools or [],


### PR DESCRIPTION
## Summary

Adds support for defining custom subagents as markdown files with YAML frontmatter in the `.deepagents/agents/` directory.

- Users can now create custom subagents by adding `.md` files to `.deepagents/agents/{name}/{name}.md`
- Subagents are automatically loaded at CLI startup and available via the `task` tool
- Project-level agents override user-level agents with the same name
- Custom subagents can optionally specify a different model (e.g., Haiku for research tasks)

## File Format

```
.deepagents/agents/researcher/researcher.md
```

```markdown
---
name: researcher
description: Research topics before writing content
model: anthropic:claude-haiku-4-5-20251001
---

You are a research assistant with access to web search.

## Your Process
1. Search for relevant information
2. Summarize findings clearly
```

## Changes

| File | Description |
|------|-------------|
| `libs/deepagents/deepagents/middleware/subagents.py` | Make `tools` optional in `SubAgent`, inject available subagents into system prompt |
| `libs/deepagents-cli/deepagents_cli/subagents.py` | New module for loading subagent definitions from filesystem |
| `libs/deepagents-cli/deepagents_cli/config.py` | Add `get_user_agents_dir()` and `get_project_agents_dir()` |
| `libs/deepagents-cli/deepagents_cli/agent.py` | Load subagents and pass to `create_deep_agent()` |
| `libs/deepagents-cli/tests/unit_tests/test_subagents.py` | Unit tests (27 tests) |

## Test plan

- [x] Unit tests pass (27 new tests for subagent loading)
- [x] Manual testing: subagents appear in system prompt
- [x] Manual testing: invoking custom subagent via task tool works
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)