### PR TITLE
fix(cli): make escape reject pending HITL approval first

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1531,6 +1531,14 @@ class DeepAgentsApp(App):
             self.screen.dismiss(None)
             return
 
+        # If approval menu is active, reject it first.
+        # During HITL, the agent worker remains active while awaiting approval.
+        # Prioritizing rejection prevents a stale approval widget from staying
+        # interactive after an interruption.
+        if self._pending_approval_widget:
+            self._pending_approval_widget.action_select_reject()
+            return
+
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
             self._pending_messages.clear()
@@ -1539,10 +1547,6 @@ class DeepAgentsApp(App):
             self._queued_widgets.clear()
             self._agent_worker.cancel()
             return
-
-        # If approval menu is active, reject it
-        if self._pending_approval_widget:
-            self._pending_approval_widget.action_select_reject()
 
     def action_quit_app(self) -> None:
         """Handle quit action (Ctrl+D)."""


### PR DESCRIPTION
## Summary
This fixes escape-key behavior for HITL approval prompts.

Fixes #1090.

## Problem
When a HITL approval menu is open, pressing Escape could show an interrupted state while still leaving the approval menu interactive. Users could continue switching options and submitting after pressing Escape.

## Root cause
`action_interrupt()` handled the running worker before handling a pending approval widget. During HITL, the worker is active while waiting for approval, so Escape canceled the worker path first instead of rejecting the approval prompt.

## Changes
- In `DeepAgentsApp.action_interrupt`, prioritize pending approval rejection before worker cancellation.
- Added focused regression tests:
  - Escape rejects pending approval before canceling worker when both are active.
  - Escape still cancels worker and clears queued messages when no approval is pending.

## Validation
Ran locally in `libs/cli`:
- `uv run --all-groups ruff check deepagents_cli/app.py tests/unit_tests/test_app.py`
- `uv run --all-groups ty check deepagents_cli/app.py tests/unit_tests/test_app.py`
- `uv run --group test pytest -q tests/unit_tests/test_app.py`

## AI assistance disclosure
AI assistance was intentionally limited to unit-test drafting, code review suggestions, and formatting/lint checks. The final implementation choices and code changes were completed manually.
