### PR TITLE
fix(cli): escape `Rich` markup in shell command display

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1311,6 +1311,10 @@ class DeepAgentsApp(App):
                 image_tracker=self._image_tracker,
             )
         except Exception as e:  # noqa: BLE001  # Resilient tool rendering
+            # Ensure any in-flight tool calls don't remain stuck in "Running..."
+            # when streaming aborts before tool results arrive.
+            if self._ui_adapter:
+                self._ui_adapter.finalize_pending_tools_with_error(f"Agent error: {e}")
             await self._mount_message(ErrorMessage(f"Agent error: {e}"))
         finally:
             # Clean up loading widget and agent state

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -177,6 +177,23 @@ class TextualUIAdapter:
         """Set the token tracker for usage tracking."""
         self._token_tracker = tracker
 
+    def finalize_pending_tools_with_error(self, error: str) -> None:
+        """Mark all pending/running tool widgets as error and clear tracking.
+
+        This is used as a safety net when an unexpected exception aborts
+        streaming before matching `ToolMessage` results are received.
+
+        Args:
+            error: Error text to display in each pending tool widget.
+        """
+        for tool_msg in list(self._current_tool_messages.values()):
+            tool_msg.set_error(error)
+        self._current_tool_messages.clear()
+
+        # Clear active streaming message to avoid stale "active" state in the store.
+        if self._set_active_message:
+            self._set_active_message(None)
+
 
 def _build_interrupted_ai_message(
     pending_text_by_namespace: dict[tuple, str],

--- a/libs/cli/deepagents_cli/widgets/approval.py
+++ b/libs/cli/deepagents_cli/widgets/approval.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
 from textual.message import Message
@@ -149,10 +150,12 @@ class ApprovalMenu(Container):
         req = self._action_requests[0]
         command = str(req.get("args", {}).get("command", ""))
         if expanded or len(command) <= _SHELL_COMMAND_TRUNCATE_LENGTH:
-            return f"[bold #f59e0b]{command}[/bold #f59e0b]"
+            return f"[bold #f59e0b]{escape_markup(command)}[/bold #f59e0b]"
         truncated = command[:_SHELL_COMMAND_TRUNCATE_LENGTH] + get_glyphs().ellipsis
+        escaped_truncated = escape_markup(truncated)
         return (
-            f"[bold #f59e0b]{truncated}[/bold #f59e0b] [dim](press 'e' to expand)[/dim]"
+            f"[bold #f59e0b]{escaped_truncated}[/bold #f59e0b] "
+            "[dim](press 'e' to expand)[/dim]"
         )
 
     def compose(self) -> ComposeResult:

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -449,7 +449,7 @@ class ToolCallMessage(Vertical):
         Yields:
             Widgets for header, arguments, status, and output display.
         """
-        tool_label = format_tool_display(self._tool_name, self._args)
+        tool_label = escape_markup(format_tool_display(self._tool_name, self._args))
         yield Static(
             f"[bold #f59e0b]{tool_label}[/bold #f59e0b]",
             classes="tool-header",
@@ -463,7 +463,10 @@ class ToolCallMessage(Vertical):
                 )
                 if len(args) > _MAX_INLINE_ARGS:
                     args_str += ", ..."
-                yield Static(f"[dim]({args_str})[/dim]", classes="tool-args")
+                yield Static(
+                    f"[dim]({escape_markup(args_str)})[/dim]",
+                    classes="tool-args",
+                )
         # Status - shows running animation while pending, then final status
         yield Static("", classes="tool-status", id="status")
         # Output area - hidden initially, shown when output is set
@@ -1223,7 +1226,10 @@ class DiffMessage(Static):
             Widgets displaying the diff header and formatted content.
         """
         if self._file_path:
-            yield Static(f"[bold]File: {self._file_path}[/bold]", classes="diff-header")
+            yield Static(
+                f"[bold]File: {escape_markup(self._file_path)}[/bold]",
+                classes="diff-header",
+            )
 
         # Render the diff with enhanced formatting
         rendered = format_diff_textual(self._diff_content, max_lines=100)

--- a/libs/cli/tests/unit_tests/test_approval.py
+++ b/libs/cli/tests/unit_tests/test_approval.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from rich.markup import render
 
 from deepagents_cli.config import get_glyphs
 from deepagents_cli.widgets.approval import (
@@ -119,6 +120,14 @@ class TestGetCommandDisplay:
         assert menu._has_expandable_command is False
         display = menu._get_command_display(expanded=False)
         assert "12345" in display
+
+    def test_command_display_escapes_markup_tags(self) -> None:
+        """Shell command display should escape literal Rich tag sequences."""
+        command = "echo [/dim] [literal]"
+        menu = ApprovalMenu({"name": "shell", "args": {"command": command}})
+        display = menu._get_command_display(expanded=True)
+        rendered = render(display)
+        assert command in rendered.plain
 
 
 class TestToggleExpand:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -86,6 +86,27 @@ class TestTextualUIAdapterInit:
         adapter.set_token_tracker(mock_tracker)
         assert adapter._token_tracker is mock_tracker
 
+    def test_finalize_pending_tools_with_error_marks_and_clears(self) -> None:
+        """Pending tool widgets should be marked error and then cleared."""
+        set_active = MagicMock()
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_active_message=set_active,
+        )
+
+        tool_1 = MagicMock()
+        tool_2 = MagicMock()
+        adapter._current_tool_messages = {"a": tool_1, "b": tool_2}
+
+        adapter.finalize_pending_tools_with_error("Agent error: boom")
+
+        tool_1.set_error.assert_called_once_with("Agent error: boom")
+        tool_2.set_error.assert_called_once_with("Agent error: boom")
+        assert adapter._current_tool_messages == {}
+        set_active.assert_called_once_with(None)
+
 
 class TestBuildStreamConfig:
     """Tests for `_build_stream_config` metadata construction."""


### PR DESCRIPTION
Fixes a rendering crash when shell commands contain literal `Rich` tag-like text (for example `[/dim]`), which was being interpreted as markup instead of plain text.

**Before**  
`ApprovalMenu._get_command_display()` built a Rich-marked string by interpolating raw command text:

```python
f"[bold #f59e0b]{command}[/bold #f59e0b]"
```

If `command` contained `[` or `]` tag sequences, Rich parsed them.  

Example input:

```text
echo [/dim] [literal]
```

could raise:

```text
... closing tag '[/dim]' does not match any open tag
```

**After**  
`command` (and truncated command) is escaped before insertion into markup:

```python
f"[bold #f59e0b]{escape_markup(command)}[/bold #f59e0b]"
```

Result: Rich renders the command text literally, including bracket sequences, with no parse error.
