### PR TITLE
feat(cli): add drag-and-drop image attachment to chat input

### DIFF
--- a/libs/cli/deepagents_cli/image_utils.py
+++ b/libs/cli/deepagents_cli/image_utils.py
@@ -94,7 +94,8 @@ def get_image_from_path(path: pathlib.Path) -> ImageData | None:
             format=image_format,
             placeholder="[image]",
         )
-    except (UnidentifiedImageError, OSError):
+    except (UnidentifiedImageError, OSError) as e:
+        logger.debug("Failed to load image from %s: %s", path, e, exc_info=True)
         return None
 
 

--- a/libs/cli/deepagents_cli/image_utils.py
+++ b/libs/cli/deepagents_cli/image_utils.py
@@ -64,6 +64,40 @@ def get_clipboard_image() -> ImageData | None:
     return None
 
 
+def get_image_from_path(path: pathlib.Path) -> ImageData | None:
+    """Read and encode an image file from disk.
+
+    Args:
+        path: Path to the image file.
+
+    Returns:
+        `ImageData` when the file is a valid image, otherwise `None`.
+    """
+    try:
+        image_bytes = path.read_bytes()
+        if not image_bytes:
+            return None
+
+        with Image.open(io.BytesIO(image_bytes)) as image:
+            image_format = (image.format or "").lower()
+
+        if image_format == "jpg":
+            image_format = "jpeg"
+        if not image_format:
+            suffix = path.suffix.lower().removeprefix(".")
+            image_format = "jpeg" if suffix == "jpg" else suffix
+        if not image_format:
+            image_format = "png"
+
+        return ImageData(
+            base64_data=encode_image_to_base64(image_bytes),
+            format=image_format,
+            placeholder="[image]",
+        )
+    except (UnidentifiedImageError, OSError):
+        return None
+
+
 def _get_macos_clipboard_image() -> ImageData | None:
     """Get clipboard image on macOS using pngpaste or osascript.
 

--- a/libs/cli/deepagents_cli/input.py
+++ b/libs/cli/deepagents_cli/input.py
@@ -1,7 +1,9 @@
 """Input handling utilities including image tracking and file mention parsing."""
 
 import re
+import shlex
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from deepagents_cli.config import console
 from deepagents_cli.image_utils import ImageData
@@ -46,6 +48,9 @@ in `UserMessage.compose()` additionally checks `start == 0` before styling
 slash commands, so a `/` mid-string is not highlighted.
 """
 
+IMAGE_PLACEHOLDER_PATTERN = re.compile(r"\[image (?P<id>\d+)\]")
+"""Pattern for image placeholders in composed user text."""
+
 
 class ImageTracker:
     """Track pasted images in the current conversation."""
@@ -86,6 +91,33 @@ class ImageTracker:
         """Clear all tracked images and reset counter."""
         self.images.clear()
         self.next_id = 1
+
+    def sync_to_text(self, text: str) -> None:
+        """Retain only images still referenced by placeholders in current text.
+
+        Args:
+            text: Current input text shown to the user.
+        """
+        placeholders = {
+            match.group(0) for match in IMAGE_PLACEHOLDER_PATTERN.finditer(text)
+        }
+        if not placeholders:
+            self.clear()
+            return
+
+        self.images = [img for img in self.images if img.placeholder in placeholders]
+        if not self.images:
+            self.next_id = 1
+            return
+
+        max_id = 0
+        for image in self.images:
+            match = IMAGE_PLACEHOLDER_PATTERN.fullmatch(image.placeholder)
+            if match is None:
+                continue
+            max_id = max(max_id, int(match.group("id")))
+
+        self.next_id = max_id + 1 if max_id else len(self.images) + 1
 
 
 def parse_file_mentions(text: str) -> tuple[str, list[Path]]:
@@ -139,3 +171,103 @@ def parse_file_mentions(text: str) -> tuple[str, list[Path]]:
             console.print(f"[yellow]Warning: Invalid path {raw_path}: {e}[/yellow]")
 
     return text, files
+
+
+def parse_pasted_file_paths(text: str) -> list[Path]:
+    r"""Parse a paste payload that may contain dragged-and-dropped file paths.
+
+    The parser is strict on purpose: it only returns paths when the entire paste
+    payload can be interpreted as one or more existing files. Any invalid token
+    falls back to normal text paste behavior by returning an empty list.
+
+    Supports common dropped-path formats:
+
+    - Absolute/relative paths
+    - POSIX shell quoting and escaping
+    - `file://` URLs
+
+    Args:
+        text: Raw paste payload from the terminal.
+
+    Returns:
+        List of resolved file paths, or an empty list when parsing fails.
+    """
+    payload = text.strip()
+    if not payload:
+        return []
+
+    tokens: list[str] = []
+    for raw_line in payload.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line_tokens = _split_paste_line(line)
+        if not line_tokens:
+            return []
+        tokens.extend(line_tokens)
+
+    if not tokens:
+        return []
+
+    paths: list[Path] = []
+    for token in tokens:
+        path = _token_to_path(token)
+        if path is None:
+            return []
+        try:
+            resolved = path.expanduser().resolve()
+        except (OSError, RuntimeError):
+            return []
+        if not resolved.exists() or not resolved.is_file():
+            return []
+        paths.append(resolved)
+
+    return paths
+
+
+def _split_paste_line(line: str) -> list[str]:
+    """Split a single pasted line into path-like tokens.
+
+    Returns:
+        Parsed shell-like tokens, or an empty list when parsing fails.
+    """
+    try:
+        return shlex.split(line, posix=True)
+    except ValueError:
+        # Unbalanced quotes or other tokenization errors: treat as plain text.
+        return []
+
+
+def _token_to_path(token: str) -> Path | None:
+    """Convert a pasted token into a path candidate.
+
+    Returns:
+        A parsed path candidate, or `None` when token parsing fails.
+    """
+    value = token.strip()
+    if not value:
+        return None
+
+    if value.startswith("<") and value.endswith(">"):
+        value = value[1:-1].strip()
+        if not value:
+            return None
+
+    if value.startswith("file://"):
+        parsed = urlparse(value)
+        path_text = unquote(parsed.path or "")
+        if parsed.netloc and parsed.netloc != "localhost":
+            path_text = f"//{parsed.netloc}{path_text}"
+        if (
+            path_text.startswith("/")
+            and len(path_text) > 2  # noqa: PLR2004  # '/C:' minimum for Windows file URI
+            and path_text[2] == ":"
+            and path_text[1].isalpha()
+        ):
+            # `file:///C:/...` on Windows includes an extra leading slash.
+            path_text = path_text[1:]
+        if not path_text:
+            return None
+        return Path(path_text)
+
+    return Path(value)

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -35,10 +36,15 @@ logger = logging.getLogger(__name__)
 _PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
 """Reverse lookup: trigger character -> mode name."""
 
+_IMAGE_PLACEHOLDER_PATTERN = re.compile(r"\[image \d+\]")
+"""Pattern for image placeholder tokens inserted into composer text."""
+
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
     from textual.events import Click
+
+    from deepagents_cli.input import ImageTracker
 
 
 class CompletionOption(Static):
@@ -268,6 +274,15 @@ class ChatTextArea(TextArea):
     class HistoryNext(Message):
         """Request next history entry."""
 
+    class PastedPaths(Message):
+        """Message sent when paste payload resolves to file paths."""
+
+        def __init__(self, raw_text: str, paths: list[Path]) -> None:
+            """Initialize with raw pasted text and parsed file paths."""
+            self.raw_text = raw_text
+            self.paths = paths
+            super().__init__()
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the chat text area."""
         # Remove placeholder if passed, TextArea doesn't support it the same way
@@ -315,6 +330,16 @@ class ChatTextArea(TextArea):
             self.insert("\n")
             return
 
+        if event.key == "backspace" and self._delete_image_placeholder(backwards=True):
+            event.prevent_default()
+            event.stop()
+            return
+
+        if event.key == "delete" and self._delete_image_placeholder(backwards=False):
+            event.prevent_default()
+            event.stop()
+            return
+
         # If completion is active, let parent handle navigation keys
         if self._completion_active and event.key in {"up", "down", "tab", "enter"}:
             # Prevent TextArea's default behavior (e.g., Enter inserting newline)
@@ -353,6 +378,68 @@ class ChatTextArea(TextArea):
                 return
 
         await super()._on_key(event)
+
+    def _delete_image_placeholder(self, *, backwards: bool) -> bool:
+        """Delete a full image placeholder token in one keypress.
+
+        Args:
+            backwards: Whether the delete action is backwards (`backspace`) or
+                forwards (`delete`).
+
+        Returns:
+            `True` when a placeholder token was deleted.
+        """
+        if not self.text or not self.selection.is_empty:
+            return False
+
+        cursor_offset = self.document.get_index_from_location(self.cursor_location)  # type: ignore[attr-defined]  # Document has this method; DocumentBase stub is narrower
+        span = self._find_image_placeholder_span(cursor_offset, backwards=backwards)
+        if span is None:
+            return False
+
+        start, end = span
+        start_location = self.document.get_location_from_index(start)  # type: ignore[attr-defined]  # Document has this method; DocumentBase stub is narrower
+        end_location = self.document.get_location_from_index(end)  # type: ignore[attr-defined]
+        self.delete(start_location, end_location)
+        self.move_cursor(start_location)
+        return True
+
+    def _find_image_placeholder_span(
+        self, cursor_offset: int, *, backwards: bool
+    ) -> tuple[int, int] | None:
+        """Return placeholder span to delete for current cursor and key direction."""
+        text = self.text
+        for match in _IMAGE_PLACEHOLDER_PATTERN.finditer(text):
+            start, end = match.span()
+            if backwards:
+                # Cursor is inside token or right after a trailing space inserted
+                # with the token.
+                if start < cursor_offset <= end:
+                    return start, end
+                if cursor_offset > 0:
+                    previous_index = cursor_offset - 1
+                    if (
+                        previous_index < len(text)
+                        and previous_index == end
+                        and text[previous_index].isspace()
+                    ):
+                        return start, cursor_offset
+            elif start <= cursor_offset < end:
+                return start, end
+        return None
+
+    async def _on_paste(self, event: events.Paste) -> None:
+        """Handle paste events and detect dragged file paths."""
+        from deepagents_cli.input import parse_pasted_file_paths
+
+        paths = parse_pasted_file_paths(event.text)
+        if not paths:
+            await super()._on_paste(event)
+            return
+
+        event.prevent_default()
+        event.stop()
+        self.post_message(self.PastedPaths(event.text, paths))
 
     def set_text_from_history(self, text: str) -> None:
         """Set text from history navigation."""
@@ -486,6 +573,7 @@ class ChatInput(Vertical):
         self,
         cwd: str | Path | None = None,
         history_file: Path | None = None,
+        image_tracker: ImageTracker | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the chat input widget.
@@ -493,10 +581,12 @@ class ChatInput(Vertical):
         Args:
             cwd: Current working directory for file completion
             history_file: Path to history file (default: ~/.deepagents/history.jsonl)
+            image_tracker: Optional tracker for attached images
             **kwargs: Additional arguments for parent
         """
         super().__init__(**kwargs)
         self._cwd = Path(cwd) if cwd else Path.cwd()
+        self._image_tracker = image_tracker
         self._text_area: ChatTextArea | None = None
         self._popup: CompletionPopup | None = None
         self._completion_manager: MultiCompletionManager | None = None
@@ -506,6 +596,7 @@ class ChatInput(Vertical):
         # prefix character so the resulting text-change event does not
         # re-evaluate mode.
         self._stripping_prefix = False
+        self._skip_image_sync_events = 0
         # Number of virtual prefix characters currently injected for
         # completion controller calls (0 for normal, 1 for bash/command).
         self._completion_prefix_len = 0
@@ -554,6 +645,8 @@ class ChatInput(Vertical):
     def on_text_area_changed(self, event: TextArea.Changed) -> None:
         """Detect input mode and update completions."""
         text = event.text_area.text
+        is_path_payload = self._is_dropped_path_payload(text)
+        self._sync_image_tracker_to_text(text)
 
         # History handlers explicitly decide mode and stripped display text.
         # Skip mode detection here so recalled entries don't inherit stale mode.
@@ -568,28 +661,56 @@ class ChatInput(Vertical):
         if self._stripping_prefix:
             self._stripping_prefix = False
         elif text and text[0] in _PREFIX_TO_MODE:
-            # Detected a mode-trigger prefix (e.g. "!" or "/").
-            # Strip it unconditionally -- even when already in the correct
-            # mode -- because completion controllers may write replacement
-            # text that re-includes the trigger character.  The
-            # _stripping_prefix guard prevents the resulting change event
-            # from looping back here.
-            detected = _PREFIX_TO_MODE[text[0]]
-            if self.mode != detected:
-                self.mode = detected
-            self._strip_mode_prefix()
-            return
+            if text[0] == "/" and is_path_payload:
+                # Absolute dropped paths stay normal input, not slash-command mode.
+                if self.mode != "normal":
+                    self.mode = "normal"
+            else:
+                # Detected a mode-trigger prefix (e.g. "!" or "/").
+                # Strip it unconditionally -- even when already in the correct
+                # mode -- because completion controllers may write replacement
+                # text that re-includes the trigger character.  The
+                # _stripping_prefix guard prevents the resulting change event
+                # from looping back here.
+                detected = _PREFIX_TO_MODE[text[0]]
+                if self.mode != detected:
+                    self.mode = detected
+                self._strip_mode_prefix()
+                return
         elif not text and self.mode != "normal":
             # Reset mode when text is fully cleared
             self.mode = "normal"
 
         # Update completion suggestions using completion-space text/cursor.
         if self._completion_manager and self._text_area:
-            vtext, vcursor = self._completion_text_and_cursor()
-            self._completion_manager.on_text_changed(vtext, vcursor)
+            if is_path_payload:
+                self._completion_manager.reset()
+            else:
+                vtext, vcursor = self._completion_text_and_cursor()
+                self._completion_manager.on_text_changed(vtext, vcursor)
 
         # Scroll input into view when content changes (handles text wrap)
         self.scroll_visible()
+
+    @staticmethod
+    def _is_existing_path_payload(text: str) -> bool:
+        """Return whether text is a dropped-path payload for existing files."""
+        from deepagents_cli.input import parse_pasted_file_paths
+
+        if len(text) < 2:  # noqa: PLR2004  # Need at least '/' + one char
+            return False
+        return bool(parse_pasted_file_paths(text))
+
+    def _is_dropped_path_payload(self, text: str) -> bool:
+        """Return whether current text looks like a dropped file-path payload."""
+        if not text:
+            return False
+        if self._is_existing_path_payload(text):
+            return True
+        if self.mode == "command":
+            candidate = f"/{text.lstrip('/')}"
+            return self._is_existing_path_payload(candidate)
+        return False
 
     def _strip_mode_prefix(self) -> None:
         """Remove the first character (mode trigger) from the text area.
@@ -674,6 +795,8 @@ class ChatInput(Vertical):
         if self._completion_manager:
             self._completion_manager.reset()
 
+        value = self._replace_submitted_paths_with_images(value)
+
         # Prepend mode prefix so the app layer receives the original trigger
         # form (e.g. "!ls", "/help"). The value may already contain the prefix
         # when a completion controller wrote it back into the text area before
@@ -686,8 +809,19 @@ class ChatInput(Vertical):
         self.post_message(self.Submitted(value, self.mode))
 
         if self._text_area:
+            # Preserve submission-time attachments until adapter consumes them.
+            self._skip_image_sync_events += 1
             self._text_area.clear_text()
         self.mode = "normal"
+
+    def _sync_image_tracker_to_text(self, text: str) -> None:
+        """Keep tracked images aligned with placeholder tokens in input text."""
+        if not self._image_tracker:
+            return
+        if self._skip_image_sync_events:
+            self._skip_image_sync_events -= 1
+            return
+        self._image_tracker.sync_to_text(text)
 
     def on_chat_text_area_submitted(self, event: ChatTextArea.Submitted) -> None:
         """Handle text submission.
@@ -721,6 +855,113 @@ class ChatInput(Vertical):
             self._text_area.set_text_from_history(display_text)
         elif self._text_area:
             self._text_area._navigating_history = False
+
+    def on_chat_text_area_pasted_paths(self, event: ChatTextArea.PastedPaths) -> None:
+        """Handle paste payloads that resolve to dropped file paths."""
+        if not self._text_area:
+            return
+
+        self._insert_pasted_paths(event.raw_text, event.paths)
+
+    def handle_external_paste(self, pasted: str) -> bool:
+        """Handle paste text from app-level routing when input is not focused.
+
+        Args:
+            pasted: Raw pasted text payload.
+
+        Returns:
+            `True` when paste was handled by the input, otherwise `False`.
+        """
+        if not self._text_area:
+            return False
+
+        from deepagents_cli.input import parse_pasted_file_paths
+
+        paths = parse_pasted_file_paths(pasted)
+        if paths:
+            self._insert_pasted_paths(pasted, paths)
+        else:
+            self._text_area.insert(pasted)
+
+        self._text_area.focus()
+        return True
+
+    def _insert_pasted_paths(self, raw_text: str, paths: list[Path]) -> None:
+        """Insert pasted path payload, attaching images when possible."""
+        if not self._text_area:
+            return
+        replacement, attached = self._build_path_replacement(
+            raw_text, paths, add_trailing_space=True
+        )
+        if attached:
+            self._text_area.insert(replacement)
+            return
+        self._text_area.insert(raw_text)
+
+    def _build_path_replacement(
+        self,
+        raw_text: str,
+        paths: list[Path],
+        *,
+        add_trailing_space: bool,
+    ) -> tuple[str, bool]:
+        """Build replacement text for dropped paths and attach any images.
+
+        Returns:
+            Tuple of `(replacement, attached)` where `attached` indicates whether
+            at least one image attachment was created.
+        """
+        if not self._image_tracker:
+            return raw_text, False
+
+        from deepagents_cli.image_utils import get_image_from_path
+
+        parts: list[str] = []
+        attached = False
+        for path in paths:
+            image_data = get_image_from_path(path)
+            if image_data is None:
+                parts.append(str(path))
+                continue
+            parts.append(self._image_tracker.add_image(image_data))
+            attached = True
+
+        if not attached:
+            return raw_text, False
+
+        separator = "\n" if "\n" in raw_text else " "
+        replacement = separator.join(parts)
+        if separator == " " and add_trailing_space:
+            replacement += " "
+        return replacement, True
+
+    def _replace_submitted_paths_with_images(self, value: str) -> str:
+        """Replace dropped-path payloads in submitted text with image placeholders.
+
+        Returns:
+            Submitted text with image placeholders when attachment succeeded.
+        """
+        from deepagents_cli.input import parse_pasted_file_paths
+
+        paths = parse_pasted_file_paths(value)
+        candidate = value
+
+        # Recovery path: if command mode stripped the leading slash from an
+        # absolute dropped path, rehydrate it before resolving attachments.
+        if not paths and self.mode == "command":
+            prefixed = f"/{value.lstrip('/')}"
+            paths = parse_pasted_file_paths(prefixed)
+            if paths:
+                candidate = prefixed
+                self.mode = "normal"
+
+        if paths:
+            replacement, attached = self._build_path_replacement(
+                candidate, paths, add_trailing_space=False
+            )
+            if attached:
+                return replacement.strip()
+        return value
 
     @staticmethod
     def _history_entry_mode_and_text(entry: str) -> tuple[str, str]:

--- a/libs/cli/tests/unit_tests/test_image_utils.py
+++ b/libs/cli/tests/unit_tests/test_image_utils.py
@@ -5,6 +5,7 @@ Covers clipboard detection, base64 encoding, and multimodal content.
 
 import base64
 import io
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from PIL import Image
@@ -14,6 +15,7 @@ from deepagents_cli.image_utils import (
     create_multimodal_content,
     encode_image_to_base64,
     get_clipboard_image,
+    get_image_from_path,
 )
 from deepagents_cli.input import ImageTracker
 
@@ -106,21 +108,31 @@ class TestImageTracker:
 
         assert placeholder == "[image 1]"
 
-    def test_remove_image_and_reset_counter(self) -> None:
-        """Test removing an image resets the counter appropriately."""
+    def test_sync_to_text_resets_when_placeholders_removed(self) -> None:
+        """Removing placeholders from input should clear tracked images and IDs."""
+        tracker = ImageTracker()
+        img = ImageData(base64_data="abc", format="png", placeholder="")
+
+        tracker.add_image(img)
+        tracker.add_image(img)
+        tracker.sync_to_text("")
+
+        assert tracker.images == []
+        assert tracker.next_id == 1
+
+    def test_sync_to_text_keeps_referenced_images(self) -> None:
+        """Sync should prune unreferenced images while preserving next ID order."""
         tracker = ImageTracker()
         img1 = ImageData(base64_data="abc", format="png", placeholder="")
         img2 = ImageData(base64_data="def", format="png", placeholder="")
 
         tracker.add_image(img1)
         tracker.add_image(img2)
+        tracker.sync_to_text("keep [image 2] only")
 
-        # Simulate what happens on backspace delete
-        tracker.images.pop(1)  # Remove image 2
-        tracker.next_id = len(tracker.images) + 1
-
-        assert tracker.next_id == 2
+        assert tracker.next_id == 3
         assert len(tracker.images) == 1
+        assert tracker.images[0].placeholder == "[image 2]"
 
 
 class TestEncodeImageToBase64:
@@ -280,3 +292,32 @@ class TestGetClipboardImage:
 
         result = get_clipboard_image()
         assert result is None
+
+
+class TestGetImageFromPath:
+    """Tests for loading local images from dropped file paths."""
+
+    def test_get_image_from_path_png(self, tmp_path: Path) -> None:
+        """Valid PNG files should be returned as ImageData."""
+        img_path = tmp_path / "dropped.png"
+        img = Image.new("RGB", (4, 4), color="red")
+        img.save(img_path, format="PNG")
+
+        result = get_image_from_path(img_path)
+
+        assert result is not None
+        assert result.format == "png"
+        assert result.placeholder == "[image]"
+        assert base64.b64decode(result.base64_data)
+
+    def test_get_image_from_path_non_image_returns_none(self, tmp_path: Path) -> None:
+        """Non-image files should be ignored."""
+        file_path = tmp_path / "notes.txt"
+        file_path.write_text("not an image")
+
+        assert get_image_from_path(file_path) is None
+
+    def test_get_image_from_path_missing_returns_none(self, tmp_path: Path) -> None:
+        """Missing files should return None instead of raising."""
+        file_path = tmp_path / "missing.png"
+        assert get_image_from_path(file_path) is None

--- a/libs/cli/tests/unit_tests/test_input_parsing.py
+++ b/libs/cli/tests/unit_tests/test_input_parsing.py
@@ -289,3 +289,25 @@ def test_parse_pasted_file_paths_returns_empty_for_missing_file(tmp_path: Path) 
     """Missing dropped files should fall back to regular text paste."""
     missing = tmp_path / "missing.png"
     assert parse_pasted_file_paths(str(missing)) == []
+
+
+def test_parse_pasted_file_paths_returns_empty_for_empty_string() -> None:
+    """Empty string should return an empty list."""
+    assert parse_pasted_file_paths("") == []
+
+
+def test_parse_pasted_file_paths_returns_empty_for_whitespace() -> None:
+    """Whitespace-only payloads should return an empty list."""
+    assert parse_pasted_file_paths("   \n\t  ") == []
+
+
+def test_parse_pasted_file_paths_handles_angle_bracket_wrapped_path(
+    tmp_path: Path,
+) -> None:
+    """Angle-bracket wrapped paths (e.g. from some terminals) should resolve."""
+    img = tmp_path / "bracketed.png"
+    img.write_bytes(b"img")
+
+    result = parse_pasted_file_paths(f"<{img}>")
+
+    assert result == [img.resolve()]

--- a/libs/cli/tests/unit_tests/test_input_parsing.py
+++ b/libs/cli/tests/unit_tests/test_input_parsing.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from deepagents_cli.input import parse_file_mentions
+from deepagents_cli.input import (
+    parse_file_mentions,
+    parse_pasted_file_paths,
+)
 
 
 def test_parse_file_mentions_with_chinese_sentence(
@@ -243,3 +246,46 @@ def test_parse_file_mentions_handles_bad_tilde_user(
     mock_console.print.assert_called_once()
     call_arg = mock_console.print.call_args[0][0]
     assert "nonexistentuser12345" in call_arg
+
+
+def test_parse_pasted_file_paths_with_quoted_paths(tmp_path: Path) -> None:
+    """Quoted dropped paths should resolve correctly."""
+    img = tmp_path / "my image.png"
+    img.write_bytes(b"img")
+
+    result = parse_pasted_file_paths(f'"{img}"')
+
+    assert result == [img.resolve()]
+
+
+def test_parse_pasted_file_paths_with_file_url(tmp_path: Path) -> None:
+    """`file://` dropped paths should be URL-decoded and resolved."""
+    img = tmp_path / "space name.png"
+    img.write_bytes(b"img")
+
+    result = parse_pasted_file_paths(f"file://{str(img).replace(' ', '%20')}")
+
+    assert result == [img.resolve()]
+
+
+def test_parse_pasted_file_paths_with_multiple_lines(tmp_path: Path) -> None:
+    """Multiple dropped paths separated by newlines should all resolve."""
+    first = tmp_path / "a.png"
+    second = tmp_path / "b.png"
+    first.write_bytes(b"a")
+    second.write_bytes(b"b")
+
+    result = parse_pasted_file_paths(f"{first}\n{second}")
+
+    assert result == [first.resolve(), second.resolve()]
+
+
+def test_parse_pasted_file_paths_returns_empty_for_text_payload() -> None:
+    """Normal prose should not be interpreted as dropped file paths."""
+    assert parse_pasted_file_paths("please inspect this image") == []
+
+
+def test_parse_pasted_file_paths_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    """Missing dropped files should fall back to regular text paste."""
+    missing = tmp_path / "missing.png"
+    assert parse_pasted_file_paths(str(missing)) == []


### PR DESCRIPTION
Add drag-and-drop image attachment to the CLI chat input. 

Dropping image files onto the terminal (or pasting their paths) encodes them as base64 and inserts `[image N]` placeholder tokens into the composer, treating each placeholder as an atomic unit for editing.