### PR TITLE
feat(cli): add `--no-stream` flag for buffered non-interactive output

### DIFF
--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -489,6 +489,165 @@ class TestQuietMode:
         assert "Running task" not in stderr
 
 
+class TestNoStreamMode:
+    """Tests for --no-stream flag in run_non_interactive."""
+
+    @pytest.mark.asyncio
+    async def test_no_stream_buffers_output(self) -> None:
+        """In no-stream mode, stdout should receive text only after completion."""
+        # Build two text chunks to verify buffering vs streaming
+        ai_msg1 = MagicMock(spec=AIMessage)
+        ai_msg1.content_blocks = [{"type": "text", "text": "Hello "}]
+        ai_msg2 = MagicMock(spec=AIMessage)
+        ai_msg2.content_blocks = [{"type": "text", "text": "world"}]
+
+        stream_chunks = [
+            ("", "messages", (ai_msg1, {})),
+            ("", "messages", (ai_msg2, {})),
+        ]
+
+        stdout_writes: list[str] = []
+
+        class TrackingStringIO(io.StringIO):
+            """StringIO that records each write call separately."""
+
+            def write(self, s: str) -> int:
+                stdout_writes.append(s)
+                return super().write(s)
+
+        stdout_buf = TrackingStringIO()
+
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.get_langsmith_project_name",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch.object(sys, "stdout", stdout_buf),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter(stream_chunks))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=True, stream=False)
+
+        stdout = stdout_buf.getvalue()
+        assert "Hello world" in stdout
+
+        # Verify the text was NOT written incrementally — the first
+        # text write should contain the full concatenated response
+        text_writes = [w for w in stdout_writes if w != "\n"]
+        assert len(text_writes) == 1
+        assert text_writes[0] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_stream_mode_writes_incrementally(self) -> None:
+        """Default stream mode should write text chunks as they arrive."""
+        ai_msg1 = MagicMock(spec=AIMessage)
+        ai_msg1.content_blocks = [{"type": "text", "text": "Hello "}]
+        ai_msg2 = MagicMock(spec=AIMessage)
+        ai_msg2.content_blocks = [{"type": "text", "text": "world"}]
+
+        stream_chunks = [
+            ("", "messages", (ai_msg1, {})),
+            ("", "messages", (ai_msg2, {})),
+        ]
+
+        stdout_writes: list[str] = []
+
+        class TrackingStringIO(io.StringIO):
+            """StringIO that records each write call separately."""
+
+            def write(self, s: str) -> int:
+                stdout_writes.append(s)
+                return super().write(s)
+
+        stdout_buf = TrackingStringIO()
+
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.get_langsmith_project_name",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch.object(sys, "stdout", stdout_buf),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter(stream_chunks))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=True, stream=True)
+
+        stdout = stdout_buf.getvalue()
+        assert "Hello world" in stdout
+
+        # Verify text was written incrementally (two separate writes)
+        text_writes = [w for w in stdout_writes if w != "\n"]
+        assert len(text_writes) == 2
+        assert text_writes[0] == "Hello "
+        assert text_writes[1] == "world"
+
+
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029
     """Create an async iterator from a list for testing."""
     for item in items:


### PR DESCRIPTION
- Add `--no-stream` flag to non-interactive mode that buffers the full agent response and writes it to stdout in one shot after completion, instead of streaming token-by-token
- Useful for scripting/piping workflows where programmatic consumers want the final result without incremental output
- Reuses existing `StreamState.full_response` buffer — the only behavioral change is gating the real-time `_write_text()` call and flushing at the end

## Usage

```bash
# Buffer full response (no token-by-token streaming)
deepagents -n "explain quicksort" --no-stream

# Combine with --quiet for clean piping
echo "list 3 prime numbers" | deepagents --no-stream -q | wc -w

# Pipe into jq, downstream tools, etc.
deepagents -n "output a JSON array of colors" --no-stream -q | jq '.[0]'
```