### PR TITLE
feat(cli): add FeedbackChoiceScreen for /feedback command

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -40,6 +40,7 @@ from deepagents_cli.model_config import ModelSpec, save_recent_model
 from deepagents_cli.textual_adapter import TextualUIAdapter, execute_task_textual
 from deepagents_cli.widgets.approval import ApprovalMenu
 from deepagents_cli.widgets.chat_input import ChatInput
+from deepagents_cli.widgets.feedback_choice import FeedbackChoiceScreen
 from deepagents_cli.widgets.loading import LoadingWidget
 from deepagents_cli.widgets.message_store import (
     MessageData,
@@ -1145,8 +1146,10 @@ class DeepAgentsApp(App):
             help_text.stylize(f"link {DOCS_URL}", help_text.plain.index(DOCS_URL))
             await self._mount_message(AppMessage(help_text))
 
-        elif cmd in {"/changelog", "/docs", "/feedback"}:
+        elif cmd in {"/changelog", "/docs"}:
             await self._open_url_command(command, cmd)
+        elif cmd == "/feedback":
+            self.push_screen(FeedbackChoiceScreen())
         elif cmd == "/version":
             await self._mount_message(UserMessage(command))
             # Show CLI and SDK package versions

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -97,7 +97,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/changelog", "Open changelog in browser"),
     ("/clear", "Clear chat and start new thread"),
     ("/docs", "Open documentation in browser"),
-    ("/feedback", "Submit a bug report or feature request"),
+    ("/feedback", "Choose bug report or feature request"),
     ("/model", "Switch model, show selector, or set default (--default)"),
     ("/remember", "Update memory and skills from conversation"),
     ("/quit", "Exit app"),

--- a/libs/cli/deepagents_cli/widgets/feedback_choice.py
+++ b/libs/cli/deepagents_cli/widgets/feedback_choice.py
@@ -28,15 +28,20 @@ class FeedbackOption(Static):
             super().__init__()
             self.url = url
 
-    def __init__(self, label: str, url: str, *args: object) -> None:
+    def __init__(
+        self,
+        label: str,
+        url: str,
+        **kwargs: object,
+    ) -> None:
         """Initialize the FeedbackOption.
 
         Args:
             label: The display label for this option.
             url: The URL to open when this option is clicked.
-            *args: Additional arguments passed to parent.
+            **kwargs: Additional arguments passed to parent.
         """
-        super().__init__(*args)
+        super().__init__(label, **kwargs)
         self.label = label
         self.url = url
 

--- a/libs/cli/deepagents_cli/widgets/feedback_choice.py
+++ b/libs/cli/deepagents_cli/widgets/feedback_choice.py
@@ -56,7 +56,9 @@ class FeedbackOption(Static):
 class FeedbackChoiceScreen(ModalScreen[None]):
     """Screen for choosing feedback type (bug report or feature request)."""
 
-    BUG_URL = "https://github.com/langchain-ai/deepagents/issues/new?template=bug_report.yml"
+    BUG_URL = (
+        "https://github.com/langchain-ai/deepagents/issues/new?template=bug_report.yml"
+    )
     FEATURE_URL = "https://github.com/langchain-ai/deepagents/issues/new?template=feature_request.yml"
 
     def compose(self) -> ComposeResult:

--- a/libs/cli/deepagents_cli/widgets/feedback_choice.py
+++ b/libs/cli/deepagents_cli/widgets/feedback_choice.py
@@ -1,0 +1,81 @@
+"""Feedback choice screen for /feedback command."""
+
+from __future__ import annotations
+
+import webbrowser
+from typing import TYPE_CHECKING
+
+from textual.message import Message
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class FeedbackOption(Static):
+    """Clickable feedback option widget."""
+
+    class Clicked(Message):
+        """Message sent when a feedback option is clicked."""
+
+        def __init__(self, url: str) -> None:
+            """Initialize the Clicked message.
+
+            Args:
+                url: The URL to open when clicked.
+            """
+            super().__init__()
+            self.url = url
+
+    def __init__(self, label: str, url: str, *args: object) -> None:
+        """Initialize the FeedbackOption.
+
+        Args:
+            label: The display label for this option.
+            url: The URL to open when this option is clicked.
+            *args: Additional arguments passed to parent.
+        """
+        super().__init__(*args)
+        self.label = label
+        self.url = url
+
+    def compose(self) -> ComposeResult:
+        """Compose the widget content.
+
+        Yields:
+            The Static widget with the label.
+        """
+        yield Static(self.label)
+
+    def on_click(self) -> None:
+        """Handle click on this option by posting a Clicked message."""
+        self.post_message(self.Clicked(self.url))
+
+
+class FeedbackChoiceScreen(ModalScreen[None]):
+    """Screen for choosing feedback type (bug report or feature request)."""
+
+    BUG_URL = "https://github.com/langchain-ai/deepagents/issues/new?template=bug_report.yml"
+    FEATURE_URL = "https://github.com/langchain-ai/deepagents/issues/new?template=feature_request.yml"
+
+    def compose(self) -> ComposeResult:
+        """Compose the feedback choice screen.
+
+        Yields:
+            The Static title and feedback option widgets.
+        """
+        yield Static("What type of feedback would you like to submit?", id="title")
+        yield FeedbackOption("🐛 Bug Report", self.BUG_URL, id="bug-option")
+        yield FeedbackOption(
+            "✨ Feature Request", self.FEATURE_URL, id="feature-option"
+        )
+
+    def on_feedback_option_clicked(self, event: FeedbackOption.Clicked) -> None:
+        """Handle option click - open URL and close screen.
+
+        Args:
+            event: The Clicked event containing the URL to open.
+        """
+        webbrowser.open(event.url)
+        self.app.pop_screen()

--- a/libs/cli/deepagents_cli/widgets/feedback_choice.py
+++ b/libs/cli/deepagents_cli/widgets/feedback_choice.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import webbrowser
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from textual.message import Message
 from textual.screen import ModalScreen
@@ -32,7 +32,7 @@ class FeedbackOption(Static):
         self,
         label: str,
         url: str,
-        **kwargs: object,
+        **kwargs: Any,
     ) -> None:
         """Initialize the FeedbackOption.
 

--- a/libs/cli/tests/unit_tests/test_feedback_choice.py
+++ b/libs/cli/tests/unit_tests/test_feedback_choice.py
@@ -4,7 +4,7 @@ from textual.pilot import Pilot
 from deepagents_cli.widgets.feedback_choice import FeedbackChoiceScreen
 
 
-async def test_feedback_choice_screen_mounts():
+def test_feedback_choice_screen_mounts():
     """Test that FeedbackChoiceScreen can be instantiated and mounted."""
     app = FeedbackChoiceScreen()
     assert app is not None

--- a/libs/cli/tests/unit_tests/test_feedback_choice.py
+++ b/libs/cli/tests/unit_tests/test_feedback_choice.py
@@ -1,0 +1,10 @@
+import pytest
+from textual.pilot import Pilot
+
+from deepagents_cli.widgets.feedback_choice import FeedbackChoiceScreen
+
+
+async def test_feedback_choice_screen_mounts():
+    """Test that FeedbackChoiceScreen can be instantiated and mounted."""
+    app = FeedbackChoiceScreen()
+    assert app is not None


### PR DESCRIPTION
## Summary
- Add FeedbackChoiceScreen modal for /feedback command
- User can choose bug report or feature request
- Opens corresponding GitHub issue template in browser
- Update autocomplete description

Closes #1472

## Test Plan
- [ ] Unit tests pass
- [ ] Manual CLI testing of /feedback command