### PR TITLE
feat(cli): add visual mode indicators to chat input

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -55,6 +55,8 @@ COLORS = {
     "agent": "#10b981",
     "thinking": "#34d399",
     "tool": "#fbbf24",
+    "mode_bash": "#ff1493",
+    "mode_command": "#8b5cf6",
 }
 
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -555,6 +555,8 @@ class ChatInput(Vertical):
         entry = self._history.get_previous(event.current_text)
         if entry is not None and self._text_area:
             self._text_area.set_text_from_history(entry)
+        elif self._text_area:
+            self._text_area._navigating_history = False
 
     def on_chat_text_area_history_next(
         self,
@@ -564,6 +566,8 @@ class ChatInput(Vertical):
         entry = self._history.get_next()
         if entry is not None and self._text_area:
             self._text_area.set_text_from_history(entry)
+        elif self._text_area:
+            self._text_area._navigating_history = False
 
     async def on_key(self, event: events.Key) -> None:
         """Handle key events for completion navigation."""

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -7,12 +7,13 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static, TextArea
 from textual.widgets.text_area import Selection
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import COLORS, CharsetMode, _detect_charset_mode, get_glyphs
 from deepagents_cli.widgets.autocomplete import (
     SLASH_COMMANDS,
     CompletionResult,
@@ -379,11 +380,11 @@ class ChatInput(Vertical):
     }
 
     ChatInput.mode-bash {
-        border: solid #ff1493;
+        border: solid __MODE_BASH__;
     }
 
     ChatInput.mode-command {
-        border: solid #8b5cf6;
+        border: solid __MODE_CMD__;
     }
 
     ChatInput .input-row {
@@ -400,11 +401,11 @@ class ChatInput(Vertical):
     }
 
     ChatInput.mode-bash .input-prompt {
-        color: #ff1493;
+        color: __MODE_BASH__;
     }
 
     ChatInput.mode-command .input-prompt {
-        color: #8b5cf6;
+        color: __MODE_CMD__;
     }
 
     ChatInput ChatTextArea {
@@ -420,7 +421,9 @@ class ChatInput(Vertical):
     ChatInput ChatTextArea:focus {
         border: none;
     }
-    """
+    """.replace("__MODE_BASH__", COLORS["mode_bash"]).replace(
+        "__MODE_CMD__", COLORS["mode_command"]
+    )
 
     class Submitted(Message):
         """Message sent when input is submitted."""
@@ -621,7 +624,10 @@ class ChatInput(Vertical):
 
     def watch_mode(self, mode: str) -> None:
         """Post mode changed message and update prompt indicator."""
-        prompt = self.query_one("#prompt", Static)
+        try:
+            prompt = self.query_one("#prompt", Static)
+        except NoMatches:
+            return
         self.remove_class("mode-bash", "mode-command")
         if mode == "bash":
             prompt.update("!")

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -378,6 +378,14 @@ class ChatInput(Vertical):
         border: solid $primary;
     }
 
+    ChatInput.mode-bash {
+        border: solid #ff1493;
+    }
+
+    ChatInput.mode-command {
+        border: solid #8b5cf6;
+    }
+
     ChatInput .input-row {
         height: auto;
         width: 100%;
@@ -389,6 +397,14 @@ class ChatInput(Vertical):
         padding: 0 1;
         color: $primary;
         text-style: bold;
+    }
+
+    ChatInput.mode-bash .input-prompt {
+        color: #ff1493;
+    }
+
+    ChatInput.mode-command .input-prompt {
+        color: #8b5cf6;
     }
 
     ChatInput ChatTextArea {
@@ -604,7 +620,17 @@ class ChatInput(Vertical):
         return offset + min(col, len(lines[row]))
 
     def watch_mode(self, mode: str) -> None:
-        """Post mode changed message when mode changes."""
+        """Post mode changed message and update prompt indicator."""
+        prompt = self.query_one("#prompt", Static)
+        self.remove_class("mode-bash", "mode-command")
+        if mode == "bash":
+            prompt.update("!")
+            self.add_class("mode-bash")
+        elif mode == "command":
+            prompt.update("/")
+            self.add_class("mode-command")
+        else:
+            prompt.update(">")
         self.post_message(self.ModeChanged(mode))
 
     def focus_input(self) -> None:

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -11,7 +11,7 @@ from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widgets import Static
 
-from deepagents_cli.config import settings
+from deepagents_cli.config import COLORS, settings
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +40,13 @@ class StatusBar(Horizontal):
     }
 
     StatusBar .status-mode.bash {
-        background: #ff1493;
+        background: __MODE_BASH__;
         color: white;
         text-style: bold;
     }
 
     StatusBar .status-mode.command {
-        background: #8b5cf6;
+        background: __MODE_CMD__;
         color: white;
     }
 
@@ -92,7 +92,9 @@ class StatusBar(Horizontal):
         padding: 0 1;
         color: $text-muted;
     }
-    """
+    """.replace("__MODE_BASH__", COLORS["mode_bash"]).replace(
+        "__MODE_CMD__", COLORS["mode_command"]
+    )
 
     mode: reactive[str] = reactive("normal", init=False)
     status_message: reactive[str] = reactive("", init=False)


### PR DESCRIPTION
Give the chat input box visual feedback when the user enters bash or command mode. The prompt character, border color, and prompt color all update to reflect the active mode.
<img width="720" height="137" alt="Screenshot 19" src="https://github.com/user-attachments/assets/c949ef79-21bb-42b2-80b7-f6a82cb53192" />
<img width="716" height="327" alt="Screenshot 10" src="https://github.com/user-attachments/assets/1f3a91f2-9118-45b6-9313-d196f2d14c6f" />
<img width="713" height="138" alt="Screenshot 9" src="https://github.com/user-attachments/assets/9cc6ec3a-45bb-4854-9430-efde45b8aa94" />
