### PR TITLE
feat(cli): display thread ID at splash

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -294,7 +294,7 @@ class DeepAgentsApp(App):
         # Main chat area with scrollable messages
         # VerticalScroll tracks user scroll intent for better auto-scroll behavior
         with VerticalScroll(id="chat"):
-            yield WelcomeBanner(id="welcome-banner")
+            yield WelcomeBanner(thread_id=self._lc_thread_id, id="welcome-banner")
             yield Container(id="messages")
             with Container(id="bottom-app-container"):
                 yield ChatInput(cwd=self._cwd, id="input-area")

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -36,8 +36,14 @@ class WelcomeBanner(Static):
     }
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        """Initialize the welcome banner."""
+    def __init__(self, thread_id: str | None = None, **kwargs: Any) -> None:
+        """Initialize the welcome banner.
+
+        Args:
+            thread_id: Optional thread ID to display in the banner.
+            **kwargs: Additional arguments passed to parent.
+        """
+        self._thread_id: str | None = thread_id
         self._project_name: str | None = None
 
         langsmith_key = os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGCHAIN_API_KEY")
@@ -87,6 +93,9 @@ class WelcomeBanner(Static):
             else:
                 banner.append(f"'{self._project_name}'", style="cyan")
             banner.append("\n")
+
+        if self._thread_id:
+            banner.append(f"Thread: {self._thread_id}\n", style="dim")
 
         banner.append("Ready to code! What would you like to build?\n", style="#10b981")
         banner.append("Enter send • Ctrl+J newline • @ files • / commands", style="dim")


### PR DESCRIPTION
above "Ready to code!"

<img width="470" height="484" alt="Screenshot" src="https://github.com/user-attachments/assets/335be9a6-a064-4cbc-8f37-769457369c60" />

splash can be made to look nicer later