### PR TITLE
feat(cli): set openrouter headers, default to `gemini-3.1-pro-preview`

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1145,10 +1145,10 @@ def _get_default_model_spec() -> str:
         model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-5-20250929")
         return f"anthropic:{model}"
     if settings.has_google:
-        model = os.environ.get("GOOGLE_MODEL", "gemini-3-pro-preview")
+        model = os.environ.get("GOOGLE_MODEL", "gemini-3.1-pro-preview")
         return f"google_genai:{model}"
     if settings.has_vertex_ai:
-        model = os.environ.get("VERTEX_AI_MODEL", "gemini-3-pro-preview")
+        model = os.environ.get("VERTEX_AI_MODEL", "gemini-3.1-pro-preview")
         return f"google_vertexai:{model}"
 
     msg = (
@@ -1157,6 +1157,16 @@ def _get_default_model_spec() -> str:
         "or GOOGLE_CLOUD_PROJECT"
     )
     raise ModelConfigError(msg)
+
+
+_OPENROUTER_DEFAULT_HEADERS: dict[str, str] = {
+    "HTTP-Referer": "https://github.com/langchain-ai/deepagents",
+    "X-Title": "Deep Agents CLI",
+}
+"""Default attribution headers sent with every OpenRouter request.
+
+See https://openrouter.ai/docs/app-attribution for details.
+"""
 
 
 def _get_provider_kwargs(
@@ -1169,6 +1179,10 @@ def _get_provider_kwargs(
 
     When `model_name` is provided, per-model overrides from the `params`
     sub-table are shallow-merged on top.
+
+    For the `openrouter` provider, default attribution headers (`HTTP-Referer`
+    and `X-Title`) are injected automatically. User-supplied `default_headers`
+    in config take precedence.
 
     Args:
         provider: Provider name (e.g., openai, anthropic, fireworks, ollama).
@@ -1187,6 +1201,11 @@ def _get_provider_kwargs(
         api_key = os.environ.get(api_key_env)
         if api_key:
             result["api_key"] = api_key
+
+    if provider == "openrouter":
+        user_headers = result.get("default_headers") or {}
+        result["default_headers"] = {**_OPENROUTER_DEFAULT_HEADERS, **user_headers}
+
     return result
 
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -898,7 +898,7 @@ class TestOpenRouterHeaders:
         assert kwargs["default_headers"]["HTTP-Referer"] == (
             "https://github.com/langchain-ai/deepagents"
         )
-        assert kwargs["default_headers"]["X-Title"] == "Deep Agents"
+        assert kwargs["default_headers"]["X-Title"] == "Deep Agents CLI"
 
     def test_per_model_headers_override_defaults(self, tmp_path: Path) -> None:
         """Per-model default_headers override built-in defaults."""

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -883,6 +883,50 @@ base_url = "https://wrong-url.com"
         assert kwargs["base_url"] == "https://correct-url.com"
 
 
+class TestOpenRouterHeaders:
+    """Tests for OpenRouter default attribution headers."""
+
+    def setup_method(self) -> None:
+        """Clear model config cache before each test."""
+        clear_caches()
+
+    def test_injects_default_headers(self) -> None:
+        """Injects HTTP-Referer and X-Title for openrouter provider."""
+        kwargs = _get_provider_kwargs("openrouter")
+
+        assert "default_headers" in kwargs
+        assert kwargs["default_headers"]["HTTP-Referer"] == (
+            "https://github.com/langchain-ai/deepagents"
+        )
+        assert kwargs["default_headers"]["X-Title"] == "Deep Agents"
+
+    def test_per_model_headers_override_defaults(self, tmp_path: Path) -> None:
+        """Per-model default_headers override built-in defaults."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openrouter]
+models = ["deepseek/deepseek-chat"]
+
+[models.providers.openrouter.params."deepseek/deepseek-chat"]
+default_headers = {X-Title = "My Custom App"}
+""")
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            kwargs = _get_provider_kwargs(
+                "openrouter", model_name="deepseek/deepseek-chat"
+            )
+
+        assert kwargs["default_headers"]["X-Title"] == "My Custom App"
+        # Built-in HTTP-Referer should still be present
+        assert kwargs["default_headers"]["HTTP-Referer"] == (
+            "https://github.com/langchain-ai/deepagents"
+        )
+
+    def test_no_headers_for_other_providers(self) -> None:
+        """Other providers do not get OpenRouter attribution headers."""
+        kwargs = _get_provider_kwargs("openai")
+        assert "default_headers" not in kwargs
+
+
 class TestCreateModelFromClass:
     """Tests for _create_model_from_class() custom class factory."""
 
@@ -1182,7 +1226,7 @@ class TestDetectProvider:
             ("o4-mini", "openai"),
             ("claude-sonnet-4-5", "anthropic"),
             ("claude-opus-4-5", "anthropic"),
-            ("gemini-3-pro-preview", "google_genai"),
+            ("gemini-3.1-pro-preview", "google_genai"),
             ("llama3", None),
             ("mistral-large", None),
             ("some-unknown-model", None),


### PR DESCRIPTION
Closes #1454

https://openrouter.ai/docs/app-attribution