### PR TITLE
revert(sdk): default to Responses API

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -144,16 +144,7 @@ def create_deep_agent(
     if model is None:
         model = get_default_model()
     elif isinstance(model, str):
-        if model.startswith("openai:"):
-            # Use Responses API by default. To use chat completions, use
-            # `model=init_chat_model("openai:...")`
-            # To enable data retention with the Responses API, use
-            # `model=init_chat_model("openai:...", use_responses_api=True, store=True)``
-            model_init_params: dict = {"use_responses_api": True, "store": False}
-        else:
-            model_init_params = {}
-
-        model = init_chat_model(model, **model_init_params)
+        model = init_chat_model(model)
 
     # Compute summarization defaults based on model profile
     summarization_defaults = _compute_summarization_defaults(model)


### PR DESCRIPTION
Reverts langchain-ai/deepagents#1171

Responses with `store=False` [does not appear to support image generation](https://community.openai.com/t/how-to-achieve-multi-turn-image-editing-when-manually-managing-conversation-state/1358313/5?u=chester.curme) in (general) multi-turn contexts.

Need to decide among:
- Defaulting to Responses (`store=True` by default)
- Not defaulting to Responses and letting users opt-in
- Resolving issue with image generation or else hacking some handling for it (not recommended)

For now, reverting to get out of a broken state.