### PR TITLE
feat(cli): warn when ripgrep is not installed

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -38,7 +38,7 @@ from deepagents_cli.config import (
     is_shell_command_allowed,
     settings,
 )
-from deepagents_cli.main import check_optional_tools
+from deepagents_cli.main import check_optional_tools, format_tool_warning_tui
 from deepagents_cli.model_config import (
     ModelConfigError,
     ModelSpec,
@@ -514,9 +514,14 @@ class DeepAgentsApp(App):
         # Focus the input (autocomplete is now built into ChatInput)
         self._chat_input.focus_input()
 
-        # Warn about missing optional tools
-        for warning in check_optional_tools():
-            self.notify(warning, severity="warning", timeout=7)
+        # Warn about missing optional tools (advisory only — never block startup)
+        try:
+            for tool in check_optional_tools():
+                self.notify(
+                    format_tool_warning_tui(tool), severity="warning", timeout=15
+                )
+        except Exception:
+            logger.debug("Failed to check for optional tools", exc_info=True)
 
         # Size the spacer to fill remaining viewport below input
         self.call_after_refresh(self._size_initial_spacer)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -26,6 +26,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from deepagents_cli.agent import create_cli_agent
+from deepagents_cli.main import check_optional_tools
 from deepagents_cli.clipboard import copy_selection_to_clipboard
 from deepagents_cli.config import (
     DOCS_URL,
@@ -512,6 +513,10 @@ class DeepAgentsApp(App):
 
         # Focus the input (autocomplete is now built into ChatInput)
         self._chat_input.focus_input()
+
+        # Warn about missing optional tools
+        for warning in check_optional_tools():
+            self.notify(warning, severity="warning", timeout=7)
 
         # Size the spacer to fill remaining viewport below input
         self.call_after_refresh(self._size_initial_spacer)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -26,7 +26,6 @@ from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from deepagents_cli.agent import create_cli_agent
-from deepagents_cli.main import check_optional_tools
 from deepagents_cli.clipboard import copy_selection_to_clipboard
 from deepagents_cli.config import (
     DOCS_URL,
@@ -39,6 +38,7 @@ from deepagents_cli.config import (
     is_shell_command_allowed,
     settings,
 )
+from deepagents_cli.main import check_optional_tools
 from deepagents_cli.model_config import (
     ModelConfigError,
     ModelSpec,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -101,19 +101,31 @@ def check_cli_dependencies() -> None:
         sys.exit(1)
 
 
-def check_optional_tools() -> list[str]:
+def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
     """Check for recommended external tools.
+
+    Skips warnings that the user has suppressed via
+    `[warnings].suppress` in `config.toml`.
+
+    Args:
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
 
     Returns:
         List of warning messages for missing tools.
     """
-    warnings: list[str] = []
-    if shutil.which("rg") is None:
-        warnings.append(
+    from deepagents_cli.model_config import is_warning_suppressed
+
+    result: list[str] = []
+    if shutil.which("rg") is None and not is_warning_suppressed("ripgrep", config_path):
+        result.append(
             "ripgrep is not installed, grep will use a slower fallback. "
-            "Install: https://github.com/BurntSushi/ripgrep#installation"
+            "Install: https://github.com/BurntSushi/ripgrep#installation\n"
+            "Suppress: add 'ripgrep' to [warnings].suppress "
+            "in ~/.deepagents/config.toml"
         )
-    return warnings
+    return result
 
 
 def parse_args() -> argparse.Namespace:

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -16,6 +16,7 @@ import importlib.util
 import json
 import logging
 import os
+import shutil
 import sys
 import traceback
 from collections.abc import Callable, Sequence
@@ -98,6 +99,21 @@ def check_cli_dependencies() -> None:
         print("\nOr install all dependencies:")
         print("  pip install 'deepagents[cli]'")
         sys.exit(1)
+
+
+def check_optional_tools() -> list[str]:
+    """Check for recommended external tools.
+
+    Returns:
+        List of warning messages for missing tools.
+    """
+    warnings: list[str] = []
+    if shutil.which("rg") is None:
+        warnings.append(
+            "ripgrep is not installed, grep will use a slower fallback. "
+            "Install: https://github.com/BurntSushi/ripgrep#installation"
+        )
+    return warnings
 
 
 def parse_args() -> argparse.Namespace:
@@ -737,6 +753,9 @@ def cli_main() -> None:
                 # No subcommand provided, show threads help screen
                 show_threads_help()
         elif args.non_interactive_message:
+            # Check for optional tools before running agent
+            for warning in check_optional_tools():
+                console.print(f"[yellow]Warning:[/yellow] {warning}")
             # Non-interactive mode - execute single task and exit
             from deepagents_cli.non_interactive import run_non_interactive
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -832,16 +832,27 @@ def is_warning_suppressed(key: str, config_path: Path | None = None) -> bool:
     if config_path is None:
         config_path = DEFAULT_CONFIG_PATH
 
-    if not config_path.exists():
-        return False
-
     try:
+        if not config_path.exists():
+            return False
         with config_path.open("rb") as f:
             data = tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError):
+        logger.debug(
+            "Could not read config file %s for warning suppression check",
+            config_path,
+            exc_info=True,
+        )
         return False
 
     suppress_list = data.get("warnings", {}).get("suppress", [])
+    if not isinstance(suppress_list, list):
+        logger.debug(
+            "[warnings].suppress in %s should be a list, got %s",
+            config_path,
+            type(suppress_list).__name__,
+        )
+        return False
     return key in suppress_list
 
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -698,7 +698,9 @@ def _save_model_field(
     Args:
         field: Key name under the `[models]` table (e.g., `'default'` or `'recent'`).
         model_spec: The model to save in `provider:model` format.
-        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
 
     Returns:
         True if save succeeded, False if it failed due to I/O errors.
@@ -749,7 +751,9 @@ def save_default_model(model_spec: str, config_path: Path | None = None) -> bool
 
     Args:
         model_spec: The model to set as default in `provider:model` format.
-        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
 
     Returns:
         True if save succeeded, False if it failed due to I/O errors.
@@ -767,7 +771,9 @@ def clear_default_model(config_path: Path | None = None) -> bool:
     `[models].recent` or environment auto-detection.
 
     Args:
-        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
 
     Returns:
         True if the key was removed (or was already absent), False on I/O error.
@@ -806,6 +812,88 @@ def clear_default_model(config_path: Path | None = None) -> bool:
         return True
 
 
+def is_warning_suppressed(key: str, config_path: Path | None = None) -> bool:
+    """Check if a warning key is suppressed in the config file.
+
+    Reads the `[warnings].suppress` list from `config.toml` and checks
+    whether `key` is present.
+
+    Args:
+        key: Warning identifier to check (e.g., `'ripgrep'`).
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        `True` if the warning is suppressed, `False` otherwise (including
+            when the file is missing, unreadable, or has no
+            `[warnings]` section).
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+
+    if not config_path.exists():
+        return False
+
+    try:
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    suppress_list = data.get("warnings", {}).get("suppress", [])
+    return key in suppress_list
+
+
+def suppress_warning(key: str, config_path: Path | None = None) -> bool:
+    """Add a warning key to the suppression list in the config file.
+
+    Reads existing config (if any), adds `key` to `[warnings].suppress`,
+    and writes back using atomic temp-file rename. Deduplicates entries.
+
+    Args:
+        key: Warning identifier to suppress (e.g., `'ripgrep'`).
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        `True` if save succeeded, `False` if it failed due to I/O errors.
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if config_path.exists():
+            with config_path.open("rb") as f:
+                data = tomllib.load(f)
+        else:
+            data = {}
+
+        if "warnings" not in data:
+            data["warnings"] = {}
+        suppress_list: list[str] = data["warnings"].get("suppress", [])
+        if key not in suppress_list:
+            suppress_list.append(key)
+        data["warnings"]["suppress"] = suppress_list
+
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.exception("Could not save warning suppression for '%s'", key)
+        return False
+    return True
+
+
 def save_recent_model(model_spec: str, config_path: Path | None = None) -> bool:
     """Update the recently used model in config file.
 
@@ -814,7 +902,9 @@ def save_recent_model(model_spec: str, config_path: Path | None = None) -> bool:
 
     Args:
         model_spec: The model to save in `provider:model` format.
-        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
 
     Returns:
         True if save succeeded, False if it failed due to I/O errors.

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -1,13 +1,19 @@
 """Unit tests for main entry point."""
 
 import inspect
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from deepagents_cli.app import run_textual_app
 from deepagents_cli.config import build_langsmith_thread_url, reset_langsmith_url_cache
-from deepagents_cli.main import check_optional_tools, run_textual_cli_async
+from deepagents_cli.main import (
+    check_optional_tools,
+    format_tool_warning_cli,
+    format_tool_warning_tui,
+    run_textual_cli_async,
+)
 
 
 class TestResumeHintLogic:
@@ -130,28 +136,85 @@ class TestThreadMessage:
 class TestCheckOptionalTools:
     """Tests for check_optional_tools() function."""
 
-    def test_returns_warning_when_rg_not_found(self) -> None:
-        """Returns a warning about ripgrep when `rg` is not on PATH."""
+    def test_returns_tool_name_when_rg_not_found(self) -> None:
+        """Returns `['ripgrep']` when `rg` is not on PATH."""
         with patch("deepagents_cli.main.shutil.which", return_value=None):
-            warnings = check_optional_tools()
+            missing = check_optional_tools()
 
-        assert len(warnings) == 1
-        assert "ripgrep" in warnings[0]
-        assert "https://github.com/BurntSushi/ripgrep" in warnings[0]
+        assert missing == ["ripgrep"]
 
     def test_returns_empty_when_rg_found(self) -> None:
         """Returns empty list when `rg` is found on PATH."""
         with patch("deepagents_cli.main.shutil.which", return_value="/usr/bin/rg"):
-            warnings = check_optional_tools()
+            missing = check_optional_tools()
 
-        assert warnings == []
+        assert missing == []
 
-    def test_warning_suppressed_via_config(self, tmp_path) -> None:
+    def test_warning_suppressed_via_config(self, tmp_path: Path) -> None:
         """Returns empty list when ripgrep warning is suppressed in config."""
         config_path = tmp_path / "config.toml"
         config_path.write_text('[warnings]\nsuppress = ["ripgrep"]\n')
 
         with patch("deepagents_cli.main.shutil.which", return_value=None):
-            warnings = check_optional_tools(config_path=config_path)
+            missing = check_optional_tools(config_path=config_path)
 
-        assert warnings == []
+        assert missing == []
+
+    def test_malformed_config_does_not_suppress(self, tmp_path: Path) -> None:
+        """Malformed TOML config degrades gracefully instead of crashing."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("this is not valid toml [[[")
+
+        with patch("deepagents_cli.main.shutil.which", return_value=None):
+            missing = check_optional_tools(config_path=config_path)
+
+        assert missing == ["ripgrep"]
+
+    def test_non_list_suppress_does_not_crash(self, tmp_path: Path) -> None:
+        """Non-list `suppress` value degrades gracefully instead of crashing."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[warnings]\nsuppress = true\n")
+
+        with patch("deepagents_cli.main.shutil.which", return_value=None):
+            missing = check_optional_tools(config_path=config_path)
+
+        assert missing == ["ripgrep"]
+
+    def test_unrelated_suppress_key_does_not_suppress(self, tmp_path: Path) -> None:
+        """Suppressing a different key does not suppress the ripgrep warning."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["something_else"]\n')
+
+        with patch("deepagents_cli.main.shutil.which", return_value=None):
+            missing = check_optional_tools(config_path=config_path)
+
+        assert missing == ["ripgrep"]
+
+
+class TestFormatToolWarnings:
+    """Tests for TUI and CLI warning formatters."""
+
+    def test_tui_format_contains_url(self) -> None:
+        """TUI format includes the install URL as plain text."""
+        msg = format_tool_warning_tui("ripgrep")
+        assert "https://github.com/BurntSushi/ripgrep#installation" in msg
+        assert "[link=" not in msg
+
+    def test_cli_format_contains_rich_link(self) -> None:
+        """CLI format wraps the URL in Rich `[link]` markup."""
+        msg = format_tool_warning_cli("ripgrep")
+        assert "[link=https://github.com/BurntSushi/ripgrep#installation]" in msg
+        assert "[/link]" in msg
+
+    def test_both_formats_contain_suppress_hint(self) -> None:
+        """Both formats include the config suppression hint."""
+        formatters = (format_tool_warning_tui, format_tool_warning_cli)
+        for fmt in formatters:
+            msg = fmt("ripgrep")
+            assert "\\[warnings]" in msg
+            assert 'suppress = \\["ripgrep"]' in msg
+
+    def test_unknown_tool_fallback(self) -> None:
+        """Unknown tools get a generic message."""
+        assert format_tool_warning_tui("foo") == "foo is not installed."
+        assert format_tool_warning_cli("foo") == "foo is not installed."

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -21,7 +21,9 @@ from deepagents_cli.model_config import (
     clear_default_model,
     get_available_models,
     has_provider_credentials,
+    is_warning_suppressed,
     save_recent_model,
+    suppress_warning,
 )
 
 
@@ -1559,3 +1561,93 @@ recent = "openai:gpt-5.2"
             result = _get_default_model_spec()
 
         assert result == "anthropic:claude-sonnet-4-5-20250929"
+
+
+class TestIsWarningSuppressed:
+    """Tests for is_warning_suppressed() function."""
+
+    def test_returns_true_when_key_present(self, tmp_path) -> None:
+        """Returns True when key is in [warnings].suppress list."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["ripgrep"]\n')
+
+        assert is_warning_suppressed("ripgrep", config_path) is True
+
+    def test_returns_false_when_key_absent(self, tmp_path) -> None:
+        """Returns False when key is not in [warnings].suppress list."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["other"]\n')
+
+        assert is_warning_suppressed("ripgrep", config_path) is False
+
+    def test_returns_false_when_file_missing(self, tmp_path) -> None:
+        """Returns False when config file does not exist."""
+        config_path = tmp_path / "nonexistent.toml"
+
+        assert is_warning_suppressed("ripgrep", config_path) is False
+
+    def test_returns_false_on_corrupt_toml(self, tmp_path) -> None:
+        """Returns False when config file has invalid TOML."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[[invalid toml")
+
+        assert is_warning_suppressed("ripgrep", config_path) is False
+
+    def test_returns_false_when_no_warnings_section(self, tmp_path) -> None:
+        """Returns False when config has no [warnings] section."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models]\ndefault = "some:model"\n')
+
+        assert is_warning_suppressed("ripgrep", config_path) is False
+
+
+class TestSuppressWarning:
+    """Tests for suppress_warning() function."""
+
+    def test_creates_file_with_key(self, tmp_path) -> None:
+        """Creates config file with [warnings].suppress list."""
+        config_path = tmp_path / "config.toml"
+
+        result = suppress_warning("ripgrep", config_path)
+
+        assert result is True
+        assert config_path.exists()
+        assert is_warning_suppressed("ripgrep", config_path) is True
+
+    def test_adds_to_existing_list(self, tmp_path) -> None:
+        """Adds key to existing [warnings].suppress list."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["other"]\n')
+
+        result = suppress_warning("ripgrep", config_path)
+
+        assert result is True
+        assert is_warning_suppressed("other", config_path) is True
+        assert is_warning_suppressed("ripgrep", config_path) is True
+
+    def test_deduplicates(self, tmp_path) -> None:
+        """Does not add duplicate entries."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["ripgrep"]\n')
+
+        suppress_warning("ripgrep", config_path)
+
+        import tomllib
+
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["warnings"]["suppress"].count("ripgrep") == 1
+
+    def test_preserves_other_config(self, tmp_path) -> None:
+        """Preserves existing config sections when adding suppression."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models]\ndefault = "some:model"\n')
+
+        suppress_warning("ripgrep", config_path)
+
+        import tomllib
+
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["models"]["default"] == "some:model"
+        assert "ripgrep" in data["warnings"]["suppress"]


### PR DESCRIPTION
Closes #1145

Adds a runtime warning when ripgrep (rg) is not installed, since the grep tool silently falls back to a slower Python-based search. Warning displays as a toast notification in interactive TUI mode and as console output in non-interactive mode.