### PR TITLE
fix(cli): support `-h`/`--help` flags

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -88,6 +88,12 @@ def parse_args() -> argparse.Namespace:
         add_help=False,
     )
     parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        help="Show this help message and exit",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"deepagents {__version__}",
@@ -289,6 +295,11 @@ def cli_main() -> None:
 
     try:
         args = parse_args()
+
+        # Handle -h/--help flag (custom help display)
+        if getattr(args, "help", False):
+            show_help()
+            sys.exit(0)
 
         if args.command == "help":
             show_help()

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -233,6 +233,7 @@ def show_help() -> None:
     console.print()
 
     console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  -h, --help                    Show this help message and exit")
     console.print("  --agent NAME                  Agent identifier (default: agent)")
     console.print(
         "  --model MODEL                 Model to use (e.g., claude-sonnet-4-5-20250929, gpt-4o)"  # noqa: E501

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -59,3 +59,33 @@ def test_help_mentions_version_flag() -> None:
     assert result.returncode == 0
     # Help output should mention --version
     assert "--version" in result.stdout
+
+
+def test_cli_help_flag() -> None:
+    """Verify that --help flag shows help and exits with code 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "deepagents_cli.main", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # --help should exit with 0
+    assert result.returncode == 0
+    # Help output should mention key options
+    assert "--version" in result.stdout
+    assert "--agent" in result.stdout
+
+
+def test_cli_help_flag_short() -> None:
+    """Verify that -h flag shows help and exits with code 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "deepagents_cli.main", "-h"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # -h should exit with 0
+    assert result.returncode == 0
+    # Help output should mention key options
+    assert "--version" in result.stdout
+    assert "--agent" in result.stdout


### PR DESCRIPTION
Closes #1096

The CLI was configured with `add_help=False` to use a custom help display (`show_help()`), but no `-h/--help`
argument was defined to trigger it. Running `deepagents --help` resulted in:

```bash
deepagents: error: unrecognized arguments: --help
```

Related: #1089, #1098