### PR TITLE
fix(cli): unify spinner API to support dynamic status text

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -498,7 +498,7 @@ class DeepAgentsApp(App):
 
         Args:
             status: The status text to display (e.g., "Thinking", "Summarizing"),
-                or None to hide the spinner.
+                or `None` to hide the spinner.
         """
         if status is None:
             # Hide

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -426,8 +426,7 @@ class DeepAgentsApp(App):
                 request_approval=self._request_approval,
                 on_auto_approve_enabled=self._on_auto_approve_enabled,
                 scroll_to_bottom=self._scroll_chat_to_bottom,
-                show_thinking=self._show_thinking,
-                hide_thinking=self._hide_thinking,
+                set_spinner=self._set_spinner,
             )
             self._ui_adapter.set_token_tracker(self._token_tracker)
 
@@ -494,23 +493,36 @@ class DeepAgentsApp(App):
         if distance_from_bottom < 100:
             chat.scroll_end(animate=False)
 
-    async def _show_thinking(self) -> None:
-        """Show or reposition the thinking spinner at the bottom of messages."""
-        if self._loading_widget:
-            await self._loading_widget.remove()
-            self._loading_widget = None
+    async def _set_spinner(self, status: str | None) -> None:
+        """Show, update, or hide the loading spinner.
 
-        self._loading_widget = LoadingWidget("Thinking")
+        Args:
+            status: The status text to display (e.g., "Thinking", "Summarizing"),
+                or None to hide the spinner.
+        """
+        if status is None:
+            # Hide
+            if self._loading_widget:
+                await self._loading_widget.remove()
+                self._loading_widget = None
+            return
+
         messages = self.query_one("#messages", Container)
-        await messages.mount(self._loading_widget)
+
+        if self._loading_widget is None:
+            # Create new
+            self._loading_widget = LoadingWidget(status)
+            await messages.mount(self._loading_widget)
+        else:
+            # Update existing
+            self._loading_widget.set_status(status)
+            # Reposition if not at the end (e.g., after tool message was added)
+            children = list(messages.children)
+            if children and children[-1] != self._loading_widget:
+                await self._loading_widget.remove()
+                await messages.mount(self._loading_widget)
         # NOTE: Don't call _scroll_chat_to_bottom() here - it would re-anchor
         # and drag user back to bottom if they've scrolled away during streaming
-
-    async def _hide_thinking(self) -> None:
-        """Hide the thinking spinner."""
-        if self._loading_widget:
-            await self._loading_widget.remove()
-            self._loading_widget = None
 
     def _size_initial_spacer(self) -> None:
         """Size the spacer to fill remaining viewport below input."""
@@ -829,8 +841,8 @@ class DeepAgentsApp(App):
         self._agent_running = False
         self._agent_worker = None
 
-        # Remove thinking spinner if present
-        await self._hide_thinking()
+        # Remove spinner if present
+        await self._set_spinner(None)
 
         # Re-enable submission now that agent is done
         if self._chat_input:

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -57,19 +57,51 @@ def _is_summarization_chunk(metadata: dict | None) -> bool:
 class TextualUIAdapter:
     """Adapter for rendering agent output to Textual widgets.
 
-    This adapter provides an abstraction layer between the agent execution
-    and the Textual UI, allowing streaming output to be rendered as widgets.
+    This adapter provides an abstraction layer between the agent execution and the
+    Textual UI, allowing streaming output to be rendered as widgets.
     """
+
+    _mount_message: Callable
+    """Async callback to mount a message widget to the chat."""
+
+    _update_status: Callable[[str], None]
+    """Callback to update the status bar text."""
+
+    _request_approval: Callable
+    """Async callback that returns a Future for HITL approval."""
+
+    _on_auto_approve_enabled: Callable[[], None] | None
+    """Callback invoked when auto-approve is enabled."""
+
+    _scroll_to_bottom: Callable[[], None] | None
+    """Callback to scroll chat to bottom."""
+
+    _set_spinner: Callable[[str | None], Awaitable[None]] | None
+    """Callback to show/hide loading spinner.
+
+    Pass `None` to hide, or a status string to show.
+    """
+
+    _current_assistant_message: AssistantMessage | None
+    """The currently streaming assistant message widget."""
+
+    _current_tool_messages: dict[str, ToolCallMessage]
+    """Map of tool call IDs to their message widgets."""
+
+    _pending_text: str
+    """Buffered text waiting to be flushed to the UI."""
+
+    _token_tracker: Any
+    """Token usage tracker for displaying counts."""
 
     def __init__(
         self,
         mount_message: Callable,
         update_status: Callable[[str], None],
-        request_approval: Callable,  # async callable returning Future
+        request_approval: Callable,
         on_auto_approve_enabled: Callable[[], None] | None = None,
         scroll_to_bottom: Callable[[], None] | None = None,
-        show_thinking: Callable[[], Awaitable[None]] | None = None,
-        hide_thinking: Callable[[], Awaitable[None]] | None = None,
+        set_spinner: Callable[[str | None], Awaitable[None]] | None = None,
     ) -> None:
         """Initialize the adapter.
 
@@ -79,22 +111,20 @@ class TextualUIAdapter:
             request_approval: Callable that returns a Future for HITL approval
             on_auto_approve_enabled: Callback when auto-approve is enabled
             scroll_to_bottom: Callback to scroll chat to bottom
-            show_thinking: Callback to show/reposition thinking spinner
-            hide_thinking: Callback to hide thinking spinner
+            set_spinner: Callback to show/hide loading spinner (pass None to hide)
         """
         self._mount_message = mount_message
         self._update_status = update_status
         self._request_approval = request_approval
         self._on_auto_approve_enabled = on_auto_approve_enabled
         self._scroll_to_bottom = scroll_to_bottom
-        self._show_thinking = show_thinking
-        self._hide_thinking = hide_thinking
+        self._set_spinner = set_spinner
 
         # State tracking
         self._current_assistant_message: AssistantMessage | None = None
         self._current_tool_messages: dict[str, ToolCallMessage] = {}
         self._pending_text = ""
-        self._token_tracker: Any = None
+        self._token_tracker = None
 
     def set_token_tracker(self, tracker: Any) -> None:
         """Set the token tracker for usage tracking."""
@@ -222,9 +252,9 @@ async def execute_task_textual(
     captured_input_tokens = 0
     captured_output_tokens = 0
 
-    # Show thinking spinner
-    if adapter._show_thinking:
-        await adapter._show_thinking()
+    # Show spinner
+    if adapter._set_spinner:
+        await adapter._set_spinner("Thinking")
 
     # Hide token display during streaming (will be shown with accurate count at end)
     if adapter._token_tracker:
@@ -341,9 +371,9 @@ async def execute_task_textual(
                         tool_content = format_tool_message_content(message.content)
                         record = file_op_tracker.complete_with_message(message)
 
-                        # Reshow thinking spinner after tool result
-                        if adapter._show_thinking:
-                            await adapter._show_thinking()
+                        # Reshow spinner after tool result
+                        if adapter._set_spinner:
+                            await adapter._set_spinner("Thinking")
 
                         # Update tool call status with output
                         tool_id = getattr(message, "tool_call_id", None)
@@ -414,10 +444,9 @@ async def execute_task_textual(
                                 # Get or create assistant message for this namespace
                                 current_msg = assistant_message_by_namespace.get(ns_key)
                                 if current_msg is None:
-                                    # Hide thinking spinner when assistant starts
-                                    # responding
-                                    if adapter._hide_thinking:
-                                        await adapter._hide_thinking()
+                                    # Hide spinner when assistant starts responding
+                                    if adapter._set_spinner:
+                                        await adapter._set_spinner(None)
                                     current_msg = AssistantMessage()
                                     await adapter._mount_message(current_msg)
                                     assistant_message_by_namespace[ns_key] = current_msg
@@ -516,9 +545,9 @@ async def execute_task_textual(
                                     buffer_name, parsed_args, buffer_id
                                 )
 
-                                # Hide thinking spinner before showing tool call
-                                if adapter._hide_thinking:
-                                    await adapter._hide_thinking()
+                                # Hide spinner before showing tool call
+                                if adapter._set_spinner:
+                                    await adapter._set_spinner(None)
 
                                 # Mount tool call message
                                 tool_msg = ToolCallMessage(buffer_name, parsed_args)

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -61,13 +61,13 @@ class TextualUIAdapter:
     Textual UI, allowing streaming output to be rendered as widgets.
     """
 
-    _mount_message: Callable
+    _mount_message: Callable[..., Awaitable[None]]
     """Async callback to mount a message widget to the chat."""
 
     _update_status: Callable[[str], None]
     """Callback to update the status bar text."""
 
-    _request_approval: Callable
+    _request_approval: Callable[..., Awaitable[Any]]
     """Async callback that returns a Future for HITL approval."""
 
     _on_auto_approve_enabled: Callable[[], None] | None
@@ -82,23 +82,17 @@ class TextualUIAdapter:
     Pass `None` to hide, or a status string to show.
     """
 
-    _current_assistant_message: AssistantMessage | None
-    """The currently streaming assistant message widget."""
-
     _current_tool_messages: dict[str, ToolCallMessage]
     """Map of tool call IDs to their message widgets."""
-
-    _pending_text: str
-    """Buffered text waiting to be flushed to the UI."""
 
     _token_tracker: Any
     """Token usage tracker for displaying counts."""
 
     def __init__(
         self,
-        mount_message: Callable,
+        mount_message: Callable[..., Awaitable[None]],
         update_status: Callable[[str], None],
-        request_approval: Callable,
+        request_approval: Callable[..., Awaitable[Any]],
         on_auto_approve_enabled: Callable[[], None] | None = None,
         scroll_to_bottom: Callable[[], None] | None = None,
         set_spinner: Callable[[str | None], Awaitable[None]] | None = None,
@@ -106,12 +100,12 @@ class TextualUIAdapter:
         """Initialize the adapter.
 
         Args:
-            mount_message: Async callable to mount a message widget
-            update_status: Callable to update the status bar message
-            request_approval: Callable that returns a Future for HITL approval
-            on_auto_approve_enabled: Callback when auto-approve is enabled
-            scroll_to_bottom: Callback to scroll chat to bottom
-            set_spinner: Callback to show/hide loading spinner (pass None to hide)
+            mount_message: Async callable to mount a message widget.
+            update_status: Callable to update the status bar message.
+            request_approval: Async callable that returns a Future for HITL approval.
+            on_auto_approve_enabled: Callback when auto-approve is enabled.
+            scroll_to_bottom: Callback to scroll chat to bottom.
+            set_spinner: Callback to show/hide loading spinner (pass `None` to hide).
         """
         self._mount_message = mount_message
         self._update_status = update_status
@@ -121,10 +115,8 @@ class TextualUIAdapter:
         self._set_spinner = set_spinner
 
         # State tracking
-        self._current_assistant_message: AssistantMessage | None = None
         self._current_tool_messages: dict[str, ToolCallMessage] = {}
-        self._pending_text = ""
-        self._token_tracker = None
+        self._token_tracker: Any = None
 
     def set_token_tracker(self, tracker: Any) -> None:
         """Set the token tracker for usage tracking."""

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -1,6 +1,79 @@
 """Unit tests for textual_adapter functions."""
 
-from deepagents_cli.textual_adapter import _is_summarization_chunk
+from asyncio import Future
+
+from deepagents_cli.textual_adapter import TextualUIAdapter, _is_summarization_chunk
+
+
+async def _mock_mount(widget: object) -> None:
+    """Mock mount function for tests."""
+
+
+def _mock_approval() -> Future[object]:
+    """Mock approval function for tests."""
+    future: Future[object] = Future()
+    return future
+
+
+def _noop_status(_: str) -> None:
+    """No-op status callback for tests."""
+
+
+class TestTextualUIAdapterInit:
+    """Tests for `TextualUIAdapter` initialization."""
+
+    def test_set_spinner_callback_stored(self) -> None:
+        """Verify `set_spinner` callback is properly stored."""
+
+        async def mock_spinner(status: str | None) -> None:
+            pass
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=mock_spinner,
+        )
+        assert adapter._set_spinner is mock_spinner
+
+    def test_set_spinner_defaults_to_none(self) -> None:
+        """Verify `set_spinner` is optional and defaults to `None`."""
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        assert adapter._set_spinner is None
+
+    def test_current_tool_messages_initialized_empty(self) -> None:
+        """Verify `_current_tool_messages` is initialized as empty dict."""
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        assert adapter._current_tool_messages == {}
+
+    def test_token_tracker_initialized_none(self) -> None:
+        """Verify `_token_tracker` is initialized as `None`."""
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        assert adapter._token_tracker is None
+
+    def test_set_token_tracker(self) -> None:
+        """Verify `set_token_tracker` stores the tracker."""
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        mock_tracker = object()
+        adapter.set_token_tracker(mock_tracker)
+        assert adapter._token_tracker is mock_tracker
 
 
 class TestIsSummarizationChunk:


### PR DESCRIPTION
- Refactor loading spinner from `show_thinking`/`hide_thinking` to unified `set_spinner(status)` API
- Enable dynamic status text updates without recreating the spinner widget
- Add class-level attribute documentation to `TextualUIAdapter` & fix some types

## Motivation
Prepares the spinner infrastructure to display contextual status messages (e.g., "Thinking", "Summarizing") during different agent operations.