### PR TITLE
fix(sdk): resolve silent exception handling in backends and middleware

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -7,6 +7,7 @@ on the host machine with full system access.
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import uuid
@@ -17,6 +18,9 @@ from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 
 class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
@@ -295,6 +299,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         except Exception as e:  # noqa: BLE001
             # Broad exception catch is intentional: we want to catch all execution errors
             # and return a consistent ExecuteResponse rather than propagating exceptions
+            logger.debug("Local shell execution failed: %s", e, exc_info=True)
             return ExecuteResponse(
                 output=f"Error executing command: {e}",
                 exit_code=1,

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -213,7 +213,7 @@ class SummarizationMiddleware(BaseSummarizationMiddleware):
                 return str(thread_id)
         except RuntimeError:
             # Not in a runnable context
-            pass
+            logger.debug("Could not get thread_id from config (RuntimeError), falling back to generated ID")
 
         # Fallback: generate session ID
         generated_id = f"session_{uuid.uuid4().hex[:8]}"

--- a/libs/deepagents/tests/unit_tests/test_sdk_exception_logging.py
+++ b/libs/deepagents/tests/unit_tests/test_sdk_exception_logging.py
@@ -1,0 +1,95 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from deepagents.backends.local_shell import LocalShellBackend
+from deepagents.backends.store import StoreBackend
+from deepagents.middleware.summarization import SummarizationMiddleware
+
+# --- StoreBackend Tests ---
+
+
+@pytest.fixture
+def store_backend() -> StoreBackend:
+    runtime = MagicMock()
+    runtime.store = MagicMock()
+    # Mock config to avoid "Could not get namespace" log noise, or let it be.
+    # We'll patch get_config in tests if needed.
+    return StoreBackend(runtime=runtime)
+
+
+def test_store_backend_ls_info_logs_value_error(store_backend: StoreBackend, caplog: LogCaptureFixture) -> None:
+    """Verify that ls_info logs debug message when item conversion fails."""
+    # Create a mock item that will cause ValueError logic
+    mock_item = MagicMock()
+    mock_item.key = "/bad_file"
+
+    store_backend.runtime.store.search.return_value = [mock_item]
+
+    # Mock _convert_store_item_to_file_data to raise ValueError
+    with patch.object(store_backend, "_convert_store_item_to_file_data", side_effect=ValueError("Invalid content")), caplog.at_level(logging.DEBUG):
+        # We don't care about namespace failure log, just check for our log
+        store_backend.ls_info("/")
+
+    assert "Skipping invalid store item /bad_file" in caplog.text
+    assert "Invalid content" in caplog.text
+
+
+def test_store_backend_grep_raw_logs_value_error(store_backend: StoreBackend, caplog: LogCaptureFixture) -> None:
+    """Verify that grep_raw logs debug message when item conversion fails."""
+    mock_item = MagicMock()
+    mock_item.key = "bad_file"
+    store_backend.runtime.store.search.return_value = [mock_item]
+
+    with patch.object(store_backend, "_convert_store_item_to_file_data", side_effect=ValueError("Invalid content")), caplog.at_level(logging.DEBUG):
+        store_backend.grep_raw("some_pattern", "/")
+
+    assert "Skipping invalid store item bad_file during grep" in caplog.text
+
+
+def test_store_backend_glob_info_logs_value_error(store_backend: StoreBackend, caplog: LogCaptureFixture) -> None:
+    """Verify that glob_info logs debug message when item conversion fails."""
+    mock_item = MagicMock()
+    mock_item.key = "bad_file"
+    store_backend.runtime.store.search.return_value = [mock_item]
+
+    with patch.object(store_backend, "_convert_store_item_to_file_data", side_effect=ValueError("Invalid content")), caplog.at_level(logging.DEBUG):
+        store_backend.glob_info("*.py", "/")
+
+    assert "Skipping invalid store item bad_file during glob" in caplog.text
+
+
+# --- LocalShellBackend Tests ---
+
+
+def test_local_shell_execute_logs_exception(caplog: LogCaptureFixture) -> None:
+    """Verify that execute logs debug message with exception info on failure."""
+    # LocalShellBackend does not take runtime argument
+    backend = LocalShellBackend()
+
+    # subprocess.run is mocked to raise a generic Exception
+    with patch("subprocess.run", side_effect=Exception("Something went wrong")), caplog.at_level(logging.DEBUG):
+        response = backend.execute("ls")
+
+    assert response.exit_code == 1
+    assert "Error executing command: Something went wrong" in response.output
+
+    # Check logs
+    assert "Local shell execution failed: Something went wrong" in caplog.text
+
+
+# --- SummarizationMiddleware Tests ---
+
+
+def test_summarization_get_thread_id_logs_runtime_error(caplog: LogCaptureFixture) -> None:
+    """Verify that _get_thread_id logs debug message when get_config fails."""
+    # SummarizationMiddleware requires model and backend
+    middleware = SummarizationMiddleware(model=MagicMock(), backend=MagicMock())
+
+    with patch("deepagents.middleware.summarization.get_config", side_effect=RuntimeError("No context")), caplog.at_level(logging.DEBUG):
+        thread_id = middleware._get_thread_id()
+
+    assert thread_id.startswith("session_")
+    assert "Could not get thread_id from config (RuntimeError)" in caplog.text


### PR DESCRIPTION
This PR fixes multiple instances where exceptions were being silently swallowed across the SDK, making debugging difficult. I've replaced these silent failures with proper DEBUG-level logging to improve observability without changing the runtime behavior.

Changes:
store.py: Added logging when retrieving the namespace fails or when encountering invalid items during store searches.
local_shell.py: Added logging with full stack traces for failed shell command executions.
summarization.py: Added logging when the thread ID cannot be retrieved from the config.