### PR TITLE
fix(cli): load root-level `AGENTS.md` into agent system prompt

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -466,9 +466,7 @@ def create_cli_agent(
     # Add memory middleware
     if enable_memory:
         memory_sources = [str(settings.get_user_agent_md_path(assistant_id))]
-        project_agent_md = settings.get_project_agent_md_path()
-        if project_agent_md:
-            memory_sources.append(str(project_agent_md))
+        memory_sources.extend(str(p) for p in settings.get_project_agent_md_path())
 
         agent_middleware.append(
             MemoryMiddleware(

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -564,17 +564,18 @@ class Settings:
         """
         return Path.home() / ".deepagents" / agent_name / "AGENTS.md"
 
-    def get_project_agent_md_path(self) -> Path | None:
-        """Get project-level AGENTS.md path.
+    def get_project_agent_md_path(self) -> list[Path]:
+        """Get project-level AGENTS.md paths.
 
-        Returns path regardless of whether the file exists.
+        Checks both `{project_root}/.deepagents/AGENTS.md` and
+        `{project_root}/AGENTS.md`, returning all that exist.
 
         Returns:
-            Path to {project_root}/.deepagents/AGENTS.md, or None if not in a project
+            List of paths to project AGENTS.md files (may contain 0, 1, or 2 paths).
         """
         if not self.project_root:
-            return None
-        return self.project_root / ".deepagents" / "AGENTS.md"
+            return []
+        return _find_project_agent_md(self.project_root)
 
     @staticmethod
     def _is_valid_agent_name(agent_name: str) -> bool:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -356,20 +356,22 @@ def _find_project_agent_md(project_root: Path) -> list[Path]:
         project_root: Path to the project root directory.
 
     Returns:
-        List of paths to project AGENTS.md files (may contain 0, 1, or 2 paths).
+        Existing AGENTS.md paths.
+
+            Empty if neither file exists, one entry if only one is present, or
+            two entries if both locations have the file.
     """
-    paths = []
-
-    # Check .deepagents/AGENTS.md (preferred)  # noqa: ERA001
-    deepagents_md = project_root / ".deepagents" / "AGENTS.md"
-    if deepagents_md.exists():
-        paths.append(deepagents_md)
-
-    # Check root AGENTS.md (fallback, but also include if both exist)
-    root_md = project_root / "AGENTS.md"
-    if root_md.exists():
-        paths.append(root_md)
-
+    candidates = [
+        project_root / ".deepagents" / "AGENTS.md",
+        project_root / "AGENTS.md",
+    ]
+    paths: list[Path] = []
+    for candidate in candidates:
+        try:
+            if candidate.exists():
+                paths.append(candidate)
+        except OSError:
+            pass
     return paths
 
 
@@ -568,10 +570,16 @@ class Settings:
         """Get project-level AGENTS.md paths.
 
         Checks both `{project_root}/.deepagents/AGENTS.md` and
-        `{project_root}/AGENTS.md`, returning all that exist.
+        `{project_root}/AGENTS.md`, returning all that exist. If both are
+        present, both are loaded and their instructions are combined, with
+        `.deepagents/AGENTS.md` first.
 
         Returns:
-            List of paths to project AGENTS.md files (may contain 0, 1, or 2 paths).
+            Existing AGENTS.md paths.
+
+                Empty if neither file exists or not in a project, one entry if
+                only one is present, or two entries if both locations have the
+                file.
         """
         if not self.project_root:
             return []

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -467,7 +467,7 @@ class TestCreateCliAgentSkillsSources:
         mock_settings.get_project_skills_dir.return_value = None
         mock_settings.get_built_in_skills_dir.return_value = built_in_dir
         mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
-        mock_settings.get_project_agent_md_path.return_value = None
+        mock_settings.get_project_agent_md_path.return_value = []
         mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
         mock_settings.get_project_agents_dir.return_value = None
         # Needed by get_system_prompt() which formats model identity

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -507,3 +507,131 @@ class TestCreateCliAgentSkillsSources:
         assert sources[0] == str(built_in_dir)
         # User skills dir should follow
         assert sources[1] == str(skills_dir)
+
+
+class TestCreateCliAgentMemorySources:
+    """Test that `create_cli_agent` wires project AGENTS.md into memory sources."""
+
+    def test_project_agent_md_paths_in_memory_sources(self, tmp_path: Path) -> None:
+        """Project AGENTS.md paths should be passed to MemoryMiddleware sources."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        project_inner = tmp_path / ".deepagents" / "AGENTS.md"
+        project_root = tmp_path / "AGENTS.md"
+
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = [
+            project_inner,
+            project_root,
+        ]
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = tmp_path
+
+        captured: list[list[str]] = []
+
+        class FakeMemoryMiddleware:
+            """Capture the sources arg passed to MemoryMiddleware."""
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.append(kwargs.get("sources", []))
+
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware", FakeMemoryMiddleware),
+            patch("deepagents_cli.agent.FilesystemBackend"),
+            patch(
+                "deepagents_cli.agent.create_deep_agent",
+                return_value=mock_agent,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=True,
+                enable_skills=False,
+                enable_shell=False,
+            )
+
+        assert len(captured) == 1
+        sources = captured[0]
+        # User AGENTS.md is always first
+        assert sources[0] == str(agent_dir / "AGENTS.md")
+        # Both project paths follow
+        assert sources[1] == str(project_inner)
+        assert sources[2] == str(project_root)
+        assert len(sources) == 3
+
+    def test_empty_project_paths_no_extra_sources(self, tmp_path: Path) -> None:
+        """Empty project path list should not add extra memory sources."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+
+        captured: list[list[str]] = []
+
+        class FakeMemoryMiddleware:
+            """Capture the sources arg passed to MemoryMiddleware."""
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.append(kwargs.get("sources", []))
+
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware", FakeMemoryMiddleware),
+            patch("deepagents_cli.agent.FilesystemBackend"),
+            patch(
+                "deepagents_cli.agent.create_deep_agent",
+                return_value=mock_agent,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=True,
+                enable_skills=False,
+                enable_shell=False,
+            )
+
+        assert len(captured) == 1
+        sources = captured[0]
+        # Only user AGENTS.md, no project paths
+        assert sources == [str(agent_dir / "AGENTS.md")]

--- a/libs/cli/tests/unit_tests/test_end_to_end.py
+++ b/libs/cli/tests/unit_tests/test_end_to_end.py
@@ -96,7 +96,7 @@ def mock_settings(
             return tmp_path / "agents" / agent_id
 
         mock_settings_obj.get_user_agent_md_path = get_user_agent_md_path
-        mock_settings_obj.get_project_agent_md_path.return_value = None
+        mock_settings_obj.get_project_agent_md_path.return_value = []
         mock_settings_obj.get_agent_dir = get_agent_dir
         mock_settings_obj.project_root = None
 


### PR DESCRIPTION
Fixes #1440

---

Ensure that a root-level `AGENTS.md` is loaded into the agent system prompt alongside the `.deepagents/AGENTS.md` path. 

Previously, only retrieved the `.deepagents/` path without checking the project root — the discovery logic existed but was never called.

> [!WARNING]
> **Breaking change:** `Settings.get_project_agent_md_path()` now returns `list[Path]` instead of `Path | None`.
> 
> The method previously returned a single path to `{project_root}/.deepagents/AGENTS.md` regardless of whether the file existed. It now checks both `{project_root}/.deepagents/AGENTS.md` and `{project_root}/AGENTS.md`, returning only paths that actually exist on disk. If both files are present, both are loaded and their instructions are combined, with `.deepagents/AGENTS.md` first. This enables loading project instructions from the repo root, matching the convention used by other tools. `Settings` is not publicly exported, and all internal callers have been updated.