### PR TITLE
style(cli): update welcome banner color for editable install

### DIFF
--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -10,7 +10,7 @@ from rich.style import Style
 from rich.text import Text
 from textual.widgets import Static
 
-from deepagents_cli.config import get_banner, get_glyphs, settings
+from deepagents_cli.config import _is_editable_install, get_banner, get_glyphs, settings
 
 
 def _fetch_project_url(project_name: str) -> str | None:
@@ -92,7 +92,9 @@ class WelcomeBanner(Static):
             Rich Text object containing the formatted banner.
         """
         banner = Text()
-        banner.append(get_banner() + "\n", style=Style(bold=True, color="#10b981"))
+        # Use orange for local install, green for production
+        banner_color = "#f97316" if _is_editable_install() else "#10b981"
+        banner.append(get_banner() + "\n", style=Style(bold=True, color=banner_color))
 
         if self._project_name:
             banner.append(f"{get_glyphs().checkmark} ", style="green")

--- a/libs/cli/tests/unit_tests/test_charset.py
+++ b/libs/cli/tests/unit_tests/test_charset.py
@@ -12,6 +12,7 @@ from deepagents_cli.config import (
     UNICODE_GLYPHS,
     CharsetMode,
     Glyphs,
+    __version__,
     _detect_charset_mode,
     get_banner,
     get_glyphs,
@@ -324,14 +325,32 @@ class TestGetBanner:
     @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
     def test_get_banner_returns_unicode_for_unicode_mode(self) -> None:
         """Test get_banner returns Unicode banner for unicode mode."""
-        banner = get_banner()
+        with patch("deepagents_cli.config._is_editable_install", return_value=False):
+            banner = get_banner()
         assert banner is _UNICODE_BANNER
 
     @patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}, clear=False)
     def test_get_banner_returns_ascii_for_ascii_mode(self) -> None:
         """Test get_banner returns ASCII banner for ascii mode."""
-        banner = get_banner()
+        with patch("deepagents_cli.config._is_editable_install", return_value=False):
+            banner = get_banner()
         assert banner is _ASCII_BANNER
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
+    def test_get_banner_adds_local_install_suffix_for_editable(self) -> None:
+        """Test get_banner adds (local install) suffix for editable installs."""
+        with patch("deepagents_cli.config._is_editable_install", return_value=True):
+            banner = get_banner()
+        assert "(local install)" in banner
+        assert f"v{__version__} (local install)" in banner
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}, clear=False)
+    def test_get_banner_adds_local_install_suffix_for_editable_ascii(self) -> None:
+        """Test get_banner adds (local install) suffix in ASCII mode."""
+        with patch("deepagents_cli.config._is_editable_install", return_value=True):
+            banner = get_banner()
+        assert "(local install)" in banner
+        assert f"v{__version__} (local install)" in banner
 
     def test_unicode_banner_contains_box_drawing_chars(self) -> None:
         """Test that Unicode banner contains non-ASCII box drawing characters."""


### PR DESCRIPTION
Detects whether the CLI is installed in editable mode, and, if so, update the splash to visibily indicate so (sanity check for development)