### PR TITLE
fix(deepagents): prevent state merge error in parallel sub-agents

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -155,7 +155,7 @@ class SkillsState(AgentState):
     """State for the skills middleware."""
 
     skills_metadata: NotRequired[Annotated[list[SkillMetadata], PrivateStateAttr]]
-    """List of loaded skill metadata from all configured sources."""
+    """List of loaded skill metadata from configured sources. Not propagated to parent agents."""
 
 
 class SkillsStateUpdate(TypedDict):

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -108,9 +108,10 @@ DEFAULT_SUBAGENT_PROMPT = "In order to complete the objective that the user asks
 # updates from subagents.
 # When returning updates:
 # 1. The messages key is handled explicitly to ensure only the final message is included
-# 2. The todos and structured_response keys are excluded as they do not have a defined reducer
-#    and no clear meaning for returning them from a subagent to the main agent.
-_EXCLUDED_STATE_KEYS = {"messages", "todos", "structured_response"}
+# 2. The todos, structured_response, and skills_metadata keys are excluded as they do not have
+#    a defined reducer and no clear meaning for returning them from a subagent to the main agent.
+#    Each agent loads its own skills independently based on its middleware configuration.
+_EXCLUDED_STATE_KEYS = {"messages", "todos", "structured_response", "skills_metadata"}
 
 TASK_TOOL_DESCRIPTION = """Launch an ephemeral subagent to handle complex, multi-step independent tasks with isolated context windows.
 


### PR DESCRIPTION
Fixes #923
Fixes #798

Fixes `InvalidUpdateError` when parallel sub-agents with `SkillsMiddleware` return to parent.

Added `skills_metadata` to `_EXCLUDED_STATE_KEYS` in `SubAgentMiddleware` to prevent merge conflicts. Each agent loads its own skills independently based on middleware configuration, so skills_metadata has no semantic meaning when propagated from sub-agents to parent.