### PR TITLE
feat(sdk): add sandbox provider exceptions

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -15,7 +15,7 @@ import base64
 import json
 import shlex
 from abc import ABC, abstractmethod
-from typing import Any, Generic, NotRequired, TypeVar, cast
+from typing import Any, Generic, NotRequired, TypeVar
 
 from typing_extensions import TypedDict
 


### PR DESCRIPTION
Adds a small exception hierarchy for sandbox providers (SandboxError and SandboxNotFoundError). SandboxError supports standard exception chaining (raise ... from e) and exposes the chained exception via original_exc for callers that need provider-specific inspection.