### PR TITLE
feat(cli): show langsmith thread url on session teardown

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -161,8 +161,8 @@ _glyphs_cache: Glyphs | None = None
 # Module-level cache for editable install detection
 _editable_cache: bool | None = None
 
-# Module-level cache for LangSmith project URL (sentinel dict means "not fetched yet")
-_langsmith_url_cache: dict[str, str | None] | None = None
+# Module-level cache for LangSmith project URL (None means "not yet fetched")
+_langsmith_url_cache: tuple[str, str | None] | None = None
 
 
 def _is_editable_install() -> bool:
@@ -976,9 +976,8 @@ def get_langsmith_project_name() -> str | None:
 def fetch_langsmith_project_url(project_name: str) -> str | None:
     """Fetch the LangSmith project URL via the LangSmith client.
 
-    Results are cached at module level so repeated calls (e.g. startup
-    banner then teardown) do not make additional network requests. Failed
-    lookups are also cached to avoid retries.
+    Results are cached at module level so repeated calls do not make additional
+    network requests. Failed lookups are also cached to avoid retries.
 
     This is a blocking network call on the first invocation. In async
     contexts, run it in a thread (e.g. via `asyncio.to_thread`).
@@ -996,7 +995,10 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
     global _langsmith_url_cache  # noqa: PLW0603
 
     if _langsmith_url_cache is not None:
-        return _langsmith_url_cache.get(project_name)
+        cached_name, cached_url = _langsmith_url_cache
+        if cached_name == project_name:
+            return cached_url
+        # Different project name — fall through to fetch.
 
     try:
         from langsmith import Client
@@ -1008,12 +1010,36 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
             project_name,
             exc_info=True,
         )
-        _langsmith_url_cache = {project_name: None}
+        _langsmith_url_cache = (project_name, None)
         return None
     else:
         url = project.url or None
-        _langsmith_url_cache = {project_name: url}
+        _langsmith_url_cache = (project_name, url)
         return url
+
+
+def build_langsmith_thread_url(thread_id: str) -> str | None:
+    """Build a full LangSmith thread URL if tracing is configured.
+
+    Combines `get_langsmith_project_name` and `fetch_langsmith_project_url`
+    into a single convenience helper.
+
+    Args:
+        thread_id: Thread identifier to build the URL for.
+
+    Returns:
+        Full thread URL string, or `None` if unavailable (LangSmith is not
+            configured or the project URL cannot be resolved.)
+    """
+    project_name = get_langsmith_project_name()
+    if not project_name:
+        return None
+
+    project_url = fetch_langsmith_project_url(project_name)
+    if not project_url:
+        return None
+
+    return f"{project_url.rstrip('/')}/t/{thread_id}"
 
 
 def reset_langsmith_url_cache() -> None:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -161,6 +161,9 @@ _glyphs_cache: Glyphs | None = None
 # Module-level cache for editable install detection
 _editable_cache: bool | None = None
 
+# Module-level cache for LangSmith project URL (sentinel dict means "not fetched yet")
+_langsmith_url_cache: dict[str, str | None] | None = None
+
 
 def _is_editable_install() -> bool:
     """Check if deepagents-cli is installed in editable mode.
@@ -973,8 +976,12 @@ def get_langsmith_project_name() -> str | None:
 def fetch_langsmith_project_url(project_name: str) -> str | None:
     """Fetch the LangSmith project URL via the LangSmith client.
 
-    This is a blocking network call. In async contexts, run it in a thread
-    (e.g. via `asyncio.to_thread`).
+    Results are cached at module level so repeated calls (e.g. startup
+    banner then teardown) do not make additional network requests. Failed
+    lookups are also cached to avoid retries.
+
+    This is a blocking network call on the first invocation. In async
+    contexts, run it in a thread (e.g. via `asyncio.to_thread`).
 
     Returns None (with a debug log) on any expected failure: missing
     `langsmith` package, network errors, invalid project names, or client
@@ -986,6 +993,11 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
     Returns:
         Project URL string if found, None otherwise.
     """
+    global _langsmith_url_cache  # noqa: PLW0603
+
+    if _langsmith_url_cache is not None:
+        return _langsmith_url_cache.get(project_name)
+
     try:
         from langsmith import Client
 
@@ -996,9 +1008,18 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
             project_name,
             exc_info=True,
         )
+        _langsmith_url_cache = {project_name: None}
         return None
     else:
-        return project.url or None
+        url = project.url or None
+        _langsmith_url_cache = {project_name: url}
+        return url
+
+
+def reset_langsmith_url_cache() -> None:
+    """Reset the LangSmith URL cache (for testing)."""
+    global _langsmith_url_cache  # noqa: PLW0603
+    _langsmith_url_cache = None
 
 
 def get_default_coding_instructions() -> str:

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -38,9 +38,8 @@ from rich.text import Text
 from deepagents_cli.agent import DEFAULT_AGENT_NAME, create_cli_agent
 from deepagents_cli.config import (
     SHELL_TOOL_NAMES,
+    build_langsmith_thread_url,
     create_model,
-    fetch_langsmith_project_url,
-    get_langsmith_project_name,
     is_shell_command_allowed,
     settings,
 )
@@ -508,7 +507,7 @@ def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:
     parts.append((" | ", "dim"))
 
     # Attempt to build a clickable thread link via LangSmith
-    thread_url = _get_thread_url(thread_id)
+    thread_url = build_langsmith_thread_url(thread_id)
     if thread_url:
         parts.extend(
             [
@@ -520,32 +519,6 @@ def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:
         parts.append((f"Thread: {thread_id}", "dim"))
 
     return Text.assemble(*parts)
-
-
-def _get_thread_url(thread_id: str) -> str | None:
-    """Build a LangSmith thread URL if tracing is configured.
-
-    Delegates to shared helpers in `config` for env-var checks and the
-    LangSmith client call, avoiding duplication with the interactive
-    welcome banner.
-
-    Args:
-        thread_id: Thread identifier to build the URL for.
-
-    Returns:
-        Full thread URL string, or None if LangSmith is not configured.
-    """
-    project_name = get_langsmith_project_name()
-    if not project_name:
-        logger.debug("LangSmith project name not configured, skipping thread URL")
-        return None
-
-    project_url = fetch_langsmith_project_url(project_name)
-    if not project_url:
-        logger.debug("Could not fetch LangSmith project URL for %r", project_name)
-        return None
-
-    return f"{project_url.rstrip('/')}/t/{thread_id}"
 
 
 async def run_non_interactive(

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -14,6 +14,7 @@ from deepagents_cli.config import (
     _find_project_agent_md,
     _find_project_root,
     _get_provider_kwargs,
+    build_langsmith_thread_url,
     create_model,
     detect_provider,
     fetch_langsmith_project_url,
@@ -575,6 +576,99 @@ class TestFetchLangsmithProjectUrl:
         assert first is None
         assert second is None
         mock_client_cls.assert_called_once()
+
+    def test_different_project_name_fetches_again(self) -> None:
+        """Should fetch again when called with a different project name."""
+
+        class FakeProjectA:
+            url = "https://smith.langchain.com/o/org/projects/p/a"
+
+        class FakeProjectB:
+            url = "https://smith.langchain.com/o/org/projects/p/b"
+
+        with patch("langsmith.Client") as mock_client_cls:
+            mock_client_cls.return_value.read_project.side_effect = [
+                FakeProjectA(),
+                FakeProjectB(),
+            ]
+            first = fetch_langsmith_project_url("project-a")
+            second = fetch_langsmith_project_url("project-b")
+
+        assert first == "https://smith.langchain.com/o/org/projects/p/a"
+        assert second == "https://smith.langchain.com/o/org/projects/p/b"
+        assert mock_client_cls.return_value.read_project.call_count == 2
+
+
+class TestBuildLangsmithThreadUrl:
+    """Tests for build_langsmith_thread_url()."""
+
+    def setup_method(self) -> None:
+        """Clear LangSmith URL cache before each test."""
+        reset_langsmith_url_cache()
+
+    def test_returns_url_when_configured(self) -> None:
+        """Should return a full thread URL when LangSmith is configured."""
+
+        class FakeProject:
+            url = "https://smith.langchain.com/o/org/projects/p/proj"
+
+        with (
+            patch(
+                "deepagents_cli.config.get_langsmith_project_name",
+                return_value="my-project",
+            ),
+            patch("langsmith.Client") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.read_project.return_value = FakeProject()
+            result = build_langsmith_thread_url("thread-123")
+
+        assert (
+            result == "https://smith.langchain.com/o/org/projects/p/proj/t/thread-123"
+        )
+
+    def test_strips_trailing_slash(self) -> None:
+        """Should not produce double slashes when project URL has trailing slash."""
+
+        class FakeProject:
+            url = "https://smith.langchain.com/o/org/projects/p/proj/"
+
+        with (
+            patch(
+                "deepagents_cli.config.get_langsmith_project_name",
+                return_value="my-project",
+            ),
+            patch("langsmith.Client") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.read_project.return_value = FakeProject()
+            result = build_langsmith_thread_url("thread-123")
+
+        assert (
+            result == "https://smith.langchain.com/o/org/projects/p/proj/t/thread-123"
+        )
+
+    def test_returns_none_when_no_project_name(self) -> None:
+        """Should return None when LangSmith project name is not configured."""
+        with patch(
+            "deepagents_cli.config.get_langsmith_project_name",
+            return_value=None,
+        ):
+            result = build_langsmith_thread_url("thread-123")
+
+        assert result is None
+
+    def test_returns_none_when_fetch_fails(self) -> None:
+        """Should return None when the project URL cannot be resolved."""
+        with (
+            patch(
+                "deepagents_cli.config.get_langsmith_project_name",
+                return_value="my-project",
+            ),
+            patch("langsmith.Client") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.read_project.side_effect = OSError("timeout")
+            result = build_langsmith_thread_url("thread-123")
+
+        assert result is None
 
 
 class TestGetProviderKwargsConfigFallback:

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -5,6 +5,7 @@ import inspect
 import pytest
 
 from deepagents_cli.app import run_textual_app
+from deepagents_cli.config import build_langsmith_thread_url, reset_langsmith_url_cache
 from deepagents_cli.main import run_textual_cli_async
 
 
@@ -41,6 +42,41 @@ class TestResumeHintLogic:
 
         show_resume_hint = thread_id and not is_resumed and return_code == 0
         assert not show_resume_hint, "Resume hint not shown for resumed threads"
+
+
+class TestLangSmithTeardownUrl:
+    """Test LangSmith thread URL display logic on teardown."""
+
+    def setup_method(self) -> None:
+        """Clear LangSmith URL cache before each test."""
+        reset_langsmith_url_cache()
+
+    def test_thread_url_requires_all_components(self) -> None:
+        """LangSmith link requires thread_id, project_name, and project_url."""
+        thread_url = build_langsmith_thread_url("abc123")
+        # Without LangSmith configured, should return None
+        assert thread_url is None
+
+    def test_thread_url_not_shown_for_none_thread_id(self) -> None:
+        """Guard condition: thread_url and thread_exists both needed."""
+        thread_url = None
+        thread_exists = True
+        show_link = bool(thread_url and thread_exists)
+        assert not show_link
+
+    def test_thread_url_not_shown_when_no_checkpoints(self) -> None:
+        """Guard condition: thread must have checkpointed content."""
+        thread_url = "https://smith.langchain.com/o/org/projects/p/proj/t/abc"
+        thread_exists = False
+        show_link = bool(thread_url and thread_exists)
+        assert not show_link
+
+    def test_thread_url_shown_when_all_conditions_met(self) -> None:
+        """Guard condition: both thread_url and thread_exists must be truthy."""
+        thread_url = "https://smith.langchain.com/o/org/projects/p/proj/t/abc"
+        thread_exists = True
+        show_link = bool(thread_url and thread_exists)
+        assert show_link
 
 
 class TestRunTextualAppReturnType:


### PR DESCRIPTION
Closes #1215

Print a clickable LangSmith thread URL on session teardown so users can jump straight to the trace view after a conversation ends. The URL is built from the project URL (already fetched during startup banner rendering) plus the thread ID, and only appears when tracing is configured and the thread has checkpointed content.

`fetch_langsmith_project_url` now caches its result at module level — both successful lookups and failures — so the teardown call reuses the startup result without an extra network round-trip.