### PR TITLE
feat(cli): add per-command `timeout` override to `execute` tool

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -435,7 +435,7 @@ def create_cli_agent(
             Useful for automated workflows.
         enable_memory: Enable `MemoryMiddleware` for persistent memory
         enable_skills: Enable `SkillsMiddleware` for custom agent skills
-        enable_shell: Enable shell execution via `LocalShellBackend`
+        enable_shell: Enable shell execution via `CLIShellBackend`
             (only in local mode). When enabled, the `execute` tool is available.
         checkpointer: Optional checkpointer for session persistence.
 
@@ -589,9 +589,11 @@ def create_cli_agent(
 
     # Create the agent
     # Use provided checkpointer or fallback to InMemorySaver
-    # Patch FilesystemMiddleware so the SDK constructs our subclass with
-    # per-command timeout support on the execute tool.
-    patch_filesystem_middleware()
+    if sandbox is None and enable_shell:
+        # Patch FilesystemMiddleware so the SDK constructs our subclass with
+        # per-command timeout support on the execute tool. Only needed in local
+        # shell mode -- remote sandbox backends do not accept the timeout kwarg.
+        patch_filesystem_middleware()
     final_checkpointer = checkpointer if checkpointer is not None else InMemorySaver()
     agent = create_deep_agent(
         model=model,

--- a/libs/cli/deepagents_cli/backends.py
+++ b/libs/cli/deepagents_cli/backends.py
@@ -1,0 +1,288 @@
+"""CLI-specific backend and middleware overrides for per-command timeout support.
+
+Subclasses `LocalShellBackend` and `FilesystemMiddleware` to add a per-command
+`timeout` keyword argument to `execute()`, so the LLM can override the default
+timeout for long-running commands.
+
+When the SDK adds this natively, these subclasses can be removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess  # noqa: S404
+from typing import Annotated
+
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.local_shell import LocalShellBackend
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    ExecuteResponse,
+    SandboxBackendProtocol,
+)
+from deepagents.middleware.filesystem import (
+    EXECUTE_TOOL_DESCRIPTION,
+    FilesystemMiddleware,
+    FilesystemState,
+)
+from langchain.tools import ToolRuntime  # noqa: TC002
+from langchain_core.tools import BaseTool, StructuredTool
+
+_TIMEOUT_DESC = (
+    "Optional timeout in seconds. Overrides the default. Use for long-running commands."
+)
+
+DEFAULT_EXECUTE_TIMEOUT = 120
+"""Default timeout in seconds for shell command execution."""
+
+
+class CLIShellBackend(LocalShellBackend):
+    """Local shell backend with per-command timeout override support.
+
+    Extends `LocalShellBackend` to accept an optional `timeout` keyword on
+    each `execute()` call.
+    """
+
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+    ) -> ExecuteResponse:
+        r"""Execute a shell command with optional per-command timeout.
+
+        Overrides `LocalShellBackend.execute()` to accept a per-command
+        `timeout` that overrides the default set at init time.
+
+        Args:
+            command: Shell command string to execute.
+            timeout: Maximum time in seconds to wait for this command.
+
+                Overrides the default timeout set at init.
+
+                If None, uses the default of 120 seconds.
+
+        Returns:
+            ExecuteResponse containing output, exit code, and truncation flag.
+
+        Raises:
+            ValueError: If per-command timeout is not positive.
+        """
+        if not command or not isinstance(command, str):
+            return ExecuteResponse(
+                output="Error: Command must be a non-empty string.",
+                exit_code=1,
+                truncated=False,
+            )
+
+        effective_timeout = timeout if timeout is not None else self._timeout
+        if effective_timeout <= 0:
+            msg = f"timeout must be positive, got {effective_timeout}"
+            raise ValueError(msg)
+
+        try:
+            result = subprocess.run(  # noqa: S602
+                command,
+                check=False,
+                shell=True,  # Intentional: designed for LLM-controlled shell execution
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+                env=self._env,
+                cwd=str(self.cwd),
+            )
+
+            # Combine stdout and stderr
+            # Prefix each stderr line with [stderr] for clear attribution.
+            output_parts = []
+            if result.stdout:
+                output_parts.append(result.stdout)
+            if result.stderr:
+                stderr_lines = result.stderr.strip().split("\n")
+                output_parts.extend(f"[stderr] {line}" for line in stderr_lines)
+
+            output = "\n".join(output_parts) if output_parts else "<no output>"
+
+            # Check for truncation
+            truncated = False
+            if len(output) > self._max_output_bytes:
+                output = output[: self._max_output_bytes]
+                output += f"\n\n... Output truncated at {self._max_output_bytes} bytes."
+                truncated = True
+
+            # Add exit code info if non-zero
+            if result.returncode != 0:
+                output = f"{output.rstrip()}\n\nExit code: {result.returncode}"
+
+            return ExecuteResponse(
+                output=output,
+                exit_code=result.returncode,
+                truncated=truncated,
+            )
+
+        except subprocess.TimeoutExpired:
+            return ExecuteResponse(
+                output=(
+                    f"Error: Command timed out after {effective_timeout} seconds."
+                    " For long-running commands, re-run using the timeout parameter."
+                ),
+                exit_code=124,  # Standard timeout exit code
+                truncated=False,
+            )
+        except Exception as e:  # noqa: BLE001
+            return ExecuteResponse(
+                output=f"Error executing command: {e}",
+                exit_code=1,
+                truncated=False,
+            )
+
+
+def _format_execute_result(result: ExecuteResponse) -> str:
+    """Format an `ExecuteResponse` for LLM consumption.
+
+    Args:
+        result: The execution response to format.
+
+    Returns:
+        Formatted string with output, status, and truncation info.
+    """
+    parts = [result.output]
+    if result.exit_code is not None:
+        status = "succeeded" if result.exit_code == 0 else "failed"
+        parts.append(f"\n[Command {status} with exit code {result.exit_code}]")
+    if result.truncated:
+        parts.append("\n[Output was truncated due to size limits]")
+    return "".join(parts)
+
+
+def _get_sandbox_backend(
+    backend: BackendProtocol,
+) -> SandboxBackendProtocol | None:
+    """Unwrap a `CompositeBackend` to find the sandbox backend.
+
+    `CompositeBackend.execute()` delegates to `self.default.execute()` but
+    doesn't forward extra kwargs like `timeout`. This helper reaches through
+    to the actual sandbox backend so we can call `execute(timeout=...)` on it.
+
+    Args:
+        backend: The resolved backend, possibly a `CompositeBackend`.
+
+    Returns:
+        The sandbox backend if found, None otherwise.
+    """
+    if isinstance(backend, CompositeBackend):
+        default = backend.default
+        if isinstance(default, SandboxBackendProtocol):
+            return default
+        return None
+    if isinstance(backend, SandboxBackendProtocol):
+        return backend
+    return None
+
+
+class CLIFilesystemMiddleware(FilesystemMiddleware):
+    """Filesystem middleware with per-command timeout on the execute tool.
+
+    Overrides `_create_execute_tool` to expose a `timeout` parameter in the
+    tool schema so the LLM can pass it for long-running commands.
+    """
+
+    def _create_execute_tool(self) -> BaseTool:
+        """Create the execute tool with an additional `timeout` parameter.
+
+        Returns:
+            A `StructuredTool` for shell command execution with timeout support.
+        """
+        tool_description = (
+            self._custom_tool_descriptions.get("execute") or EXECUTE_TOOL_DESCRIPTION
+        )
+
+        def sync_execute(
+            command: Annotated[
+                str, "Shell command to execute in the sandbox environment."
+            ],
+            runtime: ToolRuntime[None, FilesystemState],
+            timeout: Annotated[int | None, _TIMEOUT_DESC] = None,
+        ) -> str:
+            """Synchronous wrapper for execute tool.
+
+            Returns:
+                Formatted command output for LLM consumption.
+            """
+            if timeout is not None and timeout <= 0:
+                return f"Error: timeout must be a positive integer, got {timeout}."
+
+            resolved_backend = self._get_backend(runtime)  # type: ignore[arg-type]
+            sandbox = _get_sandbox_backend(resolved_backend)
+
+            if sandbox is None:
+                return (
+                    "Error: Execution not available. This agent's backend "
+                    "does not support command execution."
+                )
+
+            try:
+                result = sandbox.execute(command, timeout=timeout)  # type: ignore[call-arg]
+            except NotImplementedError as e:
+                return f"Error: Execution not available. {e}"
+            except ValueError as e:
+                return f"Error: Invalid parameter. {e}"
+
+            return _format_execute_result(result)
+
+        async def async_execute(
+            command: Annotated[
+                str, "Shell command to execute in the sandbox environment."
+            ],
+            runtime: ToolRuntime[None, FilesystemState],
+            timeout: Annotated[  # noqa: ASYNC109
+                int | None, _TIMEOUT_DESC
+            ] = None,
+        ) -> str:
+            """Asynchronous wrapper for execute tool.
+
+            Returns:
+                Formatted command output for LLM consumption.
+            """
+            if timeout is not None and timeout <= 0:
+                return f"Error: timeout must be a positive integer, got {timeout}."
+
+            resolved_backend = self._get_backend(runtime)  # type: ignore[arg-type]
+            sandbox = _get_sandbox_backend(resolved_backend)
+
+            if sandbox is None:
+                return (
+                    "Error: Execution not available. This agent's backend "
+                    "does not support command execution."
+                )
+
+            try:
+                result = await asyncio.to_thread(
+                    lambda: sandbox.execute(command, timeout=timeout)  # type: ignore[call-arg]
+                )
+            except NotImplementedError as e:
+                return f"Error: Execution not available. {e}"
+            except ValueError as e:
+                return f"Error: Invalid parameter. {e}"
+
+            return _format_execute_result(result)
+
+        return StructuredTool.from_function(
+            name="execute",
+            description=tool_description,
+            func=sync_execute,
+            coroutine=async_execute,
+        )
+
+
+def patch_filesystem_middleware() -> None:
+    """Monkey-patch the SDK to use `CLIFilesystemMiddleware`.
+
+    Must be called before `create_deep_agent` is invoked so the SDK's internal
+    `FilesystemMiddleware(backend=...)` calls construct our subclass instead.
+    """
+    import deepagents.graph as graph_module
+    import deepagents.middleware.filesystem as fs_module
+
+    fs_module.FilesystemMiddleware = CLIFilesystemMiddleware  # type: ignore[misc]
+    graph_module.FilesystemMiddleware = CLIFilesystemMiddleware  # type: ignore[misc]

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from deepagents_cli.backends import DEFAULT_EXECUTE_TIMEOUT
 from deepagents_cli.config import (
     COLORS,
     MAX_ARG_LENGTH,
@@ -13,12 +14,12 @@ from deepagents_cli.config import (
     get_glyphs,
 )
 
-# Default timeout for execute tool (matches LocalShellBackend default)
-_DEFAULT_EXECUTE_TIMEOUT = 120
-
 
 def _format_timeout(seconds: int) -> str:
     """Format timeout in human-readable units (e.g., 300 -> '5m', 3600 -> '1h').
+
+    Args:
+        seconds: The timeout value in seconds to format.
 
     Returns:
         Human-readable timeout string (e.g., '5m', '1h', '300s').
@@ -127,7 +128,7 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             command = str(tool_args["command"])
             command = truncate_value(command, 120)
             timeout = tool_args.get("timeout")
-            if timeout is not None and timeout != _DEFAULT_EXECUTE_TIMEOUT:
+            if timeout is not None and timeout != DEFAULT_EXECUTE_TIMEOUT:
                 timeout_str = _format_timeout(timeout)
                 return f'{prefix} {tool_name}("{command}", timeout={timeout_str})'
             return f'{prefix} {tool_name}("{command}")'

--- a/libs/cli/tests/unit_tests/test_backend_timeout.py
+++ b/libs/cli/tests/unit_tests/test_backend_timeout.py
@@ -1,0 +1,84 @@
+"""Unit tests for CLIShellBackend per-command timeout features."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from deepagents_cli.backends import DEFAULT_EXECUTE_TIMEOUT, CLIShellBackend
+
+
+class TestDefaultTimeoutConstant:
+    """Tests for the named default timeout constant."""
+
+    def test_default_timeout_uses_constant(self) -> None:
+        """Backend created without explicit timeout should use the default constant."""
+        backend = CLIShellBackend()
+        assert backend._timeout == DEFAULT_EXECUTE_TIMEOUT
+
+
+class TestPerCommandTimeout:
+    """Tests for per-command timeout override in execute()."""
+
+    def test_per_command_timeout_used(self) -> None:
+        """When timeout is passed to execute(), it should override the default."""
+        backend = CLIShellBackend(timeout=10, inherit_env=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args="echo hello",
+                returncode=0,
+                stdout="hello\n",
+                stderr="",
+            )
+            backend.execute("echo hello", timeout=300)
+            _, kwargs = mock_run.call_args
+            assert kwargs["timeout"] == 300
+
+    def test_default_timeout_when_not_specified(self) -> None:
+        """When no per-command timeout, the default should be used."""
+        backend = CLIShellBackend(timeout=60, inherit_env=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args="echo hello",
+                returncode=0,
+                stdout="hello\n",
+                stderr="",
+            )
+            backend.execute("echo hello")
+            _, kwargs = mock_run.call_args
+            assert kwargs["timeout"] == 60
+
+    def test_per_command_zero_timeout_raises(self) -> None:
+        """Zero per-command timeout should raise ValueError."""
+        backend = CLIShellBackend(inherit_env=True)
+        with pytest.raises(ValueError, match="timeout must be positive"):
+            backend.execute("echo hello", timeout=0)
+
+    def test_per_command_negative_timeout_raises(self) -> None:
+        """Negative per-command timeout should raise ValueError."""
+        backend = CLIShellBackend(inherit_env=True)
+        with pytest.raises(ValueError, match="timeout must be positive"):
+            backend.execute("echo hello", timeout=-5)
+
+
+class TestTimeoutErrorMessage:
+    """Tests for timeout error message with retry guidance."""
+
+    def test_timeout_error_includes_retry_guidance(self) -> None:
+        """Timeout error message should include guidance to use timeout parameter."""
+        backend = CLIShellBackend(timeout=1, inherit_env=True)
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 1)):
+            result = backend.execute("sleep 10")
+            assert "timed out" in result.output.lower()
+            assert "timeout parameter" in result.output.lower()
+            assert result.exit_code == 124
+
+    def test_timeout_error_shows_effective_timeout(self) -> None:
+        """Timeout error should show the effective timeout value used."""
+        backend = CLIShellBackend(timeout=60, inherit_env=True)
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 5)):
+            result = backend.execute("sleep 10", timeout=5)
+            assert "5" in result.output
+            assert "timeout parameter" in result.output.lower()


### PR DESCRIPTION
This functionality was lost in #1107

> [!WARNING]
> This is a temporary CLI-side implementation until #1154 lands the feature natively in the SDK. Once merged, these subclasses and the monkey-patch can be removed in favor of the SDK's built-in support.

---

Adds per-command timeout support to the CLI's execute tool so the LLM can override the default 120s timeout for long-running commands.