### PR TITLE
fix(cli): fix stale model settings during model hot-swap

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1739,6 +1739,7 @@ class DeepAgentsApp(App):
         # create_cli_agent because it builds the system prompt from global
         # settings (model name, provider, context limit). Otherwise the
         # prompt would describe the old model to the new one.
+        #
         # Save previous values for rollback if agent creation fails.
         prev_name = settings.model_name
         prev_provider = settings.model_provider

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1735,6 +1735,16 @@ class DeepAgentsApp(App):
             await self._mount_message(ErrorMessage(f"Failed to create model: {e}"))
             return
 
+        # When switching models, settings must be updated before
+        # create_cli_agent because it builds the system prompt from global
+        # settings (model name, provider, context limit). Otherwise the
+        # prompt would describe the old model to the new one.
+        # Save previous values for rollback if agent creation fails.
+        prev_name = settings.model_name
+        prev_provider = settings.model_provider
+        prev_context_limit = settings.model_context_limit
+        result.apply_to_settings()
+
         try:
             new_agent, new_backend = create_cli_agent(
                 model=result.model,
@@ -1746,12 +1756,13 @@ class DeepAgentsApp(App):
                 checkpointer=self._checkpointer,
             )
         except Exception as e:
+            # Roll back settings so the running agent isn't misrepresented.
+            settings.model_name = prev_name
+            settings.model_provider = prev_provider
+            settings.model_context_limit = prev_context_limit
             logger.exception("Failed to create agent for model switch")
             await self._mount_message(ErrorMessage(f"Model switch failed: {e}"))
             return
-
-        # Both model and agent succeeded — now commit to settings atomically.
-        result.apply_to_settings()
 
         # Swap agent
         self._agent = new_agent

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1246,8 +1246,7 @@ class ModelResult:
         """Commit this result's metadata to global `settings`."""
         settings.model_name = self.model_name
         settings.model_provider = self.provider
-        if self.context_limit is not None:
-            settings.model_context_limit = self.context_limit
+        settings.model_context_limit = self.context_limit
 
 
 def create_model(

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -212,6 +212,69 @@ class TestModelSwitchErrorHandling:
         assert settings.model_context_limit == 128_000
 
     @pytest.mark.asyncio
+    async def test_context_limit_cleared_when_new_model_has_none(self) -> None:
+        """Switching to a model without a context limit clears the old value."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+        settings.model_context_limit = 128_000
+
+        mock_result = ModelResult(
+            model=MagicMock(),
+            model_name="custom-model",
+            provider="ollama",
+            context_limit=None,
+        )
+        mock_agent = MagicMock()
+        mock_backend = MagicMock()
+
+        with (
+            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch("deepagents_cli.app.create_model", return_value=mock_result),
+            patch(
+                "deepagents_cli.app.create_cli_agent",
+                return_value=(mock_agent, mock_backend),
+            ),
+            patch("deepagents_cli.app.save_recent_model", return_value=True),
+        ):
+            await app._switch_model("ollama:custom-model")
+
+        assert settings.model_context_limit is None
+
+    @pytest.mark.asyncio
+    async def test_agent_failure_rollback_with_none_context_limit(self) -> None:
+        """Rollback restores previous context limit when new model has None."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+        settings.model_context_limit = 128_000
+
+        mock_result = ModelResult(
+            model=MagicMock(),
+            model_name="custom-model",
+            provider="custom",
+            context_limit=None,
+        )
+
+        with (
+            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch("deepagents_cli.app.create_model", return_value=mock_result),
+            patch(
+                "deepagents_cli.app.create_cli_agent",
+                side_effect=RuntimeError("fail"),
+            ),
+        ):
+            await app._switch_model("custom:custom-model")
+
+        assert settings.model_context_limit == 128_000
+
+    @pytest.mark.asyncio
     async def test_no_checkpointer_saves_preference(self) -> None:
         """_switch_model without checkpointer saves preference but doesn't hot-swap."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -206,7 +206,7 @@ class TestModelSwitchErrorHandling:
         assert "Model switch failed" in captured_errors[0]
         assert "Agent creation failed" in captured_errors[0]
 
-        # Settings are never mutated — no rollback needed
+        # Settings are rolled back to previous values on agent creation failure
         assert settings.model_name == "gpt-4o"
         assert settings.model_provider == "openai"
         assert settings.model_context_limit == 128_000


### PR DESCRIPTION
Switching to a model that doesn't report a context limit (e.g., Ollama) would leave the previous model's limit in place, causing the system prompt to advertise the wrong context window. Fixes this, in addition to guarding setting updates on case of switching failure.