### PR TITLE
fix(cli): handle `None` selection endpoint, `IndexError` in clipboard copy

### DIFF
--- a/libs/cli/deepagents_cli/clipboard.py
+++ b/libs/cli/deepagents_cli/clipboard.py
@@ -57,9 +57,12 @@ def copy_selection_to_clipboard(app: App) -> None:
 
         selection = widget.text_selection
 
+        if selection.end is None:
+            continue
+
         try:
             result = widget.get_selection(selection)
-        except (AttributeError, TypeError, ValueError) as e:
+        except (AttributeError, TypeError, ValueError, IndexError) as e:
             logger.debug(
                 "Failed to get selection from widget %s: %s",
                 type(widget).__name__,


### PR DESCRIPTION
Guard against `None` selection endpoints and `IndexError` in `copy_selection_to_clipboard`. I think this may resolve an issue Angus encountered...