### PR TITLE
ci(cli): add SDK version pin check to CI and release workflows

### DIFF
--- a/.github/workflows/check_versions.yml
+++ b/.github/workflows/check_versions.yml
@@ -49,3 +49,27 @@ jobs:
           else
             echo "deepagents-cli versions match: $CLI_PYPROJECT_VERSION"
           fi
+
+  check_sdk_pin:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ignore-sdk-pin-check') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "✅ Verify CLI pins latest SDK version"
+        run: |
+          SDK_VERSION=$(grep -Po '(?<=^version = ")[^"]*' libs/deepagents/pyproject.toml)
+          CLI_SDK_PIN=$(grep -Po '(?<=deepagents==)[0-9]+\.[0-9]+\.[0-9]+' libs/cli/pyproject.toml)
+
+          if [ "$SDK_VERSION" != "$CLI_SDK_PIN" ]; then
+            echo "::error::CLI SDK pin does not match SDK version!"
+            echo "SDK version (libs/deepagents/pyproject.toml): $SDK_VERSION"
+            echo "CLI SDK pin (libs/cli/pyproject.toml): $CLI_SDK_PIN"
+            echo ""
+            echo "Update the deepagents dependency in libs/cli/pyproject.toml to deepagents==$SDK_VERSION"
+            echo "Or add the 'ignore-sdk-pin-check' label to skip this check."
+            exit 1
+          else
+            echo "CLI SDK pin matches SDK version: $SDK_VERSION"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         default: false
         description: "Release from a non-master branch (danger!) - Only use for hotfixes"
+      dangerous-skip-sdk-pin-check:
+        required: false
+        type: boolean
+        default: false
+        description: "Skip CLI SDK pin validation (danger!) - Only use when intentionally pinning an older SDK"
 
 env:
   PYTHON_VERSION: "3.11"
@@ -484,6 +489,24 @@ jobs:
         with:
           name: dist
           path: ${{ env.WORKING_DIR }}/dist/
+
+      - name: Verify CLI pins latest SDK version
+        if: needs.build.outputs.pkg-name == 'deepagents-cli' && !inputs.dangerous-skip-sdk-pin-check
+        run: |
+          SDK_VERSION=$(grep -Po '(?<=^version = ")[^"]*' libs/deepagents/pyproject.toml)
+          CLI_SDK_PIN=$(grep -Po '(?<=deepagents==)[0-9]+\.[0-9]+\.[0-9]+' libs/cli/pyproject.toml)
+
+          if [ "$SDK_VERSION" != "$CLI_SDK_PIN" ]; then
+            echo "::error::CLI SDK pin does not match SDK version!"
+            echo "SDK version (libs/deepagents/pyproject.toml): $SDK_VERSION"
+            echo "CLI SDK pin (libs/cli/pyproject.toml): $CLI_SDK_PIN"
+            echo ""
+            echo "Update the deepagents dependency in libs/cli/pyproject.toml to deepagents==$SDK_VERSION"
+            echo "Or re-run with 'dangerous-skip-sdk-pin-check' enabled to bypass."
+            exit 1
+          else
+            echo "CLI SDK pin matches SDK version: $SDK_VERSION"
+          fi
 
       - name: Import dist package
         shell: bash


### PR DESCRIPTION
The CLI hard-pins the SDK version, but nothing prevented shipping with a stale pin if someone bumped the SDK without updating the CLI dependency.

- Add a `check_sdk_pin` job to `check_versions.yml` that verifies the CLI's `deepagents==` pin in `libs/cli/pyproject.toml` matches the SDK's actual version in `libs/deepagents/pyproject.toml`
- Adds a pre-release validation step in `release.yml` that runs the same check when releasing `deepagents-cli`
- PR-time check can be skipped with the `ignore-sdk-pin-check` label; release-time check can be skipped with the `dangerous-skip-sdk-pin-check` workflow dispatch input (automated release-please runs always enforce it)