### PR TITLE
fix(sdk): add default chunked upload/download to `BaseSandbox`

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -444,9 +444,7 @@ except PermissionError:
                 responses.append(FileUploadResponse(path=path))
             else:
                 log.warning("Failed to upload %s: %s", path, result.output)
-                responses.append(
-                    FileUploadResponse(path=path, error="permission_denied")
-                )
+                responses.append(FileUploadResponse(path=path, error="permission_denied"))
 
         return responses
 
@@ -467,8 +465,7 @@ except PermissionError:
             "p = pathlib.Path('" + file_path + "')\n"
             "p.parent.mkdir(parents=True, exist_ok=True)\n"
             "p.write_bytes(base64.b64decode(b64))\n"
-            "\" <<'__DEEPAGENTS_EOF__'\n"
-            + b64 + "\n"
+            "\" <<'__DEEPAGENTS_EOF__'\n" + b64 + "\n"
             "__DEEPAGENTS_EOF__"
         )
         return self.execute(cmd)
@@ -490,12 +487,7 @@ except PermissionError:
         tmp_b64 = file_path + ".__b64_tmp"
 
         # Ensure parent directory exists.
-        result = self.execute(
-            'python3 -c "'
-            "import pathlib; "
-            "pathlib.Path('" + file_path + "').parent.mkdir(parents=True, exist_ok=True)"
-            '"'
-        )
+        result = self.execute("python3 -c \"import pathlib; pathlib.Path('" + file_path + "').parent.mkdir(parents=True, exist_ok=True)\"")
         if result.exit_code != 0:
             return result
 
@@ -509,8 +501,7 @@ except PermissionError:
                 "chunk = sys.stdin.read().strip()\n"
                 "with open('" + tmp_b64 + "', 'a') as f:\n"
                 "    f.write(chunk)\n"
-                "\" <<'__DEEPAGENTS_EOF__'\n"
-                + chunk + "\n"
+                "\" <<'__DEEPAGENTS_EOF__'\n" + chunk + "\n"
                 "__DEEPAGENTS_EOF__"
             )
             result = self.execute(append_cmd)
@@ -555,25 +546,16 @@ except PermissionError:
 
         for path in paths:
             # Get file size to decide between single and chunked download.
-            size_cmd = (
-                'python3 -c "'
-                "import os; "
-                "print(os.path.getsize('" + path + "'))"
-                '"'
-            )
+            size_cmd = "python3 -c \"import os; print(os.path.getsize('" + path + "'))\""
             size_result = self.execute(size_cmd)
             if size_result.exit_code != 0:
-                responses.append(
-                    FileDownloadResponse(path=path, error="file_not_found")
-                )
+                responses.append(FileDownloadResponse(path=path, error="file_not_found"))
                 continue
 
             try:
                 file_size = int(size_result.output.strip())
             except ValueError:
-                responses.append(
-                    FileDownloadResponse(path=path, error="file_not_found")
-                )
+                responses.append(FileDownloadResponse(path=path, error="file_not_found"))
                 continue
 
             # Small files can be downloaded in one shot.
@@ -591,12 +573,7 @@ except PermissionError:
         Returns:
             FileDownloadResponse with content or error.
         """
-        cmd = (
-            'python3 -c "'
-            "import base64; "
-            "print(base64.b64encode(open('" + file_path + "', 'rb').read()).decode())"
-            '"'
-        )
+        cmd = "python3 -c \"import base64; print(base64.b64encode(open('" + file_path + "', 'rb').read()).decode())\""
         result = self.execute(cmd)
         if result.exit_code == 0 and result.output.strip():
             try:
@@ -606,9 +583,7 @@ except PermissionError:
                 return FileDownloadResponse(path=file_path, error="file_not_found")
         return FileDownloadResponse(path=file_path, error="file_not_found")
 
-    def _download_chunked(
-        self, file_path: str, file_size: int
-    ) -> FileDownloadResponse:
+    def _download_chunked(self, file_path: str, file_size: int) -> FileDownloadResponse:
         """Download a large file in chunks to avoid output truncation.
 
         Reads the file in fixed-size binary chunks inside the sandbox,

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -213,9 +213,7 @@ def test_upload_returns_error_on_failure() -> None:
 
     class FailingSandbox(MockSandbox):
         def execute(self, command: str) -> ExecuteResponse:
-            return ExecuteResponse(
-                output="some error", exit_code=1, truncated=False
-            )
+            return ExecuteResponse(output="some error", exit_code=1, truncated=False)
 
     sandbox = FailingSandbox()
     responses = sandbox.upload_files([("/fail.txt", b"content")])
@@ -235,12 +233,8 @@ def test_download_small_file() -> None:
             nonlocal call_count
             call_count += 1
             if "getsize" in command:
-                return ExecuteResponse(
-                    output=str(len(content)), exit_code=0, truncated=False
-                )
-            return ExecuteResponse(
-                output=b64_content, exit_code=0, truncated=False
-            )
+                return ExecuteResponse(output=str(len(content)), exit_code=0, truncated=False)
+            return ExecuteResponse(output=b64_content, exit_code=0, truncated=False)
 
     sandbox = DownloadSandbox()
     responses = sandbox.download_files(["/test.txt"])
@@ -275,9 +269,7 @@ def test_download_large_file_uses_chunks() -> None:
                 offset = int(offset_str)
                 chunk = full_content[offset : offset + chunk_size]
                 b64_chunk = base64.b64encode(chunk).decode("ascii")
-                return ExecuteResponse(
-                    output=b64_chunk, exit_code=0, truncated=False
-                )
+                return ExecuteResponse(output=b64_chunk, exit_code=0, truncated=False)
             return ExecuteResponse(output="", exit_code=0, truncated=False)
 
     sandbox = ChunkedDownloadSandbox()
@@ -295,9 +287,7 @@ def test_download_returns_error_for_missing_file() -> None:
 
     class MissingSandbox(MockSandbox):
         def execute(self, command: str) -> ExecuteResponse:
-            return ExecuteResponse(
-                output="FileNotFoundError", exit_code=1, truncated=False
-            )
+            return ExecuteResponse(output="FileNotFoundError", exit_code=1, truncated=False)
 
     sandbox = MissingSandbox()
     responses = sandbox.download_files(["/missing.txt"])

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -11,11 +11,7 @@ that need to be escaped as {{e}} for Python's .format() method.
 import base64
 import json
 
-from deepagents.backends.protocol import (
-    ExecuteResponse,
-    FileDownloadResponse,
-    FileUploadResponse,
-)
+from deepagents.backends.protocol import ExecuteResponse
 from deepagents.backends.sandbox import (
     _EDIT_COMMAND_TEMPLATE,
     _GLOB_COMMAND_TEMPLATE,

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -40,12 +40,6 @@ class MockSandbox(BaseSandbox):
         # Return "1" for edit commands (simulates 1 occurrence replaced)
         return ExecuteResponse(output="1", exit_code=0, truncated=False)
 
-    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        return [FileUploadResponse(path=f[0], error=None) for f in files]
-
-    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        return [FileDownloadResponse(path=p, content=None, error="not_implemented") for p in paths]
-
 
 def test_write_command_template_format() -> None:
     """Test that _WRITE_COMMAND_TEMPLATE can be formatted without KeyError."""
@@ -174,3 +168,144 @@ def test_sandbox_grep_literal_search() -> None:
     # Verify the command uses grep -rHnF for literal search (combined flags)
     assert sandbox.last_command is not None
     assert "grep -rHnF" in sandbox.last_command
+
+
+# -- Upload/download tests ------------------------------------------------
+
+
+def test_upload_small_file_uses_single_command() -> None:
+    """Test that small files are uploaded in a single execute() call."""
+    commands: list[str] = []
+
+    class TrackingSandbox(MockSandbox):
+        def execute(self, command: str) -> ExecuteResponse:
+            commands.append(command)
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+    sandbox = TrackingSandbox()
+    small_content = b"hello world"
+    sandbox.upload_files([("/test.txt", small_content)])
+
+    # Should be exactly one command (no chunking).
+    assert len(commands) == 1
+    assert "__DEEPAGENTS_EOF__" in commands[0]
+
+
+def test_upload_large_file_uses_chunked_commands() -> None:
+    """Test that large files are split into multiple execute() calls."""
+    commands: list[str] = []
+
+    class TrackingSandbox(MockSandbox):
+        def execute(self, command: str) -> ExecuteResponse:
+            commands.append(command)
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+    sandbox = TrackingSandbox()
+    # Create content larger than _UPLOAD_CHUNK_BYTES (64KB).
+    large_content = b"x" * 100_000
+    sandbox.upload_files([("/large.bin", large_content)])
+
+    # Should have: 1 mkdir + N chunk appends + 1 decode = more than 1 command.
+    assert len(commands) > 1
+    # Last command should be the decode step.
+    assert "base64.b64decode" in commands[-1]
+    assert "unlink" in commands[-1]
+
+
+def test_upload_returns_error_on_failure() -> None:
+    """Test that upload returns error when execute() fails."""
+
+    class FailingSandbox(MockSandbox):
+        def execute(self, command: str) -> ExecuteResponse:
+            return ExecuteResponse(
+                output="some error", exit_code=1, truncated=False
+            )
+
+    sandbox = FailingSandbox()
+    responses = sandbox.upload_files([("/fail.txt", b"content")])
+
+    assert len(responses) == 1
+    assert responses[0].error == "permission_denied"
+
+
+def test_download_small_file() -> None:
+    """Test downloading a small file in a single command."""
+    content = b"hello world"
+    b64_content = base64.b64encode(content).decode("ascii")
+    call_count = 0
+
+    class DownloadSandbox(MockSandbox):
+        def execute(self, command: str) -> ExecuteResponse:
+            nonlocal call_count
+            call_count += 1
+            if "getsize" in command:
+                return ExecuteResponse(
+                    output=str(len(content)), exit_code=0, truncated=False
+                )
+            return ExecuteResponse(
+                output=b64_content, exit_code=0, truncated=False
+            )
+
+    sandbox = DownloadSandbox()
+    responses = sandbox.download_files(["/test.txt"])
+
+    assert len(responses) == 1
+    assert responses[0].content == content
+    assert responses[0].error is None
+    # 1 size check + 1 download = 2 calls.
+    assert call_count == 2
+
+
+def test_download_large_file_uses_chunks() -> None:
+    """Test that large files are downloaded in multiple chunks."""
+    # 100KB file — larger than _DOWNLOAD_CHUNK_BYTES (64KB).
+    full_content = b"A" * 100_000
+    chunk_size = BaseSandbox._DOWNLOAD_CHUNK_BYTES
+    call_count = 0
+
+    class ChunkedDownloadSandbox(MockSandbox):
+        def execute(self, command: str) -> ExecuteResponse:
+            nonlocal call_count
+            call_count += 1
+            if "getsize" in command:
+                return ExecuteResponse(
+                    output=str(len(full_content)),
+                    exit_code=0,
+                    truncated=False,
+                )
+            if "f.seek" in command:
+                # Parse offset from the command.
+                offset_str = command.split("f.seek(")[1].split(")")[0]
+                offset = int(offset_str)
+                chunk = full_content[offset : offset + chunk_size]
+                b64_chunk = base64.b64encode(chunk).decode("ascii")
+                return ExecuteResponse(
+                    output=b64_chunk, exit_code=0, truncated=False
+                )
+            return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+    sandbox = ChunkedDownloadSandbox()
+    responses = sandbox.download_files(["/large.bin"])
+
+    assert len(responses) == 1
+    assert responses[0].content == full_content
+    assert responses[0].error is None
+    # 1 size check + 2 chunk downloads = 3 calls.
+    assert call_count == 3
+
+
+def test_download_returns_error_for_missing_file() -> None:
+    """Test that download returns error when file does not exist."""
+
+    class MissingSandbox(MockSandbox):
+        def execute(self, command: str) -> ExecuteResponse:
+            return ExecuteResponse(
+                output="FileNotFoundError", exit_code=1, truncated=False
+            )
+
+    sandbox = MissingSandbox()
+    responses = sandbox.download_files(["/missing.txt"])
+
+    assert len(responses) == 1
+    assert responses[0].error == "file_not_found"
+    assert responses[0].content is None


### PR DESCRIPTION
## Summary

- Add concrete `upload_files()` and `download_files()` implementations to `BaseSandbox`, replacing the current `@abstractmethod` stubs
- Small files (<64KB) use a single `execute()` call (same as before)
- Large files are split into 64KB base64 chunks to avoid hitting the Linux kernel `ARG_MAX` limit (~128KB per argument)
- Downloads also chunk to avoid `execute()` output truncation
- Methods are non-abstract so backends with native file transfer (SSH/SFTP, Daytona REST) can still override them

## Problem

When using sandbox backends that route file transfers through `execute()` (Docker with tmpfs, microsandbox), uploading binary files larger than ~100KB fails with:

```
exec /bin/bash: argument list too long
```

This happens because the base64-encoded file content is embedded in the command string passed to `exec_run()`, which exceeds the kernel's `ARG_MAX` limit. Docker's `put_archive` API cannot be used as a workaround because tmpfs mounts are invisible to it.

The error is particularly problematic for autonomous workflows that generate binary artifacts (PDFs, images) inside sandboxed containers.

## Solution

`BaseSandbox` already provides default implementations of `read()`, `write()`, `edit()`, `ls_info()`, `glob_info()`, and `grep_raw()` via `execute()`. This PR extends that pattern to `upload_files()` and `download_files()`:

- **Upload**: Files over 64KB are base64-encoded, split into chunks, each chunk appended to a temp file inside the sandbox via separate `execute()` calls, then the assembled base64 is decoded to the final path
- **Download**: Files over 64KB are read in binary chunks inside the sandbox, each chunk base64-encoded and returned via separate `execute()` calls, then reassembled on the host

All operations go through `execute()`, respecting the full middleware chain.

## Test plan

- [x] Unit tests: 6 new tests covering small file upload, large file chunking, upload error handling, small file download, large file chunked download, and missing file error
- [x] All 15 sandbox backend tests pass
- [x] Verified end-to-end with Docker backend: 301KB PDF upload/download roundtrip succeeds
- [x] Verified 1MB random binary roundtrip with byte-level fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)