### PR TITLE
fix(cli): preserve path context in file tool display

### DIFF
--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -92,6 +92,21 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
     """
     prefix = get_glyphs().tool_prefix
 
+    def truncate_path_middle(path_str: str, max_length: int = 60) -> str:
+        """Truncate a path while preserving both prefix and filename.
+
+        Returns:
+            A potentially shortened path string with middle ellipsis.
+        """
+        if len(path_str) <= max_length:
+            return path_str
+        ellipsis = get_glyphs().ellipsis
+        if max_length <= len(ellipsis) + 2:
+            return truncate_value(path_str, max_length)
+        head_len = (max_length - len(ellipsis)) // 2
+        tail_len = max_length - len(ellipsis) - head_len
+        return f"{path_str[:head_len]}{ellipsis}{path_str[-tail_len:]}"
+
     def abbreviate_path(path_str: str, max_length: int = 60) -> str:
         """Abbreviate a file path intelligently - show basename or relative path.
 
@@ -121,10 +136,10 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
                 return path_str
         except Exception:
             # Fallback to original string if any error
-            return truncate_value(path_str, max_length)
+            return truncate_path_middle(path_str, max_length)
         else:
-            # Otherwise, just show basename (filename only)
-            return path.name
+            # Preserve both root context and file name for long absolute paths.
+            return truncate_path_middle(path_str, max_length)
 
     # Tool-specific formatting - show the most important argument(s)
     if tool_name in {"read_file", "write_file", "edit_file"}:

--- a/libs/cli/tests/unit_tests/test_ui.py
+++ b/libs/cli/tests/unit_tests/test_ui.py
@@ -118,6 +118,20 @@ class TestFormatToolDisplayOther:
         assert result.startswith(f"{prefix} read_file(")
         assert "file.py" in result
 
+    def test_read_file_long_absolute_path_keeps_context(self) -> None:
+        """Long absolute paths should keep directory context, not basename only."""
+        prefix = get_glyphs().tool_prefix
+        long_path = (
+            "/Users/liweiguang/worktrees/project-alpha/service-a/src/deep/module/"
+            "very_important_file.py"
+        )
+        result = format_tool_display("read_file", {"file_path": long_path})
+
+        assert result.startswith(f"{prefix} read_file(")
+        assert "very_important_file.py" in result
+        assert "/" in result
+        assert get_glyphs().ellipsis in result
+
     def test_web_search(self) -> None:
         """Test web_search display shows query."""
         prefix = get_glyphs().tool_prefix


### PR DESCRIPTION
Fix the path display in CLI tool call output so users can distinguish files in monorepos and worktrees. Previously, `abbreviate_path` fell back to showing only the basename (e.g., `file.py`) for long absolute paths — useless when multiple packages contain identically named files.

Fixes #1142

## Changes
- Add `truncate_path_middle` helper inside `format_tool_display` that preserves both the leading directory context and the filename, joining them with an ellipsis (`…`) when the path exceeds 60 characters — replaces the old basename-only fallback in `abbreviate_path`
- Both the error/fallback branch and the normal long-path branch in `abbreviate_path` now route through `truncate_path_middle` instead of `truncate_value` / `path.name`

## Testing
- Add `test_read_file_long_absolute_path_keeps_context` asserting that a deeply nested absolute path retains directory context and the ellipsis glyph in the formatted output

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)