### PR TITLE
chore: auto-generate makefile help from target annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help: ## Show this help message
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 lock: ## Update all lockfiles
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,17 @@ PACKAGE_DIRS = libs/deepagents libs/cli libs/acp libs/harbor libs/partners/dayto
 # acp requires 3.14, everything else uses 3.12
 python_version = $(if $(filter libs/acp,$1),3.14,3.12)
 
-.PHONY: lock lock-check lint format
+.PHONY: help lock lock-check lint format
 
-lock:
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+lock: ## Update all lockfiles
 	@set -e; \
 	for dir in $(PACKAGE_DIRS); do \
 		echo "🔒 Locking $$dir"; \
@@ -14,7 +22,7 @@ lock:
 	done
 	@echo "✅ All lockfiles updated!"
 
-lock-check:
+lock-check: ## Check all lockfiles are up-to-date
 	@set -e; \
 	for dir in $(PACKAGE_DIRS); do \
 		echo "🔍 Checking $$dir"; \
@@ -22,7 +30,7 @@ lock-check:
 	done
 	@echo "✅ All lockfiles are up-to-date!"
 
-lint:
+lint: ## Lint all packages
 	@set -e; \
 	for dir in $(PACKAGE_DIRS); do \
 		echo "🔍 Linting $$dir"; \
@@ -30,7 +38,7 @@ lint:
 	done
 	@echo "✅ All packages linted!"
 
-format:
+format: ## Format all packages
 	@set -e; \
 	for dir in $(PACKAGE_DIRS); do \
 		echo "🎨 Formatting $$dir"; \

--- a/libs/acp/Makefile
+++ b/libs/acp/Makefile
@@ -43,7 +43,7 @@ format format_diff:
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/acp/Makefile
+++ b/libs/acp/Makefile
@@ -1,7 +1,6 @@
-.PHONY: all lint format test help
+.PHONY: lint format test help test_watch toad
 
-# Default target executed when no arguments are given to make.
-all: help
+.DEFAULT_GOAL := help
 
 ######################
 # TESTING AND COVERAGE
@@ -10,13 +9,13 @@ all: help
 # Define a variable for the test file path.
 TEST_FILE ?= tests/
 
-test:
+test: ## Run unit tests with coverage
 	uv run pytest --disable-socket --allow-unix-socket $(TEST_FILE) --timeout 10 --cov=deepagents_acp --cov-report=term-missing --cov-report=xml
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run ptw . -- $(TEST_FILE)
 
-toad:
+toad: ## Run toad ACP server
 	uv run toad acp 'bash ./run.sh'
 
 
@@ -28,28 +27,23 @@ toad:
 lint format: PYTHON_FILES=deepagents_acp/ tests/
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=. --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 
+lint: ## Run linters and type checker
 lint lint_diff:
 	[ "$(PYTHON_FILES)" = "" ] ||	uv run --group test ruff format $(PYTHON_FILES) --diff
 	[ "$(PYTHON_FILES)" = "" ] ||	uv run --group test ruff check $(PYTHON_FILES)
 	uv run --group test ty check deepagents_acp
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --group test ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --group test ruff check --fix $(PYTHON_FILES)
-
-
 
 ######################
 # HELP
 ######################
 
-help:
-	@echo '===================='
-	@echo '-- LINTING --'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters'
-	@echo '-- TESTS --'
-	@echo 'test                         - run unit tests'
-	@echo 'test_cov                     - run unit tests with coverage'
-	@echo 'test TEST_FILE=<test_file>   - run all tests in file'
-	@echo '-- DOCUMENTATION tasks are from the top-level Makefile --'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -46,7 +46,9 @@ run: ## Reinstall and run package
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/cli --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
+lint_package: ## Lint only the package
 lint_package: PYTHON_FILES=deepagents_cli
+lint_tests: ## Lint only tests
 lint_tests: PYTHON_FILES=tests
 
 lint: ## Run linters and type checker
@@ -72,7 +74,7 @@ check_imports: $(shell find deepagents_cli -name '*.py')
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -1,7 +1,6 @@
-.PHONY: all format lint type test tests integration_test integration_tests test_watch benchmark help run lint_package lint_tests check_imports coverage
+.PHONY: format lint type test tests integration_test integration_tests test_watch benchmark help run lint_package lint_tests check_imports coverage
 
-# Default target executed when no arguments are given to make.
-all: help
+.DEFAULT_GOAL := help
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -14,26 +13,28 @@ UV_FROZEN = true
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
+test: ## Run unit tests
 test tests:
 	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE)
 
-coverage:
+coverage: ## Run unit tests with coverage
 	uv run --group test pytest --cov \
 		--cov-config=.coveragerc \
 		--cov-report xml \
 		--cov-report term-missing:skip-covered \
 		$(TEST_FILE)
 
+integration_test: ## Run integration tests
 integration_test integration_tests:
 	uv run --group test pytest -n auto -vvv --timeout 30 $(TEST_FILE)
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)
 
-benchmark:
+benchmark: ## Run benchmark tests
 	uv run --group test pytest ./tests -m benchmark
 
-run:
+run: ## Reinstall and run package
 	uvx --no-cache --reinstall .
 
 
@@ -48,18 +49,21 @@ lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/cli --name-
 lint_package: PYTHON_FILES=deepagents_cli
 lint_tests: PYTHON_FILES=tests
 
+lint: ## Run linters and type checker
 lint lint_diff lint_package lint_tests:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES) --diff
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ty check $(PYTHON_FILES)
 
-type:
+type: ## Run type checker
 	uv run --all-groups ty check $(PYTHON_FILES)
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check --fix $(PYTHON_FILES)
 
+check_imports: ## Check imports
 check_imports: $(shell find deepagents_cli -name '*.py')
 	uv run --all-groups python ./scripts/check_imports.py $^
 
@@ -67,19 +71,8 @@ check_imports: $(shell find deepagents_cli -name '*.py')
 # HELP
 ######################
 
-help:
-	@echo '----'
-	@echo 'coverage                     - run unit tests and generate coverage report'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters'
-	@echo 'type                         - run type checking'
-	@echo 'check_imports                - check imports'
-	@echo 'lint_package                 - lint only the package'
-	@echo 'lint_tests                   - lint only tests'
-	@echo 'test                         - run unit tests'
-	@echo 'tests                        - run unit tests'
-	@echo 'test TEST_FILE=<test_file>   - run all tests in file'
-	@echo 'integration_test             - run integration tests'
-	@echo 'integration_tests            - run integration tests'
-	@echo 'test_watch                   - run tests in watch mode'
-	@echo 'benchmark                    - run benchmark tests'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/deepagents/Makefile
+++ b/libs/deepagents/Makefile
@@ -1,7 +1,6 @@
-.PHONY: all format lint test tests evals integration_test integration_tests test_watch benchmark help run lint_package lint_tests check_imports coverage typecheck update-snapshots
+.PHONY: format lint test tests evals integration_test integration_tests test_watch benchmark help run lint_package lint_tests check_imports coverage typecheck update-snapshots
 
-# Default target executed when no arguments are given to make.
-all: help
+.DEFAULT_GOAL := help
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -15,33 +14,35 @@ TEST_FILE ?= tests/unit_tests/
 SMOKE_TESTS ?= tests/unit_tests/smoke_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
+test: ## Run unit tests
 test tests:
 	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
 
-update-snapshots:
+update-snapshots: ## Update smoke test snapshots
 	# update snapshots for smoke tests
 	uv run --group test pytest -vvv --disable-socket --allow-unix-socket --update-snapshots $(SMOKE_TESTS)
 
-coverage:
+coverage: ## Run unit tests with coverage
 	uv run --group test pytest --cov \
 		--cov-config=.coveragerc \
 		--cov-report xml \
 		--cov-report term-missing:skip-covered \
 		$(TEST_FILE)
 
+integration_test: ## Run integration tests
 integration_test integration_tests:
 	uv run --group test pytest -n auto -vvv --timeout 30 $(TEST_FILE)
 
-evals:
-	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest -n auto tests/evals 
+evals: ## Run evals
+	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest -n auto tests/evals
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)
 
-benchmark:
+benchmark: ## Run benchmark tests
 	uv run --group test pytest ./tests -m benchmark
 
-run:
+run: ## Reinstall and run package
 	uvx --no-cache --reinstall .
 
 
@@ -56,18 +57,21 @@ lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/deepagents 
 lint_package: PYTHON_FILES=deepagents
 lint_tests: PYTHON_FILES=tests
 
+lint: ## Run linters and type checker
 lint lint_diff lint_package lint_tests:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES) --diff
 	uv run --all-groups ty check deepagents
 
-typecheck:
+typecheck: ## Run type checker
 	uv run --all-groups ty check deepagents
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check --fix $(PYTHON_FILES)
 
+check_imports: ## Check imports
 check_imports: $(shell find deepagents -name '*.py')
 	uv run --all-groups python ./scripts/check_imports.py $^
 
@@ -75,20 +79,8 @@ check_imports: $(shell find deepagents -name '*.py')
 # HELP
 ######################
 
-help:
-	@echo '----'
-	@echo 'coverage                     - run unit tests and generate coverage report'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters and type checker'
-	@echo 'typecheck                    - run type checker (ty)'
-	@echo 'check_imports                - check imports'
-	@echo 'lint_package                 - lint only the package'
-	@echo 'lint_tests                   - lint only tests'
-	@echo 'test                         - run unit tests'
-	@echo 'tests                        - run unit tests'
-	@echo 'test TEST_FILE=<test_file>   - run all tests in file'
-	@echo 'integration_test             - run integration tests'
-	@echo 'integration_tests            - run integration tests'
-	@echo 'evals                        - run eval scenarios (LangSmith test suite: deepagents-evals)'
-	@echo 'test_watch                   - run tests in watch mode'
-	@echo 'benchmark                    - run benchmark tests'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/deepagents/Makefile
+++ b/libs/deepagents/Makefile
@@ -54,7 +54,9 @@ run: ## Reinstall and run package
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/deepagents --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
+lint_package: ## Lint only the package
 lint_package: PYTHON_FILES=deepagents
+lint_tests: ## Lint only tests
 lint_tests: PYTHON_FILES=tests
 
 lint: ## Run linters and type checker
@@ -80,7 +82,7 @@ check_imports: $(shell find deepagents -name '*.py')
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/harbor/Makefile
+++ b/libs/harbor/Makefile
@@ -1,7 +1,6 @@
-.PHONY: all lint format test help run-hello-world run-terminal-bench-modal run-terminal-bench-docker
+.PHONY: lint format test help test_integration test_watch run-hello-world run-terminal-bench-modal run-terminal-bench-docker run-terminal-bench-daytona run-terminal-bench-runloop format_unsafe
 
-# Default target executed when no arguments are given to make.
-all: help
+.DEFAULT_GOAL := help
 
 ######################
 # TESTING AND COVERAGE
@@ -11,34 +10,34 @@ all: help
 TEST_FILE ?= tests/unit_tests
 INTEGRATION_FILES ?= tests/integration_tests
 
-test:
+test: ## Run unit tests
 	uv run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
-test_integration:
+test_integration: ## Run integration tests
 	uv run pytest $(INTEGRATION_FILES)
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run ptw . -- $(TEST_FILE)
 
 
 # Run jobs
-run-hello-world:
+run-hello-world: ## Run hello-world job
 	@mkdir -p jobs/hello-world
 	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset hello-world --task-name hello-world -n 1 --jobs-dir tmp/hello-world --env docker
 
-run-terminal-bench-modal:
+run-terminal-bench-modal: ## Run terminal-bench on Modal
 	@mkdir -p jobs/terminal-bench
 	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 4 --jobs-dir jobs/terminal-bench --env modal
 
-run-terminal-bench-daytona:
+run-terminal-bench-daytona: ## Run terminal-bench on Daytona
 	@mkdir -p jobs/terminal-bench
 	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 40 --jobs-dir jobs/terminal-bench --env daytona
 
-run-terminal-bench-docker:
+run-terminal-bench-docker: ## Run terminal-bench on Docker
 	@mkdir -p jobs/terminal-bench
 	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env docker
 
-run-terminal-bench-runloop:
+run-terminal-bench-runloop: ## Run terminal-bench on Runloop
 	@mkdir -p jobs/terminal-bench
 	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 10 --jobs-dir jobs/terminal-bench --env runloop
 
@@ -50,6 +49,7 @@ run-terminal-bench-runloop:
 lint format: PYTHON_FILES=deepagents_harbor/ tests/
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=. --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 
+lint: ## Run linters and type checker
 lint lint_diff:
 	[ "$(PYTHON_FILES)" = "" ] ||	uv run --group test ruff format $(PYTHON_FILES) --diff
 	@if [ "$(LINT)" != "minimal" ]; then \
@@ -59,24 +59,20 @@ lint lint_diff:
 	fi
 	[ "$(PYTHON_FILES)" = "" ] || uv run --group test ty check $(PYTHON_FILES)
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --group test ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --group test ruff check --fix $(PYTHON_FILES)
 
-format_unsafe:
+format_unsafe: ## Run formatters with unsafe fixes
 	[ "$(PYTHON_FILES)" = "" ] || uv run --group test ruff format --unsafe-fixes $(PYTHON_FILES)
-
 
 ######################
 # HELP
 ######################
 
-help:
-	@echo '===================='
-	@echo '-- LINTING --'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters'
-	@echo '-- TESTS --'
-	@echo 'test                         - run unit tests'
-	@echo 'test TEST_FILE=<test_file>   - run all tests in file'
-	@echo '-- DOCUMENTATION tasks are from the top-level Makefile --'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-28s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/harbor/Makefile
+++ b/libs/harbor/Makefile
@@ -72,7 +72,7 @@ format_unsafe: ## Run formatters with unsafe fixes
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-28s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/partners/daytona/Makefile
+++ b/libs/partners/daytona/Makefile
@@ -34,6 +34,7 @@ benchmark: ## Run benchmark tests
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/daytona --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
+lint_package: ## Lint only the package
 lint_package: PYTHON_FILES=langchain_daytona
 
 lint: ## Run linters and type checker
@@ -52,7 +53,7 @@ format format_diff:
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/partners/daytona/Makefile
+++ b/libs/partners/daytona/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all format lint test tests integration_test integration_tests test_watch benchmark help
+.PHONY: format lint test tests integration_test integration_tests test_watch benchmark help lint_package
 
-all: help
+.DEFAULT_GOAL := help
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -13,16 +13,18 @@ TEST_FILE ?= tests/unit_tests/
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
+test: ## Run unit tests
 test tests:
 	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
 
+integration_test: ## Run integration tests
 integration_test integration_tests:
 	uv run --group test pytest -vvv --timeout 30 $(TEST_FILE)
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)
 
-benchmark:
+benchmark: ## Run benchmark tests
 	uv run --group test pytest ./tests -m benchmark
 
 ######################
@@ -34,11 +36,13 @@ lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/daytona --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_daytona
 
+lint: ## Run linters and type checker
 lint lint_diff lint_package:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES) --diff
 	uv run --all-groups ty check langchain_daytona
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check --fix $(PYTHON_FILES)
@@ -47,12 +51,8 @@ format format_diff:
 # HELP
 ######################
 
-help:
-	@echo '----'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters'
-	@echo 'lint_package                 - lint only the package'
-	@echo 'test                         - run unit tests'
-	@echo 'integration_test             - run integration tests'
-	@echo 'test_watch                   - run tests in watch mode'
-	@echo 'benchmark                    - run benchmark tests'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/partners/modal/Makefile
+++ b/libs/partners/modal/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all format lint test tests integration_test integration_tests test_watch benchmark help
+.PHONY: format lint test tests integration_test integration_tests test_watch benchmark help lint_package
 
-all: help
+.DEFAULT_GOAL := help
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -13,16 +13,18 @@ TEST_FILE ?= tests/unit_tests/
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
+test: ## Run unit tests
 test tests:
 	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
 
+integration_test: ## Run integration tests
 integration_test integration_tests:
 	uv run --group test pytest -vvv --timeout 30 $(TEST_FILE)
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)
 
-benchmark:
+benchmark: ## Run benchmark tests
 	uv run --group test pytest ./tests -m benchmark
 
 ######################
@@ -34,11 +36,13 @@ lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/modal --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_modal
 
+lint: ## Run linters and type checker
 lint lint_diff lint_package:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES) --diff
 	uv run --all-groups ty check langchain_modal
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check --fix $(PYTHON_FILES)
@@ -47,12 +51,8 @@ format format_diff:
 # HELP
 ######################
 
-help:
-	@echo '----'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters'
-	@echo 'lint_package                 - lint only the package'
-	@echo 'test                         - run unit tests'
-	@echo 'integration_test             - run integration tests'
-	@echo 'test_watch                   - run tests in watch mode'
-	@echo 'benchmark                    - run benchmark tests'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/partners/modal/Makefile
+++ b/libs/partners/modal/Makefile
@@ -34,6 +34,7 @@ benchmark: ## Run benchmark tests
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/modal --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
+lint_package: ## Lint only the package
 lint_package: PYTHON_FILES=langchain_modal
 
 lint: ## Run linters and type checker
@@ -52,7 +53,7 @@ format format_diff:
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/partners/runloop/Makefile
+++ b/libs/partners/runloop/Makefile
@@ -34,6 +34,7 @@ benchmark: ## Run benchmark tests
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/runloop --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
+lint_package: ## Lint only the package
 lint_package: PYTHON_FILES=langchain_runloop
 
 lint: ## Run linters and type checker
@@ -52,7 +53,7 @@ format format_diff:
 ######################
 
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [TEST_FILE=path/to/tests/]"
 	@echo ""
 	@echo "Targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/libs/partners/runloop/Makefile
+++ b/libs/partners/runloop/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all format lint test tests integration_test integration_tests test_watch benchmark help
+.PHONY: format lint test tests integration_test integration_tests test_watch benchmark help lint_package
 
-all: help
+.DEFAULT_GOAL := help
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -13,16 +13,18 @@ TEST_FILE ?= tests/unit_tests/
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
+test: ## Run unit tests
 test tests:
 	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
 
+integration_test: ## Run integration tests
 integration_test integration_tests:
 	uv run --group test pytest -vvv --timeout 30 $(TEST_FILE)
 
-test_watch:
+test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)
 
-benchmark:
+benchmark: ## Run benchmark tests
 	uv run --group test pytest ./tests -m benchmark
 
 ######################
@@ -34,11 +36,13 @@ lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/runloop --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_runloop
 
+lint: ## Run linters and type checker
 lint lint_diff lint_package:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES) --diff
 	uv run --all-groups ty check langchain_runloop
 
+format: ## Run code formatters
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff format $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || uv run --all-groups ruff check --fix $(PYTHON_FILES)
@@ -47,12 +51,8 @@ format format_diff:
 # HELP
 ######################
 
-help:
-	@echo '----'
-	@echo 'format                       - run code formatters'
-	@echo 'lint                         - run linters'
-	@echo 'lint_package                 - lint only the package'
-	@echo 'test                         - run unit tests'
-	@echo 'integration_test             - run integration tests'
-	@echo 'test_watch                   - run tests in watch mode'
-	@echo 'benchmark                    - run benchmark tests'
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
Replace hand-maintained help targets across all `Makefile`s

The manual echo blocks were already drifting out of sync with actual targets