### PR TITLE
fix(cli): `-m` initial prompt submission

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -437,19 +437,21 @@ class DeepAgentsApp(App):
         # Size the spacer to fill remaining viewport below input
         self.call_after_refresh(self._size_initial_spacer)
 
-        # Load thread history if resuming a session
-        if self._lc_thread_id and self._agent:
-            self.call_after_refresh(
-                lambda: asyncio.create_task(self._load_thread_history())
-            )
-        # Auto-submit initial prompt if provided
-        # (but not when resuming - let user see history first)
-        elif self._initial_prompt and self._initial_prompt.strip():
+        # Auto-submit initial prompt if provided via -m flag.
+        # This check must come first because _lc_thread_id and _agent are
+        # always set (even for brand-new sessions), so an elif after the
+        # thread-history branch would never execute.
+        if self._initial_prompt and self._initial_prompt.strip():
             # Use call_after_refresh to ensure UI is fully mounted before submitting
             # Capture value for closure to satisfy type checker
             prompt = self._initial_prompt
             self.call_after_refresh(
                 lambda: asyncio.create_task(self._handle_user_message(prompt))
+            )
+        # Load thread history if resuming a session (no initial prompt)
+        elif self._lc_thread_id and self._agent:
+            self.call_after_refresh(
+                lambda: asyncio.create_task(self._load_thread_history())
             )
 
     def on_resize(self, _event: Resize) -> None:

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -252,8 +252,9 @@ def show_help() -> None:
         "  --sandbox-id ID               Reuse existing sandbox (skips creation/cleanup)"  # noqa: E501
     )
     console.print(
-        "  -r, --resume [ID]             Resume thread: -r for most recent, -r <ID> for specific"  # noqa: E501
+        "  -m, --message TEXT            Initial prompt to auto-submit on start"
     )
+    console.print("  -r, --resume [ID]             Resume thread: -r for most recent")
     console.print()
 
     console.print("[bold]Examples:[/bold]", style=COLORS["primary"])

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -34,7 +34,8 @@ class TestInitialPromptOnMount:
         )
         submitted: list[str] = []
 
-        async def capture(msg: str) -> None:
+        # Must be async to match _handle_user_message's signature
+        async def capture(msg: str) -> None:  # noqa: RUF029
             submitted.append(msg)
 
         app._handle_user_message = capture  # type: ignore[assignment]

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -20,6 +20,33 @@ from deepagents_cli.app import (
 )
 
 
+class TestInitialPromptOnMount:
+    """Test that -m initial prompt is submitted on mount."""
+
+    @pytest.mark.asyncio
+    async def test_initial_prompt_triggers_handle_user_message(self) -> None:
+        """When initial_prompt is set, the prompt should be auto-submitted."""
+        mock_agent = MagicMock()
+        app = DeepAgentsApp(
+            agent=mock_agent,
+            thread_id="new-thread-123",
+            initial_prompt="hello world",
+        )
+        submitted: list[str] = []
+
+        async def capture(msg: str) -> None:
+            submitted.append(msg)
+
+        app._handle_user_message = capture  # type: ignore[assignment]
+
+        async with app.run_test() as pilot:
+            # Give call_after_refresh time to fire
+            await pilot.pause()
+            await pilot.pause()
+
+        assert submitted == ["hello world"]
+
+
 class TestAppCSSValidation:
     """Test that app CSS is valid and doesn't cause runtime errors."""
 


### PR DESCRIPTION
The `-m`/`--message` flag for passing an initial prompt was silently broken. 

`_lc_thread_id` and `_agent` are always set (even for brand-new sessions), so the `elif` that checked for an initial prompt never executed. Swap the branch order in `on_mount` so the initial-prompt check runs first.