### PR TITLE
feat(sdk): default to Responses API

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -147,9 +147,9 @@ def create_deep_agent(
         if model.startswith("openai:"):
             # Use Responses API by default. To use chat completions, use
             # `model=init_chat_model("openai:...")`
-            # To disable data retention with the Responses API, use
-            # `model=init_chat_model("openai:...", use_responses_api=True, store=False)``
-            model_init_params: dict = {"use_responses_api": True}
+            # To enable data retention with the Responses API, use
+            # `model=init_chat_model("openai:...", use_responses_api=True, store=True)``
+            model_init_params: dict = {"use_responses_api": True, "store": False}
         else:
             model_init_params = {}
 


### PR DESCRIPTION
`create_deep_agent(model="openai:...")` now defaults to use the Responses API with `store=False`.

To use chat completions instead, use
```python
from langchain.chat_models import init_chat_model

model = init_chat_model("openai:...")
agent = create_deep_agent(model=model)
```

To enable data retention with the Responses API, use
```python
model = init_chat_model("openai:...", use_responses_api=True, store=True)
```