### PR TITLE
feat(cli): add single-click link opening for rich-style hyperlinks

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1797,8 +1797,9 @@ class DeepAgentsApp(App):
         """Restore chat input focus when the terminal regains OS focus.
 
         When the user opens a link via `webbrowser.open`, OS focus shifts to
-        the browser. On returning (e.g. Alt+Tab), Textual fires `AppFocus`.
-        Re-focusing the chat input here keeps the input ready for typing.
+        the browser. On returning to the terminal, Textual fires `AppFocus`
+        (requires a terminal that supports FocusIn events). Re-focusing the chat
+        input here keeps it ready for typing.
         """
         if not self._chat_input:
             return

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1793,6 +1793,21 @@ class DeepAgentsApp(App):
             event.prevent_default()
             event.stop()
 
+    def on_app_focus(self) -> None:
+        """Restore chat input focus when the terminal regains OS focus.
+
+        When the user opens a link via `webbrowser.open`, OS focus shifts to
+        the browser. On returning (e.g. Alt+Tab), Textual fires `AppFocus`.
+        Re-focusing the chat input here keeps the input ready for typing.
+        """
+        if not self._chat_input:
+            return
+        if isinstance(self.screen, ModalScreen):
+            return
+        if self._pending_approval_widget:
+            return
+        self._chat_input.focus_input()
+
     def on_click(self, _event: Click) -> None:
         """Handle clicks anywhere in the terminal to focus on the command line."""
         if not self._chat_input:

--- a/libs/cli/deepagents_cli/widgets/_links.py
+++ b/libs/cli/deepagents_cli/widgets/_links.py
@@ -1,0 +1,38 @@
+"""Shared link-click handling for Textual widgets."""
+
+from __future__ import annotations
+
+import logging
+import webbrowser
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from textual.events import Click
+
+logger = logging.getLogger(__name__)
+
+
+def open_style_link(event: Click) -> None:
+    """Open the URL from a Rich link style on click, if present.
+
+    Rich `Style(link=...)` embeds OSC 8 terminal hyperlinks, but Textual's
+    mouse capture intercepts normal clicks before the terminal can act on them.
+    By handling the Textual click event directly we open the URL with a single
+    click, matching the behavior of links in the Markdown widget.
+
+    On success the event is stopped so it does not bubble further. On failure
+    (e.g. no browser available in a headless environment) the error is logged at
+    debug level and the event bubbles normally.
+
+    Args:
+        event: The Textual click event to inspect.
+    """
+    url = event.style.link
+    if not url:
+        return
+    try:
+        webbrowser.open(url)
+    except Exception:
+        logger.debug("Could not open browser for URL: %s", url, exc_info=True)
+        return
+    event.stop()

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -6,6 +6,7 @@ import ast
 import json
 import logging
 import re
+import webbrowser
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
@@ -1278,6 +1279,13 @@ class ErrorMessage(Static):
 class AppMessage(Static):
     """Widget displaying an app message."""
 
+    # Disable Textual's auto_links to prevent a flicker cycle. When auto_links
+    # is enabled, hovering over a link combines styles via Rich's
+    # Style.__add__, which generates a new random link ID each time. Textual
+    # sees the new ID as a style change, repaints, and the cycle repeats on
+    # every mouse event — causing visible flicker.
+    auto_links = False
+
     DEFAULT_CSS = """
     AppMessage {
         height: auto;
@@ -1302,3 +1310,15 @@ class AppMessage(Static):
             message if isinstance(message, Text) else Text(message, style="dim italic")
         )
         super().__init__(content, **kwargs)
+
+    def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
+        """Open Rich-style hyperlinks on single click.
+
+        Rich `Style(link=...)` produces OSC 8 terminal hyperlinks that require
+        Ctrl+Click in most terminals. By intercepting the Textual click event we
+        open the URL directly, matching the single-click behavior of links
+        rendered by the Markdown widget.
+        """
+        if event.style.link:
+            webbrowser.open(event.style.link)
+            event.stop()

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-import webbrowser
 from typing import TYPE_CHECKING, ClassVar
 
 from rich.style import Style
@@ -29,6 +28,7 @@ from deepagents_cli.config import (
     build_langsmith_thread_url,
     get_glyphs,
 )
+from deepagents_cli.widgets._links import open_style_link
 
 logger = logging.getLogger(__name__)
 
@@ -540,11 +540,10 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         """Open Rich-style hyperlinks on single click.
 
         `ThreadOption` clicks are already stopped before bubbling here, so this
-        only fires for non-option widgets such as the title.
+        only fires for non-option widgets such as the title. Non-link clicks
+        bubble normally.
         """
-        if event.style.link:
-            webbrowser.open(event.style.link)
-            event.stop()
+        open_style_link(event)
 
     def on_thread_option_clicked(self, event: ThreadOption.Clicked) -> None:
         """Handle click on a thread option.

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+import webbrowser
 from typing import TYPE_CHECKING, ClassVar
 
 from rich.style import Style
@@ -534,6 +535,16 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         if self._threads:
             thread_id = self._threads[self._selected_index]["thread_id"]
             self.dismiss(thread_id)
+
+    def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
+        """Open Rich-style hyperlinks on single click.
+
+        `ThreadOption` clicks are already stopped before bubbling here, so this
+        only fires for non-option widgets such as the title.
+        """
+        if event.style.link:
+            webbrowser.open(event.style.link)
+            event.stop()
 
     def on_thread_option_clicked(self, event: ThreadOption.Clicked) -> None:
         """Handle click on a thread option.

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -707,6 +707,66 @@ class TestRunAgentTaskImageTracker:
             assert any("Agent error: boom" in str(w._content) for w in errors)
 
 
+class TestAppFocusRestoresChatInput:
+    """Test `on_app_focus` restores chat input focus after terminal regains focus."""
+
+    @pytest.mark.asyncio
+    async def test_app_focus_restores_chat_input(self) -> None:
+        """Regaining terminal focus should re-focus the chat input."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+
+            # Blur the input to simulate focus loss from webbrowser.open
+            app._chat_input._text_area.blur()
+            await pilot.pause()
+
+            app.on_app_focus()
+            await pilot.pause()
+
+            # chat_input.focus_input should have been called
+            assert app._chat_input._text_area.has_focus
+
+    @pytest.mark.asyncio
+    async def test_app_focus_skips_when_modal_open(self) -> None:
+        """Regaining focus should not steal focus from an open modal."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Push a modal screen
+            from deepagents_cli.widgets.thread_selector import ThreadSelectorScreen
+
+            screen = ThreadSelectorScreen(current_thread=None)
+            app.push_screen(screen)
+            await pilot.pause()
+
+            assert isinstance(app.screen, ModalScreen)
+
+            # on_app_focus should be a no-op with modal open
+            with patch.object(app._chat_input, "focus_input") as mock_focus:
+                app.on_app_focus()
+
+            mock_focus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_app_focus_skips_when_approval_pending(self) -> None:
+        """Regaining focus should not steal focus from the approval widget."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+
+            # Simulate a pending approval widget
+            app._pending_approval_widget = MagicMock()
+
+            with patch.object(app._chat_input, "focus_input") as mock_focus:
+                app.on_app_focus()
+
+            mock_focus.assert_not_called()
+
+
 class TestPasteRouting:
     """Tests app-level paste routing when chat input focus lags."""
 

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -347,6 +347,9 @@ class TestAppMessageAutoLinksDisabled:
         assert AppMessage.auto_links is False
 
 
+_WEBBROWSER_OPEN = "deepagents_cli.widgets._links.webbrowser.open"
+
+
 class TestAppMessageOnClickOpensLink:
     """Tests for `AppMessage.on_click` opening Rich-style hyperlinks."""
 
@@ -356,7 +359,7 @@ class TestAppMessageOnClickOpensLink:
         event = MagicMock()
         event.style = Style(link="https://example.com")
 
-        with patch("webbrowser.open") as mock_open:
+        with patch(_WEBBROWSER_OPEN) as mock_open:
             msg.on_click(event)
 
         mock_open.assert_called_once_with("https://example.com")
@@ -368,8 +371,19 @@ class TestAppMessageOnClickOpensLink:
         event = MagicMock()
         event.style = Style()
 
-        with patch("webbrowser.open") as mock_open:
+        with patch(_WEBBROWSER_OPEN) as mock_open:
             msg.on_click(event)
 
         mock_open.assert_not_called()
+        event.stop.assert_not_called()
+
+    def test_click_with_browser_error_is_graceful(self) -> None:
+        """Browser failure should not crash the widget."""
+        msg = AppMessage("test")
+        event = MagicMock()
+        event.style = Style(link="https://example.com")
+
+        with patch(_WEBBROWSER_OPEN, side_effect=OSError("no display")):
+            msg.on_click(event)  # should not raise
+
         event.stop.assert_not_called()

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -1,7 +1,10 @@
 """Unit tests for message widgets markup safety."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from rich.markup import render
+from rich.style import Style
 from rich.text import Text
 
 from deepagents_cli.config import COLORS
@@ -334,3 +337,39 @@ class TestQueuedUserMessageModeRendering:
         """`QueuedUserMessage('')` should not crash and should render `'> '`."""
         text = _compose_text(QueuedUserMessage(""))
         assert text.plain == "> "
+
+
+class TestAppMessageAutoLinksDisabled:
+    """Tests that `auto_links` is disabled to prevent hover flicker."""
+
+    def test_auto_links_is_false(self) -> None:
+        """`AppMessage` should disable Textual's `auto_links`."""
+        assert AppMessage.auto_links is False
+
+
+class TestAppMessageOnClickOpensLink:
+    """Tests for `AppMessage.on_click` opening Rich-style hyperlinks."""
+
+    def test_click_on_link_opens_browser(self) -> None:
+        """Clicking a Rich link should call `webbrowser.open`."""
+        msg = AppMessage("test")
+        event = MagicMock()
+        event.style = Style(link="https://example.com")
+
+        with patch("webbrowser.open") as mock_open:
+            msg.on_click(event)
+
+        mock_open.assert_called_once_with("https://example.com")
+        event.stop.assert_called_once()
+
+    def test_click_without_link_is_noop(self) -> None:
+        """Clicking on non-link text should not open the browser."""
+        msg = AppMessage("test")
+        event = MagicMock()
+        event.style = Style()
+
+        with patch("webbrowser.open") as mock_open:
+            msg.on_click(event)
+
+        mock_open.assert_not_called()
+        event.stop.assert_not_called()

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -1,6 +1,6 @@
 """Unit tests for the welcome banner widget."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from rich.style import Style
 from rich.text import Text
@@ -173,3 +173,39 @@ class TestBuildBannerReturnType:
         widget = _make_banner(thread_id="abc")
         result = widget._build_banner()
         assert isinstance(result, Text)
+
+
+class TestAutoLinksDisabled:
+    """Tests that `auto_links` is disabled to prevent hover flicker."""
+
+    def test_auto_links_is_false(self) -> None:
+        """`WelcomeBanner` should disable Textual's `auto_links`."""
+        assert WelcomeBanner.auto_links is False
+
+
+class TestOnClickOpensLink:
+    """Tests for `WelcomeBanner.on_click` opening Rich-style hyperlinks."""
+
+    def test_click_on_link_opens_browser(self) -> None:
+        """Clicking a Rich link should call `webbrowser.open`."""
+        widget = _make_banner(thread_id="abc")
+        event = MagicMock()
+        event.style = Style(link="https://example.com")
+
+        with patch("deepagents_cli.widgets.welcome.webbrowser.open") as mock_open:
+            widget.on_click(event)
+
+        mock_open.assert_called_once_with("https://example.com")
+        event.stop.assert_called_once()
+
+    def test_click_without_link_is_noop(self) -> None:
+        """Clicking on non-link text should not open the browser."""
+        widget = _make_banner(thread_id="abc")
+        event = MagicMock()
+        event.style = Style()
+
+        with patch("deepagents_cli.widgets.welcome.webbrowser.open") as mock_open:
+            widget.on_click(event)
+
+        mock_open.assert_not_called()
+        event.stop.assert_not_called()

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -183,6 +183,9 @@ class TestAutoLinksDisabled:
         assert WelcomeBanner.auto_links is False
 
 
+_WEBBROWSER_OPEN = "deepagents_cli.widgets._links.webbrowser.open"
+
+
 class TestOnClickOpensLink:
     """Tests for `WelcomeBanner.on_click` opening Rich-style hyperlinks."""
 
@@ -192,7 +195,7 @@ class TestOnClickOpensLink:
         event = MagicMock()
         event.style = Style(link="https://example.com")
 
-        with patch("deepagents_cli.widgets.welcome.webbrowser.open") as mock_open:
+        with patch(_WEBBROWSER_OPEN) as mock_open:
             widget.on_click(event)
 
         mock_open.assert_called_once_with("https://example.com")
@@ -204,8 +207,19 @@ class TestOnClickOpensLink:
         event = MagicMock()
         event.style = Style()
 
-        with patch("deepagents_cli.widgets.welcome.webbrowser.open") as mock_open:
+        with patch(_WEBBROWSER_OPEN) as mock_open:
             widget.on_click(event)
 
         mock_open.assert_not_called()
+        event.stop.assert_not_called()
+
+    def test_click_with_browser_error_is_graceful(self) -> None:
+        """Browser failure should not crash the widget."""
+        widget = _make_banner(thread_id="abc")
+        event = MagicMock()
+        event.style = Style(link="https://example.com")
+
+        with patch(_WEBBROWSER_OPEN, side_effect=OSError("no display")):
+            widget.on_click(event)  # should not raise
+
         event.stop.assert_not_called()


### PR DESCRIPTION
Rich-style hyperlinks (OSC 8) require Ctrl+Click in most terminals, which is unintuitive. This adds single-click link opening across screens by intercepting Textual click events and calling `webbrowser.open` directly. Also restores chat input focus after the browser steals it.