### PR TITLE
fix(cli): show full shell command in error output

### DIFF
--- a/libs/cli/deepagents_cli/file_ops.py
+++ b/libs/cli/deepagents_cli/file_ops.py
@@ -15,7 +15,7 @@ from deepagents_cli.config import settings
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from deepagents.backends.protocol import BACKEND_TYPES
+    from deepagents.backends.protocol import BackendProtocol
 
 FileOpStatus = Literal["pending", "success", "error"]
 
@@ -274,7 +274,7 @@ class FileOpTracker:
     """Collect file operation metrics during a CLI interaction."""
 
     def __init__(
-        self, *, assistant_id: str | None, backend: BACKEND_TYPES | None = None
+        self, *, assistant_id: str | None, backend: BackendProtocol | None = None
     ) -> None:
         """Initialize the tracker."""
         self.assistant_id = assistant_id

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -406,8 +406,12 @@ class ToolCallMessage(Vertical):
         self._stop_animation()
         self._status = "error"
         # For shell commands, prepend the full command so users can see what failed
-        if self._tool_name in {"shell", "bash", "execute"} and "command" in self._args:
-            command = str(self._args["command"])
+        command = (
+            self._args.get("command")
+            if self._tool_name in {"shell", "bash", "execute"}
+            else None
+        )
+        if command and isinstance(command, str) and command.strip():
             self._output = f"$ {command}\n\n{error}"
         else:
             self._output = error

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -717,10 +717,10 @@ class ToolCallMessage(Vertical):
         max_lines = 4 if is_preview else len(lines)  # Show all when expanded
 
         formatted_lines = []
-        for line in lines[:max_lines]:
+        for i, line in enumerate(lines[:max_lines]):
             escaped = self._escape_markup(line)
-            # Style the command line ($ prefix) in dim grey
-            if escaped.startswith("$ "):
+            # Style only the first line (the command) in dim grey
+            if i == 0 and escaped.startswith("$ "):
                 formatted_lines.append(f"[dim]{escaped}[/dim]")
             else:
                 formatted_lines.append(escaped)

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -405,7 +405,12 @@ class ToolCallMessage(Vertical):
         """
         self._stop_animation()
         self._status = "error"
-        self._output = error
+        # For shell commands, prepend the full command so users can see what failed
+        if self._tool_name in {"shell", "bash", "execute"} and "command" in self._args:
+            command = str(self._args["command"])
+            self._output = f"$ {command}\n\n{error}"
+        else:
+            self._output = error
         if self._status_widget:
             self._status_widget.remove_class("pending")
             self._status_widget.add_class("error")
@@ -707,7 +712,15 @@ class ToolCallMessage(Vertical):
         lines = output.split("\n")
         max_lines = 4 if is_preview else len(lines)  # Show all when expanded
 
-        formatted_lines = [self._escape_markup(line) for line in lines[:max_lines]]
+        formatted_lines = []
+        for line in lines[:max_lines]:
+            escaped = self._escape_markup(line)
+            # Style the command line ($ prefix) in dim grey
+            if escaped.startswith("$ "):
+                formatted_lines.append(f"[dim]{escaped}[/dim]")
+            else:
+                formatted_lines.append(escaped)
+
         result = "\n".join(formatted_lines)
 
         if is_preview and len(lines) > max_lines:

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -177,14 +177,15 @@ class TestToolCallMessageShellCommand:
         assert msg._output == error
         assert not msg._output.startswith("$ ")
 
-    def test_format_shell_output_styles_command_line_dim(self) -> None:
-        """Shell output formatting should style command lines in dim."""
+    def test_format_shell_output_styles_only_first_line_dim(self) -> None:
+        """Shell output formatting should only style the first command line in dim."""
         msg = ToolCallMessage("shell", {"command": "echo test"})
-        output = "$ echo test\ntest output"
+        # Include a line that looks like a command prompt in the output
+        output = "$ echo test\ntest output\n$ not a command"
         formatted = msg._format_shell_output(output, is_preview=False)
 
-        # Command line should be wrapped in [dim] markup
-        assert "[dim]" in formatted
-        assert "$ echo test" in formatted
-        # Regular output should not be dim
-        assert "test output" in formatted
+        # First line (the command) should be wrapped in [dim] markup
+        assert "[dim]$ echo test[/dim]" in formatted
+        # Subsequent lines starting with $ should NOT be dimmed
+        assert "$ not a command" in formatted
+        assert "[dim]$ not a command" not in formatted

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -141,3 +141,50 @@ class TestToolCallMessageShellCommand:
 
         assert msg._output == error
         assert not msg._output.startswith("$ ")
+
+    def test_shell_error_with_none_command(self) -> None:
+        """Shell tool with None command should fall back to error-only output."""
+        msg = ToolCallMessage("shell", {"command": None})
+        error = "Some error"
+        msg.set_error(error)
+
+        assert "$ None" not in msg._output
+        assert msg._output == error
+
+    def test_shell_error_with_empty_command(self) -> None:
+        """Shell tool with empty command should fall back to error-only output."""
+        msg = ToolCallMessage("shell", {"command": ""})
+        error = "Some error"
+        msg.set_error(error)
+
+        assert msg._output == error
+        assert not msg._output.startswith("$ ")
+
+    def test_shell_error_with_whitespace_command(self) -> None:
+        """Shell tool with whitespace command should fall back to error-only output."""
+        msg = ToolCallMessage("shell", {"command": "   "})
+        error = "Some error"
+        msg.set_error(error)
+
+        assert msg._output == error
+
+    def test_shell_error_with_no_command_key(self) -> None:
+        """Shell tool with no command key should fall back to error-only output."""
+        msg = ToolCallMessage("shell", {"other_arg": "value"})
+        error = "Some error"
+        msg.set_error(error)
+
+        assert msg._output == error
+        assert not msg._output.startswith("$ ")
+
+    def test_format_shell_output_styles_command_line_dim(self) -> None:
+        """Shell output formatting should style command lines in dim."""
+        msg = ToolCallMessage("shell", {"command": "echo test"})
+        output = "$ echo test\ntest output"
+        formatted = msg._format_shell_output(output, is_preview=False)
+
+        # Command line should be wrapped in [dim] markup
+        assert "[dim]" in formatted
+        assert "$ echo test" in formatted
+        # Regular output should not be dim
+        assert "test output" in formatted

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -84,3 +84,60 @@ class TestToolCallMessageMarkupSafety:
         args = {"code": "arr[0] = val[1]", "file": "test.py"}
         msg = ToolCallMessage("write_file", args)
         assert msg._args == args
+
+
+class TestToolCallMessageShellCommand:
+    """Test ToolCallMessage shows full shell command for errors.
+
+    When a shell command fails, users need to see the full command to debug.
+    The header is truncated for display, but the full command should be
+    included in the error output for visibility.
+    """
+
+    def test_shell_error_includes_full_command(self) -> None:
+        """Error output should include the full command that was executed."""
+        long_cmd = "pip install " + " ".join(f"package{i}" for i in range(50))
+        assert len(long_cmd) > 120  # Exceeds truncation limit
+
+        msg = ToolCallMessage("shell", {"command": long_cmd})
+        msg.set_error("Command not found: pip")
+
+        # The error output should include the full command
+        assert long_cmd in msg._output
+
+    def test_shell_error_command_prefix(self) -> None:
+        """Error output should have shell prompt prefix."""
+        cmd = "echo hello"
+        msg = ToolCallMessage("shell", {"command": cmd})
+        msg.set_error("Permission denied")
+
+        # Output should have shell prompt prefix
+        assert msg._output.startswith("$ ")
+        assert cmd in msg._output
+
+    def test_bash_error_includes_full_command(self) -> None:
+        """Error output should include full command for bash tool too."""
+        cmd = "make build"
+        msg = ToolCallMessage("bash", {"command": cmd})
+        msg.set_error("make: *** No rule to make target")
+
+        assert msg._output.startswith("$ ")
+        assert cmd in msg._output
+
+    def test_execute_error_includes_full_command(self) -> None:
+        """Error output should include full command for execute tool too."""
+        cmd = "docker build ."
+        msg = ToolCallMessage("execute", {"command": cmd})
+        msg.set_error("Cannot connect to Docker daemon")
+
+        assert msg._output.startswith("$ ")
+        assert cmd in msg._output
+
+    def test_non_shell_error_unchanged(self) -> None:
+        """Non-shell tools should not have command prepended."""
+        msg = ToolCallMessage("read_file", {"path": "/etc/passwd"})
+        error = "Permission denied"
+        msg.set_error(error)
+
+        assert msg._output == error
+        assert not msg._output.startswith("$ ")


### PR DESCRIPTION
- When a shell command fails, the full command is now prepended to the error output with a `$` prefix
- Applies to shell, bash, and execute tool types
- The command line is styled in dim grey for visual distinction from the error message

Fixes #1080