### PR TITLE
feat(cli): Add Responses API support for OpenAI reasoning models

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -169,6 +169,12 @@ def parse_args() -> argparse.Namespace:
         "Provider is auto-detected from model name.",
     )
     parser.add_argument(
+        "--reasoning-effort",
+        choices=["low", "medium", "high", "xhigh"],
+        default="high",
+        help="Reasoning effort for OpenAI reasoning models (default: high)",
+    )
+    parser.add_argument(
         "--auto-approve",
         action="store_true",
         help="Auto-approve tool usage without prompting (disables human-in-the-loop)",
@@ -197,6 +203,7 @@ async def run_textual_cli_async(
     sandbox_type: str = "none",
     sandbox_id: str | None = None,
     model_name: str | None = None,
+    reasoning_effort: str = "high",
     thread_id: str | None = None,
     is_resumed: bool = False,
     initial_prompt: str | None = None,
@@ -210,13 +217,14 @@ async def run_textual_cli_async(
             ("none", "modal", "runloop", "daytona", "langsmith")
         sandbox_id: Optional existing sandbox ID to reuse
         model_name: Optional model name to use
+        reasoning_effort: Reasoning effort for OpenAI reasoning models
         thread_id: Thread ID to use (new or resumed)
         is_resumed: Whether this is a resumed session
         initial_prompt: Optional prompt to auto-submit when session starts
     """
     from deepagents_cli.app import run_textual_app
 
-    model = create_model(model_name)
+    model = create_model(model_name, reasoning_effort=reasoning_effort)
 
     # Show thread info
     if is_resumed:
@@ -395,6 +403,7 @@ def cli_main() -> None:
                     sandbox_type=args.sandbox,
                     sandbox_id=args.sandbox_id,
                     model_name=getattr(args, "model", None),
+                    reasoning_effort=getattr(args, "reasoning_effort", "high"),
                     thread_id=thread_id,
                     is_resumed=is_resumed,
                     initial_prompt=getattr(args, "initial_prompt", None),

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -3,6 +3,8 @@
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from deepagents_cli.main import parse_args
 
 
@@ -93,3 +95,56 @@ class TestResumeArg:
             args = parse_args()
         assert args.resume_thread == "thread456"
         assert args.initial_prompt == "continue work"
+
+
+class TestReasoningEffortArg:
+    """Tests for --reasoning-effort argument."""
+
+    def test_default_value(self) -> None:
+        """Verify default reasoning_effort is 'high'."""
+        with patch.object(sys, "argv", ["deepagents"]):
+            args = parse_args()
+        assert args.reasoning_effort == "high"
+
+    def test_low_value(self) -> None:
+        """Verify --reasoning-effort low is accepted."""
+        with patch.object(sys, "argv", ["deepagents", "--reasoning-effort", "low"]):
+            args = parse_args()
+        assert args.reasoning_effort == "low"
+
+    def test_medium_value(self) -> None:
+        """Verify --reasoning-effort medium is accepted."""
+        with patch.object(sys, "argv", ["deepagents", "--reasoning-effort", "medium"]):
+            args = parse_args()
+        assert args.reasoning_effort == "medium"
+
+    def test_high_value(self) -> None:
+        """Verify --reasoning-effort high is accepted."""
+        with patch.object(sys, "argv", ["deepagents", "--reasoning-effort", "high"]):
+            args = parse_args()
+        assert args.reasoning_effort == "high"
+
+    def test_xhigh_value(self) -> None:
+        """Verify --reasoning-effort xhigh is accepted."""
+        with patch.object(sys, "argv", ["deepagents", "--reasoning-effort", "xhigh"]):
+            args = parse_args()
+        assert args.reasoning_effort == "xhigh"
+
+    def test_with_model_arg(self) -> None:
+        """Verify --reasoning-effort works with --model."""
+        with patch.object(
+            sys,
+            "argv",
+            ["deepagents", "--model", "gpt-5.2-codex", "--reasoning-effort", "xhigh"],
+        ):
+            args = parse_args()
+        assert args.model == "gpt-5.2-codex"
+        assert args.reasoning_effort == "xhigh"
+
+    def test_invalid_value_rejected(self) -> None:
+        """Verify invalid reasoning_effort values are rejected."""
+        with (
+            patch.object(sys, "argv", ["deepagents", "--reasoning-effort", "invalid"]),
+            pytest.raises(SystemExit),
+        ):
+            parse_args()


### PR DESCRIPTION
## Summary

  - Adds `--reasoning-effort` CLI flag (low/medium/high/xhigh) for controlling reasoning intensity
  - Automatically enables Responses API for GPT-5.x and Codex models (required by OpenAI)
  - Shows warning when `--reasoning-effort` is used with incompatible models

  ## Usage

  ```bash
  # Uses Responses API automatically with reasoning_effort=high (default)
  deepagents --model gpt-5.2-codex

  ## Custom reasoning effort
  deepagents --model gpt-5.2-codex --reasoning-effort xhigh

  ## Why

  GPT-5.x and Codex models are only available via OpenAI's Responses API. This change:
  - Enables CLI users to use these models
  - Aligns with harbor's existing implementation
  - Provides reasoning_effort control for tuning cost/quality tradeoff

  ## Test plan

  - Added unit tests for --reasoning-effort argument parsing
  - Added unit tests for Responses API model creation
  - make format && make lint && make test passes