### PR TITLE
feat(cli): show sdk version alongside cli version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,14 @@ def send_email(to: str, msg: str, *, priority: str = "normal") -> bool:
 - **Message passing** for widget communication - see [Events guide](https://textual.textualize.io/guide/events/)
 - **Reactive attributes** for state management - see [Reactivity guide](https://textual.textualize.io/guide/reactivity/)
 
+**Startup performance:**
+
+The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents`, LangChain, LangGraph) at module level or in the argument-parsing path. These imports pull in large dependency trees and add seconds to every invocation, including trivial commands like `deepagents -v`.
+
+- Keep top-level imports in `main.py` and other entry-point modules minimal.
+- Defer heavy imports to the point where they are actually needed (inside functions/methods).
+- To read another package's version without importing it, use `importlib.metadata.version("package-name")`.
+
 **Building chat/streaming interfaces:**
 
 - Blog post: [Anatomy of a Textual User Interface](https://textual.textualize.io/blog/2024/09/15/anatomy-of-a-textual-user-interface/) - demonstrates building an AI chat interface with streaming responses

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1116,15 +1116,23 @@ class DeepAgentsApp(App):
             await self._open_url_command(command, cmd)
         elif cmd == "/version":
             await self._mount_message(UserMessage(command))
-            # Show CLI package version
+            # Show CLI and SDK package versions
             try:
-                from deepagents_cli._version import __version__
-
-                await self._mount_message(
-                    AppMessage(f"deepagents version: {__version__}")
+                from deepagents_cli._version import (
+                    __version__ as cli_version,
                 )
-            except Exception:  # noqa: BLE001  # Resilient model selector error handling
-                await self._mount_message(AppMessage("deepagents version: unknown"))
+
+                cli_line = f"deepagents-cli version: {cli_version}"
+            except Exception:  # noqa: BLE001  # Resilient version lookup
+                cli_line = "deepagents-cli version: unknown"
+            try:
+                from importlib.metadata import version as _pkg_version
+
+                sdk_version = _pkg_version("deepagents")
+                sdk_line = f"deepagents (SDK) version: {sdk_version}"
+            except Exception:  # noqa: BLE001  # Resilient version lookup
+                sdk_line = "deepagents (SDK) version: unknown"
+            await self._mount_message(AppMessage(f"{cli_line}\n{sdk_line}"))
         elif cmd == "/clear":
             self._pending_messages.clear()
             self._queued_widgets.clear()

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1123,14 +1123,25 @@ class DeepAgentsApp(App):
                 )
 
                 cli_line = f"deepagents-cli version: {cli_version}"
-            except Exception:  # noqa: BLE001  # Resilient version lookup
+            except ImportError:
+                logger.debug("deepagents_cli._version module not found")
+                cli_line = "deepagents-cli version: unknown"
+            except Exception:
+                logger.warning("Unexpected error looking up CLI version", exc_info=True)
                 cli_line = "deepagents-cli version: unknown"
             try:
-                from importlib.metadata import version as _pkg_version
+                from importlib.metadata import (
+                    PackageNotFoundError,
+                    version as _pkg_version,
+                )
 
                 sdk_version = _pkg_version("deepagents")
                 sdk_line = f"deepagents (SDK) version: {sdk_version}"
-            except Exception:  # noqa: BLE001  # Resilient version lookup
+            except PackageNotFoundError:
+                logger.debug("deepagents SDK package not found in environment")
+                sdk_line = "deepagents (SDK) version: unknown"
+            except Exception:
+                logger.warning("Unexpected error looking up SDK version", exc_info=True)
                 sdk_line = "deepagents (SDK) version: unknown"
             await self._mount_message(AppMessage(f"{cli_line}\n{sdk_line}"))
         elif cmd == "/clear":

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -394,11 +394,17 @@ def parse_args() -> argparse.Namespace:
         "Applies to both -n and interactive modes.",
     )
 
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        sdk_version = _pkg_version("deepagents")
+    except Exception:  # noqa: BLE001  # Resilient version lookup
+        sdk_version = "unknown"
     parser.add_argument(
         "-v",
         "--version",
         action="version",
-        version=f"deepagents-cli {__version__}",
+        version=f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}",
     )
     parser.add_argument(
         "-h",

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -395,10 +395,17 @@ def parse_args() -> argparse.Namespace:
     )
 
     try:
-        from importlib.metadata import version as _pkg_version
+        from importlib.metadata import (
+            PackageNotFoundError,
+            version as _pkg_version,
+        )
 
         sdk_version = _pkg_version("deepagents")
-    except Exception:  # noqa: BLE001  # Resilient version lookup
+    except PackageNotFoundError:
+        logger.debug("deepagents SDK package not found in environment")
+        sdk_version = "unknown"
+    except Exception:
+        logger.warning("Unexpected error looking up SDK version", exc_info=True)
         sdk_version = "unknown"
     parser.add_argument(
         "-v",

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -98,7 +98,7 @@ def show_help() -> None:
     )
     console.print("  --default-model [MODEL]    Set, show, or manage the default model")
     console.print("  --clear-default-model      Clear the default model")
-    console.print("  -v, --version              Show deepagents CLI version")
+    console.print("  -v, --version              Show deepagents CLI and SDK versions")
     console.print("  -h, --help                 Show this help message and exit")
     console.print()
 

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -68,14 +68,27 @@ def test_cli_version_flag() -> None:
     # argparse exits with 0 for --version
     assert result.returncode == 0
     assert f"deepagents-cli {__version__}" in result.stdout
+    from importlib.metadata import version as pkg_version
+
+    sdk_version = pkg_version("deepagents")
+    assert f"deepagents (SDK) {sdk_version}" in result.stdout
 
 
 def test_version_slash_command_message_format() -> None:
     """Verify the `/version` slash command message format matches expected output."""
-    # This tests the exact message format used in app.py's _handle_command for /version
-    expected_message = f"deepagents version: {__version__}"
-    assert "deepagents version:" in expected_message
-    assert __version__ in expected_message
+    from importlib.metadata import version as pkg_version
+
+    sdk_version = pkg_version("deepagents")
+
+    # CLI version line
+    cli_line = f"deepagents-cli version: {__version__}"
+    assert "deepagents-cli version:" in cli_line
+    assert __version__ in cli_line
+
+    # SDK version line
+    sdk_line = f"deepagents (SDK) version: {sdk_version}"
+    assert "deepagents (SDK) version:" in sdk_line
+    assert sdk_version in sdk_line
 
 
 def test_help_mentions_version_flag() -> None:


### PR DESCRIPTION
The `/version` slash command and `--version` CLI flag previously only showed the `deepagents-cli` package version. Now both surfaces display the SDK (`deepagents`) version alongside the CLI version, making it easier to triage issues.