### PR TITLE
POC: stateless loop detection middleware

### DIFF
--- a/libs/cli/deepagents_cli/loop_detection.py
+++ b/libs/cli/deepagents_cli/loop_detection.py
@@ -1,0 +1,241 @@
+"""Stateless middleware that detects edit loops on the same file.
+
+NOT YET WIRED IN — add ``LoopDetectionMiddleware()`` to the middleware
+list in ``agent.py:create_cli_agent()`` to enable.
+
+Soft warning at 8 edits (appended to tool output), hard warning at 12
+(injected HumanMessage + ``jump_to: "model"``).  All counts derived
+from ``state["messages"]`` — no mutable instance state.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    hook_config,
+)
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.tools.tool_node import ToolCallRequest
+    from langgraph.runtime import Runtime
+    from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Warning templates
+# ---------------------------------------------------------------------------
+
+LOOP_WARNING_SOFT = """
+**NOTE**: You've edited `{file_path}` {count} times. If you're stuck, consider:
+- Is there a fundamentally different approach?
+- Can you use a different library or tool?
+- Should you step back and re-read the original requirements?
+"""
+
+LOOP_WARNING_HARD = """
+You've edited `{file_path}` {count} times without resolving the issue.
+
+Stop and ask the user what to do — describe what you've tried and what's
+not working so they can help you course-correct.
+"""
+
+# Tool names we track
+_EDIT_TOOL_NAMES = frozenset({"edit_file", "write_file"})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_file_edits(messages: list[Any]) -> dict[str, int]:
+    """Count per-file edit_file/write_file calls from AIMessage tool_calls."""
+    counts: dict[str, int] = {}
+    for msg in messages:
+        if not isinstance(msg, AIMessage):
+            continue
+        for tc in getattr(msg, "tool_calls", []) or []:
+            if tc.get("name") not in _EDIT_TOOL_NAMES:
+                continue
+            args = tc.get("args") or {}
+            raw_path = args.get("file_path") or args.get("path") or "unknown"
+            path = str(Path(raw_path).resolve())
+            counts[path] = counts.get(path, 0) + 1
+    return counts
+
+
+def _soft_warning_already_shown(messages: list[Any], file_path: str) -> bool:
+    """Check if a soft warning for *file_path* was already appended."""
+    marker = f"**NOTE**: You've edited `{file_path}`"
+    for msg in messages:
+        if isinstance(msg, ToolMessage) and marker in str(msg.content):
+            return True
+    return False
+
+
+def _hard_warning_already_shown(messages: list[Any], file_path: str) -> bool:
+    """Check if a hard warning for *file_path* was already injected."""
+    marker = f"You've edited `{file_path}`"
+    for msg in messages:
+        if isinstance(msg, HumanMessage) and marker in str(msg.content):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+class LoopDetectionMiddleware(AgentMiddleware):
+    """Detect edit loops on the same file via message scanning."""
+
+    DEFAULT_SOFT_THRESHOLD = 8
+    DEFAULT_HARD_THRESHOLD = 12
+
+    def __init__(
+        self,
+        *,
+        soft_threshold: int = DEFAULT_SOFT_THRESHOLD,
+        hard_threshold: int = DEFAULT_HARD_THRESHOLD,
+    ) -> None:
+        """Initialize with edit-count thresholds.
+
+        Raises:
+            ValueError: If thresholds are invalid.
+        """
+        if soft_threshold < 1:
+            msg = "soft_threshold must be >= 1"
+            raise ValueError(msg)
+        if hard_threshold <= soft_threshold:
+            msg = "hard_threshold must be greater than soft_threshold"
+            raise ValueError(msg)
+
+        self.soft_threshold = soft_threshold
+        self.hard_threshold = hard_threshold
+
+    # -- tool call hook -----------------------------------------------------
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Track file edits and inject soft warnings at threshold."""
+        result = handler(request)
+        return self._maybe_append_soft_warning(request, result)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Async version of wrap_tool_call."""
+        result = await handler(request)
+        return self._maybe_append_soft_warning(request, result)
+
+    def _maybe_append_soft_warning(
+        self,
+        request: ToolCallRequest,
+        result: ToolMessage | Command[Any],
+    ) -> ToolMessage | Command[Any]:
+        """Append soft warning to tool result if threshold is reached."""
+        tool_name = request.tool_call.get("name", "")
+        if tool_name not in _EDIT_TOOL_NAMES:
+            return result
+
+        args = request.tool_call.get("args") or {}
+        raw_path = args.get("file_path") or args.get("path") or "unknown"
+        file_path = str(Path(raw_path).resolve())
+
+        messages = request.state.get("messages", [])
+        counts = _count_file_edits(messages)
+        # The current tool call may not yet be reflected in messages,
+        # so add 1 for this invocation.
+        count = counts.get(file_path, 0) + 1
+
+        if count < self.soft_threshold:
+            return result
+
+        if _soft_warning_already_shown(messages, file_path):
+            return result
+
+        logger.info(
+            "Loop detection: %s edited %d times (soft warning)",
+            file_path,
+            count,
+        )
+        if isinstance(result, ToolMessage):
+            result.content = str(result.content) + LOOP_WARNING_SOFT.format(
+                file_path=file_path, count=count
+            )
+
+        return result
+
+    # -- after model hook ---------------------------------------------------
+
+    @hook_config(can_jump_to=["model"])
+    def after_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[Any],  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        """Inject escalation prompt at hard threshold."""
+        return self._check_hard_threshold(state)
+
+    @hook_config(can_jump_to=["model"])
+    async def aafter_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[Any],  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        """Async version of after_model."""
+        return self._check_hard_threshold(state)
+
+    def _check_hard_threshold(self, state: AgentState[Any]) -> dict[str, Any] | None:
+        """Check if any file has hit the hard threshold and inject warning."""
+        messages = state.get("messages", [])
+
+        # Don't inject between AI tool_call and tool_result
+        if messages:
+            last_msg = messages[-1]
+            if hasattr(last_msg, "tool_calls") and last_msg.tool_calls:
+                return None
+
+        counts = _count_file_edits(messages)
+
+        for file_path, count in counts.items():
+            if count < self.hard_threshold:
+                continue
+            if _hard_warning_already_shown(messages, file_path):
+                continue
+
+            logger.warning(
+                "Loop detection: %s edited %d times (hard warning)",
+                file_path,
+                count,
+            )
+            return {
+                "messages": [
+                    HumanMessage(
+                        content=LOOP_WARNING_HARD.format(
+                            file_path=file_path, count=count
+                        )
+                    )
+                ],
+                "jump_to": "model",
+            }
+
+        return None
+
+
+__all__ = ["LoopDetectionMiddleware"]

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -171,6 +171,9 @@ ignore-var-parameters = true
 "tests/**" = ["ANN001", "ANN201", "D1", "DOC", "F401", "PLC0415", "PLC1901", "PLC2701", "PLR2004", "PLR6201", "PLR6301", "PLW0108", "RUF001", "S", "SLF"]
 "tests/unit_tests/test_imports.py" = ["PLC0415"]  # Imports inside function ARE the test
 "scripts/**" = ["BLE001", "INP", "S", "T201"]
+"deepagents_cli/loop_detection.py" = [
+    "DOC201",  # Returns section not needed for simple one-line docstrings
+]
 "deepagents_cli/agent.py" = [
     "PLR2004",  # Magic value used in comparison
     "SIM108",   # Use ternary operator instead of if-else

--- a/libs/cli/tests/unit_tests/test_loop_detection.py
+++ b/libs/cli/tests/unit_tests/test_loop_detection.py
@@ -1,0 +1,519 @@
+"""Tests for LoopDetectionMiddleware (stateless rewrite)."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from deepagents_cli.loop_detection import (
+    LOOP_WARNING_HARD,
+    LOOP_WARNING_SOFT,
+    LoopDetectionMiddleware,
+    _count_file_edits,
+    _hard_warning_already_shown,
+    _soft_warning_already_shown,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ai_with_tool_calls(
+    calls: list[dict[str, Any]],
+    *,
+    pending: bool = False,
+) -> AIMessage:
+    """Create an AIMessage with tool_calls."""
+    tool_calls = [
+        {"name": c["name"], "args": c.get("args", {}), "id": c.get("id", "id-1")}
+        for c in calls
+    ]
+    msg = AIMessage(content="", tool_calls=tool_calls if pending else [])
+    # For counting purposes, tool_calls on the message must be set
+    # regardless of whether they are "pending" (for after_model guard).
+    # The pending flag controls whether the last message looks like it
+    # still has unprocessed tool calls.
+    if not pending:
+        # Put tool_calls for counting but mark them as resolved
+        # by having them on a non-last message.
+        msg = AIMessage(content="", tool_calls=tool_calls)
+    return msg
+
+
+def _make_edit_calls(file_path: str, n: int) -> list[AIMessage]:
+    """Create *n* AIMessages each with one edit_file tool_call."""
+    return [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "edit_file", "args": {"file_path": file_path}, "id": f"id-{i}"}
+            ],
+        )
+        for i in range(n)
+    ]
+
+
+def _make_tool_call_request(
+    tool_name: str,
+    args: dict[str, Any],
+    messages: list[Any],
+) -> Mock:
+    """Create a mock ToolCallRequest."""
+    request = Mock()
+    request.tool_call = {"name": tool_name, "args": args, "id": "call-1"}
+    request.state = {"messages": messages}
+    return request
+
+
+# ---------------------------------------------------------------------------
+# _count_file_edits
+# ---------------------------------------------------------------------------
+
+
+class TestCountFileEdits:
+    def test_empty_messages(self) -> None:
+        assert _count_file_edits([]) == {}
+
+    def test_no_edit_tools(self) -> None:
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "read_file", "args": {"file_path": "/a.py"}, "id": "1"}
+                ],
+            )
+        ]
+        assert _count_file_edits(messages) == {}
+
+    def test_single_file(self) -> None:
+        messages = _make_edit_calls("/a.py", 3)
+        assert _count_file_edits(messages) == {"/a.py": 3}
+
+    def test_multiple_files(self) -> None:
+        messages = [
+            *_make_edit_calls("/a.py", 2),
+            *_make_edit_calls("/b.py", 1),
+        ]
+        counts = _count_file_edits(messages)
+        assert counts == {"/a.py": 2, "/b.py": 1}
+
+    def test_ignores_non_edit_tools(self) -> None:
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "execute", "args": {"command": "ls"}, "id": "1"}],
+            ),
+            *_make_edit_calls("/a.py", 1),
+        ]
+        assert _count_file_edits(messages) == {"/a.py": 1}
+
+    def test_handles_write_file(self) -> None:
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "write_file", "args": {"file_path": "/a.py"}, "id": "1"}
+                ],
+            )
+        ]
+        assert _count_file_edits(messages) == {"/a.py": 1}
+
+    def test_path_normalization(self) -> None:
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "edit_file",
+                        "args": {"file_path": "/foo/../bar/./a.py"},
+                        "id": "1",
+                    }
+                ],
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "edit_file",
+                        "args": {"file_path": "/bar/a.py"},
+                        "id": "2",
+                    }
+                ],
+            ),
+        ]
+        assert _count_file_edits(messages) == {"/bar/a.py": 2}
+
+    def test_relative_and_absolute_resolve_to_same(self) -> None:
+        """Relative path resolves to absolute, matching an absolute edit."""
+        from pathlib import Path
+
+        abs_path = str(Path("src/a.py").resolve())
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "edit_file", "args": {"file_path": "src/a.py"}, "id": "1"}
+                ],
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "edit_file", "args": {"file_path": abs_path}, "id": "2"}
+                ],
+            ),
+        ]
+        assert _count_file_edits(messages) == {abs_path: 2}
+
+    def test_ignores_non_ai_messages(self) -> None:
+        messages = [
+            HumanMessage(content="hello"),
+            ToolMessage(content="result", tool_call_id="1"),
+            *_make_edit_calls("/a.py", 1),
+        ]
+        assert _count_file_edits(messages) == {"/a.py": 1}
+
+    def test_fallback_to_path_arg(self) -> None:
+        """Falls back to 'path' arg when 'file_path' is absent."""
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "edit_file", "args": {"path": "/a.py"}, "id": "1"}
+                ],
+            )
+        ]
+        assert _count_file_edits(messages) == {"/a.py": 1}
+
+    def test_fallback_to_unknown(self) -> None:
+        """Falls back to 'unknown' (resolved) when no path arg is present."""
+        from pathlib import Path
+
+        messages = [
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "edit_file", "args": {}, "id": "1"}],
+            )
+        ]
+        resolved = str(Path("unknown").resolve())
+        assert _count_file_edits(messages) == {resolved: 1}
+
+
+# ---------------------------------------------------------------------------
+# Marker deduplication helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerDetection:
+    def test_soft_warning_not_shown(self) -> None:
+        assert not _soft_warning_already_shown([], "/a.py")
+
+    def test_soft_warning_shown(self) -> None:
+        messages = [
+            ToolMessage(
+                content="OK" + LOOP_WARNING_SOFT.format(file_path="/a.py", count=4),
+                tool_call_id="1",
+            )
+        ]
+        assert _soft_warning_already_shown(messages, "/a.py")
+
+    def test_soft_warning_different_file(self) -> None:
+        messages = [
+            ToolMessage(
+                content="OK" + LOOP_WARNING_SOFT.format(file_path="/b.py", count=4),
+                tool_call_id="1",
+            )
+        ]
+        assert not _soft_warning_already_shown(messages, "/a.py")
+
+    def test_hard_warning_not_shown(self) -> None:
+        assert not _hard_warning_already_shown([], "/a.py")
+
+    def test_hard_warning_shown(self) -> None:
+        messages = [
+            HumanMessage(content=LOOP_WARNING_HARD.format(file_path="/a.py", count=8))
+        ]
+        assert _hard_warning_already_shown(messages, "/a.py")
+
+    def test_hard_warning_different_file(self) -> None:
+        messages = [
+            HumanMessage(content=LOOP_WARNING_HARD.format(file_path="/b.py", count=8))
+        ]
+        assert not _hard_warning_already_shown(messages, "/a.py")
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_defaults(self) -> None:
+        mw = LoopDetectionMiddleware()
+        assert mw.soft_threshold == 8
+        assert mw.hard_threshold == 12
+
+    def test_custom_thresholds(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=2, hard_threshold=5)
+        assert mw.soft_threshold == 2
+        assert mw.hard_threshold == 5
+
+    def test_soft_below_one_raises(self) -> None:
+        with pytest.raises(ValueError, match="soft_threshold must be >= 1"):
+            LoopDetectionMiddleware(soft_threshold=0)
+
+    def test_hard_not_greater_raises(self) -> None:
+        with pytest.raises(
+            ValueError, match="hard_threshold must be greater than soft_threshold"
+        ):
+            LoopDetectionMiddleware(soft_threshold=5, hard_threshold=5)
+
+    def test_hard_less_than_soft_raises(self) -> None:
+        with pytest.raises(
+            ValueError, match="hard_threshold must be greater than soft_threshold"
+        ):
+            LoopDetectionMiddleware(soft_threshold=5, hard_threshold=3)
+
+
+# ---------------------------------------------------------------------------
+# No mutable state
+# ---------------------------------------------------------------------------
+
+
+class TestNoMutableState:
+    def test_only_threshold_attrs(self) -> None:
+        mw = LoopDetectionMiddleware()
+        instance_vars = vars(mw)
+        assert set(instance_vars.keys()) == {"soft_threshold", "hard_threshold"}
+
+
+# ---------------------------------------------------------------------------
+# Soft warning (wrap_tool_call)
+# ---------------------------------------------------------------------------
+
+
+class TestSoftWarning:
+    def test_no_warning_below_threshold(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 2 prior edits + 1 current = 3, below threshold of 4
+        messages = _make_edit_calls("/a.py", 2)
+        request = _make_tool_call_request("edit_file", {"file_path": "/a.py"}, messages)
+        tool_result = ToolMessage(content="OK", tool_call_id="call-1")
+        handler = Mock(return_value=tool_result)
+
+        result = mw.wrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert isinstance(result, ToolMessage)
+        assert "NOTE" not in str(result.content)
+
+    def test_warning_at_threshold(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 3 prior edits + 1 current = 4, hits threshold
+        messages = _make_edit_calls("/a.py", 3)
+        request = _make_tool_call_request("edit_file", {"file_path": "/a.py"}, messages)
+        tool_result = ToolMessage(content="OK", tool_call_id="call-1")
+        handler = Mock(return_value=tool_result)
+
+        result = mw.wrap_tool_call(request, handler)
+
+        assert isinstance(result, ToolMessage)
+        assert "**NOTE**" in str(result.content)
+        assert "/a.py" in str(result.content)
+
+    def test_warning_only_once(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 4 prior edits + soft warning already in messages
+        messages = [
+            *_make_edit_calls("/a.py", 4),
+            ToolMessage(
+                content="OK" + LOOP_WARNING_SOFT.format(file_path="/a.py", count=4),
+                tool_call_id="prev",
+            ),
+        ]
+        request = _make_tool_call_request("edit_file", {"file_path": "/a.py"}, messages)
+        tool_result = ToolMessage(content="OK", tool_call_id="call-1")
+        handler = Mock(return_value=tool_result)
+
+        result = mw.wrap_tool_call(request, handler)
+
+        assert isinstance(result, ToolMessage)
+        # Should NOT have a new warning appended
+        assert str(result.content) == "OK"
+
+    def test_non_edit_tool_passes_through(self) -> None:
+        mw = LoopDetectionMiddleware()
+        request = _make_tool_call_request("read_file", {"file_path": "/a.py"}, [])
+        tool_result = ToolMessage(content="file contents", tool_call_id="call-1")
+        handler = Mock(return_value=tool_result)
+
+        result = mw.wrap_tool_call(request, handler)
+
+        assert str(result.content) == "file contents"
+
+
+# ---------------------------------------------------------------------------
+# Soft warning (async)
+# ---------------------------------------------------------------------------
+
+
+class TestSoftWarningAsync:
+    @pytest.mark.asyncio
+    async def test_async_warning_at_threshold(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        messages = _make_edit_calls("/a.py", 3)
+        request = _make_tool_call_request("edit_file", {"file_path": "/a.py"}, messages)
+        tool_result = ToolMessage(content="OK", tool_call_id="call-1")
+
+        async def async_handler(_req: object) -> ToolMessage:  # noqa: RUF029
+            return tool_result
+
+        result = await mw.awrap_tool_call(request, async_handler)
+
+        assert isinstance(result, ToolMessage)
+        assert "**NOTE**" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Hard warning (after_model)
+# ---------------------------------------------------------------------------
+
+
+class TestHardWarning:
+    def test_no_warning_below_threshold(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 7 edits, below hard threshold of 8
+        messages = [
+            *_make_edit_calls("/a.py", 7),
+            ToolMessage(content="OK", tool_call_id="last"),
+        ]
+        state = cast("Any", {"messages": messages})
+
+        result = mw.after_model(state, Mock())
+        assert result is None
+
+    def test_warning_at_threshold(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 8 edits = hard threshold
+        messages = [
+            *_make_edit_calls("/a.py", 8),
+            ToolMessage(content="OK", tool_call_id="last"),
+        ]
+        state = cast("Any", {"messages": messages})
+
+        result = mw.after_model(state, Mock())
+
+        assert result is not None
+        assert result["jump_to"] == "model"
+        injected = result["messages"][0]
+        assert isinstance(injected, HumanMessage)
+        assert "/a.py" in injected.content
+        assert "8 times" in injected.content
+
+    def test_skipped_when_tool_calls_pending(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 8 edits but last message has pending tool calls
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "edit_file", "args": {"file_path": "/a.py"}, "id": "pending"}
+            ],
+        )
+        messages = [*_make_edit_calls("/a.py", 7), ai_msg]
+        state = cast("Any", {"messages": messages})
+
+        result = mw.after_model(state, Mock())
+        assert result is None
+
+    def test_warning_only_once(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        # 8 edits + hard warning already injected
+        messages = [
+            *_make_edit_calls("/a.py", 8),
+            HumanMessage(content=LOOP_WARNING_HARD.format(file_path="/a.py", count=8)),
+            ToolMessage(content="OK", tool_call_id="after-hard"),
+        ]
+        state = cast("Any", {"messages": messages})
+
+        result = mw.after_model(state, Mock())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_async_warning_at_threshold(self) -> None:
+        mw = LoopDetectionMiddleware(soft_threshold=4, hard_threshold=8)
+        messages = [
+            *_make_edit_calls("/a.py", 8),
+            ToolMessage(content="OK", tool_call_id="last"),
+        ]
+        state = cast("Any", {"messages": messages})
+
+        result = await mw.aafter_model(state, Mock())
+
+        assert result is not None
+        assert result["jump_to"] == "model"
+
+
+# ---------------------------------------------------------------------------
+# Concurrent safety (same instance, different states)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentSafety:
+    def test_independent_states(self) -> None:
+        """Same middleware instance, two different state dicts → independent."""
+        mw = LoopDetectionMiddleware(soft_threshold=2, hard_threshold=4)
+
+        # State A: 1 edit to /a.py (+ 1 current = 2, hits soft)
+        messages_a = _make_edit_calls("/a.py", 1)
+        request_a = _make_tool_call_request(
+            "edit_file", {"file_path": "/a.py"}, messages_a
+        )
+        tool_result_a = ToolMessage(content="OK-A", tool_call_id="call-a")
+        handler_a = Mock(return_value=tool_result_a)
+
+        # State B: 0 edits to /a.py (+ 1 current = 1, no warning)
+        request_b = _make_tool_call_request("edit_file", {"file_path": "/a.py"}, [])
+        tool_result_b = ToolMessage(content="OK-B", tool_call_id="call-b")
+        handler_b = Mock(return_value=tool_result_b)
+
+        result_a = mw.wrap_tool_call(request_a, handler_a)
+        result_b = mw.wrap_tool_call(request_b, handler_b)
+
+        # A should have warning, B should not
+        assert "**NOTE**" in str(result_a.content)
+        assert "**NOTE**" not in str(result_b.content)
+
+    def test_hard_warning_independent_states(self) -> None:
+        """after_model with different states should be independent."""
+        mw = LoopDetectionMiddleware(soft_threshold=2, hard_threshold=4)
+
+        # State A: 4 edits → hard warning
+        state_a = cast(
+            "Any",
+            {
+                "messages": [
+                    *_make_edit_calls("/a.py", 4),
+                    ToolMessage(content="OK", tool_call_id="last"),
+                ]
+            },
+        )
+        # State B: 3 edits → no hard warning
+        state_b = cast(
+            "Any",
+            {
+                "messages": [
+                    *_make_edit_calls("/a.py", 3),
+                    ToolMessage(content="OK", tool_call_id="last"),
+                ]
+            },
+        )
+
+        result_a = mw.after_model(state_a, Mock())
+        result_b = mw.after_model(state_b, Mock())
+
+        assert result_a is not None
+        assert result_a["jump_to"] == "model"
+        assert result_b is None


### PR DESCRIPTION
- Rewrites the loop detection middleware proposed in #1295 to be fully stateless, addressing review feedback from @eyurtsev and @ccurme
- Edit counts and warning dedup are derived by scanning `state["messages"]` on each hook invocation — no mutable instance state
- Thread-safe, sub-agent safe (shared instance, different state dicts), and summarization-aware (old messages compress → counts naturally reset)

## How it works

- `wrap_tool_call`: after each `edit_file`/`write_file`, counts edits from messages. At soft threshold (8), appends a nudge to the ToolMessage content. Agent can acknowledge or ignore.
- `after_model`: counts edits from messages. At hard threshold (12) with no pending tool calls, injects a HumanMessage telling the agent to stop and ask the user, then forces a new model turn via `jump_to: "model"`.
- Warning dedup: checks if marker text already exists in message history. No sets or dicts on the instance.
- Path resolution: uses `Path.resolve()` so relative and absolute paths to the same file are counted together.
- Only instance attrs are `soft_threshold` and `hard_threshold` (immutable config).

Not yet wired into `agent.py` — kept as a standalone proposal with tests.