### PR TITLE
fix(cli): only navigate prompt history at input boundaries

### DIFF
--- a/libs/cli/deepagents_cli/widgets/history.py
+++ b/libs/cli/deepagents_cli/widgets/history.py
@@ -149,6 +149,11 @@ class HistoryManager:
         self.reset_navigation()
         return result
 
+    @property
+    def in_history(self) -> bool:
+        """Whether currently navigating history entries."""
+        return self._current_index >= 0
+
     def reset_navigation(self) -> None:
         """Reset navigation state."""
         self._current_index = -1

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -346,6 +346,162 @@ class TestHistoryNavigationFlag:
             assert controller is not None
 
 
+class TestHistoryBoundaryNavigation:
+    """Test that history navigation only triggers at input boundaries."""
+
+    @pytest.mark.asyncio
+    async def test_up_arrow_only_triggers_at_cursor_start(self) -> None:
+        """Up arrow should only navigate history when cursor is at (0, 0)."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("previous entry")
+
+            # Type some text — cursor ends up at the end
+            chat._text_area.insert("hello")
+            await pilot.pause()
+            assert chat._text_area.cursor_location == (0, 5)
+
+            # Up arrow should NOT trigger history (cursor not at start)
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_up_arrow_triggers_at_cursor_zero(self) -> None:
+        """Up arrow should navigate history when cursor is at (0, 0)."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("previous entry")
+
+            # Type text then move cursor to start
+            chat._text_area.insert("hello")
+            await pilot.pause()
+            chat._text_area.move_cursor((0, 0))
+            await pilot.pause()
+
+            # Up arrow should trigger history (cursor at start)
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "previous entry"
+
+    @pytest.mark.asyncio
+    async def test_down_arrow_only_triggers_at_cursor_end(self) -> None:
+        """Down arrow should only navigate history when cursor is at end."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.extend(["first", "second"])
+
+            # Navigate into history first (cursor at start on empty)
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "second"
+
+            # Move cursor to start (not at end)
+            chat._text_area.move_cursor((0, 0))
+            await pilot.pause()
+
+            # Down arrow should NOT trigger history (cursor not at end)
+            # but _in_history allows navigation at start too
+            await pilot.press("down")
+            await pilot.pause()
+            # Since _in_history is True and cursor is at start (boundary),
+            # navigation should still work
+            assert chat._text_area.text == ""
+
+    @pytest.mark.asyncio
+    async def test_down_arrow_at_end_triggers_history(self) -> None:
+        """Down arrow at end of text should navigate history forward."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.extend(["first", "second"])
+
+            # Navigate up twice into history
+            await pilot.press("up")
+            await pilot.pause()
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "first"
+
+            # Cursor should be at end after set_text_from_history
+            # Down arrow at end should navigate forward
+            await pilot.press("down")
+            await pilot.pause()
+            assert chat._text_area.text == "second"
+
+    @pytest.mark.asyncio
+    async def test_up_at_middle_of_multiline_does_not_trigger(self) -> None:
+        """Up arrow on a middle line should not navigate history."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("previous entry")
+
+            # Insert multiline text and place cursor on line 1
+            chat._text_area.text = "line one\nline two\nline three"
+            await pilot.pause()
+            chat._text_area.move_cursor((1, 3))
+            await pilot.pause()
+
+            # Up arrow should move cursor, not navigate history
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "line one\nline two\nline three"
+
+    @pytest.mark.asyncio
+    async def test_in_history_allows_up_from_end(self) -> None:
+        """When browsing history, up arrow at end should also navigate."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.extend(["first", "second"])
+
+            # Navigate into history
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "second"
+            assert chat._text_area._in_history is True
+
+            # Cursor is at end after set_text_from_history; up should
+            # still navigate because _in_history is True and at boundary
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "first"
+
+    @pytest.mark.asyncio
+    async def test_in_history_resets_after_submission(self) -> None:
+        """Submitting should clear the _in_history flag."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("recalled entry")
+
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area._in_history is True
+
+            await pilot.press("enter")
+            await pilot.pause()
+            assert chat._text_area._in_history is False
+
+
 class TestCompletionPopupClickBubbling:
     """Test that clicks on options bubble up through the popup."""
 

--- a/libs/cli/tests/unit_tests/test_history.py
+++ b/libs/cli/tests/unit_tests/test_history.py
@@ -1,0 +1,81 @@
+"""Unit tests for HistoryManager."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from deepagents_cli.widgets.history import HistoryManager
+
+
+@pytest.fixture
+def history(tmp_path: Path) -> HistoryManager:
+    """Create a HistoryManager with a temp file and seed entries."""
+    mgr = HistoryManager(tmp_path / "history.jsonl")
+    mgr._entries = ["first", "second", "third"]
+    return mgr
+
+
+class TestInHistoryProperty:
+    """Test HistoryManager.in_history property."""
+
+    def test_initial_state_is_false(self, tmp_path: Path) -> None:
+        """in_history should be False before any navigation."""
+        mgr = HistoryManager(tmp_path / "history.jsonl")
+        assert mgr.in_history is False
+
+    def test_true_after_get_previous(self, history: HistoryManager) -> None:
+        """in_history should be True after get_previous returns an entry."""
+        entry = history.get_previous("")
+        assert entry is not None
+        assert history.in_history is True
+
+    def test_true_while_browsing(self, history: HistoryManager) -> None:
+        """in_history should stay True while navigating through entries."""
+        history.get_previous("")
+        assert history.in_history is True
+
+        history.get_previous("")
+        assert history.in_history is True
+
+    def test_false_after_get_next_past_end(self, history: HistoryManager) -> None:
+        """in_history should be False after navigating past the newest entry."""
+        history.get_previous("current text")
+        assert history.in_history is True
+
+        # Navigate forward past the end — returns to original input
+        history.get_next()
+        assert history.in_history is False
+
+    def test_false_after_reset_navigation(self, history: HistoryManager) -> None:
+        """in_history should be False after explicit reset."""
+        history.get_previous("")
+        assert history.in_history is True
+
+        history.reset_navigation()
+        assert history.in_history is False
+
+    def test_false_after_add(self, history: HistoryManager) -> None:
+        """in_history should be False after add() since it calls reset_navigation."""
+        history.get_previous("")
+        assert history.in_history is True
+
+        history.add("new entry")
+        assert history.in_history is False
+
+    def test_true_at_oldest_entry(self, history: HistoryManager) -> None:
+        """in_history should stay True when at the oldest entry with no older match."""
+        # Navigate to oldest
+        history.get_previous("")
+        history.get_previous("")
+        history.get_previous("")
+        assert history.in_history is True
+
+        # Try to go further back — returns None but stays in history
+        result = history.get_previous("")
+        assert result is None
+        assert history.in_history is True


### PR DESCRIPTION
Restrict prompt history navigation to true input boundaries — up arrow only triggers at cursor position `(0, 0)`, down arrow only at the end of input. Previously, being anywhere on the first or last line was enough, which hijacked normal cursor movement while editing multi-character or multiline prompts. When already browsing history (`_in_history`), navigation is allowed from either boundary so cycling through entries still works naturally.