### PR TITLE
fix(cli): disable iTerm2 cursor guide during execution

### DIFF
--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1,8 +1,17 @@
 """Unit tests for DeepAgentsApp."""
 
+import io
+import os
+from unittest.mock import MagicMock, patch
+
 from textual.binding import Binding
 
-from deepagents_cli.app import DeepAgentsApp
+from deepagents_cli.app import (
+    _ITERM_CURSOR_GUIDE_OFF,
+    _ITERM_CURSOR_GUIDE_ON,
+    DeepAgentsApp,
+    _write_iterm_escape,
+)
 
 
 class TestAppBindings:
@@ -23,3 +32,116 @@ class TestAppBindings:
         bindings = [b for b in DeepAgentsApp.BINDINGS if isinstance(b, Binding)]
         bindings_by_key = {b.key: b for b in bindings}
         assert "ctrl+o" not in bindings_by_key
+
+
+class TestITerm2CursorGuide:
+    """Test iTerm2 cursor guide handling."""
+
+    def test_escape_sequences_are_valid(self) -> None:
+        """Escape sequences should be properly formatted OSC 1337 commands.
+
+        Format: OSC (ESC ]) + "1337;" + command + ST (ESC backslash)
+        """
+        assert _ITERM_CURSOR_GUIDE_OFF.startswith("\x1b]1337;")
+        assert _ITERM_CURSOR_GUIDE_OFF.endswith("\x1b\\")
+        assert "HighlightCursorLine=no" in _ITERM_CURSOR_GUIDE_OFF
+
+        assert _ITERM_CURSOR_GUIDE_ON.startswith("\x1b]1337;")
+        assert _ITERM_CURSOR_GUIDE_ON.endswith("\x1b\\")
+        assert "HighlightCursorLine=yes" in _ITERM_CURSOR_GUIDE_ON
+
+    def test_write_iterm_escape_does_nothing_when_not_iterm(self) -> None:
+        """_write_iterm_escape should no-op when _IS_ITERM is False."""
+        mock_stderr = MagicMock()
+        with (
+            patch("deepagents_cli.app._IS_ITERM", False),
+            patch("sys.__stderr__", mock_stderr),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+            mock_stderr.write.assert_not_called()
+
+    def test_write_iterm_escape_writes_sequence_when_iterm(self) -> None:
+        """_write_iterm_escape should write sequence when in iTerm2."""
+        mock_stderr = io.StringIO()
+        with (
+            patch("deepagents_cli.app._IS_ITERM", True),
+            patch("sys.__stderr__", mock_stderr),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+            assert mock_stderr.getvalue() == _ITERM_CURSOR_GUIDE_ON
+
+    def test_write_iterm_escape_handles_oserror_gracefully(self) -> None:
+        """_write_iterm_escape should not raise on OSError."""
+        mock_stderr = MagicMock()
+        mock_stderr.write.side_effect = OSError("Broken pipe")
+        with (
+            patch("deepagents_cli.app._IS_ITERM", True),
+            patch("sys.__stderr__", mock_stderr),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+
+    def test_write_iterm_escape_handles_none_stderr(self) -> None:
+        """_write_iterm_escape should handle None __stderr__ gracefully."""
+        with (
+            patch("deepagents_cli.app._IS_ITERM", True),
+            patch("sys.__stderr__", None),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+
+
+class TestITerm2Detection:
+    """Test iTerm2 detection logic."""
+
+    def test_detection_requires_tty(self) -> None:
+        """_IS_ITERM should check that stderr is a TTY.
+
+        Detection happens at module load, so we test the logic pattern directly.
+        """
+        with (
+            patch.dict(os.environ, {"LC_TERMINAL": "iTerm2"}, clear=False),
+            patch("os.isatty", return_value=False),
+        ):
+            result = (
+                (
+                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
+                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+                )
+                and hasattr(os, "isatty")
+                and os.isatty(2)
+            )
+            assert result is False
+
+    def test_detection_via_lc_terminal(self) -> None:
+        """Detection should match LC_TERMINAL=iTerm2."""
+        with (
+            patch.dict(
+                os.environ, {"LC_TERMINAL": "iTerm2", "TERM_PROGRAM": ""}, clear=False
+            ),
+            patch("os.isatty", return_value=True),
+        ):
+            result = (
+                (
+                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
+                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+                )
+                and hasattr(os, "isatty")
+                and os.isatty(2)
+            )
+            assert result is True
+
+    def test_detection_via_term_program(self) -> None:
+        """Detection should match TERM_PROGRAM=iTerm.app."""
+        env = {"LC_TERMINAL": "", "TERM_PROGRAM": "iTerm.app"}
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("os.isatty", return_value=True),
+        ):
+            result = (
+                (
+                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
+                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+                )
+                and hasattr(os, "isatty")
+                and os.isatty(2)
+            )
+            assert result is True


### PR DESCRIPTION
- Detects iTerm2 via `LC_TERMINAL` and `TERM_PROGRAM` environment variables
- Disables [cursor guide](https://gist.github.com/dasgoll/adc27f64c30a02ece3755ae7301038c2) (highlight cursor line) at module load before Textual takes over
- Restores cursor guide on exit via atexit handler and `exit()` override

---

From iTerm2 docs:

```txt
Do you have trouble finding your cursor? You can turn on the cursor guide by toggling the View > Show Cursor Guide menu item or turning on Settings > Profiles > Colors > Cursor Guide. This can also be toggled by an escape sequence. For example, add this to your .vimrc:

let &t_ti.="\<Esc>]1337;HighlightCursorLine=true\x7"
let &t_te.="\<Esc>]1337;HighlightCursorLine=false\x7"

If you've lost your cursor, press Cmd-/ or select View > Find Cursor and the cursor's position on the screen will be indicated very clearly
```

```txt
The cursor guide is a horizontal rule that indicates the vertical position of the cursor. You can adjust its color, including alpha value, to make it more visible against your background color.
```