### PR TITLE
fix(deepagents): preserve ToolMessage artifact when evicting large outputs

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1138,6 +1138,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             content=replacement_text,
             tool_call_id=message.tool_call_id,
             name=message.name,
+            id=message.id,
+            artifact=message.artifact,
+            status=message.status,
+            additional_kwargs=dict(message.additional_kwargs),
+            response_metadata=dict(message.response_metadata),
         )
         return processed_message, result.files_update
 
@@ -1194,6 +1199,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             content=replacement_text,
             tool_call_id=message.tool_call_id,
             name=message.name,
+            id=message.id,
+            artifact=message.artifact,
+            status=message.status,
+            additional_kwargs=dict(message.additional_kwargs),
+            response_metadata=dict(message.response_metadata),
         )
         return processed_message, result.files_update
 


### PR DESCRIPTION
## Summary
Fixes data loss when large `ToolMessage` content is evicted to `/large_tool_results/...`.

Before this change, eviction rebuilt the message with only `content/tool_call_id/name`, which dropped runtime fields like `artifact`.

This patch preserves the original message metadata when generating the evicted replacement message:
- `artifact`
- `id`
- `status`
- `additional_kwargs`
- `response_metadata`

## Why this matters
`artifact` is not model-facing text, but it is part of runtime semantics for downstream tooling, tracing, and replay/debug flows. Dropping it caused structured tool metadata to disappear after middleware processing.

## Tests
Added regression coverage for both sync and async interception paths:
- `test_intercept_long_toolmessage_preserves_artifact_and_metadata`
- `test_store_backend_aintercept_large_tool_result_async` (extended)

Local validation:
- `uv run --all-groups ruff check deepagents/middleware/filesystem.py tests/unit_tests/test_middleware.py tests/unit_tests/backends/test_store_backend_async.py`
- `uv run --all-groups ty check deepagents/middleware/filesystem.py`
- `uv run --all-groups ty check tests/unit_tests/backends/test_store_backend_async.py`
- `uv run --group test pytest -q tests/unit_tests/test_middleware.py -k "preserves_artifact_and_metadata or preserves_name"`
- `uv run --group test pytest -q tests/unit_tests/backends/test_store_backend_async.py -k "aintercept_large_tool_result_async"`

Additionally verified via `trace` that the new preservation lines are executed in both sync and async code paths.

Closes #1450.

---
AI assistance disclosure: AI support was limited to unit-test drafting, code review pass, and style/lint checks. Final code decisions and edits were manually validated.
