### PR TITLE
fix(cli): per-subcommand help screens, short flags, and skills enhancements

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -41,6 +41,9 @@ from deepagents_cli.integrations.sandbox_factory import get_default_working_dir
 from deepagents_cli.local_context import LocalContextMiddleware
 from deepagents_cli.subagents import list_subagents
 
+DEFAULT_AGENT_NAME = "agent"
+"""The default agent name used when no `-a` flag is provided."""
+
 
 def list_agents() -> None:
     """List all available agents."""
@@ -61,16 +64,20 @@ def list_agents() -> None:
         if agent_path.is_dir():
             agent_name = agent_path.name
             agent_md = agent_path / "AGENTS.md"
+            is_default = agent_name == DEFAULT_AGENT_NAME
+            default_label = " [dim](default)[/dim]" if is_default else ""
 
             bullet = get_glyphs().bullet
             if agent_md.exists():
                 console.print(
-                    f"  {bullet} [bold]{agent_name}[/bold]", style=COLORS["primary"]
+                    f"  {bullet} [bold]{agent_name}[/bold]{default_label}",
+                    style=COLORS["primary"],
                 )
                 console.print(f"    {agent_path}", style=COLORS["dim"])
             else:
                 console.print(
-                    f"  {bullet} [bold]{agent_name}[/bold] [dim](incomplete)[/dim]",
+                    f"  {bullet} [bold]{agent_name}[/bold]{default_label}"
+                    " [dim](incomplete)[/dim]",
                     style=COLORS["tool"],
                 )
                 console.print(f"    {agent_path}", style=COLORS["dim"])

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -16,7 +16,9 @@ import os
 import sys
 import traceback
 import warnings
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any
 
 # Suppress Pydantic v1 compatibility warnings from langchain on Python 3.14+
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
@@ -26,7 +28,12 @@ from rich.text import Text
 from deepagents_cli._version import __version__
 
 # Now safe to import agent (which imports LangChain modules)
-from deepagents_cli.agent import create_cli_agent, list_agents, reset_agent
+from deepagents_cli.agent import (
+    DEFAULT_AGENT_NAME,
+    create_cli_agent,
+    list_agents,
+    reset_agent,
+)
 
 # CRITICAL: Import config FIRST to set LANGSMITH_PROJECT before LangChain loads
 from deepagents_cli.config import (
@@ -47,7 +54,14 @@ from deepagents_cli.sessions import (
 )
 from deepagents_cli.skills import execute_skills_command, setup_skills_parser
 from deepagents_cli.tools import fetch_url, http_request, web_search
-from deepagents_cli.ui import show_help
+from deepagents_cli.ui import (
+    show_help,
+    show_list_help,
+    show_reset_help,
+    show_threads_delete_help,
+    show_threads_help,
+    show_threads_list_help,
+)
 
 
 def check_cli_dependencies() -> None:
@@ -84,49 +98,122 @@ def parse_args() -> argparse.Namespace:
     Returns:
         Parsed arguments namespace.
     """
+
+    # Factory that builds an argparse Action whose __call__ invokes the
+    # supplied *help_fn* instead of argparse's default help text.  Each
+    # subcommand can pass its own Rich-formatted help screen so that
+    # `deepagents <subcommand> -h` shows context-specific help.
+    def _make_help_action(
+        help_fn: Callable[[], None],
+    ) -> type[argparse.Action]:
+        """Create an argparse Action that displays *help_fn* and exits.
+
+        Args:
+            help_fn: Callable that prints help text to the console.
+
+        Returns:
+            An argparse Action class wired to the given help function.
+        """
+
+        class _ShowHelp(argparse.Action):
+            def __init__(
+                self,
+                option_strings: list[str],
+                dest: str = argparse.SUPPRESS,
+                default: str = argparse.SUPPRESS,
+                **kwargs: Any,
+            ) -> None:
+                super().__init__(
+                    option_strings=option_strings,
+                    dest=dest,
+                    default=default,
+                    nargs=0,
+                    **kwargs,
+                )
+
+            def __call__(
+                self,
+                parser: argparse.ArgumentParser,
+                namespace: argparse.Namespace,  # noqa: ARG002
+                values: str | Sequence[Any] | None,  # noqa: ARG002
+                option_string: str | None = None,  # noqa: ARG002
+            ) -> None:
+                help_fn()
+                parser.exit()
+
+        return _ShowHelp
+
+    # Shared parent for subcommands that should show the global help
+    help_parent = argparse.ArgumentParser(add_help=False)
+    help_parent.add_argument("-h", "--help", action=_make_help_action(show_help))
+
+    # Threads subcommand gets its own help parent
+    threads_help_parent = argparse.ArgumentParser(add_help=False)
+    threads_help_parent.add_argument(
+        "-h", "--help", action=_make_help_action(show_threads_help)
+    )
+
     parser = argparse.ArgumentParser(
         description="Deep Agents - AI Coding Assistant",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         add_help=False,
     )
-    parser.add_argument(
-        "-h",
-        "--help",
-        action="store_true",
-        help="Show this help message and exit",
-    )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"deepagents {__version__}",
-    )
-
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
-    # List command
-    subparsers.add_parser("list", help="List all available agents")
+    subparsers.add_parser(
+        "help",
+        help="Show help information",
+        add_help=False,
+        parents=[help_parent],
+    )
 
-    # Help command
-    subparsers.add_parser("help", help="Show help information")
+    list_help_parent = argparse.ArgumentParser(add_help=False)
+    list_help_parent.add_argument(
+        "-h", "--help", action=_make_help_action(show_list_help)
+    )
+    subparsers.add_parser(
+        "list",
+        help="List all available agents",
+        add_help=False,
+        parents=[list_help_parent],
+    )
 
-    # Reset command
-    reset_parser = subparsers.add_parser("reset", help="Reset an agent")
+    reset_help_parent = argparse.ArgumentParser(add_help=False)
+    reset_help_parent.add_argument(
+        "-h", "--help", action=_make_help_action(show_reset_help)
+    )
+    reset_parser = subparsers.add_parser(
+        "reset",
+        help="Reset an agent",
+        add_help=False,
+        parents=[reset_help_parent],
+    )
     reset_parser.add_argument("--agent", required=True, help="Name of agent to reset")
     reset_parser.add_argument(
         "--target", dest="source_agent", help="Copy prompt from another agent"
     )
 
-    # Skills command - setup delegated to skills module
-    setup_skills_parser(subparsers)
+    setup_skills_parser(subparsers, make_help_action=_make_help_action)
 
-    # Threads command
     threads_parser = subparsers.add_parser(
-        "threads", help="Manage conversation threads"
+        "threads",
+        help="Manage conversation threads",
+        add_help=False,
+        parents=[threads_help_parent],
     )
     threads_sub = threads_parser.add_subparsers(dest="threads_command")
 
-    # threads list
-    threads_list = threads_sub.add_parser("list", help="List threads")
+    threads_list_help_parent = argparse.ArgumentParser(add_help=False)
+    threads_list_help_parent.add_argument(
+        "-h", "--help", action=_make_help_action(show_threads_list_help)
+    )
+    threads_list = threads_sub.add_parser(
+        "list",
+        aliases=["ls"],
+        help="List threads",
+        add_help=False,
+        parents=[threads_list_help_parent],
+    )
     threads_list.add_argument(
         "--agent", default=None, help="Filter by agent name (default: show all)"
     )
@@ -136,19 +223,20 @@ def parse_args() -> argparse.Namespace:
         default=20,
         help="Max number of threads to display (default: 20)",
     )
-
-    # threads delete
-    threads_delete = threads_sub.add_parser("delete", help="Delete a thread")
+    threads_delete_help_parent = argparse.ArgumentParser(add_help=False)
+    threads_delete_help_parent.add_argument(
+        "-h", "--help", action=_make_help_action(show_threads_delete_help)
+    )
+    threads_delete = threads_sub.add_parser(
+        "delete",
+        help="Delete a thread",
+        add_help=False,
+        parents=[threads_delete_help_parent],
+    )
     threads_delete.add_argument("thread_id", help="Thread ID to delete")
 
-    # Default interactive mode
-    parser.add_argument(
-        "--agent",
-        default="agent",
-        help="Agent identifier for separate memory stores (default: agent).",
-    )
-
-    # Thread resume argument - matches PR #638: -r for most recent, -r <ID> for specific
+    # Default interactive mode — argument order here determines the
+    # usage line printed by argparse; keep in sync with ui.show_help().
     parser.add_argument(
         "-r",
         "--resume",
@@ -156,41 +244,72 @@ def parse_args() -> argparse.Namespace:
         nargs="?",
         const="__MOST_RECENT__",
         default=None,
+        metavar="ID",
         help="Resume thread: -r for most recent, -r <ID> for specific thread",
     )
 
-    # Initial prompt - auto-submit when session starts
+    parser.add_argument(
+        "-a",
+        "--agent",
+        default=DEFAULT_AGENT_NAME,
+        metavar="NAME",
+        help="Agent to use (e.g., coder, researcher).",
+    )
+
+    parser.add_argument(
+        "-M",
+        "--model",
+        metavar="MODEL",
+        help="Model to use (e.g., claude-sonnet-4-5-20250929, gpt-5.2). "
+        "Provider is auto-detected from model name.",
+    )
+
     parser.add_argument(
         "-m",
         "--message",
         dest="initial_prompt",
+        metavar="TEXT",
         help="Initial prompt to auto-submit when session starts",
     )
 
-    parser.add_argument(
-        "--model",
-        help="Model to use (e.g., claude-sonnet-4-5-20250929, gpt-5.2). "
-        "Provider is auto-detected from model name.",
-    )
     parser.add_argument(
         "--auto-approve",
         action="store_true",
         help="Auto-approve tool usage without prompting (disables human-in-the-loop)",
     )
+
     parser.add_argument(
         "--sandbox",
         choices=["none", "modal", "daytona", "runloop", "langsmith"],
         default="none",
+        metavar="TYPE",
         help="Remote sandbox for code execution (default: none - local only)",
     )
+
     parser.add_argument(
         "--sandbox-id",
+        metavar="ID",
         help="Existing sandbox ID to reuse (skips creation and cleanup)",
     )
+
     parser.add_argument(
         "--sandbox-setup",
+        metavar="PATH",
         help="Path to setup script to run in sandbox after creation",
     )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"deepagents-cli {__version__}",
+    )
+    parser.add_argument(
+        "-h",
+        "--help",
+        action=_make_help_action(show_help),
+    )
+
     return parser.parse_args()
 
 
@@ -307,11 +426,6 @@ def cli_main() -> None:
     try:
         args = parse_args()
 
-        # Handle -h/--help flag (custom help display)
-        if getattr(args, "help", False):
-            show_help()
-            sys.exit(0)
-
         if args.command == "help":
             show_help()
         elif args.command == "list":
@@ -321,7 +435,7 @@ def cli_main() -> None:
         elif args.command == "skills":
             execute_skills_command(args)
         elif args.command == "threads":
-            if args.threads_command == "list":
+            if args.threads_command in {"list", "ls"}:
                 asyncio.run(
                     list_threads_command(
                         agent_name=getattr(args, "agent", None),
@@ -331,9 +445,8 @@ def cli_main() -> None:
             elif args.threads_command == "delete":
                 asyncio.run(delete_thread_command(args.thread_id))
             else:
-                console.print(
-                    "[yellow]Usage: deepagents threads <list|delete>[/yellow]"
-                )
+                # No subcommand provided, show threads help screen
+                show_threads_help()
         else:
             # Interactive mode - handle thread resume
             thread_id = None
@@ -343,7 +456,7 @@ def cli_main() -> None:
                 # -r (no ID): Get most recent thread
                 # If --agent specified, filter by that agent; otherwise get
                 # most recent overall
-                agent_filter = args.agent if args.agent != "agent" else None
+                agent_filter = args.agent if args.agent != DEFAULT_AGENT_NAME else None
                 thread_id = asyncio.run(get_most_recent(agent_filter))
                 if thread_id:
                     is_resumed = True
@@ -364,7 +477,7 @@ def cli_main() -> None:
                 if asyncio.run(thread_exists(args.resume_thread)):
                     thread_id = args.resume_thread
                     is_resumed = True
-                    if args.agent == "agent":
+                    if args.agent == DEFAULT_AGENT_NAME:
                         agent_name = asyncio.run(get_thread_agent(thread_id))
                         if agent_name:
                             args.agent = agent_name

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -1,6 +1,6 @@
 """CLI commands for skill management.
 
-These commands are registered with the CLI via cli.py:
+These commands are registered with the CLI via main.py:
 - deepagents skills list --agent <agent> [--project]
 - deepagents skills create <name>
 - deepagents skills info <name>
@@ -8,11 +8,20 @@ These commands are registered with the CLI via cli.py:
 
 import argparse
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from deepagents.middleware.skills import SkillMetadata
+
 from deepagents_cli.config import COLORS, Settings, console, get_glyphs
 from deepagents_cli.skills.load import list_skills
+from deepagents_cli.ui import (
+    show_skills_create_help,
+    show_skills_help,
+    show_skills_info_help,
+    show_skills_list_help,
+)
 
 MAX_SKILL_NAME_LENGTH = 64
 
@@ -89,6 +98,32 @@ def _validate_skill_path(skill_dir: Path, base_dir: Path) -> tuple[bool, str]:
         return True, ""
 
 
+def _format_info_fields(skill: SkillMetadata) -> list[tuple[str, str]]:
+    """Extract non-empty optional metadata fields for display.
+
+    Args:
+        skill: Skill metadata to extract display fields from.
+
+    Returns:
+        Ordered list of (label, value) tuples for non-empty fields.
+            Fields appear in order: License, Compatibility, Allowed Tools,
+            Metadata.
+    """
+    fields: list[tuple[str, str]] = []
+    license_val = skill.get("license")
+    if license_val:
+        fields.append(("License", license_val))
+    compat_val = skill.get("compatibility")
+    if compat_val:
+        fields.append(("Compatibility", compat_val))
+    if skill.get("allowed_tools"):
+        fields.append(("Allowed Tools", ", ".join(skill["allowed_tools"])))
+    if skill.get("metadata"):
+        formatted = ", ".join(f"{k}={v}" for k, v in skill["metadata"].items())
+        fields.append(("Metadata", formatted))
+    return fields
+
+
 def _list(agent: str, *, project: bool = False) -> None:
     """List all available skills for the specified agent.
 
@@ -155,14 +190,16 @@ def _list(agent: str, *, project: bool = False) -> None:
         )
 
         if not skills:
+            console.print()
             console.print("[yellow]No skills found.[/yellow]")
+            console.print()
             console.print(
                 "[dim]Skills are loaded from these directories "
-                "(lowest to highest precedence):\n"
-                "  1. ~/.deepagents/<agent>/skills/   (user, deepagents alias)\n"
-                "  2. ~/.agents/skills/               (user)\n"
-                "  3. .deepagents/skills/             (project, deepagents alias)\n"
-                "  4. .agents/skills/                 (project)[/dim]",
+                "(highest precedence first):\n"
+                "  1. .agents/skills/                 project skills\n"
+                "  2. .deepagents/skills/             project skills (alias)\n"
+                "  3. ~/.agents/skills/               user skills\n"
+                "  4. ~/.deepagents/<agent>/skills/   user skills (alias)[/dim]",
                 style=COLORS["dim"],
             )
             console.print(
@@ -186,8 +223,9 @@ def _list(agent: str, *, project: bool = False) -> None:
             skill_path = Path(skill["path"])
             name = skill["name"]
             console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
+            console.print(f"    {skill_path.parent}/", style=COLORS["dim"])
+            console.print()
             console.print(f"    {skill['description']}", style=COLORS["dim"])
-            console.print(f"    Location: {skill_path.parent}/", style=COLORS["dim"])
             console.print()
 
     # Show project skills
@@ -202,8 +240,9 @@ def _list(agent: str, *, project: bool = False) -> None:
             skill_path = Path(skill["path"])
             name = skill["name"]
             console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
+            console.print(f"    {skill_path.parent}/", style=COLORS["dim"])
+            console.print()
             console.print(f"    {skill['description']}", style=COLORS["dim"])
-            console.print(f"    Location: {skill_path.parent}/", style=COLORS["dim"])
             console.print()
 
 
@@ -212,6 +251,7 @@ def _generate_template(skill_name: str) -> str:
 
     The template follows the Agent Skills spec
     (https://agentskills.io/specification) and the skill-creator guidance:
+
     - Description includes "when to use" trigger information (not the body)
     - Body contains only instructions loaded after the skill triggers
 
@@ -234,7 +274,7 @@ name: {skill_name}
 description: "{description}"
 # Optional fields per Agent Skills spec:
 # license: Apache-2.0
-# compatibility: Designed for deepagents CLI
+# compatibility: Designed for Deep Agents CLI
 # metadata:
 #   author: your-org
 #   version: "1.0"
@@ -341,7 +381,7 @@ def _create(skill_name: str, agent: str, project: bool = False) -> None:
     skill_md.write_text(template)
 
     console.print(
-        f"{get_glyphs().checkmark} Skill '{skill_name}' created successfully!",
+        f"\n[bold]{get_glyphs().checkmark} Skill '{skill_name}' created successfully![/bold]",  # noqa: E501
         style=COLORS["primary"],
     )
     console.print(f"Location: {skill_dir}\n", style=COLORS["dim"])
@@ -353,7 +393,7 @@ def _create(skill_name: str, agent: str, project: bool = False) -> None:
         "\n"
         f"  nano {skill_md}\n"
         "\n"
-        "💡 See examples/skills/ in the deepagents repo for example skills:\n"
+        "  See examples/skills/ in the deepagents-cli repo for example skills:\n"
         "   - web-research: Structured research workflow\n"
         "   - langgraph-docs: LangGraph documentation lookup\n"
         "\n"
@@ -415,15 +455,35 @@ def _info(skill_name: str, *, agent: str = "agent", project: bool = False) -> No
     source_label = "Project Skill" if skill["source"] == "project" else "User Skill"
     source_color = "green" if skill["source"] == "project" else "cyan"
 
+    # Check if this project skill shadows a user skill with the same name
+    shadowed_user_skill = False
+    if skill["source"] == "project" and not project:
+        user_only = list_skills(
+            user_skills_dir=user_skills_dir,
+            project_skills_dir=None,
+            user_agent_skills_dir=user_agent_skills_dir,
+            project_agent_skills_dir=None,
+        )
+        shadowed_user_skill = any(s["name"] == skill_name for s in user_only)
+
     console.print(
         f"\n[bold]Skill: {skill['name']}[/bold] "
         f"[bold {source_color}]({source_label})[/bold {source_color}]\n",
         style=COLORS["primary"],
     )
+    if shadowed_user_skill:
+        console.print(
+            f"[yellow]Note: Overrides user skill '{skill_name}' "
+            "of the same name[/yellow]\n"
+        )
+    console.print(f"[bold]Location:[/bold] {skill_path.parent}/\n", style=COLORS["dim"])
     console.print(
         f"[bold]Description:[/bold] {skill['description']}\n", style=COLORS["dim"]
     )
-    console.print(f"[bold]Location:[/bold] {skill_path.parent}/\n", style=COLORS["dim"])
+
+    # Show optional metadata fields
+    for label, value in _format_info_fields(skill):
+        console.print(f"[bold]{label}:[/bold] {value}\n", style=COLORS["dim"])
 
     # List supporting files
     skill_dir = skill_path.parent
@@ -443,28 +503,46 @@ def _info(skill_name: str, *, agent: str = "agent", project: bool = False) -> No
 
 def setup_skills_parser(
     subparsers: Any,
+    *,
+    make_help_action: Callable[[Callable[[], None]], type[argparse.Action]],
 ) -> argparse.ArgumentParser:
     """Setup the skills subcommand parser with all its subcommands.
+
+    Each subcommand gets a dedicated help screen so that
+    `deepagents skills -h` shows skills-specific help, not the
+    global help.
+
+    Args:
+        subparsers: The parent subparsers object to add the skills parser to.
+        make_help_action: Factory that accepts a zero-argument help
+            callable and returns an argparse Action class wired to it.
 
     Returns:
         The skills subparser for argument handling.
     """
-    skills_epilog = """\
-skill directories (lowest to highest precedence):
-  1. ~/.deepagents/<agent>/skills/   user skills (deepagents alias)
-  2. ~/.agents/skills/               user skills
-  3. .deepagents/skills/             project skills (deepagents alias)
-  4. .agents/skills/                 project skills
 
-When two directories contain a skill with the same name, the
-higher-precedence version wins. Project skills override user skills.
-"""
+    def _parent(
+        help_fn: Callable[[], None],
+    ) -> list[argparse.ArgumentParser]:
+        """Build a one-off parent parser wired to *help_fn*.
+
+        Args:
+            help_fn: Zero-argument callable that renders a Rich help screen.
+
+        Returns:
+            Single-element list suitable for the `parents` kwarg of
+            `add_parser`.
+        """
+        parent = argparse.ArgumentParser(add_help=False)
+        parent.add_argument("-h", "--help", action=make_help_action(help_fn))
+        return [parent]
+
     skills_parser = subparsers.add_parser(
         "skills",
         help="Manage agent skills",
-        description="Manage agent skills - create, list, and view skill information.",
-        epilog=skills_epilog,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=("Manage agent skills - create, list, and view skill information."),
+        add_help=False,
+        parents=_parent(show_skills_help),
     )
     skills_subparsers = skills_parser.add_subparsers(
         dest="skills_command", help="Skills command"
@@ -473,11 +551,14 @@ higher-precedence version wins. Project skills override user skills.
     # Skills list
     list_parser = skills_subparsers.add_parser(
         "list",
+        aliases=["ls"],
         help="List all available skills",
         description=(
             "List skills from all four skill directories "
             "(user, user alias, project, project alias)."
         ),
+        add_help=False,
+        parents=_parent(show_skills_list_help),
     )
     list_parser.add_argument(
         "--agent",
@@ -496,12 +577,17 @@ higher-precedence version wins. Project skills override user skills.
         help="Create a new skill",
         description=(
             "Create a new skill with a template SKILL.md file. "
-            "By default, skills are created in ~/.deepagents/<agent>/skills/. "
-            "Use --project to create in the project's .deepagents/skills/ directory."
+            "By default, skills are created in "
+            "~/.deepagents/<agent>/skills/. "
+            "Use --project to create in the project's "
+            ".deepagents/skills/ directory."
         ),
+        add_help=False,
+        parents=_parent(show_skills_create_help),
     )
     create_parser.add_argument(
-        "name", help="Name of the skill to create (e.g., web-research)"
+        "name",
+        help="Name of the skill to create (e.g., web-research)",
     )
     create_parser.add_argument(
         "--agent",
@@ -511,14 +597,16 @@ higher-precedence version wins. Project skills override user skills.
     create_parser.add_argument(
         "--project",
         action="store_true",
-        help="Create skill in project directory instead of user directory",
+        help=("Create skill in project directory instead of user directory"),
     )
 
     # Skills info
     info_parser = skills_subparsers.add_parser(
         "info",
         help="Show detailed information about a skill",
-        description="Show detailed information about a specific skill",
+        description=("Show detailed information about a specific skill"),
+        add_help=False,
+        parents=_parent(show_skills_info_help),
     )
     info_parser.add_argument("name", help="Name of the skill to show info for")
     info_parser.add_argument(
@@ -554,31 +642,15 @@ def execute_skills_command(args: argparse.Namespace) -> None:
             )
             return
 
-    if args.skills_command == "list":
+    if args.skills_command in {"list", "ls"}:
         _list(agent=args.agent, project=args.project)
     elif args.skills_command == "create":
         _create(args.name, agent=args.agent, project=args.project)
     elif args.skills_command == "info":
         _info(args.name, agent=args.agent, project=args.project)
     else:
-        # No subcommand provided, show help
-        console.print(
-            "[yellow]Please specify a skills subcommand: list, create, or info[/yellow]"
-        )
-        console.print("\n[bold]Usage:[/bold]", style=COLORS["primary"])
-        console.print("  deepagents skills <command> [options]\n")
-        console.print("[bold]Available commands:[/bold]", style=COLORS["primary"])
-        console.print("  list              List all available skills")
-        console.print("  create <name>     Create a new skill")
-        console.print("  info <name>       Show detailed information about a skill")
-        console.print("\n[bold]Examples:[/bold]", style=COLORS["primary"])
-        console.print("  deepagents skills list")
-        console.print("  deepagents skills create web-research")
-        console.print("  deepagents skills info web-research")
-        console.print(
-            "\n[dim]For more help on a specific command:[/dim]", style=COLORS["dim"]
-        )
-        console.print("  deepagents skills <command> --help", style=COLORS["dim"])
+        # No subcommand provided, show skills help screen
+        show_skills_help()
 
 
 __all__ = [

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -281,6 +281,7 @@ def _generate_template(skill_name: str) -> str:
     return f"""---
 name: {skill_name}
 description: "{description}"
+# (Warning: SKILL.md files exceeding 10 MB are silently skipped at load time.)
 # Optional fields per Agent Skills spec:
 # license: Apache-2.0
 # compatibility: Designed for Deep Agents CLI

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -218,7 +218,7 @@ def show_help() -> None:
     )
     console.print()
     console.print(
-        f"[bold {banner_color}]deepagents[/bold {banner_color}]"
+        f"[bold {banner_color}]deepagents-cli[/bold {banner_color}]"
         f" v{__version__}{install_type}"
     )
     console.print()
@@ -230,78 +230,203 @@ def show_help() -> None:
         "  deepagents list                                List all available agents"
     )
     console.print(
-        "  deepagents reset --agent AGENT                 Reset agent to default prompt"
+        "  deepagents reset --agent AGENT [--target SRC]  Reset an agent's prompt"
     )
     console.print(
-        "  deepagents reset --agent AGENT --target SOURCE Reset agent to copy of another agent"  # noqa: E501
+        "  deepagents skills <list|create|info>           Manage agent skills"
     )
     console.print(
-        "  deepagents help                                Show this help message"
-    )
-    console.print(
-        "  deepagents --version                           Show deepagents version"
+        "  deepagents threads <list|delete>               Manage conversation threads"
     )
     console.print()
 
     console.print("[bold]Options:[/bold]", style=COLORS["primary"])
-    console.print("  -h, --help                    Show this help message and exit")
-    console.print("  --agent NAME                  Agent identifier (default: agent)")
     console.print(
-        "  --model MODEL                 Model to use (e.g., claude-sonnet-4-5-20250929, gpt-4o)"  # noqa: E501
+        "  -r, --resume [ID]          Resume thread: -r for most recent, -r ID for specific"  # noqa: E501
+    )
+    console.print("  -a, --agent NAME           Agent to use (e.g., coder, researcher)")
+    console.print("  -M, --model MODEL          Model to use (e.g., gpt-4o)")
+    console.print("  -m, --message TEXT         Initial prompt to auto-submit on start")
+    console.print(
+        "  --auto-approve             Auto-approve tool usage without prompting"
+    )
+    console.print("  --sandbox TYPE             Remote sandbox for execution")
+    console.print(
+        "  --sandbox-id ID            Reuse existing sandbox (skips creation/cleanup)"
     )
     console.print(
-        "  --auto-approve                Auto-approve tool usage without prompting"
+        "  --sandbox-setup PATH       Setup script to run in sandbox after creation"
     )
-    console.print(
-        "  --sandbox TYPE                Remote sandbox for execution (modal, runloop, daytona)"  # noqa: E501
-    )
-    console.print(
-        "  --sandbox-id ID               Reuse existing sandbox (skips creation/cleanup)"  # noqa: E501
-    )
-    console.print(
-        "  -m, --message TEXT            Initial prompt to auto-submit on start"
-    )
-    console.print("  -r, --resume [ID]             Resume thread: -r for most recent")
+    console.print("  -v, --version              Show deepagents CLI version")
+    console.print("  -h, --help                 Show this help message and exit")
     console.print()
 
+
+def show_list_help() -> None:
+    """Show help information for the `list` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents list")
+    console.print()
+    console.print(
+        "List all agents found in ~/.deepagents/. Each agent has its own",
+    )
+    console.print(
+        "AGENTS.md system prompt and separate thread history.",
+    )
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  -h, --help        Show this help message")
+    console.print()
+
+
+def show_reset_help() -> None:
+    """Show help information for the `reset` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents reset --agent NAME [--target SRC]")
+    console.print()
+    console.print(
+        "Restore an agent's AGENTS.md to the built-in default, or copy",
+    )
+    console.print(
+        "another agent's AGENTS.md. This deletes the agent's directory",
+    )
+    console.print(
+        "and recreates it with the new prompt.",
+    )
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  --agent NAME      Agent to reset (required)")
+    console.print("  --target SRC      Copy AGENTS.md from another agent instead")
+    console.print("  -h, --help        Show this help message")
+    console.print()
     console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
-    console.print(
-        "  deepagents                              # Start with default agent",
-        style=COLORS["dim"],
-    )
-    console.print(
-        "  deepagents --agent mybot                # Start with agent named 'mybot'",
-        style=COLORS["dim"],
-    )
-    console.print(
-        "  deepagents --model gpt-4o               # Use specific model (auto-detects provider)",  # noqa: E501
-        style=COLORS["dim"],
-    )
-    console.print(
-        "  deepagents -r                           # Resume most recent thread",
-        style=COLORS["dim"],
-    )
-    console.print(
-        "  deepagents -r abc123                    # Resume specific thread",
-        style=COLORS["dim"],
-    )
-    console.print(
-        "  deepagents --auto-approve               # Start with auto-approve enabled",
-        style=COLORS["dim"],
-    )
-    console.print(
-        "  deepagents --sandbox runloop            # Execute code in Runloop sandbox",
-        style=COLORS["dim"],
-    )
+    console.print("  deepagents reset --agent coder")
+    console.print("  deepagents reset --agent coder --target researcher")
     console.print()
 
-    console.print("[bold]Thread Management:[/bold]", style=COLORS["primary"])
+
+def show_skills_help() -> None:
+    """Show help information for the `skills` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents skills <command> [options]")
+    console.print()
+    console.print("[bold]Commands:[/bold]", style=COLORS["primary"])
+    console.print("  list|ls           List all available skills")
+    console.print("  create <name>     Create a new skill")
+    console.print("  info <name>       Show detailed information about a skill")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  -h, --help        Show this help message")
+    console.print()
     console.print(
-        "  deepagents threads list                 # List all threads",
+        "[dim]Skills are loaded from these directories "
+        "(highest precedence first):\n"
+        "  1. .agents/skills/                 project skills\n"
+        "  2. .deepagents/skills/             project skills (alias)\n"
+        "  3. ~/.agents/skills/               user skills\n"
+        "  4. ~/.deepagents/<agent>/skills/   user skills (alias)[/dim]",
         style=COLORS["dim"],
     )
     console.print(
-        "  deepagents threads delete <ID>          # Delete a thread",
+        "\n[dim]Create your first skill:\n  deepagents skills create my-skill[/dim]",
         style=COLORS["dim"],
     )
+
+
+def show_skills_list_help() -> None:
+    """Show help information for the `skills list` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents skills list [options]")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  --agent NAME      Agent identifier (default: agent)")
+    console.print("  --project         Show only project-level skills")
+    console.print("  -h, --help        Show this help message")
+    console.print()
+
+
+def show_skills_create_help() -> None:
+    """Show help information for the `skills create` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents skills create <name> [options]")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  --agent NAME      Agent identifier (default: agent)")
+    console.print(
+        "  --project         Create in project directory instead of user directory"
+    )
+    console.print("  -h, --help        Show this help message")
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents skills create web-research")
+    console.print("  deepagents skills create my-skill --project")
+    console.print()
+
+
+def show_skills_info_help() -> None:
+    """Show help information for the `skills info` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents skills info <name> [options]")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  --agent NAME      Agent identifier (default: agent)")
+    console.print("  --project         Search only in project skills")
+    console.print("  -h, --help        Show this help message")
+    console.print()
+
+
+def show_threads_help() -> None:
+    """Show help information for the `threads` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents threads <command> [options]")
+    console.print()
+    console.print("[bold]Commands:[/bold]", style=COLORS["primary"])
+    console.print("  list|ls           List all threads")
+    console.print("  delete <ID>       Delete a thread")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  -h, --help        Show this help message")
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents threads list")
+    console.print("  deepagents threads delete abc123")
+    console.print()
+
+
+def show_threads_delete_help() -> None:
+    """Show help information for the `threads delete` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents threads delete <ID>")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  -h, --help        Show this help message")
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents threads delete abc123")
+    console.print()
+
+
+def show_threads_list_help() -> None:
+    """Show help information for the `threads list` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents threads list [options]")
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print("  --agent NAME      Filter by agent name")
+    console.print("  --limit N         Maximum threads to display (default: 20)")
+    console.print("  -h, --help        Show this help message")
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents threads list")
+    console.print("  deepagents threads list --agent mybot")
+    console.print("  deepagents threads list --limit 50")
     console.print()

--- a/libs/cli/examples/skills/skill-creator/SKILL.md
+++ b/libs/cli/examples/skills/skill-creator/SKILL.md
@@ -147,7 +147,7 @@ Skills use a three-level loading system to manage context efficiently:
 
 #### Progressive Disclosure Patterns
 
-Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. SKILL.md files exceeding 10 MB are silently skipped by the agent runtime. Split content into separate files when approaching the line limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
 
 **Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
 

--- a/libs/cli/tests/unit_tests/skills/test_commands.py
+++ b/libs/cli/tests/unit_tests/skills/test_commands.py
@@ -496,6 +496,24 @@ class TestThreadsListAlias:
         assert args.threads_command == "list"
 
 
+class TestSkillsListAlias:
+    """Test that `deepagents skills ls` is parsed as a `list` alias."""
+
+    def test_skills_ls_alias_parsed(self) -> None:
+        """Verify `skills ls` sets skills_command to 'ls'."""
+        with patch("sys.argv", ["deepagents", "skills", "ls"]):
+            args = parse_args()
+        assert args.command == "skills"
+        assert args.skills_command == "ls"
+
+    def test_skills_list_still_works(self) -> None:
+        """Verify `skills list` still works after alias addition."""
+        with patch("sys.argv", ["deepagents", "skills", "list"]):
+            args = parse_args()
+        assert args.command == "skills"
+        assert args.skills_command == "list"
+
+
 class TestInfoShadowWarning:
     """Test that `skills info` warns when a project skill shadows a user skill."""
 

--- a/libs/cli/tests/unit_tests/skills/test_commands.py
+++ b/libs/cli/tests/unit_tests/skills/test_commands.py
@@ -1,13 +1,19 @@
 """Unit tests for skills command sanitization and validation."""
 
+import io
 import re
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
-from deepagents.middleware.skills import _parse_skill_metadata
+from deepagents.middleware.skills import SkillMetadata, _parse_skill_metadata
+from rich.console import Console
 
+from deepagents_cli.main import parse_args
 from deepagents_cli.skills.commands import (
+    _format_info_fields,
     _generate_template,
+    _info,
     _validate_name,
     _validate_skill_path,
 )
@@ -269,3 +275,314 @@ class TestGenerateTemplate:
         assert "when" in description, (
             "Description placeholder should guide users to include 'when to use' info"
         )
+
+
+def _make_skill(
+    *,
+    name: str = "test-skill",
+    description: str = "A test skill",
+    path: str = "/tmp/test-skill/SKILL.md",
+    skill_license: str | None = None,
+    compatibility: str | None = None,
+    metadata: dict[str, str] | None = None,
+    allowed_tools: list[str] | None = None,
+) -> SkillMetadata:
+    """Build a minimal `SkillMetadata` dict with overrides.
+
+    Args:
+        name: Skill identifier.
+        description: What the skill does.
+        path: Path to the SKILL.md file.
+        skill_license: License name or `None`.
+        compatibility: Environment requirements or `None`.
+        metadata: Arbitrary key-value pairs.
+        allowed_tools: Recommended tool names.
+
+    Returns:
+        A `SkillMetadata` TypedDict with the given values.
+    """
+    return SkillMetadata(
+        name=name,
+        description=description,
+        path=path,
+        license=skill_license,
+        compatibility=compatibility,
+        metadata=metadata if metadata is not None else {},
+        allowed_tools=allowed_tools if allowed_tools is not None else [],
+    )
+
+
+class TestFormatInfoFields:
+    """Tests for `_format_info_fields` optional metadata extraction."""
+
+    def test_all_fields_present(self) -> None:
+        """All four optional fields populated should produce four entries."""
+        skill = _make_skill(
+            skill_license="MIT",
+            compatibility="Python 3.10+",
+            allowed_tools=["Bash(git:*)", "Read"],
+            metadata={"author": "acme", "version": "1.0"},
+        )
+        result = _format_info_fields(skill)
+        labels = [label for label, _ in result]
+        assert labels == [
+            "License",
+            "Compatibility",
+            "Allowed Tools",
+            "Metadata",
+        ]
+        assert result[0] == ("License", "MIT")
+        assert result[1] == ("Compatibility", "Python 3.10+")
+        assert result[2] == ("Allowed Tools", "Bash(git:*), Read")
+        assert "author=acme" in result[3][1]
+        assert "version=1.0" in result[3][1]
+
+    def test_no_optional_fields(self) -> None:
+        """When all optional fields are None/empty, return empty list."""
+        skill = _make_skill()
+        result = _format_info_fields(skill)
+        assert result == []
+
+    def test_license_only(self) -> None:
+        """Only license set should return a single License entry."""
+        skill = _make_skill(skill_license="Apache-2.0")
+        result = _format_info_fields(skill)
+        assert len(result) == 1
+        assert result[0] == ("License", "Apache-2.0")
+
+    def test_compatibility_only(self) -> None:
+        """Only compatibility set should return a single Compatibility entry."""
+        skill = _make_skill(compatibility="Requires poppler")
+        result = _format_info_fields(skill)
+        assert len(result) == 1
+        assert result[0] == ("Compatibility", "Requires poppler")
+
+    def test_allowed_tools_only(self) -> None:
+        """Only allowed_tools populated should return entry."""
+        skill = _make_skill(allowed_tools=["Bash", "Read"])
+        result = _format_info_fields(skill)
+        assert len(result) == 1
+        assert result[0] == ("Allowed Tools", "Bash, Read")
+
+    def test_metadata_only(self) -> None:
+        """Only metadata populated should return a Metadata entry."""
+        skill = _make_skill(metadata={"author": "test-org"})
+        result = _format_info_fields(skill)
+        assert len(result) == 1
+        assert result[0] == ("Metadata", "author=test-org")
+
+    def test_field_order(self) -> None:
+        """Fields appear in order: License, Compatibility, Allowed Tools, Metadata."""
+        skill = _make_skill(
+            metadata={"k": "v"},
+            skill_license="GPL-3.0",
+            allowed_tools=["Write"],
+            compatibility="macOS only",
+        )
+        result = _format_info_fields(skill)
+        labels = [label for label, _ in result]
+        assert labels == [
+            "License",
+            "Compatibility",
+            "Allowed Tools",
+            "Metadata",
+        ]
+
+
+class TestSkillsHelpFlag:
+    """Test that `deepagents skills -h` shows skills-specific help."""
+
+    def test_skills_help_shows_subcommands(self) -> None:
+        """Running `deepagents skills -h` should show skills subcommands.
+
+        Regression: -h on the skills subcommand was falling through to the
+        global help screen, showing top-level options (--sandbox, --model, etc.)
+        instead of skills-specific commands (list, create, info).
+        """
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=120)
+
+        with (
+            patch("sys.argv", ["deepagents", "skills", "-h"]),
+            patch("deepagents_cli.ui.console", test_console),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+
+        assert exc_info.value.code in (0, None)
+        output = buf.getvalue()
+
+        # Should contain skills-specific content
+        assert "list" in output.lower()
+        assert "create" in output.lower()
+        assert "info" in output.lower()
+
+        # Should NOT contain global-only content
+        assert "Start interactive thread" not in output
+        assert "--sandbox" not in output
+        assert "--model" not in output
+
+    def test_skills_list_help_shows_list_options(self) -> None:
+        """Running `deepagents skills list -h` should show list-specific options."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=120)
+
+        with (
+            patch("sys.argv", ["deepagents", "skills", "list", "-h"]),
+            patch("deepagents_cli.ui.console", test_console),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+
+        assert exc_info.value.code in (0, None)
+        output = buf.getvalue()
+
+        # Should contain list-specific content
+        assert "--agent" in output
+        assert "--project" in output
+
+        # Should NOT contain global-only content
+        assert "Start interactive thread" not in output
+        assert "--sandbox" not in output
+
+
+class TestThreadsHelpFlag:
+    """Test that `deepagents threads -h` shows threads-specific help."""
+
+    def test_threads_help_shows_threads_content(self) -> None:
+        """Running `deepagents threads -h` should show threads subcommands.
+
+        Regression: same pattern as skills -- -h on the threads subcommand
+        should show threads-specific help, not the global help screen.
+        """
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=120)
+
+        with (
+            patch("sys.argv", ["deepagents", "threads", "-h"]),
+            patch("deepagents_cli.ui.console", test_console),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+
+        assert exc_info.value.code in (0, None)
+        output = buf.getvalue()
+
+        # Should contain threads-specific content
+        assert "list" in output.lower()
+        assert "delete" in output.lower()
+
+        # Should NOT contain global-only content
+        assert "Start interactive thread" not in output
+        assert "--sandbox" not in output
+        assert "--model" not in output
+
+
+class TestThreadsListAlias:
+    """Test that `deepagents threads ls` is parsed as a `list` alias."""
+
+    def test_threads_ls_alias_parsed(self) -> None:
+        """Verify `threads ls` sets threads_command to 'ls'."""
+        with patch("sys.argv", ["deepagents", "threads", "ls"]):
+            args = parse_args()
+        assert args.command == "threads"
+        assert args.threads_command == "ls"
+
+    def test_threads_list_still_works(self) -> None:
+        """Verify `threads list` still works after alias addition."""
+        with patch("sys.argv", ["deepagents", "threads", "list"]):
+            args = parse_args()
+        assert args.command == "threads"
+        assert args.threads_command == "list"
+
+
+class TestInfoShadowWarning:
+    """Test that `skills info` warns when a project skill shadows a user skill."""
+
+    def _make_skill_dir(self, parent: Path, name: str, description: str) -> None:
+        """Create a minimal skill directory with a valid SKILL.md.
+
+        Args:
+            parent: Parent skills directory.
+            name: Skill name (used as directory name and frontmatter name).
+            description: Skill description for frontmatter.
+        """
+        skill_dir = parent / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {description}\n---\nContent\n"
+        )
+
+    def test_shadow_note_shown_when_project_overrides_user(
+        self, tmp_path: Path
+    ) -> None:
+        """When a project skill shadows a user skill, info should note it."""
+        user_dir = tmp_path / "user_skills"
+        project_dir = tmp_path / "project_skills"
+        self._make_skill_dir(user_dir, "web-research", "User version")
+        self._make_skill_dir(project_dir, "web-research", "Project version")
+
+        mock_settings = patch(
+            "deepagents_cli.skills.commands.Settings.from_environment",
+            return_value=type(
+                "FakeSettings",
+                (),
+                {
+                    "get_user_skills_dir": lambda _, _a: user_dir,
+                    "get_project_skills_dir": lambda _: project_dir,
+                    "get_user_agent_skills_dir": lambda _: None,
+                    "get_project_agent_skills_dir": lambda _: None,
+                },
+            )(),
+        )
+
+        output: list[str] = []
+
+        def capture_print(*args: str, **_: str) -> None:
+            output.append(" ".join(str(a) for a in args))
+
+        with (
+            mock_settings,
+            patch("deepagents_cli.skills.commands.console") as mock_console,
+        ):
+            mock_console.print = capture_print
+            _info("web-research", agent="agent")
+
+        joined = "\n".join(output)
+        assert "overrides" in joined.lower() or "shadows" in joined.lower()
+
+    def test_no_shadow_note_when_no_conflict(self, tmp_path: Path) -> None:
+        """When there is no name conflict, no shadow note should appear."""
+        user_dir = tmp_path / "user_skills"
+        project_dir = tmp_path / "project_skills"
+        self._make_skill_dir(user_dir, "web-research", "User only skill")
+
+        mock_settings = patch(
+            "deepagents_cli.skills.commands.Settings.from_environment",
+            return_value=type(
+                "FakeSettings",
+                (),
+                {
+                    "get_user_skills_dir": lambda _, _a: user_dir,
+                    "get_project_skills_dir": lambda _: project_dir,
+                    "get_user_agent_skills_dir": lambda _: None,
+                    "get_project_agent_skills_dir": lambda _: None,
+                },
+            )(),
+        )
+
+        output: list[str] = []
+
+        def capture_print(*args: str, **_: str) -> None:
+            output.append(" ".join(str(a) for a in args))
+
+        with (
+            mock_settings,
+            patch("deepagents_cli.skills.commands.console") as mock_console,
+        ):
+            mock_console.print = capture_print
+            _info("web-research", agent="agent")
+
+        joined = "\n".join(output)
+        assert "overrides" not in joined.lower()
+        assert "shadows" not in joined.lower()

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -360,6 +360,18 @@ class TestGetSystemPromptModelIdentity:
         assert "context window" not in prompt
 
 
+class TestDefaultAgentName:
+    """Tests for the DEFAULT_AGENT_NAME constant."""
+
+    def test_default_agent_name_value(self) -> None:
+        """Guard against accidental renames of the default agent identifier.
+
+        Other modules (main.py, commands.py) rely on this value matching
+        the directory name under `~/.deepagents/`.
+        """
+        assert DEFAULT_AGENT_NAME == "agent"
+
+
 class TestListAgents:
     """Tests for list_agents output."""
 

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from langgraph.runtime import Runtime
 
 from deepagents_cli.agent import (
+    DEFAULT_AGENT_NAME,
     _format_edit_file_description,
     _format_execute_description,
     _format_fetch_url_description,
@@ -17,6 +18,7 @@ from deepagents_cli.agent import (
     _format_web_search_description,
     _format_write_file_description,
     get_system_prompt,
+    list_agents,
 )
 from deepagents_cli.config import get_glyphs
 
@@ -356,3 +358,77 @@ class TestGetSystemPromptModelIdentity:
         assert "You are running as model `test-model`." in prompt
         assert "(provider:" not in prompt
         assert "context window" not in prompt
+
+
+class TestListAgents:
+    """Tests for list_agents output."""
+
+    def test_default_agent_marked(self, tmp_path: Path) -> None:
+        """Test that the default agent is labeled as (default) in list output."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+
+        # Create the default agent directory with AGENTS.md
+        default_dir = agents_dir / DEFAULT_AGENT_NAME
+        default_dir.mkdir()
+        (default_dir / "AGENTS.md").touch()
+
+        # Create a non-default agent
+        other_dir = agents_dir / "researcher"
+        other_dir.mkdir()
+        (other_dir / "AGENTS.md").touch()
+
+        mock_settings = Mock()
+        mock_settings.user_deepagents_dir = agents_dir
+
+        output: list[str] = []
+
+        def capture_print(*args: Any, **_: Any) -> None:
+            output.append(" ".join(str(a) for a in args))
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.console") as mock_console,
+        ):
+            mock_console.print = capture_print
+            list_agents()
+
+        joined = "\n".join(output)
+        assert "(default)" in joined
+        # Only the default agent should be marked
+        assert joined.count("(default)") == 1
+        # The default agent name should appear with the (default) label
+        assert DEFAULT_AGENT_NAME in joined
+        # The other agent should NOT be marked as default
+        for line in output:
+            if "researcher" in line and "(default)" in line:
+                msg = "Non-default agent should not be marked as (default)"
+                raise AssertionError(msg)
+
+    def test_non_default_agent_not_marked(self, tmp_path: Path) -> None:
+        """Test that non-default agents are not labeled as (default)."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+
+        # Only create a non-default agent
+        custom_dir = agents_dir / "researcher"
+        custom_dir.mkdir()
+        (custom_dir / "AGENTS.md").touch()
+
+        mock_settings = Mock()
+        mock_settings.user_deepagents_dir = agents_dir
+
+        output: list[str] = []
+
+        def capture_print(*args: Any, **_: Any) -> None:
+            output.append(" ".join(str(a) for a in args))
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.console") as mock_console,
+        ):
+            mock_console.print = capture_print
+            list_agents()
+
+        joined = "\n".join(output)
+        assert "(default)" not in joined

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -1,7 +1,11 @@
 """Tests for CLI argument parsing."""
 
+import io
 import sys
 from unittest.mock import patch
+
+import pytest
+from rich.console import Console
 
 from deepagents_cli.main import parse_args
 
@@ -93,3 +97,60 @@ class TestResumeArg:
             args = parse_args()
         assert args.resume_thread == "thread456"
         assert args.initial_prompt == "continue work"
+
+
+class TestTopLevelHelp:
+    """Test that `deepagents -h` shows the global help screen via _make_help_action."""
+
+    def test_top_level_help_exits_cleanly(self) -> None:
+        """Running `deepagents -h` should show help and exit with code 0."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=120)
+
+        with (
+            patch.object(sys, "argv", ["deepagents", "-h"]),
+            patch("deepagents_cli.ui.console", test_console),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+
+        assert exc_info.value.code in (0, None)
+        output = buf.getvalue()
+
+        # Should contain global help content
+        assert "deepagents" in output.lower()
+        assert "--help" in output
+
+    def test_help_subcommand_parses(self) -> None:
+        """Running `deepagents help` should parse as command='help'.
+
+        The actual help display happens in `cli_main()`, not `parse_args()`.
+        """
+        with patch.object(sys, "argv", ["deepagents", "help"]):
+            args = parse_args()
+        assert args.command == "help"
+
+
+class TestShortFlags:
+    """Test that short flag aliases (-a, -M, -v) parse correctly."""
+
+    def test_short_agent_flag(self) -> None:
+        """Verify -a sets agent."""
+        with patch.object(sys, "argv", ["deepagents", "-a", "mybot"]):
+            args = parse_args()
+        assert args.agent == "mybot"
+
+    def test_short_model_flag(self) -> None:
+        """Verify -M sets model."""
+        with patch.object(sys, "argv", ["deepagents", "-M", "gpt-4o"]):
+            args = parse_args()
+        assert args.model == "gpt-4o"
+
+    def test_short_version_flag(self) -> None:
+        """Verify -v shows version and exits."""
+        with (
+            patch.object(sys, "argv", ["deepagents", "-v"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code in (0, None)

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -36,7 +36,7 @@ def test_cli_version_flag() -> None:
     )
     # argparse exits with 0 for --version
     assert result.returncode == 0
-    assert f"deepagents {__version__}" in result.stdout
+    assert f"deepagents-cli {__version__}" in result.stdout
 
 
 def test_version_slash_command_message_format() -> None:


### PR DESCRIPTION
- Add per-subcommand Rich help screens so that `deepagents <subcommand> -h` shows context-specific help instead of the global help or argparse defaults
- Add short flags: `-a` (agent), `-M` (model), `-v` (version)
- Add `ls` alias for `list` in `threads` and `skills` subcommands
- Add `(default)` label in `deepagents list` output
- Add shadow detection in `skills info` (warns when a project skill overrides a user skill)
- Add `_format_info_fields()` to display optional skill metadata (license, compatibility, etc.)
- Reverse skill precedence display order to "highest precedence first" for clarity                                                                       

(Hard to factor out, as some of this was intertwined)