### PR TITLE
feat(cli): enrich built-in skill metadata with license and compatibility info

### DIFF
--- a/libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md
+++ b/libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: skill-creator
 description: "Guide for creating effective skills that extend agent capabilities with specialized knowledge, workflows, or tool integrations. Use this skill when the user asks to: (1) create a new skill, (2) make a skill, (3) build a skill, (4) set up a skill, (5) initialize a skill, (6) scaffold a skill, (7) update or modify an existing skill, (8) validate a skill, (9) learn about skill structure, (10) understand how skills work, or (11) get guidance on skill design patterns. Trigger on phrases like \"create a skill\", \"new skill\", \"make a skill\", \"skill for X\", \"how do I create a skill\", or \"help me build a skill\"."
+license: MIT
+compatibility: designed for deepagents-cli
 ---
 
 # Skill Creator

--- a/libs/cli/deepagents_cli/skills/load.py
+++ b/libs/cli/deepagents_cli/skills/load.py
@@ -23,6 +23,8 @@ from deepagents.middleware.skills import (
     _list_skills as list_skills_from_backend,
 )
 
+from deepagents_cli._version import __version__ as _cli_version
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,9 +90,16 @@ def list_skills(
                 backend=built_in_backend, source_path="."
             )
             for skill in built_in_skills:
+                # Inject the installed CLI version into built-in skill metadata
+                # so consumers can see which version shipped the skill.
+                enriched_metadata = {
+                    **skill["metadata"],
+                    "deepagents-cli-version": _cli_version,
+                }
                 # cast(): type checkers can't infer TypedDict from spread syntax
                 extended_skill = cast(
-                    "ExtendedSkillMetadata", {**skill, "source": "built-in"}
+                    "ExtendedSkillMetadata",
+                    {**skill, "source": "built-in", "metadata": enriched_metadata},
                 )
                 all_skills[skill["name"]] = extended_skill
         except OSError:

--- a/libs/cli/tests/unit_tests/skills/test_load.py
+++ b/libs/cli/tests/unit_tests/skills/test_load.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
+from deepagents_cli._version import __version__ as _cli_version
 from deepagents_cli.config import Settings
 from deepagents_cli.skills.load import list_skills
 
@@ -650,6 +651,10 @@ class TestListSkillsBuiltIn:
         creator = next(s for s in skills if s["name"] == "skill-creator")
         assert creator["source"] == "built-in"
         assert len(creator["description"]) > 0
+        assert creator["license"] == "MIT"
+        assert creator["compatibility"] == "designed for deepagents-cli"
+        assert "deepagents-cli-version" in creator["metadata"]
+        assert creator["metadata"]["deepagents-cli-version"] == _cli_version
 
     def test_oserror_in_one_source_does_not_break_others(self, tmp_path: Path) -> None:
         """An OSError in one source should not prevent other sources from loading.


### PR DESCRIPTION
Stamp built-in skills with the running CLI version and add `license` / `compatibility` frontmatter fields to `skill-creator`. This gives downstream consumers (skill registries, `list` commands, UIs) enough metadata to display provenance and compatibility without a separate lookup.