### PR TITLE
fix(cli): consolidate tool output expand/collapse hint placement

### DIFF
--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -182,10 +182,10 @@ class TestToolCallMessageShellCommand:
         msg = ToolCallMessage("shell", {"command": "echo test"})
         # Include a line that looks like a command prompt in the output
         output = "$ echo test\ntest output\n$ not a command"
-        formatted = msg._format_shell_output(output, is_preview=False)
+        result = msg._format_shell_output(output, is_preview=False)
 
         # First line (the command) should be wrapped in [dim] markup
-        assert "[dim]$ echo test[/dim]" in formatted
+        assert "[dim]$ echo test[/dim]" in result.content
         # Subsequent lines starting with $ should NOT be dimmed
-        assert "$ not a command" in formatted
-        assert "[dim]$ not a command" not in formatted
+        assert "$ not a command" in result.content
+        assert "[dim]$ not a command" not in result.content


### PR DESCRIPTION
- Refactors tool output formatting to use a structured `FormattedOutput` dataclass instead of embedding truncation suffixes directly into formatted strings
- Merges `"X more lines"` with `"click or Ctrl+E to expand"` onto the same line when output is collapsed
- Fixes collapse hint to appear underneath expanded output (was incorrectly appearing above due to widget DOM order)

`frozen=True` since format methods return data that shouldn't be modified by consumers.

`slots=True` since many FormattedOutput instances may be created during a session, and reduced per-instance overhead.