### PR TITLE
fix: unblock release by writing to dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,8 @@ jobs:
       # > from the publish job.
       # https://github.com/pypa/gh-action-pypi-publish#non-goals
       - name: Build project for distribution
-        run: uv build
+        # --out-dir is needed because uv writes dist/ to the workspace root by default
+        run: uv build --out-dir dist
         working-directory: ${{ env.WORKING_DIR }}
 
       - name: Upload build


### PR DESCRIPTION
need to do this now that workspace root is not in each individual package folder