### PR TITLE
refactor(sdk): add logging to silent path skips, rename `validate_path`

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -1,6 +1,7 @@
 """`FilesystemBackend`: Read and write files directly from the filesystem."""
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -23,6 +24,8 @@ from deepagents.backends.utils import (
     format_content_with_line_numbers,
     perform_string_replacement,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class FilesystemBackend(BackendProtocol):
@@ -162,7 +165,7 @@ class FilesystemBackend(BackendProtocol):
         """
         return "/" + path.resolve().relative_to(self.cwd).as_posix()
 
-    def ls_info(self, path: str) -> list[FileInfo]:  # noqa: C901, PLR0912  # Complex virtual_mode logic
+    def ls_info(self, path: str) -> list[FileInfo]:  # noqa: C901, PLR0912, PLR0915  # Complex virtual_mode logic
         """List files and directories in the specified directory (non-recursive).
 
         Args:
@@ -227,8 +230,11 @@ class FilesystemBackend(BackendProtocol):
                     # Virtual mode: strip cwd prefix using Path for cross-platform support
                     try:
                         virt_path = self._to_virtual_path(child_path)
-                    except (ValueError, OSError):
-                        # Path escaped root or could not be resolved -- skip it
+                    except ValueError:
+                        logger.debug("Skipping path outside root: %s", child_path)
+                        continue
+                    except OSError:
+                        logger.warning("Could not resolve path: %s", child_path, exc_info=True)
                         continue
 
                     if is_file:
@@ -433,7 +439,7 @@ class FilesystemBackend(BackendProtocol):
                 matches.append({"path": fpath, "line": int(line_num), "text": line_text})
         return matches
 
-    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:
+    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:  # noqa: C901  # Split except clauses for logging
         """Search using ripgrep with fixed-string (literal) mode.
 
         Args:
@@ -477,7 +483,11 @@ class FilesystemBackend(BackendProtocol):
             if self.virtual_mode:
                 try:
                     virt = self._to_virtual_path(p)
-                except (ValueError, OSError):
+                except ValueError:
+                    logger.debug("Skipping grep result outside root: %s", p)
+                    continue
+                except OSError:
+                    logger.warning("Could not resolve grep result path: %s", p, exc_info=True)
                     continue
             else:
                 virt = str(p)
@@ -489,7 +499,7 @@ class FilesystemBackend(BackendProtocol):
 
         return results
 
-    def _python_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]]:  # noqa: C901
+    def _python_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]]:  # noqa: C901, PLR0912
         """Fallback search using Python when ripgrep is unavailable.
 
         Recursively searches files, respecting `max_file_size_bytes` limit.
@@ -530,7 +540,11 @@ class FilesystemBackend(BackendProtocol):
                     if self.virtual_mode:
                         try:
                             virt_path = self._to_virtual_path(fp)
-                        except (ValueError, OSError):
+                        except ValueError:
+                            logger.debug("Skipping grep result outside root: %s", fp)
+                            continue
+                        except OSError:
+                            logger.warning("Could not resolve grep result path: %s", fp, exc_info=True)
                             continue
                     else:
                         virt_path = str(fp)
@@ -593,8 +607,11 @@ class FilesystemBackend(BackendProtocol):
                     # Virtual mode: use Path for cross-platform support
                     try:
                         virt = self._to_virtual_path(matched_path)
-                    except (ValueError, OSError):
-                        # Path escaped root or could not be resolved -- skip it
+                    except ValueError:
+                        logger.debug("Skipping glob result outside root: %s", matched_path)
+                        continue
+                    except OSError:
+                        logger.warning("Could not resolve glob result path: %s", matched_path, exc_info=True)
                         continue
                     try:
                         st = matched_path.stat()

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -231,7 +231,7 @@ def truncate_if_too_long(result: list[str] | str) -> list[str] | str:
     return result
 
 
-def _validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -> str:
+def validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -> str:
     r"""Validate and normalize file path for security.
 
     Ensures paths are safe to use by preventing directory traversal attacks
@@ -259,12 +259,12 @@ def _validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) 
 
     Example:
         ```python
-        _validate_path("foo/bar")  # Returns: "/foo/bar"
-        _validate_path("/./foo//bar")  # Returns: "/foo/bar"
-        _validate_path("../etc/passwd")  # Raises ValueError
-        _validate_path(r"C:\\Users\\file.txt")  # Raises ValueError
-        _validate_path("/data/file.txt", allowed_prefixes=["/data/"])  # OK
-        _validate_path("/etc/file.txt", allowed_prefixes=["/data/"])  # Raises ValueError
+        validate_path("foo/bar")  # Returns: "/foo/bar"
+        validate_path("/./foo//bar")  # Returns: "/foo/bar"
+        validate_path("../etc/passwd")  # Raises ValueError
+        validate_path(r"C:\\Users\\file.txt")  # Raises ValueError
+        validate_path("/data/file.txt", allowed_prefixes=["/data/"])  # OK
+        validate_path("/etc/file.txt", allowed_prefixes=["/data/"])  # Raises ValueError
         ```
     """
     # Check for traversal as a path component (not substring) to avoid

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -32,11 +32,11 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
-    _validate_path,
     format_content_with_line_numbers,
     format_grep_matches,
     sanitize_tool_call_id,
     truncate_if_too_long,
+    validate_path,
 )
 from deepagents.middleware._utils import append_to_system_message
 
@@ -458,7 +458,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for ls tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(path)
+                validated_path = validate_path(path)
             except ValueError as e:
                 return f"Error: {e}"
             infos = resolved_backend.ls_info(validated_path)
@@ -473,7 +473,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for ls tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(path)
+                validated_path = validate_path(path)
             except ValueError as e:
                 return f"Error: {e}"
             infos = await resolved_backend.als_info(validated_path)
@@ -502,7 +502,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for read_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(file_path)
+                validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
 
@@ -551,7 +551,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for read_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(file_path)
+                validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
 
@@ -610,7 +610,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(file_path)
+                validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
             res: WriteResult = resolved_backend.write(validated_path, content)
@@ -639,7 +639,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(file_path)
+                validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
             res: WriteResult = await resolved_backend.awrite(validated_path, content)
@@ -682,7 +682,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for edit_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(file_path)
+                validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
             res: EditResult = resolved_backend.edit(validated_path, old_string, new_string, replace_all=replace_all)
@@ -713,7 +713,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for edit_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(file_path)
+                validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
             res: EditResult = await resolved_backend.aedit(validated_path, old_string, new_string, replace_all=replace_all)
@@ -752,7 +752,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for glob tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(path)
+                validated_path = validate_path(path)
             except ValueError as e:
                 return f"Error: {e}"
             infos = resolved_backend.glob_info(pattern, path=validated_path)
@@ -768,7 +768,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for glob tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = _validate_path(path)
+                validated_path = validate_path(path)
             except ValueError as e:
                 return f"Error: {e}"
             infos = await resolved_backend.aglob_info(pattern, path=validated_path)

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -200,11 +200,11 @@ def test_state_backend_grep_literal_search_special_chars(pattern: str, expected_
 def test_state_backend_grep_exact_file_path() -> None:
     """Test that grep works with exact file paths (no trailing slash).
 
-    This reproduces the bug where _validate_path adds a trailing slash to all paths,
+    This reproduces the bug where validate_path adds a trailing slash to all paths,
     causing exact file path matching to fail with startswith filter.
 
     Bug: When grep is called with an exact file path like "/data/result_abc123",
-    _validate_path adds a trailing slash making it "/data/result_abc123/",
+    validate_path adds a trailing slash making it "/data/result_abc123/",
     which doesn't match the key in state (which has no trailing slash).
     """
     rt = make_runtime()

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend_async.py
@@ -276,11 +276,11 @@ async def test_state_backend_intercept_large_tool_result_async():
 async def test_state_backend_agrep_exact_file_path() -> None:
     """Test that async grep works with exact file paths (no trailing slash).
 
-    This reproduces the bug where _validate_path adds a trailing slash to all paths,
+    This reproduces the bug where validate_path adds a trailing slash to all paths,
     causing exact file path matching to fail with startswith filter.
 
     Bug: When grep is called with an exact file path like "/data/result_abc123",
-    _validate_path adds a trailing slash making it "/data/result_abc123/",
+    validate_path adds a trailing slash making it "/data/result_abc123/",
     which doesn't match the key in state (which has no trailing slash).
     """
     rt = make_runtime()


### PR DESCRIPTION
Following #918

- Log skipped paths in `FilesystemBackend` virtual mode instead of silently
  continuing (DEBUG for outside-root, WARNING for OS errors)
- Rename `_validate_path` to `validate_path` since used cross-module, not private