### PR TITLE
perf(cli): defer more heavy imports to speed up startup

### DIFF
--- a/libs/cli/deepagents_cli/image_utils.py
+++ b/libs/cli/deepagents_cli/image_utils.py
@@ -13,8 +13,6 @@ import sys
 import tempfile
 from dataclasses import dataclass
 
-from PIL import Image, UnidentifiedImageError
-
 logger = logging.getLogger(__name__)
 
 
@@ -73,6 +71,8 @@ def get_image_from_path(path: pathlib.Path) -> ImageData | None:
     Returns:
         `ImageData` when the file is a valid image, otherwise `None`.
     """
+    from PIL import Image, UnidentifiedImageError
+
     try:
         image_bytes = path.read_bytes()
         if not image_bytes:
@@ -107,6 +107,8 @@ def _get_macos_clipboard_image() -> ImageData | None:
     Returns:
         ImageData if an image is found, None otherwise.
     """
+    from PIL import Image, UnidentifiedImageError
+
     # Try pngpaste first (fast if installed)
     pngpaste_path = _get_executable("pngpaste")
     if pngpaste_path:
@@ -155,6 +157,8 @@ def _get_clipboard_via_osascript() -> ImageData | None:
     Returns:
         ImageData if an image is found, None otherwise.
     """
+    from PIL import Image, UnidentifiedImageError
+
     # Get osascript path - it's a macOS builtin so should always exist
     osascript_path = _get_executable("osascript")
     if not osascript_path:

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -1,20 +1,22 @@
 """Sandbox lifecycle management with provider abstraction."""
 
+from __future__ import annotations
+
 import os
 import shlex
 import string
-from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-
-from deepagents.backends.protocol import SandboxBackendProtocol
+from typing import TYPE_CHECKING
 
 from deepagents_cli.config import console, get_glyphs
-from deepagents_cli.integrations.daytona import DaytonaProvider
-from deepagents_cli.integrations.langsmith import LangSmithProvider
-from deepagents_cli.integrations.modal import ModalProvider
-from deepagents_cli.integrations.runloop import RunloopProvider
-from deepagents_cli.integrations.sandbox_provider import SandboxProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from deepagents.backends.protocol import SandboxBackendProtocol
+
+    from deepagents_cli.integrations.sandbox_provider import SandboxProvider
 
 
 def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) -> None:
@@ -162,12 +164,20 @@ def _get_provider(provider_name: str) -> SandboxProvider:
         ValueError: If provider_name is unknown
     """
     if provider_name == "daytona":
+        from deepagents_cli.integrations.daytona import DaytonaProvider
+
         return DaytonaProvider()
     if provider_name == "langsmith":
+        from deepagents_cli.integrations.langsmith import LangSmithProvider
+
         return LangSmithProvider()
     if provider_name == "modal":
+        from deepagents_cli.integrations.modal import ModalProvider
+
         return ModalProvider()
     if provider_name == "runloop":
+        from deepagents_cli.integrations.runloop import RunloopProvider
+
         return RunloopProvider()
     msg = (
         f"Unknown sandbox provider: {provider_name}. "

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -684,6 +684,17 @@ def cli_main() -> None:
     # DEEPAGENTS_LANGSMITH_PROJECT while shell commands use the
     # user's original LANGSMITH_PROJECT (via LocalShellBackend env).
 
+    # Fast path: print version without loading heavy dependencies
+    if len(sys.argv) == 2 and sys.argv[1] in {"-v", "--version"}:  # noqa: PLR2004  # argv length check for fast-path
+        try:
+            from importlib.metadata import version as _pkg_version
+
+            sdk_version = _pkg_version("deepagents")
+        except Exception:  # noqa: BLE001  # Best-effort SDK version lookup
+            sdk_version = "unknown"
+        print(f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}")  # noqa: T201  # CLI version output
+        sys.exit(0)
+
     # Check dependencies first
     check_cli_dependencies()
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -687,10 +687,16 @@ def cli_main() -> None:
     # Fast path: print version without loading heavy dependencies
     if len(sys.argv) == 2 and sys.argv[1] in {"-v", "--version"}:  # noqa: PLR2004  # argv length check for fast-path
         try:
-            from importlib.metadata import version as _pkg_version
+            from importlib.metadata import (
+                PackageNotFoundError,
+                version as _pkg_version,
+            )
 
             sdk_version = _pkg_version("deepagents")
-        except Exception:  # noqa: BLE001  # Best-effort SDK version lookup
+        except PackageNotFoundError:
+            sdk_version = "unknown"
+        except Exception:  # Best-effort SDK version lookup
+            logger.debug("Unexpected error looking up SDK version", exc_info=True)
             sdk_version = "unknown"
         print(f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}")  # noqa: T201  # CLI version output
         sys.exit(0)

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -1,21 +1,53 @@
 """Thread management using LangGraph's built-in checkpoint persistence."""
 
+from __future__ import annotations
+
 import logging
 import uuid
-from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
-import aiosqlite
-from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-from rich.table import Table
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
 
-from deepagents_cli.config import COLORS, console
+    import aiosqlite
+    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
 logger = logging.getLogger(__name__)
+
+_aiosqlite_patched = False
+
+
+def _patch_aiosqlite() -> None:
+    """Patch aiosqlite.Connection with `is_alive()` if missing.
+
+    Required by langgraph-checkpoint>=2.1.0.
+    See: https://github.com/langchain-ai/langgraph/issues/6583
+    """
+    global _aiosqlite_patched  # noqa: PLW0603  # Module-level flag requires global statement
+    if _aiosqlite_patched:
+        return
+
+    import aiosqlite as _aiosqlite
+
+    if not hasattr(_aiosqlite.Connection, "is_alive"):
+
+        def _is_alive(self: _aiosqlite.Connection) -> bool:
+            """Check if the connection is still alive.
+
+            Returns:
+                True if connection is alive, False otherwise.
+            """
+            return self._connection is not None
+
+        # Dynamically adding a method to aiosqlite.Connection at runtime.
+        # Type checkers can't understand this monkey-patch, so we suppress the
+        # "attr-defined" error that would otherwise be raised.
+        _aiosqlite.Connection.is_alive = _is_alive  # type: ignore[attr-defined]
+
+    _aiosqlite_patched = True
 
 
 class ThreadInfo(TypedDict):
@@ -32,25 +64,6 @@ class ThreadInfo(TypedDict):
 
     message_count: NotRequired[int]
     """Number of messages in the thread."""
-
-
-# Patch aiosqlite.Connection to add is_alive() method required by
-# langgraph-checkpoint>=2.1.0
-# See: https://github.com/langchain-ai/langgraph/issues/6583
-if not hasattr(aiosqlite.Connection, "is_alive"):
-
-    def _is_alive(self: aiosqlite.Connection) -> bool:
-        """Check if the connection is still alive.
-
-        Returns:
-            True if connection is alive, False otherwise.
-        """
-        return self._connection is not None
-
-    # Dynamically adding a method to aiosqlite.Connection at runtime.
-    # Type checkers can't understand this monkey-patch, so we suppress the
-    # "attr-defined" error that would otherwise be raised.
-    aiosqlite.Connection.is_alive = _is_alive  # type: ignore[attr-defined]
 
 
 def format_timestamp(iso_timestamp: str | None) -> str:
@@ -128,8 +141,12 @@ async def list_threads(
         List of `ThreadInfo` dicts with `thread_id`, `agent_name`,
             `updated_at`, and optionally `message_count`.
     """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
     db_path = str(get_db_path())
-    async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+    async with _aiosqlite.connect(db_path, timeout=30.0) as conn:
         # Return empty if table doesn't exist yet (fresh install)
         if not await _table_exists(conn, "checkpoints"):
             return []
@@ -167,6 +184,8 @@ async def list_threads(
 
         # Fetch message counts if requested
         if include_message_count and threads:
+            from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
             serde = JsonPlusSerializer()
             for thread in threads:
                 thread["message_count"] = await _count_messages_from_checkpoint(
@@ -229,8 +248,12 @@ async def get_most_recent(agent_name: str | None = None) -> str | None:
     Returns:
         Most recent thread_id or None if no threads exist.
     """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
     db_path = str(get_db_path())
-    async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+    async with _aiosqlite.connect(db_path, timeout=30.0) as conn:
         if not await _table_exists(conn, "checkpoints"):
             return None
 
@@ -259,8 +282,12 @@ async def get_thread_agent(thread_id: str) -> str | None:
     Returns:
         Agent name associated with the thread, or None if not found.
     """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
     db_path = str(get_db_path())
-    async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+    async with _aiosqlite.connect(db_path, timeout=30.0) as conn:
         if not await _table_exists(conn, "checkpoints"):
             return None
 
@@ -281,8 +308,12 @@ async def thread_exists(thread_id: str) -> bool:
     Returns:
         True if thread exists, False otherwise.
     """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
     db_path = str(get_db_path())
-    async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+    async with _aiosqlite.connect(db_path, timeout=30.0) as conn:
         if not await _table_exists(conn, "checkpoints"):
             return False
 
@@ -302,8 +333,12 @@ async def find_similar_threads(thread_id: str, limit: int = 3) -> list[str]:
     Returns:
         List of thread IDs that begin with the given prefix.
     """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
     db_path = str(get_db_path())
-    async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+    async with _aiosqlite.connect(db_path, timeout=30.0) as conn:
         if not await _table_exists(conn, "checkpoints"):
             return []
 
@@ -326,8 +361,12 @@ async def delete_thread(thread_id: str) -> bool:
     Returns:
         True if thread was deleted, False if not found.
     """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
     db_path = str(get_db_path())
-    async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+    async with _aiosqlite.connect(db_path, timeout=30.0) as conn:
         if not await _table_exists(conn, "checkpoints"):
             return False
 
@@ -342,12 +381,16 @@ async def delete_thread(thread_id: str) -> bool:
 
 
 @asynccontextmanager
-async def get_checkpointer() -> AsyncIterator[AsyncSqliteSaver]:
+async def get_checkpointer() -> AsyncIterator[Any]:
     """Get AsyncSqliteSaver for the global database.
 
     Yields:
         AsyncSqliteSaver instance for checkpoint persistence.
     """
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+    _patch_aiosqlite()
+
     async with AsyncSqliteSaver.from_conn_string(str(get_db_path())) as checkpointer:
         yield checkpointer
 
@@ -367,6 +410,10 @@ async def list_threads_command(
             When `None`, threads for all agents are shown.
         limit: Maximum number of threads to display.
     """
+    from rich.table import Table
+
+    from deepagents_cli.config import COLORS, console
+
     threads = await list_threads(agent_name, limit=limit, include_message_count=True)
 
     if not threads:
@@ -408,6 +455,8 @@ async def list_threads_command(
 
 async def delete_thread_command(thread_id: str) -> None:
     """CLI handler for: deepagents threads delete."""
+    from deepagents_cli.config import console
+
     deleted = await delete_thread(thread_id)
 
     if deleted:

--- a/libs/cli/deepagents_cli/tools.py
+++ b/libs/cli/deepagents_cli/tools.py
@@ -134,14 +134,21 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
     4. Cite sources by mentioning the page titles or URLs
     5. NEVER show the raw JSON to the user - always provide a formatted response
     """
-    import requests
-    from tavily import (
-        BadRequestError,
-        InvalidAPIKeyError,
-        MissingAPIKeyError,
-        UsageLimitExceededError,
-    )
-    from tavily.errors import ForbiddenError, TimeoutError as TavilyTimeoutError
+    try:
+        import requests
+        from tavily import (
+            BadRequestError,
+            InvalidAPIKeyError,
+            MissingAPIKeyError,
+            UsageLimitExceededError,
+        )
+        from tavily.errors import ForbiddenError, TimeoutError as TavilyTimeoutError
+    except ImportError as exc:
+        return {
+            "error": f"Required package not installed: {exc.name}. "
+            "Install with: pip install 'deepagents[cli]'",
+            "query": query,
+        }
 
     client = _get_tavily_client()
     if client is None:
@@ -198,8 +205,15 @@ def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
     3. Synthesize this into a clear, natural language response
     4. NEVER show the raw markdown to the user unless specifically requested
     """
-    import requests
-    from markdownify import markdownify
+    try:
+        import requests
+        from markdownify import markdownify
+    except ImportError as exc:
+        return {
+            "error": f"Required package not installed: {exc.name}. "
+            "Install with: pip install 'deepagents[cli]'",
+            "url": url,
+        }
 
     try:
         response = requests.get(

--- a/libs/cli/deepagents_cli/tools.py
+++ b/libs/cli/deepagents_cli/tools.py
@@ -1,24 +1,35 @@
 """Custom tools for the CLI agent."""
 
-from typing import Any, Literal
+from __future__ import annotations
 
-import requests
-from markdownify import markdownify
-from tavily import (
-    BadRequestError,
-    InvalidAPIKeyError,
-    MissingAPIKeyError,
-    TavilyClient,
-    UsageLimitExceededError,
-)
-from tavily.errors import ForbiddenError, TimeoutError as TavilyTimeoutError
+from typing import TYPE_CHECKING, Any, Literal
 
-from deepagents_cli.config import settings
+if TYPE_CHECKING:
+    from tavily import TavilyClient
 
-# Initialize Tavily client if API key is available
-tavily_client = (
-    TavilyClient(api_key=settings.tavily_api_key) if settings.has_tavily else None
-)
+_UNSET = object()
+_tavily_client: TavilyClient | object | None = _UNSET
+
+
+def _get_tavily_client() -> TavilyClient | None:
+    """Get or initialize the lazy Tavily client singleton.
+
+    Returns:
+        TavilyClient instance, or None if API key is not configured.
+    """
+    global _tavily_client  # noqa: PLW0603  # Module-level cache requires global statement
+    if _tavily_client is not _UNSET:
+        return _tavily_client  # type: ignore[return-value]  # narrowed by sentinel check
+
+    from deepagents_cli.config import settings
+
+    if settings.has_tavily:
+        from tavily import TavilyClient as _TavilyClient
+
+        _tavily_client = _TavilyClient(api_key=settings.tavily_api_key)
+    else:
+        _tavily_client = None
+    return _tavily_client
 
 
 def http_request(
@@ -42,6 +53,8 @@ def http_request(
     Returns:
         Dictionary with response data including status, headers, and content
     """
+    import requests
+
     try:
         kwargs: dict[str, Any] = {}
 
@@ -121,7 +134,17 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
     4. Cite sources by mentioning the page titles or URLs
     5. NEVER show the raw JSON to the user - always provide a formatted response
     """
-    if tavily_client is None:
+    import requests
+    from tavily import (
+        BadRequestError,
+        InvalidAPIKeyError,
+        MissingAPIKeyError,
+        UsageLimitExceededError,
+    )
+    from tavily.errors import ForbiddenError, TimeoutError as TavilyTimeoutError
+
+    client = _get_tavily_client()
+    if client is None:
         return {
             "error": "Tavily API key not configured. "
             "Please set TAVILY_API_KEY environment variable.",
@@ -129,7 +152,7 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
         }
 
     try:
-        return tavily_client.search(
+        return client.search(
             query,
             max_results=max_results,
             include_raw_content=include_raw_content,
@@ -175,6 +198,9 @@ def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
     3. Synthesize this into a clear, natural language response
     4. NEVER show the raw markdown to the user unless specifically requested
     """
+    import requests
+    from markdownify import markdownify
+
     try:
         response = requests.get(
             url,

--- a/libs/cli/deepagents_cli/widgets/__init__.py
+++ b/libs/cli/deepagents_cli/widgets/__init__.py
@@ -1,27 +1,9 @@
-"""Textual widgets for deepagents-cli."""
+"""Textual widgets for deepagents-cli.
 
-from __future__ import annotations
+Import directly from submodules, e.g.:
 
-from deepagents_cli.widgets.chat_input import ChatInput
-from deepagents_cli.widgets.messages import (
-    AppMessage,
-    AssistantMessage,
-    DiffMessage,
-    ErrorMessage,
-    ToolCallMessage,
-    UserMessage,
-)
-from deepagents_cli.widgets.status import StatusBar
-from deepagents_cli.widgets.welcome import WelcomeBanner
-
-__all__ = [
-    "AppMessage",
-    "AssistantMessage",
-    "ChatInput",
-    "DiffMessage",
-    "ErrorMessage",
-    "StatusBar",
-    "ToolCallMessage",
-    "UserMessage",
-    "WelcomeBanner",
-]
+    ```python
+    from deepagents_cli.widgets.chat_input import ChatInput
+    from deepagents_cli.widgets.messages import AssistantMessage
+    ```
+"""

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -20,13 +20,14 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
     from textual.events import Click
 
+    from deepagents_cli.sessions import ThreadInfo
+
 from deepagents_cli.config import (
     CharsetMode,
     _detect_charset_mode,
     build_langsmith_thread_url,
     get_glyphs,
 )
-from deepagents_cli.sessions import ThreadInfo, format_timestamp, list_threads
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +243,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             container = self.query_one(Vertical)
             container.styles.border = ("ascii", "green")
 
+        from deepagents_cli.sessions import list_threads
+
         try:
             self._threads = await list_threads(limit=20, include_message_count=True)
         except (OSError, sqlite3.Error) as exc:
@@ -409,6 +412,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         Returns:
             Rich-markup label string.
         """
+        from deepagents_cli.sessions import format_timestamp
+
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if selected else "  "
         tid = thread["thread_id"][:_COL_TID]

--- a/libs/cli/tests/unit_tests/test_exception_handling.py
+++ b/libs/cli/tests/unit_tests/test_exception_handling.py
@@ -72,9 +72,9 @@ class TestToolsExceptionHandling:
 
     def test_web_search_handles_tavily_usage_limit_error(self):
         """Test that web_search catches Tavily UsageLimitExceededError."""
-        with patch("deepagents_cli.tools.tavily_client") as mock_client:
-            mock_client.search.side_effect = UsageLimitExceededError("Rate limit")
-
+        mock_client = MagicMock()
+        mock_client.search.side_effect = UsageLimitExceededError("Rate limit")
+        with patch("deepagents_cli.tools._get_tavily_client", return_value=mock_client):
             result = web_search("test query")
 
         assert "error" in result
@@ -83,9 +83,9 @@ class TestToolsExceptionHandling:
 
     def test_web_search_handles_tavily_invalid_api_key(self):
         """Test that web_search catches Tavily InvalidAPIKeyError."""
-        with patch("deepagents_cli.tools.tavily_client") as mock_client:
-            mock_client.search.side_effect = InvalidAPIKeyError("Invalid key")
-
+        mock_client = MagicMock()
+        mock_client.search.side_effect = InvalidAPIKeyError("Invalid key")
+        with patch("deepagents_cli.tools._get_tavily_client", return_value=mock_client):
             result = web_search("test query")
 
         assert "error" in result
@@ -93,9 +93,9 @@ class TestToolsExceptionHandling:
 
     def test_web_search_handles_tavily_bad_request(self):
         """Test that web_search catches Tavily BadRequestError."""
-        with patch("deepagents_cli.tools.tavily_client") as mock_client:
-            mock_client.search.side_effect = BadRequestError("Bad request")
-
+        mock_client = MagicMock()
+        mock_client.search.side_effect = BadRequestError("Bad request")
+        with patch("deepagents_cli.tools._get_tavily_client", return_value=mock_client):
             result = web_search("test query")
 
         assert "error" in result
@@ -103,9 +103,9 @@ class TestToolsExceptionHandling:
 
     def test_web_search_handles_tavily_timeout(self):
         """Test that web_search catches Tavily TimeoutError."""
-        with patch("deepagents_cli.tools.tavily_client") as mock_client:
-            mock_client.search.side_effect = TavilyTimeoutError(30.0)
-
+        mock_client = MagicMock()
+        mock_client.search.side_effect = TavilyTimeoutError(30.0)
+        with patch("deepagents_cli.tools._get_tavily_client", return_value=mock_client):
             result = web_search("test query")
 
         assert "error" in result

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -44,7 +44,7 @@ def _patch_list_threads(threads: list[ThreadInfo] | None = None) -> Any:  # noqa
     """
     data = threads if threads is not None else MOCK_THREADS
     return patch(
-        "deepagents_cli.widgets.thread_selector.list_threads",
+        "deepagents_cli.sessions.list_threads",
         new_callable=AsyncMock,
         return_value=data,
     )
@@ -773,7 +773,7 @@ class TestThreadSelectorErrorHandling:
     async def test_list_threads_error_still_dismissable(self) -> None:
         """Database error should not crash; Escape still works."""
         with patch(
-            "deepagents_cli.widgets.thread_selector.list_threads",
+            "deepagents_cli.sessions.list_threads",
             new_callable=AsyncMock,
             side_effect=OSError("database is locked"),
         ):


### PR DESCRIPTION
Defer heavy third-party imports out of module-level scope so the CLI loads faster. Every function that needs these libraries now imports them at call time. Also adds a fast-path version check – `deepagents -v` / `--version` now prints and exits before any heavy imports are loaded.

Roughly another 50% time savings