### PR TITLE
feat(cli): display model name and context window size using `/tokens`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1188,10 +1188,16 @@ class DeepAgentsApp(App):
                 # Get model information
                 model_name = settings.model_name or "Unknown"
                 context_limit = settings.model_context_limit
-                context_size_str = f"{context_limit:,} tokens" if context_limit is not None else "Unknown"
+                if context_limit is not None:
+                    context_size_str = f"{context_limit:,} tokens"
+                else:
+                    context_size_str = "Unknown"
 
                 await self._mount_message(
-                    AppMessage(f"Current context: {formatted} tokens + {model_name} context window size: {context_size_str}")
+                    AppMessage(
+                        f"Current context: {formatted} tokens + {model_name} "
+                        f"context window size: {context_size_str}"
+                    )
                 )
             else:
                 await self._mount_message(AppMessage("No token usage yet"))

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1184,8 +1184,14 @@ class DeepAgentsApp(App):
                     formatted = f"{count / 1000:.1f}K"
                 else:
                     formatted = str(count)
+
+                # Get model information
+                model_name = settings.model_name or "Unknown"
+                context_limit = settings.model_context_limit
+                context_size_str = f"{context_limit:,} tokens" if context_limit is not None else "Unknown"
+
                 await self._mount_message(
-                    AppMessage(f"Current context: {formatted} tokens")
+                    AppMessage(f"Current context: {formatted} tokens + {model_name} context window size: {context_size_str}")
                 )
             else:
                 await self._mount_message(AppMessage("No token usage yet"))

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -97,6 +97,22 @@ _ITERM_CURSOR_GUIDE_OFF = "\x1b]1337;HighlightCursorLine=no\x1b\\"
 _ITERM_CURSOR_GUIDE_ON = "\x1b]1337;HighlightCursorLine=yes\x1b\\"
 
 
+def _format_token_count(count: int) -> str:
+    """Format a token count into a human-readable short string.
+
+    Args:
+        count: Number of tokens.
+
+    Returns:
+        Formatted string like `"12.5K"`, `"1.2M"`, or `"500"`.
+    """
+    if count >= 1_000_000:  # noqa: PLR2004
+        return f"{count / 1_000_000:.1f}M"
+    if count >= 1000:  # noqa: PLR2004
+        return f"{count / 1000:.1f}K"
+    return str(count)
+
+
 def _write_iterm_escape(sequence: str) -> None:
     """Write an iTerm2 escape sequence to stderr.
 
@@ -1180,25 +1196,21 @@ class DeepAgentsApp(App):
             await self._mount_message(UserMessage(command))
             if self._token_tracker and self._token_tracker.current_context > 0:
                 count = self._token_tracker.current_context
-                if count >= 1000:  # noqa: SIM108, PLR2004  # Readability over ternary for count formatting
-                    formatted = f"{count / 1000:.1f}K"
-                else:
-                    formatted = str(count)
+                formatted = _format_token_count(count)
 
-                # Get model information
-                model_name = settings.model_name or "Unknown"
+                model_name = settings.model_name
                 context_limit = settings.model_context_limit
-                if context_limit is not None:
-                    context_size_str = f"{context_limit:,} tokens"
-                else:
-                    context_size_str = "Unknown"
 
-                await self._mount_message(
-                    AppMessage(
-                        f"Current context: {formatted} tokens + {model_name} "
-                        f"context window size: {context_size_str}"
-                    )
-                )
+                if context_limit is not None:
+                    limit_str = _format_token_count(context_limit)
+                    pct = count / context_limit * 100
+                    usage = f"{formatted} / {limit_str} tokens ({pct:.0f}%)"
+                else:
+                    usage = f"{formatted} tokens used"
+
+                msg = f"{model_name} · {usage}" if model_name else usage
+
+                await self._mount_message(AppMessage(msg))
             else:
                 await self._mount_message(AppMessage("No token usage yet"))
         elif cmd == "/remember" or cmd.startswith("/remember "):

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1208,7 +1208,7 @@ class DeepAgentsApp(App):
                 else:
                     usage = f"{formatted} tokens used"
 
-                msg = f"{model_name} · {usage}" if model_name else usage
+                msg = f"{usage} · {model_name}" if model_name else usage
 
                 await self._mount_message(AppMessage(msg))
             else:


### PR DESCRIPTION
This PR enhances the /tokens CLI command by displaying the active model's name and its total context window size alongside current usage. This provides users with better visibility into how much of the model's capacity is remaining.

Fixes #1434

Checklist Verification
 Ran make format, make lint and make test.
 Verified that {MODEL_NAME} and {SIZE} are pulled correctly from settings.
 Tested the /tokens command locally using different model profiles. Verified that the context limit correctly displays with comma    formatting (e.g., 200,000) and falls back to "Unknown" if the metadata is missing in the settings profile.

