### PR TITLE
fix(sdk): string interpolation in BaseSandbox write/edit tools 

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -70,12 +70,12 @@ try:
     file_path = data['path']
     content = base64.b64decode(data['content']).decode('utf-8')
 except Exception as e:
-    print(f'Error: Failed to decode write payload: {e}', file=sys.stderr)
+    print(f'Error: Failed to decode write payload: {{e}}', file=sys.stderr)
     sys.exit(1)
 
 # Check if file already exists (atomic with write)
 if os.path.exists(file_path):
-    print(f'Error: File \\'{file_path}\\' already exists', file=sys.stderr)
+    print(f'Error: File \\'{{file_path}}\\' already exists', file=sys.stderr)
     sys.exit(1)
 
 # Create parent directory if needed
@@ -111,7 +111,7 @@ try:
     old = data['old']
     new = data['new']
 except Exception as e:
-    print(f'Error: Failed to decode edit payload: {e}', file=sys.stderr)
+    print(f'Error: Failed to decode edit payload: {{e}}', file=sys.stderr)
     sys.exit(4)
 
 # Check if file exists

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -114,6 +114,7 @@ ignore-var-parameters = true
 "tests/unit_tests/backends/test_state_backend.py" = ["ANN001", "ANN201", "INP001", "PLR2004", "PT018"]
 "tests/unit_tests/backends/test_state_backend_async.py" = ["ANN001", "ANN201", "INP001", "PLR2004", "PT018"]
 "tests/unit_tests/backends/test_store_backend.py" = ["ANN201", "INP001", "PLR2004", "PT018"]
+"tests/unit_tests/backends/test_sandbox_backend.py" = ["ANN201", "INP001", "PLR2004", "PT018"]
 "tests/unit_tests/backends/test_store_backend_async.py" = ["ANN201", "INP001", "PLR2004", "PT018"]
 "tests/unit_tests/chat_model.py" = ["ARG002", "D301", "PLR0912", "RUF012"]
 "tests/unit_tests/middleware/test_memory_middleware.py" = ["F841", "PGH003", "PLR2004", "RUF001", "TC002"]

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1,0 +1,141 @@
+"""Tests for BaseSandbox backend template formatting.
+
+These tests verify that the command templates in BaseSandbox can be properly
+formatted without raising KeyError due to unescaped curly braces.
+
+Related issue: https://github.com/langchain-ai/deepagents/pull/872
+The heredoc templates introduced in PR #872 contain {e} in exception handlers
+that need to be escaped as {{e}} for Python's .format() method.
+"""
+
+import base64
+import json
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+from deepagents.backends.sandbox import (
+    _EDIT_COMMAND_TEMPLATE,
+    _GLOB_COMMAND_TEMPLATE,
+    _READ_COMMAND_TEMPLATE,
+    _WRITE_COMMAND_TEMPLATE,
+    BaseSandbox,
+)
+
+
+class MockSandbox(BaseSandbox):
+    """Minimal concrete implementation of BaseSandbox for testing."""
+
+    def __init__(self) -> None:
+        self.last_command = None
+
+    @property
+    def id(self) -> str:
+        return "mock-sandbox"
+
+    def execute(self, command: str) -> ExecuteResponse:
+        self.last_command = command
+        # Return "1" for edit commands (simulates 1 occurrence replaced)
+        return ExecuteResponse(output="1", exit_code=0, truncated=False)
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        return [FileUploadResponse(path=f[0], error=None) for f in files]
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        return [FileDownloadResponse(path=p, content=None, error="not_implemented") for p in paths]
+
+
+def test_write_command_template_format() -> None:
+    """Test that _WRITE_COMMAND_TEMPLATE can be formatted without KeyError."""
+    content = "test content with special chars: {curly} and 'quotes'"
+    content_b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    payload = json.dumps({"path": "/test/file.txt", "content": content_b64})
+    payload_b64 = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+
+    # This should not raise KeyError
+    cmd = _WRITE_COMMAND_TEMPLATE.format(payload_b64=payload_b64)
+
+    assert "python3 -c" in cmd
+    assert payload_b64 in cmd
+
+
+def test_edit_command_template_format() -> None:
+    """Test that _EDIT_COMMAND_TEMPLATE can be formatted without KeyError."""
+    payload = json.dumps({"path": "/test/file.txt", "old": "foo", "new": "bar"})
+    payload_b64 = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+
+    # This should not raise KeyError
+    cmd = _EDIT_COMMAND_TEMPLATE.format(payload_b64=payload_b64, replace_all=False)
+
+    assert "python3 -c" in cmd
+    assert payload_b64 in cmd
+
+
+def test_glob_command_template_format() -> None:
+    """Test that _GLOB_COMMAND_TEMPLATE can be formatted without KeyError."""
+    path_b64 = base64.b64encode(b"/test").decode("ascii")
+    pattern_b64 = base64.b64encode(b"*.py").decode("ascii")
+
+    cmd = _GLOB_COMMAND_TEMPLATE.format(path_b64=path_b64, pattern_b64=pattern_b64)
+
+    assert "python3 -c" in cmd
+    assert path_b64 in cmd
+    assert pattern_b64 in cmd
+
+
+def test_read_command_template_format() -> None:
+    """Test that _READ_COMMAND_TEMPLATE can be formatted without KeyError."""
+    cmd = _READ_COMMAND_TEMPLATE.format(file_path="/test/file.txt", offset=0, limit=100)
+
+    assert "python3 -c" in cmd
+    assert "/test/file.txt" in cmd
+
+
+def test_sandbox_write_method() -> None:
+    """Test that BaseSandbox.write() successfully formats the command."""
+    sandbox = MockSandbox()
+
+    # This should not raise KeyError
+    sandbox.write("/test/file.txt", "test content")
+
+    # The command should have been formatted and passed to execute()
+    assert sandbox.last_command is not None
+    assert "python3 -c" in sandbox.last_command
+
+
+def test_sandbox_edit_method() -> None:
+    """Test that BaseSandbox.edit() successfully formats the command."""
+    sandbox = MockSandbox()
+
+    # This should not raise KeyError
+    sandbox.edit("/test/file.txt", "old", "new", replace_all=False)
+
+    # The command should have been formatted and passed to execute()
+    assert sandbox.last_command is not None
+    assert "python3 -c" in sandbox.last_command
+
+
+def test_sandbox_write_with_special_content() -> None:
+    """Test write with content containing curly braces and special characters."""
+    sandbox = MockSandbox()
+
+    # Content with curly braces that could confuse format()
+    content = "def foo(): return {key: value for key, value in items.items()}"
+
+    sandbox.write("/test/code.py", content)
+
+    assert sandbox.last_command is not None
+
+
+def test_sandbox_edit_with_special_strings() -> None:
+    """Test edit with strings containing curly braces."""
+    sandbox = MockSandbox()
+
+    old_string = "{old_key}"
+    new_string = "{new_key}"
+
+    sandbox.edit("/test/file.txt", old_string, new_string, replace_all=True)
+
+    assert sandbox.last_command is not None


### PR DESCRIPTION
The heredoc-based templates introduced in #872 contain f-string placeholders like {e} and {file_path} that are incorrectly processed by Python's str.format() method, causing KeyError exceptions.

This fix escapes these placeholders as {{e}} and {{file_path}} so they become literal {e} and {file_path} after format() processing, allowing the embedded Python code to work correctly.

Fixes regression introduced in:
https://github.com/langchain-ai/deepagents/pull/872

Changes:
- _WRITE_COMMAND_TEMPLATE: escape {e} and {file_path} in exception/error handlers
- _EDIT_COMMAND_TEMPLATE: escape {e} in exception handler
- Add test_sandbox_backend.py with tests for template formatting