### PR TITLE
fix(sdk): prevent skills state disorder when leader and subagent both have skills

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -110,7 +110,9 @@ DEFAULT_SUBAGENT_PROMPT = "In order to complete the objective that the user asks
 # 1. The messages key is handled explicitly to ensure only the final message is included
 # 2. The todos and structured_response keys are excluded as they do not have a defined reducer
 #    and no clear meaning for returning them from a subagent to the main agent.
-_EXCLUDED_STATE_KEYS = {"messages", "todos", "structured_response"}
+# 3. The skills_metadata key is excluded to prevent subagent skills from overwriting
+#    the parent agent's skills context, ensuring proper skills isolation.
+_EXCLUDED_STATE_KEYS = {"messages", "todos", "structured_response", "skills_metadata"}
 
 TASK_TOOL_DESCRIPTION = """Launch an ephemeral subagent to handle complex, multi-step independent tasks with isolated context windows.
 


### PR DESCRIPTION
… skills

When both leader and subagent have skills configured, the subagent's skills_metadata was overwriting the leader's skills context after subagent execution. This happened because skills_metadata was shared between agents and not properly isolated.

This fix adds 'skills_metadata' to _EXCLUDED_STATE_KEYS to ensure:
- Subagents start with fresh skills state and load their own skills independently
- Subagent skills metadata doesn't get returned to the parent
- Leader maintains its own skills context throughout execution

Fixes #798

🤖 Generated with [Claude Code]