### PR TITLE
fix: Unreachable `except` block

### DIFF
--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -614,7 +614,7 @@ async def run_non_interactive(
                 setup_script_path=sandbox_setup,
             )
             sandbox_backend = exit_stack.enter_context(sandbox_cm)
-        except (ImportError, ValueError, RuntimeError) as e:
+        except (ImportError, ValueError) as e:
             logger.exception("Sandbox creation failed")
             console.print(f"[red]Sandbox creation failed: {e}[/red]")
             return 1
@@ -623,6 +623,10 @@ async def run_non_interactive(
             console.print(
                 f"[red]Sandbox type '{sandbox_type}' is not yet supported: {e}[/red]"
             )
+            return 1
+        except RuntimeError as e:
+            logger.exception("Sandbox creation failed")
+            console.print(f"[red]Sandbox creation failed: {e}[/red]")
             return 1
 
     try:


### PR DESCRIPTION
To fix the problem, the more specific `NotImplementedError` handler must appear before the more general `RuntimeError` handler (or be explicitly separated from it), so that `NotImplementedError` is not subsumed by the general handler. Functionality should remain the same: a generic sandbox creation failure message for most errors, and a specific “unsupported sandbox type” message for `NotImplementedError`.

The simplest and safest fix is to remove `RuntimeError` from the grouped `except` clause and handle it in a separate `except` that comes after the dedicated `NotImplementedError` block. `ImportError` and `ValueError` can remain grouped, since there is no more specific handler for them. Concretely, in `libs/cli/deepagents_cli/non_interactive.py` around lines 610–626, we will:

- Change `except (ImportError, ValueError, RuntimeError) as e:` to `except (ImportError, ValueError) as e:`.
- Add a new `except RuntimeError as e:` block after the existing `except NotImplementedError as e:` block, using the same logging and console output as the original general handler (so behavior for `RuntimeError` remains unchanged).
- Keep the existing `except NotImplementedError as e:` block as-is so it can now actually handle unsupported sandbox types specially.

No new methods, imports, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._