### PR TITLE
feat(cli): add timeout formatting to enhance `shell` command display

### DIFF
--- a/libs/cli/deepagents_cli/shell.py
+++ b/libs/cli/deepagents_cli/shell.py
@@ -12,6 +12,10 @@ from langchain_core.messages import ToolMessage
 from langchain_core.tools.base import ToolException
 
 _DEFAULT_SHELL_TIMEOUT = 120
+"""Default shell timeout in seconds.
+
+Operations longer than this will be terminated.
+"""
 
 
 class ShellMiddleware(AgentMiddleware[AgentState, Any]):
@@ -53,11 +57,12 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
 
         # Build description with working directory information
         description = (
-            f"Execute a shell command directly on the host. Commands will run in "
+            "Execute a shell command directly on the host. Commands will run in "
             f"the working directory: {workspace_root}. Each command runs in a fresh shell "
-            f"environment with the current process's environment variables. Commands may "
-            f"be truncated if they exceed the configured timeout ({self._default_timeout}s) "
-            f"or output limits. Use the optional timeout parameter for long-running commands."
+            "environment with the current process's environment variables. Commands may "
+            f"be truncated if they exceed the configured timeout ({self._default_timeout} seconds) "
+            "or output limits. Use the optional timeout parameter (in seconds) for long-running "
+            "commands."
         )
 
         @tool(self._tool_name, description=description)
@@ -71,8 +76,9 @@ class ShellMiddleware(AgentMiddleware[AgentState, Any]):
             Args:
                 command: The shell command to execute.
                 runtime: The tool runtime context.
-                timeout: Optional timeout in seconds for this command. Use for
-                    long-running commands that may exceed the default timeout.
+                timeout: Optional timeout in seconds for this command. Use for long-running
+                    commands that may exceed the default timeout.
+                    Example: timeout=300 for 5 minutes.
             """
             return self._run_shell_command(
                 command, tool_call_id=runtime.tool_call_id, timeout=timeout

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -5,6 +5,19 @@ from pathlib import Path
 from typing import Any
 
 from deepagents_cli.config import COLORS, DEEP_AGENTS_ASCII, MAX_ARG_LENGTH, console
+from deepagents_cli.shell import _DEFAULT_SHELL_TIMEOUT
+
+
+def _format_timeout(seconds: int) -> str:
+    """Format timeout in human-readable units (e.g., 300 -> '5m', 3600 -> '1h')."""
+    if seconds < 60:  # noqa: PLR2004
+        return f"{seconds}s"
+    if seconds < 3600 and seconds % 60 == 0:  # noqa: PLR2004
+        return f"{seconds // 60}m"
+    if seconds % 3600 == 0:
+        return f"{seconds // 3600}h"
+    # For odd values, just show seconds
+    return f"{seconds}s"
 
 
 def truncate_value(value: str, max_length: int = MAX_ARG_LENGTH) -> str:
@@ -86,10 +99,13 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             return f'{tool_name}("{pattern}")'
 
     elif tool_name == "shell":
-        # Shell: show the command being executed
+        # Shell: show the command, and timeout only if non-default
         if "command" in tool_args:
             command = str(tool_args["command"])
             command = truncate_value(command, 120)
+            timeout = tool_args.get("timeout")
+            if timeout is not None and timeout != _DEFAULT_SHELL_TIMEOUT:
+                return f'{tool_name}("{command}", timeout={_format_timeout(timeout)})'
             return f'{tool_name}("{command}")'
 
     elif tool_name == "execute":

--- a/libs/cli/tests/unit_tests/test_ui.py
+++ b/libs/cli/tests/unit_tests/test_ui.py
@@ -1,0 +1,119 @@
+"""Unit tests for UI rendering utilities."""
+
+from deepagents_cli.ui import _format_timeout, format_tool_display, truncate_value
+
+
+class TestFormatTimeout:
+    """Tests for `_format_timeout`."""
+
+    def test_seconds(self) -> None:
+        """Test formatting values under 60 as seconds."""
+        assert _format_timeout(30) == "30s"
+        assert _format_timeout(59) == "59s"
+
+    def test_minutes(self) -> None:
+        """Test formatting round minute values."""
+        assert _format_timeout(60) == "1m"
+        assert _format_timeout(300) == "5m"
+        assert _format_timeout(600) == "10m"
+
+    def test_hours(self) -> None:
+        """Test formatting round hour values."""
+        assert _format_timeout(3600) == "1h"
+        assert _format_timeout(7200) == "2h"
+
+    def test_odd_values_as_seconds(self) -> None:
+        """Test that non-round values show as seconds."""
+        assert _format_timeout(90) == "90s"  # 1.5 minutes
+        assert _format_timeout(3700) == "3700s"  # not round hours
+
+    def test_likely_milliseconds_shown_as_seconds(self) -> None:
+        """Test that large values (likely ms confusion) still show with unit."""
+        # 120000 looks like milliseconds for 120 seconds
+        assert _format_timeout(120000) == "120000s"
+
+
+class TestTruncateValue:
+    """Tests for `truncate_value`."""
+
+    def test_short_string_unchanged(self) -> None:
+        """Test that short strings are not truncated."""
+        result = truncate_value("hello", max_length=10)
+        assert result == "hello"
+
+    def test_long_string_truncated(self) -> None:
+        """Test that long strings are truncated with ellipsis."""
+        result = truncate_value("hello world", max_length=5)
+        assert result == "hello..."
+
+    def test_exact_length_unchanged(self) -> None:
+        """Test that strings at exact max length are unchanged."""
+        result = truncate_value("hello", max_length=5)
+        assert result == "hello"
+
+
+class TestFormatToolDisplayShell:
+    """Tests for `format_tool_display` with shell tool."""
+
+    def test_shell_command_only(self) -> None:
+        """Test shell display with command only."""
+        result = format_tool_display("shell", {"command": "echo hello"})
+        assert result == 'shell("echo hello")'
+
+    def test_shell_with_timeout_minutes(self) -> None:
+        """Test shell display formats timeout in minutes when appropriate."""
+        result = format_tool_display("shell", {"command": "make test", "timeout": 300})
+        assert result == 'shell("make test", timeout=5m)'
+
+    def test_shell_with_timeout_seconds(self) -> None:
+        """Test shell display formats timeout in seconds for small values."""
+        result = format_tool_display("shell", {"command": "make test", "timeout": 30})
+        assert result == 'shell("make test", timeout=30s)'
+
+    def test_shell_with_timeout_hours(self) -> None:
+        """Test shell display formats timeout in hours when appropriate."""
+        result = format_tool_display("shell", {"command": "make test", "timeout": 3600})
+        assert result == 'shell("make test", timeout=1h)'
+
+    def test_shell_with_none_timeout(self) -> None:
+        """Test shell display excludes timeout when `None`."""
+        result = format_tool_display("shell", {"command": "echo hello", "timeout": None})
+        assert result == 'shell("echo hello")'
+
+    def test_shell_with_default_timeout_hidden(self) -> None:
+        """Test shell display excludes timeout when it equals the default (120s)."""
+        result = format_tool_display("shell", {"command": "echo hello", "timeout": 120})
+        assert result == 'shell("echo hello")'
+
+    def test_shell_long_command_truncated(self) -> None:
+        """Test that long shell commands are truncated."""
+        long_cmd = "x" * 200
+        result = format_tool_display("shell", {"command": long_cmd})
+        assert "..." in result
+        assert len(result) < 200
+
+
+class TestFormatToolDisplayOther:
+    """Tests for `format_tool_display` with other tools."""
+
+    def test_read_file(self) -> None:
+        """Test read_file display shows filename."""
+        result = format_tool_display("read_file", {"file_path": "/path/to/file.py"})
+        assert "file.py" in result
+
+    def test_web_search(self) -> None:
+        """Test web_search display shows query."""
+        result = format_tool_display("web_search", {"query": "how to code"})
+        assert result == 'web_search("how to code")'
+
+    def test_grep(self) -> None:
+        """Test grep display shows pattern."""
+        result = format_tool_display("grep", {"pattern": "TODO"})
+        assert result == 'grep("TODO")'
+
+    def test_unknown_tool_fallback(self) -> None:
+        """Test unknown tools use generic formatting."""
+        result = format_tool_display("custom_tool", {"arg1": "val1", "arg2": "val2"})
+        assert "custom_tool(" in result
+        assert "arg1=" in result
+        assert "arg2=" in result


### PR DESCRIPTION
<img width="448" height="500" alt="Screenshot 2" src="https://github.com/user-attachments/assets/74372a95-a930-4db6-9332-bf18b0be2208" />
