### PR TITLE
feat(cli): add `--openai-reasoning-effort` flag for OpenAI reasoning models

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -170,6 +170,16 @@ def parse_args() -> argparse.Namespace:
         "Provider is auto-detected from model name.",
     )
     parser.add_argument(
+        "--openai-reasoning-effort",
+        dest="openai_reasoning_effort",
+        choices=["none", "minimal", "low", "medium", "high"],
+        help=(
+            "OpenAI reasoning effort for reasoning-capable models (e.g., gpt-5.2). "
+            "If set, routes OpenAI calls through the Responses API. "
+            "You can also set OPENAI_REASONING_EFFORT."
+        ),
+    )
+    parser.add_argument(
         "--auto-approve",
         action="store_true",
         help="Auto-approve tool usage without prompting (disables human-in-the-loop)",
@@ -198,6 +208,7 @@ async def run_textual_cli_async(
     sandbox_type: str = "none",
     sandbox_id: str | None = None,
     model_name: str | None = None,
+    openai_reasoning_effort: str | None = None,
     thread_id: str | None = None,
     is_resumed: bool = False,
     initial_prompt: str | None = None,
@@ -211,6 +222,9 @@ async def run_textual_cli_async(
             ("none", "modal", "runloop", "daytona", "langsmith")
         sandbox_id: Optional existing sandbox ID to reuse
         model_name: Optional model name to use
+        openai_reasoning_effort: Optional reasoning effort override for OpenAI models.
+            If provided, OpenAI requests will be routed through the Responses API and
+            sent with `reasoning={"effort": <value>}`.
         thread_id: Thread ID to use (new or resumed)
         is_resumed: Whether this is a resumed session
         initial_prompt: Optional prompt to auto-submit when session starts
@@ -220,7 +234,7 @@ async def run_textual_cli_async(
     """
     from deepagents_cli.app import run_textual_app
 
-    model = create_model(model_name)
+    model = create_model(model_name, openai_reasoning_effort=openai_reasoning_effort)
 
     # Show thread info
     if is_resumed:
@@ -404,6 +418,9 @@ def cli_main() -> None:
                         sandbox_type=args.sandbox,
                         sandbox_id=args.sandbox_id,
                         model_name=getattr(args, "model", None),
+                        openai_reasoning_effort=getattr(
+                            args, "openai_reasoning_effort", None
+                        ),
                         thread_id=thread_id,
                         is_resumed=is_resumed,
                         initial_prompt=getattr(args, "initial_prompt", None),

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -243,6 +243,9 @@ def show_help() -> None:
         "  --model MODEL                 Model to use (e.g., claude-sonnet-4-5-20250929, gpt-4o)"  # noqa: E501
     )
     console.print(
+        "  --openai-reasoning-effort LVL OpenAI reasoning effort (none|low|medium|high)"
+    )
+    console.print(
         "  --auto-approve                Auto-approve tool usage without prompting"
     )
     console.print(
@@ -267,6 +270,10 @@ def show_help() -> None:
     )
     console.print(
         "  deepagents --model gpt-4o               # Use specific model (auto-detects provider)",  # noqa: E501
+        style=COLORS["dim"],
+    )
+    console.print(
+        "  deepagents --model gpt-5.2 --openai-reasoning-effort high   # Increase reasoning effort (OpenAI only)",  # noqa: E501
         style=COLORS["dim"],
     )
     console.print(

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -93,3 +93,17 @@ class TestResumeArg:
             args = parse_args()
         assert args.resume_thread == "thread456"
         assert args.initial_prompt == "continue work"
+
+
+class TestOpenAIReasoningEffortArg:
+    """Tests for --openai-reasoning-effort argument."""
+
+    def test_sets_value(self) -> None:
+        """Verify --openai-reasoning-effort sets openai_reasoning_effort."""
+        with patch.object(
+            sys,
+            "argv",
+            ["deepagents", "--openai-reasoning-effort", "high"],
+        ):
+            args = parse_args()
+        assert args.openai_reasoning_effort == "high"


### PR DESCRIPTION
Support configuring reasoning effort (none/low/medium/high) for OpenAI reasoning-capable models like gpt-5.2.
When set, routes requests through the Responses API with `reasoning={"effort": ...}`.
Also readable via the OPENAI_REASONING_EFFORT environment variable.