### PR TITLE
fix(deepagents): Fix documentation link in Agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,5 +222,5 @@ def send_email(to: str, msg: str, *, priority: str = "normal") -> bool:
 
 ## Additional resources
 
-- **Documentation:** https://docs.langchain.com/oss/python/deeoagebts/overview and source at https://github.com/langchain-ai/docs or `../docs/`. Prefer the local install and use file search tools for best results. If needed, use the docs MCP server as defined in `.mcp.json` for programmatic access.
+- **Documentation:** https://docs.langchain.com/oss/python/deepagents/overview and source at https://github.com/langchain-ai/docs or `../docs/`. Prefer the local install and use file search tools for best results. If needed, use the docs MCP server as defined in `.mcp.json` for programmatic access.
 - **Contributing Guide:** [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview)


### PR DESCRIPTION
Minor documentation correction in the `AGENTS.md` file, fixing a typo in a URL.