### PR TITLE
fix(cli): update splash thread ID on `/clear`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1003,6 +1003,11 @@ class DeepAgentsApp(App):
             # Reset thread to start fresh conversation
             if self._session_state:
                 new_thread_id = self._session_state.reset_thread()
+                try:
+                    banner = self.query_one("#welcome-banner", WelcomeBanner)
+                    banner.update_thread_id(new_thread_id)
+                except NoMatches:
+                    pass
                 await self._mount_message(
                     AppMessage(f"Started new thread: {new_thread_id}")
                 )

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -40,6 +40,7 @@ class WelcomeBanner(Static):
         # Avoid collision with Widget._thread_id (Textual internal int)
         self._cli_thread_id: str | None = thread_id
         self._project_name: str | None = get_langsmith_project_name()
+        self._project_url: str | None = None
 
         super().__init__(self._build_banner(), **kwargs)
 
@@ -60,7 +61,17 @@ class WelcomeBanner(Static):
         except (TimeoutError, OSError):
             project_url = None
         if project_url:
+            self._project_url = project_url
             self.update(self._build_banner(project_url))
+
+    def update_thread_id(self, thread_id: str) -> None:
+        """Update the displayed thread ID and re-render the banner.
+
+        Args:
+            thread_id: The new thread ID to display.
+        """
+        self._cli_thread_id = thread_id
+        self.update(self._build_banner(self._project_url))
 
     def _build_banner(self, project_url: str | None = None) -> Text:
         """Build the banner rich text.

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -129,6 +129,39 @@ class TestBuildBannerThreadLink:
         assert links[0] == f"{project_url}/t/77777"
 
 
+class TestUpdateThreadId:
+    """Tests for `update_thread_id`."""
+
+    def test_update_thread_id_changes_internal_state(self) -> None:
+        """After `update_thread_id`, `_build_banner` should reflect the new ID."""
+        widget = _make_banner(thread_id="old_id")
+        assert "Thread: old_id" in widget._build_banner().plain
+
+        # Patch Static.update to avoid needing an active Textual app context
+        with patch.object(widget, "update"):
+            widget.update_thread_id("new_id")
+
+        banner = widget._build_banner()
+        assert "Thread: new_id" in banner.plain
+        assert "old_id" not in banner.plain
+
+    def test_update_thread_id_preserves_project_url(self) -> None:
+        """Thread link should use the cached project URL after update."""
+        project_url = "https://smith.langchain.com/o/org/projects/p/abc123"
+        widget = _make_banner(thread_id="old_id")
+        widget._project_url = project_url
+
+        with patch.object(widget, "update"):
+            widget.update_thread_id("new_id")
+
+        banner = widget._build_banner(project_url)
+        thread_start = banner.plain.index("new_id")
+        thread_end = thread_start + len("new_id")
+        links = _extract_links(banner, thread_start, thread_end)
+        assert links
+        assert links[0] == f"{project_url}/t/new_id"
+
+
 class TestBuildBannerReturnType:
     """Tests for `_build_banner` return value."""
 

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -151,10 +151,13 @@ class TestUpdateThreadId:
         widget = _make_banner(thread_id="old_id")
         widget._project_url = project_url
 
-        with patch.object(widget, "update"):
+        with patch.object(widget, "update") as mock_update:
             widget.update_thread_id("new_id")
 
-        banner = widget._build_banner(project_url)
+        # Verify update_thread_id passed the correct banner to Static.update
+        mock_update.assert_called_once()
+        banner = mock_update.call_args[0][0]
+        assert "Thread: new_id" in banner.plain
         thread_start = banner.plain.index("new_id")
         thread_end = thread_start + len("new_id")
         links = _extract_links(banner, thread_start, thread_end)


### PR DESCRIPTION
Closes #1054

`/clear` resets the conversation thread but the welcome banner kept showing the old thread ID, making it look stale. Now when `/clear` creates a new thread, the banner updates to reflect the new thread ID.