### PR TITLE
feat(cli): `--quiet` flag to suppress non-agent output w/ `-n`

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -267,6 +267,15 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress non-agent output (status messages, headers, tool "
+        "notifications). Only the agent's response text is written to "
+        "stdout; diagnostic output moves to stderr. Requires -n",
+    )
+
+    parser.add_argument(
         "--auto-approve",
         action="store_true",
         help=(
@@ -443,6 +452,10 @@ def cli_main() -> None:
     try:
         args = parse_args()
 
+        if args.quiet and not args.non_interactive_message:
+            print("error: --quiet requires --non-interactive (-n)", file=sys.stderr)
+            sys.exit(2)
+
         # Apply shell-allow-list from command line if provided (overrides env var)
         if args.shell_allow_list:
             from deepagents_cli.config import parse_shell_allow_list
@@ -484,6 +497,7 @@ def cli_main() -> None:
                     sandbox_type=args.sandbox,
                     sandbox_id=args.sandbox_id,
                     sandbox_setup=getattr(args, "sandbox_setup", None),
+                    quiet=args.quiet,
                 )
             )
             sys.exit(exit_code)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -270,9 +270,8 @@ def parse_args() -> argparse.Namespace:
         "-q",
         "--quiet",
         action="store_true",
-        help="Suppress non-agent output (status messages, headers, tool "
-        "notifications). Only the agent's response text is written to "
-        "stdout; diagnostic output moves to stderr. Requires -n",
+        help="Clean output for piping — only the agent's response "
+        "goes to stdout. Requires -n.",
     )
 
     parser.add_argument(
@@ -325,7 +324,12 @@ def parse_args() -> argparse.Namespace:
         action=_make_help_action(show_help),
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.quiet and not args.non_interactive_message:
+        parser.error("--quiet requires --non-interactive (-n)")
+
+    return args
 
 
 async def run_textual_cli_async(
@@ -451,10 +455,6 @@ def cli_main() -> None:
 
     try:
         args = parse_args()
-
-        if args.quiet and not args.non_interactive_message:
-            print("error: --quiet requires --non-interactive (-n)", file=sys.stderr)
-            sys.exit(2)
 
         # Apply shell-allow-list from command line if provided (overrides env var)
         if args.shell_allow_list:

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -10,6 +10,9 @@ all tool calls (shell and non-shell) pass through HITL, where non-shell
 tools are approved unconditionally and shell commands are validated against
 the list.
 
+An optional quiet mode (`--quiet` / `-q`) redirects all console output to
+stderr, leaving stdout exclusively for the agent's response text.
+
 Note: in non-interactive mode (`-n`), auto-approval is determined solely by
 whether a `--shell-allow-list` is present, not by the `--auto-approve` CLI
 flag. See `run_non_interactive` for details.
@@ -73,7 +76,11 @@ loops (e.g. when the agent keeps retrying rejected commands)."""
 
 
 def _write_text(text: str) -> None:
-    """Write text to stdout (without a trailing newline) for streaming output.
+    """Write agent response text to stdout (without a trailing newline).
+
+    Uses `sys.stdout` directly (rather than the Rich Console) so that agent
+    response text always appears on stdout, even in quiet mode where the
+    Console is redirected to stderr.
 
     Args:
         text: The text string to write.
@@ -93,6 +100,9 @@ class StreamState:
     """Mutable state accumulated while iterating over the agent stream.
 
     Attributes:
+        quiet: When `True`, diagnostic formatting that would otherwise go
+            to stdout (e.g. separator newlines before tool notifications)
+            is suppressed so that stdout contains only agent response text.
         full_response: Accumulated text fragments from the AI message stream.
         tool_call_buffers: Maps a tool-call index or ID to its name/ID
             metadata for in-progress tool calls.
@@ -107,6 +117,7 @@ class StreamState:
             received during the current stream pass.
     """
 
+    quiet: bool = False
     full_response: list[str] = field(default_factory=list)
     tool_call_buffers: dict[int | str, dict[str, str | None]] = field(
         default_factory=dict
@@ -200,7 +211,7 @@ def _process_ai_message(
                 state.tool_call_buffers[buffer_key] = {"name": None, "id": None}
             if chunk_name:
                 state.tool_call_buffers[buffer_key]["name"] = chunk_name
-                if state.full_response:
+                if state.full_response and not state.quiet:
                     _write_newline()
                 console.print(f"[dim]🔧 Calling tool: {chunk_name}[/dim]")
 
@@ -405,6 +416,8 @@ async def _run_agent_loop(
     config: RunnableConfig,
     console: Console,
     file_op_tracker: FileOpTracker,
+    *,
+    quiet: bool = False,
 ) -> None:
     """Run the agent and handle HITL interrupts until the task completes.
 
@@ -417,11 +430,12 @@ async def _run_agent_loop(
         config: LangGraph runnable config.
         console: Rich console for formatted output.
         file_op_tracker: Tracker for file-operation diffs.
+        quiet: Suppress diagnostic formatting on stdout.
 
     Raises:
         HITLIterationLimitError: If the HITL iteration limit is exceeded.
     """
-    state = StreamState()
+    state = StreamState(quiet=quiet)
     stream_input: dict[str, Any] | Command = {
         "messages": [{"role": "user", "content": message}]
     }
@@ -450,7 +464,11 @@ async def _run_agent_loop(
     if state.full_response:
         _write_newline()
 
-    console.print("[green]✓ Task completed[/green]")
+    if not quiet:
+        console.print()
+        console.print("[green]✓ Task completed[/green]")
+    else:
+        console.print("[green]✓ Task completed (response written to stdout)[/green]")
 
 
 def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:
@@ -548,13 +566,15 @@ async def run_non_interactive(
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.
-        quiet: When `True`, diagnostic output (headers, tool notifications,
-            completion status) is redirected to stderr so that only the
-            agent's response text appears on stdout.
+        quiet: When `True`, all console output (headers, status messages,
+            tool notifications, HITL decisions, errors) is redirected to
+            stderr so that only the agent's response text appears on stdout.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
     """
+    # stderr=True routes all console.print() to stderr; agent response text
+    # uses _write_text() -> sys.stdout directly.
     console = Console(stderr=True) if quiet else Console()
     model = create_model(model_name)
     thread_id = generate_thread_id()
@@ -568,7 +588,10 @@ async def run_non_interactive(
         },
     }
 
-    console.print("[dim]Running task non-interactively...[/dim]")
+    if quiet:
+        console.print("[dim]Running task non-interactively (quiet mode)...[/dim]")
+    else:
+        console.print("[dim]Running task non-interactively...[/dim]")
     header = _build_non_interactive_header(assistant_id, thread_id)
     console.print(header)
     console.print()
@@ -626,7 +649,9 @@ async def run_non_interactive(
                 assistant_id=assistant_id, backend=composite_backend
             )
 
-            await _run_agent_loop(agent, message, config, console, file_op_tracker)
+            await _run_agent_loop(
+                agent, message, config, console, file_op_tracker, quiet=quiet
+            )
             return 0
 
     except KeyboardInterrupt:

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -450,7 +450,7 @@ async def _run_agent_loop(
     if state.full_response:
         _write_newline()
 
-    console.print("\n[green]✓ Task completed[/green]")
+    console.print("[green]✓ Task completed[/green]")
 
 
 def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -524,6 +524,8 @@ async def run_non_interactive(
     sandbox_type: str = "none",  # str (not None) to match argparse choices
     sandbox_id: str | None = None,
     sandbox_setup: str | None = None,
+    *,
+    quiet: bool = False,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -546,11 +548,14 @@ async def run_non_interactive(
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.
+        quiet: When `True`, diagnostic output (headers, tool notifications,
+            completion status) is redirected to stderr so that only the
+            agent's response text appears on stdout.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
     """
-    console = Console()
+    console = Console(stderr=True) if quiet else Console()
     model = create_model(model_name)
     thread_id = generate_thread_id()
 

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -222,3 +222,41 @@ class TestShortFlags:
         ):
             parse_args()
         assert exc_info.value.code in (0, None)
+
+
+class TestQuietArg:
+    """Tests for -q/--quiet argument parsing."""
+
+    def test_short_flag(self) -> None:
+        """Verify -q sets quiet=True."""
+        with patch.object(sys, "argv", ["deepagents", "-q", "-n", "task"]):
+            args = parse_args()
+        assert args.quiet is True
+
+    def test_long_flag(self) -> None:
+        """Verify --quiet sets quiet=True."""
+        with patch.object(sys, "argv", ["deepagents", "--quiet", "-n", "task"]):
+            args = parse_args()
+        assert args.quiet is True
+
+    def test_no_flag_defaults_false(self) -> None:
+        """Verify quiet is False when not provided."""
+        with patch.object(sys, "argv", ["deepagents"]):
+            args = parse_args()
+        assert args.quiet is False
+
+    def test_combined_with_non_interactive(self) -> None:
+        """Verify -q works alongside -n."""
+        with patch.object(sys, "argv", ["deepagents", "-q", "-n", "run tests"]):
+            args = parse_args()
+        assert args.quiet is True
+        assert args.non_interactive_message == "run tests"
+
+    def test_quiet_without_non_interactive_exits(self) -> None:
+        """Verify --quiet without -n triggers parser.error (exit code 2)."""
+        with (
+            patch.object(sys, "argv", ["deepagents", "-q"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code == 2

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -1,10 +1,13 @@
 """Tests for non-interactive mode HITL decision logic."""
 
+import io
+import sys
 from collections.abc import AsyncIterator, Generator
 from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.messages import AIMessage
 from rich.console import Console
 from rich.style import Style
 from rich.text import Text
@@ -343,8 +346,17 @@ class TestQuietMode:
     """Tests for --quiet flag in run_non_interactive."""
 
     @pytest.mark.asyncio
-    async def test_quiet_redirects_console_to_stderr(self) -> None:
-        """When quiet=True, Console should be created with stderr=True."""
+    @pytest.mark.parametrize(
+        ("quiet", "expected_kwargs"),
+        [
+            pytest.param(True, {"stderr": True}, id="quiet-redirects-to-stderr"),
+            pytest.param(False, {}, id="default-uses-stdout"),
+        ],
+    )
+    async def test_console_creation(
+        self, quiet: bool, expected_kwargs: dict[str, object]
+    ) -> None:
+        """Console should use stderr when quiet=True, stdout otherwise."""
         mock_console = MagicMock(spec=Console)
 
         with (
@@ -384,59 +396,82 @@ class TestQuietMode:
 
             mock_agent = MagicMock()
             mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=quiet)
+
+        mock_console_cls.assert_called_once_with(**expected_kwargs)
+
+    @pytest.mark.asyncio
+    async def test_quiet_stdout_contains_only_agent_text(self) -> None:
+        """In quiet mode, stdout should have only agent text."""
+        # Build a fake AI message with a text block followed by a tool-call block
+        ai_msg = MagicMock(spec=AIMessage)
+        ai_msg.content_blocks = [
+            {"type": "text", "text": "Hello from agent"},
+            {"type": "tool_call_chunk", "name": "read_file", "id": "tc1", "index": 0},
+        ]
+        stream_chunks = [
+            # 3-tuple: (namespace, stream_mode, data)
+            ("", "messages", (ai_msg, {})),
+        ]
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.get_langsmith_project_name",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch.object(sys, "stdout", stdout_buf),
+            patch.object(sys, "stderr", stderr_buf),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter(stream_chunks))
             mock_create_agent.return_value = (mock_agent, MagicMock())
 
             await run_non_interactive(message="test", quiet=True)
 
-        mock_console_cls.assert_called_once_with(stderr=True)
+        stdout = stdout_buf.getvalue()
+        stderr = stderr_buf.getvalue()
 
-    @pytest.mark.asyncio
-    async def test_non_quiet_uses_stdout(self) -> None:
-        """When quiet=False (default), Console should be created without stderr."""
-        mock_console = MagicMock(spec=Console)
-
-        with (
-            patch(
-                "deepagents_cli.non_interactive.Console",
-                return_value=mock_console,
-            ) as mock_console_cls,
-            patch(
-                "deepagents_cli.non_interactive.create_model",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "deepagents_cli.non_interactive.generate_thread_id",
-                return_value="test-thread",
-            ),
-            patch(
-                "deepagents_cli.non_interactive.settings",
-            ) as mock_settings,
-            patch(
-                "deepagents_cli.non_interactive.get_langsmith_project_name",
-                return_value=None,
-            ),
-            patch(
-                "deepagents_cli.non_interactive.get_checkpointer",
-            ) as mock_checkpointer,
-            patch(
-                "deepagents_cli.non_interactive.create_cli_agent",
-            ) as mock_create_agent,
-        ):
-            mock_settings.shell_allow_list = None
-            mock_settings.has_tavily = False
-            mock_settings.model_name = None
-
-            mock_cp = MagicMock()
-            mock_checkpointer.return_value.__aenter__ = MagicMock(return_value=mock_cp)
-            mock_checkpointer.return_value.__aexit__ = MagicMock(return_value=None)
-
-            mock_agent = MagicMock()
-            mock_agent.astream = MagicMock(return_value=_async_iter([]))
-            mock_create_agent.return_value = (mock_agent, MagicMock())
-
-            await run_non_interactive(message="test", quiet=False)
-
-        mock_console_cls.assert_called_once_with()
+        # Agent response text goes to stdout
+        assert "Hello from agent" in stdout
+        # Diagnostic messages should NOT be on stdout
+        assert "Calling tool" not in stdout
+        assert "Task completed" not in stdout
+        assert "Running task" not in stdout
+        # Diagnostic messages go to stderr
+        assert "Calling tool" in stderr or "read_file" in stderr
+        assert "Task completed" in stderr
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029


### PR DESCRIPTION
Following #909

When piping non-interactive output to a file (`deepagents -n "hey" > out.txt`), the file currently includes status lines (`"Running task non-interactively..."`, `"✓ Task completed"`, etc.) mixed with the agent response.

The `--quiet` flag enables clean machine-consumable output by redirecting all non-agent output to stderr.