### PR TITLE
hotfix(cli): sdk version pin

### DIFF
--- a/.github/workflows/check_cli_sdk_pin.yml
+++ b/.github/workflows/check_cli_sdk_pin.yml
@@ -1,0 +1,48 @@
+# Ensures the CLI's pinned deepagents SDK version matches the actual SDK version.
+#
+# Only runs on CLI release PRs to catch version mismatches before publishing.
+# The CLI pins an exact SDK version (e.g. deepagents==0.4.1) and this check
+# prevents releasing a CLI that depends on an SDK version that doesn't exist.
+
+name: "🔍 Check CLI SDK Pin"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check_cli_sdk_pin:
+    if: startsWith(github.event.pull_request.title, 'release(deepagents-cli)')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "✅ Verify CLI SDK pin matches SDK version"
+        run: |
+          SDK_VERSION=$(grep -Po '(?<=^version = ")[^"]*' libs/deepagents/pyproject.toml)
+          CLI_SDK_PIN=$(grep -Po '(?<=deepagents==)[^"]*' libs/cli/pyproject.toml)
+
+          if [ -z "$SDK_VERSION" ]; then
+            echo "Error: Could not extract SDK version from libs/deepagents/pyproject.toml"
+            exit 1
+          fi
+
+          if [ -z "$CLI_SDK_PIN" ]; then
+            echo "Error: Could not extract CLI SDK pin from libs/cli/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$SDK_VERSION" != "$CLI_SDK_PIN" ]; then
+            echo "Error: CLI SDK pin does not match SDK version!"
+            echo "SDK version (libs/deepagents/pyproject.toml): $SDK_VERSION"
+            echo "CLI SDK pin (libs/cli/pyproject.toml): $CLI_SDK_PIN"
+            echo ""
+            echo "Update the deepagents dependency in libs/cli/pyproject.toml to deepagents==$SDK_VERSION"
+            exit 1
+          else
+            echo "CLI SDK pin matches SDK version: $SDK_VERSION"
+          fi

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.4.0",
+    "deepagents==0.4.1",
     "langchain>=1.2.10,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",
 


### PR DESCRIPTION
Also introduces an automated workflow to ensure that the CLI's pinned deepagents SDK version matches the actual SDK version on release PRs.