### PR TITLE
fix(cli): `esc` should terminate active execution

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-
-# S404: subprocess is required for user-initiated shell commands via ! prefix
-import subprocess  # noqa: S404
 import uuid
 import webbrowser
 from collections import deque
@@ -457,6 +454,8 @@ class DeepAgentsApp(App):
         # Agent task tracking for interruption
         self._agent_worker: Worker[None] | None = None
         self._agent_running = False
+        self._bash_process: asyncio.subprocess.Process | None = None
+        self._bash_interrupted = False
         self._loading_widget: LoadingWidget | None = None
         self._token_tracker: TextualTokenTracker | None = None
         # User message queue for sequential processing
@@ -1017,27 +1016,37 @@ class DeepAgentsApp(App):
         await self._mount_message(UserMessage(f"!{command}"))
 
         # Execute bash command (user explicitly requested via ! prefix)
-        # S604: shell=True is intentional - user requested shell execution via ! prefix
+        # S602: shell execution is intentional for !-prefixed user commands
         try:
-            result = await asyncio.to_thread(  # noqa: S604
-                subprocess.run,
+            self._bash_interrupted = False
+            process = await asyncio.create_subprocess_shell(
                 command,
-                shell=True,
-                capture_output=True,
-                text=True,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
                 cwd=self._cwd,
-                timeout=60,
             )
-            # text=True ensures stdout/stderr are str, not bytes
-            stdout = result.stdout
-            stderr = result.stderr
-            if not isinstance(stdout, str):
-                stdout = stdout.decode() if stdout else ""
-            output = stdout.strip()
+            self._bash_process = process
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    process.communicate(), timeout=60
+                )
+            except TimeoutError:
+                with suppress(ProcessLookupError):
+                    process.kill()
+                await process.communicate()
+                await self._mount_message(ErrorMessage("Command timed out (60s limit)"))
+                return
+            finally:
+                self._bash_process = None
+
+            output = (
+                stdout_bytes.decode(errors="replace").strip() if stdout_bytes else ""
+            )
+            stderr = (
+                stderr_bytes.decode(errors="replace").strip() if stderr_bytes else ""
+            )
             if stderr:
-                if not isinstance(stderr, str):
-                    stderr = stderr.decode() if stderr else ""
-                output += f"\n[stderr]\n{stderr.strip()}"
+                output += f"\n[stderr]\n{stderr}"
 
             if output:
                 # Display output as assistant message (uses markdown for code blocks)
@@ -1047,19 +1056,24 @@ class DeepAgentsApp(App):
             else:
                 await self._mount_message(AppMessage("Command completed (no output)"))
 
-            if result.returncode != 0:
+            if self._bash_interrupted:
+                await self._mount_message(AppMessage("Command interrupted"))
+                return
+
+            if process.returncode and process.returncode != 0:
                 await self._mount_message(
-                    ErrorMessage(f"Exit code: {result.returncode}")
+                    ErrorMessage(f"Exit code: {process.returncode}")
                 )
 
             # Scroll to show the output (user-initiated command, so scroll is expected)
             chat = self.query_one("#chat", VerticalScroll)
             chat.scroll_end(animate=False)
 
-        except subprocess.TimeoutExpired:
-            await self._mount_message(ErrorMessage("Command timed out (60s limit)"))
         except OSError as e:
             await self._mount_message(ErrorMessage(str(e)))
+        finally:
+            self._bash_process = None
+            self._bash_interrupted = False
 
     async def _open_url_command(self, command: str, cmd: str) -> None:
         """Open a URL in the browser and display a clickable link.
@@ -2116,6 +2130,11 @@ class DeepAgentsApp(App):
             self._quit_pending = False
             return
 
+        # If a bash command is running, terminate it.
+        if self._interrupt_bash_process():
+            self._quit_pending = False
+            return
+
         # If approval menu is active, reject it
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_reject()
@@ -2145,6 +2164,10 @@ class DeepAgentsApp(App):
         if self._chat_input and self._chat_input.dismiss_completion():
             return
 
+        # If a bash command is running, terminate it.
+        if self._interrupt_bash_process():
+            return
+
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
             self._pending_messages.clear()
@@ -2157,6 +2180,20 @@ class DeepAgentsApp(App):
         # If approval menu is active, reject it
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_reject()
+
+    def _interrupt_bash_process(self) -> bool:
+        """Terminate the active bash command, if one is running.
+
+        Returns:
+            `True` if a live process was found and termination was requested.
+        """
+        if self._bash_process is None or self._bash_process.returncode is not None:
+            return False
+
+        self._bash_interrupted = True
+        with suppress(ProcessLookupError):
+            self._bash_process.terminate()
+        return True
 
     def action_quit_app(self) -> None:
         """Handle quit action (Ctrl+D)."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
+import subprocess  # noqa: S404
 import uuid
 import webbrowser
 from collections import deque
@@ -455,6 +457,7 @@ class DeepAgentsApp(App):
         self._agent_worker: Worker[None] | None = None
         self._agent_running = False
         self._bash_process: asyncio.subprocess.Process | None = None
+        self._bash_pgid: int | None = None
         self._bash_interrupted = False
         self._loading_widget: LoadingWidget | None = None
         self._token_tracker: TextualTokenTracker | None = None
@@ -1019,13 +1022,25 @@ class DeepAgentsApp(App):
         # S602: shell execution is intentional for !-prefixed user commands
         try:
             self._bash_interrupted = False
+            create_kwargs: dict[str, Any] = {
+                "stdout": asyncio.subprocess.PIPE,
+                "stderr": asyncio.subprocess.PIPE,
+                "cwd": self._cwd,
+            }
+            if os.name == "nt":
+                creation_flag = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                if creation_flag:
+                    create_kwargs["creationflags"] = creation_flag
+            else:
+                # Run in a new session so escape/ctrl+c can terminate the full
+                # shell command group (for example `!sleep 60`).
+                create_kwargs["start_new_session"] = True
             process = await asyncio.create_subprocess_shell(
                 command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=self._cwd,
+                **create_kwargs,
             )
             self._bash_process = process
+            self._bash_pgid = process.pid if os.name != "nt" else None
             try:
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(
                     process.communicate(), timeout=60
@@ -1038,6 +1053,7 @@ class DeepAgentsApp(App):
                 return
             finally:
                 self._bash_process = None
+                self._bash_pgid = None
 
             output = (
                 stdout_bytes.decode(errors="replace").strip() if stdout_bytes else ""
@@ -1073,6 +1089,7 @@ class DeepAgentsApp(App):
             await self._mount_message(ErrorMessage(str(e)))
         finally:
             self._bash_process = None
+            self._bash_pgid = None
             self._bash_interrupted = False
 
     async def _open_url_command(self, command: str, cmd: str) -> None:
@@ -2191,7 +2208,14 @@ class DeepAgentsApp(App):
             return False
 
         self._bash_interrupted = True
-        with suppress(ProcessLookupError):
+        if os.name != "nt" and self._bash_pgid is not None:
+            with suppress(ProcessLookupError, PermissionError, OSError):
+                os.killpg(self._bash_pgid, signal.SIGTERM)
+        elif os.name == "nt" and hasattr(signal, "CTRL_BREAK_EVENT"):
+            with suppress(ProcessLookupError, OSError):
+                self._bash_process.send_signal(signal.CTRL_BREAK_EVENT)
+
+        with suppress(ProcessLookupError, OSError):
             self._bash_process.terminate()
         return True
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -3,8 +3,8 @@
 import asyncio
 import io
 import os
-import webbrowser
 import signal
+import webbrowser
 from typing import ClassVar, Never, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1,9 +1,10 @@
 """Unit tests for DeepAgentsApp."""
 
+import asyncio
 import io
 import os
 import webbrowser
-from typing import ClassVar
+from typing import ClassVar, Never, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -892,3 +893,123 @@ class TestPasteRouting:
             mock_handle.assert_not_called()
             mock_prevent.assert_not_called()
             mock_stop.assert_not_called()
+
+
+class TestBashInterrupt:
+    """Test interrupt behavior for active bash commands."""
+
+    @pytest.mark.asyncio
+    async def test_escape_interrupts_active_bash_command(self) -> None:
+        """Escape should terminate an active bash process."""
+
+        class FakeProcess:
+            """Minimal async subprocess stand-in for interrupt tests."""
+
+            def __init__(self) -> None:
+                self.returncode: int | None = None
+                self._done = asyncio.Event()
+                self.terminated = False
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                await self._done.wait()
+                return (b"", b"")
+
+            def terminate(self) -> None:
+                self.terminated = True
+                self.returncode = 130
+                self._done.set()
+
+            def kill(self) -> None:
+                self.returncode = 137
+                self._done.set()
+
+        app = DeepAgentsApp()
+        fake_process = FakeProcess()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with patch(
+                "deepagents_cli.app.asyncio.create_subprocess_shell",
+                new=AsyncMock(return_value=fake_process),
+            ):
+                task = asyncio.create_task(app._handle_bash_command("sleep 60"))
+                await pilot.pause()
+
+                assert app._bash_process is fake_process
+
+                app.action_interrupt()
+                await task
+
+            assert fake_process.terminated is True
+            assert app._bash_process is None
+            assert any(
+                msg._content == "Command interrupted" for msg in app.query(AppMessage)
+            )
+
+    @pytest.mark.asyncio
+    async def test_ctrl_c_interrupts_active_bash_command(self) -> None:
+        """Ctrl+C should terminate an active bash process."""
+
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.returncode: int | None = None
+                self.terminated = False
+
+            def terminate(self) -> None:
+                self.terminated = True
+                self.returncode = 130
+
+        app = DeepAgentsApp()
+        process = FakeProcess()
+        app._bash_process = cast("asyncio.subprocess.Process", process)
+
+        app.action_quit_or_interrupt()
+
+        assert process.terminated is True
+        assert app._bash_interrupted is True
+        assert app._quit_pending is False
+
+    @pytest.mark.asyncio
+    async def test_bash_timeout_kills_process(self) -> None:
+        """Timed-out bash command should be killed and surfaced as an error."""
+
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.returncode: int | None = None
+                self.killed = False
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return (b"", b"")
+
+            def kill(self) -> None:
+                self.killed = True
+                self.returncode = 137
+
+        app = DeepAgentsApp()
+        fake_process = FakeProcess()
+
+        def _raise_timeout(awaitable, timeout) -> Never:
+            _ = timeout
+            awaitable.close()
+            raise TimeoutError
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_cli.app.asyncio.create_subprocess_shell",
+                    new=AsyncMock(return_value=fake_process),
+                ),
+                patch(
+                    "deepagents_cli.app.asyncio.wait_for",
+                    new=AsyncMock(side_effect=_raise_timeout),
+                ),
+            ):
+                await app._handle_bash_command("sleep 60")
+
+            assert fake_process.killed is True
+            assert app._bash_process is None
+            assert any(
+                msg._content == "Command timed out (60s limit)"
+                for msg in app.query(ErrorMessage)
+            )

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import os
 import webbrowser
+import signal
 from typing import ClassVar, Never, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -906,6 +907,7 @@ class TestBashInterrupt:
             """Minimal async subprocess stand-in for interrupt tests."""
 
             def __init__(self) -> None:
+                self.pid = 43210
                 self.returncode: int | None = None
                 self._done = asyncio.Event()
                 self.terminated = False
@@ -928,9 +930,19 @@ class TestBashInterrupt:
 
         async with app.run_test() as pilot:
             await pilot.pause()
-            with patch(
-                "deepagents_cli.app.asyncio.create_subprocess_shell",
-                new=AsyncMock(return_value=fake_process),
+
+            def _killpg(_pgid: int, _sig: int) -> None:
+                fake_process.returncode = 130
+                fake_process._done.set()
+
+            with (
+                patch(
+                    "deepagents_cli.app.asyncio.create_subprocess_shell",
+                    new=AsyncMock(return_value=fake_process),
+                ),
+                patch(
+                    "deepagents_cli.app.os.killpg", side_effect=_killpg
+                ) as mock_killpg,
             ):
                 task = asyncio.create_task(app._handle_bash_command("sleep 60"))
                 await pilot.pause()
@@ -939,6 +951,7 @@ class TestBashInterrupt:
 
                 app.action_interrupt()
                 await task
+                mock_killpg.assert_called_once_with(fake_process.pid, signal.SIGTERM)
 
             assert fake_process.terminated is True
             assert app._bash_process is None
@@ -975,6 +988,7 @@ class TestBashInterrupt:
 
         class FakeProcess:
             def __init__(self) -> None:
+                self.pid = 43210
                 self.returncode: int | None = None
                 self.killed = False
 


### PR DESCRIPTION
## Summary
Fixes #1157.

When a user runs a direct shell command in CLI mode (for example `!sleep 60`), pressing `Esc` previously did not stop the active command because the process handle was not tracked.

This change makes `Esc` and `Ctrl+C` terminate an active shell execution immediately.

## Changes
- Replace blocking `subprocess.run(...)` shell execution in `_handle_bash_command` with an async subprocess (`asyncio.create_subprocess_shell`) so the running process can be interrupted.
- Track the active shell process in app state (`_bash_process`) and add `_interrupt_bash_process()`.
- Call `_interrupt_bash_process()` from both `action_interrupt` (`Esc`) and `action_quit_or_interrupt` (`Ctrl+C`).
- Keep existing timeout behavior (60s) and explicitly kill timed-out commands.
- Add regression tests for:
  - `Esc` interrupting an active bash command
  - `Ctrl+C` interrupting an active bash command
  - Timeout path killing process and showing timeout error

## Testing
- `uv run --all-groups ruff check deepagents_cli/app.py tests/unit_tests/test_app.py`
- `uv run --all-groups ty check deepagents_cli/app.py tests/unit_tests/test_app.py`
- `uv run --group test pytest -q tests/unit_tests/test_app.py`

## AI disclosure
AI assistance was used to draft and refine the patch and tests; all changes were manually reviewed and validated locally before opening this PR.
