### PR TITLE
feat(cli): make thread id in splash clickable

### DIFF
--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -47,7 +47,8 @@ class WelcomeBanner(Static):
             thread_id: Optional thread ID to display in the banner.
             **kwargs: Additional arguments passed to parent.
         """
-        self._thread_id: str | None = thread_id
+        # Avoid collision with Widget._thread_id (Textual internal int)
+        self._cli_thread_id: str | None = thread_id
         self._project_name: str | None = None
 
         langsmith_key = os.environ.get("LANGSMITH_API_KEY") or os.environ.get(
@@ -108,8 +109,17 @@ class WelcomeBanner(Static):
                 banner.append(f"'{self._project_name}'", style="cyan")
             banner.append("\n")
 
-        if self._thread_id:
-            banner.append(f"Thread: {self._thread_id}\n", style="dim")
+        if self._cli_thread_id:
+            if project_url:
+                thread_url = f"{project_url}/t/{self._cli_thread_id}"
+                thread_line = Text.assemble(
+                    ("Thread: ", "dim"),
+                    (self._cli_thread_id, Style(dim=True, link=thread_url)),
+                    ("\n", "dim"),
+                )
+                banner.append_text(thread_line)
+            else:
+                banner.append(f"Thread: {self._cli_thread_id}\n", style="dim")
 
         banner.append("Ready to code! What would you like to build?\n", style="#10b981")
         bullet = get_glyphs().bullet

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -89,6 +89,13 @@ class WelcomeBanner(Static):
     def _build_banner(self, project_url: str | None = None) -> Text:
         """Build the banner rich text.
 
+        When a `project_url` is provided and a thread ID is set, the thread ID
+        is rendered as a clickable hyperlink to the LangSmith thread view.
+
+        Args:
+            project_url: LangSmith project URL used for linking the project
+                name and thread ID. When `None`, text is rendered without links.
+
         Returns:
             Rich Text object containing the formatted banner.
         """
@@ -111,7 +118,7 @@ class WelcomeBanner(Static):
 
         if self._cli_thread_id:
             if project_url:
-                thread_url = f"{project_url}/t/{self._cli_thread_id}"
+                thread_url = f"{project_url.rstrip('/')}/t/{self._cli_thread_id}"
                 thread_line = Text.assemble(
                     ("Thread: ", "dim"),
                     (self._cli_thread_id, Style(dim=True, link=thread_url)),

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -1,6 +1,7 @@
 """Unit tests for textual_adapter functions."""
 
 from asyncio import Future
+from datetime import datetime
 
 from deepagents_cli.textual_adapter import (
     TextualUIAdapter,
@@ -90,13 +91,26 @@ class TestBuildStreamConfig:
         assert config["metadata"]["agent_name"] == "my-agent"
         assert "updated_at" in config["metadata"]
 
+    def test_updated_at_is_valid_iso_timestamp(self) -> None:
+        """`updated_at` should be a valid timezone-aware ISO 8601 timestamp."""
+        config = _build_stream_config("t-456", assistant_id="my-agent")
+        raw = config["metadata"]["updated_at"]
+        assert isinstance(raw, str)
+        parsed = datetime.fromisoformat(raw)
+        assert parsed.tzinfo is not None
+
     def test_no_assistant_fields_when_none(self) -> None:
         """Assistant-specific fields should be absent when `assistant_id` is `None`."""
         config = _build_stream_config("t-789", assistant_id=None)
         assert config["metadata"] == {}
 
+    def test_no_assistant_fields_when_empty_string(self) -> None:
+        """Empty-string `assistant_id` should be treated as absent."""
+        config = _build_stream_config("t-000", assistant_id="")
+        assert config["metadata"] == {}
+
     def test_configurable_thread_id(self) -> None:
-        """``configurable.thread_id`` should match the provided thread ID."""
+        """`configurable.thread_id` should match the provided thread ID."""
         config = _build_stream_config("t-abc", assistant_id=None)
         assert config["configurable"]["thread_id"] == "t-abc"
 

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -2,7 +2,11 @@
 
 from asyncio import Future
 
-from deepagents_cli.textual_adapter import TextualUIAdapter, _is_summarization_chunk
+from deepagents_cli.textual_adapter import (
+    TextualUIAdapter,
+    _build_stream_config,
+    _is_summarization_chunk,
+)
 
 
 async def _mock_mount(widget: object) -> None:
@@ -74,6 +78,27 @@ class TestTextualUIAdapterInit:
         mock_tracker = object()
         adapter.set_token_tracker(mock_tracker)
         assert adapter._token_tracker is mock_tracker
+
+
+class TestBuildStreamConfig:
+    """Tests for `_build_stream_config` metadata construction."""
+
+    def test_assistant_fields_present(self) -> None:
+        """Assistant-specific metadata should be present when `assistant_id` is set."""
+        config = _build_stream_config("t-456", assistant_id="my-agent")
+        assert config["metadata"]["assistant_id"] == "my-agent"
+        assert config["metadata"]["agent_name"] == "my-agent"
+        assert "updated_at" in config["metadata"]
+
+    def test_no_assistant_fields_when_none(self) -> None:
+        """Assistant-specific fields should be absent when `assistant_id` is `None`."""
+        config = _build_stream_config("t-789", assistant_id=None)
+        assert config["metadata"] == {}
+
+    def test_configurable_thread_id(self) -> None:
+        """``configurable.thread_id`` should match the provided thread ID."""
+        config = _build_stream_config("t-abc", assistant_id=None)
+        assert config["configurable"]["thread_id"] == "t-abc"
 
 
 class TestIsSummarizationChunk:

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -11,6 +11,9 @@ from deepagents_cli.widgets.welcome import WelcomeBanner
 def _extract_links(banner: Text, text_start: int, text_end: int) -> list[str]:
     """Extract link URLs from spans covering the given text range.
 
+    Note: This relies on `rich.text.Text._spans` internals and may need
+    updating if the Rich library changes its internal representation.
+
     Args:
         banner: The Rich Text object to inspect.
         text_start: Start index in the plain text.
@@ -32,7 +35,7 @@ def _make_banner(
     thread_id: str | None = None,
     project_name: str | None = None,
 ) -> WelcomeBanner:
-    """Create a `WelcomeBanner` with LangSmith env vars cleared.
+    """Create a `WelcomeBanner` with all env vars cleared.
 
     Args:
         thread_id: Optional thread ID to display.
@@ -88,7 +91,7 @@ class TestBuildBannerThreadLink:
         banner = widget._build_banner(project_url=None)
         assert "Thread:" not in banner.plain
 
-    def test_thread_line_still_present_with_project_url_and_no_thread_id(self) -> None:
+    def test_no_thread_line_when_project_url_but_no_thread_id(self) -> None:
         """Banner should not contain a thread line even with `project_url`."""
         widget = _make_banner(thread_id=None)
         banner = widget._build_banner(
@@ -96,12 +99,41 @@ class TestBuildBannerThreadLink:
         )
         assert "Thread:" not in banner.plain
 
+    def test_trailing_slash_on_project_url_normalized(self) -> None:
+        """Trailing slash on `project_url` should not cause double-slash in URL."""
+        project_url = "https://smith.langchain.com/o/org/projects/p/abc123/"
+        widget = _make_banner(thread_id="55555")
+        banner = widget._build_banner(project_url=project_url)
+
+        thread_id_start = banner.plain.index("55555")
+        thread_id_end = thread_id_start + len("55555")
+        links = _extract_links(banner, thread_id_start, thread_id_end)
+        assert links
+        # Path portion (after ://) should not contain double slashes
+        path = links[0].split("://", 1)[1]
+        assert "//" not in path
+
+    def test_thread_link_coexists_with_langsmith_project(self) -> None:
+        """Thread link should work when LangSmith project info is also shown."""
+        project_url = "https://smith.langchain.com/o/org/projects/p/abc123"
+        widget = _make_banner(thread_id="77777", project_name="my-project")
+        banner = widget._build_banner(project_url=project_url)
+
+        assert "my-project" in banner.plain
+        assert "Thread: 77777" in banner.plain
+
+        thread_id_start = banner.plain.index("77777")
+        thread_id_end = thread_id_start + len("77777")
+        links = _extract_links(banner, thread_id_start, thread_id_end)
+        assert links
+        assert links[0] == f"{project_url}/t/77777"
+
 
 class TestBuildBannerReturnType:
     """Tests for `_build_banner` return value."""
 
     def test_returns_rich_text(self) -> None:
-        """``_build_banner`` should return a `rich.text.Text` object."""
+        """`_build_banner` should return a `rich.text.Text` object."""
         widget = _make_banner(thread_id="abc")
         result = widget._build_banner()
         assert isinstance(result, Text)

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -1,0 +1,107 @@
+"""Unit tests for the welcome banner widget."""
+
+from unittest.mock import patch
+
+from rich.style import Style
+from rich.text import Text
+
+from deepagents_cli.widgets.welcome import WelcomeBanner
+
+
+def _extract_links(banner: Text, text_start: int, text_end: int) -> list[str]:
+    """Extract link URLs from spans covering the given text range.
+
+    Args:
+        banner: The Rich Text object to inspect.
+        text_start: Start index in the plain text.
+        text_end: End index in the plain text.
+
+    Returns:
+        List of link URL strings found on spans covering the range.
+    """
+    links: list[str] = []
+    for start, end, style in banner._spans:
+        if not isinstance(style, Style):
+            continue
+        if start <= text_start and end >= text_end and style.link:
+            links.append(style.link)
+    return links
+
+
+def _make_banner(
+    thread_id: str | None = None,
+    project_name: str | None = None,
+) -> WelcomeBanner:
+    """Create a `WelcomeBanner` with LangSmith env vars cleared.
+
+    Args:
+        thread_id: Optional thread ID to display.
+        project_name: If set, simulates LangSmith being configured.
+
+    Returns:
+        A `WelcomeBanner` instance ready for testing.
+    """
+    env = {}
+    if project_name:
+        env["LANGSMITH_API_KEY"] = "fake-key"
+        env["LANGSMITH_TRACING"] = "true"
+        env["LANGSMITH_PROJECT"] = project_name
+
+    with patch.dict("os.environ", env, clear=True):
+        return WelcomeBanner(thread_id=thread_id)
+
+
+class TestBuildBannerThreadLink:
+    """Tests for thread ID display in `_build_banner`."""
+
+    def test_thread_id_plain_when_no_project_url(self) -> None:
+        """Thread ID should be plain dim text when `project_url` is `None`."""
+        widget = _make_banner(thread_id="12345")
+        banner = widget._build_banner(project_url=None)
+
+        assert "Thread: 12345" in banner.plain
+
+        # Verify no link style on the thread portion
+        thread_start = banner.plain.index("Thread: 12345")
+        thread_end = thread_start + len("Thread: 12345")
+        links = _extract_links(banner, thread_start, thread_end)
+        assert not links, "Thread ID should not have a link when project_url is None"
+
+    def test_thread_id_linked_when_project_url_provided(self) -> None:
+        """Thread ID should be a hyperlink when `project_url` is provided."""
+        project_url = "https://smith.langchain.com/o/org/projects/p/abc123"
+        widget = _make_banner(thread_id="99999")
+        banner = widget._build_banner(project_url=project_url)
+
+        assert "Thread: 99999" in banner.plain
+
+        # Find a span with a link on the thread ID text
+        thread_id_start = banner.plain.index("99999")
+        thread_id_end = thread_id_start + len("99999")
+        links = _extract_links(banner, thread_id_start, thread_id_end)
+        assert links, "Expected a link style on the thread ID text"
+        assert links[0] == f"{project_url}/t/99999"
+
+    def test_no_thread_line_when_thread_id_is_none(self) -> None:
+        """Banner should not contain a thread line when `thread_id` is `None`."""
+        widget = _make_banner(thread_id=None)
+        banner = widget._build_banner(project_url=None)
+        assert "Thread:" not in banner.plain
+
+    def test_thread_line_still_present_with_project_url_and_no_thread_id(self) -> None:
+        """Banner should not contain a thread line even with `project_url`."""
+        widget = _make_banner(thread_id=None)
+        banner = widget._build_banner(
+            project_url="https://smith.langchain.com/o/org/projects/p/abc123"
+        )
+        assert "Thread:" not in banner.plain
+
+
+class TestBuildBannerReturnType:
+    """Tests for `_build_banner` return value."""
+
+    def test_returns_rich_text(self) -> None:
+        """``_build_banner`` should return a `rich.text.Text` object."""
+        widget = _make_banner(thread_id="abc")
+        result = widget._build_banner()
+        assert isinstance(result, Text)


### PR DESCRIPTION
Closes #1048

Make the thread ID in the CLI splash banner a clickable hyperlink to the corresponding LangSmith thread URL when a LangSmith project is configured. Without a project URL, the thread ID renders as plain dim text like before.
