### PR TITLE
refactor(cli): bare `AgentState` and `Runtime` without type parameters

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend
@@ -187,7 +188,7 @@ The todo list is a planning tool - use it judiciously to avoid overwhelming the 
 
 
 def _format_write_file_description(
-    tool_call: ToolCall, _state: AgentState, _runtime: Runtime
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
 ) -> str:
     """Format write_file tool call for approval prompt."""
     args = tool_call["args"]
@@ -201,7 +202,7 @@ def _format_write_file_description(
 
 
 def _format_edit_file_description(
-    tool_call: ToolCall, _state: AgentState, _runtime: Runtime
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
 ) -> str:
     """Format edit_file tool call for approval prompt."""
     args = tool_call["args"]
@@ -215,7 +216,7 @@ def _format_edit_file_description(
 
 
 def _format_web_search_description(
-    tool_call: ToolCall, _state: AgentState, _runtime: Runtime
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
 ) -> str:
     """Format web_search tool call for approval prompt."""
     args = tool_call["args"]
@@ -226,7 +227,7 @@ def _format_web_search_description(
 
 
 def _format_fetch_url_description(
-    tool_call: ToolCall, _state: AgentState, _runtime: Runtime
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
 ) -> str:
     """Format fetch_url tool call for approval prompt."""
     args = tool_call["args"]
@@ -236,7 +237,9 @@ def _format_fetch_url_description(
     return f"URL: {url}\nTimeout: {timeout}s\n\n⚠️  Will fetch and convert web content to markdown"
 
 
-def _format_task_description(tool_call: ToolCall, _state: AgentState, _runtime: Runtime) -> str:
+def _format_task_description(
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
+) -> str:
     """Format task (subagent) tool call for approval prompt.
 
     The task tool signature is: task(description: str, subagent_type: str)
@@ -261,14 +264,18 @@ def _format_task_description(tool_call: ToolCall, _state: AgentState, _runtime: 
     )
 
 
-def _format_shell_description(tool_call: ToolCall, _state: AgentState, _runtime: Runtime) -> str:
+def _format_shell_description(
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
+) -> str:
     """Format shell tool call for approval prompt."""
     args = tool_call["args"]
     command = args.get("command", "N/A")
     return f"Shell Command: {command}\nWorking Directory: {Path.cwd()}"
 
 
-def _format_execute_description(tool_call: ToolCall, _state: AgentState, _runtime: Runtime) -> str:
+def _format_execute_description(
+    tool_call: ToolCall, _state: AgentState[Any], _runtime: Runtime[Any]
+) -> str:
     """Format execute tool call for approval prompt."""
     args = tool_call["args"]
     command = args.get("command", "N/A")


### PR DESCRIPTION
Functions were using bare `AgentState` and `Runtime` without type parameters, which mypy inferred as `AgentState[Any]` and `Runtime[None]`. The `Runtime[None]` was incompatible with the protocol's `Runtime[ContextT]`.