### PR TITLE
test(cli): parallelize unit tests with pytest-xdist

### DIFF
--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -15,7 +15,7 @@ TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests:
-	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE)
 
 coverage:
 	uv run --group test pytest --cov \

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -223,5 +223,11 @@ omit = ["tests/*"]
 timeout = 30  # Default timeout for all tests (can be overridden per-test)
 
 addopts = "--strict-markers --strict-config --durations=5"
+# pytest-benchmark warns once per xdist worker that benchmarks are disabled
+# under parallel execution. Both plugins are needed: xdist for `make test`,
+# benchmark for `make benchmark`. Suppress the noise here.
+filterwarnings = [
+    "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
+]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -634,7 +634,7 @@ class TestFetchThreadUrl:
         import time
 
         def _blocking(_tid: str) -> str:
-            time.sleep(10)
+            time.sleep(3)
             return "https://example.com"
 
         with (


### PR DESCRIPTION
Switch the CLI's unit test runner from sequential to parallel execution via `pytest-xdist` (`-n auto`). Cuts total test time by ~75% locally, ~50% in CI