### PR TITLE
fix(cli): installed default prompt not updated following upgrade

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -450,36 +450,9 @@ def create_cli_agent(
         agent_dir = settings.ensure_agent_dir(assistant_id)
         agent_md = agent_dir / "AGENTS.md"
         if not agent_md.exists():
-            # Create empty user customization file with header
-            # Note: Base instructions are now always loaded fresh from the package
-            # via get_system_prompt(). This file is for USER CUSTOMIZATIONS ONLY.
-            user_memory_header = """# User Customizations
-
-Add your custom instructions, preferences, or notes below.
-These will be appended to the base agent instructions.
-
-The base instructions are loaded fresh from the deepagents-cli package,
-so you'll automatically get updates when you upgrade.
-
----
-
-"""
-            agent_md.write_text(user_memory_header)
-        else:
-            # Check for old format (full prompt was copied to AGENTS.md)
-            # and warn user to reset for cleaner setup
-            content = agent_md.read_text()
-            if content.strip().startswith("You are an AI assistant"):
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(
-                    "Your AGENTS.md contains the old prompt format. "
-                    "Base instructions are now loaded fresh from the package. "
-                    "Run 'deepagents reset --agent %s' to clean up, or keep your "
-                    "customizations (you may see some duplicate content).",
-                    assistant_id,
-                )
+            # Create empty file for user customizations
+            # Base instructions are loaded fresh from get_system_prompt()
+            agent_md.touch()
 
     # Skills directories (if enabled)
     skills_dir = None


### PR DESCRIPTION
Issue:                                                                                                                                                                                                                                       
  - Default prompt lives in default_agent_prompt.md in the package                                                                                                                                                                             
  - On first run, it was copied to ~/.deepagents/agent/AGENTS.md                                                                                                                                                                               
  - Subsequent runs used the user's copy, ignoring package updates                                                                                                                                                                             
  - Result: Updating the prompt in the package had no effect for existing users                                                                                                                                                                
                                                                                                                                                                                                                                               
  Fix:                                                                                                                                                                                                                                         
  - Base instructions now always loaded fresh from the package via get_system_prompt()                                                                                                                                                         
  - AGENTS.md is now just an empty file for user customizations (appended via MemoryMiddleware)                                                                                                                                                
  - Existing users with old format get a warning to run deepagents reset                                                                                                                                                                       
                                                                                                                                                                                                                                               
  For maintainers:                                                                                                                                                                                                                             
  - Edit libs/cli/deepagents_cli/default_agent_prompt.md                                                                                                                                                                                       
  - All users (new and existing) will get the update on next CLI upgrade