### PR TITLE
fix(cli): prioritize direct URL fetch over search queries containing URLs

### DIFF
--- a/libs/cli/deepagents_cli/tools.py
+++ b/libs/cli/deepagents_cli/tools.py
@@ -1,5 +1,6 @@
 """Custom tools for the CLI agent."""
 
+import re
 from typing import Any, Literal
 
 import requests
@@ -19,6 +20,21 @@ from deepagents_cli.config import settings
 tavily_client = (
     TavilyClient(api_key=settings.tavily_api_key) if settings.has_tavily else None
 )
+
+
+_HTTP_URL_PATTERN = re.compile(r"https?://[^\s)\]}>\"']+")
+
+
+def _extract_first_http_url(text: str) -> str | None:
+    """Extract the first HTTP(S) URL from text.
+
+    Returns:
+        First detected HTTP(S) URL, or `None` when no URL is present.
+    """
+    match = _HTTP_URL_PATTERN.search(text)
+    if not match:
+        return None
+    return match.group(0).rstrip(".,;:!?")
 
 
 def http_request(
@@ -121,6 +137,16 @@ def web_search(
     4. Cite sources by mentioning the page titles or URLs
     5. NEVER show the raw JSON to the user - always provide a formatted response
     """
+    direct_url = _extract_first_http_url(query)
+    if direct_url:
+        fetched = fetch_url(direct_url)
+        return {
+            "query": query,
+            "direct_fetch": True,
+            "source_tool": "fetch_url",
+            **fetched,
+        }
+
     if tavily_client is None:
         return {
             "error": "Tavily API key not configured. "

--- a/libs/cli/tests/unit_tests/tools/test_fetch_url.py
+++ b/libs/cli/tests/unit_tests/tools/test_fetch_url.py
@@ -1,9 +1,11 @@
 """Tests for tools module."""
 
+from unittest.mock import patch
+
 import requests
 import responses
 
-from deepagents_cli.tools import fetch_url
+from deepagents_cli.tools import fetch_url, web_search
 
 
 @responses.activate
@@ -70,3 +72,35 @@ def test_fetch_url_connection_error() -> None:
     assert "error" in result
     assert "Fetch URL error" in result["error"]
     assert result["url"] == "http://example.com/error"
+
+
+@responses.activate
+def test_web_search_delegates_to_fetch_url_when_query_contains_url() -> None:
+    """web_search should directly fetch a concrete URL instead of searching."""
+    responses.add(
+        responses.GET,
+        "https://example.com/docs",
+        body="<html><body><h1>Doc</h1><p>Detail</p></body></html>",
+        status=200,
+    )
+
+    with patch("deepagents_cli.tools.tavily_client") as mock_tavily:
+        result = web_search("Please summarize https://example.com/docs")
+
+    assert result["direct_fetch"] is True
+    assert result["source_tool"] == "fetch_url"
+    assert result["url"].startswith("https://example.com/docs")
+    assert "Doc" in result["markdown_content"]
+    mock_tavily.search.assert_not_called()
+
+
+def test_web_search_uses_tavily_when_query_has_no_url() -> None:
+    """web_search should use Tavily for normal keyword queries."""
+    expected = {"results": [{"title": "Result", "url": "https://x", "content": "c"}]}
+
+    with patch("deepagents_cli.tools.tavily_client") as mock_tavily:
+        mock_tavily.search.return_value = expected
+        result = web_search("langgraph state checkpointing")
+
+    assert result == expected
+    mock_tavily.search.assert_called_once()


### PR DESCRIPTION
## Summary
This addresses #1304 by avoiding Tavily search when the `web_search` query already contains a concrete HTTP(S) URL.

## What changed
- Added URL extraction helper in `libs/cli/deepagents_cli/tools.py`.
- Updated `web_search` to delegate to `fetch_url` when a URL is present in the query.
- Added regression tests in `libs/cli/tests/unit_tests/tools/test_fetch_url.py` for:
  - URL-containing query delegates to `fetch_url` and does not call Tavily.
  - Normal keyword query still uses Tavily.

## Why this helps
When users provide an exact URL with context, the CLI now reliably fetches page content directly instead of running a broad web search first.

## Validation
- `uv run --project libs/cli ruff check libs/cli/deepagents_cli/tools.py libs/cli/tests/unit_tests/tools/test_fetch_url.py`
- `uv run --project libs/cli pytest libs/cli/tests/unit_tests/tools/test_fetch_url.py -q`
