### PR TITLE
feat(cli): support piped stdin as prompt input

### DIFF
--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -180,8 +180,10 @@ def _process_ai_message(
 ) -> None:
     """Extract text and tool-call blocks from an AI message and render them.
 
-    Text blocks are streamed to stdout; tool-call blocks are buffered and
-    their names are printed to the console.
+    When streaming is enabled, text blocks are written to stdout immediately;
+    otherwise they are accumulated in `state.full_response` for deferred
+    output. Tool-call blocks are buffered and their names are printed to the
+    console.
 
     Args:
         message_obj: The `AIMessage` received from the stream.
@@ -578,7 +580,7 @@ async def run_non_interactive(
 
             These override config file values.
         sandbox_type: Type of sandbox (`'none'`, `'modal'`,
-            `'runloop'`, `'daytona'`).
+            `'runloop'`, `'daytona'`, `'langsmith'`).
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -468,8 +468,6 @@ async def _run_agent_loop(
     if not quiet:
         console.print()
         console.print("[green]✓ Task completed[/green]")
-    else:
-        console.print("[green]✓ Task completed (response written to stdout)[/green]")
 
 
 def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:
@@ -600,13 +598,11 @@ async def run_non_interactive(
         },
     }
 
-    if quiet:
-        console.print("[dim]Running task non-interactively (quiet mode)...[/dim]")
-    else:
+    if not quiet:
         console.print("[dim]Running task non-interactively...[/dim]")
-    header = _build_non_interactive_header(assistant_id, thread_id)
-    console.print(header)
-    console.print()
+        header = _build_non_interactive_header(assistant_id, thread_id)
+        console.print(header)
+        console.print()
 
     sandbox_backend = None
     exit_stack = contextlib.ExitStack()

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -252,11 +252,13 @@ class TestQuietArg:
         assert args.quiet is True
         assert args.non_interactive_message == "run tests"
 
-    def test_quiet_without_non_interactive_exits(self) -> None:
-        """Verify --quiet without -n triggers parser.error (exit code 2)."""
-        with (
-            patch.object(sys, "argv", ["deepagents", "-q"]),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            parse_args()
-        assert exc_info.value.code == 2
+    def test_quiet_without_non_interactive_parses(self) -> None:
+        """Verify --quiet without -n parses successfully.
+
+        The usage-error guard now lives in `cli_main` (after stdin pipe
+        processing), so `parse_args` itself should not reject this combo.
+        """
+        with patch.object(sys, "argv", ["deepagents", "-q"]):
+            args = parse_args()
+        assert args.quiet is True
+        assert args.non_interactive_message is None

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -1,14 +1,17 @@
 """Tests for command-line argument parsing."""
 
+import argparse
+import io
+import os
 import sys
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from deepagents_cli.config import parse_shell_allow_list
-from deepagents_cli.main import parse_args
+from deepagents_cli.main import apply_stdin_pipe, parse_args
 
 MockArgvType = Callable[..., AbstractContextManager[object]]
 
@@ -149,3 +152,140 @@ class TestModelParamsArgument:
             parsed = parse_args()
             assert parsed.model == "gpt-4o"
             assert parsed.model_params == '{"temperature": 0.5, "max_tokens": 2048}'
+
+
+def _make_args(
+    *,
+    non_interactive_message: str | None = None,
+    initial_prompt: str | None = None,
+) -> argparse.Namespace:
+    """Create a minimal argument namespace for stdin pipe tests."""
+    return argparse.Namespace(
+        non_interactive_message=non_interactive_message,
+        initial_prompt=initial_prompt,
+    )
+
+
+class TestApplyStdinPipe:
+    """Tests for apply_stdin_pipe — reading piped stdin into CLI args."""
+
+    def test_tty_is_noop(self) -> None:
+        """When stdin is a TTY, args are not modified."""
+        args = _make_args()
+        with patch.object(sys, "stdin", wraps=sys.stdin) as mock_stdin:
+            mock_stdin.isatty = lambda: True
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message is None
+        assert args.initial_prompt is None
+
+    def test_empty_stdin_is_noop(self) -> None:
+        """When piped stdin is empty/whitespace, args are not modified."""
+        args = _make_args()
+        fake_stdin = io.StringIO("   \n  ")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message is None
+        assert args.initial_prompt is None
+
+    def test_stdin_sets_non_interactive(self) -> None:
+        """Piped stdin with no flags sets non_interactive_message."""
+        args = _make_args()
+        fake_stdin = io.StringIO("my prompt")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message == "my prompt"
+        assert args.initial_prompt is None
+
+    def test_stdin_prepends_to_non_interactive(self) -> None:
+        """Piped stdin is prepended to an existing -n message."""
+        args = _make_args(non_interactive_message="do something")
+        fake_stdin = io.StringIO("context from pipe")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message == "context from pipe\n\ndo something"
+
+    def test_stdin_prepends_to_initial_prompt(self) -> None:
+        """Piped stdin is prepended to an existing -m message."""
+        args = _make_args(initial_prompt="explain this")
+        fake_stdin = io.StringIO("error log contents")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.initial_prompt == "error log contents\n\nexplain this"
+        assert args.non_interactive_message is None
+
+    def test_non_interactive_takes_priority_over_initial_prompt(self) -> None:
+        """When both -n and -m are set, stdin is prepended to -n."""
+        args = _make_args(
+            non_interactive_message="task", initial_prompt="ignored"
+        )
+        fake_stdin = io.StringIO("piped")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message == "piped\n\ntask"
+        assert args.initial_prompt == "ignored"
+
+    def test_multiline_stdin(self) -> None:
+        """Multiline piped input is preserved."""
+        args = _make_args()
+        fake_stdin = io.StringIO("line one\nline two\nline three")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message == "line one\nline two\nline three"
+        assert args.initial_prompt is None
+
+    def test_none_stdin_is_noop(self) -> None:
+        """When sys.stdin is None (embedded Python), args are not modified."""
+        args = _make_args()
+        with patch.object(sys, "stdin", None):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message is None
+        assert args.initial_prompt is None
+
+    def test_closed_stdin_is_noop(self) -> None:
+        """When stdin.isatty() raises ValueError, treat as no pipe input."""
+        args = _make_args()
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.side_effect = ValueError("I/O operation on closed file")
+        with patch.object(sys, "stdin", mock_stdin):
+            apply_stdin_pipe(args)
+        assert args.non_interactive_message is None
+        assert args.initial_prompt is None
+
+    def test_unicode_decode_error_exits(self) -> None:
+        """Binary piped input triggers a clean exit, not a raw traceback."""
+        args = _make_args()
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.side_effect = UnicodeDecodeError(
+            "utf-8", b"\x80", 0, 1, "invalid start byte"
+        )
+        with (
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            apply_stdin_pipe(args)
+        assert exc_info.value.code == 1
+
+    def test_stdin_restores_tty(self) -> None:
+        """After reading piped input, fd 0 is replaced with /dev/tty."""
+        args = _make_args()
+        fake_stdin = io.StringIO("hello")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with (
+            patch.object(sys, "stdin", fake_stdin),
+            patch("os.open", return_value=99) as mock_os_open,
+            patch("os.dup2") as mock_dup2,
+            patch("os.close") as mock_close,
+            patch("builtins.open") as mock_open,
+        ):
+            apply_stdin_pipe(args)
+        mock_os_open.assert_called_once_with("/dev/tty", os.O_RDONLY)
+        mock_dup2.assert_called_once_with(99, 0)
+        mock_close.assert_called_once_with(99)
+        mock_open.assert_called_once_with(0, encoding="utf-8", closefd=False)

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -489,6 +489,165 @@ class TestQuietMode:
         assert "Running task" not in stderr
 
 
+class TestNoStreamMode:
+    """Tests for --no-stream flag in run_non_interactive."""
+
+    @pytest.mark.asyncio
+    async def test_no_stream_buffers_output(self) -> None:
+        """In no-stream mode, stdout should receive text only after completion."""
+        # Build two text chunks to verify buffering vs streaming
+        ai_msg1 = MagicMock(spec=AIMessage)
+        ai_msg1.content_blocks = [{"type": "text", "text": "Hello "}]
+        ai_msg2 = MagicMock(spec=AIMessage)
+        ai_msg2.content_blocks = [{"type": "text", "text": "world"}]
+
+        stream_chunks = [
+            ("", "messages", (ai_msg1, {})),
+            ("", "messages", (ai_msg2, {})),
+        ]
+
+        stdout_writes: list[str] = []
+
+        class TrackingStringIO(io.StringIO):
+            """StringIO that records each write call separately."""
+
+            def write(self, s: str) -> int:
+                stdout_writes.append(s)
+                return super().write(s)
+
+        stdout_buf = TrackingStringIO()
+
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.get_langsmith_project_name",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch.object(sys, "stdout", stdout_buf),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter(stream_chunks))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=True, stream=False)
+
+        stdout = stdout_buf.getvalue()
+        assert "Hello world" in stdout
+
+        # Verify the text was NOT written incrementally — the first
+        # text write should contain the full concatenated response
+        text_writes = [w for w in stdout_writes if w != "\n"]
+        assert len(text_writes) == 1
+        assert text_writes[0] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_stream_mode_writes_incrementally(self) -> None:
+        """Default stream mode should write text chunks as they arrive."""
+        ai_msg1 = MagicMock(spec=AIMessage)
+        ai_msg1.content_blocks = [{"type": "text", "text": "Hello "}]
+        ai_msg2 = MagicMock(spec=AIMessage)
+        ai_msg2.content_blocks = [{"type": "text", "text": "world"}]
+
+        stream_chunks = [
+            ("", "messages", (ai_msg1, {})),
+            ("", "messages", (ai_msg2, {})),
+        ]
+
+        stdout_writes: list[str] = []
+
+        class TrackingStringIO(io.StringIO):
+            """StringIO that records each write call separately."""
+
+            def write(self, s: str) -> int:
+                stdout_writes.append(s)
+                return super().write(s)
+
+        stdout_buf = TrackingStringIO()
+
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.get_langsmith_project_name",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch.object(sys, "stdout", stdout_buf),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter(stream_chunks))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=True, stream=True)
+
+        stdout = stdout_buf.getvalue()
+        assert "Hello world" in stdout
+
+        # Verify text was written incrementally (two separate writes)
+        text_writes = [w for w in stdout_writes if w != "\n"]
+        assert len(text_writes) == 2
+        assert text_writes[0] == "Hello "
+        assert text_writes[1] == "world"
+
+
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029
     """Create an async iterator from a list for testing."""
     for item in items:

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -482,9 +482,11 @@ class TestQuietMode:
         assert "Calling tool" not in stdout
         assert "Task completed" not in stdout
         assert "Running task" not in stdout
-        # Diagnostic messages go to stderr
+        # Tool notifications still go to stderr
         assert "Calling tool" in stderr or "read_file" in stderr
-        assert "Task completed" in stderr
+        # Header and completion messages are fully suppressed in quiet mode
+        assert "Task completed" not in stderr
+        assert "Running task" not in stderr
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029


### PR DESCRIPTION
Support piping input into the CLI (`echo "fix typo" | deepagents`) and add a `--no-stream` flag for scripts that need the full response as a single write. Previously, the CLI required all prompts to be passed as flag arguments — there was no way to pipe content in, and streaming output could cause issues for downstream consumers expecting a complete response.

## Usage

```bash
# Pipe content as the prompt (runs non-interactively)
echo "fix the typo in README.md" | deepagents

# Pipe context + explicit prompt
cat error.log | deepagents -n "explain this"

# Pipe context into interactive mode
cat schema.sql | deepagents -m "add a users table"

# Buffer full response for downstream consumption
echo "list all TODO comments" | deepagents --no-stream -q > todos.txt

# Combine with other CLI tools
git diff | deepagents -n "write a commit message" --no-stream -q | pbcopy
```