### PR TITLE
feat(cli): add langsmith sandbox integration

### DIFF
--- a/libs/cli/deepagents_cli/integrations/langsmith.py
+++ b/libs/cli/deepagents_cli/integrations/langsmith.py
@@ -1,0 +1,262 @@
+"""LangSmith sandbox backend implementation."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+    SandboxBackendProtocol,
+)
+from deepagents.backends.sandbox import (
+    BaseSandbox,
+    SandboxListResponse,
+    SandboxProvider,
+)
+
+if TYPE_CHECKING:
+    from langsmith.sandbox import Sandbox, SandboxClient
+
+
+# Default template configuration
+DEFAULT_TEMPLATE_NAME = "deepagents-cli"
+DEFAULT_TEMPLATE_IMAGE = "python:3"
+
+
+class LangSmithBackend(BaseSandbox):
+    """LangSmith backend implementation conforming to SandboxBackendProtocol.
+
+    This implementation inherits all file operation methods from BaseSandbox
+    and only implements the execute() method using LangSmith's API.
+    """
+
+    def __init__(self, sandbox: Sandbox) -> None:
+        """Initialize the LangSmithBackend with a sandbox instance.
+
+        Args:
+            sandbox: LangSmith Sandbox instance
+        """
+        self._sandbox = sandbox
+        self._timeout: int = 30 * 60  # 30 mins default
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for the sandbox backend."""
+        return self._sandbox.name
+
+    def execute(self, command: str) -> ExecuteResponse:
+        """Execute a command in the sandbox and return ExecuteResponse.
+
+        Args:
+            command: Full shell command string to execute.
+
+        Returns:
+            ExecuteResponse with combined output, exit code, and truncation flag.
+        """
+        result = self._sandbox.run(command, timeout=self._timeout)
+
+        # Combine stdout and stderr (matching other backends' approach)
+        output = result.stdout or ""
+        if result.stderr:
+            output += "\n" + result.stderr if output else result.stderr
+
+        return ExecuteResponse(
+            output=output,
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Download multiple files from the LangSmith sandbox.
+
+        Leverages LangSmith's native file read API for efficiency.
+        Supports partial success - individual downloads may fail without
+        affecting others.
+
+        Args:
+            paths: List of file paths to download.
+
+        Returns:
+            List of FileDownloadResponse objects, one per input path.
+            Response order matches input order.
+
+        TODO: Map LangSmith API error strings to standardized FileOperationError codes.
+        Currently only implements happy path.
+        """
+        responses: list[FileDownloadResponse] = []
+
+        for path in paths:
+            # Use LangSmith's native file read API (returns bytes)
+            content = self._sandbox.read(path)
+            responses.append(
+                FileDownloadResponse(path=path, content=content, error=None)
+            )
+
+        return responses
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload multiple files to the LangSmith sandbox.
+
+        Leverages LangSmith's native file write API for efficiency.
+        Supports partial success - individual uploads may fail without
+        affecting others.
+
+        Args:
+            files: List of (path, content) tuples to upload.
+
+        Returns:
+            List of FileUploadResponse objects, one per input file.
+            Response order matches input order.
+
+        TODO: Map LangSmith API error strings to standardized FileOperationError codes.
+        Currently only implements happy path.
+        """
+        responses: list[FileUploadResponse] = []
+
+        for path, content in files:
+            # Use LangSmith's native file write API
+            self._sandbox.write(path, content)
+            responses.append(FileUploadResponse(path=path, error=None))
+
+        return responses
+
+
+class LangSmithProvider(SandboxProvider[dict[str, Any]]):
+    """LangSmith sandbox provider implementation.
+
+    Manages LangSmith sandbox lifecycle using the LangSmith SDK.
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """Initialize LangSmith provider.
+
+        Args:
+            api_key: LangSmith API key (defaults to LANGSMITH_API_KEY env var)
+
+        Raises:
+            ValueError: If LANGSMITH_API_KEY environment variable not set
+        """
+        from langsmith import sandbox
+
+        self._api_key = api_key or os.environ.get("LANGSMITH_API_KEY")
+        if not self._api_key:
+            msg = "LANGSMITH_API_KEY environment variable not set"
+            raise ValueError(msg)
+        self._client: SandboxClient = sandbox.SandboxClient()
+
+    def list(
+        self,
+        *,
+        cursor: str | None = None,
+        **kwargs: Any,
+    ) -> SandboxListResponse[dict[str, Any]]:
+        """List available LangSmith sandboxes.
+
+        Raises:
+            NotImplementedError: LangSmith SDK list API not yet implemented.
+        """
+        msg = "Listing with LangSmith SDK not yet implemented"
+        raise NotImplementedError(msg)
+
+    def get_or_create(
+        self,
+        *,
+        sandbox_id: str | None = None,
+        timeout: int = 180,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> SandboxBackendProtocol:
+        """Get existing or create new LangSmith sandbox.
+
+        Args:
+            sandbox_id: Optional existing sandbox name to reuse
+            timeout: Timeout in seconds for sandbox startup (default: 180)
+            **kwargs: Additional LangSmith-specific parameters
+
+        Returns:
+            LangSmithBackend instance
+
+        Raises:
+            RuntimeError: Sandbox connection or startup failed
+        """
+        if sandbox_id:
+            # Connect to existing sandbox by name
+            try:
+                sandbox = self._client.get_sandbox(name=sandbox_id)
+            except Exception as e:
+                msg = f"Failed to connect to existing sandbox '{sandbox_id}': {e}"
+                raise RuntimeError(msg) from e
+            return LangSmithBackend(sandbox)
+
+        # Create new sandbox - ensure template exists first
+        self._ensure_template()
+
+        try:
+            sandbox = self._client.create_sandbox(
+                template_name=DEFAULT_TEMPLATE_NAME, timeout=timeout
+            )
+        except Exception as e:
+            msg = (
+                f"Failed to create sandbox from template '{DEFAULT_TEMPLATE_NAME}': {e}"
+            )
+            raise RuntimeError(msg) from e
+
+        # Verify sandbox is ready by polling
+        for _ in range(timeout // 2):
+            try:
+                result = sandbox.run("echo ready", timeout=5)
+                if result.exit_code == 0:
+                    break
+            except Exception:  # noqa: S110, BLE001
+                # Sandbox not ready yet, continue polling
+                pass
+            time.sleep(2)
+        else:
+            # Cleanup on failure
+            with contextlib.suppress(Exception):
+                self._client.delete_sandbox(sandbox.name)
+            msg = f"LangSmith sandbox failed to start within {timeout} seconds"
+            raise RuntimeError(msg)
+
+        return LangSmithBackend(sandbox)
+
+    def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002
+        """Delete a LangSmith sandbox.
+
+        Args:
+            sandbox_id: Sandbox name to delete
+            **kwargs: Additional parameters
+        """
+        self._client.delete_sandbox(sandbox_id)
+
+    def _ensure_template(self) -> None:
+        """Ensure template exists, creating it if needed.
+
+        Raises:
+            RuntimeError: If template check or creation fails
+        """
+        from langsmith.sandbox import ResourceNotFoundError
+
+        try:
+            self._client.get_template(DEFAULT_TEMPLATE_NAME)
+        except ResourceNotFoundError as e:
+            if e.resource_type != "template":
+                msg = f"Unexpected resource not found: {e}"
+                raise RuntimeError(msg) from e
+            # Template doesn't exist, create it
+            try:
+                self._client.create_template(
+                    name=DEFAULT_TEMPLATE_NAME, image=DEFAULT_TEMPLATE_IMAGE
+                )
+            except Exception as create_err:
+                msg = (
+                    f"Failed to create template '{DEFAULT_TEMPLATE_NAME}': {create_err}"
+                )
+                raise RuntimeError(msg) from create_err
+        except Exception as e:
+            msg = f"Failed to check template '{DEFAULT_TEMPLATE_NAME}': {e}"
+            raise RuntimeError(msg) from e

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -12,6 +12,7 @@ from deepagents.backends.sandbox import SandboxProvider
 
 from deepagents_cli.config import console
 from deepagents_cli.integrations.daytona import DaytonaProvider
+from deepagents_cli.integrations.langsmith import LangSmithProvider
 from deepagents_cli.integrations.modal import ModalProvider
 from deepagents_cli.integrations.runloop import RunloopProvider
 
@@ -54,9 +55,10 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
 
 
 _PROVIDER_TO_WORKING_DIR = {
+    "daytona": "/home/daytona",
+    "langsmith": "/tmp",  # noqa: S108
     "modal": "/workspace",
     "runloop": "/home/user",
-    "daytona": "/home/daytona",
 }
 
 
@@ -72,7 +74,7 @@ def create_sandbox(
     This is the unified interface for sandbox creation using the provider abstraction.
 
     Args:
-        provider: Sandbox provider ("modal", "runloop", "daytona")
+        provider: Sandbox provider ("daytona", "langsmith", "modal", "runloop")
         sandbox_id: Optional existing sandbox ID to reuse
         setup_script_path: Optional path to setup script to run after sandbox starts
 
@@ -126,7 +128,7 @@ def get_default_working_dir(provider: str) -> str:
     """Get the default working directory for a given sandbox provider.
 
     Args:
-        provider: Sandbox provider name ("modal", "runloop", "daytona")
+        provider: Sandbox provider name ("daytona", "langsmith", "modal", "runloop")
 
     Returns:
         Default working directory path as string
@@ -144,7 +146,7 @@ def _get_provider(provider_name: str) -> SandboxProvider:
     """Get a SandboxProvider instance for the specified provider (internal).
 
     Args:
-        provider_name: Name of the provider ("modal", "runloop", "daytona")
+        provider_name: Name of the provider ("daytona", "langsmith", "modal", "runloop")
 
     Returns:
         SandboxProvider instance
@@ -152,12 +154,14 @@ def _get_provider(provider_name: str) -> SandboxProvider:
     Raises:
         ValueError: If provider_name is unknown
     """
+    if provider_name == "daytona":
+        return DaytonaProvider()
+    if provider_name == "langsmith":
+        return LangSmithProvider()
     if provider_name == "modal":
         return ModalProvider()
     if provider_name == "runloop":
         return RunloopProvider()
-    if provider_name == "daytona":
-        return DaytonaProvider()
     msg = (
         f"Unknown sandbox provider: {provider_name}. "
         f"Available providers: {', '.join(_get_available_sandbox_types())}"

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -168,7 +168,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--sandbox",
-        choices=["none", "modal", "daytona", "runloop"],
+        choices=["none", "modal", "daytona", "runloop", "langsmith"],
         default="none",
         help="Remote sandbox for code execution (default: none - local only)",
     )
@@ -199,7 +199,8 @@ async def run_textual_cli_async(
     Args:
         assistant_id: Agent identifier for memory storage
         auto_approve: Whether to auto-approve tool usage
-        sandbox_type: Type of sandbox ("none", "modal", "runloop", "daytona")
+        sandbox_type: Type of sandbox
+            ("none", "modal", "runloop", "daytona", "langsmith")
         sandbox_id: Optional existing sandbox ID to reuse
         model_name: Optional model name to use
         thread_id: Thread ID to use (new or resumed)

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 
   # Sandbox integrations
   "daytona>=0.113.0,<1.0.0",
+  "langsmith>=0.6.0",
   "modal>=0.65.0,<2.0.0",
   "runloop-api-client>=0.69.0",
 
@@ -98,6 +99,7 @@ packages = ["deepagents_cli"]
 
 [tool.uv.sources]
 deepagents = { path = "../deepagents", editable = true }
+langsmith = { git = "https://github.com/langchain-ai/langsmith-sdk", subdirectory = "python", branch = "main" }
 
 [tool.ty.environment]
 extra-paths = ["../deepagents"]

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 
   # Sandbox integrations
   "daytona>=0.113.0,<1.0.0",
-  "langsmith>=0.6.0",
+  "langsmith>=0.6.6",
   "modal>=0.65.0,<2.0.0",
   "runloop-api-client>=0.69.0",
 
@@ -99,7 +99,6 @@ packages = ["deepagents_cli"]
 
 [tool.uv.sources]
 deepagents = { path = "../deepagents", editable = true }
-langsmith = { git = "https://github.com/langchain-ai/langsmith-sdk", subdirectory = "python", branch = "main" }
 
 [tool.ty.environment]
 extra-paths = ["../deepagents"]

--- a/libs/cli/tests/integration_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/integration_tests/test_sandbox_factory.py
@@ -1,6 +1,6 @@
 """Test sandbox integrations with upload/download functionality.
 
-This module tests sandbox backends (RunLoop, Daytona, Modal) with support for
+This module tests sandbox backends (RunLoop, Daytona, Modal, LangSmith) with support for
 optional sandbox reuse to reduce test execution time.
 
 Set REUSE_SANDBOX=1 environment variable to reuse sandboxes across tests within
@@ -315,4 +315,14 @@ class TestModalIntegration(BaseSandboxIntegrationTest):
     def sandbox(self) -> Iterator[BaseSandbox]:
         """Provide a Modal sandbox instance."""
         with create_sandbox("modal") as sandbox:
+            yield sandbox
+
+
+class TestLangSmithIntegration(BaseSandboxIntegrationTest):
+    """Test LangSmith backend integration."""
+
+    @pytest.fixture(scope="class")
+    def sandbox(self) -> Iterator[BaseSandbox]:
+        """Provide a LangSmith sandbox instance."""
+        with create_sandbox("langsmith") as sandbox:
             yield sandbox

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "langchain-google-vertexai", marker = "extra == 'vertexai'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.7,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0,<4.0.0" },
-    { name = "langsmith", git = "https://github.com/langchain-ai/langsmith-sdk?subdirectory=python&branch=main" },
+    { name = "langsmith", specifier = ">=0.6.6" },
     { name = "markdownify", specifier = ">=0.13.0,<2.0.0" },
     { name = "modal", specifier = ">=0.65.0,<2.0.0" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
@@ -1860,8 +1860,8 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.6.8"
-source = { git = "https://github.com/langchain-ai/langsmith-sdk?subdirectory=python&branch=main#96b84cd04982c843927b24e1cb015d2b534050e9" }
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
@@ -1872,6 +1872,10 @@ dependencies = [
     { name = "uuid-utils" },
     { name = "xxhash" },
     { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/bb/b8a196c9b9a7ca8b8845eaec7dbae35bcfcb0da3068794e76b29211eae2b/langsmith-0.6.7.tar.gz", hash = "sha256:d89c604a18fc606b7835d8e7924f7cdbe130ca2207bdff8f989590e50d65b802", size = 963940, upload-time = "2026-01-31T02:10:34.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/9a/5bc17ea3c746363e73c11df5e89068fea1ed175ca9c00fdb6886efc35b21/langsmith-0.6.7-py3-none-any.whl", hash = "sha256:4bd4372b8bf724b86314f64644562b5598407614e04e74b536c09490d153bd61", size = 309369, upload-time = "2026-01-31T02:10:32.6Z" },
 ]
 
 [[package]]

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -806,6 +806,7 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-openai" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "langsmith" },
     { name = "markdownify" },
     { name = "modal" },
     { name = "pillow" },
@@ -852,6 +853,7 @@ requires-dist = [
     { name = "langchain-google-vertexai", marker = "extra == 'vertexai'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.7,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langsmith", git = "https://github.com/langchain-ai/langsmith-sdk?subdirectory=python&branch=main" },
     { name = "markdownify", specifier = ">=0.13.0,<2.0.0" },
     { name = "modal", specifier = ">=0.65.0,<2.0.0" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
@@ -1858,8 +1860,8 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
+version = "0.6.8"
+source = { git = "https://github.com/langchain-ai/langsmith-sdk?subdirectory=python&branch=main#96b84cd04982c843927b24e1cb015d2b534050e9" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
@@ -1870,10 +1872,6 @@ dependencies = [
     { name = "uuid-utils" },
     { name = "xxhash" },
     { name = "zstandard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/bb/b8a196c9b9a7ca8b8845eaec7dbae35bcfcb0da3068794e76b29211eae2b/langsmith-0.6.7.tar.gz", hash = "sha256:d89c604a18fc606b7835d8e7924f7cdbe130ca2207bdff8f989590e50d65b802", size = 963940, upload-time = "2026-01-31T02:10:34.069Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/9a/5bc17ea3c746363e73c11df5e89068fea1ed175ca9c00fdb6886efc35b21/langsmith-0.6.7-py3-none-any.whl", hash = "sha256:4bd4372b8bf724b86314f64644562b5598407614e04e74b536c09490d153bd61", size = 309369, upload-time = "2026-01-31T02:10:32.6Z" },
 ]
 
 [[package]]

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -713,6 +713,7 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-openai" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "langsmith" },
     { name = "markdownify" },
     { name = "modal" },
     { name = "pillow" },
@@ -737,6 +738,7 @@ requires-dist = [
     { name = "langchain-google-vertexai", marker = "extra == 'vertexai'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.7,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langsmith", specifier = ">=0.6.6" },
     { name = "markdownify", specifier = ">=0.13.0,<2.0.0" },
     { name = "modal", specifier = ">=0.65.0,<2.0.0" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
@@ -1680,7 +1682,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.6.3"
+version = "0.6.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1690,11 +1692,12 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
+    { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/02/ac91c812238cd232ff3270c253eea31b28253fdeb28df61571932cb26e88/langsmith-0.6.3.tar.gz", hash = "sha256:33246769c0bb24e2c17e0c34bb21931084437613cd37faf83bd0978a297b826f", size = 1739709, upload-time = "2026-01-14T19:26:23.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/15/35f49a0b2efd33002fdcb9a7b0bdb65d77e40b4739104ffe843a3479874a/langsmith-0.6.8.tar.gz", hash = "sha256:3a7eb7155f2839dc729a5aa5b0bfc4aa1cb617b09a2290cf77031041271a7cdf", size = 973475, upload-time = "2026-02-02T23:20:02.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/11/22a56b615f1ca84f65fda68b1a53b6e2765f2bdb1c6d885793430a664bfe/langsmith-0.6.3-py3-none-any.whl", hash = "sha256:44fdf8084165513e6bede9dda715e7b460b1b3f57ac69f2ca3f03afa911233ec", size = 282991, upload-time = "2026-01-14T19:26:21.882Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2d/2389e65522ebeab17489df72b4fabcfc661fced8af178aa6c2bc3b9afff5/langsmith-0.6.8-py3-none-any.whl", hash = "sha256:d17da18aeef15fdb4c3baec348bad64056591d785629cd5ba4846fd93cab166b", size = 319165, upload-time = "2026-02-02T23:20:00.456Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add LangSmith as a new sandbox backend for remote code execution.

> [!WARNING]
> Both the LangSmith sandbox SDK and this integration are experimental. The feature is functional but not advertised (yet).

Sandboxes are isolated environments that provide:

- Isolated execution for running commands securely
- Filesystem access for file operations
- Persistent storage via volumes that survive sandbox deletion
- Pre-provisioned pools for faster cold starts

This integration uses the "Sandbox as Tool" pattern—the agent runs locally on your machine, and when it needs to execute code, it calls out to LangSmith's sandbox API. This keeps your API keys outside the sandbox and allows you to iterate on agent logic without rebuilding container images.

## Usage

```python
deepagents --sandbox langsmith
```

Requires:
- `LANGSMITH_API_KEY` environment variable set
- A sandbox template configured in your LangSmith workspace. Currently, the template used in the CLI is hardcoded and will be created for you if one doesn't exist (`deepagents-cli` using `python:3`).

Optional:
- `LANGSMITH_ENDPOINT` environment variable (defaults to production)
