### PR TITLE
feat(cli): strip mode-trigger prefix from chat input text

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -45,8 +45,8 @@ if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
 
 DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
+"""URL for deepagents-cli documentation."""
 
-# Color scheme
 COLORS = {
     "primary": "#10b981",
     "primary_dev": "#f97316",
@@ -58,6 +58,13 @@ COLORS = {
     "mode_bash": "#ff1493",
     "mode_command": "#8b5cf6",
 }
+"""App color scheme."""
+
+MODE_PREFIXES: dict[str, str] = {
+    "bash": "!",
+    "command": "/",
+}
+"""Maps each non-normal mode to its trigger character."""
 
 
 # Charset mode configuration

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -14,7 +14,13 @@ from textual.reactive import reactive
 from textual.widgets import Static, TextArea
 from textual.widgets.text_area import Selection
 
-from deepagents_cli.config import COLORS, CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import (
+    COLORS,
+    MODE_PREFIXES,
+    CharsetMode,
+    _detect_charset_mode,
+    get_glyphs,
+)
 from deepagents_cli.widgets.autocomplete import (
     SLASH_COMMANDS,
     CompletionResult,
@@ -25,12 +31,6 @@ from deepagents_cli.widgets.autocomplete import (
 from deepagents_cli.widgets.history import HistoryManager
 
 logger = logging.getLogger(__name__)
-
-MODE_PREFIXES: dict[str, str] = {
-    "bash": "!",
-    "command": "/",
-}
-"""Maps each non-normal mode to its trigger character."""
 
 _PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
 """Reverse lookup: trigger character -> mode name."""

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -14,7 +14,13 @@ from rich.text import Text
 from textual.containers import Vertical
 from textual.widgets import Markdown, Static
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import (
+    COLORS,
+    MODE_PREFIXES,
+    CharsetMode,
+    _detect_charset_mode,
+    get_glyphs,
+)
 from deepagents_cli.input import EMAIL_PREFIX_PATTERN, INPUT_HIGHLIGHT_PATTERN
 from deepagents_cli.tool_display import format_tool_display
 from deepagents_cli.widgets.diff import format_diff_textual
@@ -24,6 +30,9 @@ if TYPE_CHECKING:
     from textual.events import Click
     from textual.timer import Timer
     from textual.widgets._markdown import MarkdownStream
+
+_PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
+"""Reverse lookup: trigger character -> mode name."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,9 +103,11 @@ class UserMessage(Static):
         self._content = content
 
     def on_mount(self) -> None:
-        """Set border style based on charset mode."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
-            self.styles.border_left = ("ascii", "#10b981")
+        """Set border style based on charset mode and content prefix."""
+        mode = _PREFIX_TO_MODE.get(self._content[:1]) if self._content else None
+        color = COLORS[f"mode_{mode}"] if mode else COLORS["primary"]
+        border_type = "ascii" if _detect_charset_mode() == CharsetMode.ASCII else "wide"
+        self.styles.border_left = (border_type, color)
 
     def compose(self) -> ComposeResult:
         """Compose the user message layout.
@@ -105,10 +116,18 @@ class UserMessage(Static):
             Static widget containing the formatted user message.
         """
         text = Text()
-        text.append("> ", style="bold #10b981")
+        content = self._content
+
+        # Use mode-specific prefix indicator when content starts with a
+        # mode trigger character (e.g. "!" for bash, "/" for commands).
+        mode = _PREFIX_TO_MODE.get(content[:1]) if content else None
+        if mode:
+            text.append(f"{content[0]} ", style=f"bold {COLORS[f'mode_{mode}']}")
+            content = content[1:]
+        else:
+            text.append("> ", style=f"bold {COLORS['primary']}")
 
         # Highlight @mentions and /commands in the content
-        content = self._content
         last_end = 0
         for match in INPUT_HIGHLIGHT_PATTERN.finditer(content):
             start, end = match.span()
@@ -179,8 +198,14 @@ class QueuedUserMessage(Static):
             Static widget containing the formatted queued message (greyed out).
         """
         text = Text()
-        text.append("> ", style="bold #6b7280")
-        text.append(self._content, style="#9ca3af")
+        content = self._content
+        mode = _PREFIX_TO_MODE.get(content[:1]) if content else None
+        if mode:
+            text.append(f"{content[0]} ", style=f"bold {COLORS['dim']}")
+            content = content[1:]
+        else:
+            text.append("> ", style=f"bold {COLORS['dim']}")
+        text.append(content, style="#9ca3af")
         yield Static(text)
 
 


### PR DESCRIPTION
Strip mode-trigger characters (`!`, `/`) from the text area after they switch the input mode, so users see clean input (e.g. `ls` instead of `!ls`) while the mode indicator badge communicates the active mode visually.

<img width="298" height="127" alt="Screenshot 9" src="https://github.com/user-attachments/assets/369a67a9-181b-450e-b90c-47cb0dd70395" />
<img width="316" height="137" alt="Screenshot 8" src="https://github.com/user-attachments/assets/c4fc57cd-0123-4381-9fd1-645a5e4c2342" />

Also shows in history:

<img width="587" height="437" alt="Screenshot" src="https://github.com/user-attachments/assets/e1f7afed-f0e2-4757-97c3-2599e849e3cf" />
