### PR TITLE
perf(cli): defer heavy imports

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1,5 +1,7 @@
 """Configuration, constants, and model creation for the CLI."""
 
+from __future__ import annotations
+
 import importlib
 import json
 import logging
@@ -12,7 +14,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import dotenv
 from rich.console import Console
@@ -32,16 +34,15 @@ if _deepagents_project:
     # Override LANGSMITH_PROJECT for agent traces
     os.environ["LANGSMITH_PROJECT"] = _deepagents_project
 
-# E402: Now safe to import LangChain modules
-from langchain.chat_models import init_chat_model  # noqa: E402
-from langchain_core.language_models import BaseChatModel  # noqa: E402
-from langchain_core.runnables import RunnableConfig  # noqa: E402
-
 from deepagents_cli.model_config import (  # noqa: E402
     ModelConfig,
     ModelConfigError,
     ModelSpec,
 )
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.runnables import RunnableConfig
 
 DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
 
@@ -456,7 +457,7 @@ class Settings:
     shell_allow_list: list[str] | None = None
 
     @classmethod
-    def from_environment(cls, *, start_path: Path | None = None) -> "Settings":
+    def from_environment(cls, *, start_path: Path | None = None) -> Settings:
         """Create settings by detecting the current environment.
 
         Args:
@@ -1192,6 +1193,10 @@ def _create_model_from_class(
         ModelConfigError: If the class cannot be imported, is not a
             `BaseChatModel` subclass, or fails to instantiate.
     """
+    from langchain_core.language_models import (
+        BaseChatModel as _BaseChatModel,  # Runtime import; module level is typing only
+    )
+
     if ":" not in class_path:
         msg = (
             f"Invalid class_path '{class_path}' for provider '{provider}': "
@@ -1215,7 +1220,7 @@ def _create_model_from_class(
         )
         raise ModelConfigError(msg)
 
-    if not (isinstance(cls, type) and issubclass(cls, BaseChatModel)):
+    if not (isinstance(cls, type) and issubclass(cls, _BaseChatModel)):
         msg = (
             f"'{class_path}' is not a BaseChatModel subclass (got {type(cls).__name__})"
         )
@@ -1246,6 +1251,8 @@ def _create_model_via_init(
     Raises:
         ModelConfigError: On import, value, or runtime errors.
     """
+    from langchain.chat_models import init_chat_model
+
     try:
         if provider:
             return init_chat_model(model_name, model_provider=provider, **kwargs)

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -214,6 +214,8 @@ def _get_builtin_providers() -> dict[str, Any]:
     if _builtin_providers_cache is not None:
         return _builtin_providers_cache
 
+    # Deferred: langchain.chat_models pulls in heavy provider registry,
+    # only needed when resolving provider names for model config.
     from langchain.chat_models import base  # noqa: PLC0415
 
     registry: dict[str, Any] | None = getattr(base, "_BUILTIN_PROVIDERS", None)

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -601,6 +601,8 @@ async def run_non_interactive(
     exit_stack = contextlib.ExitStack()
 
     if sandbox_type != "none":
+        # Conditional: sandbox_factory transitively imports provider modules
+        # and SDKs — skip that cost for the common no-sandbox path.
         from deepagents_cli.integrations.sandbox_factory import (  # noqa: PLC0415
             create_sandbox,
         )

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -6,16 +6,19 @@ These commands are registered with the CLI via main.py:
 - deepagents skills info <name>
 """
 
-import argparse
-import functools
-from collections.abc import Callable
-from pathlib import Path
-from typing import Any
+from __future__ import annotations
 
-from deepagents.middleware.skills import SkillMetadata
+import functools
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Callable
+
+    from deepagents.middleware.skills import SkillMetadata
 
 from deepagents_cli.config import COLORS, Settings, console, get_glyphs
-from deepagents_cli.skills.load import list_skills
 from deepagents_cli.ui import (
     build_help_parent,
     show_skills_create_help,
@@ -157,6 +160,11 @@ def _list(agent: str, *, project: bool = False) -> None:
         project: If True, show only project skills.
             If False, show all skills (user + project).
     """
+    # Deferred: skills.load imports the deepagents SDK. This module is
+    # imported at CLI startup for setup_skills_parser(), so a top-level
+    # import here would penalize every command (e.g. `--help`).
+    from deepagents_cli.skills.load import list_skills  # noqa: PLC0415
+
     settings = Settings.from_environment()
     user_skills_dir = settings.get_user_skills_dir(agent)
     project_skills_dir = settings.get_project_skills_dir()
@@ -457,6 +465,11 @@ def _info(skill_name: str, *, agent: str = "agent", project: bool = False) -> No
         project: If True, only search in project skills.
             If False, search in both user and project skills.
     """
+    # Deferred: skills.load imports the deepagents SDK. This module is
+    # imported at CLI startup for setup_skills_parser(), so a top-level
+    # import here would penalize every command (e.g. `--help`).
+    from deepagents_cli.skills.load import list_skills  # noqa: PLC0415
+
     settings = Settings.from_environment()
     user_skills_dir = settings.get_user_skills_dir(agent)
     project_skills_dir = settings.get_project_skills_dir()

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -27,7 +27,7 @@ from pydantic import TypeAdapter, ValidationError
 from deepagents_cli.file_ops import FileOpTracker
 from deepagents_cli.image_utils import create_multimodal_content
 from deepagents_cli.input import ImageTracker, parse_file_mentions
-from deepagents_cli.ui import format_tool_message_content
+from deepagents_cli.tool_display import format_tool_message_content
 from deepagents_cli.widgets.messages import (
     AppMessage,
     AssistantMessage,

--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -1,0 +1,209 @@
+"""Formatting utilities for tool call display in the CLI.
+
+This module handles rendering tool calls and tool messages for the TUI.
+
+Imported at runtime (not at CLI startup), so it can safely depend
+on heavier modules like `backends`.
+"""
+
+import json
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from deepagents_cli.backends import DEFAULT_EXECUTE_TIMEOUT
+from deepagents_cli.config import MAX_ARG_LENGTH, get_glyphs
+
+
+def _format_timeout(seconds: int) -> str:
+    """Format timeout in human-readable units (e.g., 300 -> '5m', 3600 -> '1h').
+
+    Args:
+        seconds: The timeout value in seconds to format.
+
+    Returns:
+        Human-readable timeout string (e.g., '5m', '1h', '300s').
+    """
+    if seconds < 60:  # noqa: PLR2004
+        return f"{seconds}s"
+    if seconds < 3600 and seconds % 60 == 0:  # noqa: PLR2004
+        return f"{seconds // 60}m"
+    if seconds % 3600 == 0:
+        return f"{seconds // 3600}h"
+    # For odd values, just show seconds
+    return f"{seconds}s"
+
+
+def truncate_value(value: str, max_length: int = MAX_ARG_LENGTH) -> str:
+    """Truncate a string value if it exceeds max_length.
+
+    Returns:
+        Truncated string with ellipsis suffix if exceeded, otherwise original.
+    """
+    if len(value) > max_length:
+        return value[:max_length] + get_glyphs().ellipsis
+    return value
+
+
+def format_tool_display(tool_name: str, tool_args: dict) -> str:
+    """Format tool calls for display with tool-specific smart formatting.
+
+    Shows the most relevant information for each tool type rather than all arguments.
+
+    Args:
+        tool_name: Name of the tool being called
+        tool_args: Dictionary of tool arguments
+
+    Returns:
+        Formatted string for display (e.g., "(*) read_file(config.py)" in ASCII mode)
+
+    Examples:
+        read_file(path="/long/path/file.py") → "<prefix> read_file(file.py)"
+        web_search(query="how to code") → '<prefix> web_search("how to code")'
+        execute(command="pip install foo") → '<prefix> execute("pip install foo")'
+    """
+    prefix = get_glyphs().tool_prefix
+
+    def abbreviate_path(path_str: str, max_length: int = 60) -> str:
+        """Abbreviate a file path intelligently - show basename or relative path.
+
+        Returns:
+            Shortened path string suitable for display.
+        """
+        try:
+            path = Path(path_str)
+
+            # If it's just a filename (no directory parts), return as-is
+            if len(path.parts) == 1:
+                return path_str
+
+            # Try to get relative path from current working directory
+            with suppress(
+                ValueError,  # ValueError: path is not relative to cwd
+                OSError,  # OSError: filesystem errors when resolving paths
+            ):
+                rel_path = path.relative_to(Path.cwd())
+                rel_str = str(rel_path)
+                # Use relative if it's shorter and not too long
+                if len(rel_str) < len(path_str) and len(rel_str) <= max_length:
+                    return rel_str
+
+            # If absolute path is reasonable length, use it
+            if len(path_str) <= max_length:
+                return path_str
+        except Exception:  # noqa: BLE001
+            # Fallback to original string if any error
+            return truncate_value(path_str, max_length)
+        else:
+            # Otherwise, just show basename (filename only)
+            return path.name
+
+    # Tool-specific formatting - show the most important argument(s)
+    if tool_name in {"read_file", "write_file", "edit_file"}:
+        # File operations: show the primary file path argument (file_path or path)
+        path_value = tool_args.get("file_path")
+        if path_value is None:
+            path_value = tool_args.get("path")
+        if path_value is not None:
+            path = abbreviate_path(str(path_value))
+            return f"{prefix} {tool_name}({path})"
+
+    elif tool_name == "web_search":
+        # Web search: show the query string
+        if "query" in tool_args:
+            query = str(tool_args["query"])
+            query = truncate_value(query, 100)
+            return f'{prefix} {tool_name}("{query}")'
+
+    elif tool_name == "grep":
+        # Grep: show the search pattern
+        if "pattern" in tool_args:
+            pattern = str(tool_args["pattern"])
+            pattern = truncate_value(pattern, 70)
+            return f'{prefix} {tool_name}("{pattern}")'
+
+    elif tool_name == "execute":
+        # Execute: show the command, and timeout only if non-default
+        if "command" in tool_args:
+            command = str(tool_args["command"])
+            command = truncate_value(command, 120)
+            timeout = tool_args.get("timeout")
+            if timeout is not None and timeout != DEFAULT_EXECUTE_TIMEOUT:
+                timeout_str = _format_timeout(timeout)
+                return f'{prefix} {tool_name}("{command}", timeout={timeout_str})'
+            return f'{prefix} {tool_name}("{command}")'
+
+    elif tool_name == "ls":
+        # ls: show directory, or empty if current directory
+        if tool_args.get("path"):
+            path = abbreviate_path(str(tool_args["path"]))
+            return f"{prefix} {tool_name}({path})"
+        return f"{prefix} {tool_name}()"
+
+    elif tool_name == "glob":
+        # Glob: show the pattern
+        if "pattern" in tool_args:
+            pattern = str(tool_args["pattern"])
+            pattern = truncate_value(pattern, 80)
+            return f'{prefix} {tool_name}("{pattern}")'
+
+    elif tool_name == "http_request":
+        # HTTP: show method and URL
+        parts = []
+        if "method" in tool_args:
+            parts.append(str(tool_args["method"]).upper())
+        if "url" in tool_args:
+            url = str(tool_args["url"])
+            url = truncate_value(url, 80)
+            parts.append(url)
+        if parts:
+            return f"{prefix} {tool_name}({' '.join(parts)})"
+
+    elif tool_name == "fetch_url":
+        # Fetch URL: show the URL being fetched
+        if "url" in tool_args:
+            url = str(tool_args["url"])
+            url = truncate_value(url, 80)
+            return f'{prefix} {tool_name}("{url}")'
+
+    elif tool_name == "task":
+        # Task: show the task description
+        if "description" in tool_args:
+            desc = str(tool_args["description"])
+            desc = truncate_value(desc, 100)
+            return f'{prefix} {tool_name}("{desc}")'
+
+    elif tool_name == "write_todos":
+        # Todos: show count of items
+        if "todos" in tool_args and isinstance(tool_args["todos"], list):
+            count = len(tool_args["todos"])
+            return f"{prefix} {tool_name}({count} items)"
+
+    # Fallback: generic formatting for unknown tools
+    # Show all arguments in key=value format
+    args_str = ", ".join(
+        f"{k}={truncate_value(str(v), 50)}" for k, v in tool_args.items()
+    )
+    return f"{prefix} {tool_name}({args_str})"
+
+
+def format_tool_message_content(content: Any) -> str:  # noqa: ANN401
+    """Convert `ToolMessage` content into a printable string.
+
+    Returns:
+        Formatted string representation of the tool message content.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            else:
+                try:
+                    parts.append(json.dumps(item))
+                except (TypeError, ValueError):
+                    parts.append(str(item))
+        return "\n".join(parts)
+    return str(content)

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -1,21 +1,18 @@
-"""UI rendering and display utilities for the CLI."""
+"""Help screens and argparse utilities for the CLI.
+
+This module is imported at CLI startup to wire `-h` actions into the
+argparse tree.  It must stay lightweight — no SDK or langchain imports.
+"""
 
 import argparse
-import json
 from collections.abc import Callable
-from contextlib import suppress
-from pathlib import Path
-from typing import Any
 
 from deepagents_cli._version import __version__
-from deepagents_cli.backends import DEFAULT_EXECUTE_TIMEOUT
 from deepagents_cli.config import (
     COLORS,
     DOCS_URL,
-    MAX_ARG_LENGTH,
     _is_editable_install,
     console,
-    get_glyphs,
 )
 
 
@@ -41,200 +38,6 @@ def build_help_parent(
     parent = argparse.ArgumentParser(add_help=False)
     parent.add_argument("-h", "--help", action=make_help_action(help_fn))
     return [parent]
-
-
-def _format_timeout(seconds: int) -> str:
-    """Format timeout in human-readable units (e.g., 300 -> '5m', 3600 -> '1h').
-
-    Args:
-        seconds: The timeout value in seconds to format.
-
-    Returns:
-        Human-readable timeout string (e.g., '5m', '1h', '300s').
-    """
-    if seconds < 60:
-        return f"{seconds}s"
-    if seconds < 3600 and seconds % 60 == 0:
-        return f"{seconds // 60}m"
-    if seconds % 3600 == 0:
-        return f"{seconds // 3600}h"
-    # For odd values, just show seconds
-    return f"{seconds}s"
-
-
-def truncate_value(value: str, max_length: int = MAX_ARG_LENGTH) -> str:
-    """Truncate a string value if it exceeds max_length.
-
-    Returns:
-        Truncated string with ellipsis suffix if exceeded, otherwise original.
-    """
-    if len(value) > max_length:
-        return value[:max_length] + get_glyphs().ellipsis
-    return value
-
-
-def format_tool_display(tool_name: str, tool_args: dict) -> str:
-    """Format tool calls for display with tool-specific smart formatting.
-
-    Shows the most relevant information for each tool type rather than all arguments.
-
-    Args:
-        tool_name: Name of the tool being called
-        tool_args: Dictionary of tool arguments
-
-    Returns:
-        Formatted string for display (e.g., "(*) read_file(config.py)" in ASCII mode)
-
-    Examples:
-        read_file(path="/long/path/file.py") → "<prefix> read_file(file.py)"
-        web_search(query="how to code") → '<prefix> web_search("how to code")'
-        execute(command="pip install foo") → '<prefix> execute("pip install foo")'
-    """
-    prefix = get_glyphs().tool_prefix
-
-    def abbreviate_path(path_str: str, max_length: int = 60) -> str:
-        """Abbreviate a file path intelligently - show basename or relative path.
-
-        Returns:
-            Shortened path string suitable for display.
-        """
-        try:
-            path = Path(path_str)
-
-            # If it's just a filename (no directory parts), return as-is
-            if len(path.parts) == 1:
-                return path_str
-
-            # Try to get relative path from current working directory
-            with suppress(
-                ValueError,  # ValueError: path is not relative to cwd
-                OSError,  # OSError: filesystem errors when resolving paths
-            ):
-                rel_path = path.relative_to(Path.cwd())
-                rel_str = str(rel_path)
-                # Use relative if it's shorter and not too long
-                if len(rel_str) < len(path_str) and len(rel_str) <= max_length:
-                    return rel_str
-
-            # If absolute path is reasonable length, use it
-            if len(path_str) <= max_length:
-                return path_str
-        except Exception:
-            # Fallback to original string if any error
-            return truncate_value(path_str, max_length)
-        else:
-            # Otherwise, just show basename (filename only)
-            return path.name
-
-    # Tool-specific formatting - show the most important argument(s)
-    if tool_name in {"read_file", "write_file", "edit_file"}:
-        # File operations: show the primary file path argument (file_path or path)
-        path_value = tool_args.get("file_path")
-        if path_value is None:
-            path_value = tool_args.get("path")
-        if path_value is not None:
-            path = abbreviate_path(str(path_value))
-            return f"{prefix} {tool_name}({path})"
-
-    elif tool_name == "web_search":
-        # Web search: show the query string
-        if "query" in tool_args:
-            query = str(tool_args["query"])
-            query = truncate_value(query, 100)
-            return f'{prefix} {tool_name}("{query}")'
-
-    elif tool_name == "grep":
-        # Grep: show the search pattern
-        if "pattern" in tool_args:
-            pattern = str(tool_args["pattern"])
-            pattern = truncate_value(pattern, 70)
-            return f'{prefix} {tool_name}("{pattern}")'
-
-    elif tool_name == "execute":
-        # Execute: show the command, and timeout only if non-default
-        if "command" in tool_args:
-            command = str(tool_args["command"])
-            command = truncate_value(command, 120)
-            timeout = tool_args.get("timeout")
-            if timeout is not None and timeout != DEFAULT_EXECUTE_TIMEOUT:
-                timeout_str = _format_timeout(timeout)
-                return f'{prefix} {tool_name}("{command}", timeout={timeout_str})'
-            return f'{prefix} {tool_name}("{command}")'
-
-    elif tool_name == "ls":
-        # ls: show directory, or empty if current directory
-        if tool_args.get("path"):
-            path = abbreviate_path(str(tool_args["path"]))
-            return f"{prefix} {tool_name}({path})"
-        return f"{prefix} {tool_name}()"
-
-    elif tool_name == "glob":
-        # Glob: show the pattern
-        if "pattern" in tool_args:
-            pattern = str(tool_args["pattern"])
-            pattern = truncate_value(pattern, 80)
-            return f'{prefix} {tool_name}("{pattern}")'
-
-    elif tool_name == "http_request":
-        # HTTP: show method and URL
-        parts = []
-        if "method" in tool_args:
-            parts.append(str(tool_args["method"]).upper())
-        if "url" in tool_args:
-            url = str(tool_args["url"])
-            url = truncate_value(url, 80)
-            parts.append(url)
-        if parts:
-            return f"{prefix} {tool_name}({' '.join(parts)})"
-
-    elif tool_name == "fetch_url":
-        # Fetch URL: show the URL being fetched
-        if "url" in tool_args:
-            url = str(tool_args["url"])
-            url = truncate_value(url, 80)
-            return f'{prefix} {tool_name}("{url}")'
-
-    elif tool_name == "task":
-        # Task: show the task description
-        if "description" in tool_args:
-            desc = str(tool_args["description"])
-            desc = truncate_value(desc, 100)
-            return f'{prefix} {tool_name}("{desc}")'
-
-    elif tool_name == "write_todos":
-        # Todos: show count of items
-        if "todos" in tool_args and isinstance(tool_args["todos"], list):
-            count = len(tool_args["todos"])
-            return f"{prefix} {tool_name}({count} items)"
-
-    # Fallback: generic formatting for unknown tools
-    # Show all arguments in key=value format
-    args_str = ", ".join(
-        f"{k}={truncate_value(str(v), 50)}" for k, v in tool_args.items()
-    )
-    return f"{prefix} {tool_name}({args_str})"
-
-
-def format_tool_message_content(content: Any) -> str:
-    """Convert ToolMessage content into a printable string.
-
-    Returns:
-        Formatted string representation of the tool message content.
-    """
-    if content is None:
-        return ""
-    if isinstance(content, list):
-        parts = []
-        for item in content:
-            if isinstance(item, str):
-                parts.append(item)
-            else:
-                try:
-                    parts.append(json.dumps(item))
-                except Exception:
-                    parts.append(str(item))
-        return "\n".join(parts)
-    return str(content)
 
 
 def show_help() -> None:

--- a/libs/cli/deepagents_cli/widgets/message_store.py
+++ b/libs/cli/deepagents_cli/widgets/message_store.py
@@ -202,6 +202,8 @@ class MessageData:
         Returns:
             MessageData containing all the widget's state.
         """
+        # Deferred: prevents import-order issue — both modules live in the
+        # widgets package, and messages is re-exported from widgets/__init__.
         from deepagents_cli.widgets.messages import (  # noqa: PLC0415
             AppMessage,
             AssistantMessage,

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -16,7 +16,7 @@ from textual.widgets import Markdown, Static
 
 from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
 from deepagents_cli.input import EMAIL_PREFIX_PATTERN, INPUT_HIGHLIGHT_PATTERN
-from deepagents_cli.ui import format_tool_display
+from deepagents_cli.tool_display import format_tool_display
 from deepagents_cli.widgets.diff import format_diff_textual
 
 if TYPE_CHECKING:

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -259,12 +259,6 @@ ignore-var-parameters = true
     "E722",     # Do not use bare `except`
     "PLR2004",  # Magic value used in comparison
 ]
-"deepagents_cli/ui.py" = [
-    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
-    "ARG002",   # Unused method argument
-    "BLE001",   # Do not catch blind exception
-    "PLR2004",  # Magic value used in comparison
-]
 "deepagents_cli/widgets/approval.py" = [
     "A002",     # Argument shadows a Python builtin
     "ARG002",   # Unused method argument

--- a/libs/cli/tests/integration_tests/benchmarks/test_startup_benchmarks.py
+++ b/libs/cli/tests/integration_tests/benchmarks/test_startup_benchmarks.py
@@ -1,0 +1,304 @@
+"""Benchmarks for CLI startup and import performance.
+
+The CLI defers heavy dependencies (langchain, agent, sessions, etc.) so that
+fast-path commands like `--help` and `--version` stay snappy. These tests guard
+that invariant: if a top-level import is accidentally re-added, the relevant
+test will fail before the regression reaches users.
+
+Run with::
+
+    make benchmark          # uses the `benchmark` pytest marker
+    uv run --group test pytest tests/ -m benchmark -v
+
+Each test spawns a **fresh subprocess** so `sys.modules` is clean and measured
+times reflect a cold-start import.
+
+If a test fails
+~~~~~~~~~~~~~~~~
+- **Import isolation failure** — a module in `HEAVY_MODULES` was loaded
+    when it shouldn't be. Move the offending import inside the function that
+    needs it (see `main.cli_main` for examples of deferred imports).
+- **Timing failure** — an import or CLI command exceeded its threshold.
+    Profile with `python -X importtime -c "import deepagents_cli.main"`
+    to find the slow import.
+- **Deferred-import failure** — a heavy module was *not* loaded when it
+    should have been. The deferred import is likely wired incorrectly; check
+    that the lazy import path still executes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Modules considered "heavy" — importing any of these at startup defeats
+# the purpose of the deferred-import optimisation.
+HEAVY_MODULES = frozenset(
+    {
+        "langchain",
+        "langchain.chat_models",
+        "langchain_core",
+        "langchain_core.messages",
+        "langchain_core.language_models",
+        "langchain_core.runnables",
+        "langchain_openai",
+        "langchain_anthropic",
+        "deepagents_cli.agent",
+        "deepagents_cli.sessions",
+        "deepagents_cli.integrations.sandbox_factory",
+        "deepagents_cli.tools",
+    }
+)
+
+
+def _run_python(code: str, *, timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    """Run *code* in a **fresh** Python interpreter and return the result.
+
+    Args:
+        code: Python source code to execute.
+        timeout: Maximum seconds to wait.
+
+    Returns:
+        Completed process with captured stdout/stderr.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _get_loaded_modules(import_statement: str) -> set[str]:
+    """Return the set of ``sys.modules`` keys after executing *import_statement*.
+
+    Runs in a subprocess so the module cache is completely fresh.
+
+    Args:
+        import_statement: A valid Python import statement.
+
+    Returns:
+        Set of module names present in ``sys.modules``.
+    """
+    result = _run_python(f"""
+        import json, sys
+        {import_statement}
+        print(json.dumps(sorted(sys.modules.keys())))
+    """)
+    assert result.returncode == 0, (
+        f"Subprocess failed ({result.returncode}):\n{result.stderr}"
+    )
+    return set(json.loads(result.stdout))
+
+
+# ---------------------------------------------------------------------------
+# Benchmark marker — matches ``make benchmark`` (pytest -m benchmark)
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.benchmark
+
+
+# ---------------------------------------------------------------------------
+# 1. Module-level import isolation
+#
+# Verify that importing lightweight entry-point modules does NOT pull in the
+# heavy langchain / agent / sessions stack.
+# ---------------------------------------------------------------------------
+
+
+class TestImportIsolation:
+    """Guard that lightweight entry points don't pull in the heavy stack.
+
+    Without deferred imports, `deepagents --help` takes 3+ seconds because
+    langchain, agent, and sessions all load eagerly. These tests catch any
+    accidental top-level import that would re-introduce that latency.
+    """
+
+    @pytest.mark.parametrize(
+        "import_stmt",
+        [
+            "from deepagents_cli.main import parse_args",
+            "from deepagents_cli.main import check_cli_dependencies",
+            "import deepagents_cli.ui",
+            "import deepagents_cli.skills.commands",
+        ],
+        ids=[
+            "main.parse_args",
+            "main.check_cli_dependencies",
+            "ui",
+            "skills.commands",
+        ],
+    )
+    def test_no_heavy_imports_on_lightweight_path(self, import_stmt: str) -> None:
+        """Importing lightweight CLI modules must not load heavy deps.
+
+        Args:
+            import_stmt: The import statement to test in isolation.
+        """
+        loaded = _get_loaded_modules(import_stmt)
+        leaked = HEAVY_MODULES & loaded
+        assert not leaked, (
+            f"Heavy modules loaded when running `{import_stmt}`: {sorted(leaked)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. CLI command timing
+#
+# Measure wall-clock time for common "fast-path" CLI invocations that should
+# NOT need the agent/LLM stack.
+# ---------------------------------------------------------------------------
+
+
+class TestCLIStartupTime:
+    """End-to-end wall-clock check for commands that should never need the LLM stack.
+
+    Complements `TestImportIsolation` with a user-facing timing gate: even if
+    individual imports stay light, a slow composition of many small imports
+    could still hurt perceived startup.
+    """
+
+    @staticmethod
+    def _time_cli_command(args: str) -> float:
+        """Return wall-clock seconds to run `python -m deepagents_cli <args>`.
+
+        Args:
+            args: CLI arguments string (e.g., `"--help"`).
+
+        Returns:
+            Elapsed wall-clock time in seconds.
+        """
+        code = f"""
+            import time, subprocess, sys
+            start = time.perf_counter()
+            subprocess.run(
+                [sys.executable, "-m", "deepagents_cli", {args!r}],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            elapsed = time.perf_counter() - start
+            print(elapsed)
+        """
+        result = _run_python(code)
+        assert result.returncode == 0, f"Timing harness failed:\n{result.stderr}"
+        return float(result.stdout.strip())
+
+    def test_help_under_threshold(self) -> None:
+        """`deepagents --help` should complete well under 10 s.
+
+        A generous threshold to avoid flaky CI; the real goal is catching
+        regressions where a heavy import is accidentally re-added at
+        module level.
+        """
+        elapsed = self._time_cli_command("--help")
+        assert elapsed < 10, f"`deepagents --help` took {elapsed:.2f}s — expected < 10s"
+
+    def test_version_under_threshold(self) -> None:
+        """`deepagents --version` should complete well under 10 s."""
+        elapsed = self._time_cli_command("--version")
+        assert elapsed < 10, (
+            f"`deepagents --version` took {elapsed:.2f}s — expected < 10s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Import time measurement
+#
+# Measure absolute import times for key modules so regressions show up
+# clearly in `pytest --durations`.
+# ---------------------------------------------------------------------------
+
+
+class TestImportTiming:
+    """Catch order-of-magnitude import regressions in key modules.
+
+    The 10 s threshold is generous to avoid CI flakiness; the real value
+    is that `pytest --durations` surfaces the numbers for trend analysis.
+    """
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "deepagents_cli.main",
+            "deepagents_cli.ui",
+            "deepagents_cli.config",
+            "deepagents_cli.skills.commands",
+            "deepagents_cli.tool_display",
+        ],
+        ids=[
+            "main",
+            "ui",
+            "config",
+            "skills.commands",
+            "tool_display",
+        ],
+    )
+    def test_module_import_time(self, module: str) -> None:
+        """Import *module* in a fresh process and assert it finishes quickly.
+
+        Args:
+            module: Fully qualified module name to import.
+        """
+        code = f"""
+            import time
+            start = time.perf_counter()
+            import {module}
+            elapsed = time.perf_counter() - start
+            print(elapsed)
+        """
+        result = _run_python(code)
+        assert result.returncode == 0, f"Failed to import {module}:\n{result.stderr}"
+        elapsed = float(result.stdout.strip())
+        # 10 s is generous; the point is to catch order-of-magnitude
+        # regressions, not enforce a tight budget.
+        assert elapsed < 10, f"Importing {module} took {elapsed:.2f}s — expected < 10s"
+
+
+# ---------------------------------------------------------------------------
+# 4. Deferred import paths
+#
+# Verify that heavy modules ARE loaded once we actually exercise code paths
+# that need them. This ensures the deferred imports are wired correctly and
+# nothing is silently broken.
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredImportsWork:
+    """Verify the heavy modules *do* load when the code paths that need them run.
+
+    Deferred imports can silently break (e.g., a renamed module, a missing
+    re-export). Without these tests, the failure would surface only at
+    runtime when a user starts a session — not in CI.
+    """
+
+    def test_agent_import_loads_langchain(self) -> None:
+        """Importing ``deepagents_cli.agent`` should pull in langchain."""
+        loaded = _get_loaded_modules("import deepagents_cli.agent")
+        langchain_modules = {m for m in loaded if m.startswith("langchain")}
+        assert langchain_modules, (
+            "`deepagents_cli.agent` should transitively load `langchain` modules"
+        )
+
+    def test_sessions_import_available(self) -> None:
+        """`deepagents_cli.sessions` should be importable."""
+        result = _run_python("import deepagents_cli.sessions")
+        assert result.returncode == 0, (
+            f"Cannot import `deepagents_cli.sessions`:\n{result.stderr}"
+        )
+
+    def test_tool_display_loads_backends(self) -> None:
+        """`deepagents_cli.tool_display` should load backends module."""
+        loaded = _get_loaded_modules("import deepagents_cli.tool_display")
+        assert "deepagents_cli.backends" in loaded, (
+            "`tool_display` should import `backends` for `DEFAULT_EXECUTE_TIMEOUT`"
+        )

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -8,7 +8,7 @@ import pytest
 from rich.console import Console
 
 from deepagents_cli.agent import DEFAULT_AGENT_NAME
-from deepagents_cli.main import parse_args
+from deepagents_cli.main import _DEFAULT_AGENT_NAME, parse_args
 
 
 class TestInitialPromptArg:
@@ -262,3 +262,8 @@ class TestQuietArg:
             args = parse_args()
         assert args.quiet is True
         assert args.non_interactive_message is None
+
+
+def test_default_agent_name_matches_canonical() -> None:
+    """Ensure the duplicated constant in main.py stays in sync with agent.py."""
+    assert _DEFAULT_AGENT_NAME == DEFAULT_AGENT_NAME

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -293,7 +293,7 @@ class TestCreateModelProfileExtraction:
     now uses it internally.
     """
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_extracts_context_limit_from_profile(
         self, mock_init_chat_model: Mock
     ) -> None:
@@ -305,7 +305,7 @@ class TestCreateModelProfileExtraction:
         result = create_model("anthropic:claude-sonnet-4-5")
         assert result.context_limit == 200000
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_handles_missing_profile_gracefully(
         self, mock_init_chat_model: Mock
     ) -> None:
@@ -316,7 +316,7 @@ class TestCreateModelProfileExtraction:
         result = create_model("anthropic:claude-sonnet-4-5")
         assert result.context_limit is None
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_handles_none_profile(self, mock_init_chat_model: Mock) -> None:
         """Test that profile=None leaves context_limit as None."""
         mock_model = Mock()
@@ -326,7 +326,7 @@ class TestCreateModelProfileExtraction:
         result = create_model("anthropic:claude-sonnet-4-5")
         assert result.context_limit is None
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_handles_non_dict_profile(self, mock_init_chat_model: Mock) -> None:
         """Test that non-dict profile is handled safely."""
         mock_model = Mock()
@@ -336,7 +336,7 @@ class TestCreateModelProfileExtraction:
         result = create_model("anthropic:claude-sonnet-4-5")
         assert result.context_limit is None
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_handles_non_int_max_input_tokens(self, mock_init_chat_model: Mock) -> None:
         """Test that string max_input_tokens is ignored."""
         mock_model = Mock()
@@ -346,7 +346,7 @@ class TestCreateModelProfileExtraction:
         result = create_model("anthropic:claude-sonnet-4-5")
         assert result.context_limit is None
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_handles_missing_max_input_tokens_key(
         self, mock_init_chat_model: Mock
     ) -> None:
@@ -1010,7 +1010,7 @@ api_key_env = "FIREWORKS_API_KEY"
 class TestCreateModelExtraKwargs:
     """Tests for create_model() with extra_kwargs from --model-params."""
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_extra_kwargs_passed_to_model(self, mock_init_chat_model: Mock) -> None:
         """extra_kwargs are forwarded to init_chat_model."""
         mock_model = Mock()
@@ -1022,7 +1022,7 @@ class TestCreateModelExtraKwargs:
         _, call_kwargs = mock_init_chat_model.call_args
         assert call_kwargs["temperature"] == 0.7
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_extra_kwargs_override_config(
         self, mock_init_chat_model: Mock, tmp_path: Path
     ) -> None:
@@ -1053,7 +1053,7 @@ max_tokens = 1024
         # Config kwarg preserved when not overridden
         assert call_kwargs["max_tokens"] == 1024
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_none_extra_kwargs_is_noop(self, mock_init_chat_model: Mock) -> None:
         """extra_kwargs=None does not affect behavior."""
         mock_model = Mock()
@@ -1063,7 +1063,7 @@ max_tokens = 1024
         create_model("anthropic:claude-sonnet-4-5", extra_kwargs=None)
         mock_init_chat_model.assert_called_once()
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_empty_extra_kwargs_is_noop(self, mock_init_chat_model: Mock) -> None:
         """extra_kwargs={} does not affect behavior."""
         mock_model = Mock()
@@ -1077,7 +1077,7 @@ max_tokens = 1024
 class TestCreateModelEdgeCaseParsing:
     """Tests for create_model() edge-case spec parsing."""
 
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_leading_colon_treated_as_bare_model(
         self, mock_init_chat_model: Mock
     ) -> None:
@@ -1101,7 +1101,7 @@ class TestCreateModelEdgeCaseParsing:
             create_model("anthropic:")
 
     @patch("deepagents_cli.config._get_default_model_spec")
-    @patch("deepagents_cli.config.init_chat_model")
+    @patch("langchain.chat_models.init_chat_model")
     def test_empty_string_uses_default(
         self, mock_init_chat_model: Mock, mock_default: Mock
     ) -> None:

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -52,7 +52,10 @@ class TestModelSwitchNoOp:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch.object(AppMessage, "__init__", capture_init),
         ):
             # Attempt to switch to the same model
@@ -88,9 +91,12 @@ class TestModelSwitchErrorHandling:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=False),
             patch(
-                "deepagents_cli.app.get_credential_env_var",
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.model_config.get_credential_env_var",
                 return_value="ANTHROPIC_API_KEY",
             ),
             patch.object(ErrorMessage, "__init__", capture_init),
@@ -122,7 +128,10 @@ class TestModelSwitchErrorHandling:
 
         error = ModelConfigError("Missing package for provider 'anthropic'")
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", side_effect=error),
             patch.object(ErrorMessage, "__init__", capture_init),
         ):
@@ -152,7 +161,10 @@ class TestModelSwitchErrorHandling:
 
         model_error = ValueError("Invalid model")
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", side_effect=model_error),
             patch.object(ErrorMessage, "__init__", capture_init),
         ):
@@ -194,9 +206,12 @@ class TestModelSwitchErrorHandling:
 
         agent_error = RuntimeError("Agent creation failed")
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
-            patch("deepagents_cli.app.create_cli_agent", side_effect=agent_error),
+            patch("deepagents_cli.agent.create_cli_agent", side_effect=agent_error),
             patch.object(ErrorMessage, "__init__", capture_init),
         ):
             await app._switch_model("anthropic:claude-sonnet-4-5")
@@ -232,10 +247,13 @@ class TestModelSwitchErrorHandling:
         mock_backend = MagicMock()
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
             patch(
-                "deepagents_cli.app.create_cli_agent",
+                "deepagents_cli.agent.create_cli_agent",
                 return_value=(mock_agent, mock_backend),
             ),
             patch("deepagents_cli.app.save_recent_model", return_value=True),
@@ -263,10 +281,13 @@ class TestModelSwitchErrorHandling:
         )
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
             patch(
-                "deepagents_cli.app.create_cli_agent",
+                "deepagents_cli.agent.create_cli_agent",
                 side_effect=RuntimeError("fail"),
             ),
         ):
@@ -293,7 +314,10 @@ class TestModelSwitchErrorHandling:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.save_recent_model", return_value=True),
             patch.object(AppMessage, "__init__", capture_init),
         ):
@@ -322,7 +346,10 @@ class TestModelSwitchErrorHandling:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.save_recent_model", return_value=False),
             patch.object(ErrorMessage, "__init__", capture_init),
         ):
@@ -359,10 +386,13 @@ class TestModelSwitchErrorHandling:
         mock_backend = MagicMock()
 
         with (
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
             patch(
-                "deepagents_cli.app.create_cli_agent",
+                "deepagents_cli.agent.create_cli_agent",
                 return_value=(mock_agent, mock_backend),
             ),
             patch("deepagents_cli.app.save_recent_model", return_value=False),
@@ -424,7 +454,7 @@ api_key_env = "FIREWORKS_API_KEY"
             patch.dict("os.environ", {"FIREWORKS_API_KEY": "test-key"}),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
             patch(
-                "deepagents_cli.app.create_cli_agent",
+                "deepagents_cli.agent.create_cli_agent",
                 return_value=(mock_agent, mock_backend),
             ),
             patch("deepagents_cli.app.save_recent_model", return_value=True),
@@ -506,7 +536,7 @@ models = ["llama3"]
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
             patch(
-                "deepagents_cli.app.create_cli_agent",
+                "deepagents_cli.agent.create_cli_agent",
                 return_value=(mock_agent, mock_backend),
             ),
             patch("deepagents_cli.app.save_recent_model", return_value=True),
@@ -548,10 +578,13 @@ class TestModelSwitchBareModelName:
 
         with (
             patch("deepagents_cli.app.detect_provider", return_value="openai"),
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch("deepagents_cli.app.create_model", return_value=mock_result),
             patch(
-                "deepagents_cli.app.create_cli_agent",
+                "deepagents_cli.agent.create_cli_agent",
                 return_value=(mock_agent, mock_backend),
             ),
             patch("deepagents_cli.app.save_recent_model", return_value=True),
@@ -580,9 +613,12 @@ class TestModelSwitchBareModelName:
 
         with (
             patch("deepagents_cli.app.detect_provider", return_value="openai"),
-            patch("deepagents_cli.app.has_provider_credentials", return_value=False),
             patch(
-                "deepagents_cli.app.get_credential_env_var",
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.model_config.get_credential_env_var",
                 return_value="OPENAI_API_KEY",
             ),
             patch.object(ErrorMessage, "__init__", capture_init),
@@ -613,7 +649,10 @@ class TestModelSwitchBareModelName:
 
         with (
             patch("deepagents_cli.app.detect_provider", return_value="openai"),
-            patch("deepagents_cli.app.has_provider_credentials", return_value=True),
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
             patch.object(AppMessage, "__init__", capture_init),
         ):
             await app._switch_model("gpt-4o")


### PR DESCRIPTION
Defer heavy module imports (`langchain`, agent creation, session management, sandbox SDKs) from CLI startup to the point where they're actually needed.

Previously, running `deepagents --help` or `deepagents threads list` paid the cost of importing the entire agent/LLM stack.

This brings `deepagents --help/--version` down from 0.5s to ~80ms.
