### PR TITLE
fix(cli): update stale SDK pin from 0.4.1 to 0.4.2

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.4.1",
+    "deepagents==0.4.2",
     "langchain>=1.2.10,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",
 


### PR DESCRIPTION
The CLI pins `deepagents==0.4.1` in `libs/cli/pyproject.toml` but the SDK
is at version `0.4.2`. This mismatch is masked by `[tool.uv.sources]` editable
installs during local development, but would cause the published CLI package on
PyPI to depend on an outdated SDK version.

Fixes #1344

## How was this verified?

- Confirmed SDK version is `0.4.2` in `libs/deepagents/pyproject.toml`
- Confirmed CLI pinned `0.4.1` in `libs/cli/pyproject.toml` line 29
- The `check_cli_sdk_pin` CI workflow validates this match on CLI release PRs
- Ran `make format`, `make lint`, and `make test` from `libs/cli/`