### PR TITLE
feat(sdk,cli): add package version tracking to tracing metadata

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -15,7 +15,6 @@ from enum import StrEnum
 from importlib.metadata import (
     PackageNotFoundError,
     distribution,
-    version as pkg_version,
 )
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -26,13 +25,6 @@ from rich.console import Console
 from deepagents_cli._version import __version__
 
 logger = logging.getLogger(__name__)
-
-# Version constants for LangSmith trace metadata
-try:
-    _sdk_version: str = pkg_version("deepagents")
-except PackageNotFoundError:
-    _sdk_version = "unknown"
-_cli_version: str = __version__
 
 dotenv.load_dotenv()
 
@@ -333,6 +325,10 @@ def build_stream_config(
 ) -> RunnableConfig:
     """Build the LangGraph stream config dict.
 
+    Injects `deepagents_cli_version` into every config so LangSmith traces
+    can be filtered by CLI release. The SDK version (`deepagents_version`)
+    is attached separately by the SDK's `create_deep_agent` via `with_config`.
+
     The `thread_id` in `configurable` is automatically propagated as run
     metadata by LangGraph, so it can be used for LangSmith filtering without
     a separate metadata key.
@@ -347,8 +343,7 @@ def build_stream_config(
     from datetime import UTC, datetime
 
     metadata: dict[str, str] = {
-        "deepagents_version": _sdk_version,
-        "deepagents_cli_version": _cli_version,
+        "deepagents_cli_version": __version__,
     }
     if assistant_id:
         metadata.update(

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -24,7 +24,6 @@ import contextlib
 import logging
 import sys
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain.agents.middleware.human_in_the_loop import ActionRequest, HITLRequest
@@ -39,6 +38,7 @@ from deepagents_cli.agent import DEFAULT_AGENT_NAME, create_cli_agent
 from deepagents_cli.config import (
     SHELL_TOOL_NAMES,
     build_langsmith_thread_url,
+    build_stream_config,
     create_model,
     is_shell_command_allowed,
     settings,
@@ -582,14 +582,7 @@ async def run_non_interactive(
     result.apply_to_settings()
     thread_id = generate_thread_id()
 
-    config: RunnableConfig = {
-        "configurable": {"thread_id": thread_id},
-        "metadata": {
-            "assistant_id": assistant_id,
-            "agent_name": assistant_id,
-            "updated_at": datetime.now(UTC).isoformat(),
-        },
-    }
+    config: RunnableConfig = build_stream_config(thread_id, assistant_id)
 
     if not quiet:
         console.print("[dim]Running task non-interactively...[/dim]")

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -191,8 +191,8 @@ class TestNonInteractiveVersionMetadata:
 
         assert len(captured_configs) == 1
         metadata = captured_configs[0]["metadata"]
-        assert "deepagents_version" in metadata
         assert "deepagents_cli_version" in metadata
+        assert "deepagents_version" not in metadata
 
 
 class TestBuildNonInteractiveHeader:

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -193,7 +193,8 @@ class TestNonInteractiveVersionMetadata:
         metadata = captured_configs[0]["metadata"]
         versions = metadata["versions"]
         assert "deepagents-cli" in versions
-        assert "deepagents" in versions
+        # SDK version is set by create_deep_agent, not the CLI config
+        assert "deepagents" not in versions
 
 
 class TestBuildNonInteractiveHeader:

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -191,8 +191,9 @@ class TestNonInteractiveVersionMetadata:
 
         assert len(captured_configs) == 1
         metadata = captured_configs[0]["metadata"]
-        assert "deepagents_cli_version" in metadata
-        assert "deepagents_version" not in metadata
+        versions = metadata["versions"]
+        assert "deepagents-cli" in versions
+        assert "deepagents" in versions
 
 
 class TestBuildNonInteractiveHeader:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -119,23 +119,30 @@ class TestBuildStreamConfig:
         assert "agent_name" not in config["metadata"]
         assert "updated_at" not in config["metadata"]
 
-    def test_cli_version_metadata_always_present(self) -> None:
-        """CLI version should be present regardless of `assistant_id`."""
+    def test_versions_dict_always_present(self) -> None:
+        """Nested `versions` dict should be present regardless of `assistant_id`."""
         from deepagents_cli._version import __version__
 
         config = build_stream_config("t-100", assistant_id=None)
-        assert config["metadata"]["deepagents_cli_version"] == __version__
+        versions = config["metadata"]["versions"]
+        assert versions["deepagents-cli"] == __version__
+        assert "deepagents" in versions
 
-    def test_cli_version_metadata_with_assistant(self) -> None:
-        """CLI version should coexist with assistant-specific metadata."""
+    def test_versions_dict_with_assistant(self) -> None:
+        """`versions` dict should coexist with assistant-specific metadata."""
         config = build_stream_config("t-200", assistant_id="my-agent")
-        assert "deepagents_cli_version" in config["metadata"]
+        assert "versions" in config["metadata"]
         assert config["metadata"]["assistant_id"] == "my-agent"
 
-    def test_sdk_version_not_set_by_cli(self) -> None:
-        """SDK version should not be set by the CLI; the SDK owns that key."""
+    def test_versions_uses_package_name_keys(self) -> None:
+        """Version keys should be PyPI package names, not suffixed variants."""
         config = build_stream_config("t-300", assistant_id=None)
+        versions = config["metadata"]["versions"]
+        # Keys are package names, not legacy flat keys
+        assert "deepagents" in versions
+        assert "deepagents-cli" in versions
         assert "deepagents_version" not in config["metadata"]
+        assert "deepagents_cli_version" not in config["metadata"]
 
     def test_configurable_thread_id(self) -> None:
         """`configurable.thread_id` should match the provided thread ID."""

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -126,7 +126,6 @@ class TestBuildStreamConfig:
         config = build_stream_config("t-100", assistant_id=None)
         versions = config["metadata"]["versions"]
         assert versions["deepagents-cli"] == __version__
-        assert "deepagents" in versions
 
     def test_versions_dict_with_assistant(self) -> None:
         """`versions` dict should coexist with assistant-specific metadata."""
@@ -134,15 +133,15 @@ class TestBuildStreamConfig:
         assert "versions" in config["metadata"]
         assert config["metadata"]["assistant_id"] == "my-agent"
 
-    def test_versions_uses_package_name_keys(self) -> None:
-        """Version keys should be PyPI package names, not suffixed variants."""
+    def test_sdk_version_not_set_by_cli(self) -> None:
+        """SDK version should not be set by the CLI; the SDK owns that key.
+
+        The SDK attaches its version via `create_deep_agent`'s
+        `with_config` and langchain-core's `merge_configs` deep-merges
+        the `versions` dicts so both survive.
+        """
         config = build_stream_config("t-300", assistant_id=None)
-        versions = config["metadata"]["versions"]
-        # Keys are package names, not legacy flat keys
-        assert "deepagents" in versions
-        assert "deepagents-cli" in versions
-        assert "deepagents_version" not in config["metadata"]
-        assert "deepagents_cli_version" not in config["metadata"]
+        assert "deepagents" not in config["metadata"]["versions"]
 
     def test_configurable_thread_id(self) -> None:
         """`configurable.thread_id` should match the provided thread ID."""

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -119,18 +119,23 @@ class TestBuildStreamConfig:
         assert "agent_name" not in config["metadata"]
         assert "updated_at" not in config["metadata"]
 
-    def test_version_metadata_always_present(self) -> None:
-        """Version keys should be present regardless of `assistant_id`."""
-        config = build_stream_config("t-100", assistant_id=None)
-        assert "deepagents_version" in config["metadata"]
-        assert "deepagents_cli_version" in config["metadata"]
+    def test_cli_version_metadata_always_present(self) -> None:
+        """CLI version should be present regardless of `assistant_id`."""
+        from deepagents_cli._version import __version__
 
-    def test_version_metadata_with_assistant(self) -> None:
-        """Version keys should coexist with assistant-specific metadata."""
+        config = build_stream_config("t-100", assistant_id=None)
+        assert config["metadata"]["deepagents_cli_version"] == __version__
+
+    def test_cli_version_metadata_with_assistant(self) -> None:
+        """CLI version should coexist with assistant-specific metadata."""
         config = build_stream_config("t-200", assistant_id="my-agent")
-        assert "deepagents_version" in config["metadata"]
         assert "deepagents_cli_version" in config["metadata"]
         assert config["metadata"]["assistant_id"] == "my-agent"
+
+    def test_sdk_version_not_set_by_cli(self) -> None:
+        """SDK version should not be set by the CLI; the SDK owns that key."""
+        config = build_stream_config("t-300", assistant_id=None)
+        assert "deepagents_version" not in config["metadata"]
 
     def test_configurable_thread_id(self) -> None:
         """`configurable.thread_id` should match the provided thread ID."""

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -286,4 +286,4 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         debug=debug,
         name=name,
         cache=cache,
-    ).with_config({"recursion_limit": 1000, "metadata": {"deepagents_version": __version__}})
+    ).with_config({"recursion_limit": 1000, "metadata": {"versions": {"deepagents": __version__}}})

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -19,6 +19,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
+from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -285,4 +286,4 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         debug=debug,
         name=name,
         cache=cache,
-    ).with_config({"recursion_limit": 1000})
+    ).with_config({"recursion_limit": 1000, "metadata": {"deepagents_version": __version__}})

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -1,0 +1,16 @@
+"""Unit tests for deepagents.graph module."""
+
+from langchain_core.messages import AIMessage
+
+from deepagents._version import __version__
+from deepagents.graph import create_deep_agent
+
+from .chat_model import GenericFakeChatModel
+
+
+def test_create_deep_agent_includes_version_metadata() -> None:
+    """`create_deep_agent` should attach `deepagents_version` to graph config metadata."""
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="hi")]))
+    agent = create_deep_agent(model=model)
+    assert agent.config is not None
+    assert agent.config["metadata"]["deepagents_version"] == __version__

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -9,8 +9,9 @@ from .chat_model import GenericFakeChatModel
 
 
 def test_create_deep_agent_includes_version_metadata() -> None:
-    """`create_deep_agent` should attach `deepagents_version` to graph config metadata."""
+    """`create_deep_agent` should nest SDK version under `metadata.versions`."""
     model = GenericFakeChatModel(messages=iter([AIMessage(content="hi")]))
     agent = create_deep_agent(model=model)
     assert agent.config is not None
-    assert agent.config["metadata"]["deepagents_version"] == __version__
+    versions = agent.config["metadata"]["versions"]
+    assert versions["deepagents"] == __version__


### PR DESCRIPTION
Depends on https://github.com/langchain-ai/langchain/pull/35295
Should consider bumping min version

---

LangSmith traces from `deepagents`/`deepagents-cli` don't include installed package versions, making it hard to correlate failures with specific versions. Every LangSmith run now automatically carries `deepagents_version` and (when using the CLI) `deepagents_cli_version` in run metadata.