### PR TITLE
fix: Variable defined multiple times

### DIFF
--- a/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
@@ -1056,7 +1056,7 @@ def assert_longterm_mem_tools(agent, store):
 
     # Edit the longterm memory file
     config4 = {"configurable": {"thread_id": uuid.uuid4()}}
-    response = agent.invoke(
+    agent.invoke(
         {"messages": [HumanMessage(content="Edit the haiku about Charmander at /memories/charmander.txt to use the word 'ember'")]},
         config=config4,
     )


### PR DESCRIPTION
To fix the problem, remove the unnecessary assignment to `response` on line 1059 while still performing the side-effectful `agent.invoke` call. In Python, this can be done by either calling `agent.invoke(...)` without assigning its result, or by assigning it to the throwaway variable `_` to make the intentional discard explicit. This keeps all existing behavior (the invocation still occurs) while eliminating the dead store that CodeQL reports.

The best minimal change without altering functionality is: replace `response = agent.invoke(...)` with `agent.invoke(...)`. This avoids introducing a new variable, keeps the code straightforward, and satisfies the static analyzer because there is no longer an unused store. Concretely, in `libs/deepagents/tests/integration_tests/test_filesystem_middleware.py`, within the "Edit the longterm memory file" section around line 1058–1062, update the line that currently reads `response = agent.invoke(` to just `agent.invoke(`. No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._