### PR TITLE
chore: add deprecation warning to readme [closes LC-478]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 
 <br>
 
+> [!CAUTION]
+> **This repository is deprecated and is no longer maintained.** Please do not use it for new projects. It may contain outdated or unsupported code.
+
 Deep Agents is an agent harness.  An opinionated, ready-to-run agent out of the box. Instead of wiring up prompts, tools, and context management yourself, you get a working agent immediately and customize what you need.
 
 **What's included:**


### PR DESCRIPTION
## Description
Adds a prominent deprecation warning to the root README to inform users that this repository is deprecated and should not be used for new projects.

Changes:
- Added a `[!CAUTION]` callout block at the top of `README.md` (below the logo/badges, above the description) warning that the repo is deprecated and no longer maintained.

Resolves LC-478

## Test Plan
- [ ] Verify the deprecation warning renders correctly on GitHub (uses `[!CAUTION]` alert syntax)
- [ ] Verify the warning is prominently visible at the top of the README