### PR TITLE
fix(infra): prevent duplicate github releases from release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Must be set as action input — the config file setting alone is
+          # overridden by the action's default (false), causing duplicate
+          # GitHub releases when mark-release also creates one.
+          skip-github-release: true
 
       # Detect CLI release by checking if this commit updated the CLI's CHANGELOG.md
       # release-please ALWAYS updates CHANGELOG.md when merging a release PR


### PR DESCRIPTION
`release-please` `skip-github-release` input defaults to `false`, overriding the config file setting. This caused release-please to create a GitHub release on merged release PRs, and then `mark-release` in `release.yml` created a second (draft) release for the same tag.

Explicitly sets `skip-github-release: true` as an action input so only `mark-release` creates the GitHub release (as a draft).