### PR TITLE
fix(cli): substitute image base64 for placeholder in result block

### DIFF
--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -198,7 +198,7 @@ def _format_content_block(block: dict) -> str:
     Returns:
         A display-friendly string for the block.
     """
-    if block.get("type") == "image" and "base64" in block:
+    if block.get("type") == "image" and isinstance(block.get("base64"), str):
         b64 = block["base64"]
         size_kb = len(b64) * 3 // 4 // 1024  # approximate decoded size
         mime = block.get("mime_type", "image")

--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -186,6 +186,29 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
     return f"{prefix} {tool_name}({args_str})"
 
 
+def _format_content_block(block: dict) -> str:
+    """Format a single content block dict for display.
+
+    Replaces large binary payloads (e.g. base64 image data) with a
+    human-readable placeholder so they don't flood the terminal.
+
+    Args:
+        block: An `ImageContentBlock` dictionary.
+
+    Returns:
+        A display-friendly string for the block.
+    """
+    if block.get("type") == "image" and "base64" in block:
+        b64 = block["base64"]
+        size_kb = len(b64) * 3 // 4 // 1024  # approximate decoded size
+        mime = block.get("mime_type", "image")
+        return f"[Image: {mime}, ~{size_kb}KB]"
+    try:
+        return json.dumps(block)
+    except (TypeError, ValueError):
+        return str(block)
+
+
 def format_tool_message_content(content: Any) -> str:  # noqa: ANN401  # Content can be str, list, or dict
     """Convert `ToolMessage` content into a printable string.
 
@@ -199,6 +222,8 @@ def format_tool_message_content(content: Any) -> str:  # noqa: ANN401  # Content
         for item in content:
             if isinstance(item, str):
                 parts.append(item)
+            elif isinstance(item, dict):
+                parts.append(_format_content_block(item))
             else:
                 try:
                     parts.append(json.dumps(item))

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any
 
+from rich.markup import escape as escape_markup
 from rich.text import Text
 from textual.containers import Vertical
 from textual.widgets import Markdown, Static
@@ -695,13 +696,19 @@ class ToolCallMessage(Vertical):
         # Default: return as-is but escape markup
         return FormattedOutput(content=self._escape_markup(output))
 
-    def _escape_markup(self, text: str) -> str:  # noqa: PLR6301  # Grouped as method for widget cohesion
+    @staticmethod
+    def _escape_markup(text: str) -> str:
         """Escape Rich markup characters.
+
+        Uses Rich's built-in `escape` which only targets actual markup
+        patterns (e.g. `[bold]`, `[red]`). Unlike a blanket bracket
+        replacement, this avoids rendering visible backslashes before `]`
+        in tool output.
 
         Returns:
             Escaped text safe for Rich rendering.
         """
-        return text.replace("[", r"\[").replace("]", r"\]")
+        return escape_markup(text)
 
     def _prefix_output(self, content: str) -> str:  # noqa: PLR6301  # Grouped as method for widget cohesion
         """Prefix output with output marker and indent continuation lines.


### PR DESCRIPTION
Fixes #1351
Fixes #1006

---

When tool results contain base64-encoded images (e.g. from screenshot or vision tools), the raw data would flood the terminal with thousands of characters of noise. This replaces those payloads with a compact `[Image: mime/type, ~NKB]` placeholder. Also fixes a separate issue where `_escape_markup` was doing a bracket replacement (`\[`, `\]`) that caused visible backslashes in tool output — now delegates to Rich's [`escape`](https://rich.readthedocs.io/en/latest/markup.html#escaping) which only targets actual markup patterns.