### PR TITLE
refactor(infra): ordering of tests

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -142,6 +142,18 @@ For hotfixes or exceptional cases, you can trigger a release manually. Use the `
 
 ## Troubleshooting
 
+### "Found release tag with component X, but not configured in manifest" Warnings
+
+You may see warnings in the release-please logs like:
+
+```txt
+⚠ Found release tag with component 'deepagents=', but not configured in manifest
+```
+
+This is **harmless**. Release-please scans existing tags in the repository and warns when it finds tags for packages that aren't in the current configuration. The `deepagents` SDK package has existing release tags (`deepagents==0.x.x`) but is not currently managed by release-please.
+
+These warnings will disappear once the SDK is added to `release-please-config.json`. Until then, they can be safely ignored—they don't affect CLI releases.
+
 ### Unexpected Commit Authors in Release PRs
 
 When viewing a release-please PR on GitHub, you may see commits attributed to contributors who didn't directly push to that PR. For example:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@
 # - Manually via workflow_dispatch
 #
 # Flow:
-# - CLI: build -> test-pypi -> pre-release-checks -> DRAFT release (PyPI publish happens when draft is published)
-# - Other packages: build -> test-pypi -> pre-release-checks -> publish -> release
+# - CLI: build -> pre-release-checks -> test-pypi -> DRAFT release (PyPI publish happens when draft is published)
+# - Other packages: build -> pre-release-checks -> test-pypi -> publish -> release
 
 name: "🚀 Package Release"
 run-name: "Release ${{ inputs.package }}"
@@ -410,6 +410,7 @@ jobs:
     needs:
       - setup
       - build
+      - pre-release-checks
     runs-on: ubuntu-latest
     permissions:
       # This permission is used for trusted publishing:
@@ -447,7 +448,6 @@ jobs:
     needs:
       - setup
       - build
-      - test-pypi-publish
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Tests now run before any publishing. If tests fail, we fail fast without uploading anything to Test PyPI. Previously, a broken package would get uploaded to Test PyPI before we discovered the tests failed.