### PR TITLE
feat(cli): add `/trace` command to open LangSmith thread, link in switcher

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -32,6 +32,7 @@ from deepagents_cli.config import (
     SHELL_TOOL_NAMES,
     CharsetMode,
     _detect_charset_mode,
+    build_langsmith_thread_url,
     create_model,
     detect_provider,
     is_shell_command_allowed,
@@ -1002,6 +1003,31 @@ class DeepAgentsApp(App):
         link.stylize(f"link {url}", 0)
         await self._mount_message(AppMessage(link))
 
+    async def _handle_trace_command(self, command: str) -> None:
+        """Open the current thread in LangSmith.
+
+        Args:
+            command: The raw command text (displayed as user message).
+        """
+        await self._mount_message(UserMessage(command))
+        if not self._session_state:
+            await self._mount_message(AppMessage("No active session."))
+            return
+        thread_id = self._session_state.thread_id
+        url = await asyncio.to_thread(build_langsmith_thread_url, thread_id)
+        if not url:
+            await self._mount_message(
+                AppMessage(
+                    "LangSmith tracing is not configured. "
+                    "Set LANGSMITH_API_KEY and LANGSMITH_TRACING=true to enable."
+                )
+            )
+            return
+        webbrowser.open(url)
+        link = Text(url, style="dim italic")
+        link.stylize(f"link {url}", 0)
+        await self._mount_message(AppMessage(link))
+
     async def _handle_command(self, command: str) -> None:
         """Handle a slash command.
 
@@ -1016,7 +1042,7 @@ class DeepAgentsApp(App):
             await self._mount_message(UserMessage(command))
             help_text = Text(
                 "Commands: /quit, /clear, /model [--default], /remember, "
-                "/tokens, /threads, /changelog, /docs, /feedback, /help\n\n"
+                "/tokens, /threads, /trace, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
                 "  Ctrl+J          Insert newline\n"
@@ -1064,6 +1090,8 @@ class DeepAgentsApp(App):
                 )
         elif cmd == "/threads":
             await self._show_thread_selector()
+        elif cmd == "/trace":
+            await self._handle_trace_command(command)
         elif cmd == "/tokens":
             await self._mount_message(UserMessage(command))
             if self._token_tracker and self._token_tracker.current_context > 0:

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -103,6 +103,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/quit", "Exit app"),
     ("/tokens", "Token usage"),
     ("/threads", "Browse and resume previous threads"),
+    ("/trace", "Open current thread in LangSmith"),
     ("/version", "Show version"),
 ]
 """Built-in slash commands with descriptions."""

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 from typing import TYPE_CHECKING, ClassVar
 
+from rich.style import Style
+from rich.text import Text
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical, VerticalScroll
 from textual.css.query import NoMatches
@@ -17,7 +20,12 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
     from textual.events import Click
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import (
+    CharsetMode,
+    _detect_charset_mode,
+    build_langsmith_thread_url,
+    get_glyphs,
+)
 from deepagents_cli.sessions import ThreadInfo, format_timestamp, list_threads
 
 logger = logging.getLogger(__name__)
@@ -181,6 +189,26 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._selected_index = 0
         self._option_widgets: list[ThreadOption] = []
 
+    def _build_title(self, thread_url: str | None = None) -> str | Text:
+        """Build the title, optionally with a clickable thread ID link.
+
+        Args:
+            thread_url: LangSmith thread URL. When provided, the thread ID is
+                rendered as a clickable hyperlink.
+
+        Returns:
+            Plain string or Rich `Text` with an embedded hyperlink.
+        """
+        if not self._current_thread:
+            return "Select Thread"
+        if thread_url:
+            return Text.assemble(
+                "Select Thread (current: ",
+                (self._current_thread, Style(color="cyan", link=thread_url)),
+                ")",
+            )
+        return f"Select Thread (current: {self._current_thread})"
+
     def compose(self) -> ComposeResult:
         """Compose the screen layout.
 
@@ -190,12 +218,9 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         glyphs = get_glyphs()
 
         with Vertical():
-            title = (
-                f"Select Thread (current: {self._current_thread})"
-                if self._current_thread
-                else "Select Thread"
+            yield Static(
+                self._build_title(), classes="thread-selector-title", id="thread-title"
             )
-            yield Static(title, classes="thread-selector-title")
             yield Static(self._format_header(), classes="thread-list-header")
 
             with VerticalScroll(classes="thread-list"):
@@ -234,7 +259,33 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 break
 
         await self._build_list()
+
+        if self._current_thread:
+            self._resolve_thread_url()
+
         self.focus()
+
+    def _resolve_thread_url(self) -> None:
+        """Kick off a background worker to resolve the LangSmith thread URL."""
+        self.run_worker(self._fetch_thread_url, exclusive=True)
+
+    async def _fetch_thread_url(self) -> None:
+        """Resolve the LangSmith URL and update the title with a clickable link."""
+        if not self._current_thread:
+            return
+        try:
+            thread_url = await asyncio.wait_for(
+                asyncio.to_thread(build_langsmith_thread_url, self._current_thread),
+                timeout=2.0,
+            )
+        except (TimeoutError, OSError):
+            return
+        if thread_url:
+            try:
+                title_widget = self.query_one("#thread-title", Static)
+                title_widget.update(self._build_title(thread_url))
+            except NoMatches:
+                pass
 
     async def _show_mount_error(self, detail: str) -> None:
         """Display an error message inside the thread list and refocus.

--- a/libs/cli/tests/unit_tests/skills/test_commands.py
+++ b/libs/cli/tests/unit_tests/skills/test_commands.py
@@ -238,7 +238,7 @@ class TestValidateSkillPath:
             assert error != ""
         except OSError:
             # Symlink creation might fail on some systems
-            pytest.skip("Symlink creation not supported")  # ty: ignore[invalid-argument-type, too-many-positional-arguments]
+            pytest.skip("Symlink creation not supported")
 
     def test_nonexistent_path_validation(self, tmp_path: Path) -> None:
         """Test validation of paths that don't exist yet."""

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -518,7 +518,11 @@ class TestTraceCommand:
                 "https://smith.langchain.com/o/org/projects/p/proj/t/test-thread-123"
             )
             app_msgs = app.query(AppMessage)
-            assert any("smith.langchain.com" in str(w._content) for w in app_msgs)
+            assert any(  # not a URL check—just verifying the link was rendered
+                "https://smith.langchain.com/o/org/projects/p/proj/t/test-thread-123"
+                in str(w._content)
+                for w in app_msgs
+            )
 
     @pytest.mark.asyncio
     async def test_trace_shows_error_when_not_configured(self) -> None:
@@ -574,7 +578,10 @@ class TestTraceCommand:
                 await pilot.pause()
 
             app_msgs = app.query(AppMessage)
-            assert any("smith.langchain.com" in str(w._content) for w in app_msgs)
+            assert any(  # not a URL check—just verifying the link was rendered
+                "https://smith.langchain.com/t/test-thread-123" in str(w._content)
+                for w in app_msgs
+            )
 
     @pytest.mark.asyncio
     async def test_trace_shows_error_when_url_build_raises(self) -> None:

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -202,7 +202,7 @@ class TestBuildNonInteractiveHeader:
                 assert style.link == url
                 break
         else:
-            pytest.fail("Thread ID span with hyperlink not found")  # ty: ignore[invalid-argument-type]
+            pytest.fail("Thread ID span with hyperlink not found")
 
 
 class TestSandboxSetupForwarding:


### PR DESCRIPTION
Closes #1206

Add a `/trace` slash command that opens the current thread's LangSmith trace in the user's browser. The thread selector also gets a clickable thread ID hyperlink that links to LangSmith when tracing is configured.
