### PR TITLE
fix(cli): `Ctrl+E` for tool output toggle

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -247,7 +247,13 @@ class DeepAgentsApp(App):
             show=False,
             priority=True,
         ),
-        Binding("ctrl+o", "toggle_tool_output", "Toggle Tool Output", show=False),
+        Binding(
+            "ctrl+e",
+            "toggle_tool_output",
+            "Toggle Tool Output",
+            show=False,
+            priority=True,
+        ),
         # Approval menu keys (handled at App level for reliability)
         Binding("up", "approval_up", "Up", show=False),
         Binding("k", "approval_up", "Up", show=False),

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -192,7 +192,7 @@ class ToolCallMessage(Vertical):
     """Widget displaying a tool call with collapsible output.
 
     Tool outputs are shown as a 3-line preview by default.
-    Press Ctrl+O to expand/collapse the full output.
+    Press Ctrl+E to expand/collapse the full output.
     Shows an animated "Running..." indicator while the tool is executing.
     """
 
@@ -878,7 +878,9 @@ class ToolCallMessage(Vertical):
             self._full_widget.update(formatted)
             self._full_widget.display = True
             # Show collapse hint
-            self._hint_widget.update("[dim italic]click to collapse[/dim italic]")
+            self._hint_widget.update(
+                "[dim italic]click or Ctrl+E to collapse[/dim italic]"
+            )
             self._hint_widget.display = True
         else:
             # Show preview
@@ -890,7 +892,9 @@ class ToolCallMessage(Vertical):
                 self._preview_widget.display = True
 
                 # Show expand hint
-                self._hint_widget.update("[dim italic]click to expand[/dim italic]")
+                self._hint_widget.update(
+                    "[dim italic]click or Ctrl+E to expand[/dim italic]"
+                )
                 self._hint_widget.display = True
             elif output_stripped:
                 # Output fits in preview, show formatted

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1,5 +1,7 @@
 """Unit tests for DeepAgentsApp."""
 
+from textual.binding import Binding
+
 from deepagents_cli.app import DeepAgentsApp
 
 
@@ -7,9 +9,17 @@ class TestAppBindings:
     """Test app keybindings."""
 
     def test_toggle_tool_output_has_ctrl_e_binding(self) -> None:
-        """Ctrl+E should be bound to toggle_tool_output."""
-        bindings_by_key = {b.key: b for b in DeepAgentsApp.BINDINGS}
+        """Ctrl+E should be bound to toggle_tool_output with priority."""
+        bindings = [b for b in DeepAgentsApp.BINDINGS if isinstance(b, Binding)]
+        bindings_by_key = {b.key: b for b in bindings}
         ctrl_e = bindings_by_key.get("ctrl+e")
 
         assert ctrl_e is not None
         assert ctrl_e.action == "toggle_tool_output"
+        assert ctrl_e.priority is True
+
+    def test_ctrl_o_not_bound_to_toggle_tool_output(self) -> None:
+        """Ctrl+O should not exist (replaced by Ctrl+E)."""
+        bindings = [b for b in DeepAgentsApp.BINDINGS if isinstance(b, Binding)]
+        bindings_by_key = {b.key: b for b in bindings}
+        assert "ctrl+o" not in bindings_by_key

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1,0 +1,15 @@
+"""Unit tests for DeepAgentsApp."""
+
+from deepagents_cli.app import DeepAgentsApp
+
+
+class TestAppBindings:
+    """Test app keybindings."""
+
+    def test_toggle_tool_output_has_ctrl_e_binding(self) -> None:
+        """Ctrl+E should be bound to toggle_tool_output."""
+        bindings_by_key = {b.key: b for b in DeepAgentsApp.BINDINGS}
+        ctrl_e = bindings_by_key.get("ctrl+e")
+
+        assert ctrl_e is not None
+        assert ctrl_e.action == "toggle_tool_output"


### PR DESCRIPTION
- Replace `Ctrl+O` keybinding with `Ctrl+E` for toggling tool output expand/collapse
- Update hint text to show `"click or Ctrl+E to expand/collapse"`

AFAICT, `Ctrl+O` was added in the original Textual refactor without documentation or rationale. It conflicts with "Open file" in common editors (nano, etc.). Ctrl+E is a cleaner choice since we use `e` to expand long tool inputs in the HITL dialogue.