### PR TITLE
fix(cli): remove Interactive Features from --help output

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -705,11 +705,17 @@ class DeepAgentsApp(App):
             self.exit()
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))
-            await self._mount_message(
-                AppMessage(
-                    "Commands: /quit, /clear, /remember, /tokens, /threads, /help"
-                )
+            help_text = (
+                "Commands: /quit, /clear, /remember, /tokens, /threads, /help\n\n"
+                "Interactive Features:\n"
+                "  Enter           Submit your message\n"
+                "  Ctrl+J          Insert newline\n"
+                "  Shift+Tab       Toggle auto-approve mode\n"
+                "  @filename       Auto-complete files and inject content\n"
+                "  /command        Slash commands (/help, /clear, /quit)\n"
+                "  !command        Run bash commands directly"
             )
+            await self._mount_message(AppMessage(help_text))
 
         elif cmd == "/version":
             await self._mount_message(UserMessage(command))

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -296,16 +296,3 @@ def show_help() -> None:
         style=COLORS["dim"],
     )
     console.print()
-
-    console.print("[bold]Interactive Features:[/bold]", style=COLORS["primary"])
-    console.print("  Enter           Submit your message", style=COLORS["dim"])
-    console.print("  Ctrl+J          Insert newline", style=COLORS["dim"])
-    console.print("  Shift+Tab       Toggle auto-approve mode", style=COLORS["dim"])
-    console.print(
-        "  @filename       Auto-complete files and inject content", style=COLORS["dim"]
-    )
-    console.print(
-        "  /command        Slash commands (/help, /clear, /quit)", style=COLORS["dim"]
-    )
-    console.print("  !command        Run bash commands directly", style=COLORS["dim"])
-    console.print()

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -89,3 +89,17 @@ def test_cli_help_flag_short() -> None:
     # Help output should mention key options
     assert "--version" in result.stdout
     assert "--agent" in result.stdout
+
+
+def test_help_excludes_interactive_features() -> None:
+    """Verify that --help does not contain Interactive Features section."""
+    result = subprocess.run(
+        [sys.executable, "-m", "deepagents_cli.main", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # Help should succeed
+    assert result.returncode == 0
+    # Help should NOT contain Interactive Features section
+    assert "Interactive Features" not in result.stdout


### PR DESCRIPTION
## Summary

- Remove the Interactive Features section from --help / help output, as these keyboard shortcuts and session commands are only relevant inside the interactive session
- Move the Interactive Features info into the /help slash command, where users can discover it during an active session
- Add test to verify --help no longer includes the Interactive Features section

Closes #1156

<img width="669" height="786" alt="image" src="https://github.com/user-attachments/assets/e51a2266-a658-401a-acfc-85a1581ca98e" />

<img width="479" height="607" alt="image" src="https://github.com/user-attachments/assets/75d0405f-af02-4eb7-a79a-09cc9a518195" />


## Changes

| File | Change |
|------|--------|
| libs/cli/deepagents_cli/ui.py | Remove Interactive Features block from show_help() |
| libs/cli/deepagents_cli/app.py | Enhance /help slash command to include Interactive Features |
| libs/cli/tests/unit_tests/test_version.py | Add test_help_excludes_interactive_features() |

## Test plan

- [x] deepagents --help no longer shows Interactive Features section
- [x] /help in interactive session shows Commands + Interactive Features
- [x] All existing help/version tests pass (7/7)
- [x] No linter errors
