### PR TITLE
fix(deepagents): `_validate_skill_name` method consistently returns false on Windows 

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -193,6 +193,11 @@ def _validate_skill_name(name: str, directory_name: str) -> tuple[bool, str]:
         return False, f"name '{name}' must match directory name '{directory_name}'"
     return True, ""
 
+def _normalize_to_posix_path(path_str: str) -> PurePosixPath:
+    if "\\" in path_str or (len(path_str) >= 2 and path_str[1] == ":"):
+        return PurePosixPath(path_str.replace("\\", "/"))
+    else:
+        return PurePosixPath(path_str)
 
 def _parse_skill_metadata(
     content: str,
@@ -342,7 +347,7 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
             continue
 
         # Extract directory name from path using PurePosixPath
-        directory_name = PurePosixPath(skill_dir_path).name
+        directory_name = _normalize_to_posix_path(skill_dir_path).name
 
         # Parse metadata
         skill_metadata = _parse_skill_metadata(


### PR DESCRIPTION
root cause: In the if name != directory_name check, directory_name was holding the directory path instead of the directory name, which caused the validation logic to fail on Windows.

fix: updated the logic to correctly derive and compare the directory name, ensuring _validate_skill_name behaves as expected across platforms.