### PR TITLE
feat(deepagents): refactor summarization middleware

### DIFF
--- a/libs/cli/tests/unit_tests/test_end_to_end.py
+++ b/libs/cli/tests/unit_tests/test_end_to_end.py
@@ -9,11 +9,14 @@ from unittest.mock import patch
 
 from deepagents.backends import CompositeBackend
 from deepagents.backends.filesystem import FilesystemBackend
+from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool, tool
+from pydantic import Field
 
 from deepagents_cli.agent import create_cli_agent
 
@@ -27,6 +30,8 @@ def sample_tool(sample_input: str) -> str:
 class FixedGenericFakeChatModel(GenericFakeChatModel):
     """Fixed version of GenericFakeChatModel that properly handles bind_tools."""
 
+    captured_calls: list[tuple[list[Any], Any]] = Field(default_factory=list)
+
     def bind_tools(
         self,
         tools: Sequence[dict[str, Any] | type | Callable | BaseTool],  # noqa: ARG002
@@ -36,6 +41,20 @@ class FixedGenericFakeChatModel(GenericFakeChatModel):
     ) -> Runnable[LanguageModelInput, AIMessage]:
         """Override bind_tools to return self."""
         return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Override _generate to capture inputs and outputs."""
+        result = super()._generate(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        )
+        self.captured_calls.append((messages, result))
+        return result
 
 
 @contextmanager
@@ -183,9 +202,33 @@ class TestDeepAgentsCLIEndToEnd:
                 {"messages": input_messages},
                 {"configurable": {"thread_id": thread_id}},
             )
+            assert len(result["messages"]) == 8  # 7 inputs + response
+            assert result["messages"][-1].content == "response"
+
+            # two calls: one to summarize, one for response
+            assert len(model.captured_calls) == 2
+
+            # summarization call
+            summarization_input_messages, summarization_response = model.captured_calls[
+                0
+            ]
+            assert len(summarization_input_messages) == 1
+            assert "Messages to summarize:" in summarization_input_messages[0].content
             assert (
-                result["messages"][0].additional_kwargs["lc_source"] == "summarization"
+                summarization_response.generations[0].message.content
+                == "summary goes here"
             )
+
+            # model call on reduced context
+            summarized_messages, agent_response = model.captured_calls[1]
+            assert len(summarized_messages) < len(input_messages)
+            assert isinstance(summarized_messages[0], SystemMessage)
+            summary_message = summarized_messages[1]
+            assert isinstance(summary_message, HumanMessage)
+            assert "summary goes here" in summary_message.content
+            assert agent_response.generations[0].message.content == "response"
+
+            # Verify conversation history was offloaded to backend
             assert backend.ls_info("/conversation_history/")
 
     def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.77.0"
+version = "0.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -184,9 +184,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/85/6cb5da3cf91de2eeea89726316e8c5c8c31e2d61ee7cb1233d7e95512c31/anthropic-0.77.0.tar.gz", hash = "sha256:ce36efeb80cb1e25430a88440dc0f9aa5c87f10d080ab70a1bdfd5c2c5fbedb4", size = 504575, upload-time = "2026-01-29T18:20:41.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/51/32849a48f9b1cfe80a508fd269b20bd8f0b1357c70ba092890fde5a6a10b/anthropic-0.78.0.tar.gz", hash = "sha256:55fd978ab9b049c61857463f4c4e9e092b24f892519c6d8078cee1713d8af06e", size = 509136, upload-time = "2026-02-05T17:52:04.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/27/9df785d3f94df9ac72f43ee9e14b8120b37d992b18f4952774ed46145022/anthropic-0.77.0-py3-none-any.whl", hash = "sha256:65cc83a3c82ce622d5c677d0d7706c77d29dc83958c6b10286e12fda6ffb2651", size = 397867, upload-time = "2026-01-29T18:20:39.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/2f50931a942e5e13f80e24d83406714672c57964be593fc046d81369335b/anthropic-0.78.0-py3-none-any.whl", hash = "sha256:2a9887d2e99d1b0f9fe08857a1e9fe5d2d4030455dbf9ac65aab052e2efaeac4", size = 405485, upload-time = "2026-02-05T17:52:03.674Z" },
 ]
 
 [[package]]
@@ -772,9 +772,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.2.7,<2.0.0" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.7,<2.0.0" },
+    { name = "langchain", specifier = ">=1.2.9,<2.0.0" },
+    { name = "langchain-anthropic", specifier = ">=1.3.2,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.2.9,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
     { name = "wcmatch" },
 ]
@@ -1669,35 +1669,35 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.8"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/b7/a1d95dbb58e5e82dbd05e3730e2d4b99f784a4c6d39435579a1c2b8a8d12/langchain-1.2.8.tar.gz", hash = "sha256:d2bc45f8279f6291b152f28df3bb060b27c9a71163fe2e2a1ac878bd314d0dec", size = 558326, upload-time = "2026-02-02T15:51:59.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/d5/e7c8d18bf1ee2d37839dde161d523049fd0a5b172cf4c62f17090e1b4dcb/langchain-1.2.9.tar.gz", hash = "sha256:ae266c640b63c38f16b6d996a50aea575940b29b63cbc652c5d12f0111357f01", size = 569621, upload-time = "2026-02-06T12:39:41.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/1a/e1cabc08d8b12349fa6a898f033cc6b00a9a031b470582f4a9eb4cf8e55b/langchain-1.2.8-py3-none-any.whl", hash = "sha256:74a9595420b90e2fd6dc42e323e5e6c9f2a5d059b0ab51e4ad383893b86f8fbe", size = 108986, upload-time = "2026-02-02T15:51:58.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/ee07b79f8f1cfd87a6b147879149bdb03c04656e83e5a8c97f38d8915d07/langchain-1.2.9-py3-none-any.whl", hash = "sha256:c1af39d22b7f0415a6f8fa63b37f692335601d3333592c481b899166c55f3fcb", size = 111240, upload-time = "2026-02-06T12:39:39.833Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b6/ac5ee84e15bf79844c9c791f99a614c7ec7e1a63c2947e55977be01a81b4/langchain_anthropic-1.3.1.tar.gz", hash = "sha256:4f3d7a4a7729ab1aeaf62d32c87d4d227c1b5421668ca9e3734562b383470b07", size = 708940, upload-time = "2026-01-05T21:07:19.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/dd/c5e094079bdd748ca3f0bd0a09189ed2fa46bba56b5a8351198dc7c19e1f/langchain_anthropic-1.3.2.tar.gz", hash = "sha256:e551726a6ebf20229bde06022b5149d33bd48d28e34bd002a744953667b8ad48", size = 686239, upload-time = "2026-02-06T16:14:46.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/4f/7a5b32764addf4b757545b89899b9d76688176f19e4ee89868e3b8bbfd0f/langchain_anthropic-1.3.1-py3-none-any.whl", hash = "sha256:1fc28cf8037c30597ee6172fc2ff9e345efe8149a8c2a39897b1eebba2948322", size = 46328, upload-time = "2026-01-05T21:07:18.261Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/2da16c32308f79bb4588cec7095edbc770722ae4b3c3a1c135e05b0bdc2e/langchain_anthropic-1.3.2-py3-none-any.whl", hash = "sha256:35bc30862696a493680b898eb76bd6c866841f8e48a57d5eca1420a4fd807ac0", size = 46751, upload-time = "2026-02-06T16:14:44.734Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.8"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1709,9 +1709,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/cc/55bf57b83cbc164cbf84cbf0c5e4fb640d673546af131db70797b97b125b/langchain_core-1.2.8.tar.gz", hash = "sha256:76d933c3f4cfd8484d8131c39bf25f562e2df4d0d5fe3218e05ff773210713b6", size = 814506, upload-time = "2026-02-02T15:35:33.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/f501592b5d76b27a198f1102bafe365151a0a6f69444122fad6d10e6f4bf/langchain_core-1.2.9.tar.gz", hash = "sha256:a3768febc762307241d153b0f8bc58fd4b70c0ff077fda3274606741fca3f5a7", size = 815900, upload-time = "2026-02-05T14:21:43.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/d4/37fef9639b701c1fb1eea9e68447b72d86852ca3dc3253cdfd9c0afe228d/langchain_core-1.2.8-py3-none-any.whl", hash = "sha256:c732301272d63cfbcd75d114540257678627878f11b87046241272a25ba12ea7", size = 495753, upload-time = "2026-02-02T15:35:31.284Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/77846a98913e444d0d564070a9056bd999daada52bd099dc1e8812272810/langchain_core-1.2.9-py3-none-any.whl", hash = "sha256:7e5ecba5ed7a65852e8d5288e9ceeba05340fa9baf32baf672818b497bbaea8f", size = 496296, upload-time = "2026-02-05T14:21:42.816Z" },
 ]
 
 [[package]]

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -30,7 +30,7 @@ from deepagents.middleware.subagents import (
     SubAgent,
     SubAgentMiddleware,
 )
-from deepagents.middleware.summarization import SummarizationMiddleware, _compute_summarization_defaults
+from deepagents.middleware.summarization import _compute_summarization_defaults, _DeepAgentsSummarizationMiddleware
 
 BASE_AGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."
 
@@ -155,7 +155,7 @@ def create_deep_agent(
     gp_middleware: list[AgentMiddleware] = [
         TodoListMiddleware(),
         FilesystemMiddleware(backend=backend),
-        SummarizationMiddleware(
+        _DeepAgentsSummarizationMiddleware(
             model=model,
             backend=backend,
             trigger=summarization_defaults["trigger"],
@@ -195,7 +195,7 @@ def create_deep_agent(
             subagent_middleware: list[AgentMiddleware] = [
                 TodoListMiddleware(),
                 FilesystemMiddleware(backend=backend),
-                SummarizationMiddleware(
+                _DeepAgentsSummarizationMiddleware(
                     model=subagent_model,
                     backend=backend,
                     trigger=subagent_summarization_defaults["trigger"],
@@ -237,7 +237,7 @@ def create_deep_agent(
                 backend=backend,
                 subagents=all_subagents,
             ),
-            SummarizationMiddleware(
+            _DeepAgentsSummarizationMiddleware(
                 model=model,
                 backend=backend,
                 trigger=summarization_defaults["trigger"],

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -36,25 +36,28 @@ import logging
 import uuid
 import warnings
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired, cast
 
 from langchain.agents.middleware.summarization import (
     _DEFAULT_MESSAGES_TO_KEEP,
     _DEFAULT_TRIM_TOKEN_LIMIT,
     DEFAULT_SUMMARY_PROMPT,
     ContextSize,
-    SummarizationMiddleware as BaseSummarizationMiddleware,
+    SummarizationMiddleware as LCSummarizationMiddleware,
     TokenCounter,
 )
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
 from langchain.tools import ToolRuntime
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, RemoveMessage, get_buffer_string
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, get_buffer_string
 from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.config import get_config
-from langgraph.graph.message import REMOVE_ALL_MESSAGES
-from typing_extensions import TypedDict, override
+from langgraph.types import Command
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
-    from langchain.agents.middleware.types import AgentState
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
     from langchain.chat_models import BaseChatModel
     from langchain_core.runnables.config import RunnableConfig
     from langgraph.runtime import Runtime
@@ -62,6 +65,20 @@ if TYPE_CHECKING:
     from deepagents.backends.protocol import BACKEND_TYPES, BackendProtocol
 
 logger = logging.getLogger(__name__)
+
+
+class SummarizationEvent(TypedDict):
+    """Represents a summarization event.
+
+    Attributes:
+        cutoff_index: The index in the messages list where summarization occurred.
+        summary_message: The HumanMessage containing the summary.
+        file_path: Path where the conversation history was offloaded, or None if offload failed.
+    """
+
+    cutoff_index: int
+    summary_message: HumanMessage
+    file_path: str | None
 
 
 class TruncateArgsSettings(TypedDict, total=False):
@@ -78,6 +95,16 @@ class TruncateArgsSettings(TypedDict, total=False):
     keep: ContextSize
     max_length: int
     truncation_text: str
+
+
+class SummarizationState(AgentState):
+    """State for the summarization middleware.
+
+    Extends AgentState with a private field for tracking summarization events.
+    """
+
+    _summarization_event: Annotated[NotRequired[SummarizationEvent | None], PrivateStateAttr]
+    """Private field storing the most recent summarization event."""
 
 
 class SummarizationDefaults(TypedDict):
@@ -127,8 +154,10 @@ def _compute_summarization_defaults(model: BaseChatModel) -> SummarizationDefaul
     }
 
 
-class SummarizationMiddleware(BaseSummarizationMiddleware):
+class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
     """Summarization middleware with backend for conversation history offloading."""
+
+    state_schema = SummarizationState
 
     def __init__(
         self,
@@ -187,7 +216,8 @@ class SummarizationMiddleware(BaseSummarizationMiddleware):
             )
             ```
         """
-        super().__init__(
+        # Initialize langchain helper for core summarization logic
+        self._lc_helper = LCSummarizationMiddleware(
             model=model,
             trigger=trigger,
             keep=keep,
@@ -196,6 +226,8 @@ class SummarizationMiddleware(BaseSummarizationMiddleware):
             trim_tokens_to_summarize=trim_tokens_to_summarize,
             **deprecated_kwargs,
         )
+
+        # DeepAgents-specific attributes
         self._backend = backend
         self._history_path_prefix = history_path_prefix
 
@@ -210,6 +242,45 @@ class SummarizationMiddleware(BaseSummarizationMiddleware):
             self._truncate_args_keep = truncate_args_settings.get("keep", ("messages", 20))
             self._max_arg_length = truncate_args_settings.get("max_length", 2000)
             self._truncation_text = truncate_args_settings.get("truncation_text", "...(argument truncated)")
+
+    # Delegated properties and methods from langchain helper
+    @property
+    def model(self) -> BaseChatModel:
+        """The language model used for generating summaries."""
+        return self._lc_helper.model
+
+    @property
+    def token_counter(self) -> TokenCounter:
+        """Function to count tokens in messages."""
+        return self._lc_helper.token_counter
+
+    def _get_profile_limits(self) -> int | None:
+        """Retrieve max input token limit from the model profile."""
+        return self._lc_helper._get_profile_limits()
+
+    def _should_summarize(self, messages: list[AnyMessage], total_tokens: int) -> bool:
+        """Determine whether summarization should run for the current token usage."""
+        return self._lc_helper._should_summarize(messages, total_tokens)
+
+    def _determine_cutoff_index(self, messages: list[AnyMessage]) -> int:
+        """Choose cutoff index respecting retention configuration."""
+        return self._lc_helper._determine_cutoff_index(messages)
+
+    def _partition_messages(
+        self,
+        conversation_messages: list[AnyMessage],
+        cutoff_index: int,
+    ) -> tuple[list[AnyMessage], list[AnyMessage]]:
+        """Partition messages into those to summarize and those to preserve."""
+        return self._lc_helper._partition_messages(conversation_messages, cutoff_index)
+
+    def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
+        """Generate summary for the given messages."""
+        return self._lc_helper._create_summary(messages_to_summarize)
+
+    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
+        """Generate summary for the given messages (async)."""
+        return await self._lc_helper._acreate_summary(messages_to_summarize)
 
     def _get_backend(
         self,
@@ -342,6 +413,42 @@ A condensed summary follows:
                 additional_kwargs={"lc_source": "summarization"},
             )
         ]
+
+    def _get_effective_messages(self, request: ModelRequest) -> list[AnyMessage]:
+        """Generate effective messages for model call based on summarization event.
+
+        This reconstructs the message list by applying the most recent summarization event.
+        After summarization, instead of using all messages from state, we use the summary
+        message plus messages after the cutoff index.
+
+        Args:
+            request: The model request with messages from state.
+
+        Returns:
+            The effective message list to use for the model call. This includes the
+            most recent summary message (if we've summarized) and all preserved
+            messages from the cutoff index onward.
+        """
+        # Get messages from request (these are from state["messages"])
+        messages = request.messages
+
+        # Get summarization event from state
+        event = request.state.get("_summarization_event")
+
+        # If no summarization event, return all messages as-is
+        if event is None:
+            return messages
+
+        # Apply the summarization event
+        # The cutoff_index tells us: messages before cutoff are summarized, messages at/after are kept
+
+        # Build effective messages: summary message, then messages from cutoff onward
+        result = [event["summary_message"]]
+
+        # Add messages from cutoff_index onward (messages at cutoff_index and after are preserved)
+        result.extend(messages[event["cutoff_index"] :])
+
+        return result
 
     def _should_truncate_args(self, messages: list[AnyMessage], total_tokens: int) -> bool:
         """Check if argument truncation should be triggered.
@@ -644,31 +751,33 @@ A condensed summary follows:
             logger.debug("Offloaded %d messages to %s", len(filtered_messages), path)
             return path
 
-    @override
-    def before_model(
+    def wrap_model_call(
         self,
-        state: AgentState[Any],
-        runtime: Runtime,
-    ) -> dict[str, Any] | None:
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse | ExtendedModelResponse:
         """Process messages before model invocation, with history offloading and arg truncation.
 
-        First truncates large tool arguments in old messages if configured.
-        Then offloads messages to backend before summarization if thresholds are met.
-        The summary message includes a reference to the file path where the full
-        conversation history was stored.
+        First applies any previous summarization events to reconstruct the effective message list.
+        Then truncates large tool arguments in old messages if configured.
+        Finally offloads messages to backend before summarization if thresholds are met.
+
+        Unlike the legacy `before_model` approach, this does NOT modify the LangGraph state.
+        Instead, it tracks summarization events in middleware state and modifies the model
+        request directly.
 
         Args:
-            state: The agent state.
-            runtime: The runtime environment.
+            request: The model request to process.
+            handler: The handler to call with the (possibly modified) request.
 
         Returns:
-            Updated state with truncated/summarized messages if processing was performed.
+            The model response from the handler.
         """
-        messages = state["messages"]
-        self._ensure_message_ids(messages)
+        # Get effective messages based on previous summarization events
+        effective_messages = self._get_effective_messages(request)
 
         # Step 1: Truncate args if configured
-        truncated_messages, args_were_truncated = self._truncate_args(messages)
+        truncated_messages, args_were_truncated = self._truncate_args(effective_messages)
 
         # Step 2: Check if summarization should happen
         total_tokens = self.token_counter(truncated_messages)
@@ -676,34 +785,24 @@ A condensed summary follows:
 
         # If only truncation happened (no summarization)
         if args_were_truncated and not should_summarize:
-            return {
-                "messages": [
-                    RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                    *truncated_messages,
-                ]
-            }
+            return handler(request.override(messages=truncated_messages))
 
         # If no truncation and no summarization
         if not should_summarize:
-            return None
+            return handler(request.override(messages=truncated_messages))
 
         # Step 3: Perform summarization
         cutoff_index = self._determine_cutoff_index(truncated_messages)
         if cutoff_index <= 0:
             # If truncation happened but we can't summarize, still return truncated messages
             if args_were_truncated:
-                return {
-                    "messages": [
-                        RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                        *truncated_messages,
-                    ]
-                }
-            return None
+                return handler(request.override(messages=truncated_messages))
+            return handler(request.override(messages=truncated_messages))
 
         messages_to_summarize, preserved_messages = self._partition_messages(truncated_messages, cutoff_index)
 
         # Offload to backend first - abort summarization if this fails to prevent data loss
-        backend = self._get_backend(state, runtime)
+        backend = self._get_backend(request.state, request.runtime)
         file_path = self._offload_to_backend(backend, messages_to_summarize)
         if file_path is None:
             warnings.warn(
@@ -717,42 +816,57 @@ A condensed summary follows:
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
 
-        return {
-            "messages": [
-                RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                *new_messages,
-                *preserved_messages,
-            ]
+        # Calculate state cutoff index
+        # If this is a subsequent summarization, convert effective message index to state index
+        # new_state_cutoff = old_state_cutoff + effective_cutoff - 1  # noqa: ERA001
+        # The -1 accounts for the summary message at effective[0]
+        previous_event = request.state.get("_summarization_event")
+        state_cutoff_index = previous_event["cutoff_index"] + cutoff_index - 1 if previous_event is not None else cutoff_index
+
+        # Create new summarization event
+        new_event: SummarizationEvent = {
+            "cutoff_index": state_cutoff_index,
+            "summary_message": new_messages[0],  # The HumanMessage with summary
+            "file_path": file_path,
         }
 
-    @override
-    async def abefore_model(
+        # Modify request to use summarized messages
+        modified_messages = [*new_messages, *preserved_messages]
+        response = handler(request.override(messages=modified_messages))
+
+        # Return WrapModelCallResult with state update
+        return ExtendedModelResponse(
+            model_response=response,
+            command=Command(update={"_summarization_event": new_event}),
+        )
+
+    async def awrap_model_call(
         self,
-        state: AgentState[Any],
-        runtime: Runtime,
-    ) -> dict[str, Any] | None:
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse | ExtendedModelResponse:
         """Process messages before model invocation, with history offloading and arg truncation (async).
 
-        First truncates large tool arguments in old messages if configured.
-        Then offloads messages to backend before summarization if thresholds are met.
-        The summary message includes a reference to the file path where the
-        full conversation history was stored.
+        First applies any previous summarization events to reconstruct the effective message list.
+        Then truncates large tool arguments in old messages if configured.
+        Finally offloads messages to backend before summarization if thresholds are met.
 
-        The summary message includes a reference to the file path where the full
-        conversation history was stored.
+        Unlike the legacy `abefore_model` approach, this does NOT modify the LangGraph state.
+        Instead, it tracks summarization events in middleware state and modifies the model
+        request directly.
 
         Args:
-            state: The agent state.
-            runtime: The runtime environment.
+            request: The model request to process.
+            handler: The handler to call with the (possibly modified) request.
 
         Returns:
-            Updated state with truncated/summarized messages if processing was performed.
+            The model response from the handler.
         """
-        messages = state["messages"]
-        self._ensure_message_ids(messages)
+        # Get effective messages based on previous summarization events
+        effective_messages = self._get_effective_messages(request)
 
         # Step 1: Truncate args if configured
-        truncated_messages, args_were_truncated = self._truncate_args(messages)
+        truncated_messages, args_were_truncated = self._truncate_args(effective_messages)
 
         # Step 2: Check if summarization should happen
         total_tokens = self.token_counter(truncated_messages)
@@ -760,34 +874,24 @@ A condensed summary follows:
 
         # If only truncation happened (no summarization)
         if args_were_truncated and not should_summarize:
-            return {
-                "messages": [
-                    RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                    *truncated_messages,
-                ]
-            }
+            return await handler(request.override(messages=truncated_messages))
 
         # If no truncation and no summarization
         if not should_summarize:
-            return None
+            return await handler(request.override(messages=truncated_messages))
 
         # Step 3: Perform summarization
         cutoff_index = self._determine_cutoff_index(truncated_messages)
         if cutoff_index <= 0:
             # If truncation happened but we can't summarize, still return truncated messages
             if args_were_truncated:
-                return {
-                    "messages": [
-                        RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                        *truncated_messages,
-                    ]
-                }
-            return None
+                return await handler(request.override(messages=truncated_messages))
+            return await handler(request.override(messages=truncated_messages))
 
         messages_to_summarize, preserved_messages = self._partition_messages(truncated_messages, cutoff_index)
 
         # Offload to backend first - abort summarization if this fails to prevent data loss
-        backend = self._get_backend(state, runtime)
+        backend = self._get_backend(request.state, request.runtime)
         file_path = await self._aoffload_to_backend(backend, messages_to_summarize)
         if file_path is None:
             warnings.warn(
@@ -801,10 +905,30 @@ A condensed summary follows:
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
 
-        return {
-            "messages": [
-                RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                *new_messages,
-                *preserved_messages,
-            ]
+        # Calculate state cutoff index
+        # If this is a subsequent summarization, convert effective message index to state index
+        # new_state_cutoff = old_state_cutoff + effective_cutoff - 1  # noqa: ERA001
+        # The -1 accounts for the summary message at effective[0]
+        previous_event = request.state.get("_summarization_event")
+        state_cutoff_index = previous_event["cutoff_index"] + cutoff_index - 1 if previous_event is not None else cutoff_index
+
+        # Create new summarization event
+        new_event: SummarizationEvent = {
+            "cutoff_index": state_cutoff_index,
+            "summary_message": new_messages[0],  # The HumanMessage with summary
+            "file_path": file_path,
         }
+
+        # Modify request to use summarized messages
+        modified_messages = [*new_messages, *preserved_messages]
+        response = await handler(request.override(messages=modified_messages))
+
+        # Return WrapModelCallResult with state update
+        return ExtendedModelResponse(
+            model_response=response,
+            command=Command(update={"_summarization_event": new_event}),
+        )
+
+
+# Public alias
+SummarizationMiddleware = _DeepAgentsSummarizationMiddleware

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "langchain-core>=1.2.7,<2.0.0",
-    "langchain>=1.2.7,<2.0.0",
-    "langchain-anthropic>=1.3.1,<2.0.0",
+    "langchain-core>=1.2.9,<2.0.0",
+    "langchain>=1.2.9,<2.0.0",
+    "langchain-anthropic>=1.3.2,<2.0.0",
     "langchain-google-genai>=4.2.0,<5.0.0",
     "wcmatch",
 ]

--- a/libs/deepagents/tests/integration_tests/test_summarization.py
+++ b/libs/deepagents/tests/integration_tests/test_summarization.py
@@ -91,12 +91,13 @@ def test_summarize_continues_task(tmp_path: Path, model_name: str) -> None:
 
     input_message = {
         "role": "user",
-        "content": "Can you read the entirety of base.py and summarize it?",
+        "content": "Can you read the entirety of base.py, 500 lines at a time, and summarize it?",
     }
     result = agent.invoke({"messages": [input_message]}, config)
 
     # Check we summarized
-    assert result["messages"][0].additional_kwargs["lc_source"] == "summarization"
+    state = agent.get_state(config)
+    assert state.values["_summarization_event"]
 
     # Verify the agent made substantial progress reading the file after summarization.
     # We check the highest line number seen across all tool messages to confirm
@@ -135,12 +136,13 @@ def test_summarization_offloads_to_filesystem(tmp_path: Path, model_name: str) -
 
     input_message = {
         "role": "user",
-        "content": "Can you read the entirety of base.py and summarize it?",
+        "content": "Can you read the entirety of base.py, 500 lines at a time, and summarize it?",
     }
-    result = agent.invoke({"messages": [input_message]}, config)
+    _ = agent.invoke({"messages": [input_message]}, config)
 
     # Check we summarized
-    assert result["messages"][0].additional_kwargs["lc_source"] == "summarization"
+    state = agent.get_state(config)
+    assert state.values["_summarization_event"]
 
     # Verify conversation history was offloaded to filesystem
     conversation_history_root = root / "conversation_history"
@@ -161,7 +163,7 @@ def test_summarization_offloads_to_filesystem(tmp_path: Path, model_name: str) -
     assert "Human:" in content or "AI:" in content, "Missing message content in markdown file"
 
     # Verify the summary message references the conversation_history path
-    summary_message = result["messages"][0]
+    summary_message = state.values["_summarization_event"]["summary_message"]
     assert "conversation_history" in summary_message.content
     assert f"{thread_id}.md" in summary_message.content
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain.agents.middleware.types import ExtendedModelResponse, ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 
 from deepagents.backends.protocol import BackendProtocol, EditResult, FileDownloadResponse, WriteResult
@@ -228,6 +229,90 @@ def make_mock_model(summary_response: str = "This is a test summary.") -> MagicM
     return model
 
 
+def make_model_request(
+    state: "AgentState[Any]",
+    runtime: Any,  # noqa: ANN401
+) -> ModelRequest:
+    """Create a ModelRequest from a state dict.
+
+    Args:
+        state: The agent state containing messages.
+        runtime: The runtime object.
+
+    Returns:
+        A ModelRequest suitable for calling wrap_model_call.
+    """
+    mock_model = make_mock_model()
+    return ModelRequest(
+        model=mock_model,
+        messages=state["messages"],
+        system_message=None,
+        tools=[],
+        runtime=runtime,
+        state=state,
+    )
+
+
+def call_wrap_model_call(
+    middleware: SummarizationMiddleware,
+    state: "AgentState[Any]",
+    runtime: Any,  # noqa: ANN401
+) -> tuple["ModelResponse | ExtendedModelResponse", ModelRequest | None]:
+    """Helper to call wrap_model_call and capture what was passed to handler.
+
+    Args:
+        middleware: The middleware instance to test.
+        state: The agent state.
+        runtime: The runtime object.
+
+    Returns:
+        Tuple of (result, modified_request) where:
+        - result is the return value from wrap_model_call
+        - modified_request is the request passed to the handler (or None if handler wasn't called)
+    """
+    request = make_model_request(state, runtime)
+    captured_request = None
+
+    def handler(req: ModelRequest) -> "ModelResponse":
+        nonlocal captured_request
+        captured_request = req
+        # Return a mock response
+        return AIMessage(content="Mock response")
+
+    result = middleware.wrap_model_call(request, handler)
+    return result, captured_request
+
+
+async def call_awrap_model_call(
+    middleware: SummarizationMiddleware,
+    state: "AgentState[Any]",
+    runtime: Any,  # noqa: ANN401
+) -> tuple["ModelResponse | ExtendedModelResponse", ModelRequest | None]:
+    """Helper to call awrap_model_call and capture what was passed to handler (async version).
+
+    Args:
+        middleware: The middleware instance to test.
+        state: The agent state.
+        runtime: The runtime object.
+
+    Returns:
+        Tuple of (result, modified_request) where:
+        - result is the return value from awrap_model_call
+        - modified_request is the request passed to the handler (or None if handler wasn't called)
+    """
+    request = make_model_request(state, runtime)
+    captured_request = None
+
+    async def handler(req: ModelRequest) -> "ModelResponse":
+        nonlocal captured_request
+        captured_request = req
+        # Return a mock response
+        return AIMessage(content="Mock response")
+
+    result = await middleware.awrap_model_call(request, handler)
+    return result, captured_request
+
+
 # -----------------------------------------------------------------------------
 
 
@@ -282,10 +367,13 @@ class TestOffloadingBasic:
         runtime = make_mock_runtime()
 
         with mock_get_config():
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         # Should have triggered summarization
-        assert result is not None
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert "_summarization_event" in result.command.update
         assert len(backend.write_calls) == 1
 
         path, content = backend.write_calls[0]
@@ -311,7 +399,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        middleware.before_model(state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         assert len(backend.edit_calls) == 1
         _, old_string, new_string = backend.edit_calls[0]
@@ -367,9 +455,11 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = middleware.before_model(state, runtime)
+        result, _ = call_wrap_model_call(middleware, state, runtime)
 
-        assert result is not None
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
         assert len(backend.write_calls) == 1
 
         _, content = backend.write_calls[0]
@@ -413,9 +503,11 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = middleware.before_model(state, runtime)
+        result, _ = call_wrap_model_call(middleware, state, runtime)
 
-        assert result is not None
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
 
         _, content = backend.write_calls[0]
 
@@ -451,7 +543,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        middleware.before_model(state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         _, content = backend.write_calls[0]
 
@@ -480,11 +572,15 @@ class TestSummaryMessageFormat:
         runtime = make_mock_runtime()
 
         with mock_get_config(thread_id="test-thread"):
-            result = middleware.before_model(state, runtime)
-        assert result is not None
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-        # Get the summary message (second in list, after RemoveMessage)
-        summary_msg = result["messages"][1]
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
+
+        # Get the summary message (first in modified messages list)
+        summary_msg = modified_request.messages[0]
 
         # Should include the file path reference
         assert "full conversation history has been saved to" in summary_msg.content
@@ -511,10 +607,11 @@ class TestSummaryMessageFormat:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = middleware.before_model(state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-        assert result is not None
-        summary_msg = result["messages"][1]
+        assert isinstance(result, ExtendedModelResponse)
+        assert modified_request is not None
+        summary_msg = modified_request.messages[0]
 
         assert summary_msg.additional_kwargs.get("lc_source") == "summarization"
 
@@ -535,11 +632,13 @@ class TestSummaryMessageFormat:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
     def test_summary_includes_file_path_after_second_summarization(self) -> None:
         """Test that summary message includes file path reference after multiple summarizations.
@@ -577,12 +676,15 @@ class TestSummaryMessageFormat:
         runtime = make_mock_runtime()
 
         with mock_get_config(thread_id="multi-summarize-thread"):
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-        assert result is not None
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
-        # The summary message should be at index 1 (after RemoveMessage)
-        summary_msg = result["messages"][1]
+        # The summary message should be the first message
+        summary_msg = modified_request.messages[0]
 
         # Should include the file path reference
         assert "full conversation history has been saved to" in summary_msg.content
@@ -616,10 +718,10 @@ class TestNoSummarizationTriggered:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = middleware.before_model(state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-        # Should return None (no summarization)
-        assert result is None
+        # Should return ModelResponse (no summarization)
+        assert not isinstance(result, ExtendedModelResponse)
 
         # No writes should have occurred
         assert len(backend.write_calls) == 0
@@ -645,11 +747,13 @@ class TestBackendFailureHandling:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
     def test_summarization_aborts_on_write_exception(self) -> None:
         """Test that summarization warns when backend raises exception but still summarizes."""
@@ -670,11 +774,13 @@ class TestBackendFailureHandling:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
 
 class TestThreadIdExtraction:
@@ -697,7 +803,7 @@ class TestThreadIdExtraction:
         runtime = make_mock_runtime()
 
         with mock_get_config(thread_id="custom-thread-456"):
-            middleware.before_model(state, runtime)
+            call_wrap_model_call(middleware, state, runtime)
 
         path, _ = backend.write_calls[0]
         assert path == "/conversation_history/custom-thread-456.md"
@@ -719,7 +825,7 @@ class TestThreadIdExtraction:
         runtime = make_mock_runtime()
 
         with mock_get_config(thread_id=None):
-            middleware.before_model(state, runtime)
+            call_wrap_model_call(middleware, state, runtime)
 
         path, _ = backend.write_calls[0]
 
@@ -750,9 +856,11 @@ class TestAsyncBehavior:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = await middleware.abefore_model(state, runtime)
+        result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
-        assert result is not None
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
         assert len(backend.write_calls) == 1
 
     @pytest.mark.anyio
@@ -774,11 +882,13 @@ class TestAsyncBehavior:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = await middleware.abefore_model(state, runtime)
+            result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
 
 class TestBackendFactoryInvocation:
@@ -804,7 +914,7 @@ class TestBackendFactoryInvocation:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        middleware.before_model(state, runtime)
+        call_wrap_model_call(middleware, state, runtime)
 
         # Factory should have been called once
         assert len(factory_called_with) == 1
@@ -833,7 +943,7 @@ class TestCustomHistoryPathPrefix:
         runtime = make_mock_runtime()
 
         with mock_get_config(thread_id="test-thread"):
-            middleware.before_model(state, runtime)
+            call_wrap_model_call(middleware, state, runtime)
 
         path, _ = backend.write_calls[0]
         assert path == "/custom/path/test-thread.md"
@@ -858,8 +968,10 @@ class TestMarkdownFormatting:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = middleware.before_model(state, runtime)
-        assert result is not None
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
 
         # Verify the offloaded content is markdown formatted
         _, content = backend.write_calls[0]
@@ -890,10 +1002,11 @@ class TestDownloadFilesException:
         runtime = make_mock_runtime()
 
         # Should not raise - summarization should continue
-        result = middleware.before_model(state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
         # download_files was called (and raised)
         assert len(backend.download_files_calls) == 1
         # write should still be called (with no existing content)
@@ -918,10 +1031,11 @@ class TestDownloadFilesException:
         runtime = make_mock_runtime()
 
         # Should not raise - summarization should continue
-        result = await middleware.abefore_model(state, runtime)
+        result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
         # write should still be called (with no existing content)
         assert len(backend.write_calls) == 1
 
@@ -949,11 +1063,13 @@ class TestWriteEditException:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
     @pytest.mark.anyio
     async def test_async_summarization_aborts_on_write_exception(self) -> None:
@@ -977,11 +1093,13 @@ class TestWriteEditException:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = await middleware.abefore_model(state, runtime)
+            result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
     def test_summarization_aborts_on_edit_exception(self) -> None:
         """Test that summarization warns when `edit` raises an exception but still summarizes (existing content).
@@ -1004,11 +1122,13 @@ class TestWriteEditException:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = middleware.before_model(state, runtime)
+            result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
     @pytest.mark.anyio
     async def test_async_summarization_aborts_on_edit_exception(self) -> None:
@@ -1033,11 +1153,13 @@ class TestWriteEditException:
         runtime = make_mock_runtime()
 
         with pytest.warns(UserWarning, match="Offloading conversation history to backend failed"):
-            result = await middleware.abefore_model(state, runtime)
+            result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
         # Should still produce summarization result despite backend failure
-        assert result is not None
-        assert "messages" in result
+        assert isinstance(result, ExtendedModelResponse)
+        assert result.command is not None
+        assert result.command.update is not None
+        assert modified_request is not None
 
 
 class TestCutoffIndexEdgeCases:
@@ -1064,10 +1186,10 @@ class TestCutoffIndexEdgeCases:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = middleware.before_model(state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-        # Should return None because cutoff_index would be 0 or negative
-        assert result is None
+        # Should return ModelResponse (no summarization) because cutoff_index would be 0 or negative
+        assert not isinstance(result, ExtendedModelResponse)
         # No writes should occur
         assert len(backend.write_calls) == 0
 
@@ -1088,10 +1210,10 @@ class TestCutoffIndexEdgeCases:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = await middleware.abefore_model(state, runtime)
+        result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
-        # Should return None (no summarization)
-        assert result is None
+        # Should return ModelResponse (no summarization)
+        assert not isinstance(result, ExtendedModelResponse)
         # No writes should have occurred
         assert len(backend.write_calls) == 0
 
@@ -1118,10 +1240,10 @@ class TestCutoffIndexEdgeCases:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        result = await middleware.abefore_model(state, runtime)
+        result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
-        # Should return None because cutoff_index would be 0 or negative
-        assert result is None
+        # Should return ModelResponse (no summarization) because cutoff_index would be 0 or negative
+        assert not isinstance(result, ExtendedModelResponse)
         # No writes should occur
         assert len(backend.write_calls) == 0
 
@@ -1164,10 +1286,10 @@ def test_no_truncation_when_trigger_is_none() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    # Should return None (no truncation, no summarization)
-    assert result is None
+    # Should return ModelResponse (no truncation, no summarization)
+    assert not isinstance(result, ExtendedModelResponse)
 
 
 def test_truncate_old_write_file_tool_call() -> None:
@@ -1211,11 +1333,13 @@ def test_truncate_old_write_file_tool_call() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
 
     # Check that the old tool call was cleaned
     first_ai_msg = cleaned_messages[0]
@@ -1271,11 +1395,13 @@ def test_truncate_old_edit_file_tool_call() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
 
     first_ai_msg = cleaned_messages[0]
     assert first_ai_msg.tool_calls[0]["name"] == "edit_file"
@@ -1323,10 +1449,16 @@ def test_truncate_ignores_other_tool_calls() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    # Should return None since read_file is not cleaned
-    assert result is None
+    # Should return AIMessage since read_file is not cleaned (no truncation)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+
+    # Verify read_file args are unchanged
+    first_msg = modified_request.messages[0]
+    assert isinstance(first_msg, AIMessage)
+    assert first_msg.tool_calls[0]["args"]["content"] == large_content
 
 
 def test_truncate_respects_recent_messages() -> None:
@@ -1370,10 +1502,16 @@ def test_truncate_respects_recent_messages() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     # No truncation should happen since the tool call is in the keep window (last 4 messages)
-    assert result is None
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+
+    # Verify the write_file content is unchanged
+    write_file_msg = modified_request.messages[2]
+    assert isinstance(write_file_msg, AIMessage)
+    assert write_file_msg.tool_calls[0]["args"]["content"] == large_content
 
 
 def test_truncate_with_token_keep_policy() -> None:
@@ -1421,11 +1559,13 @@ def test_truncate_with_token_keep_policy() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
 
     # First message should be cleaned since it's outside the token window
     first_ai_msg = cleaned_messages[0]
@@ -1475,14 +1615,16 @@ def test_truncate_with_fraction_trigger_and_keep() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     # Should trigger truncation: 3 messages * 200 = 600 tokens > 500 threshold
     # Should keep only ~200 tokens (1 message) from the end
     # So first 2 messages should be in truncation zone
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
     first_ai_msg = cleaned_messages[0]
     assert first_ai_msg.tool_calls[0]["args"]["content"] == "x" * 20 + "...(argument truncated)"
 
@@ -1526,16 +1668,19 @@ def test_truncate_before_summarization() -> None:
     runtime = make_mock_runtime()
 
     with mock_get_config(thread_id="test-thread"):
-        result = middleware.before_model(state, runtime)
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
+    assert isinstance(result, ExtendedModelResponse)
+    assert result.command is not None
+    assert result.command.update is not None
+    assert modified_request is not None
 
     # Should have triggered both truncation and summarization
     # Backend should have received a write call for offloading
     assert len(backend.write_calls) == 1
 
-    # Result should contain summary message (skip RemoveMessage at index 0)
-    new_messages = result["messages"][1:]
+    # Result should contain summary message
+    new_messages = modified_request.messages
     assert any("summary" in str(msg.content).lower() for msg in new_messages)
 
 
@@ -1579,16 +1724,18 @@ def test_truncate_without_summarization() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
 
     # No backend write (no summarization)
     assert len(backend.write_calls) == 0
 
     # But truncation should have happened
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
     first_ai_msg = cleaned_messages[0]
     assert first_ai_msg.tool_calls[0]["args"]["content"] == "x" * 20 + "...(argument truncated)"
 
@@ -1633,10 +1780,16 @@ def test_truncate_preserves_small_arguments() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
     # No modification should happen since content is small
-    assert result is None
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+
+    # Verify the content is unchanged
+    first_msg = modified_request.messages[0]
+    assert isinstance(first_msg, AIMessage)
+    assert first_msg.tool_calls[0]["args"]["content"] == small_content
 
 
 def test_truncate_mixed_tool_calls() -> None:
@@ -1691,11 +1844,13 @@ def test_truncate_mixed_tool_calls() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
 
     first_ai_msg = cleaned_messages[0]
     assert len(first_ai_msg.tool_calls) == 3
@@ -1754,11 +1909,13 @@ def test_truncate_custom_truncation_text() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = middleware.before_model(state, runtime)
+    result, modified_request = call_wrap_model_call(middleware, state, runtime)
 
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
 
     first_ai_msg = cleaned_messages[0]
     assert first_ai_msg.tool_calls[0]["args"]["content"] == "y" * 20 + "[TRUNCATED]"
@@ -1805,11 +1962,106 @@ async def test_truncate_async_works() -> None:
     state = {"messages": messages}
     runtime = make_mock_runtime()
 
-    result = await middleware.abefore_model(state, runtime)
+    result, modified_request = await call_awrap_model_call(middleware, state, runtime)
 
-    assert result is not None
-    # Skip RemoveMessage at index 0, actual messages start at index 1
-    cleaned_messages = result["messages"][1:]
+    # Truncation only - returns AIMessage (ModelResponse)
+    assert isinstance(result, AIMessage)
+    assert modified_request is not None
+    # Truncation modifies messages inline
+    cleaned_messages = modified_request.messages
 
     first_ai_msg = cleaned_messages[0]
     assert first_ai_msg.tool_calls[0]["args"]["content"] == "x" * 20 + "...(argument truncated)"
+
+
+# -----------------------------------------------------------------------------
+# Chained summarization cutoff index tests
+# -----------------------------------------------------------------------------
+
+
+def test_chained_summarization_cutoff_index() -> None:
+    """Test that state_cutoff_index is computed correctly across three chained summarizations.
+
+    The formula is:
+        state_cutoff = old_state_cutoff + effective_cutoff - 1
+
+    The -1 accounts for the synthetic summary message at effective[0] which does not
+    correspond to any state message.
+
+    Setup: trigger=("messages", 5), keep=("messages", 2).
+
+    Round 1 (no previous event):
+        State: [S0..S7] (8 messages), cutoff = 8 - 2 = 6.
+        Preserved: [S6, S7]. Event: cutoff_index=6.
+
+    Round 2 (previous cutoff=6):
+        State: [S0..S13] (14 messages).
+        effective = [summary_1, S6..S13] (9 messages), effective cutoff = 9 - 2 = 7.
+        state_cutoff = 6 + 7 - 1 = 12. Preserved: [S12, S13].
+
+    Round 3 (previous cutoff=12):
+        State: [S0..S19] (20 messages).
+        effective = [summary_2, S12..S19] (9 messages), effective cutoff = 9 - 2 = 7.
+        state_cutoff = 12 + 7 - 1 = 18. Preserved: [S18, S19].
+    """
+    backend = MockBackend()
+    mock_model = make_mock_model()
+    middleware = SummarizationMiddleware(
+        model=mock_model,
+        backend=backend,
+        trigger=("messages", 5),
+        keep=("messages", 2),
+    )
+    runtime = make_mock_runtime()
+
+    def make_state_messages(n: int) -> list:
+        return [HumanMessage(content=f"S{i}", id=f"s{i}") if i % 2 == 0 else AIMessage(content=f"S{i}", id=f"s{i}") for i in range(n)]
+
+    def offloaded_labels(write_call_content: str) -> list[str]:
+        """Extract S-labels from backend write content (e.g. "Human: S0" -> "S0")."""
+        return [word for word in write_call_content.split() if word.startswith("S") and word[1:].isdigit()]
+
+    # --- Round 1: first summarization, no previous event ---
+    state = cast("AgentState[Any]", {"messages": make_state_messages(8)})
+    with mock_get_config():
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+
+    assert isinstance(result, ExtendedModelResponse)
+    event_1 = result.command.update["_summarization_event"]
+    assert event_1["cutoff_index"] == 6
+    assert modified_request is not None
+    assert [m.content for m in modified_request.messages[1:]] == ["S6", "S7"]
+    _, content = backend.write_calls[0]
+    assert offloaded_labels(content) == ["S0", "S1", "S2", "S3", "S4", "S5"]
+
+    # --- Round 2: second summarization, feed back event from round 1 ---
+    state = cast(
+        "AgentState[Any]",
+        {"messages": make_state_messages(14), "_summarization_event": event_1},
+    )
+    with mock_get_config():
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+
+    assert isinstance(result, ExtendedModelResponse)
+    event_2 = result.command.update["_summarization_event"]
+    assert event_2["cutoff_index"] == 12
+    assert modified_request is not None
+    assert [m.content for m in modified_request.messages[1:]] == ["S12", "S13"]
+    _, content = backend.write_calls[1]
+    assert offloaded_labels(content) == ["S6", "S7", "S8", "S9", "S10", "S11"]
+
+    # --- Round 3: third summarization, feed back event from round 2 ---
+    state = cast(
+        "AgentState[Any]",
+        {"messages": make_state_messages(20), "_summarization_event": event_2},
+    )
+    with mock_get_config():
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+
+    assert isinstance(result, ExtendedModelResponse)
+    event_3 = result.command.update["_summarization_event"]
+    assert event_3["cutoff_index"] == 18
+    assert modified_request is not None
+    assert [m.content for m in modified_request.messages[1:]] == ["S18", "S19"]
+    _, content = backend.write_calls[2]
+    assert offloaded_labels(content) == ["S12", "S13", "S14", "S15", "S16", "S17"]

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.75.0"
+version = "0.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -30,9 +30,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1f/08e95f4b7e2d35205ae5dcbb4ae97e7d477fc521c275c02609e2931ece2d/anthropic-0.75.0.tar.gz", hash = "sha256:e8607422f4ab616db2ea5baacc215dd5f028da99ce2f022e33c7c535b29f3dfb", size = 439565, upload-time = "2025-11-24T20:41:45.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/51/32849a48f9b1cfe80a508fd269b20bd8f0b1357c70ba092890fde5a6a10b/anthropic-0.78.0.tar.gz", hash = "sha256:55fd978ab9b049c61857463f4c4e9e092b24f892519c6d8078cee1713d8af06e", size = 509136, upload-time = "2026-02-05T17:52:04.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/1c/1cd02b7ae64302a6e06724bf80a96401d5313708651d277b1458504a1730/anthropic-0.75.0-py3-none-any.whl", hash = "sha256:ea8317271b6c15d80225a9f3c670152746e88805a7a61e14d4a374577164965b", size = 388164, upload-time = "2025-11-24T20:41:43.587Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/2f50931a942e5e13f80e24d83406714672c57964be593fc046d81369335b/anthropic-0.78.0-py3-none-any.whl", hash = "sha256:2a9887d2e99d1b0f9fe08857a1e9fe5d2d4030455dbf9ac65aab052e2efaeac4", size = 405485, upload-time = "2026-02-05T17:52:03.674Z" },
 ]
 
 [[package]]
@@ -387,9 +387,9 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.2.7,<2.0.0" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.7,<2.0.0" },
+    { name = "langchain", specifier = ">=1.2.9,<2.0.0" },
+    { name = "langchain-anthropic", specifier = ">=1.3.2,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.2.9,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
     { name = "wcmatch" },
 ]
@@ -744,35 +744,35 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.7"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/f2/478ca9f3455b5d66402066d287eae7e8d6c722acfb8553937e06af708334/langchain-1.2.7.tar.gz", hash = "sha256:ba40e8d5b069a22f7085f54f405973da3d87cfdebf116282e77c692271432ecb", size = 556837, upload-time = "2026-01-23T15:22:10.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/d5/e7c8d18bf1ee2d37839dde161d523049fd0a5b172cf4c62f17090e1b4dcb/langchain-1.2.9.tar.gz", hash = "sha256:ae266c640b63c38f16b6d996a50aea575940b29b63cbc652c5d12f0111357f01", size = 569621, upload-time = "2026-02-06T12:39:41.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/c8/9ce37ae34870834c7d00bb14ff4876b700db31b928635e3307804dc41d74/langchain-1.2.7-py3-none-any.whl", hash = "sha256:1d643c8ca569bcde2470b853807f74f0768b3982d25d66d57db21a166aabda72", size = 108827, upload-time = "2026-01-23T15:22:09.771Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/ee07b79f8f1cfd87a6b147879149bdb03c04656e83e5a8c97f38d8915d07/langchain-1.2.9-py3-none-any.whl", hash = "sha256:c1af39d22b7f0415a6f8fa63b37f692335601d3333592c481b899166c55f3fcb", size = 111240, upload-time = "2026-02-06T12:39:39.833Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b6/ac5ee84e15bf79844c9c791f99a614c7ec7e1a63c2947e55977be01a81b4/langchain_anthropic-1.3.1.tar.gz", hash = "sha256:4f3d7a4a7729ab1aeaf62d32c87d4d227c1b5421668ca9e3734562b383470b07", size = 708940, upload-time = "2026-01-05T21:07:19.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/dd/c5e094079bdd748ca3f0bd0a09189ed2fa46bba56b5a8351198dc7c19e1f/langchain_anthropic-1.3.2.tar.gz", hash = "sha256:e551726a6ebf20229bde06022b5149d33bd48d28e34bd002a744953667b8ad48", size = 686239, upload-time = "2026-02-06T16:14:46.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/4f/7a5b32764addf4b757545b89899b9d76688176f19e4ee89868e3b8bbfd0f/langchain_anthropic-1.3.1-py3-none-any.whl", hash = "sha256:1fc28cf8037c30597ee6172fc2ff9e345efe8149a8c2a39897b1eebba2948322", size = 46328, upload-time = "2026-01-05T21:07:18.261Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/2da16c32308f79bb4588cec7095edbc770722ae4b3c3a1c135e05b0bdc2e/langchain_anthropic-1.3.2-py3-none-any.whl", hash = "sha256:35bc30862696a493680b898eb76bd6c866841f8e48a57d5eca1420a4fd807ac0", size = 46751, upload-time = "2026-02-06T16:14:44.734Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -784,9 +784,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/0e/664d8d81b3493e09cbab72448d2f9d693d1fa5aa2bcc488602203a9b6da0/langchain_core-1.2.7.tar.gz", hash = "sha256:e1460639f96c352b4a41c375f25aeb8d16ffc1769499fb1c20503aad59305ced", size = 837039, upload-time = "2026-01-09T17:44:25.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/f501592b5d76b27a198f1102bafe365151a0a6f69444122fad6d10e6f4bf/langchain_core-1.2.9.tar.gz", hash = "sha256:a3768febc762307241d153b0f8bc58fd4b70c0ff077fda3274606741fca3f5a7", size = 815900, upload-time = "2026-02-05T14:21:43.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/6f/34a9fba14d191a67f7e2ee3dbce3e9b86d2fa7310e2c7f2c713583481bd2/langchain_core-1.2.7-py3-none-any.whl", hash = "sha256:452f4fef7a3d883357b22600788d37e3d8854ef29da345b7ac7099f33c31828b", size = 490232, upload-time = "2026-01-09T17:44:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/77846a98913e444d0d564070a9056bd999daada52bd099dc1e8812272810/langchain_core-1.2.9-py3-none-any.whl", hash = "sha256:7e5ecba5ed7a65852e8d5288e9ceeba05340fa9baf32baf672818b497bbaea8f", size = 496296, upload-time = "2026-02-05T14:21:42.816Z" },
 ]
 
 [[package]]

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.76.0"
+version = "0.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -174,9 +174,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/be/d11abafaa15d6304826438170f7574d750218f49a106c54424a40cef4494/anthropic-0.76.0.tar.gz", hash = "sha256:e0cae6a368986d5cf6df743dfbb1b9519e6a9eee9c6c942ad8121c0b34416ffe", size = 495483, upload-time = "2026-01-13T18:41:14.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/51/32849a48f9b1cfe80a508fd269b20bd8f0b1357c70ba092890fde5a6a10b/anthropic-0.78.0.tar.gz", hash = "sha256:55fd978ab9b049c61857463f4c4e9e092b24f892519c6d8078cee1713d8af06e", size = 509136, upload-time = "2026-02-05T17:52:04.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/70/7b0fd9c1a738f59d3babe2b4212031c34ab7d0fda4ffef15b58a55c5bcea/anthropic-0.76.0-py3-none-any.whl", hash = "sha256:81efa3113901192af2f0fe977d3ec73fdadb1e691586306c4256cd6d5ccc331c", size = 390309, upload-time = "2026-01-13T18:41:13.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/2f50931a942e5e13f80e24d83406714672c57964be593fc046d81369335b/anthropic-0.78.0-py3-none-any.whl", hash = "sha256:2a9887d2e99d1b0f9fe08857a1e9fe5d2d4030455dbf9ac65aab052e2efaeac4", size = 405485, upload-time = "2026-02-05T17:52:03.674Z" },
 ]
 
 [[package]]
@@ -679,9 +679,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.2.7,<2.0.0" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.7,<2.0.0" },
+    { name = "langchain", specifier = ">=1.2.9,<2.0.0" },
+    { name = "langchain-anthropic", specifier = ">=1.3.2,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.2.9,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
     { name = "wcmatch" },
 ]
@@ -1536,35 +1536,35 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.7"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/f2/478ca9f3455b5d66402066d287eae7e8d6c722acfb8553937e06af708334/langchain-1.2.7.tar.gz", hash = "sha256:ba40e8d5b069a22f7085f54f405973da3d87cfdebf116282e77c692271432ecb", size = 556837, upload-time = "2026-01-23T15:22:10.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/d5/e7c8d18bf1ee2d37839dde161d523049fd0a5b172cf4c62f17090e1b4dcb/langchain-1.2.9.tar.gz", hash = "sha256:ae266c640b63c38f16b6d996a50aea575940b29b63cbc652c5d12f0111357f01", size = 569621, upload-time = "2026-02-06T12:39:41.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/c8/9ce37ae34870834c7d00bb14ff4876b700db31b928635e3307804dc41d74/langchain-1.2.7-py3-none-any.whl", hash = "sha256:1d643c8ca569bcde2470b853807f74f0768b3982d25d66d57db21a166aabda72", size = 108827, upload-time = "2026-01-23T15:22:09.771Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/ee07b79f8f1cfd87a6b147879149bdb03c04656e83e5a8c97f38d8915d07/langchain-1.2.9-py3-none-any.whl", hash = "sha256:c1af39d22b7f0415a6f8fa63b37f692335601d3333592c481b899166c55f3fcb", size = 111240, upload-time = "2026-02-06T12:39:39.833Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b6/ac5ee84e15bf79844c9c791f99a614c7ec7e1a63c2947e55977be01a81b4/langchain_anthropic-1.3.1.tar.gz", hash = "sha256:4f3d7a4a7729ab1aeaf62d32c87d4d227c1b5421668ca9e3734562b383470b07", size = 708940, upload-time = "2026-01-05T21:07:19.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/dd/c5e094079bdd748ca3f0bd0a09189ed2fa46bba56b5a8351198dc7c19e1f/langchain_anthropic-1.3.2.tar.gz", hash = "sha256:e551726a6ebf20229bde06022b5149d33bd48d28e34bd002a744953667b8ad48", size = 686239, upload-time = "2026-02-06T16:14:46.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/4f/7a5b32764addf4b757545b89899b9d76688176f19e4ee89868e3b8bbfd0f/langchain_anthropic-1.3.1-py3-none-any.whl", hash = "sha256:1fc28cf8037c30597ee6172fc2ff9e345efe8149a8c2a39897b1eebba2948322", size = 46328, upload-time = "2026-01-05T21:07:18.261Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/2da16c32308f79bb4588cec7095edbc770722ae4b3c3a1c135e05b0bdc2e/langchain_anthropic-1.3.2-py3-none-any.whl", hash = "sha256:35bc30862696a493680b898eb76bd6c866841f8e48a57d5eca1420a4fd807ac0", size = 46751, upload-time = "2026-02-06T16:14:44.734Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1576,9 +1576,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/0e/664d8d81b3493e09cbab72448d2f9d693d1fa5aa2bcc488602203a9b6da0/langchain_core-1.2.7.tar.gz", hash = "sha256:e1460639f96c352b4a41c375f25aeb8d16ffc1769499fb1c20503aad59305ced", size = 837039, upload-time = "2026-01-09T17:44:25.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/f501592b5d76b27a198f1102bafe365151a0a6f69444122fad6d10e6f4bf/langchain_core-1.2.9.tar.gz", hash = "sha256:a3768febc762307241d153b0f8bc58fd4b70c0ff077fda3274606741fca3f5a7", size = 815900, upload-time = "2026-02-05T14:21:43.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/6f/34a9fba14d191a67f7e2ee3dbce3e9b86d2fa7310e2c7f2c713583481bd2/langchain_core-1.2.7-py3-none-any.whl", hash = "sha256:452f4fef7a3d883357b22600788d37e3d8854ef29da345b7ac7099f33c31828b", size = 490232, upload-time = "2026-01-09T17:44:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/77846a98913e444d0d564070a9056bd999daada52bd099dc1e8812272810/langchain_core-1.2.9-py3-none-any.whl", hash = "sha256:7e5ecba5ed7a65852e8d5288e9ceeba05340fa9baf32baf672818b497bbaea8f", size = 496296, upload-time = "2026-02-05T14:21:42.816Z" },
 ]
 
 [[package]]

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <4.0"
 
 [manifest]
@@ -623,9 +623,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.2.7,<2.0.0" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.7,<2.0.0" },
+    { name = "langchain", specifier = ">=1.2.9,<2.0.0" },
+    { name = "langchain-anthropic", specifier = ">=1.3.2,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.2.9,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
     { name = "wcmatch" },
 ]
@@ -1015,30 +1015,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.8"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/b7/a1d95dbb58e5e82dbd05e3730e2d4b99f784a4c6d39435579a1c2b8a8d12/langchain-1.2.8.tar.gz", hash = "sha256:d2bc45f8279f6291b152f28df3bb060b27c9a71163fe2e2a1ac878bd314d0dec", size = 558326, upload-time = "2026-02-02T15:51:59.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/d5/e7c8d18bf1ee2d37839dde161d523049fd0a5b172cf4c62f17090e1b4dcb/langchain-1.2.9.tar.gz", hash = "sha256:ae266c640b63c38f16b6d996a50aea575940b29b63cbc652c5d12f0111357f01", size = 569621, upload-time = "2026-02-06T12:39:41.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/1a/e1cabc08d8b12349fa6a898f033cc6b00a9a031b470582f4a9eb4cf8e55b/langchain-1.2.8-py3-none-any.whl", hash = "sha256:74a9595420b90e2fd6dc42e323e5e6c9f2a5d059b0ab51e4ad383893b86f8fbe", size = 108986, upload-time = "2026-02-02T15:51:58.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/ee07b79f8f1cfd87a6b147879149bdb03c04656e83e5a8c97f38d8915d07/langchain-1.2.9-py3-none-any.whl", hash = "sha256:c1af39d22b7f0415a6f8fa63b37f692335601d3333592c481b899166c55f3fcb", size = 111240, upload-time = "2026-02-06T12:39:39.833Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b6/ac5ee84e15bf79844c9c791f99a614c7ec7e1a63c2947e55977be01a81b4/langchain_anthropic-1.3.1.tar.gz", hash = "sha256:4f3d7a4a7729ab1aeaf62d32c87d4d227c1b5421668ca9e3734562b383470b07", size = 708940, upload-time = "2026-01-05T21:07:19.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/dd/c5e094079bdd748ca3f0bd0a09189ed2fa46bba56b5a8351198dc7c19e1f/langchain_anthropic-1.3.2.tar.gz", hash = "sha256:e551726a6ebf20229bde06022b5149d33bd48d28e34bd002a744953667b8ad48", size = 686239, upload-time = "2026-02-06T16:14:46.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/4f/7a5b32764addf4b757545b89899b9d76688176f19e4ee89868e3b8bbfd0f/langchain_anthropic-1.3.1-py3-none-any.whl", hash = "sha256:1fc28cf8037c30597ee6172fc2ff9e345efe8149a8c2a39897b1eebba2948322", size = 46328, upload-time = "2026-01-05T21:07:18.261Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/2da16c32308f79bb4588cec7095edbc770722ae4b3c3a1c135e05b0bdc2e/langchain_anthropic-1.3.2-py3-none-any.whl", hash = "sha256:35bc30862696a493680b898eb76bd6c866841f8e48a57d5eca1420a4fd807ac0", size = 46751, upload-time = "2026-02-06T16:14:44.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate `SummarizationMiddleware` from the inherited `before_model`/`abefore_model` pattern to the `wrap_model_call` protocol. Instead of mutating LangGraph state with `RemoveMessage(REMOVE_ALL_MESSAGES)` on each summarization, the middleware now tracks a `SummarizationEvent` in private state and reconstructs the effective message list on each call, avoiding full state rewrites.

Sample trace: https://smith.langchain.com/public/19d8beae-abb7-4d47-b8b4-18b284804b84/r