### PR TITLE
feat(cli): add working_dir and LangSmith template customization

### DIFF
--- a/libs/cli/deepagents_cli/integrations/langsmith.py
+++ b/libs/cli/deepagents_cli/integrations/langsmith.py
@@ -20,51 +20,36 @@ from deepagents.backends.sandbox import (
 )
 
 if TYPE_CHECKING:
-    from langsmith.sandbox import Sandbox, SandboxClient
-
+    from langsmith.sandbox import Sandbox, SandboxClient, SandboxTemplate
 
 # Default template configuration
-DEFAULT_TEMPLATE_NAME = "deepagents-cli"
-DEFAULT_TEMPLATE_IMAGE = "python:3"
+DEFAULT_TEMPLATE_NAME = os.getenv("LANGSMITH_SANDBOX_TEMPLATE_NAME", "deepagents-cli")
+DEFAULT_TEMPLATE_IMAGE = os.getenv("LANGSMITH_SANDBOX_TEMPLATE_IMAGE", "python:3")
 
 
 class LangSmithBackend(BaseSandbox):
-    """LangSmith backend implementation conforming to SandboxBackendProtocol.
-
-    This implementation inherits all file operation methods from BaseSandbox
-    and only implements the execute() method using LangSmith's API.
-    """
+    """LangSmith backend implementation."""
 
     def __init__(self, sandbox: Sandbox) -> None:
-        """Initialize the LangSmithBackend with a sandbox instance.
-
-        Args:
-            sandbox: LangSmith Sandbox instance
-        """
+        """Initialize with sandbox instance."""
         self._sandbox = sandbox
-        self._timeout: int = 30 * 60  # 30 mins default
+        self._timeout: int = 30 * 60
 
     @property
     def id(self) -> str:
-        """Unique identifier for the sandbox backend."""
+        """Return sandbox name as ID."""
         return self._sandbox.name
 
     def execute(self, command: str) -> ExecuteResponse:
-        """Execute a command in the sandbox and return ExecuteResponse.
-
-        Args:
-            command: Full shell command string to execute.
+        """Execute command in sandbox.
 
         Returns:
-            ExecuteResponse with combined output, exit code, and truncation flag.
+            ExecuteResponse with output and exit code.
         """
         result = self._sandbox.run(command, timeout=self._timeout)
-
-        # Combine stdout and stderr (matching other backends' approach)
         output = result.stdout or ""
         if result.stderr:
             output += "\n" + result.stderr if output else result.stderr
-
         return ExecuteResponse(
             output=output,
             exit_code=result.exit_code,
@@ -72,74 +57,40 @@ class LangSmithBackend(BaseSandbox):
         )
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        """Download multiple files from the LangSmith sandbox.
-
-        Leverages LangSmith's native file read API for efficiency.
-        Supports partial success - individual downloads may fail without
-        affecting others.
-
-        Args:
-            paths: List of file paths to download.
+        """Download files from sandbox.
 
         Returns:
-            List of FileDownloadResponse objects, one per input path.
-            Response order matches input order.
-
-        TODO: Map LangSmith API error strings to standardized FileOperationError codes.
-        Currently only implements happy path.
+            List of FileDownloadResponse objects.
         """
         responses: list[FileDownloadResponse] = []
-
         for path in paths:
-            # Use LangSmith's native file read API (returns bytes)
             content = self._sandbox.read(path)
             responses.append(
                 FileDownloadResponse(path=path, content=content, error=None)
             )
-
         return responses
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        """Upload multiple files to the LangSmith sandbox.
-
-        Leverages LangSmith's native file write API for efficiency.
-        Supports partial success - individual uploads may fail without
-        affecting others.
-
-        Args:
-            files: List of (path, content) tuples to upload.
+        """Upload files to sandbox.
 
         Returns:
-            List of FileUploadResponse objects, one per input file.
-            Response order matches input order.
-
-        TODO: Map LangSmith API error strings to standardized FileOperationError codes.
-        Currently only implements happy path.
+            List of FileUploadResponse objects.
         """
         responses: list[FileUploadResponse] = []
-
         for path, content in files:
-            # Use LangSmith's native file write API
             self._sandbox.write(path, content)
             responses.append(FileUploadResponse(path=path, error=None))
-
         return responses
 
 
 class LangSmithProvider(SandboxProvider[dict[str, Any]]):
-    """LangSmith sandbox provider implementation.
-
-    Manages LangSmith sandbox lifecycle using the LangSmith SDK.
-    """
+    """LangSmith sandbox provider implementation."""
 
     def __init__(self, api_key: str | None = None) -> None:
-        """Initialize LangSmith provider.
-
-        Args:
-            api_key: LangSmith API key (defaults to LANGSMITH_API_KEY env var)
+        """Initialize provider with API key.
 
         Raises:
-            ValueError: If LANGSMITH_API_KEY environment variable not set
+            ValueError: If LANGSMITH_API_KEY is not set.
         """
         from langsmith import sandbox
 
@@ -155,11 +106,7 @@ class LangSmithProvider(SandboxProvider[dict[str, Any]]):
         cursor: str | None = None,
         **kwargs: Any,
     ) -> SandboxListResponse[dict[str, Any]]:
-        """List available LangSmith sandboxes.
-
-        Raises:
-            NotImplementedError: LangSmith SDK list API not yet implemented.
-        """
+        """List sandboxes (not implemented)."""
         msg = "Listing with LangSmith SDK not yet implemented"
         raise NotImplementedError(msg)
 
@@ -168,23 +115,25 @@ class LangSmithProvider(SandboxProvider[dict[str, Any]]):
         *,
         sandbox_id: str | None = None,
         timeout: int = 180,
+        template: SandboxTemplate | str | None = None,
+        template_image: str | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> SandboxBackendProtocol:
         """Get existing or create new LangSmith sandbox.
 
         Args:
             sandbox_id: Optional existing sandbox name to reuse
-            timeout: Timeout in seconds for sandbox startup (default: 180)
-            **kwargs: Additional LangSmith-specific parameters
+            timeout: Timeout in seconds for sandbox startup
+            template: Template name/ID or SandboxTemplate object
+            template_image: Docker image for template creation
 
         Returns:
             LangSmithBackend instance
 
         Raises:
-            RuntimeError: Sandbox connection or startup failed
+            RuntimeError: If sandbox connection or startup fails
         """
         if sandbox_id:
-            # Connect to existing sandbox by name
             try:
                 sandbox = self._client.get_sandbox(name=sandbox_id)
             except Exception as e:
@@ -192,31 +141,26 @@ class LangSmithProvider(SandboxProvider[dict[str, Any]]):
                 raise RuntimeError(msg) from e
             return LangSmithBackend(sandbox)
 
-        # Create new sandbox - ensure template exists first
-        self._ensure_template()
+        template_name = self._resolve_template_name(template)
+        self._ensure_template(template_name, template_image)
 
         try:
             sandbox = self._client.create_sandbox(
-                template_name=DEFAULT_TEMPLATE_NAME, timeout=timeout
+                template_name=template_name, timeout=timeout
             )
         except Exception as e:
-            msg = (
-                f"Failed to create sandbox from template '{DEFAULT_TEMPLATE_NAME}': {e}"
-            )
+            msg = f"Failed to create sandbox from template '{template_name}': {e}"
             raise RuntimeError(msg) from e
 
-        # Verify sandbox is ready by polling
         for _ in range(timeout // 2):
             try:
                 result = sandbox.run("echo ready", timeout=5)
                 if result.exit_code == 0:
                     break
             except Exception:  # noqa: S110, BLE001
-                # Sandbox not ready yet, continue polling
                 pass
             time.sleep(2)
         else:
-            # Cleanup on failure
             with contextlib.suppress(Exception):
                 self._client.delete_sandbox(sandbox.name)
             msg = f"LangSmith sandbox failed to start within {timeout} seconds"
@@ -225,38 +169,38 @@ class LangSmithProvider(SandboxProvider[dict[str, Any]]):
         return LangSmithBackend(sandbox)
 
     def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002
-        """Delete a LangSmith sandbox.
-
-        Args:
-            sandbox_id: Sandbox name to delete
-            **kwargs: Additional parameters
-        """
+        """Delete a sandbox."""
         self._client.delete_sandbox(sandbox_id)
 
-    def _ensure_template(self) -> None:
-        """Ensure template exists, creating it if needed.
+    @staticmethod
+    def _resolve_template_name(template: SandboxTemplate | str | None) -> str:
+        if template is None:
+            return DEFAULT_TEMPLATE_NAME
+        if isinstance(template, str):
+            return template
+        return template.name
 
-        Raises:
-            RuntimeError: If template check or creation fails
-        """
+    def _ensure_template(
+        self,
+        template_name: str | None = None,
+        template_image: str | None = None,
+    ) -> None:
         from langsmith.sandbox import ResourceNotFoundError
 
+        name = template_name or DEFAULT_TEMPLATE_NAME
+        image = template_image or DEFAULT_TEMPLATE_IMAGE
+
         try:
-            self._client.get_template(DEFAULT_TEMPLATE_NAME)
+            self._client.get_template(name)
         except ResourceNotFoundError as e:
             if e.resource_type != "template":
                 msg = f"Unexpected resource not found: {e}"
                 raise RuntimeError(msg) from e
-            # Template doesn't exist, create it
             try:
-                self._client.create_template(
-                    name=DEFAULT_TEMPLATE_NAME, image=DEFAULT_TEMPLATE_IMAGE
-                )
+                self._client.create_template(name=name, image=image)
             except Exception as create_err:
-                msg = (
-                    f"Failed to create template '{DEFAULT_TEMPLATE_NAME}': {create_err}"
-                )
+                msg = f"Failed to create template '{name}': {create_err}"
                 raise RuntimeError(msg) from create_err
         except Exception as e:
-            msg = f"Failed to check template '{DEFAULT_TEMPLATE_NAME}': {e}"
+            msg = f"Failed to check template '{name}': {e}"
             raise RuntimeError(msg) from e

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -6,6 +6,7 @@ import string
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.sandbox import SandboxProvider
@@ -68,8 +69,7 @@ def create_sandbox(
     *,
     sandbox_id: str | None = None,
     setup_script_path: str | None = None,
-    template: str | None = None,
-    template_image: str | None = None,
+    **kwargs: Any,
 ) -> Generator[SandboxBackendProtocol, None, None]:
     """Create or connect to a sandbox of the specified provider.
 
@@ -79,10 +79,7 @@ def create_sandbox(
         provider: Sandbox provider ("daytona", "langsmith", "modal", "runloop")
         sandbox_id: Optional existing sandbox ID to reuse
         setup_script_path: Optional path to setup script to run after sandbox starts
-        template: Optional template name/ID to use for sandbox creation.
-                 Currently only supported by langsmith provider.
-        template_image: Optional Docker image to use when creating a new template.
-                 Currently only supported by langsmith provider.
+        **kwargs: Additional provider-specific parameters
 
     Yields:
         SandboxBackendProtocol instance
@@ -95,9 +92,7 @@ def create_sandbox(
 
     # Create or connect to sandbox
     console.print(f"[yellow]Starting {provider} sandbox...[/yellow]")
-    backend = provider_obj.get_or_create(
-        sandbox_id=sandbox_id, template=template, template_image=template_image
-    )
+    backend = provider_obj.get_or_create(sandbox_id=sandbox_id, **kwargs)
     console.print(
         f"[green]✓ {provider.capitalize()} sandbox ready: {backend.id}[/green]"
     )

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -68,6 +68,8 @@ def create_sandbox(
     *,
     sandbox_id: str | None = None,
     setup_script_path: str | None = None,
+    template: str | None = None,
+    template_image: str | None = None,
 ) -> Generator[SandboxBackendProtocol, None, None]:
     """Create or connect to a sandbox of the specified provider.
 
@@ -77,6 +79,10 @@ def create_sandbox(
         provider: Sandbox provider ("daytona", "langsmith", "modal", "runloop")
         sandbox_id: Optional existing sandbox ID to reuse
         setup_script_path: Optional path to setup script to run after sandbox starts
+        template: Optional template name/ID to use for sandbox creation.
+                 Currently only supported by langsmith provider.
+        template_image: Optional Docker image to use when creating a new template.
+                 Currently only supported by langsmith provider.
 
     Yields:
         SandboxBackendProtocol instance
@@ -89,7 +95,9 @@ def create_sandbox(
 
     # Create or connect to sandbox
     console.print(f"[yellow]Starting {provider} sandbox...[/yellow]")
-    backend = provider_obj.get_or_create(sandbox_id=sandbox_id)
+    backend = provider_obj.get_or_create(
+        sandbox_id=sandbox_id, template=template, template_image=template_image
+    )
     console.print(
         f"[green]✓ {provider.capitalize()} sandbox ready: {backend.id}[/green]"
     )


### PR DESCRIPTION
Changes:
- Add working_dir parameter to get_system_prompt() and create_cli_agent() to override default sandbox working directory
- Add template and template_image parameters to LangSmithProvider.get_or_create() for custom sandbox templates
- Add template and template_image pass-through in create_sandbox() factory function
- Support env vars LANGSMITH_SANDBOX_TEMPLATE_NAME and LANGSMITH_SANDBOX_TEMPLATE_IMAGE for defaults