### PR TITLE
fix(cli): clipboard image paste fallback

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1114,7 +1114,7 @@ class DeepAgentsApp(App):
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))
             help_text = Text(
-                "Commands: /quit, /clear, /model [--default], /remember, "
+                "Commands: /quit, /clear, /image, /model [--default], /remember, "
                 "/tokens, /threads, /trace, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
@@ -1131,6 +1131,8 @@ class DeepAgentsApp(App):
 
         elif cmd in {"/changelog", "/docs", "/feedback"}:
             await self._open_url_command(command, cmd)
+        elif cmd == "/image":
+            await self._handle_image_command(command)
         elif cmd == "/version":
             await self._mount_message(UserMessage(command))
             # Show CLI and SDK package versions
@@ -1261,6 +1263,22 @@ class DeepAgentsApp(App):
                 pass
 
         self.call_after_refresh(_scroll_after_command)
+
+    async def _handle_image_command(self, command: str) -> None:
+        """Handle the /image command to paste an image from the clipboard.
+
+        Args:
+            command: The raw command text.
+        """
+        await self._mount_message(UserMessage(command))
+        if self._chat_input and self._chat_input._try_attach_clipboard_image():
+            await self._mount_message(AppMessage("Image attached from clipboard."))
+        else:
+            await self._mount_message(
+                AppMessage(
+                    "No image found on clipboard. Copy an image first, then run /image."
+                )
+            )
 
     async def _handle_user_message(self, message: str) -> None:
         """Handle a user message to send to the agent.

--- a/libs/cli/deepagents_cli/local_context.py
+++ b/libs/cli/deepagents_cli/local_context.py
@@ -436,7 +436,7 @@ class LocalContextMiddleware(AgentMiddleware):
         # (and should not) redeclare it.
         raw_event = state.get("_summarization_event")
         if raw_event is not None:
-            event: SummarizationEvent = raw_event  # type: ignore[assignment]
+            event: SummarizationEvent = raw_event
             cutoff = event.get("cutoff_index")
             refreshed_cutoff = state.get("_local_context_refreshed_at_cutoff")
             if cutoff != refreshed_cutoff:

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -98,6 +98,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/clear", "Clear chat and start new thread"),
     ("/docs", "Open documentation in browser"),
     ("/feedback", "Submit a bug report or feature request"),
+    ("/image", "Paste image from clipboard"),
     ("/model", "Switch model, show selector, or set default (--default)"),
     ("/remember", "Update memory and skills from conversation"),
     ("/quit", "Exit app"),

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -103,7 +103,7 @@ class TestToolCallMessageMarkupSafety:
 
         # `task` has no inline args widget, so this validates the header markup.
         header = next(iter(msg.compose()))
-        content = header._Static__content  # type: ignore[attr-defined]
+        content = header._Static__content
         assert isinstance(content, str)
         rendered = render(content)
         assert "[/dim]" in rendered.plain


### PR DESCRIPTION
Wire up the existing `get_clipboard_image()` as a fallback when a paste
event has empty text (the behavior in Cursor's terminal). Add `/image`
slash command as an explicit alternative.

Closes #1432