### PR TITLE
feat(cli): support  .`agents/skills` dir alias

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -423,6 +423,37 @@ class Settings:
             return None
         return self.project_root / ".deepagents" / "agents"
 
+    @property
+    def user_agents_dir(self) -> Path:
+        """Get the base user-level `.agents` directory (`~/.agents`).
+
+        Returns:
+            Path to `~/.agents`
+        """
+        return Path.home() / ".agents"
+
+    def get_user_agent_skills_dir(self) -> Path:
+        """Get user-level `~/.agents/skills/` directory.
+
+        This is a generic alias path for skills that is tool-agnostic.
+
+        Returns:
+            Path to `~/.agents/skills/`
+        """
+        return self.user_agents_dir / "skills"
+
+    def get_project_agent_skills_dir(self) -> Path | None:
+        """Get project-level `.agents/skills/` directory.
+
+        This is a generic alias path for skills that is tool-agnostic.
+
+        Returns:
+            Path to `{project_root}/.agents/skills/`, or `None` if not in a project
+        """
+        if not self.project_root:
+            return None
+        return self.project_root / ".agents" / "skills"
+
 
 # Global settings instance (initialized once)
 settings = Settings.from_environment()

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -100,6 +100,8 @@ def _list(agent: str, *, project: bool = False) -> None:
     settings = Settings.from_environment()
     user_skills_dir = settings.get_user_skills_dir(agent)
     project_skills_dir = settings.get_project_skills_dir()
+    user_agent_skills_dir = settings.get_user_agent_skills_dir()
+    project_agent_skills_dir = settings.get_project_agent_skills_dir()
 
     # If --project flag is used, only show project skills
     if project:
@@ -112,7 +114,17 @@ def _list(agent: str, *, project: bool = False) -> None:
             )
             return
 
-        if not project_skills_dir.exists() or not any(project_skills_dir.iterdir()):
+        # Check both project skill directories
+        has_deepagents_skills = project_skills_dir.exists() and any(
+            project_skills_dir.iterdir()
+        )
+        has_agent_skills = (
+            project_agent_skills_dir
+            and project_agent_skills_dir.exists()
+            and any(project_agent_skills_dir.iterdir())
+        )
+
+        if not has_deepagents_skills and not has_agent_skills:
             console.print("[yellow]No project skills found.[/yellow]")
             console.print(
                 f"[dim]Project skills will be created in {project_skills_dir}/ "
@@ -127,13 +139,19 @@ def _list(agent: str, *, project: bool = False) -> None:
             return
 
         skills = list_skills(
-            user_skills_dir=None, project_skills_dir=project_skills_dir
+            user_skills_dir=None,
+            project_skills_dir=project_skills_dir,
+            user_agent_skills_dir=None,
+            project_agent_skills_dir=project_agent_skills_dir,
         )
         console.print("\n[bold]Project Skills:[/bold]\n", style=COLORS["primary"])
     else:
-        # Load both user and project skills
+        # Load skills from all directories
         skills = list_skills(
-            user_skills_dir=user_skills_dir, project_skills_dir=project_skills_dir
+            user_skills_dir=user_skills_dir,
+            project_skills_dir=project_skills_dir,
+            user_agent_skills_dir=user_agent_skills_dir,
+            project_agent_skills_dir=project_agent_skills_dir,
         )
 
         if not skills:
@@ -348,6 +366,8 @@ def _info(skill_name: str, *, agent: str = "agent", project: bool = False) -> No
     settings = Settings.from_environment()
     user_skills_dir = settings.get_user_skills_dir(agent)
     project_skills_dir = settings.get_project_skills_dir()
+    user_agent_skills_dir = settings.get_user_agent_skills_dir()
+    project_agent_skills_dir = settings.get_project_agent_skills_dir()
 
     # Load skills based on --project flag
     if project:
@@ -355,11 +375,17 @@ def _info(skill_name: str, *, agent: str = "agent", project: bool = False) -> No
             console.print("[bold red]Error:[/bold red] Not in a project directory.")
             return
         skills = list_skills(
-            user_skills_dir=None, project_skills_dir=project_skills_dir
+            user_skills_dir=None,
+            project_skills_dir=project_skills_dir,
+            user_agent_skills_dir=None,
+            project_agent_skills_dir=project_agent_skills_dir,
         )
     else:
         skills = list_skills(
-            user_skills_dir=user_skills_dir, project_skills_dir=project_skills_dir
+            user_skills_dir=user_skills_dir,
+            project_skills_dir=project_skills_dir,
+            user_agent_skills_dir=user_agent_skills_dir,
+            project_agent_skills_dir=project_agent_skills_dir,
         )
 
     # Find the skill

--- a/libs/cli/tests/unit_tests/skills/test_load.py
+++ b/libs/cli/tests/unit_tests/skills/test_load.py
@@ -290,3 +290,208 @@ Content
         skills = list_skills(user_skills_dir=user_dir, project_skills_dir=None)
         assert len(skills) == 1
         assert skills[0]["name"] == "valid-skill"
+
+
+class TestListSkillsAliasDirectories:
+    """Test `list_skills` with `.agents` alias directories."""
+
+    def _create_skill(self, skill_dir: Path, name: str, description: str) -> None:
+        """Helper to create a skill directory with `SKILL.md`."""
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(f"""---
+name: {name}
+description: {description}
+---
+Content
+""")
+
+    def test_user_agent_skills_dir_precedence(self, tmp_path: Path) -> None:
+        """Test that `~/.agents/skills` overrides `~/.deepagents/agent/skills`."""
+        user_deepagents_dir = tmp_path / "user_deepagents_skills"
+        user_agent_dir = tmp_path / "user_agent_skills"
+
+        # Create same skill in both directories
+        self._create_skill(
+            user_deepagents_dir / "shared-skill",
+            "shared-skill",
+            "From deepagents user dir",
+        )
+        self._create_skill(
+            user_agent_dir / "shared-skill",
+            "shared-skill",
+            "From agents user dir",
+        )
+
+        skills = list_skills(
+            user_skills_dir=user_deepagents_dir,
+            project_skills_dir=None,
+            user_agent_skills_dir=user_agent_dir,
+            project_agent_skills_dir=None,
+        )
+
+        assert len(skills) == 1
+        assert skills[0]["name"] == "shared-skill"
+        assert skills[0]["description"] == "From agents user dir"
+        assert skills[0]["source"] == "user"
+
+    def test_project_agent_skills_dir_precedence(self, tmp_path: Path) -> None:
+        """Test that `.agents/skills` overrides `.deepagents/skills`."""
+        project_deepagents_dir = tmp_path / "project_deepagents_skills"
+        project_agent_dir = tmp_path / "project_agent_skills"
+
+        # Create same skill in both directories
+        self._create_skill(
+            project_deepagents_dir / "shared-skill",
+            "shared-skill",
+            "From deepagents project dir",
+        )
+        self._create_skill(
+            project_agent_dir / "shared-skill",
+            "shared-skill",
+            "From agents project dir",
+        )
+
+        skills = list_skills(
+            user_skills_dir=None,
+            project_skills_dir=project_deepagents_dir,
+            user_agent_skills_dir=None,
+            project_agent_skills_dir=project_agent_dir,
+        )
+
+        assert len(skills) == 1
+        assert skills[0]["name"] == "shared-skill"
+        assert skills[0]["description"] == "From agents project dir"
+        assert skills[0]["source"] == "project"
+
+    def test_full_precedence_chain(self, tmp_path: Path) -> None:
+        """Test full precedence: `.agents/skills` (project) wins over all."""
+        user_deepagents_dir = tmp_path / "user_deepagents_skills"
+        user_agent_dir = tmp_path / "user_agent_skills"
+        project_deepagents_dir = tmp_path / "project_deepagents_skills"
+        project_agent_dir = tmp_path / "project_agent_skills"
+
+        # Create same skill in all 4 directories
+        self._create_skill(
+            user_deepagents_dir / "shared-skill",
+            "shared-skill",
+            "From deepagents user dir (lowest)",
+        )
+        self._create_skill(
+            user_agent_dir / "shared-skill",
+            "shared-skill",
+            "From agents user dir",
+        )
+        self._create_skill(
+            project_deepagents_dir / "shared-skill",
+            "shared-skill",
+            "From deepagents project dir",
+        )
+        self._create_skill(
+            project_agent_dir / "shared-skill",
+            "shared-skill",
+            "From agents project dir (highest)",
+        )
+
+        skills = list_skills(
+            user_skills_dir=user_deepagents_dir,
+            project_skills_dir=project_deepagents_dir,
+            user_agent_skills_dir=user_agent_dir,
+            project_agent_skills_dir=project_agent_dir,
+        )
+
+        assert len(skills) == 1
+        assert skills[0]["name"] == "shared-skill"
+        assert skills[0]["description"] == "From agents project dir (highest)"
+        assert skills[0]["source"] == "project"
+
+    def test_mixed_sources_with_aliases(self, tmp_path: Path) -> None:
+        """Test different skills from different directories are all discovered."""
+        user_deepagents_dir = tmp_path / "user_deepagents_skills"
+        user_agent_dir = tmp_path / "user_agent_skills"
+        project_deepagents_dir = tmp_path / "project_deepagents_skills"
+        project_agent_dir = tmp_path / "project_agent_skills"
+
+        # Create different skills in each directory
+        self._create_skill(
+            user_deepagents_dir / "skill-a",
+            "skill-a",
+            "Skill A from deepagents user",
+        )
+        self._create_skill(
+            user_agent_dir / "skill-b",
+            "skill-b",
+            "Skill B from agents user",
+        )
+        self._create_skill(
+            project_deepagents_dir / "skill-c",
+            "skill-c",
+            "Skill C from deepagents project",
+        )
+        self._create_skill(
+            project_agent_dir / "skill-d",
+            "skill-d",
+            "Skill D from agents project",
+        )
+
+        skills = list_skills(
+            user_skills_dir=user_deepagents_dir,
+            project_skills_dir=project_deepagents_dir,
+            user_agent_skills_dir=user_agent_dir,
+            project_agent_skills_dir=project_agent_dir,
+        )
+
+        assert len(skills) == 4
+        skill_names = {s["name"] for s in skills}
+        assert skill_names == {"skill-a", "skill-b", "skill-c", "skill-d"}
+
+        # Verify sources
+        skill_a = next(s for s in skills if s["name"] == "skill-a")
+        skill_b = next(s for s in skills if s["name"] == "skill-b")
+        skill_c = next(s for s in skills if s["name"] == "skill-c")
+        skill_d = next(s for s in skills if s["name"] == "skill-d")
+
+        assert skill_a["source"] == "user"
+        assert skill_b["source"] == "user"
+        assert skill_c["source"] == "project"
+        assert skill_d["source"] == "project"
+
+    def test_alias_directories_only(self, tmp_path: Path) -> None:
+        """Test loading skills from only the alias directories."""
+        user_agent_dir = tmp_path / "user_agent_skills"
+        project_agent_dir = tmp_path / "project_agent_skills"
+
+        self._create_skill(
+            user_agent_dir / "user-skill",
+            "user-skill",
+            "From agents user dir",
+        )
+        self._create_skill(
+            project_agent_dir / "project-skill",
+            "project-skill",
+            "From agents project dir",
+        )
+
+        skills = list_skills(
+            user_skills_dir=None,
+            project_skills_dir=None,
+            user_agent_skills_dir=user_agent_dir,
+            project_agent_skills_dir=project_agent_dir,
+        )
+
+        assert len(skills) == 2
+        skill_names = {s["name"] for s in skills}
+        assert skill_names == {"user-skill", "project-skill"}
+
+    def test_nonexistent_alias_directories(self, tmp_path: Path) -> None:
+        """Test that nonexistent alias directories are handled gracefully."""
+        nonexistent_user = tmp_path / "nonexistent_user"
+        nonexistent_project = tmp_path / "nonexistent_project"
+
+        skills = list_skills(
+            user_skills_dir=None,
+            project_skills_dir=None,
+            user_agent_skills_dir=nonexistent_user,
+            project_agent_skills_dir=nonexistent_project,
+        )
+
+        assert skills == []

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -236,6 +236,50 @@ class TestValidateModelCapabilities:
         mock_console.print.assert_not_called()
 
 
+class TestAgentsAliasDirectories:
+    """Tests for .agents directory alias methods."""
+
+    def test_user_agents_dir(self) -> None:
+        """Test user_agents_dir returns ~/.agents."""
+        from deepagents_cli.config import Settings
+
+        settings = Settings.from_environment()
+        expected = Path.home() / ".agents"
+        assert settings.user_agents_dir == expected
+
+    def test_get_user_agent_skills_dir(self) -> None:
+        """Test get_user_agent_skills_dir returns ~/.agents/skills."""
+        from deepagents_cli.config import Settings
+
+        settings = Settings.from_environment()
+        expected = Path.home() / ".agents" / "skills"
+        assert settings.get_user_agent_skills_dir() == expected
+
+    def test_get_project_agent_skills_dir_with_project(self, tmp_path: Path) -> None:
+        """Test get_project_agent_skills_dir returns .agents/skills in project."""
+        from deepagents_cli.config import Settings
+
+        # Create a mock project with .git
+        project_root = tmp_path / "my-project"
+        project_root.mkdir()
+        (project_root / ".git").mkdir()
+
+        settings = Settings.from_environment(start_path=project_root)
+        expected = project_root / ".agents" / "skills"
+        assert settings.get_project_agent_skills_dir() == expected
+
+    def test_get_project_agent_skills_dir_without_project(self, tmp_path: Path) -> None:
+        """Test get_project_agent_skills_dir returns None when not in a project."""
+        from deepagents_cli.config import Settings
+
+        # Create a directory without .git
+        no_project = tmp_path / "no-project"
+        no_project.mkdir()
+
+        settings = Settings.from_environment(start_path=no_project)
+        assert settings.get_project_agent_skills_dir() is None
+
+
 class TestCreateModelProfileExtraction:
     """Tests for profile extraction in create_model."""
 


### PR DESCRIPTION
Skills can now be placed in `.agents/skills/` (project) or `~/.agents/skills/` (user) as a generic alternative to `.deepagents/skills/`. The `.agents/` paths take precedence over `.deepagents/` when skills have the same name.

When a skill with the same name exists in multiple directories, the skill from the **highest-precedence directory wins completely**. There is no merging of skill properties - the entire skill definition is replaced.

### Recommended Usage

- Use `.agents/skills/` for skills you want to share across different AI CLI tools
- Use `.deepagents/skills/` for Deep Agents-specific skills
- Project-level skills override user-level skills of the same name