### PR TITLE
fix(cli): dismiss modal screens on escape key

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -17,6 +17,7 @@ from textual.app import App
 from textual.binding import Binding, BindingType
 from textual.containers import Container, VerticalScroll
 from textual.css.query import NoMatches
+from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
@@ -1022,10 +1023,15 @@ class DeepAgentsApp(App):
             self.notify("Press Ctrl+C again to quit", timeout=3)
 
     def action_interrupt(self) -> None:
-        """Handle escape key - interrupt agent or reject approval.
+        """Handle escape key - interrupt agent, reject approval, or dismiss modal.
 
         This is the primary way to stop a running agent.
         """
+        # If a modal screen is active, dismiss it
+        if isinstance(self.screen, ModalScreen):
+            self.screen.dismiss(None)
+            return
+
         # If agent is running, interrupt it
         if self._agent_running and self._agent_worker:
             self._agent_worker.cancel()


### PR DESCRIPTION
- Escape key now properly dismisses modal screens (e.g., upcoming model selector)
- The app's `action_interrupt` binding was intercepting escape before modals could handle it
- Adds check at the start of `action_interrupt` to dismiss any active `ModalScreen`