### PR TITLE
chore(sdk): add support for `,` in allowed-tools, fail gently for bullet list

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -242,7 +242,7 @@ def _validate_skill_name(name: str, directory_name: str) -> tuple[bool, str]:
     return True, ""
 
 
-def _parse_skill_metadata(  # noqa: PLR0912
+def _parse_skill_metadata(
     content: str,
     skill_path: str,
     directory_name: str,
@@ -312,19 +312,19 @@ def _parse_skill_metadata(  # noqa: PLR0912
         description_str = description_str[:MAX_SKILL_DESCRIPTION_LENGTH]
 
     raw_tools = frontmatter_data.get("allowed-tools")
-    if raw_tools:
-        if isinstance(raw_tools, list):
-            allowed_tools = [t.strip() for t in raw_tools if isinstance(t, str) and t.strip()]
-        elif isinstance(raw_tools, str):
-            allowed_tools = raw_tools.split()
-        else:
-            logger.warning(
-                "Invalid 'allowed-tools' type %s in %s; expected list or string. Ignoring value.",
-                type(raw_tools).__name__,
-                skill_path,
-            )
-            allowed_tools = []
+    if isinstance(raw_tools, str):
+        allowed_tools = [
+            t.strip(",")  # Support commas for compatibility with skills created for Claude Code.
+            for t in raw_tools.split()
+            if t.strip(",")
+        ]
     else:
+        if raw_tools is not None:
+            logger.warning(
+                "Ignoring non-string 'allowed-tools' in %s (got %s)",
+                skill_path,
+                type(raw_tools).__name__,
+            )
         allowed_tools = []
 
     compatibility_str = str(frontmatter_data.get("compatibility", "")).strip() or None

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -433,7 +433,7 @@ def test_validate_metadata_valid_dict_passthrough() -> None:
     assert result == {"author": "acme"}
 
 
-def test_parse_skill_metadata_allowed_tools_yaml_list() -> None:
+def test_parse_skill_metadata_allowed_tools_yaml_list_ignored() -> None:
     content = """---
 name: test-skill
 description: A test skill
@@ -448,7 +448,7 @@ Content
 
     result = _parse_skill_metadata(content, "/skills/test-skill/SKILL.md", "test-skill")
     assert result is not None
-    assert result["allowed_tools"] == ["Bash", "Read", "Write"]
+    assert result["allowed_tools"] == []
 
 
 def test_parse_skill_metadata_allowed_tools_yaml_list_non_strings_ignored() -> None:
@@ -469,7 +469,7 @@ Content
 
     result = _parse_skill_metadata(content, "/skills/test-skill/SKILL.md", "test-skill")
     assert result is not None
-    assert result["allowed_tools"] == ["Read", "Write"]
+    assert result["allowed_tools"] == []
 
 
 def test_parse_skill_metadata_license_boolean_coerced() -> None:


### PR DESCRIPTION
* Support for `,` for consistency with claude code
* Drop support for bullet list in YAML as it's unclear whether it's supported right now. If it is we could add support, but I suspect the goal is to move away so one doesn't need to use a a more complex parser to parse the YAML front-matter