### PR TITLE
style(cli): update styling and refactor for modular glyphs

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -32,6 +32,7 @@ from deepagents_cli.config import (
     config,
     console,
     get_default_coding_instructions,
+    get_glyphs,
     settings,
 )
 from deepagents_cli.integrations.sandbox_factory import get_default_working_dir
@@ -60,12 +61,15 @@ def list_agents() -> None:
             agent_name = agent_path.name
             agent_md = agent_path / "AGENTS.md"
 
+            bullet = get_glyphs().bullet
             if agent_md.exists():
-                console.print(f"  • [bold]{agent_name}[/bold]", style=COLORS["primary"])
+                console.print(
+                    f"  {bullet} [bold]{agent_name}[/bold]", style=COLORS["primary"]
+                )
                 console.print(f"    {agent_path}", style=COLORS["dim"])
             else:
                 console.print(
-                    f"  • [bold]{agent_name}[/bold] [dim](incomplete)[/dim]",
+                    f"  {bullet} [bold]{agent_name}[/bold] [dim](incomplete)[/dim]",
                     style=COLORS["tool"],
                 )
                 console.print(f"    {agent_path}", style=COLORS["dim"])
@@ -106,7 +110,8 @@ def reset_agent(agent_name: str, source_agent: str | None = None) -> None:
     agent_md.write_text(source_content)
 
     console.print(
-        f"✓ Agent '{agent_name}' reset to {action_desc}", style=COLORS["primary"]
+        f"{get_glyphs().checkmark} Agent '{agent_name}' reset to {action_desc}",
+        style=COLORS["primary"],
     )
     console.print(f"Location: {agent_dir}\n", style=COLORS["dim"])
 
@@ -120,8 +125,10 @@ def get_system_prompt(assistant_id: str, sandbox_type: str | None = None) -> str
 
     Args:
         assistant_id: The agent identifier for path references
-        sandbox_type: Type of sandbox provider ("modal", "runloop", "daytona").
-                     If None, agent is operating in local mode.
+        sandbox_type: Type of sandbox provider
+            ("daytona", "langsmith", "modal", "runloop").
+
+            If None, agent is operating in local mode.
 
     Returns:
         The system prompt string (base instructions + environment context)
@@ -275,7 +282,7 @@ def _format_web_search_description(
 
     return (
         f"Query: {query}\nMax results: {max_results}\n\n"
-        "⚠️  This will use Tavily API credits"
+        f"{get_glyphs().warning}  This will use Tavily API credits"
     )
 
 
@@ -293,7 +300,7 @@ def _format_fetch_url_description(
 
     return (
         f"URL: {url}\nTimeout: {timeout}s\n\n"
-        "⚠️  Will fetch and convert web content to markdown"
+        f"{get_glyphs().warning}  Will fetch and convert web content to markdown"
     )
 
 
@@ -317,13 +324,16 @@ def _format_task_description(
     if len(description) > 500:
         description_preview = description[:500] + "..."
 
+    glyphs = get_glyphs()
+    separator = glyphs.box_horizontal * 40
+    warning_msg = "Subagent will have access to file operations and shell commands"
     return (
         f"Subagent Type: {subagent_type}\n\n"
         f"Task Instructions:\n"
-        f"{'─' * 40}\n"
+        f"{separator}\n"
         f"{description_preview}\n"
-        f"{'─' * 40}\n\n"
-        f"⚠️  Subagent will have access to file operations and shell commands"
+        f"{separator}\n\n"
+        f"{glyphs.warning}  {warning_msg}"
     )
 
 
@@ -432,8 +442,7 @@ def create_cli_agent(
 
             If `None`, uses local filesystem + shell.
         sandbox_type: Type of sandbox provider
-            (`'modal'`, `'runloop'`, `'daytona'`).
-
+            (`'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
             Used for system prompt generation.
         system_prompt: Override the default system prompt.
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -19,6 +19,7 @@ from textual.css.query import NoMatches
 from textual.widgets import Static
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
+from deepagents_cli.config import CharsetMode, _detect_charset_mode
 from deepagents_cli.textual_adapter import TextualUIAdapter, execute_task_textual
 from deepagents_cli.widgets.approval import ApprovalMenu
 from deepagents_cli.widgets.chat_input import ChatInput
@@ -333,6 +334,10 @@ class DeepAgentsApp(App):
 
     async def on_mount(self) -> None:
         """Initialize components after mount."""
+        if _detect_charset_mode() == CharsetMode.ASCII:
+            chat = self.query_one("#chat", VerticalScroll)
+            chat.styles.scrollbar_size_vertical = 0
+
         self._status_bar = self.query_one("#status-bar", StatusBar)
         self._chat_input = self.query_one("#input-area", ChatInput)
 

--- a/libs/cli/deepagents_cli/clipboard.py
+++ b/libs/cli/deepagents_cli/clipboard.py
@@ -8,6 +8,8 @@ import os
 import pathlib
 from typing import TYPE_CHECKING
 
+from deepagents_cli.config import get_glyphs
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -34,9 +36,10 @@ def _shorten_preview(texts: list[str]) -> str:
     Returns:
         Shortened preview text suitable for notification display.
     """
-    dense_text = "⏎".join(texts).replace("\n", "⏎")
+    glyphs = get_glyphs()
+    dense_text = glyphs.newline.join(texts).replace("\n", glyphs.newline)
     if len(dense_text) > _PREVIEW_MAX_LENGTH:
-        return f"{dense_text[: _PREVIEW_MAX_LENGTH - 1]}…"
+        return f"{dense_text[: _PREVIEW_MAX_LENGTH - 1]}{glyphs.ellipsis}"
     return dense_text
 
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -5,6 +5,7 @@ import re
 import sys
 import uuid
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 import dotenv
@@ -37,24 +38,197 @@ COLORS = {
     "tool": "#fbbf24",
 }
 
-# ASCII art banner
 
-DEEP_AGENTS_ASCII = f"""
- ██████╗  ███████╗ ███████╗ ██████╗
- ██╔══██╗ ██╔════╝ ██╔════╝ ██╔══██╗
- ██║  ██║ █████╗   █████╗   ██████╔╝
- ██║  ██║ ██╔══╝   ██╔══╝   ██╔═══╝
- ██████╔╝ ███████╗ ███████╗ ██║
- ╚═════╝  ╚══════╝ ╚══════╝ ╚═╝
+# Charset mode configuration
+class CharsetMode(StrEnum):
+    """Character set mode for TUI display."""
 
-  █████╗   ██████╗  ███████╗ ███╗   ██╗ ████████╗ ███████╗
- ██╔══██╗ ██╔════╝  ██╔════╝ ████╗  ██║ ╚══██╔══╝ ██╔════╝
- ███████║ ██║  ███╗ █████╗   ██╔██╗ ██║    ██║    ███████╗
- ██╔══██║ ██║   ██║ ██╔══╝   ██║╚██╗██║    ██║    ╚════██║
- ██║  ██║ ╚██████╔╝ ███████╗ ██║ ╚████║    ██║    ███████║
- ╚═╝  ╚═╝  ╚═════╝  ╚══════╝ ╚═╝  ╚═══╝    ╚═╝    ╚══════╝
-                                              v{__version__}
+    UNICODE = "unicode"
+    ASCII = "ascii"
+    AUTO = "auto"
+
+
+@dataclass(frozen=True)
+class Glyphs:
+    """Character glyphs for TUI display."""
+
+    tool_prefix: str  # ⏺ vs (*)
+    ellipsis: str  # … vs ...
+    checkmark: str  # ✓ vs [OK]
+    error: str  # ✗ vs [X]
+    circle_empty: str  # ○ vs [ ]
+    circle_filled: str  # ● vs [*]
+    output_prefix: str  # ⎿ vs L
+    spinner_frames: tuple[str, ...]  # Braille vs ASCII spinner
+    pause: str  # ⏸ vs ||
+    newline: str  # ⏎ vs \\n
+    warning: str  # ⚠ vs [!]
+    arrow_up: str  # up arrow vs ^
+    arrow_down: str  # down arrow vs v
+    bullet: str  # bullet vs -
+    cursor: str  # cursor vs >
+
+    # Box-drawing characters
+    box_vertical: str  # │ vs |
+    box_horizontal: str  # ─ vs -
+    box_double_horizontal: str  # ═ vs =
+
+    # Diff-specific
+    gutter_bar: str  # ▌ vs |
+
+    # Tree connectors (full prefixes for tree display)
+    tree_branch: str  # "├── " vs "+-- "
+    tree_last: str  # "└── " vs "`-- "
+    tree_vertical: str  # "│   " vs "|   "
+
+
+UNICODE_GLYPHS = Glyphs(
+    tool_prefix="⏺",
+    ellipsis="…",
+    checkmark="✓",
+    error="✗",
+    circle_empty="○",
+    circle_filled="●",
+    output_prefix="⎿",
+    spinner_frames=("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"),
+    pause="⏸",
+    newline="⏎",
+    warning="⚠",
+    arrow_up="↑",
+    arrow_down="↓",
+    bullet="•",
+    cursor="›",  # noqa: RUF001
+    # Box-drawing characters
+    box_vertical="│",
+    box_horizontal="─",
+    box_double_horizontal="═",
+    gutter_bar="▌",
+    tree_branch="├── ",
+    tree_last="└── ",
+    tree_vertical="│   ",
+)
+
+ASCII_GLYPHS = Glyphs(
+    tool_prefix="(*)",
+    ellipsis="...",
+    checkmark="[OK]",
+    error="[X]",
+    circle_empty="[ ]",
+    circle_filled="[*]",
+    output_prefix="L",
+    spinner_frames=("(-)", "(\\)", "(|)", "(/)"),
+    pause="||",
+    newline="\\n",
+    warning="[!]",
+    arrow_up="^",
+    arrow_down="v",
+    bullet="-",
+    cursor=">",
+    # Box-drawing characters
+    box_vertical="|",
+    box_horizontal="-",
+    box_double_horizontal="=",
+    gutter_bar="|",
+    tree_branch="+-- ",
+    tree_last="`-- ",
+    tree_vertical="|   ",
+)
+
+# Module-level cache for detected glyphs
+_glyphs_cache: Glyphs | None = None
+
+
+def _detect_charset_mode() -> CharsetMode:
+    """Auto-detect terminal charset capabilities.
+
+    Returns:
+        The detected CharsetMode based on environment and terminal encoding.
+    """
+    env_mode = os.environ.get("UI_CHARSET_MODE", "auto").lower()
+    if env_mode == "unicode":
+        return CharsetMode.UNICODE
+    if env_mode == "ascii":
+        return CharsetMode.ASCII
+
+    # Auto: check stdout encoding and LANG
+    encoding = getattr(sys.stdout, "encoding", "") or ""
+    if "utf" in encoding.lower():
+        return CharsetMode.UNICODE
+    lang = os.environ.get("LANG", "") or os.environ.get("LC_ALL", "")
+    if "utf" in lang.lower():
+        return CharsetMode.UNICODE
+    return CharsetMode.ASCII
+
+
+def get_glyphs() -> Glyphs:
+    """Get the glyph set for the current charset mode.
+
+    Returns:
+        The appropriate Glyphs instance based on charset mode detection.
+    """
+    global _glyphs_cache  # noqa: PLW0603
+    if _glyphs_cache is not None:
+        return _glyphs_cache
+
+    mode = _detect_charset_mode()
+    _glyphs_cache = ASCII_GLYPHS if mode == CharsetMode.ASCII else UNICODE_GLYPHS
+    return _glyphs_cache
+
+
+def reset_glyphs_cache() -> None:
+    """Reset the glyphs cache (for testing)."""
+    global _glyphs_cache  # noqa: PLW0603
+    _glyphs_cache = None
+
+
+# Text art banners (Unicode and ASCII variants)
+
+_UNICODE_BANNER = f"""
+██████╗  ███████╗ ███████╗ ██████╗
+██╔══██╗ ██╔════╝ ██╔════╝ ██╔══██╗
+██║  ██║ █████╗   █████╗   ██████╔╝
+██║  ██║ ██╔══╝   ██╔══╝   ██╔═══╝
+██████╔╝ ███████╗ ███████╗ ██║
+╚═════╝  ╚══════╝ ╚══════╝ ╚═╝
+
+ █████╗   ██████╗  ███████╗ ███╗   ██╗ ████████╗ ███████╗
+██╔══██╗ ██╔════╝  ██╔════╝ ████╗  ██║ ╚══██╔══╝ ██╔════╝
+███████║ ██║  ███╗ █████╗   ██╔██╗ ██║    ██║    ███████╗
+██╔══██║ ██║   ██║ ██╔══╝   ██║╚██╗██║    ██║    ╚════██║
+██║  ██║ ╚██████╔╝ ███████╗ ██║ ╚████║    ██║    ███████║
+╚═╝  ╚═╝  ╚═════╝  ╚══════╝ ╚═╝  ╚═══╝    ╚═╝    ╚══════╝
+                                                  v{__version__}
 """
+
+_ASCII_BANNER = f"""
+ ____  ____  ____  ____
+|  _ \\| ___|| ___||  _ \\
+| | | | |_  | |_  | |_) |
+| |_| |  _| |  _| |  __/
+|____/|____||____||_|
+
+    _    ____  ____  _   _  _____  ____
+   / \\  / ___|| ___|| \\ | ||_   _|/ ___|
+  / _ \\| |  _ | |_  |  \\| |  | |  \\___ \\
+ / ___ \\ |_| ||  _| | |\\  |  | |   ___) |
+/_/   \\_\\____||____||_| \\_|  |_|  |____/
+                                  v{__version__}
+"""
+
+
+def get_banner() -> str:
+    """Get the appropriate banner for the current charset mode.
+
+    Returns:
+        The text art banner string (Unicode or ASCII based on charset mode).
+    """
+    if _detect_charset_mode() == CharsetMode.ASCII:
+        return _ASCII_BANNER
+    return _UNICODE_BANNER
+
+
+# Legacy alias for backwards compatibility
+DEEP_AGENTS_ASCII = _UNICODE_BANNER
 
 # Interactive commands
 COMMANDS = {

--- a/libs/cli/deepagents_cli/input.py
+++ b/libs/cli/deepagents_cli/input.py
@@ -1,4 +1,4 @@
-"""Input handling utilities for the CLI."""
+"""Input handling utilities including image tracking and file mention parsing."""
 
 import re
 from pathlib import Path

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.sandbox import SandboxProvider
 
-from deepagents_cli.config import console
+from deepagents_cli.config import console, get_glyphs
 from deepagents_cli.integrations.daytona import DaytonaProvider
 from deepagents_cli.integrations.langsmith import LangSmithProvider
 from deepagents_cli.integrations.modal import ModalProvider
@@ -51,7 +51,7 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
         msg = "Setup failed - aborting"
         raise RuntimeError(msg)
 
-    console.print("[green]✓ Setup complete[/green]")
+    console.print(f"[green]{get_glyphs().checkmark} Setup complete[/green]")
 
 
 _PROVIDER_TO_WORKING_DIR = {
@@ -90,8 +90,10 @@ def create_sandbox(
     # Create or connect to sandbox
     console.print(f"[yellow]Starting {provider} sandbox...[/yellow]")
     backend = provider_obj.get_or_create(sandbox_id=sandbox_id)
+    glyphs = get_glyphs()
     console.print(
-        f"[green]✓ {provider.capitalize()} sandbox ready: {backend.id}[/green]"
+        f"[green]{glyphs.checkmark} {provider.capitalize()} sandbox ready: "
+        f"{backend.id}[/green]"
     )
 
     # Run setup script if provided
@@ -107,12 +109,17 @@ def create_sandbox(
                     f"[dim]Terminating {provider} sandbox {backend.id}...[/dim]"
                 )
                 provider_obj.delete(sandbox_id=backend.id)
+                glyphs = get_glyphs()
                 console.print(
-                    f"[dim]✓ {provider.capitalize()} sandbox "
+                    f"[dim]{glyphs.checkmark} {provider.capitalize()} sandbox "
                     f"{backend.id} terminated[/dim]"
                 )
             except Exception as e:
-                console.print(f"[yellow]⚠ Cleanup failed: {e}[/yellow]")
+                warning = get_glyphs().warning
+                console.print(
+                    f"[yellow]{warning} Cleanup failed for {provider} sandbox "
+                    f"{backend.id}: {e}[/yellow]"
+                )
 
 
 def _get_available_sandbox_types() -> list[str]:

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from deepagents_cli.config import COLORS, Settings, console
+from deepagents_cli.config import COLORS, Settings, console, get_glyphs
 from deepagents_cli.skills.load import list_skills
 
 MAX_SKILL_NAME_LENGTH = 64
@@ -177,9 +177,11 @@ def _list(agent: str, *, project: bool = False) -> None:
     # Show user skills
     if user_skills and not project:
         console.print("[bold cyan]User Skills:[/bold cyan]", style=COLORS["primary"])
+        bullet = get_glyphs().bullet
         for skill in user_skills:
             skill_path = Path(skill["path"])
-            console.print(f"  • [bold]{skill['name']}[/bold]", style=COLORS["primary"])
+            name = skill["name"]
+            console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
             console.print(f"    {skill['description']}", style=COLORS["dim"])
             console.print(f"    Location: {skill_path.parent}/", style=COLORS["dim"])
             console.print()
@@ -191,9 +193,11 @@ def _list(agent: str, *, project: bool = False) -> None:
         console.print(
             "[bold green]Project Skills:[/bold green]", style=COLORS["primary"]
         )
+        bullet = get_glyphs().bullet
         for skill in project_skills_list:
             skill_path = Path(skill["path"])
-            console.print(f"  • [bold]{skill['name']}[/bold]", style=COLORS["primary"])
+            name = skill["name"]
+            console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
             console.print(f"    {skill['description']}", style=COLORS["dim"])
             console.print(f"    Location: {skill_path.parent}/", style=COLORS["dim"])
             console.print()
@@ -338,7 +342,8 @@ This skill directory can include supporting files referenced in the instructions
     skill_md.write_text(template)
 
     console.print(
-        f"✓ Skill '{skill_name}' created successfully!", style=COLORS["primary"]
+        f"{get_glyphs().checkmark} Skill '{skill_name}' created successfully!",
+        style=COLORS["primary"],
     )
     console.print(f"Location: {skill_dir}\n", style=COLORS["dim"])
     console.print(

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -13,6 +13,7 @@ from textual.reactive import reactive
 from textual.widgets import Static, TextArea
 from textual.widgets.text_area import Selection
 
+from deepagents_cli.config import CharsetMode, _detect_charset_mode
 from deepagents_cli.widgets.autocomplete import (
     SLASH_COMMANDS,
     CompletionResult,
@@ -332,6 +333,9 @@ class ChatInput(Vertical):
 
     def on_mount(self) -> None:
         """Initialize components after mount."""
+        if _detect_charset_mode() == CharsetMode.ASCII:
+            self.styles.border = ("ascii", "cyan")
+
         self._text_area = self.query_one("#chat-input", ChatTextArea)
         self._popup = self.query_one("#completion-popup", CompletionPopup)
 

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -10,7 +10,7 @@ from rich.style import Style
 from rich.text import Text
 from textual.widgets import Static
 
-from deepagents_cli.config import DEEP_AGENTS_ASCII, settings
+from deepagents_cli.config import get_banner, get_glyphs, settings
 
 
 def _fetch_project_url(project_name: str) -> str | None:
@@ -92,10 +92,10 @@ class WelcomeBanner(Static):
             Rich Text object containing the formatted banner.
         """
         banner = Text()
-        banner.append(DEEP_AGENTS_ASCII + "\n", style=Style(bold=True, color="#10b981"))
+        banner.append(get_banner() + "\n", style=Style(bold=True, color="#10b981"))
 
         if self._project_name:
-            banner.append("✓ ", style="green")
+            banner.append(f"{get_glyphs().checkmark} ", style="green")
             banner.append("LangSmith tracing: ")
             if project_url:
                 banner.append(
@@ -110,5 +110,9 @@ class WelcomeBanner(Static):
             banner.append(f"Thread: {self._thread_id}\n", style="dim")
 
         banner.append("Ready to code! What would you like to build?\n", style="#10b981")
-        banner.append("Enter send • Ctrl+J newline • @ files • / commands", style="dim")
+        bullet = get_glyphs().bullet
+        banner.append(
+            f"Enter send {bullet} Ctrl+J newline {bullet} @ files {bullet} / commands",
+            style="dim",
+        )
         return banner

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -19,6 +19,7 @@ from deepagents_cli.agent import (
     _format_write_file_description,
     get_system_prompt,
 )
+from deepagents_cli.config import get_glyphs
 
 
 def test_format_write_file_description_create_new_file(tmp_path: Path) -> None:
@@ -139,7 +140,7 @@ def test_format_web_search_description():
 
     assert "Query: python async programming" in description
     assert "Max results: 10" in description
-    assert "⚠️  This will use Tavily API credits" in description
+    assert f"{get_glyphs().warning}  This will use Tavily API credits" in description
 
 
 def test_format_web_search_description_default_max_results():
@@ -183,7 +184,8 @@ def test_format_fetch_url_description():
 
     assert "URL: https://example.com/docs" in description
     assert "Timeout: 60s" in description
-    assert "⚠️  Will fetch and convert web content to markdown" in description
+    warning = get_glyphs().warning
+    assert f"{warning}  Will fetch and convert web content to markdown" in description
 
 
 def test_format_fetch_url_description_default_timeout():
@@ -228,8 +230,9 @@ def test_format_task_description():
     assert "Subagent Type: general-purpose" in description
     assert "Task Instructions:" in description
     assert "Analyze code structure and identify main components." in description
+    warning = get_glyphs().warning
     assert (
-        "⚠️  Subagent will have access to file operations and shell commands"
+        f"{warning}  Subagent will have access to file operations and shell commands"
         in description
     )
 

--- a/libs/cli/tests/unit_tests/test_approval.py
+++ b/libs/cli/tests/unit_tests/test_approval.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from deepagents_cli.config import get_glyphs
 from deepagents_cli.widgets.approval import (
     _SHELL_COMMAND_TRUNCATE_LENGTH,
     ApprovalMenu,
@@ -74,7 +75,7 @@ class TestGetCommandDisplay:
         long_command = "x" * (_SHELL_COMMAND_TRUNCATE_LENGTH + 50)
         menu = ApprovalMenu({"name": "shell", "args": {"command": long_command}})
         display = menu._get_command_display(expanded=False)
-        assert "..." in display
+        assert get_glyphs().ellipsis in display
         assert "press 'e' to expand" in display
         # Check that the truncated portion is present
         assert "x" * _SHELL_COMMAND_TRUNCATE_LENGTH in display
@@ -86,7 +87,7 @@ class TestGetCommandDisplay:
         display = menu._get_command_display(expanded=True)
         assert long_command in display
         assert "press 'e' to expand" not in display
-        assert "..." not in display
+        assert get_glyphs().ellipsis not in display
 
     def test_short_command_shows_full_even_when_expanded_true(self) -> None:
         """Test that short commands show in full even when expanded=True."""
@@ -94,7 +95,7 @@ class TestGetCommandDisplay:
         display = menu._get_command_display(expanded=True)
         assert "echo hello" in display
         assert "press 'e' to expand" not in display
-        assert "..." not in display
+        assert get_glyphs().ellipsis not in display
 
     def test_command_at_boundary_plus_one_is_expandable(self) -> None:
         """Test off-by-one: command at exactly threshold + 1 is expandable."""
@@ -102,7 +103,7 @@ class TestGetCommandDisplay:
         menu = ApprovalMenu({"name": "shell", "args": {"command": boundary_command}})
         assert menu._has_expandable_command is True
         display = menu._get_command_display(expanded=False)
-        assert "..." in display
+        assert get_glyphs().ellipsis in display
         assert "press 'e' to expand" in display
 
     def test_none_command_value_handled(self) -> None:
@@ -147,14 +148,14 @@ class TestToggleExpand:
         menu._command_widget.update.assert_called_once()
         expanded_call = menu._command_widget.update.call_args[0][0]
         assert long_command in expanded_call
-        assert "..." not in expanded_call
+        assert get_glyphs().ellipsis not in expanded_call
 
         # Second toggle: collapse
         menu._command_widget.reset_mock()
         menu.action_toggle_expand()
         menu._command_widget.update.assert_called_once()
         collapsed_call = menu._command_widget.update.call_args[0][0]
-        assert "..." in collapsed_call
+        assert get_glyphs().ellipsis in collapsed_call
         assert "press 'e' to expand" in collapsed_call
 
     def test_toggle_does_nothing_for_non_expandable(self) -> None:

--- a/libs/cli/tests/unit_tests/test_charset.py
+++ b/libs/cli/tests/unit_tests/test_charset.py
@@ -1,0 +1,345 @@
+"""Tests for charset mode configuration and glyph selection."""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from deepagents_cli.config import (
+    _ASCII_BANNER,
+    _UNICODE_BANNER,
+    ASCII_GLYPHS,
+    UNICODE_GLYPHS,
+    CharsetMode,
+    Glyphs,
+    _detect_charset_mode,
+    get_banner,
+    get_glyphs,
+    reset_glyphs_cache,
+)
+
+
+class TestCharsetMode:
+    """Tests for CharsetMode enum."""
+
+    def test_charset_mode_values(self) -> None:
+        """Test that CharsetMode has expected values."""
+        assert CharsetMode.UNICODE.value == "unicode"
+        assert CharsetMode.ASCII.value == "ascii"
+        assert CharsetMode.AUTO.value == "auto"
+
+    def test_charset_mode_is_str_enum(self) -> None:
+        """Test that CharsetMode values are strings."""
+        assert isinstance(CharsetMode.UNICODE, str)
+        assert CharsetMode.ASCII == "ascii"
+
+
+class TestGlyphs:
+    """Tests for Glyphs dataclass."""
+
+    def test_unicode_glyphs_are_unicode(self) -> None:
+        """Test that UNICODE_GLYPHS contains non-ASCII characters."""
+        # These should all be non-ASCII Unicode characters
+        assert ord(UNICODE_GLYPHS.tool_prefix) > 127
+        assert ord(UNICODE_GLYPHS.ellipsis) > 127
+        assert ord(UNICODE_GLYPHS.checkmark) > 127
+        assert ord(UNICODE_GLYPHS.error) > 127
+        assert ord(UNICODE_GLYPHS.circle_empty) > 127
+        assert ord(UNICODE_GLYPHS.circle_filled) > 127
+        assert ord(UNICODE_GLYPHS.output_prefix) > 127
+        assert ord(UNICODE_GLYPHS.pause) > 127
+        assert ord(UNICODE_GLYPHS.newline) > 127
+        assert ord(UNICODE_GLYPHS.warning) > 127
+        assert ord(UNICODE_GLYPHS.arrow_up) > 127
+        assert ord(UNICODE_GLYPHS.arrow_down) > 127
+        assert ord(UNICODE_GLYPHS.bullet) > 127
+        assert ord(UNICODE_GLYPHS.cursor) > 127
+        # Spinner frames are braille characters
+        for frame in UNICODE_GLYPHS.spinner_frames:
+            assert ord(frame) > 127
+        # Box-drawing characters
+        assert ord(UNICODE_GLYPHS.box_vertical) > 127
+        assert ord(UNICODE_GLYPHS.box_horizontal) > 127
+        assert ord(UNICODE_GLYPHS.box_double_horizontal) > 127
+        assert ord(UNICODE_GLYPHS.gutter_bar) > 127
+        # Tree connectors (check first character of each)
+        assert ord(UNICODE_GLYPHS.tree_branch[0]) > 127
+        assert ord(UNICODE_GLYPHS.tree_last[0]) > 127
+        assert ord(UNICODE_GLYPHS.tree_vertical[0]) > 127
+
+    def test_ascii_glyphs_are_ascii(self) -> None:
+        """Test that ASCII_GLYPHS contains only ASCII characters."""
+        for char in ASCII_GLYPHS.tool_prefix:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.ellipsis:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.checkmark:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.error:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.circle_empty:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.circle_filled:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.output_prefix:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.pause:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.newline:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.warning:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.arrow_up:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.arrow_down:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.bullet:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.cursor:
+            assert ord(char) < 128
+        # Spinner frames should all be ASCII
+        for frame in ASCII_GLYPHS.spinner_frames:
+            for char in frame:
+                assert ord(char) < 128
+        # Box-drawing characters
+        for char in ASCII_GLYPHS.box_vertical:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.box_horizontal:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.box_double_horizontal:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.gutter_bar:
+            assert ord(char) < 128
+        # Tree connectors
+        for char in ASCII_GLYPHS.tree_branch:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.tree_last:
+            assert ord(char) < 128
+        for char in ASCII_GLYPHS.tree_vertical:
+            assert ord(char) < 128
+
+    def test_glyphs_frozen(self) -> None:
+        """Test that Glyphs instances are immutable."""
+        with pytest.raises(AttributeError):
+            UNICODE_GLYPHS.tool_prefix = "changed"  # type: ignore[misc]
+
+    def test_glyphs_all_fields_present(self) -> None:
+        """Test that both glyph sets have all required fields."""
+        required_fields = [
+            "tool_prefix",
+            "ellipsis",
+            "checkmark",
+            "error",
+            "circle_empty",
+            "circle_filled",
+            "output_prefix",
+            "spinner_frames",
+            "pause",
+            "newline",
+            "warning",
+            "arrow_up",
+            "arrow_down",
+            "bullet",
+            "cursor",
+            # Box-drawing characters
+            "box_vertical",
+            "box_horizontal",
+            "box_double_horizontal",
+            "gutter_bar",
+            # Tree connectors
+            "tree_branch",
+            "tree_last",
+            "tree_vertical",
+        ]
+        for field in required_fields:
+            assert hasattr(UNICODE_GLYPHS, field)
+            assert hasattr(ASCII_GLYPHS, field)
+            assert getattr(UNICODE_GLYPHS, field) is not None
+            assert getattr(ASCII_GLYPHS, field) is not None
+
+
+class TestDetectCharsetMode:
+    """Tests for _detect_charset_mode function."""
+
+    def setup_method(self) -> None:
+        """Reset glyphs cache before each test."""
+        reset_glyphs_cache()
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
+    def test_explicit_unicode_mode(self) -> None:
+        """Test explicit unicode mode via env var."""
+        mode = _detect_charset_mode()
+        assert mode == CharsetMode.UNICODE
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}, clear=False)
+    def test_explicit_ascii_mode(self) -> None:
+        """Test explicit ascii mode via env var."""
+        mode = _detect_charset_mode()
+        assert mode == CharsetMode.ASCII
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "UNICODE"}, clear=False)
+    def test_case_insensitive_mode(self) -> None:
+        """Test that mode parsing is case-insensitive."""
+        mode = _detect_charset_mode()
+        assert mode == CharsetMode.UNICODE
+
+    @patch.dict(
+        "os.environ", {"UI_CHARSET_MODE": "auto", "LANG": "en_US.UTF-8"}, clear=False
+    )
+    def test_auto_mode_with_utf_lang(self) -> None:
+        """Test auto mode detects UTF from LANG env var."""
+        # Mock stdout without utf encoding
+        mock_stdout = Mock()
+        mock_stdout.encoding = "ascii"
+        with patch.object(sys, "stdout", mock_stdout):
+            mode = _detect_charset_mode()
+        assert mode == CharsetMode.UNICODE
+
+    @patch.dict("os.environ", {"LANG": "C", "LC_ALL": ""}, clear=False)
+    def test_auto_mode_with_c_locale_falls_back_to_ascii(self) -> None:
+        """Test auto mode falls back to ASCII with C locale."""
+        # Remove UI_CHARSET_MODE if set
+        with patch.dict("os.environ", {"UI_CHARSET_MODE": "auto"}, clear=False):
+            mock_stdout = Mock()
+            mock_stdout.encoding = "ascii"
+            with patch.object(sys, "stdout", mock_stdout):
+                mode = _detect_charset_mode()
+        assert mode == CharsetMode.ASCII
+
+    def test_auto_mode_with_utf_stdout_encoding(self) -> None:
+        """Test auto mode detects UTF from stdout encoding."""
+        with patch.dict(
+            "os.environ", {"UI_CHARSET_MODE": "auto", "LANG": "C", "LC_ALL": ""}
+        ):
+            mock_stdout = Mock()
+            mock_stdout.encoding = "utf-8"
+            with patch.object(sys, "stdout", mock_stdout):
+                mode = _detect_charset_mode()
+        assert mode == CharsetMode.UNICODE
+
+
+class TestGetGlyphs:
+    """Tests for get_glyphs function."""
+
+    def setup_method(self) -> None:
+        """Reset glyphs cache before each test."""
+        reset_glyphs_cache()
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
+    def test_get_glyphs_returns_unicode_for_unicode_mode(self) -> None:
+        """Test get_glyphs returns UNICODE_GLYPHS for unicode mode."""
+        glyphs = get_glyphs()
+        assert glyphs is UNICODE_GLYPHS
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}, clear=False)
+    def test_get_glyphs_returns_ascii_for_ascii_mode(self) -> None:
+        """Test get_glyphs returns ASCII_GLYPHS for ascii mode."""
+        glyphs = get_glyphs()
+        assert glyphs is ASCII_GLYPHS
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
+    def test_get_glyphs_caches_result(self) -> None:
+        """Test that get_glyphs caches the result."""
+        glyphs1 = get_glyphs()
+        glyphs2 = get_glyphs()
+        assert glyphs1 is glyphs2
+
+    def test_reset_glyphs_cache_works(self) -> None:
+        """Test that reset_glyphs_cache clears the cache."""
+        with patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}):
+            glyphs1 = get_glyphs()
+            assert glyphs1 is UNICODE_GLYPHS
+
+        reset_glyphs_cache()
+
+        with patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}):
+            glyphs2 = get_glyphs()
+            assert glyphs2 is ASCII_GLYPHS
+
+
+class TestGlyphUsability:
+    """Tests to verify glyph values are usable in context."""
+
+    def test_spinner_frames_not_empty(self) -> None:
+        """Test that spinner frames have multiple frames for animation."""
+        assert len(UNICODE_GLYPHS.spinner_frames) > 1
+        assert len(ASCII_GLYPHS.spinner_frames) > 1
+
+    def test_ascii_ellipsis_is_three_dots(self) -> None:
+        """Test that ASCII ellipsis is standard three dots."""
+        assert ASCII_GLYPHS.ellipsis == "..."
+
+    def test_unicode_ellipsis_is_single_char(self) -> None:
+        """Test that Unicode ellipsis is single character."""
+        assert len(UNICODE_GLYPHS.ellipsis) == 1
+
+    def test_ascii_spinner_classic_frames(self) -> None:
+        """Test ASCII spinner uses parenthesized frames for consistent width."""
+        assert set(ASCII_GLYPHS.spinner_frames) == {"(-)", "(\\)", "(|)", "(/)"}
+
+    def test_unicode_box_drawing_characters(self) -> None:
+        """Test Unicode box-drawing characters are the expected characters."""
+        assert UNICODE_GLYPHS.box_vertical == "│"
+        assert UNICODE_GLYPHS.box_horizontal == "─"
+        assert UNICODE_GLYPHS.box_double_horizontal == "═"
+        assert UNICODE_GLYPHS.gutter_bar == "▌"
+
+    def test_ascii_box_drawing_characters(self) -> None:
+        """Test ASCII box-drawing alternatives are simple ASCII."""
+        assert ASCII_GLYPHS.box_vertical == "|"
+        assert ASCII_GLYPHS.box_horizontal == "-"
+        assert ASCII_GLYPHS.box_double_horizontal == "="
+        assert ASCII_GLYPHS.gutter_bar == "|"
+
+    def test_unicode_tree_connectors(self) -> None:
+        """Test Unicode tree connectors are the expected strings."""
+        assert UNICODE_GLYPHS.tree_branch == "├── "
+        assert UNICODE_GLYPHS.tree_last == "└── "
+        assert UNICODE_GLYPHS.tree_vertical == "│   "
+
+    def test_ascii_tree_connectors(self) -> None:
+        """Test ASCII tree connectors are simple ASCII."""
+        assert ASCII_GLYPHS.tree_branch == "+-- "
+        assert ASCII_GLYPHS.tree_last == "`-- "
+        assert ASCII_GLYPHS.tree_vertical == "|   "
+
+    def test_tree_connectors_consistent_width(self) -> None:
+        """Test that tree connectors have consistent width for alignment."""
+        # All tree connectors should be exactly 4 characters
+        assert len(UNICODE_GLYPHS.tree_branch) == 4
+        assert len(UNICODE_GLYPHS.tree_last) == 4
+        assert len(UNICODE_GLYPHS.tree_vertical) == 4
+        assert len(ASCII_GLYPHS.tree_branch) == 4
+        assert len(ASCII_GLYPHS.tree_last) == 4
+        assert len(ASCII_GLYPHS.tree_vertical) == 4
+
+
+class TestGetBanner:
+    """Tests for get_banner function."""
+
+    def setup_method(self) -> None:
+        """Reset glyphs cache before each test."""
+        reset_glyphs_cache()
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
+    def test_get_banner_returns_unicode_for_unicode_mode(self) -> None:
+        """Test get_banner returns Unicode banner for unicode mode."""
+        banner = get_banner()
+        assert banner is _UNICODE_BANNER
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}, clear=False)
+    def test_get_banner_returns_ascii_for_ascii_mode(self) -> None:
+        """Test get_banner returns ASCII banner for ascii mode."""
+        banner = get_banner()
+        assert banner is _ASCII_BANNER
+
+    def test_unicode_banner_contains_box_drawing_chars(self) -> None:
+        """Test that Unicode banner contains non-ASCII box drawing characters."""
+        # Unicode banner uses box-drawing characters like ╔ ╗ ║ etc
+        has_unicode = any(ord(c) > 127 for c in _UNICODE_BANNER)
+        assert has_unicode
+
+    def test_ascii_banner_is_pure_ascii(self) -> None:
+        """Test that ASCII banner contains only ASCII characters."""
+        for char in _ASCII_BANNER:
+            assert ord(char) < 128, f"Non-ASCII character found: {char!r}"

--- a/libs/cli/tests/unit_tests/test_ui.py
+++ b/libs/cli/tests/unit_tests/test_ui.py
@@ -1,5 +1,6 @@
 """Unit tests for UI rendering utilities."""
 
+from deepagents_cli.config import get_glyphs
 from deepagents_cli.ui import _format_timeout, format_tool_display, truncate_value
 
 
@@ -44,7 +45,7 @@ class TestTruncateValue:
     def test_long_string_truncated(self) -> None:
         """Test that long strings are truncated with ellipsis."""
         result = truncate_value("hello world", max_length=5)
-        assert result == "hello..."
+        assert result == f"hello{get_glyphs().ellipsis}"
 
     def test_exact_length_unchanged(self) -> None:
         """Test that strings at exact max length are unchanged."""
@@ -57,41 +58,47 @@ class TestFormatToolDisplayShell:
 
     def test_shell_command_only(self) -> None:
         """Test shell display with command only."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("shell", {"command": "echo hello"})
-        assert result == 'shell("echo hello")'
+        assert result == f'{prefix} shell("echo hello")'
 
     def test_shell_with_timeout_minutes(self) -> None:
         """Test shell display formats timeout in minutes when appropriate."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("shell", {"command": "make test", "timeout": 300})
-        assert result == 'shell("make test", timeout=5m)'
+        assert result == f'{prefix} shell("make test", timeout=5m)'
 
     def test_shell_with_timeout_seconds(self) -> None:
         """Test shell display formats timeout in seconds for small values."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("shell", {"command": "make test", "timeout": 30})
-        assert result == 'shell("make test", timeout=30s)'
+        assert result == f'{prefix} shell("make test", timeout=30s)'
 
     def test_shell_with_timeout_hours(self) -> None:
         """Test shell display formats timeout in hours when appropriate."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("shell", {"command": "make test", "timeout": 3600})
-        assert result == 'shell("make test", timeout=1h)'
+        assert result == f'{prefix} shell("make test", timeout=1h)'
 
     def test_shell_with_none_timeout(self) -> None:
         """Test shell display excludes timeout when `None`."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display(
             "shell", {"command": "echo hello", "timeout": None}
         )
-        assert result == 'shell("echo hello")'
+        assert result == f'{prefix} shell("echo hello")'
 
     def test_shell_with_default_timeout_hidden(self) -> None:
         """Test shell display excludes timeout when it equals the default (120s)."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("shell", {"command": "echo hello", "timeout": 120})
-        assert result == 'shell("echo hello")'
+        assert result == f'{prefix} shell("echo hello")'
 
     def test_shell_long_command_truncated(self) -> None:
         """Test that long shell commands are truncated."""
         long_cmd = "x" * 200
         result = format_tool_display("shell", {"command": long_cmd})
-        assert "..." in result
+        assert get_glyphs().ellipsis in result
         assert len(result) < 200
 
 
@@ -99,23 +106,28 @@ class TestFormatToolDisplayOther:
     """Tests for `format_tool_display` with other tools."""
 
     def test_read_file(self) -> None:
-        """Test read_file display shows filename."""
+        """Test read_file display shows filename with icon."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("read_file", {"file_path": "/path/to/file.py"})
+        assert result.startswith(f"{prefix} read_file(")
         assert "file.py" in result
 
     def test_web_search(self) -> None:
         """Test web_search display shows query."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("web_search", {"query": "how to code"})
-        assert result == 'web_search("how to code")'
+        assert result == f'{prefix} web_search("how to code")'
 
     def test_grep(self) -> None:
         """Test grep display shows pattern."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("grep", {"pattern": "TODO"})
-        assert result == 'grep("TODO")'
+        assert result == f'{prefix} grep("TODO")'
 
     def test_unknown_tool_fallback(self) -> None:
         """Test unknown tools use generic formatting."""
+        prefix = get_glyphs().tool_prefix
         result = format_tool_display("custom_tool", {"arg1": "val1", "arg2": "val2"})
-        assert "custom_tool(" in result
+        assert f"{prefix} custom_tool(" in result
         assert "arg1=" in result
         assert "arg2=" in result


### PR DESCRIPTION
- Improve some styling
- Introduce a modular glyph system for terminal display with Unicode/ASCII auto-detection
- Add `CharsetMode` enum and Glyphs dataclass centralizing all UI symbols (spinners, checkmarks, box-drawing, tree connectors, etc.)
- Refactor widgets to use `get_glyphs()` instead of hardcoded Unicode characters
- Add `UI_CHARSET_MODE` env var for manual override (unicode/ascii/auto)
- Provide separate Unicode and ASCII banner variants