### PR TITLE
fix(cli): only exit input mode on backspace, not text clear

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -724,10 +724,6 @@ class ChatInput(Vertical):
                     self.mode = detected
                 self._strip_mode_prefix()
                 return
-        elif not text and self.mode != "normal":
-            # Reset mode when text is fully cleared
-            self.mode = "normal"
-
         # Update completion suggestions using completion-space text/cursor.
         if self._completion_manager and self._text_area:
             if is_path_payload:
@@ -1072,6 +1068,18 @@ class ChatInput(Vertical):
     async def on_key(self, event: events.Key) -> None:
         """Handle key events for completion navigation."""
         if not self._completion_manager or not self._text_area:
+            return
+
+        # Backspace on empty input exits the current mode (e.g. command/bash)
+        if (
+            event.key == "backspace"
+            and not self._text_area.text
+            and self.mode != "normal"
+        ):
+            self._completion_manager.reset()
+            self.mode = "normal"
+            event.prevent_default()
+            event.stop()
             return
 
         text, cursor = self._completion_text_and_cursor()


### PR DESCRIPTION
Fixes #1387

---

The old mode-reset logic in `ChatInput` fired on every `on_changed` when the text area became empty, including when `Escape` cleared input. That meant pressing `Escape` in command or bash mode would silently drop back to normal mode as a side effect of the text being cleared, rather than only when the user explicitly intended to exit the mode.

The fix moves mode-exit to an explicit backspace-on-empty gesture in `on_key`, so `Escape` (and any other text-clearing action) leaves the mode intact.