### PR TITLE
feat(cli): show thread working directory in thread list views

### DIFF
--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -25,6 +25,7 @@ import logging
 import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain.agents.middleware.human_in_the_loop import ActionRequest, HITLRequest
@@ -588,6 +589,7 @@ async def run_non_interactive(
             "assistant_id": assistant_id,
             "agent_name": assistant_id,
             "updated_at": datetime.now(UTC).isoformat(),
+            "cwd": str(Path.cwd()),
         },
     }
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -8,6 +8,7 @@ import json
 import logging
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -60,7 +61,7 @@ def _build_stream_config(
     Returns:
         Config dict with `configurable` and `metadata` keys.
     """
-    metadata: dict[str, str] = {}
+    metadata: dict[str, str] = {"cwd": str(Path.cwd())}
     if assistant_id:
         metadata.update(
             {

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 _COL_TID = 10
 _COL_AGENT = 14
 _COL_MSGS = 4
+_COL_LOC = 24
 
 
 class ThreadOption(Static):
@@ -113,8 +114,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
     }
 
     ThreadSelectorScreen > Vertical {
-        width: 80;
-        max-width: 90%;
+        width: 100;
+        max-width: 95%;
         height: 80%;
         background: $surface;
         border: solid $primary;
@@ -395,7 +396,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         """
         return (
             f"  {'Thread':<{_COL_TID}}  {'Agent':<{_COL_AGENT}}"
-            f"  {'Msgs':>{_COL_MSGS}}  Updated"
+            f"  {'Msgs':>{_COL_MSGS}}  {'Updated':<16}  Location"
         )
 
     @staticmethod
@@ -415,7 +416,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         Returns:
             Rich-markup label string.
         """
-        from deepagents_cli.sessions import format_timestamp
+        from deepagents_cli.sessions import format_path, format_timestamp
 
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if selected else "  "
@@ -423,10 +424,13 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         agent = (thread.get("agent_name") or "unknown")[:_COL_AGENT]
         msgs = str(thread.get("message_count", 0))
         timestamp = format_timestamp(thread.get("updated_at"))
+        location = format_path(thread.get("cwd"))
+        if len(location) > _COL_LOC:
+            location = "…" + location[-(_COL_LOC - 1) :]
 
         label = (
             f"{cursor}{tid:<{_COL_TID}}  {agent:<{_COL_AGENT}}"
-            f"  {msgs:>{_COL_MSGS}}  {timestamp}"
+            f"  {msgs:>{_COL_MSGS}}  {timestamp:<16}  {location}"
         )
         if current:
             label += " [dim](current)[/dim]"

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -117,6 +117,7 @@ class TestBuildStreamConfig:
         assert config["metadata"]["assistant_id"] == "my-agent"
         assert config["metadata"]["agent_name"] == "my-agent"
         assert "updated_at" in config["metadata"]
+        assert "cwd" in config["metadata"]
 
     def test_updated_at_is_valid_iso_timestamp(self) -> None:
         """`updated_at` should be a valid timezone-aware ISO 8601 timestamp."""
@@ -129,12 +130,16 @@ class TestBuildStreamConfig:
     def test_no_assistant_fields_when_none(self) -> None:
         """Assistant-specific fields should be absent when `assistant_id` is `None`."""
         config = _build_stream_config("t-789", assistant_id=None)
-        assert config["metadata"] == {}
+        assert "assistant_id" not in config["metadata"]
+        assert "agent_name" not in config["metadata"]
+        assert "cwd" in config["metadata"]
 
     def test_no_assistant_fields_when_empty_string(self) -> None:
         """Empty-string `assistant_id` should be treated as absent."""
         config = _build_stream_config("t-000", assistant_id="")
-        assert config["metadata"] == {}
+        assert "assistant_id" not in config["metadata"]
+        assert "agent_name" not in config["metadata"]
+        assert "cwd" in config["metadata"]
 
     def test_configurable_thread_id(self) -> None:
         """`configurable.thread_id` should match the provided thread ID."""

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -21,18 +21,21 @@ MOCK_THREADS: list[ThreadInfo] = [
         "agent_name": "my-agent",
         "updated_at": "2025-01-15T10:30:00",
         "message_count": 5,
+        "cwd": "/home/user/projects/foo",
     },
     {
         "thread_id": "def67890",
         "agent_name": "other-agent",
         "updated_at": "2025-01-14T08:00:00",
         "message_count": 12,
+        "cwd": "/tmp/workspace",
     },
     {
         "thread_id": "ghi11111",
         "agent_name": "my-agent",
         "updated_at": "2025-01-13T15:45:00",
         "message_count": 3,
+        "cwd": None,
     },
 ]
 


### PR DESCRIPTION
## Summary

Adds a "Location" column to both thread list views (CLI table and Textual modal) showing the working directory where each thread was last used. This makes it easy to identify which project a thread belongs to when resuming work.

**Before**
<img width="745" height="300" alt="Screenshot 2026-02-25 at 6 46 53 PM" src="https://github.com/user-attachments/assets/9b953b3f-bdb7-4e57-9341-8579fb7537bf" />

**After**
<img width="1041" height="536" alt="Screenshot 2026-02-25 at 6 47 12 PM" src="https://github.com/user-attachments/assets/6ee7cf2b-ea38-4e7f-9efa-7eecc400b76e" />

## Changes

### Metadata recording (`textual_adapter.py`, `non_interactive.py`)

Both interactive and non-interactive session configs now include `"cwd"` in the LangGraph checkpoint metadata, recording the current working directory at session start. This is backward compatible — old threads simply won't have the field and will show a blank location.

### Data layer (`sessions.py`)

- `ThreadInfo` TypedDict gains an optional `cwd` field
- New `format_path()` helper renders paths relative to `~` when under the home directory, otherwise shows the fully qualified path
- `list_threads()` SQL queries now extract `json_extract(metadata, '$.cwd')` — returns `NULL` gracefully for old checkpoints without the field

### Thread selector widget (`widgets/thread_selector.py`)

- Added a `Location` column to the header and option labels
- Locations longer than 24 characters are truncated with a `…` prefix
- Widened the modal container from 80→100 columns to accommodate the new column

### CLI thread list (`sessions.py` — `list_threads_command`)

- Added a "Location" column to the Rich table output

### Tests

- `TestFormatPath` — covers `~` substitution, paths outside home, `None`/empty input, and edge cases
- Updated `temp_db` fixtures to include `cwd` in test metadata
- Added assertion that `list_threads` returns `cwd` values correctly
- Updated `_build_stream_config` tests to expect `cwd` in metadata
- Added `cwd` to `MOCK_THREADS` in thread selector tests

> **Note:** This PR was authored with the assistance of an AI agent.
