### PR TITLE
feat(cli): add click support and hover styling to autocomplete popup

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from rich.text import Text
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
@@ -13,7 +12,7 @@ from textual.reactive import reactive
 from textual.widgets import Static, TextArea
 from textual.widgets.text_area import Selection
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode
+from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
 from deepagents_cli.widgets.autocomplete import (
     SLASH_COMMANDS,
     CompletionResult,
@@ -26,21 +25,121 @@ from deepagents_cli.widgets.history import HistoryManager
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
+    from textual.events import Click
 
 
-class CompletionPopup(Static):
-    """Popup widget that displays completion suggestions."""
+class CompletionOption(Static):
+    """A clickable completion option in the autocomplete popup."""
+
+    DEFAULT_CSS = """
+    CompletionOption {
+        height: 1;
+        padding: 0 1;
+    }
+
+    CompletionOption:hover {
+        background: $surface-lighten-1;
+    }
+
+    CompletionOption.completion-option-selected {
+        background: $primary;
+        text-style: bold;
+    }
+
+    CompletionOption.completion-option-selected:hover {
+        background: $primary-lighten-1;
+    }
+    """
+
+    class Clicked(Message):
+        """Message sent when a completion option is clicked."""
+
+        def __init__(self, index: int) -> None:
+            """Initialize with the clicked option index."""
+            super().__init__()
+            self.index = index
+
+    def __init__(
+        self,
+        label: str,
+        description: str,
+        index: int,
+        is_selected: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the completion option.
+
+        Args:
+            label: The main label text (e.g., command name or file path)
+            description: Secondary description text
+            index: Index of this option in the suggestions list
+            is_selected: Whether this option is currently selected
+            **kwargs: Additional arguments for parent
+        """
+        super().__init__(**kwargs)
+        self._label = label
+        self._description = description
+        self._index = index
+        self._is_selected = is_selected
+
+    def on_mount(self) -> None:
+        """Set up the option display on mount."""
+        self._update_display()
+
+    def _update_display(self) -> None:
+        """Update the display text and styling."""
+        glyphs = get_glyphs()
+        cursor = f"{glyphs.cursor} " if self._is_selected else "  "
+
+        if self._description:
+            text = f"{cursor}[bold]{self._label}[/bold]  [dim]{self._description}[/dim]"
+        else:
+            text = f"{cursor}[bold]{self._label}[/bold]"
+
+        self.update(text)
+
+        if self._is_selected:
+            self.add_class("completion-option-selected")
+        else:
+            self.remove_class("completion-option-selected")
+
+    def set_selected(self, *, selected: bool) -> None:
+        """Update the selected state of this option."""
+        if self._is_selected != selected:
+            self._is_selected = selected
+            self._update_display()
+
+    def on_click(self, event: Click) -> None:
+        """Handle click on this option."""
+        event.stop()
+        self.post_message(self.Clicked(self._index))
+
+
+class CompletionPopup(Vertical):
+    """Popup widget that displays completion suggestions as clickable options."""
 
     DEFAULT_CSS = """
     CompletionPopup {
         display: none;
+        height: auto;
+        max-height: 12;
     }
     """
 
+    class OptionClicked(Message):
+        """Message sent when a completion option is clicked."""
+
+        def __init__(self, index: int) -> None:
+            """Initialize with the clicked option index."""
+            super().__init__()
+            self.index = index
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the completion popup."""
-        super().__init__("", **kwargs)
+        super().__init__(**kwargs)
         self.can_focus = False
+        self._options: list[CompletionOption] = []
+        self._selected_index = 0
 
     def update_suggestions(
         self, suggestions: list[tuple[str, str]], selected_index: int
@@ -50,31 +149,57 @@ class CompletionPopup(Static):
             self.hide()
             return
 
-        text = Text()
-        for idx, (label, description) in enumerate(suggestions):
-            if idx:
-                text.append("\n")
-
-            if idx == selected_index:
-                label_style = "bold reverse"
-                desc_style = "italic"
-            else:
-                label_style = "bold"
-                desc_style = "dim"
-
-            text.append(label, style=label_style)
-            if description:
-                text.append("  ")
-                text.append(description, style=desc_style)
-
-        self.update(text)
+        self._selected_index = selected_index
+        # Store pending update and schedule async rebuild
+        self._pending_suggestions = suggestions
+        self._pending_selected = selected_index
+        self.call_after_refresh(self._rebuild_options)
         self.show()
+
+    async def _rebuild_options(self) -> None:
+        """Rebuild option widgets from pending suggestions."""
+        suggestions = getattr(self, "_pending_suggestions", [])
+        selected_index = getattr(self, "_pending_selected", 0)
+
+        if not suggestions:
+            return
+
+        # Remove existing options
+        await self.remove_children()
+        self._options.clear()
+
+        # Create new options
+        for idx, (label, description) in enumerate(suggestions):
+            option = CompletionOption(
+                label=label,
+                description=description,
+                index=idx,
+                is_selected=(idx == selected_index),
+            )
+            self._options.append(option)
+            await self.mount(option)
+
+    def update_selection(self, selected_index: int) -> None:
+        """Update which option is selected without rebuilding the list."""
+        if self._selected_index == selected_index:
+            return
+
+        # Deselect previous
+        if 0 <= self._selected_index < len(self._options):
+            self._options[self._selected_index].set_selected(selected=False)
+
+        # Select new
+        self._selected_index = selected_index
+        if 0 <= selected_index < len(self._options):
+            self._options[selected_index].set_selected(selected=True)
+
+    def on_completion_option_clicked(self, event: CompletionOption.Clicked) -> None:
+        """Handle click on a completion option."""
+        event.stop()
+        self.post_message(self.OptionClicked(event.index))
 
     def hide(self) -> None:
         """Hide the popup."""
-        self.update("")
-        # Textual's styles.display accepts string literals at runtime but type
-        # stubs expect a narrower type; the assignment is valid Textual API usage
         self.styles.display = "none"  # type: ignore[assignment]
 
     def show(self) -> None:
@@ -313,6 +438,10 @@ class ChatInput(Vertical):
         self._popup: CompletionPopup | None = None
         self._completion_manager: MultiCompletionManager | None = None
 
+        # Track current suggestions for click handling
+        self._current_suggestions: list[tuple[str, str]] = []
+        self._current_selected_index = 0
+
         # Set up history manager
         if history_file is None:
             history_file = Path.home() / ".deepagents" / "history.jsonl"
@@ -530,6 +659,10 @@ class ChatInput(Vertical):
         self, suggestions: list[tuple[str, str]], selected_index: int
     ) -> None:
         """Render completion suggestions in the popup."""
+        # Track suggestions locally for click handling
+        self._current_suggestions = suggestions
+        self._current_selected_index = selected_index
+
         if self._popup:
             self._popup.update_suggestions(suggestions, selected_index)
         # Tell TextArea that completion is active so it yields navigation keys
@@ -538,11 +671,47 @@ class ChatInput(Vertical):
 
     def clear_completion_suggestions(self) -> None:
         """Clear/hide the completion popup."""
+        self._current_suggestions = []
+        self._current_selected_index = 0
+
         if self._popup:
             self._popup.hide()
         # Tell TextArea that completion is no longer active
         if self._text_area:
             self._text_area.set_completion_active(active=False)
+
+    def on_completion_popup_option_clicked(
+        self, event: CompletionPopup.OptionClicked
+    ) -> None:
+        """Handle click on a completion option."""
+        if not self._current_suggestions or not self._text_area:
+            return
+
+        index = event.index
+        if index < 0 or index >= len(self._current_suggestions):
+            return
+
+        # Get the selected completion
+        label, _ = self._current_suggestions[index]
+        text = self._text_area.text
+        cursor = self._get_cursor_offset()
+
+        # Determine replacement range based on completion type
+        if label.startswith("/"):
+            # Slash command: replace from start
+            self.replace_completion_range(0, cursor, label)
+        elif label.startswith("@"):
+            # File mention: replace from @ to cursor
+            at_index = text[:cursor].rfind("@")
+            if at_index >= 0:
+                self.replace_completion_range(at_index, cursor, label)
+
+        # Reset completion state
+        if self._completion_manager:
+            self._completion_manager.reset()
+
+        # Re-focus the text input after click
+        self._text_area.focus()
 
     def replace_completion_range(self, start: int, end: int, replacement: str) -> None:
         """Replace text in the input field."""

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -1,0 +1,234 @@
+"""Unit tests for ChatInput widget and completion popup."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Container
+
+from deepagents_cli.widgets.chat_input import (
+    ChatInput,
+    CompletionOption,
+    CompletionPopup,
+)
+
+
+class TestCompletionOption:
+    """Test CompletionOption widget."""
+
+    def test_clicked_message_contains_index(self) -> None:
+        """Clicked message should contain the option index."""
+        message = CompletionOption.Clicked(index=2)
+        assert message.index == 2
+
+    def test_init_stores_attributes(self) -> None:
+        """CompletionOption should store label, description, index, and state."""
+        option = CompletionOption(
+            label="/help",
+            description="Show help",
+            index=1,
+            is_selected=True,
+        )
+        assert option._label == "/help"
+        assert option._description == "Show help"
+        assert option._index == 1
+        assert option._is_selected is True
+
+    def test_set_selected_updates_state(self) -> None:
+        """set_selected should update internal state."""
+        option = CompletionOption(
+            label="/help",
+            description="Show help",
+            index=0,
+            is_selected=False,
+        )
+        assert option._is_selected is False
+
+        option.set_selected(selected=True)
+        assert option._is_selected is True
+
+        option.set_selected(selected=False)
+        assert option._is_selected is False
+
+
+class TestCompletionPopup:
+    """Test CompletionPopup widget."""
+
+    def test_option_clicked_message_contains_index(self) -> None:
+        """OptionClicked message should contain the clicked index."""
+        message = CompletionPopup.OptionClicked(index=3)
+        assert message.index == 3
+
+    def test_init_state(self) -> None:
+        """CompletionPopup should initialize with empty options."""
+        popup = CompletionPopup()
+        assert popup._options == []
+        assert popup._selected_index == 0
+        assert popup.can_focus is False
+
+
+class TestCompletionPopupIntegration:
+    """Integration tests for CompletionPopup with Textual."""
+
+    @pytest.mark.asyncio
+    async def test_update_suggestions_shows_popup(self) -> None:
+        """update_suggestions should show the popup when given suggestions."""
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield CompletionPopup(id="popup")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            popup = app.query_one("#popup", CompletionPopup)
+
+            # Initially hidden
+            assert popup.styles.display == "none"
+
+            # Update with suggestions
+            popup.update_suggestions(
+                [("/help", "Show help"), ("/clear", "Clear chat")],
+                selected_index=0,
+            )
+            await pilot.pause()
+
+            # Should be visible
+            assert popup.styles.display == "block"
+
+    @pytest.mark.asyncio
+    async def test_update_suggestions_creates_option_widgets(self) -> None:
+        """update_suggestions should create CompletionOption widgets."""
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield CompletionPopup(id="popup")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            popup = app.query_one("#popup", CompletionPopup)
+
+            popup.update_suggestions(
+                [("/help", "Show help"), ("/clear", "Clear chat")],
+                selected_index=0,
+            )
+            # Allow async rebuild to complete
+            await pilot.pause()
+
+            # Should have created 2 option widgets
+            options = popup.query(CompletionOption)
+            assert len(options) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_suggestions_hides_popup(self) -> None:
+        """Empty suggestions should hide the popup."""
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield CompletionPopup(id="popup")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            popup = app.query_one("#popup", CompletionPopup)
+
+            # Show popup first
+            popup.update_suggestions(
+                [("/help", "Show help")],
+                selected_index=0,
+            )
+            await pilot.pause()
+            assert popup.styles.display == "block"
+
+            # Hide with empty suggestions
+            popup.update_suggestions([], selected_index=0)
+            await pilot.pause()
+
+            assert popup.styles.display == "none"
+
+
+class TestCompletionOptionClick:
+    """Test click handling on CompletionOption."""
+
+    @pytest.mark.asyncio
+    async def test_click_on_option_posts_message(self) -> None:
+        """Clicking on an option should post a Clicked message."""
+
+        class TestApp(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.clicked_indices: list[int] = []
+
+            def compose(self) -> ComposeResult:
+                with Container():
+                    yield CompletionOption(
+                        label="/help",
+                        description="Show help",
+                        index=0,
+                        id="opt0",
+                    )
+                    yield CompletionOption(
+                        label="/clear",
+                        description="Clear chat",
+                        index=1,
+                        id="opt1",
+                    )
+
+            def on_completion_option_clicked(
+                self, event: CompletionOption.Clicked
+            ) -> None:
+                self.clicked_indices.append(event.index)
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            # Click on first option
+            opt0 = app.query_one("#opt0", CompletionOption)
+            await pilot.click(opt0)
+
+            assert 0 in app.clicked_indices
+
+            # Click on second option
+            opt1 = app.query_one("#opt1", CompletionOption)
+            await pilot.click(opt1)
+
+            assert 1 in app.clicked_indices
+
+
+class TestCompletionPopupClickBubbling:
+    """Test that clicks on options bubble up through the popup."""
+
+    @pytest.mark.asyncio
+    async def test_popup_receives_option_click_and_posts_message(self) -> None:
+        """Popup should receive option clicks and post OptionClicked message."""
+
+        class TestApp(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.option_clicked_indices: list[int] = []
+
+            def compose(self) -> ComposeResult:
+                yield CompletionPopup(id="popup")
+
+            def on_completion_popup_option_clicked(
+                self, event: CompletionPopup.OptionClicked
+            ) -> None:
+                self.option_clicked_indices.append(event.index)
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            popup = app.query_one("#popup", CompletionPopup)
+
+            # Add suggestions to create option widgets
+            popup.update_suggestions(
+                [("/help", "Show help"), ("/clear", "Clear chat")],
+                selected_index=0,
+            )
+            await pilot.pause()
+
+            # Click on the first option
+            options = popup.query(CompletionOption)
+            await pilot.click(options[0])
+
+            assert 0 in app.option_clicked_indices
+
+            # Click on second option
+            await pilot.click(options[1])
+            assert 1 in app.option_clicked_indices


### PR DESCRIPTION
- Autocomplete suggestions for `/` commands and `@` file mentions are now clickable
- Added hover highlighting to autocomplete options for better visual feedback
- Clicking a suggestion applies it and re-focuses the text input