### PR TITLE
feat(cli): programmatic subagent execution via jsonl file

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -8,22 +8,27 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from deepagents import create_deep_agent
-from deepagents.backends import CompositeBackend
+from deepagents.backends import CompositeBackend, StateBackend
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.sandbox import SandboxBackendProtocol
 from deepagents.middleware import MemoryMiddleware, SkillsMiddleware
+from deepagents.middleware.filesystem import FilesystemMiddleware
 
 from deepagents_cli.backends import CLIShellBackend, patch_filesystem_middleware
 
 if TYPE_CHECKING:
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
+from langchain.agents import create_agent
 from langchain.agents.middleware import (
     InterruptOnConfig,
+    TodoListMiddleware,
 )
 from langchain.agents.middleware.types import AgentState
+from langchain.chat_models import init_chat_model
 from langchain.messages import ToolCall
 from langchain.tools import BaseTool
 from langchain_core.language_models import BaseChatModel
+from langchain_core.runnables import Runnable
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.pregel import Pregel
@@ -40,6 +45,7 @@ from deepagents_cli.config import (
 from deepagents_cli.integrations.sandbox_factory import get_default_working_dir
 from deepagents_cli.local_context import LocalContextMiddleware
 from deepagents_cli.subagents import list_subagents
+from deepagents_cli.swarm.middleware import SwarmMiddleware
 
 DEFAULT_AGENT_NAME = "agent"
 """The default agent name used when no `-a` flag is provided."""
@@ -200,12 +206,14 @@ The filesystem backend is currently operating in: `{cwd}`
         + f"""### Skills Directory
 
 Your skills are stored at: `{agent_dir_path}/skills/`
-Skills may contain scripts or supporting files. When executing skill scripts with bash, use the real filesystem path:
+Skills may contain scripts or supporting files.
+When executing skill scripts with bash, use the real filesystem path:
 Example: `bash python {agent_dir_path}/skills/web-research/script.py`
 
 ### Human-in-the-Loop Tool Approval
 
-Some tool calls require user approval before execution. When a tool call is rejected by the user:
+Some tool calls require user approval before execution.
+When a tool call is rejected by the user:
 1. Accept their decision immediately - do NOT retry the same command
 2. Explain that you understand they rejected the action
 3. Suggest an alternative approach or ask for clarification
@@ -221,9 +229,11 @@ When you use the web_search tool:
 3. NEVER show raw JSON or tool results directly to the user
 4. Synthesize the information from multiple sources into a coherent answer
 5. Cite your sources by mentioning page titles or URLs when relevant
-6. If the search doesn't find what you need, explain what you found and ask clarifying questions
+6. If the search doesn't find what you need, explain what you found and ask
+   clarifying questions
 
-The user only sees your text responses - not tool results. Always provide a complete, natural language answer after using web_search.
+The user only sees your text responses - not tool results.
+Always provide a complete, natural language answer after using web_search.
 
 ### Todo List Management
 
@@ -232,13 +242,17 @@ When using the write_todos tool:
 2. Only create todos for complex, multi-step tasks that truly need tracking
 3. Break down work into clear, actionable items without over-fragmenting
 4. For simple tasks (1-2 steps), just do them directly without creating todos
-5. When first creating a todo list for a task, ALWAYS ask the user if the plan looks good before starting work
+5. When first creating a todo list for a task, ALWAYS ask the user if the
+   plan looks good before starting work
    - Create the todos, let them render, then ask: "Does this plan look good?" or similar
    - Wait for the user's response before marking the first todo as in_progress
    - If they want changes, adjust the plan accordingly
 6. Update todo status promptly as you complete each item
 
-The todo list is a planning tool - use it judiciously to avoid overwhelming the user with excessive task tracking."""  # noqa: E501
+The todo list is a planning tool - use it judiciously to avoid
+overwhelming the user with excessive task tracking.
+
+"""
     )
 
 
@@ -494,6 +508,48 @@ def create_cli_agent(
 
     # Build middleware stack based on enabled features
     agent_middleware = []
+
+    # Add swarm middleware for batch task execution
+    # The subagent factory is called lazily when swarm_execute is first invoked
+    def _create_swarm_subagent_factory() -> Callable[[], dict[str, Runnable]]:
+        """Factory that creates subagent graphs for swarm execution.
+
+        This is called lazily when swarm_execute is first used, avoiding
+        overhead if swarm execution is never needed.
+
+        Returns:
+            Callable that builds subagent graph instances on demand.
+        """
+
+        def build_subagent_graphs() -> dict[str, Runnable]:
+            # Use the same model as the main agent
+            swarm_model = init_chat_model(model) if isinstance(model, str) else model
+
+            # Build minimal middleware stack for swarm subagents
+            swarm_middleware = [
+                TodoListMiddleware(),
+                FilesystemMiddleware(backend=StateBackend),
+            ]
+
+            # Create general-purpose subagent
+            general_purpose = create_agent(
+                swarm_model,
+                system_prompt=(
+                    "You are a helpful assistant completing a specific task. "
+                    "Focus on the task description and return a concise result."
+                ),
+                tools=tools or [],
+                middleware=swarm_middleware,
+                name="general-purpose",
+            )
+
+            return {"general-purpose": general_purpose}
+
+        return build_subagent_graphs
+
+    agent_middleware.append(
+        SwarmMiddleware(subagent_factory=_create_swarm_subagent_factory())
+    )
 
     # Add memory middleware
     if enable_memory:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -9,6 +9,7 @@ import os
 import subprocess  # noqa: S404
 import uuid
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -287,6 +288,73 @@ List what you captured and where you stored it:
 - Skills created (with key best practices encoded)
 - Memory entries added (with location)
 """  # noqa: E501
+
+# Prompt template for /swarm command
+SWARM_PROMPT_TEMPLATE = """Execute a batch of tasks using swarm_execute.
+
+**Task file:** `{file_path}`
+**num_parallel:** {num_parallel}
+{output_dir_line}
+
+Call the `swarm_execute` tool with these parameters:
+- `source`: task file path
+- `num_parallel`: number of parallel subagents
+- `output_dir`: output directory (if provided)
+
+Important:
+- If a task includes `type`, it must match a configured subagent type.
+- If unsure, omit `type` and use the default subagent.
+
+Use the tool directly to run tasks in parallel.
+After execution, summarize the results for me.
+"""
+
+SWARM_USAGE = "Usage:\n  /swarm <file.jsonl> [--num-parallel N] [--output-dir DIR]"
+
+
+@dataclass
+class ParsedSwarmCommand:
+    """Parsed options for /swarm slash command."""
+
+    file_path: str
+    num_parallel: int = 10
+    output_dir: str | None = None
+
+
+def _parse_swarm_command(command: str) -> tuple[ParsedSwarmCommand | None, str | None]:
+    """Parse `/swarm` command arguments.
+
+    Returns:
+        Tuple of (parsed options, error message). Only one value is non-None.
+    """
+    args = command.strip()[len("/swarm") :].strip().split()
+    if not args:
+        return None, SWARM_USAGE
+
+    if "--enrich" in args:
+        return (
+            None,
+            "Error: --enrich was removed. Use /swarm <file.jsonl> with JSONL tasks.",
+        )
+
+    if not args:
+        return None, "Error: No file path provided"
+
+    parsed = ParsedSwarmCommand(file_path=args[0])
+
+    i = 1
+    while i < len(args):
+        if args[i] == "--num-parallel" and i + 1 < len(args):
+            with suppress(ValueError):
+                parsed.num_parallel = int(args[i + 1])
+            i += 2
+        elif args[i] == "--output-dir" and i + 1 < len(args):
+            parsed.output_dir = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    return parsed, None
 
 
 class DeepAgentsApp(App):
@@ -708,7 +776,8 @@ class DeepAgentsApp(App):
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))
             help_text = (
-                "Commands: /quit, /clear, /remember, /tokens, /threads, /help\n\n"
+                "Commands: /quit, /clear, /remember, /swarm, /tokens, /threads, "
+                "/help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
                 "  Ctrl+J          Insert newline\n"
@@ -781,6 +850,27 @@ class DeepAgentsApp(App):
             # Send as a user message to the agent
             await self._handle_user_message(final_prompt)
             return  # _handle_user_message already mounts the message
+        elif cmd == "/swarm" or cmd.startswith("/swarm "):
+            parsed, parse_error = _parse_swarm_command(command)
+            if parse_error or parsed is None:
+                await self._mount_message(UserMessage(command))
+                await self._mount_message(AppMessage(parse_error or SWARM_USAGE))
+                return
+
+            # Build execution prompt
+            output_dir_line = (
+                f"**Output directory:** `{parsed.output_dir}`"
+                if parsed.output_dir
+                else ""
+            )
+            final_prompt = SWARM_PROMPT_TEMPLATE.format(
+                file_path=parsed.file_path,
+                num_parallel=parsed.num_parallel,
+                output_dir_line=output_dir_line,
+            )
+
+            await self._handle_user_message(final_prompt)
+            return
         else:
             await self._mount_message(UserMessage(command))
             await self._mount_message(AppMessage(f"Unknown command: {cmd}"))

--- a/libs/cli/deepagents_cli/swarm/__init__.py
+++ b/libs/cli/deepagents_cli/swarm/__init__.py
@@ -1,0 +1,31 @@
+"""Minimal swarm execution primitives for parallel JSONL task runs."""
+
+from deepagents_cli.swarm.middleware import (
+    SwarmExecutionError,
+    SwarmExecutor,
+    SwarmMiddleware,
+    SwarmProgress,
+    SwarmResult,
+    SwarmResultStatus,
+    SwarmSummary,
+    SwarmTask,
+    TaskFileError,
+    generate_swarm_run_id,
+    get_default_output_dir,
+    parse_task_file,
+)
+
+__all__ = [
+    "SwarmExecutionError",
+    "SwarmExecutor",
+    "SwarmMiddleware",
+    "SwarmProgress",
+    "SwarmResult",
+    "SwarmResultStatus",
+    "SwarmSummary",
+    "SwarmTask",
+    "TaskFileError",
+    "generate_swarm_run_id",
+    "get_default_output_dir",
+    "parse_task_file",
+]

--- a/libs/cli/deepagents_cli/swarm/middleware.py
+++ b/libs/cli/deepagents_cli/swarm/middleware.py
@@ -1,0 +1,706 @@
+"""Minimal JSONL swarm execution middleware and core implementation."""
+
+import asyncio
+import json
+import time
+import traceback
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Any, NotRequired, TypedDict
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import StructuredTool
+
+SWARM_SYSTEM_PROMPT = """## Swarm Tools (parallel JSONL execution)
+
+You have access to `swarm_execute` for running many independent tasks in parallel.
+
+Use it when the user provides a JSONL task file like:
+```
+{"id": "1", "description": "Analyze company A"}
+{"id": "2", "description": "Analyze company B"}
+```
+
+Each task runs independently in its own subagent execution.
+Use `num_parallel` to control worker count.
+
+Task type support:
+- If `type` is provided, it must match a configured subagent type.
+- If unsure, omit `type` and use the default.
+"""
+
+
+class SwarmTask(TypedDict):
+    """Task definition for batch swarm execution."""
+
+    id: str
+    description: str
+    type: NotRequired[str]
+    metadata: NotRequired[dict[str, Any]]
+
+
+class SwarmResultStatus(StrEnum):
+    """Status values for swarm task results."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class SwarmResult(TypedDict):
+    """Result of a single swarm task execution."""
+
+    task_id: str
+    status: SwarmResultStatus
+    output: NotRequired[str]
+    error: NotRequired[str]
+    message: NotRequired[str]
+    traceback: NotRequired[str]
+    duration_ms: int
+    metadata: NotRequired[dict[str, Any]]
+
+
+@dataclass
+class SwarmProgress:
+    """Progress information for swarm execution."""
+
+    total: int
+    completed: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    running: list[str] = field(default_factory=list)
+
+    @property
+    def pending(self) -> int:
+        """Number of tasks not yet started (excluding currently running)."""
+        return self.total - self.completed - len(self.running)
+
+
+class SwarmSummary(TypedDict):
+    """Summary of a completed swarm batch execution."""
+
+    run_id: str
+    started_at: str
+    total: int
+    succeeded: int
+    failed: int
+    duration_seconds: float
+    concurrency: int
+    results_path: str
+    failures_path: str
+
+
+class TaskFileError(Exception):
+    """Error parsing a task file."""
+
+
+class SwarmExecutionError(Exception):
+    """Error during swarm execution."""
+
+
+def parse_task_file(path: str | Path) -> list[SwarmTask]:
+    """Parse a JSONL task file into SwarmTask objects.
+
+    Args:
+        path: Path to a JSONL task file.
+
+    Returns:
+        List of parsed task definitions.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        TaskFileError: If the file has invalid format or content.
+    """
+    task_path = Path(path)
+    if not task_path.exists():
+        msg = f"Task file not found: {task_path}"
+        raise FileNotFoundError(msg)
+
+    if task_path.suffix.lower() != ".jsonl":
+        msg = f"Task file must be JSONL (.jsonl). Got: {task_path.name}"
+        raise TaskFileError(msg)
+
+    tasks: list[SwarmTask] = []
+
+    with task_path.open("r", encoding="utf-8") as file_handle:
+        for line_num, raw_line in enumerate(file_handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            try:
+                raw_data = json.loads(line)
+            except json.JSONDecodeError as exc:
+                msg = f"Invalid JSON on line {line_num}: {exc}"
+                raise TaskFileError(msg) from exc
+
+            data = _normalize_task_payload(raw_data, line_num)
+            task = _validate_and_convert_task(
+                data,
+                line_num,
+                default_id=f"auto-{line_num}",
+            )
+            tasks.append(task)
+
+    if not tasks:
+        msg = "Task file is empty"
+        raise TaskFileError(msg)
+
+    _validate_task_ids(tasks)
+    return tasks
+
+
+def _normalize_task_payload(
+    raw_data: dict[str, Any] | str,
+    line_num: int,
+) -> dict[str, Any]:
+    """Normalize a task payload into canonical dict form.
+
+    Returns:
+        Normalized task dictionary.
+
+    Raises:
+        TaskFileError: If the payload is not a JSON object or string.
+    """
+    if isinstance(raw_data, str):
+        return {"description": raw_data}
+    if not isinstance(raw_data, dict):
+        msg = f"Line {line_num}: task entry must be a JSON object or string"
+        raise TaskFileError(msg)
+
+    data = dict(raw_data)
+    if "description" not in data:
+        for alias in ("task", "prompt"):
+            if alias in data:
+                data["description"] = data[alias]
+                break
+    return data
+
+
+def _validate_and_convert_task(
+    data: dict[str, Any], line_num: int, *, default_id: str
+) -> SwarmTask:
+    """Validate task data and convert to SwarmTask.
+
+    Returns:
+        Validated task dictionary.
+
+    Raises:
+        TaskFileError: If required fields or optional structures are invalid.
+    """
+    if "description" not in data or not str(data["description"]).strip():
+        msg = f"Line {line_num}: missing required field 'description'"
+        raise TaskFileError(msg)
+
+    if "blocked_by" in data:
+        msg = (
+            "Field 'blocked_by' is not supported in simplified swarm mode. "
+            "All tasks run independently in parallel."
+        )
+        raise TaskFileError(msg)
+
+    task: SwarmTask = {
+        "id": str(data.get("id", "")).strip() or default_id,
+        "description": str(data["description"]).strip(),
+    }
+
+    if "type" in data:
+        task["type"] = str(data["type"]).strip()
+
+    if "metadata" in data:
+        if not isinstance(data["metadata"], dict):
+            msg = f"Line {line_num}: metadata must be a dict"
+            raise TaskFileError(msg)
+        task["metadata"] = data["metadata"]
+
+    return task
+
+
+def _validate_task_ids(tasks: list[SwarmTask]) -> None:
+    """Validate that all task IDs are unique.
+
+    Raises:
+        TaskFileError: If duplicate IDs are found.
+    """
+    task_ids: set[str] = set()
+    for task in tasks:
+        task_id = task["id"]
+        if task_id in task_ids:
+            msg = f"Duplicate task ID: {task_id}"
+            raise TaskFileError(msg)
+        task_ids.add(task_id)
+
+
+class SwarmExecutor:
+    """Executes independent tasks in parallel using subagents."""
+
+    def __init__(
+        self,
+        subagent_graphs: dict[str, Runnable],
+        *,
+        default_subagent_type: str = "general-purpose",
+        timeout_seconds: float = 300.0,
+    ) -> None:
+        """Initialize the swarm executor.
+
+        Args:
+            subagent_graphs: Map of subagent type names to runnable instances.
+            default_subagent_type: Default subagent type when not specified in task.
+            timeout_seconds: Timeout for individual task execution.
+        """
+        self.subagent_graphs = subagent_graphs
+        self.default_subagent_type = default_subagent_type
+        self.timeout_seconds = timeout_seconds
+
+    async def execute(
+        self,
+        tasks: list[SwarmTask],
+        *,
+        concurrency: int = 10,
+        output_dir: Path,
+        run_id: str | None = None,
+        started_at: str | None = None,
+        progress_callback: Callable[[SwarmProgress], None] | None = None,
+    ) -> SwarmSummary:
+        """Execute independent tasks in parallel.
+
+        Args:
+            tasks: List of tasks to execute.
+            concurrency: Maximum number of parallel workers.
+            output_dir: Directory to write results.
+            run_id: Optional identifier for this swarm run.
+            started_at: Optional ISO timestamp for when the run started.
+            progress_callback: Optional callback for progress updates.
+
+        Returns:
+            SwarmSummary with execution statistics.
+        """
+        start_time = time.time()
+        run_concurrency = max(1, concurrency)
+
+        await asyncio.to_thread(output_dir.mkdir, parents=True, exist_ok=True)
+        results_path = output_dir / "results.jsonl"
+        failures_path = output_dir / "failures.jsonl"
+        await asyncio.to_thread(results_path.write_text, "")
+        await asyncio.to_thread(failures_path.write_text, "")
+
+        completed: set[str] = set()
+        failed: set[str] = set()
+        running: set[str] = set()
+
+        def _report_progress() -> None:
+            if progress_callback is None:
+                return
+            progress_callback(
+                SwarmProgress(
+                    total=len(tasks),
+                    completed=len(completed) + len(failed),
+                    succeeded=len(completed),
+                    failed=len(failed),
+                    running=sorted(running),
+                )
+            )
+
+        def _write_result(result: SwarmResult) -> None:
+            with results_path.open("a", encoding="utf-8") as results_file:
+                results_file.write(json.dumps(_result_to_dict(result)) + "\n")
+
+            if result["status"] == SwarmResultStatus.FAILED:
+                with failures_path.open("a", encoding="utf-8") as failures_file:
+                    failures_file.write(json.dumps(_result_to_dict(result)) + "\n")
+
+        async def _execute_single_task(task: SwarmTask) -> SwarmResult:
+            task_start = time.time()
+            task_metadata = task.get("metadata")
+            subagent_type = task.get("type", self.default_subagent_type)
+
+            if subagent_type not in self.subagent_graphs:
+                available = sorted(self.subagent_graphs.keys())
+                msg = (
+                    f"Unknown subagent type: {subagent_type}. Available: {available}. "
+                    "Use one of the available types or omit 'type' to use the default."
+                )
+                result: SwarmResult = {
+                    "task_id": task["id"],
+                    "status": SwarmResultStatus.FAILED,
+                    "error": "ValueError",
+                    "message": msg,
+                    "duration_ms": int((time.time() - task_start) * 1000),
+                }
+                if task_metadata is not None:
+                    result["metadata"] = task_metadata
+                return result
+
+            subagent = self.subagent_graphs[subagent_type]
+            try:
+                subagent_state = {
+                    "messages": [HumanMessage(content=task["description"])]
+                }
+                invoke_result = await asyncio.wait_for(
+                    subagent.ainvoke(subagent_state),
+                    timeout=self.timeout_seconds,
+                )
+            except TimeoutError:
+                timeout_result: SwarmResult = {
+                    "task_id": task["id"],
+                    "status": SwarmResultStatus.FAILED,
+                    "error": "TimeoutError",
+                    "message": f"Task timed out after {self.timeout_seconds}s",
+                    "duration_ms": int((time.time() - task_start) * 1000),
+                }
+                if task_metadata is not None:
+                    timeout_result["metadata"] = task_metadata
+                return timeout_result
+            except Exception as exc:  # noqa: BLE001
+                traceback_text = traceback.format_exc()
+                error_result: SwarmResult = {
+                    "task_id": task["id"],
+                    "status": SwarmResultStatus.FAILED,
+                    "error": type(exc).__name__,
+                    "message": str(exc),
+                    "traceback": traceback_text,
+                    "duration_ms": int((time.time() - task_start) * 1000),
+                }
+                if task_metadata is not None:
+                    error_result["metadata"] = task_metadata
+                return error_result
+
+            output = ""
+            if invoke_result.get("messages"):
+                final_msg = invoke_result["messages"][-1]
+                content = getattr(final_msg, "content", final_msg)
+                if isinstance(content, list):
+                    text_parts: list[str] = []
+                    for block in content:
+                        if isinstance(block, str):
+                            text_parts.append(block)
+                        elif isinstance(block, dict) and block.get("type") == "text":
+                            text_parts.append(str(block.get("text", "")))
+                    output = "\n".join(text_parts)
+                else:
+                    output = str(content)
+
+            success_result: SwarmResult = {
+                "task_id": task["id"],
+                "status": SwarmResultStatus.SUCCESS,
+                "output": output,
+                "duration_ms": int((time.time() - task_start) * 1000),
+            }
+            if task_metadata is not None:
+                success_result["metadata"] = task_metadata
+            return success_result
+
+        semaphore = asyncio.Semaphore(run_concurrency)
+
+        async def _run_with_limit(task: SwarmTask) -> SwarmResult:
+            async with semaphore:
+                task_id = task["id"]
+                running.add(task_id)
+                _report_progress()
+                try:
+                    return await _execute_single_task(task)
+                finally:
+                    running.discard(task_id)
+                    _report_progress()
+
+        _report_progress()
+        task_futures = [asyncio.create_task(_run_with_limit(task)) for task in tasks]
+
+        for task_future in asyncio.as_completed(task_futures):
+            result = await task_future
+            _write_result(result)
+            if result["status"] == SwarmResultStatus.SUCCESS:
+                completed.add(result["task_id"])
+            else:
+                failed.add(result["task_id"])
+            _report_progress()
+
+        duration_seconds = time.time() - start_time
+
+        summary: SwarmSummary = {
+            "run_id": run_id or generate_swarm_run_id(),
+            "started_at": started_at or datetime.now(UTC).isoformat(timespec="seconds"),
+            "total": len(tasks),
+            "succeeded": len(completed),
+            "failed": len(failed),
+            "duration_seconds": round(duration_seconds, 2),
+            "concurrency": run_concurrency,
+            "results_path": str(results_path),
+            "failures_path": str(failures_path),
+        }
+
+        summary_path = output_dir / "summary.json"
+        with summary_path.open("w", encoding="utf-8") as summary_file:
+            json.dump(summary, summary_file, indent=2)
+
+        return summary
+
+
+def _result_to_dict(result: SwarmResult) -> dict[str, Any]:
+    """Convert SwarmResult to a JSON-serializable dictionary.
+
+    Returns:
+        Dictionary representation suitable for JSONL output.
+    """
+    data: dict[str, Any] = {
+        "task_id": result["task_id"],
+        "status": result["status"].value,
+        "duration_ms": result["duration_ms"],
+    }
+    if "output" in result:
+        data["output"] = result["output"]
+    if "error" in result:
+        data["error"] = result["error"]
+    if "message" in result:
+        data["message"] = result["message"]
+    if "traceback" in result:
+        data["traceback"] = result["traceback"]
+    if "metadata" in result:
+        data["metadata"] = result["metadata"]
+    return data
+
+
+def generate_swarm_run_id() -> str:
+    """Generate a compact run ID for swarm executions.
+
+    Returns:
+        Eight-character lowercase hexadecimal identifier.
+    """
+    return uuid.uuid4().hex[:8]
+
+
+def get_default_output_dir(run_id: str | None = None) -> Path:
+    """Get the default output directory for swarm results.
+
+    Returns:
+        Output directory path with UTC timestamp and run ID suffix.
+    """
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d_%H%M%S")
+    resolved_run_id = run_id or generate_swarm_run_id()
+    return Path.cwd() / "batch_results" / f"{timestamp}_{resolved_run_id}"
+
+
+def _append_to_system_message(
+    system_message: SystemMessage | None,
+    text: str,
+) -> SystemMessage:
+    """Append text to a system message.
+
+    Returns:
+        Updated system message containing the additional text block.
+    """
+    if system_message is None:
+        content: list[str | dict[str, object]] = []
+    elif isinstance(system_message.content, str):
+        content = [system_message.content]
+    else:
+        content = list(system_message.content)
+
+    if content:
+        text = f"\n\n{text}"
+    content.append({"type": "text", "text": text})
+    return SystemMessage(content=content)
+
+
+class SwarmMiddleware(AgentMiddleware):
+    """Middleware that provides the `swarm_execute` tool."""
+
+    def __init__(
+        self,
+        subagent_graphs: dict[str, Runnable] | None = None,
+        *,
+        subagent_factory: Callable[[], dict[str, Runnable]] | None = None,
+        default_concurrency: int = 10,
+        max_concurrency: int = 50,
+        timeout_seconds: float = 300.0,
+        progress_callback: Callable[[SwarmProgress], None] | None = None,
+    ) -> None:
+        """Initialize middleware.
+
+        Args:
+            subagent_graphs: Pre-built map of subagent type names to runnable instances.
+            subagent_factory: Lazy factory when subagent_graphs are not pre-built.
+            default_concurrency: Default number of parallel workers.
+            max_concurrency: Maximum allowed parallel workers.
+            timeout_seconds: Timeout for individual task execution.
+            progress_callback: Optional callback for progress updates.
+
+        Raises:
+            ValueError: If neither subagent_graphs nor subagent_factory is provided.
+        """
+        super().__init__()
+        if subagent_graphs is None and subagent_factory is None:
+            msg = "Either subagent_graphs or subagent_factory must be provided"
+            raise ValueError(msg)
+
+        self._subagent_graphs = subagent_graphs
+        self._subagent_factory = subagent_factory
+        self.default_concurrency = default_concurrency
+        self.max_concurrency = max_concurrency
+        self.timeout_seconds = timeout_seconds
+        self.progress_callback = progress_callback
+
+    @property
+    def subagent_graphs(self) -> dict[str, Runnable]:
+        """Get subagent graphs, initializing lazily if needed.
+
+        Returns:
+            Mapping of subagent type to runnable graph.
+
+        Raises:
+            RuntimeError: If no prebuilt graphs or factory are configured.
+        """
+        if self._subagent_graphs is None:
+            if self._subagent_factory is None:
+                msg = "No subagent_graphs or subagent_factory configured"
+                raise RuntimeError(msg)
+            self._subagent_graphs = self._subagent_factory()
+        return self._subagent_graphs
+
+    @property
+    def tools(self) -> list[StructuredTool]:
+        """Return the swarm execution tool."""
+        return _create_swarm_tools(
+            subagent_graphs_getter=lambda: self.subagent_graphs,
+            default_concurrency=self.default_concurrency,
+            max_concurrency=self.max_concurrency,
+            timeout_seconds=self.timeout_seconds,
+            progress_callback=self.progress_callback,
+        )
+
+    def wrap_model_call(  # noqa: PLR6301
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        """Append swarm guidance to the system prompt.
+
+        Returns:
+            Response from the downstream model handler.
+        """
+        system_message = _append_to_system_message(
+            request.system_message,
+            SWARM_SYSTEM_PROMPT,
+        )
+        return handler(request.override(system_message=system_message))
+
+    async def awrap_model_call(  # noqa: PLR6301
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Append swarm guidance to the system prompt (async).
+
+        Returns:
+            Response from the downstream async model handler.
+        """
+        system_message = _append_to_system_message(
+            request.system_message,
+            SWARM_SYSTEM_PROMPT,
+        )
+        return await handler(request.override(system_message=system_message))
+
+
+def _create_swarm_tools(
+    subagent_graphs_getter: Callable[[], dict[str, Runnable]],
+    default_concurrency: int,
+    max_concurrency: int,
+    timeout_seconds: float,
+    progress_callback: Callable[[SwarmProgress], None] | None,
+) -> list[StructuredTool]:
+    """Create swarm tools.
+
+    Returns:
+        List containing the `swarm_execute` tool.
+    """
+
+    def _resolve_parallelism(*, num_parallel: int) -> int:
+        return min(max(1, num_parallel), max_concurrency)
+
+    async def swarm_execute(
+        source: Annotated[
+            str,
+            "Path to a JSONL task file. Required field: description. "
+            "Optional fields: id, type, metadata.",
+        ],
+        num_parallel: Annotated[
+            int,
+            "Maximum number of parallel subagent executions.",
+        ] = default_concurrency,
+        output_dir: Annotated[
+            str | None,
+            "Directory to write results. Defaults to "
+            "./batch_results/<timestamp>_<run_id>/",
+        ] = None,
+    ) -> str:
+        """Execute independent JSONL tasks in parallel.
+
+        Returns:
+            Human-readable summary of the swarm run and output paths.
+        """
+        parallelism = _resolve_parallelism(
+            num_parallel=num_parallel,
+        )
+
+        try:
+            tasks = parse_task_file(source)
+        except (FileNotFoundError, TaskFileError) as exc:
+            return f"Error: {exc}"
+
+        run_id = generate_swarm_run_id()
+        started_at = datetime.now(UTC).isoformat(timespec="seconds")
+        resolved_output_dir = (
+            Path(output_dir) if output_dir else get_default_output_dir(run_id=run_id)
+        )
+
+        executor = SwarmExecutor(
+            subagent_graphs=subagent_graphs_getter(),
+            timeout_seconds=timeout_seconds,
+        )
+
+        summary = await executor.execute(
+            tasks=tasks,
+            concurrency=parallelism,
+            output_dir=resolved_output_dir,
+            run_id=run_id,
+            started_at=started_at,
+            progress_callback=progress_callback,
+        )
+
+        lines = [
+            (
+                f"Batch execution complete: run {summary['run_id']} "
+                f"({summary['started_at']}) - {summary['total']} tasks in "
+                f"{summary['duration_seconds']}s"
+            ),
+            f"  Parallel workers: {summary['concurrency']}",
+            f"  Succeeded: {summary['succeeded']}",
+            f"  Failed: {summary['failed']}",
+            "",
+            "Results written to:",
+            f"  {resolved_output_dir}/",
+            "    summary.json",
+            "    results.jsonl",
+            "    failures.jsonl",
+        ]
+        return "\n".join(lines)
+
+    return [
+        StructuredTool.from_function(
+            name="swarm_execute",
+            coroutine=swarm_execute,
+            description=(
+                "Execute tasks from a JSONL file in parallel using subagents. "
+                "Tasks run independently in parallel."
+            ),
+        )
+    ]

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -568,6 +568,11 @@ async def execute_task_textual(
                                 tool_msg = ToolCallMessage(buffer_name, parsed_args)
                                 await adapter._mount_message(tool_msg)
                                 adapter._current_tool_messages[buffer_id] = tool_msg
+                                # `swarm_execute` can run for a while without
+                                # intermediate stream updates, so show inline
+                                # running animation immediately.
+                                if buffer_name == "swarm_execute":
+                                    tool_msg.set_running()
 
                                 # Sticky scroll after tool call is shown
                                 if adapter._scroll_to_bottom:

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -34,7 +34,7 @@ class CompletionResult(StrEnum):
 
     IGNORED = "ignored"  # Key not handled, let default behavior proceed
     HANDLED = "handled"  # Key handled, prevent default
-    SUBMIT = "submit"  # Key triggers submission (e.g., Enter on slash command)
+    SUBMIT = "submit"  # Key triggers submission (for controllers that opt in)
 
 
 class CompletionView(Protocol):
@@ -96,6 +96,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/help", "Show help"),
     ("/clear", "Clear chat and start new thread"),
     ("/remember", "Update memory and skills from conversation"),
+    ("/swarm", "Execute batch tasks from JSONL file"),
     ("/quit", "Exit app"),
     ("/tokens", "Token usage"),
     ("/threads", "Show thread info"),
@@ -191,7 +192,8 @@ class SlashCommandController:
                 return CompletionResult.IGNORED
             case "enter":
                 if self._apply_selected_completion(cursor_index):
-                    return CompletionResult.SUBMIT
+                    # Enter should accept the completion without auto-submitting.
+                    return CompletionResult.HANDLED
                 return CompletionResult.HANDLED
             case "down":
                 self._move_selection(1)

--- a/libs/cli/tests/unit_tests/swarm/__init__.py
+++ b/libs/cli/tests/unit_tests/swarm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for minimal swarm JSONL execution."""

--- a/libs/cli/tests/unit_tests/swarm/test_executor.py
+++ b/libs/cli/tests/unit_tests/swarm/test_executor.py
@@ -1,0 +1,291 @@
+"""Unit tests for swarm executor."""
+
+import asyncio
+import json
+import re
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from deepagents_cli.swarm.middleware import (
+    SwarmExecutor,
+    SwarmProgress,
+    SwarmTask,
+    get_default_output_dir,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import Runnable
+
+
+class MockSubagent:
+    """Mock subagent for testing."""
+
+    def __init__(
+        self,
+        response: str = "Task completed",
+        delay: float = 0.0,
+        error: Exception | None = None,
+    ) -> None:
+        self.response = response
+        self.delay = delay
+        self.error = error
+        self.invocations: list[dict] = []
+
+    async def ainvoke(self, state: dict) -> dict:
+        self.invocations.append(state)
+
+        if self.delay > 0:
+            await asyncio.sleep(self.delay)
+
+        if self.error:
+            raise self.error
+
+        return {"messages": [AIMessage(content=self.response)]}
+
+
+def make_task(task_id: str, subagent_type: str | None = None) -> SwarmTask:
+    """Helper to create SwarmTask for testing."""
+    task: SwarmTask = {"id": task_id, "description": f"Task {task_id}"}
+    if subagent_type:
+        task["type"] = subagent_type
+    return task
+
+
+@pytest.fixture
+def mock_subagent():
+    return MockSubagent()
+
+
+@pytest.fixture
+def subagent_graphs(mock_subagent):
+    return {"general-purpose": cast("Runnable", mock_subagent)}
+
+
+@pytest.fixture
+def executor(subagent_graphs):
+    return SwarmExecutor(subagent_graphs, timeout_seconds=5.0)
+
+
+@pytest.fixture
+def output_dir(tmp_path):
+    return tmp_path / "results"
+
+
+class TestBasicExecution:
+    @pytest.mark.asyncio
+    async def test_executes_single_task(self, executor, output_dir):
+        tasks = [make_task("1")]
+
+        summary = await executor.execute(tasks, concurrency=1, output_dir=output_dir)
+
+        assert summary["run_id"]
+        assert summary["started_at"]
+        assert summary["total"] == 1
+        assert summary["succeeded"] == 1
+        assert summary["failed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_executes_multiple_tasks(self, executor, output_dir):
+        tasks = [make_task("1"), make_task("2"), make_task("3")]
+
+        summary = await executor.execute(tasks, concurrency=3, output_dir=output_dir)
+
+        assert summary["total"] == 3
+        assert summary["succeeded"] == 3
+
+    @pytest.mark.asyncio
+    async def test_writes_results_file(self, executor, output_dir):
+        tasks = [make_task("1"), make_task("2")]
+
+        await executor.execute(tasks, concurrency=2, output_dir=output_dir)
+
+        results_path = output_dir / "results.jsonl"
+        assert results_path.exists()
+
+        results = [
+            json.loads(line) for line in results_path.read_text().strip().split("\n")
+        ]
+        assert len(results) == 2
+        assert {result["task_id"] for result in results} == {"1", "2"}
+
+    @pytest.mark.asyncio
+    async def test_writes_summary_file(self, executor, output_dir):
+        tasks = [make_task("1")]
+
+        await executor.execute(tasks, concurrency=1, output_dir=output_dir)
+
+        summary_path = output_dir / "summary.json"
+        assert summary_path.exists()
+
+        summary = json.loads(summary_path.read_text())
+        assert summary["run_id"]
+        assert summary["started_at"]
+        assert summary["total"] == 1
+        assert summary["succeeded"] == 1
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_handles_subagent_error(self, output_dir):
+        failing_subagent = MockSubagent(error=ValueError("Something went wrong"))
+
+        executor = SwarmExecutor(
+            {"general-purpose": cast("Runnable", failing_subagent)},
+            timeout_seconds=5.0,
+        )
+
+        summary = await executor.execute(
+            [make_task("1")],
+            concurrency=1,
+            output_dir=output_dir,
+        )
+
+        assert summary["failed"] == 1
+        assert summary["succeeded"] == 0
+
+        results = json.loads((output_dir / "results.jsonl").read_text().strip())
+        assert results["status"] == "failed"
+        assert results["error"] == "ValueError"
+        assert "traceback" in results
+        assert "ValueError: Something went wrong" in results["traceback"]
+
+    @pytest.mark.asyncio
+    async def test_handles_timeout(self, output_dir):
+        slow_subagent = MockSubagent(delay=10.0)
+
+        executor = SwarmExecutor(
+            {"general-purpose": cast("Runnable", slow_subagent)},
+            timeout_seconds=0.1,
+        )
+
+        summary = await executor.execute(
+            [make_task("1")],
+            concurrency=1,
+            output_dir=output_dir,
+        )
+
+        assert summary["failed"] == 1
+        result = json.loads((output_dir / "results.jsonl").read_text().strip())
+        assert result["status"] == "failed"
+        assert result["error"] == "TimeoutError"
+
+    @pytest.mark.asyncio
+    async def test_captures_traceback_for_recursion_error(self, output_dir):
+        recursive_subagent = MockSubagent(
+            error=RecursionError("maximum recursion depth exceeded")
+        )
+        executor = SwarmExecutor(
+            {"general-purpose": cast("Runnable", recursive_subagent)},
+            timeout_seconds=5.0,
+        )
+
+        summary = await executor.execute(
+            [make_task("1")],
+            concurrency=1,
+            output_dir=output_dir,
+        )
+
+        assert summary["failed"] == 1
+        result = json.loads((output_dir / "results.jsonl").read_text().strip())
+        assert result["status"] == "failed"
+        assert result["error"] == "RecursionError"
+        assert "traceback" in result
+        assert "RecursionError: maximum recursion depth exceeded" in result["traceback"]
+
+    @pytest.mark.asyncio
+    async def test_handles_unknown_subagent_type(self, executor, output_dir):
+        summary = await executor.execute(
+            [make_task("1", subagent_type="nonexistent-type")],
+            concurrency=1,
+            output_dir=output_dir,
+        )
+
+        assert summary["failed"] == 1
+        result = json.loads((output_dir / "results.jsonl").read_text().strip())
+        assert "Unknown subagent type" in result["message"]
+
+
+class TestProgressReporting:
+    @pytest.mark.asyncio
+    async def test_calls_progress_callback(self, executor, output_dir):
+        progress_updates = []
+
+        def track_progress(progress: SwarmProgress) -> None:
+            progress_updates.append(
+                {
+                    "completed": progress.completed,
+                    "running": len(progress.running),
+                }
+            )
+
+        tasks = [make_task("1"), make_task("2")]
+
+        await executor.execute(
+            tasks,
+            concurrency=2,
+            output_dir=output_dir,
+            progress_callback=track_progress,
+        )
+
+        assert progress_updates
+        assert progress_updates[-1]["completed"] == 2
+
+
+class TestConcurrency:
+    @pytest.mark.asyncio
+    async def test_respects_concurrency_limit(self, output_dir):
+        max_concurrent = 0
+        current_concurrent = 0
+
+        class ConcurrencyTracker:
+            async def ainvoke(self, _state: dict) -> dict:
+                nonlocal max_concurrent, current_concurrent
+                current_concurrent += 1
+                max_concurrent = max(max_concurrent, current_concurrent)
+                await asyncio.sleep(0.1)
+                current_concurrent -= 1
+                return {"messages": [AIMessage(content="Done")]}
+
+        executor = SwarmExecutor(
+            {"general-purpose": cast("Runnable", ConcurrencyTracker())},
+            timeout_seconds=5.0,
+        )
+
+        await executor.execute(
+            [make_task(str(index)) for index in range(10)],
+            concurrency=3,
+            output_dir=output_dir,
+        )
+
+        assert max_concurrent <= 3
+
+
+class TestSubagentInput:
+    @pytest.mark.asyncio
+    async def test_passes_description_as_human_message(self, output_dir):
+        subagent = MockSubagent()
+        executor = SwarmExecutor(
+            {"general-purpose": cast("Runnable", subagent)},
+            timeout_seconds=5.0,
+        )
+
+        await executor.execute(
+            [{"id": "1", "description": "Research ACME"}],
+            concurrency=1,
+            output_dir=output_dir,
+        )
+
+        invocation = subagent.invocations[0]
+        message = invocation["messages"][0]
+        assert isinstance(message, HumanMessage)
+        assert message.content == "Research ACME"
+
+
+class TestOutputDirectory:
+    def test_default_output_dir_is_timestamped_with_run_id(self):
+        output_dir = get_default_output_dir()
+
+        assert "batch_results" in str(output_dir)
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{6}_[0-9a-f]{8}", output_dir.name)

--- a/libs/cli/tests/unit_tests/swarm/test_parser.py
+++ b/libs/cli/tests/unit_tests/swarm/test_parser.py
@@ -1,0 +1,150 @@
+"""Unit tests for JSONL swarm task parser."""
+
+import json
+
+import pytest
+
+from deepagents_cli.swarm.middleware import TaskFileError, parse_task_file
+
+
+@pytest.fixture
+def jsonl_file(tmp_path):
+    """Create a sample JSONL task file."""
+    path = tmp_path / "tasks.jsonl"
+    tasks = [
+        {"id": "1", "description": "Analyze Q1 data"},
+        {"id": "2", "description": "Analyze Q2 data", "type": "analyst"},
+        {"id": "3", "description": "Summarize both analyses"},
+    ]
+    path.write_text("\n".join(json.dumps(task) for task in tasks), encoding="utf-8")
+    return path
+
+
+class TestParseJsonl:
+    def test_parses_basic_tasks(self, jsonl_file):
+        tasks = parse_task_file(jsonl_file)
+
+        assert len(tasks) == 3
+        assert tasks[0]["id"] == "1"
+        assert tasks[0]["description"] == "Analyze Q1 data"
+
+    def test_parses_optional_type(self, jsonl_file):
+        tasks = parse_task_file(jsonl_file)
+
+        assert "type" not in tasks[0]
+        assert tasks[1]["type"] == "analyst"
+
+    def test_parses_metadata(self, tmp_path):
+        path = tmp_path / "tasks.jsonl"
+        path.write_text(
+            '{"id": "1", "description": "Test", "metadata": {"key": "value"}}',
+            encoding="utf-8",
+        )
+
+        tasks = parse_task_file(path)
+
+        assert tasks[0]["metadata"] == {"key": "value"}
+
+    def test_skips_empty_lines(self, tmp_path):
+        path = tmp_path / "tasks.jsonl"
+        path.write_text(
+            '{"id": "1", "description": "Task 1"}\n\n'
+            '{"id": "2", "description": "Task 2"}\n',
+            encoding="utf-8",
+        )
+
+        tasks = parse_task_file(path)
+
+        assert len(tasks) == 2
+
+    def test_auto_generates_ids_for_missing_id(self, tmp_path):
+        path = tmp_path / "tasks.jsonl"
+        path.write_text('{"description": "Task 1"}\n{"description": "Task 2"}\n')
+
+        tasks = parse_task_file(path)
+
+        assert [task["id"] for task in tasks] == ["auto-1", "auto-2"]
+
+    def test_supports_description_aliases(self, tmp_path):
+        path = tmp_path / "tasks.jsonl"
+        path.write_text(
+            '{"id": "a", "prompt": "Task from prompt"}\n'
+            '{"id": "b", "task": "Task from task"}\n',
+            encoding="utf-8",
+        )
+
+        tasks = parse_task_file(path)
+
+        assert tasks[0]["description"] == "Task from prompt"
+        assert tasks[1]["description"] == "Task from task"
+
+    def test_supports_string_entries(self, tmp_path):
+        path = tmp_path / "tasks.jsonl"
+        path.write_text('"Task from string"', encoding="utf-8")
+
+        tasks = parse_task_file(path)
+
+        assert tasks[0]["id"] == "auto-1"
+        assert tasks[0]["description"] == "Task from string"
+
+
+class TestValidation:
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            parse_task_file(tmp_path / "nonexistent.jsonl")
+
+    def test_rejects_non_jsonl_extension(self, tmp_path):
+        path = tmp_path / "tasks.csv"
+        path.write_text("id,description\n1,Do something\n", encoding="utf-8")
+
+        with pytest.raises(TaskFileError, match="must be JSONL"):
+            parse_task_file(path)
+
+    def test_empty_file(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("", encoding="utf-8")
+
+        with pytest.raises(TaskFileError, match="empty"):
+            parse_task_file(path)
+
+    def test_missing_description(self, tmp_path):
+        path = tmp_path / "bad.jsonl"
+        path.write_text('{"id": "1"}', encoding="utf-8")
+
+        with pytest.raises(TaskFileError, match="missing required field 'description'"):
+            parse_task_file(path)
+
+    def test_duplicate_ids(self, tmp_path):
+        path = tmp_path / "dup.jsonl"
+        path.write_text(
+            '{"id": "1", "description": "Task 1"}\n'
+            '{"id": "1", "description": "Task 2"}\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(TaskFileError, match="Duplicate task ID"):
+            parse_task_file(path)
+
+    def test_blocked_by_is_not_supported(self, tmp_path):
+        path = tmp_path / "bad.jsonl"
+        path.write_text(
+            '{"id": "1", "description": "Test", "blocked_by": ["2"]}',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(TaskFileError, match="not supported"):
+            parse_task_file(path)
+
+    def test_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.jsonl"
+        path.write_text("not valid json", encoding="utf-8")
+
+        with pytest.raises(TaskFileError, match="Invalid JSON"):
+            parse_task_file(path)
+
+    def test_invalid_task_payload_type(self, tmp_path):
+        path = tmp_path / "bad.jsonl"
+        path.write_text("123", encoding="utf-8")
+
+        with pytest.raises(TaskFileError, match="must be a JSON object or string"):
+            parse_task_file(path)

--- a/libs/cli/tests/unit_tests/swarm/test_swarm_middleware.py
+++ b/libs/cli/tests/unit_tests/swarm/test_swarm_middleware.py
@@ -1,0 +1,157 @@
+"""Unit tests for SwarmMiddleware."""
+
+import json
+from typing import cast
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import StructuredTool
+
+from deepagents_cli.swarm.middleware import SwarmMiddleware
+
+
+class MockSubagent:
+    """Mock subagent for testing."""
+
+    async def ainvoke(self, _state: dict) -> dict:
+        return {"messages": [AIMessage(content="Task completed")]}
+
+
+@pytest.fixture
+def subagent_graphs():
+    return {"general-purpose": cast("Runnable", MockSubagent())}
+
+
+@pytest.fixture
+def middleware(subagent_graphs):
+    return SwarmMiddleware(subagent_graphs=subagent_graphs)
+
+
+class TestSwarmMiddleware:
+    def test_has_one_tool(self, middleware):
+        """Middleware should provide only swarm_execute."""
+        assert len(middleware.tools) == 1
+        tool_names = {tool.name for tool in middleware.tools}
+        assert tool_names == {"swarm_execute"}
+
+    def test_tool_is_structured_tool(self, middleware):
+        """Tool should be a StructuredTool instance."""
+        assert isinstance(middleware.tools[0], StructuredTool)
+
+    def test_tool_description(self, middleware):
+        """Tool should have a meaningful description."""
+        tool = middleware.tools[0]
+        assert "parallel" in tool.description.lower()
+
+    def test_requires_subagent_config(self):
+        """Middleware should require either subagent_graphs or factory."""
+        with pytest.raises(ValueError, match="subagent_graphs or subagent_factory"):
+            SwarmMiddleware()
+
+    def test_accepts_subagent_graphs(self, subagent_graphs):
+        """Middleware should accept pre-built subagent_graphs."""
+        middleware = SwarmMiddleware(subagent_graphs=subagent_graphs)
+        assert middleware.subagent_graphs is subagent_graphs
+
+    def test_accepts_subagent_factory(self, subagent_graphs):
+        """Middleware should accept a factory function."""
+        middleware = SwarmMiddleware(subagent_factory=lambda: subagent_graphs)
+
+        assert middleware._subagent_graphs is None
+        result = middleware.subagent_graphs
+        assert result is subagent_graphs
+
+    def test_lazy_initialization(self, subagent_graphs):
+        """Factory should only be called when subagent_graphs is accessed."""
+        call_count = 0
+
+        def counting_factory() -> dict[str, Runnable]:
+            nonlocal call_count
+            call_count += 1
+            return subagent_graphs
+
+        middleware = SwarmMiddleware(subagent_factory=counting_factory)
+
+        assert call_count == 0
+        _ = middleware.subagent_graphs
+        assert call_count == 1
+        _ = middleware.subagent_graphs
+        assert call_count == 1
+
+
+class TestSwarmMiddlewareConfiguration:
+    def test_default_concurrency(self, subagent_graphs):
+        middleware = SwarmMiddleware(subagent_graphs=subagent_graphs)
+        assert middleware.default_concurrency == 10
+
+    def test_custom_concurrency(self, subagent_graphs):
+        middleware = SwarmMiddleware(
+            subagent_graphs=subagent_graphs,
+            default_concurrency=20,
+        )
+        assert middleware.default_concurrency == 20
+
+    def test_max_concurrency(self, subagent_graphs):
+        middleware = SwarmMiddleware(
+            subagent_graphs=subagent_graphs,
+            max_concurrency=100,
+        )
+        assert middleware.max_concurrency == 100
+
+    def test_timeout_seconds(self, subagent_graphs):
+        middleware = SwarmMiddleware(
+            subagent_graphs=subagent_graphs,
+            timeout_seconds=600.0,
+        )
+        assert middleware.timeout_seconds == 600.0
+
+
+class TestSwarmMiddlewareParallelism:
+    @pytest.mark.asyncio
+    async def test_swarm_execute_uses_num_parallel(self, subagent_graphs, tmp_path):
+        middleware = SwarmMiddleware(
+            subagent_graphs=subagent_graphs,
+            max_concurrency=50,
+        )
+        task_file = tmp_path / "tasks.jsonl"
+        task_file.write_text('{"id": "1", "description": "Do one task"}\n')
+        output_dir = tmp_path / "batch"
+
+        tool = next(tool for tool in middleware.tools if tool.name == "swarm_execute")
+        await tool.ainvoke(
+            {
+                "source": str(task_file),
+                "num_parallel": 7,
+                "output_dir": str(output_dir),
+            }
+        )
+
+        summary = json.loads((output_dir / "summary.json").read_text())
+        assert summary["concurrency"] == 7
+
+    @pytest.mark.asyncio
+    async def test_swarm_execute_clamps_num_parallel_to_max(
+        self,
+        subagent_graphs,
+        tmp_path,
+    ):
+        middleware = SwarmMiddleware(
+            subagent_graphs=subagent_graphs,
+            max_concurrency=8,
+        )
+        task_file = tmp_path / "tasks.jsonl"
+        task_file.write_text('{"id": "1", "description": "Do one task"}\n')
+        output_dir = tmp_path / "batch"
+
+        tool = next(tool for tool in middleware.tools if tool.name == "swarm_execute")
+        await tool.ainvoke(
+            {
+                "source": str(task_file),
+                "num_parallel": 100,
+                "output_dir": str(output_dir),
+            }
+        )
+
+        summary = json.loads((output_dir / "summary.json").read_text())
+        assert summary["concurrency"] == 8

--- a/libs/cli/tests/unit_tests/test_app_swarm_command.py
+++ b/libs/cli/tests/unit_tests/test_app_swarm_command.py
@@ -1,0 +1,51 @@
+"""Unit tests for `/swarm` command parsing."""
+
+from deepagents_cli.app import _parse_swarm_command
+
+
+def test_parse_swarm_default_num_parallel() -> None:
+    """Should parse the basic swarm invocation."""
+    parsed, error = _parse_swarm_command("/swarm tasks.jsonl")
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.file_path == "tasks.jsonl"
+    assert parsed.num_parallel == 10
+
+
+def test_parse_swarm_num_parallel_flag() -> None:
+    """Should parse the preferred --num-parallel flag."""
+    parsed, error = _parse_swarm_command("/swarm tasks.jsonl --num-parallel 6")
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.num_parallel == 6
+
+
+def test_parse_swarm_output_dir() -> None:
+    """Should parse output directory override."""
+    parsed, error = _parse_swarm_command(
+        "/swarm tasks.jsonl --num-parallel 3 --output-dir ./out"
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.output_dir == "./out"
+
+
+def test_parse_swarm_rejects_removed_enrich_mode() -> None:
+    """Should return a clear error when --enrich is provided."""
+    parsed, error = _parse_swarm_command("/swarm --enrich companies.csv")
+
+    assert parsed is None
+    assert error is not None
+    assert "--enrich was removed" in error
+
+
+def test_parse_swarm_missing_file_path() -> None:
+    """Should surface a clear error for missing file path."""
+    parsed, error = _parse_swarm_command("/swarm")
+
+    assert parsed is None
+    assert error is not None
+    assert "Usage:" in error

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -8,6 +8,7 @@ import pytest
 from deepagents_cli.widgets.autocomplete import (
     SLASH_COMMANDS,
     CompletionController,
+    CompletionResult,
     FuzzyFileController,
     MultiCompletionManager,
     SlashCommandController,
@@ -242,6 +243,28 @@ class TestSlashCommandController:
         controller.reset()
 
         mock_view.clear_completion_suggestions.assert_called()
+
+    def test_enter_applies_completion_without_submit(self, controller, mock_view):
+        """Enter should accept selected slash completion without submitting."""
+        controller.on_text_changed("/sw", 3)
+        event = MagicMock()
+        event.key = "enter"
+
+        result = controller.on_key(event, "/sw", 3)
+
+        assert result == CompletionResult.HANDLED
+        mock_view.replace_completion_range.assert_called_once()
+
+    def test_tab_applies_completion(self, controller, mock_view):
+        """Tab should also accept selected slash completion."""
+        controller.on_text_changed("/sw", 3)
+        event = MagicMock()
+        event.key = "tab"
+
+        result = controller.on_key(event, "/sw", 3)
+
+        assert result == CompletionResult.HANDLED
+        mock_view.replace_completion_range.assert_called_once()
 
 
 class TestFuzzyFileControllerCanHandle:


### PR DESCRIPTION
## Summary
Add a `swarm_execute` tool to prgramatically spawn subagents from a jsonl file
- Supports `/swarm <file.jsonl> [--num-parallel N] [--output-dir DIR]`

## Behavior
- Each JSONL task runs independently via subagent invocation
- `num_parallel` controls bounded concurrency
- Outputs per run:
  - `summary.json`
  - `results.jsonl`
  - `failures.jsonl`
- Runs use `<timestamp>_<run_id>` output dirs

## Reliability
- Added traceback capture for failed swarm tasks in `failures.jsonl`
- Hardened `fetch_url`: if HTML->markdown conversion fails (`RecursionError`/`ValueError`), it falls back to plain text instead of failing the task.  Saw as common error in web based parallel work.

## UX
- Enter on `/swarm` autocomplete now accepts completion without auto-submit
- `swarm_execute` shows a running spinner immediately
- Agent can also call this tool

## Validation
- `make format`
- `make lint`
- `make test`
- Manual test + unit scripted 

<img width="1396" height="713" alt="Screenshot 2026-02-07 at 10 08 08 PM" src="https://github.com/user-attachments/assets/6a9cd3fe-5191-4a2b-8c83-7857ca812afb" />
