### PR TITLE
feat(cli): add AgentCore Code Interpreter as sandbox backend

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -133,7 +133,7 @@ def get_system_prompt(assistant_id: str, sandbox_type: str | None = None) -> str
     Args:
         assistant_id: The agent identifier for path references
         sandbox_type: Type of sandbox provider
-            (`'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
+            (`'agentcore'`, `'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
 
             If `None`, agent is operating in local mode.
 
@@ -397,7 +397,7 @@ def create_cli_agent(
 
             If `None`, uses local filesystem + shell.
         sandbox_type: Type of sandbox provider
-            (`'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
+            (`'agentcore'`, `'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
             Used for system prompt generation.
         system_prompt: Override the default system prompt.
 

--- a/libs/cli/deepagents_cli/integrations/bedrock_agentcore.py
+++ b/libs/cli/deepagents_cli/integrations/bedrock_agentcore.py
@@ -151,7 +151,7 @@ class AgentCoreBackend(BaseSandbox):
     @property
     def id(self) -> str:
         """Unique identifier for the sandbox backend (session ID)."""
-        return self._interpreter.session_id
+        return self._interpreter.session_id or ""
 
     def execute(
         self,

--- a/libs/cli/deepagents_cli/integrations/bedrock_agentcore.py
+++ b/libs/cli/deepagents_cli/integrations/bedrock_agentcore.py
@@ -1,0 +1,335 @@
+"""AgentCore Code Interpreter sandbox backend implementation.
+
+This module provides a sandbox backend that uses AWS Bedrock AgentCore
+Code Interpreter for remote code execution.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import TYPE_CHECKING, Any
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+from deepagents.backends.sandbox import BaseSandbox
+
+from deepagents_cli.integrations.sandbox_provider import SandboxProvider
+
+if TYPE_CHECKING:
+    from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+    from deepagents.backends.protocol import SandboxBackendProtocol
+
+logger = logging.getLogger(__name__)
+
+# Default session timeout from AgentCore SDK
+DEFAULT_TIMEOUT = 900  # 15 minutes (can be extended up to 8 hours)
+
+
+def _extract_text_from_stream(response: dict[str, Any]) -> tuple[str, int | None]:
+    """Extract text output and exit code from code interpreter response stream.
+
+    Args:
+        response: Response dict from code interpreter invocation
+
+    Returns:
+        Tuple of (output_text, exit_code)
+    """
+    output_parts: list[str] = []
+    exit_code: int | None = None
+
+    for event in response.get("stream", []):
+        if "result" in event:
+            result = event["result"]
+
+            # Check for exit code in result metadata
+            if "exitCode" in result:
+                exit_code = result["exitCode"]
+
+            for content_item in result.get("content", []):
+                content_type = content_item.get("type")
+
+                if content_type == "text":
+                    text = content_item.get("text", "")
+                    output_parts.append(text)
+
+                elif content_type == "error":
+                    error_msg = content_item.get("text", "Unknown error")
+                    output_parts.append(f"Error: {error_msg}")
+                    if exit_code is None:
+                        exit_code = 1
+
+    return "\n".join(output_parts), exit_code
+
+
+def _extract_files_from_stream(response: dict[str, Any]) -> dict[str, bytes]:
+    """Extract file contents from code interpreter response stream.
+
+    Parses the structured JSON response to extract file paths and contents.
+
+    Args:
+        response: Response dict from code interpreter readFiles invocation
+
+    Returns:
+        Dict mapping file paths to their contents as bytes
+    """
+    files: dict[str, bytes] = {}
+
+    for event in response.get("stream", []):
+        if "result" in event:
+            for content_item in event["result"].get("content", []):
+                if content_item.get("type") == "resource":
+                    resource = content_item.get("resource", {})
+                    uri = resource.get("uri", "")
+                    file_path = uri.replace("file://", "")
+
+                    if "text" in resource:
+                        files[file_path] = resource["text"].encode("utf-8")
+                    elif "blob" in resource:
+                        files[file_path] = base64.b64decode(resource["blob"])
+
+    return files
+
+
+class AgentCoreBackend(BaseSandbox):
+    """AgentCore Code Interpreter backend implementing SandboxBackendProtocol.
+
+    Uses AWS Bedrock AgentCore Code Interpreter to execute shell commands
+    and manage files in a secure, isolated MicroVM environment.
+
+    Session Behavior:
+        - Files created during a session persist for the session lifetime
+        - Session timeout defaults to 15 minutes (configurable up to 8 hours)
+        - Each session runs in an isolated MicroVM with dedicated resources
+
+    Note:
+        Reconnecting to a previous session (e.g., after CLI restart) is not
+        currently supported. The --sandbox-id option cannot be used with
+        AgentCore. However, within a single CLI session, all file operations
+        work normally - files written can be read back throughout the session.
+
+    Example:
+        ```python
+        from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+
+        interpreter = CodeInterpreter(
+                    region=self._region,
+                    integration_source="deepagents-cli",
+                )
+        interpreter.start()
+
+        backend = AgentCoreBackend(interpreter)
+
+        # Write a file
+        backend.upload_files([("hello.py", b"print('hello')")])
+
+        # Read it back (works within same session)
+        files = backend.download_files(["hello.py"])
+
+        # Execute it
+        result = backend.execute("python hello.py")
+
+        interpreter.stop()
+        ```
+    """
+
+    # Integration source identifier for telemetry tracking
+    INTEGRATION_SOURCE = "deepagents-cli"
+
+    def __init__(self, interpreter: CodeInterpreter) -> None:
+        """Initialize the AgentCoreBackend with a CodeInterpreter instance.
+
+        Args:
+            interpreter: Active CodeInterpreter instance (must be started)
+        """
+        self._interpreter = interpreter
+        self._timeout: int = DEFAULT_TIMEOUT  # 15 minutes
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for the sandbox backend (session ID)."""
+        return self._interpreter.session_id
+
+    def execute(
+            self,
+            command: str,
+            *,
+            timeout: int | None = None,  # noqa: ARG002
+        ) -> ExecuteResponse:
+        """Execute a shell command in the sandbox.
+
+        Args:
+            command: Shell command string to execute
+            timeout: Maximum execution time in seconds (unused —
+                AgentCore does not support per-command timeouts).
+
+        Returns:
+            ExecuteResponse with output, exit code, and truncation flag
+        """
+        try:
+            response = self._interpreter.invoke(
+                method="executeCommand", params={"command": command}
+            )
+
+            output, exit_code = _extract_text_from_stream(response)
+
+            return ExecuteResponse(
+                output=output,
+                exit_code=exit_code if exit_code is not None else 0,
+                truncated=False,
+            )
+        except Exception as e:
+            logger.exception("Error executing command: %s", command[:50])
+            return ExecuteResponse(
+                output=f"Error executing command: {e}",
+                exit_code=1,
+                truncated=False,
+            )
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Download files from the AgentCore sandbox.
+
+        Uses AgentCore's readFiles API. Supports partial success - individual
+        file downloads may fail without affecting others.
+
+        Args:
+            paths: List of file paths to download
+
+        Returns:
+            List of FileDownloadResponse objects in same order as input paths
+        """
+        try:
+            response = self._interpreter.invoke(
+                            method="readFiles", params={"paths": paths}
+                        )
+
+            # Parse structured JSON response
+            file_contents = _extract_files_from_stream(response)
+
+            # Build responses in order of input paths
+            return [
+                FileDownloadResponse(
+                    path=path,
+                    content=file_contents.get(path),
+                    error=None if path in file_contents else "file_not_found",
+                )
+                for path in paths
+            ]
+
+        except Exception:
+            logger.exception("Error downloading files: %s", paths)
+            return [
+                FileDownloadResponse(path=path, content=None, error="file_not_found")
+                for path in paths
+            ]
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload files to the AgentCore sandbox.
+
+        Uses AgentCore's writeFiles API. Text files are supported directly.
+        Binary files are base64 encoded.
+
+        Args:
+            files: List of (path, content) tuples to upload
+
+        Returns:
+            List of FileUploadResponse objects in same order as input files
+        """
+        file_list: list[dict[str, str]] = []
+
+        for path, content in files:
+            try:
+                # Try to decode as text first
+                text_content = content.decode("utf-8")
+                file_list.append({"path": path, "text": text_content})
+            except UnicodeDecodeError:
+                # Binary content - base64 encode
+                encoded = base64.b64encode(content).decode("ascii")
+                file_list.append({"path": path, "blob": encoded})
+
+        try:
+            if file_list:
+                self._interpreter.invoke(
+                                    method="writeFiles", params={"content": file_list}
+                                )
+            # All files uploaded successfully
+            return [FileUploadResponse(path=path, error=None) for path, _ in files]
+
+        except Exception:
+            logger.exception("Error uploading files")
+            return [
+                            FileUploadResponse(path=path, error="permission_denied")
+                            for path, _ in files
+                        ]
+
+
+class AgentCoreProvider(SandboxProvider):
+    """AgentCore Code Interpreter sandbox provider.
+
+    Manages AgentCore session lifecycle. Sessions cannot be reconnected
+    after the CLI exits — the ``sandbox_id`` parameter is not supported.
+    """
+
+    def __init__(self, region: str | None = None) -> None:
+        """Initialize AgentCore provider.
+
+        Args:
+            region: AWS region (defaults to AWS_REGION / AWS_DEFAULT_REGION / us-west-2)
+        """
+        import os
+
+        self._region = region or os.environ.get(
+            "AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+        )
+
+    def get_or_create(
+        self,
+        *,
+        sandbox_id: str | None = None,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> SandboxBackendProtocol:
+        """Create a new AgentCore Code Interpreter session.
+
+        Args:
+            sandbox_id: Not supported — raises NotImplementedError if provided.
+            **kwargs: Additional parameters (unused).
+
+        Returns:
+            AgentCoreBackend instance
+
+        Raises:
+            NotImplementedError: If sandbox_id is provided.
+        """
+        if sandbox_id:
+            msg = (
+                "AgentCore does not support reconnecting to existing sessions. "
+                "Remove the --sandbox-id option."
+            )
+            raise NotImplementedError(msg)
+
+        from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+
+        interpreter = CodeInterpreter(
+            region=self._region,
+            integration_source=AgentCoreBackend.INTEGRATION_SOURCE,
+        )
+        interpreter.start()
+        return AgentCoreBackend(interpreter)
+
+    def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002, PLR6301
+        """Stop an AgentCore session.
+
+        Note: AgentCore sessions are identified by internal session IDs
+        and cannot be reconnected. This is a best-effort cleanup.
+
+        Args:
+            sandbox_id: Session ID (used for logging only).
+            **kwargs: Additional parameters (unused).
+        """
+        logger.info(
+                    "AgentCore session %s cleanup requested (sessions auto-expire)",
+                    sandbox_id,
+                )

--- a/libs/cli/deepagents_cli/integrations/bedrock_agentcore.py
+++ b/libs/cli/deepagents_cli/integrations/bedrock_agentcore.py
@@ -116,9 +116,9 @@ class AgentCoreBackend(BaseSandbox):
         from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
 
         interpreter = CodeInterpreter(
-                    region=self._region,
-                    integration_source="deepagents-cli",
-                )
+            region=self._region,
+            integration_source="deepagents-cli",
+        )
         interpreter.start()
 
         backend = AgentCoreBackend(interpreter)
@@ -154,11 +154,11 @@ class AgentCoreBackend(BaseSandbox):
         return self._interpreter.session_id
 
     def execute(
-            self,
-            command: str,
-            *,
-            timeout: int | None = None,  # noqa: ARG002
-        ) -> ExecuteResponse:
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,  # noqa: ARG002
+    ) -> ExecuteResponse:
         """Execute a shell command in the sandbox.
 
         Args:
@@ -203,8 +203,8 @@ class AgentCoreBackend(BaseSandbox):
         """
         try:
             response = self._interpreter.invoke(
-                            method="readFiles", params={"paths": paths}
-                        )
+                method="readFiles", params={"paths": paths}
+            )
 
             # Parse structured JSON response
             file_contents = _extract_files_from_stream(response)
@@ -253,17 +253,17 @@ class AgentCoreBackend(BaseSandbox):
         try:
             if file_list:
                 self._interpreter.invoke(
-                                    method="writeFiles", params={"content": file_list}
-                                )
+                    method="writeFiles", params={"content": file_list}
+                )
             # All files uploaded successfully
             return [FileUploadResponse(path=path, error=None) for path, _ in files]
 
         except Exception:
             logger.exception("Error uploading files")
             return [
-                            FileUploadResponse(path=path, error="permission_denied")
-                            for path, _ in files
-                        ]
+                FileUploadResponse(path=path, error="permission_denied")
+                for path, _ in files
+            ]
 
 
 class AgentCoreProvider(SandboxProvider):
@@ -330,6 +330,6 @@ class AgentCoreProvider(SandboxProvider):
             **kwargs: Additional parameters (unused).
         """
         logger.info(
-                    "AgentCore session %s cleanup requested (sessions auto-expire)",
-                    sandbox_id,
-                )
+            "AgentCore session %s cleanup requested (sessions auto-expire)",
+            sandbox_id,
+        )

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -57,6 +57,7 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
 
 
 _PROVIDER_TO_WORKING_DIR = {
+    "agentcore": "/tmp",  # noqa: S108
     "daytona": "/home/daytona",
     "langsmith": "/tmp",  # noqa: S108  # LangSmith sandbox working directory
     "modal": "/workspace",
@@ -155,7 +156,8 @@ def _get_provider(provider_name: str) -> SandboxProvider:
     """Get a SandboxProvider instance for the specified provider (internal).
 
     Args:
-        provider_name: Name of the provider ("daytona", "langsmith", "modal", "runloop")
+        provider_name: Name of the provider
+                    ("agentcore", "daytona", "langsmith", "modal", "runloop")
 
     Returns:
         SandboxProvider instance
@@ -163,6 +165,11 @@ def _get_provider(provider_name: str) -> SandboxProvider:
     Raises:
         ValueError: If provider_name is unknown
     """
+    if provider_name == "agentcore":
+        from deepagents_cli.integrations.bedrock_agentcore import AgentCoreProvider
+
+        return AgentCoreProvider()
+
     if provider_name == "daytona":
         from deepagents_cli.integrations.daytona import DaytonaProvider
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -369,7 +369,7 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument(
         "--sandbox",
-        choices=["none", "modal", "daytona", "runloop", "langsmith"],
+        choices=["none", "modal", "daytona", "runloop", "langsmith", "agentcore"],
         default="none",
         metavar="TYPE",
         help="Remote sandbox for code execution (default: none - local only)",

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "daytona>=0.113.0,<1.0.0",
     "modal>=0.65.0,<2.0.0",
     "runloop-api-client>=0.69.0",
+    "bedrock-agentcore>=1.1.4",
 
     # Tools
     "tavily-python>=0.7.21,<1.0.0",

--- a/libs/cli/tests/integration_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/integration_tests/test_sandbox_factory.py
@@ -326,3 +326,12 @@ class TestLangSmithIntegration(BaseSandboxIntegrationTest):
         """Provide a LangSmith sandbox instance."""
         with create_sandbox("langsmith") as sandbox:
             yield sandbox
+
+class TestAgentCoreIntegration(BaseSandboxIntegrationTest):
+    """Test AgentCore Code Interpreter backend integration."""
+
+    @pytest.fixture()
+    def sandbox(self) -> Generator[SandboxBackendProtocol, None, None]:
+        """Provide an AgentCore sandbox instance."""
+        with create_sandbox("agentcore") as sandbox:
+            yield sandbox

--- a/libs/cli/tests/integration_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/integration_tests/test_sandbox_factory.py
@@ -327,11 +327,12 @@ class TestLangSmithIntegration(BaseSandboxIntegrationTest):
         with create_sandbox("langsmith") as sandbox:
             yield sandbox
 
+
 class TestAgentCoreIntegration(BaseSandboxIntegrationTest):
     """Test AgentCore Code Interpreter backend integration."""
 
-    @pytest.fixture()
-    def sandbox(self) -> Generator[SandboxBackendProtocol, None, None]:
+    @pytest.fixture(scope="class")
+    def sandbox(self) -> Iterator[BaseSandbox]:
         """Provide an AgentCore sandbox instance."""
         with create_sandbox("agentcore") as sandbox:
             yield sandbox

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -244,6 +244,25 @@ wheels = [
 ]
 
 [[package]]
+name = "bedrock-agentcore"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/aa/12f4ac520a2ccd685b802f42c963701f39cd8b172ab63f1366c4a6d0be91/bedrock_agentcore-1.3.1.tar.gz", hash = "sha256:ef6bfa78c78618e3dc3862fae4c265ca96279076f99925e1c27a82b6c4022e94", size = 419755, upload-time = "2026-02-17T21:04:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4f/ec1c6eff5c269910ca1a56031ee489bb8885fd1fe0359b59e989c1d6cbac/bedrock_agentcore-1.3.1-py3-none-any.whl", hash = "sha256:763ca3bdadac24633d1cbcb286372ccc773004c4dab66697a920e463cd476355", size = 121546, upload-time = "2026-02-17T21:04:29.853Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.46"
 source = { registry = "https://pypi.org/simple" }
@@ -896,6 +915,7 @@ version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "bedrock-agentcore" },
     { name = "daytona" },
     { name = "deepagents" },
     { name = "langchain" },
@@ -1010,6 +1030,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0,<1.0.0" },
+    { name = "bedrock-agentcore", specifier = ">=1.1.4" },
     { name = "daytona", specifier = ">=0.113.0,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-cli", extras = ["anthropic", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
@@ -4389,6 +4410,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "synchronicity"
 version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4812,6 +4846,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/c8/929d81665d83f0b2ffaecb8e66c3091a50f62c7cb5b65e678bd75a96684e/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cdbd82ff20147461caefc375551595ecf77ebb384e46267f128aca45a0f2cdfc", size = 467029, upload-time = "2026-01-20T20:37:08.277Z" },
     { url = "https://files.pythonhosted.org/packages/8e/a0/27d7daa1bfed7163f4ccaf52d7d2f4ad7bb1002a85b45077938b91ee584f/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff57e8a5d540006ce73cf0841a643d445afe78ba12e75ac53a95ca2924a56be", size = 333298, upload-time = "2026-01-20T20:37:07.271Z" },
     { url = "https://files.pythonhosted.org/packages/63/d4/acad86ce012b42ce18a12f31ee2aa3cbeeb98664f865f05f68c882945913/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3fd9112ca96978361201e669729784f26c71fecc9c13a7f8a07162c31bd4d1e2", size = 359217, upload-time = "2026-01-20T20:36:59.687Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -228,6 +228,53 @@ wheels = [
 ]
 
 [[package]]
+name = "bedrock-agentcore"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/aa/12f4ac520a2ccd685b802f42c963701f39cd8b172ab63f1366c4a6d0be91/bedrock_agentcore-1.3.1.tar.gz", hash = "sha256:ef6bfa78c78618e3dc3862fae4c265ca96279076f99925e1c27a82b6c4022e94", size = 419755, upload-time = "2026-02-17T21:04:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4f/ec1c6eff5c269910ca1a56031ee489bb8885fd1fe0359b59e989c1d6cbac/bedrock_agentcore-1.3.1-py3-none-any.whl", hash = "sha256:763ca3bdadac24633d1cbcb286372ccc773004c4dab66697a920e463cd476355", size = 121546, upload-time = "2026-02-17T21:04:29.853Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/ef/03460914019db52301a6084460f0dd738f3f9e89d2ddf5bd33cef8168e63/boto3-1.42.53.tar.gz", hash = "sha256:56bc79388763995852b6d3fe48023e661e63fc2e60a921273c422d0171b9fbfb", size = 112812, upload-time = "2026-02-19T20:33:58.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/ea/08dfba25a5822a7254b20aa905a9937177ca1532dd7f47c926875dd87299/boto3-1.42.53-py3-none-any.whl", hash = "sha256:3bd32f3508a6e9851671d0ef3b1f9e8ee7e8c095aa0488bcd9e86074aef5b7eb", size = 140555, upload-time = "2026-02-19T20:33:55.691Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/b6/0b2ab38e422e93f28b7a394a29881a9d767b79831fa1957a3ccab996a70e/botocore-1.42.53.tar.gz", hash = "sha256:0bc1a2e1b6ae4c8397c9bede3bb9007b4f16e159ef2ca7f24837e31d5860caac", size = 14918644, upload-time = "2026-02-19T20:33:44.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/dc/cf3b2ec4a419b20d2cd6ba8e1961bc59b7ec9801339628e31551dac23801/botocore-1.42.53-py3-none-any.whl", hash = "sha256:1255db56bc0a284a8caa182c20966277e6c8871b6881cf816d40e993fa5da503", size = 14589472, upload-time = "2026-02-19T20:33:40.377Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +775,7 @@ version = "0.0.23"
 source = { directory = "../cli" }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "bedrock-agentcore" },
     { name = "daytona" },
     { name = "deepagents" },
     { name = "langchain" },
@@ -753,6 +801,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0,<1.0.0" },
+    { name = "bedrock-agentcore", specifier = ">=1.1.4" },
     { name = "daytona", specifier = ">=0.113.0,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-cli", extras = ["anthropic", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
@@ -1480,6 +1529,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -3390,6 +3448,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/51/c6/2db8e00403503a6dbb220a226ccbcd9328711f7cef9e3464ad210a8e1c55/runloop_api_client-1.7.0.tar.gz", hash = "sha256:a22f79208c37cda775386a66b0621c1d902a2e264238d0ac7b9163f5ed28b6c5", size = 581178, upload-time = "2026-02-05T20:42:12.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/73/979df5289e75ce097a450613ffdfc7fd62c82cbac376db6e74c4eefc2e44/runloop_api_client-1.7.0-py3-none-any.whl", hash = "sha256:6eb1b0182daa171373d632c13095aa8e0a7b78c856b53cad302e47b662ead260", size = 352633, upload-time = "2026-02-05T20:42:14.248Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #519

---

- Add AgentCoreBackend and AgentCoreProvider following SandboxProvider pattern
- Register agentcore in sandbox_factory and CLI sandbox choices
- Add bedrock-agentcore dependency to pyproject.toml

Adds AWS Bedrock AgentCore Code Interpreter as a new sandbox provider for the Deep Agents CLI, alongside the existing Modal, Daytona, Runloop, and LangSmith providers.

**Changes:**
- New file `bedrock_agentcore.py`: `AgentCoreBackend` (implements `SandboxBackendProtocol` via `BaseSandbox`) and `AgentCoreProvider` (implements `SandboxProvider`) using the `bedrock-agentcore` SDK's `CodeInterpreter` client
- `sandbox_factory.py`: Register `"agentcore"` in `_PROVIDER_TO_WORKING_DIR` and `_get_provider()`
- `main.py`: Add `"agentcore"` to `--sandbox` CLI choices
- `agent.py`: Add `"agentcore"` to sandbox_type docstrings
- `test_sandbox_factory.py`: Add `TestAgentCoreIntegration` test class
- `pyproject.toml`: Add `bedrock-agentcore>=1.1.4` dependency

**Usage:**
```bash
deepagents --sandbox agentcore --model anthropic:claude-sonnet-4-5-20250929

Requires AWS credentials configured via environment variables or AWS CLI profile.

How I verified: Ran ruff check on all modified files (passing). Ran pytest tests/unit_tests/ (1229 passed; pre-existing failures unrelated to this change). Manually tested sandbox creation, command execution (pwd), file write, and file read via the CLI with a live AgentCore session.