### PR TITLE
feat(cli): add configurable timeout to `ShellMiddleware`

### DIFF
--- a/libs/cli/deepagents_cli/shell.py
+++ b/libs/cli/deepagents_cli/shell.py
@@ -11,7 +11,7 @@ from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 from langchain_core.tools.base import ToolException
 
-_DEFAULT_SHELL_TIMEOUT = 120.0
+_DEFAULT_SHELL_TIMEOUT = 120
 
 
 class ShellMiddleware(AgentMiddleware[AgentState, Any]):
@@ -25,7 +25,7 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
         self,
         *,
         workspace_root: str,
-        timeout: float = _DEFAULT_SHELL_TIMEOUT,
+        timeout: int = _DEFAULT_SHELL_TIMEOUT,
         max_output_bytes: int = 100_000,
         env: dict[str, str] | None = None,
     ) -> None:
@@ -64,7 +64,7 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
         def shell_tool(
             command: str,
             runtime: ToolRuntime[None, AgentState],
-            timeout: float | None = None,
+            timeout: int | None = None,
         ) -> ToolMessage | str:
             """Execute a shell command.
 
@@ -86,7 +86,7 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
         command: str,
         *,
         tool_call_id: str | None,
-        timeout: float | None = None,
+        timeout: int | None = None,
     ) -> ToolMessage:
         """Execute a shell command and return the result.
 
@@ -145,7 +145,7 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
 
         except subprocess.TimeoutExpired:
             output = (
-                f"Error: Command timed out after {effective_timeout:.1f} seconds. "
+                f"Error: Command timed out after {effective_timeout} seconds. "
                 f"For long-running commands, use the timeout parameter."
             )
             status = "error"

--- a/libs/cli/deepagents_cli/shell.py
+++ b/libs/cli/deepagents_cli/shell.py
@@ -11,6 +11,8 @@ from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 from langchain_core.tools.base import ToolException
 
+_DEFAULT_SHELL_TIMEOUT = 120.0
+
 
 class ShellMiddleware(AgentMiddleware[AgentState, Any]):
     """Give basic shell access to agents via the shell.
@@ -23,7 +25,7 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
         self,
         *,
         workspace_root: str,
-        timeout: float = 120.0,
+        timeout: float = _DEFAULT_SHELL_TIMEOUT,
         max_output_bytes: int = 100_000,
         env: dict[str, str] | None = None,
     ) -> None:
@@ -31,7 +33,8 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
 
         Args:
             workspace_root: Working directory for shell commands.
-            timeout: Maximum time in seconds to wait for command completion.
+            timeout: Default maximum time in seconds to wait for command completion.
+
                 Defaults to 120 seconds.
             max_output_bytes: Maximum number of bytes to capture from command output.
                 Defaults to 100,000 bytes.
@@ -39,7 +42,10 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
                 uses the current process's environment. Defaults to None.
         """
         super().__init__()
-        self._timeout = timeout
+        if timeout <= 0:
+            msg = f"timeout must be positive, got {timeout}"
+            raise ValueError(msg)
+        self._default_timeout = timeout
         self._max_output_bytes = max_output_bytes
         self._tool_name = "shell"
         self._env = env if env is not None else os.environ.copy()
@@ -50,21 +56,27 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
             f"Execute a shell command directly on the host. Commands will run in "
             f"the working directory: {workspace_root}. Each command runs in a fresh shell "
             f"environment with the current process's environment variables. Commands may "
-            f"be truncated if they exceed the configured timeout or output limits."
+            f"be truncated if they exceed the configured timeout ({self._default_timeout}s) "
+            f"or output limits. Use the optional timeout parameter for long-running commands."
         )
 
         @tool(self._tool_name, description=description)
         def shell_tool(
             command: str,
             runtime: ToolRuntime[None, AgentState],
+            timeout: float | None = None,
         ) -> ToolMessage | str:
             """Execute a shell command.
 
             Args:
                 command: The shell command to execute.
                 runtime: The tool runtime context.
+                timeout: Optional timeout in seconds for this command. Use for
+                    long-running commands that may exceed the default timeout.
             """
-            return self._run_shell_command(command, tool_call_id=runtime.tool_call_id)
+            return self._run_shell_command(
+                command, tool_call_id=runtime.tool_call_id, timeout=timeout
+            )
 
         self._shell_tool = shell_tool
         self.tools = [self._shell_tool]
@@ -74,18 +86,26 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
         command: str,
         *,
         tool_call_id: str | None,
-    ) -> ToolMessage | str:
+        timeout: float | None = None,
+    ) -> ToolMessage:
         """Execute a shell command and return the result.
 
         Args:
             command: The shell command to execute.
             tool_call_id: The tool call ID for creating a ToolMessage.
+            timeout: Optional per-command timeout override.
 
         Returns:
             A ToolMessage with the command output or an error message.
         """
         if not command or not isinstance(command, str):
             msg = "Shell tool expects a non-empty command string."
+            raise ToolException(msg)
+
+        # Determine effective timeout: per-command > default
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        if effective_timeout <= 0:
+            msg = f"timeout must be positive, got {effective_timeout}"
             raise ToolException(msg)
 
         try:
@@ -95,7 +115,7 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
                 shell=True,
                 capture_output=True,
                 text=True,
-                timeout=self._timeout,
+                timeout=effective_timeout,
                 env=self._env,
                 cwd=self._workspace_root,
             )
@@ -124,7 +144,10 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
                 status = "success"
 
         except subprocess.TimeoutExpired:
-            output = f"Error: Command timed out after {self._timeout:.1f} seconds."
+            output = (
+                f"Error: Command timed out after {effective_timeout:.1f} seconds. "
+                f"For long-running commands, use the timeout parameter."
+            )
             status = "error"
 
         return ToolMessage(

--- a/libs/cli/tests/unit_tests/test_shell.py
+++ b/libs/cli/tests/unit_tests/test_shell.py
@@ -1,0 +1,147 @@
+"""Unit tests for `ShellMiddleware`."""
+
+import pytest
+from langchain_core.tools.base import ToolException
+
+from deepagents_cli.shell import _DEFAULT_SHELL_TIMEOUT, ShellMiddleware
+
+
+class TestShellMiddlewareInit:
+    """Tests for `ShellMiddleware` initialization."""
+
+    def test_default_timeout(self, tmp_path: str) -> None:
+        """Test that default `timeout` is used when not specified."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        assert mw._default_timeout == _DEFAULT_SHELL_TIMEOUT
+
+    def test_custom_timeout(self, tmp_path: str) -> None:
+        """Test that custom `timeout` is accepted."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path), timeout=300.0)
+        assert mw._default_timeout == 300.0
+
+    def test_rejects_invalid_timeout(self, tmp_path: str) -> None:
+        """Test that zero/negative `timeout` raises `ValueError`."""
+        with pytest.raises(ValueError, match="positive"):
+            ShellMiddleware(workspace_root=str(tmp_path), timeout=0)
+
+    def test_tools_list_populated(self, tmp_path: str) -> None:
+        """Test that `tools` list contains the shell tool."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        assert len(mw.tools) == 1
+        assert mw.tools[0].name == "shell"
+
+
+class TestRunShellCommand:
+    """Tests for `_run_shell_command`."""
+
+    def test_basic_command(self, tmp_path: str) -> None:
+        """Test running a basic `echo` command."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("echo hello", tool_call_id="test")
+        assert "hello" in result.content
+        assert result.status == "success"
+
+    def test_command_with_stderr(self, tmp_path: str) -> None:
+        """Test that `stderr` is captured."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("echo error >&2", tool_call_id="test")
+        assert "[stderr]" in result.content
+        assert "error" in result.content
+
+    def test_nonzero_exit_code(self, tmp_path: str) -> None:
+        """Test that non-zero exit codes are reported."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("exit 1", tool_call_id="test")
+        assert "Exit code: 1" in result.content
+        assert result.status == "error"
+
+    def test_empty_command_raises(self, tmp_path: str) -> None:
+        """Test that empty command raises `ToolException`."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        with pytest.raises(ToolException, match="non-empty"):
+            mw._run_shell_command("", tool_call_id="test")
+
+    def test_per_command_timeout_override(self, tmp_path: str) -> None:
+        """Test that per-command timeout overrides default."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path), timeout=1.0)
+        # Command should succeed with longer timeout
+        result = mw._run_shell_command("sleep 0.1 && echo done", tool_call_id="test", timeout=5.0)
+        assert "done" in result.content
+        assert result.status == "success"
+
+    def test_timeout_triggers(self, tmp_path: str) -> None:
+        """Test that timeout triggers for long-running commands."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("sleep 10", tool_call_id="test", timeout=0.5)
+        assert "timed out" in result.content
+        assert "0.5" in result.content
+        assert result.status == "error"
+
+    def test_timeout_error_message_suggests_parameter(self, tmp_path: str) -> None:
+        """Test that timeout error suggests using timeout parameter."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("sleep 10", tool_call_id="test", timeout=0.5)
+        assert "timeout parameter" in result.content
+
+    def test_zero_per_command_timeout_raises(self, tmp_path: str) -> None:
+        """Test that zero per-command timeout raises `ToolException`."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        with pytest.raises(ToolException, match="positive"):
+            mw._run_shell_command("echo test", tool_call_id="test", timeout=0)
+
+    def test_negative_per_command_timeout_raises(self, tmp_path: str) -> None:
+        """Test that negative per-command timeout raises `ToolException`."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        with pytest.raises(ToolException, match="positive"):
+            mw._run_shell_command("echo test", tool_call_id="test", timeout=-5)
+
+    def test_output_truncation(self, tmp_path: str) -> None:
+        """Test that long output is truncated."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path), max_output_bytes=100)
+        result = mw._run_shell_command("echo " + "x" * 200, tool_call_id="test")
+        assert "truncated" in result.content
+        assert len(result.content) < 250  # Some overhead for message
+
+    def test_workspace_root_used(self, tmp_path: str) -> None:
+        """Test that commands run in `workspace_root`."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("pwd", tool_call_id="test")
+        assert str(tmp_path) in result.content
+
+
+class TestTimeoutRetryWorkflow:
+    """Tests simulating the model retrying with increased `timeout`."""
+
+    def test_command_fails_with_short_timeout_succeeds_with_longer(self, tmp_path: str) -> None:
+        """Test that a command timing out can succeed with increased `timeout`.
+
+        This simulates the workflow where:
+
+        1. Model runs a long command with default `timeout`
+        2. Command times out
+        3. Model retries with a longer `timeout`
+        4. Command succeeds
+        """
+        mw = ShellMiddleware(workspace_root=str(tmp_path), timeout=0.5)
+
+        # First attempt: times out with short default
+        result1 = mw._run_shell_command("sleep 1 && echo done", tool_call_id="attempt1")
+        assert result1.status == "error"
+        assert "timed out" in result1.content
+
+        # Second attempt: model increases timeout, command succeeds
+        result2 = mw._run_shell_command(
+            "sleep 1 && echo done", tool_call_id="attempt2", timeout=5.0
+        )
+        assert result2.status == "success"
+        assert "done" in result2.content
+
+    def test_timeout_error_message_guides_model_to_solution(self, tmp_path: str) -> None:
+        """Test that timeout error message tells model how to fix the issue."""
+        mw = ShellMiddleware(workspace_root=str(tmp_path))
+        result = mw._run_shell_command("sleep 10", tool_call_id="test", timeout=0.5)
+
+        # Error message should guide model to use timeout parameter
+        assert "timeout parameter" in result.content
+        # Error message should show actual timeout used (for model to know to increase)
+        assert "0.5 seconds" in result.content


### PR DESCRIPTION
Introduces per-command timeout overrides to allow for long-running commands.