### PR TITLE
fix(cli): align skill-creator example scripts with agent skills spec

### DIFF
--- a/libs/cli/examples/skills/skill-creator/SKILL.md
+++ b/libs/cli/examples/skills/skill-creator/SKILL.md
@@ -349,7 +349,7 @@ The validation script checks:
 - Skill naming conventions (hyphen-case, max 64 characters)
 - Description completeness (no angle brackets, max 1024 characters)
 - Required fields: `name` and `description`
-- Allowed frontmatter properties only: `name`, `description`, `license`, `allowed-tools`, `metadata`
+- Allowed frontmatter properties only: `name`, `description`, `license`, `compatibility`, `allowed-tools`, `metadata`
 
 If validation fails, fix the reported errors and run the validation command again.
 

--- a/libs/cli/examples/skills/skill-creator/scripts/init_skill.py
+++ b/libs/cli/examples/skills/skill-creator/scripts/init_skill.py
@@ -282,7 +282,7 @@ def main():
         print("\nSkill name requirements:")
         print(" - Hyphen-case identifier (e.g., 'data-analyzer')")
         print(" - Lowercase letters, digits, and hyphens only")
-        print(" - Max 40 characters")
+        print(" - Max 64 characters")
         print(" - Must match directory name exactly")
         print("\nExamples:")
         print(" init_skill.py my-new-skill --path skills/public")

--- a/libs/cli/examples/skills/skill-creator/scripts/quick_validate.py
+++ b/libs/cli/examples/skills/skill-creator/scripts/quick_validate.py
@@ -52,7 +52,14 @@ def validate_skill(skill_path):
         return False, f"Invalid YAML in frontmatter: {e}"
 
     # Define allowed properties
-    ALLOWED_PROPERTIES = {"name", "description", "license", "allowed-tools", "metadata"}
+    ALLOWED_PROPERTIES = {
+        "name",
+        "description",
+        "license",
+        "compatibility",
+        "allowed-tools",
+        "metadata",
+    }
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
@@ -116,6 +123,19 @@ def validate_skill(skill_path):
                 (
                     f"Description is too long ({len(description)} characters). "
                     "Maximum is 1024 characters."
+                ),
+            )
+
+    # Extract and validate compatibility (max 500 characters per spec)
+    compatibility = frontmatter.get("compatibility", "")
+    if isinstance(compatibility, str):
+        compatibility = compatibility.strip()
+        if len(compatibility) > 500:
+            return (
+                False,
+                (
+                    f"Compatibility is too long ({len(compatibility)} characters). "
+                    "Maximum is 500 characters."
                 ),
             )
 


### PR DESCRIPTION
- Fix `init_skill.py` help text from "Max 40 characters" to "Max 64 characters" to match every other reference
- Add `compatibility` to `ALLOWED_PROPERTIES` in `quick_validate.py` and add length validation (max 500 chars per [spec](https://agentskills.io/specification))
  - Add `compatibility` to the allowed properties list in skill-creator `SKILL.md` docs