### PR TITLE
feat(sdk): swarm tool

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -433,6 +433,7 @@ def create_cli_agent(
         enable_skills: Enable `SkillsMiddleware` for custom agent skills
         enable_shell: Enable shell execution via `LocalShellBackend`
             (only in local mode). When enabled, the `execute` tool is available.
+        enable_swarm: Enable the `swarm` tool for parallel fan-out across subagents.
         checkpointer: Optional checkpointer for session persistence.
 
             If `None`, uses `InMemorySaver` (no persistence across

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -89,7 +89,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     system_prompt: str | SystemMessage | None = None,
     middleware: Sequence[AgentMiddleware] = (),
     subagents: list[SubAgent | CompiledSubAgent] | None = None,
-    enable_swarm: bool = True,
+    enable_swarm: bool = False,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
     response_format: ResponseFormat | None = None,

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -82,7 +82,7 @@ def get_default_model() -> ChatAnthropic:
     )
 
 
-def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic with many conditional branches
+def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
     model: str | BaseChatModel | None = None,
     tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
     *,
@@ -135,6 +135,8 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             `SummarizationMiddleware`, `AnthropicPromptCachingMiddleware`,
             `PatchToolCallsMiddleware`).
         subagents: The subagents to use.
+        enable_swarm: Whether to include the `swarm` tool for running many subagents in
+            parallel.
 
             Each subagent should be a `dict` with the following keys:
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -2,12 +2,11 @@
 
 import asyncio
 import json
+import os
 import warnings
-from langgraph.types import Interrupt
-
 from collections.abc import Awaitable, Callable, Sequence
+from pathlib import Path
 from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
-from langgraph.errors import GraphInterrupt
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
@@ -18,7 +17,8 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import StructuredTool
-from langgraph.types import Command
+from langgraph.errors import GraphInterrupt
+from langgraph.types import Command, Interrupt
 from pydantic import TypeAdapter, ValidationError
 
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
@@ -546,6 +546,33 @@ Available subagent types:
 """
 
 
+def _sanitize_task_id(task_id: str, output_dir: str, fallback: str) -> str:
+    """Sanitize a task ID so it cannot escape the output directory.
+
+    Applies ``os.path.basename`` to strip directory components, then resolves
+    the resulting path and verifies it is still inside *output_dir*.
+
+    Args:
+        task_id: Raw task identifier (may contain path separators or ``..``).
+        output_dir: The directory that output files must stay within.
+        fallback: Value to use when *task_id* is empty after sanitization.
+
+    Returns:
+        A safe filename component (without extension).
+
+    Raises:
+        ValueError: If the resolved path escapes *output_dir*.
+    """
+    name = Path(task_id).name
+    safe = fallback if (not name or name in (".", "..")) else name
+    resolved = os.path.realpath(Path(output_dir) / f"{safe}.txt")
+    real_output_dir = os.path.realpath(output_dir)
+    if not resolved.startswith(real_output_dir + os.sep):
+        msg = f"task id {task_id!r} resolves outside output directory"
+        raise ValueError(msg)
+    return safe
+
+
 class SwarmTaskSpec(TypedDict):
     """A single task entry in a swarm config.
 
@@ -861,6 +888,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                     summaries.append(f"Error: {item}")
                     continue
                 task_id, result_text = item
+                task_id = _sanitize_task_id(task_id, output_dir_clean, fallback=str(results.index(item)))
                 output_path = f"{output_dir_clean}/{task_id}.txt"
                 outputs.append((output_path, result_text.encode("utf-8")))
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -8,7 +8,8 @@ from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
-from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, ModelResponse, ResponseT
+from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, \
+    ModelResponse, ResponseT
 from langchain.chat_models import init_chat_model
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
@@ -692,9 +693,10 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         else:
             self.system_prompt = system_prompt
 
-        self.tools = [task_tool]
+        tools = [task_tool]
         if enable_swarm:
-            self.tools.append(self._build_swarm_tool(subagent_specs))
+            tools.append(self._build_swarm_tool(subagent_specs))
+        self.tools = tools
 
     def _build_swarm_tool(self, subagents: list[_SubagentSpec]) -> BaseTool:
         """Create the `swarm` tool.
@@ -720,16 +722,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
         description = SWARM_TOOL_DESCRIPTION.format(available_agents=subagent_description_str)
 
-        def swarm(
-            config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
-            output_dir: Annotated[
-                str,
-                "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt.",
-            ],
-            runtime: ToolRuntime,
-        ) -> str:
-            raise NotImplementedError("Sync implementation is not yet available.")
-
         async def aswarm(
             config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
             output_dir: Annotated[
@@ -738,6 +730,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             ],
             runtime: ToolRuntime,
         ) -> ToolMessage:
+            """Swarm implementation."""
             if callable(backend):
                 resolved_backend = backend(runtime)  # ty: ignore[call-top-callable]
             else:
@@ -830,7 +823,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         return StructuredTool.from_function(
             name="swarm",
-            func=swarm,
             coroutine=aswarm,
             description=description,
         )

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -8,8 +8,7 @@ from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
-from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, \
-    ModelResponse, ResponseT
+from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, ModelResponse, ResponseT
 from langchain.chat_models import init_chat_model
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
@@ -17,6 +16,7 @@ from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
+from pydantic import TypeAdapter, ValidationError
 
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
@@ -507,7 +507,11 @@ def _build_task_tool(  # noqa: C901
 
 SWARM_TOOL_DESCRIPTION = """Launch many subagents in parallel from a JSON config file.
 
-Use this when you need to fan out the same (or similar) work across many chunks of data — for example, processing sections of a large file, classifying batches of entries, or querying multiple documents.
+Use this when you need to fan out the same (or similar) work across many chunks of data - for example:
+- processing sections of a large file
+- classifying batches of entries
+- querying multiple documents
+
 
 ## Workflow
 1. Write a Python script (via `execute`) that reads your data, chunks it, and generates a JSON config file.
@@ -541,6 +545,62 @@ Fields:
 Available subagent types:
 {available_agents}
 """
+
+
+class SwarmTaskSpec(TypedDict):
+    """A single task entry in a swarm config.
+
+    Only `description`, `subagent_type`, and `id` are used by the swarm implementation.
+    Additional keys may be present but are ignored.
+
+    Fields:
+        description: The instruction passed to the subagent as a single `HumanMessage`.
+        subagent_type: The subagent name to dispatch to.
+        id: Optional identifier used as the output filename. If omitted, defaults to the
+            task index. This value is stringified when writing `<output_dir>/<id>.txt`.
+    """
+
+    description: str
+    subagent_type: str
+    id: NotRequired[str | int]
+
+
+class ParsedSwarmConfig(TypedDict):
+    """Result of parsing a swarm config file."""
+
+    tasks: list[SwarmTaskSpec] | None
+    error: str | None
+
+
+async def _load_swarm_tasks(
+    resolved_backend: BackendProtocol,
+    config_file: str,
+) -> ParsedSwarmConfig:
+    responses = await resolved_backend.adownload_files([config_file])
+    response = responses[0]
+    if response.error:
+        return {"tasks": None, "error": f"Error reading config file '{config_file}': {response.error}"}
+
+    content = response.content
+    if not isinstance(content, bytes):
+        return {"tasks": None, "error": f"Content was expected to be bytes. Got {type(content)}."}
+
+    try:
+        config_data = json.loads(content.decode("utf-8"))
+    except UnicodeDecodeError as e:
+        return {"tasks": None, "error": f"Error reading config file '{config_file}': {e}"}
+
+    raw_tasks = config_data.get("tasks", [])
+    if not raw_tasks:
+        return {"tasks": None, "error": f"Error file '{config_file}' contains no tasks!"}
+
+    adapter = TypeAdapter(list[SwarmTaskSpec])
+    try:
+        tasks = adapter.validate_python(raw_tasks)
+    except ValidationError as e:
+        return {"tasks": None, "error": json.dumps(e.errors(), indent=2)}
+
+    return {"tasks": tasks, "error": None}
 
 
 class _DeprecatedKwargs(TypedDict, total=False):
@@ -659,6 +719,9 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         using_new_api = backend is not None
         using_old_api = default_model is not None
 
+        self._backend = backend
+        self._subagents = subagents
+
         if using_old_api and not using_new_api:
             # Legacy API - build subagents from deprecated args
             subagent_specs = _get_subagents_legacy(
@@ -673,8 +736,6 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             if not subagents:
                 msg = "At least one subagent must be specified when using the new API"
                 raise ValueError(msg)
-            self._backend = backend
-            self._subagents = subagents
             subagent_specs = self._get_subagents()
         else:
             msg = "SubAgentMiddleware requires either `backend` (new API) or `default_model` (deprecated API)"
@@ -694,11 +755,11 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             self.system_prompt = system_prompt
 
         tools = [task_tool]
-        if enable_swarm:
+        if enable_swarm and backend is not None:
             tools.append(self._build_swarm_tool(subagent_specs))
         self.tools = tools
 
-    def _build_swarm_tool(self, subagents: list[_SubagentSpec]) -> BaseTool:
+    def _build_swarm_tool(self, subagents: list[_SubagentSpec]) -> BaseTool:  # noqa: C901, PLR0915
         """Create the `swarm` tool.
 
         The `swarm` tool reads a JSON config file containing a list of task specs and
@@ -722,61 +783,21 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
         description = SWARM_TOOL_DESCRIPTION.format(available_agents=subagent_description_str)
 
-        async def aswarm(
-            config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
-            output_dir: Annotated[
-                str,
-                "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt.",
-            ],
-            runtime: ToolRuntime,
-        ) -> ToolMessage:
-            """Swarm implementation."""
-            if callable(backend):
-                resolved_backend = backend(runtime)  # ty: ignore[call-top-callable]
-            else:
-                resolved_backend = backend
-
-            responses = await resolved_backend.adownload_files([config_file])
-            response = responses[0]
-            if response.error:
-                return ToolMessage(
-                    content=f"Error reading config file '{config_file}': {response.error}",
-                    status="error",
-                    tool_call_id=runtime.tool_call_id,
-                )
-
-            content = response.content
-            if not isinstance(content, bytes):
-                msg = f"Content was expected to be bytes. Got {type(content)}."
-                raise AssertionError(msg)
-
-            try:
-                config_data = json.loads(content.decode("utf-8"))
-            except UnicodeDecodeError as e:
-                return ToolMessage(
-                    content=f"Error reading config file '{config_file}': {e}",
-                    status="error",
-                    tool_call_id=runtime.tool_call_id,
-                )
-
-            tasks = config_data.get("tasks", [])
-            if not tasks:
-                return ToolMessage(
-                    content=f"Error file '{config_file}' contains no tasks!",
-                    status="error",
-                    tool_call_id=runtime.tool_call_id,
-                )
-
-            parent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
+        async def _run_swarm_tasks(
+            subagents: dict[str, Runnable],
+            parent_state: dict[str, Any],
+            tasks: list[SwarmTaskSpec],
+        ) -> list[tuple[str, str] | Exception]:
+            """Run tasks."""
 
             async def run_task(task_spec: dict[str, Any], idx: int) -> tuple[str, str]:
                 task_id = str(task_spec.get("id", idx))
                 desc = task_spec["description"]
                 subagent_type = task_spec["subagent_type"]
 
-                subagent = subagent_graphs.get(subagent_type)
+                subagent = subagents.get(subagent_type)
                 if subagent is None:
-                    allowed = ", ".join(subagent_graphs.keys())
+                    allowed = ", ".join(subagents.keys())
                     return task_id, f"Error: unknown subagent_type '{subagent_type}'. Allowed: {allowed}"
 
                 subagent_state = dict(parent_state)
@@ -790,12 +811,34 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 return task_id, ""
 
             coros = [run_task(task_spec, idx) for idx, task_spec in enumerate(tasks)]
-            results = await asyncio.gather(*coros, return_exceptions=True)
+            return await asyncio.gather(*coros, return_exceptions=True)
 
+        async def aswarm(
+            config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
+            output_dir: Annotated[
+                str,
+                "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt.",
+            ],
+            runtime: ToolRuntime,
+        ) -> ToolMessage:
+            """Run swarm tasks."""
+            resolved_backend = backend(runtime) if callable(backend) else backend  # ty: ignore[call-top-callable]
+
+            parsed = await _load_swarm_tasks(resolved_backend, config_file)
+            if parsed["error"] is not None:
+                return ToolMessage(content=parsed["error"], status="error", tool_call_id=runtime.tool_call_id)
+            tasks = parsed["tasks"]
+            if tasks is None:
+                msg = "parsed swarm tasks unexpectedly missing"
+                raise AssertionError(msg)
+
+            parent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
+
+            results = await _run_swarm_tasks(subagent_graphs, parent_state, tasks)
             output_dir_clean = output_dir.rstrip("/")
+
             outputs: list[tuple[str, bytes]] = []
             summaries: list[str] = []
-
             for item in results:
                 if isinstance(item, Exception):
                     summaries.append(f"Error: {item}")
@@ -899,4 +942,3 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             new_system_message = append_to_system_message(request.system_message, self.system_prompt)
             return await handler(request.override(system_message=new_system_message))
         return await handler(request)
-

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -542,150 +542,6 @@ Available subagent types:
 """
 
 
-def _build_swarm_tool(  # noqa: C901, PLR0915
-    subagents: list[_SubagentSpec],
-    backend: "BackendProtocol | BackendFactory | None" = None,
-) -> BaseTool:
-    """Create a swarm tool that fans out many subagent tasks in parallel.
-
-    Args:
-        subagents: List of subagent specs containing name, description, and runnable.
-        backend: Backend for reading config and writing results.
-
-    Returns:
-        A StructuredTool that reads a JSON config and runs all tasks in parallel.
-    """
-    subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
-    subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
-    description = SWARM_TOOL_DESCRIPTION.format(available_agents=subagent_description_str)
-
-    def _get_backend(runtime: ToolRuntime) -> BackendProtocol:
-        resolved_backend = backend if backend is not None else runtime.state.get("__deepagents_backend")
-        if resolved_backend is None:
-            msg = "backend is required"
-            raise ValueError(msg)
-        if callable(resolved_backend):
-            resolved_backend = resolved_backend(runtime)  # ty: ignore[call-top-callable]
-        if not isinstance(resolved_backend, BackendProtocol):
-            msg = "backend must be a BackendProtocol instance"
-            raise TypeError(msg)
-        return resolved_backend
-
-    async def _run_one_task(
-        task_spec: dict,
-        parent_state: dict,
-        idx: int,
-    ) -> tuple[str, str]:
-        """Run a single swarm sub-task. Returns (task_id, result_text)."""
-        task_id = str(task_spec.get("id", idx))
-        desc = task_spec["description"]
-        subagent_type = task_spec["subagent_type"]
-
-        if subagent_type not in subagent_graphs:
-            allowed = ", ".join(subagent_graphs.keys())
-            return task_id, f"Error: unknown subagent_type '{subagent_type}'. Allowed: {allowed}"
-
-        subagent = subagent_graphs[subagent_type]
-        subagent_state = dict(parent_state)
-        subagent_state["messages"] = [HumanMessage(content=desc)]
-
-        try:
-            result = await subagent.ainvoke(subagent_state)
-            messages = result.get("messages", [])
-            if messages:
-                text = messages[-1].text or ""
-                return task_id, text.rstrip()
-            return task_id, ""  # noqa: TRY300
-        except Exception as e:
-            return task_id, f"Error: {e}"
-
-    async def _execute_swarm(
-        config_file: str,
-        output_dir: str,
-        runtime: ToolRuntime,
-    ) -> str:
-        """Core implementation of swarm."""
-        # Read config file from backend
-        try:
-            backend_ = _get_backend(runtime)
-        except (TypeError, ValueError) as e:
-            return f"Error: {e}"
-        try:
-            responses = await backend_.adownload_files([config_file])
-            response = responses[0]
-            if response.error is not None or response.content is None:
-                return f"Error reading config file '{config_file}': {response.error}"
-            config_data = json.loads(response.content.decode("utf-8"))
-        except (OSError, ValueError, TypeError, UnicodeDecodeError) as e:
-            return f"Error reading config file '{config_file}': {e}"
-
-        tasks = config_data.get("tasks", [])
-        if not tasks:
-            return "Error: config file contains no tasks."
-
-        # Prepare parent state (stripped of excluded keys)
-        parent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
-
-        # Run all tasks in parallel
-        coros = [_run_one_task(task_spec, parent_state, idx) for idx, task_spec in enumerate(tasks)]
-        results = await asyncio.gather(*coros, return_exceptions=True)
-
-        # Write results to output files
-        output_dir_clean = output_dir.rstrip("/")
-        try:
-            backend_ = _get_backend(runtime)
-        except (TypeError, ValueError) as e:
-            return f"Error: {e}"
-
-        outputs: list[tuple[str, bytes]] = []
-        summaries: list[str] = []
-        for item in results:
-            if isinstance(item, Exception):
-                summaries.append(f"Error: {item}")
-                continue
-            task_id, result_text = item
-            output_path = f"{output_dir_clean}/{task_id}.txt"
-            outputs.append((output_path, result_text.encode("utf-8")))
-
-        upload_responses = await backend_.aupload_files(outputs)
-        for upload in upload_responses:
-            if upload.error is not None:
-                summaries.append(f"✗ {upload.path}: error writing result: {upload.error}")
-            else:
-                result_len = next((len(b) for p, b in outputs if p == upload.path), 0)
-                summaries.append(f"✓ {upload.path}: wrote {result_len} chars")
-
-        completed = sum(1 for s in summaries if s.startswith("✓"))
-        summary = f"{completed}/{len(tasks)} tasks completed. Results in {output_dir_clean}/\n"
-        summary += "\n".join(summaries)
-        return summary
-
-    def swarm(
-        config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
-        output_dir: Annotated[
-            str, "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt."
-        ],
-        runtime: ToolRuntime,
-    ) -> str:
-	raise NotImlementedError("No sync path yet")
-
-    async def aswarm(
-        config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
-        output_dir: Annotated[
-            str, "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt."
-        ],
-        runtime: ToolRuntime,
-    ) -> str:
-        return await _execute_swarm(config_file, output_dir, runtime)
-
-    return StructuredTool.from_function(
-        name="swarm",
-        func=swarm,
-        coroutine=aswarm,
-        description=description,
-    )
-
-
 class _DeprecatedKwargs(TypedDict, total=False):
     """TypedDict for deprecated SubAgentMiddleware keyword arguments.
 
@@ -838,8 +694,146 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         self.tools = [task_tool]
         if enable_swarm:
-            swarm_tool = _build_swarm_tool(subagent_specs, backend=backend)
-            self.tools.append(swarm_tool)
+            self.tools.append(self._build_swarm_tool(subagent_specs))
+
+    def _build_swarm_tool(self, subagents: list[_SubagentSpec]) -> BaseTool:
+        """Create the `swarm` tool.
+
+        The `swarm` tool reads a JSON config file containing a list of task specs and
+        runs those tasks in parallel across subagents.
+
+        Each task result is written to `<output_dir>/<task_id>.txt` via the configured
+        backend.
+
+        Args:
+            subagents: The available subagents that `swarm` may dispatch to.
+
+        Returns:
+            A structured tool named `swarm`.
+        """
+        backend = self._backend
+        if backend is None:
+            msg = "backend is required"
+            raise ValueError(msg)
+
+        subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
+        subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
+        description = SWARM_TOOL_DESCRIPTION.format(available_agents=subagent_description_str)
+
+        def swarm(
+            config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
+            output_dir: Annotated[
+                str,
+                "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt.",
+            ],
+            runtime: ToolRuntime,
+        ) -> str:
+            raise NotImplementedError("Sync implementation is not yet available.")
+
+        async def aswarm(
+            config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
+            output_dir: Annotated[
+                str,
+                "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt.",
+            ],
+            runtime: ToolRuntime,
+        ) -> ToolMessage:
+            if callable(backend):
+                resolved_backend = backend(runtime)  # ty: ignore[call-top-callable]
+            else:
+                resolved_backend = backend
+
+            responses = await resolved_backend.adownload_files([config_file])
+            response = responses[0]
+            if response.error:
+                return ToolMessage(
+                    content=f"Error reading config file '{config_file}': {response.error}",
+                    status="error",
+                    tool_call_id=runtime.tool_call_id,
+                )
+
+            content = response.content
+            if not isinstance(content, bytes):
+                msg = f"Content was expected to be bytes. Got {type(content)}."
+                raise AssertionError(msg)
+
+            try:
+                config_data = json.loads(content.decode("utf-8"))
+            except UnicodeDecodeError as e:
+                return ToolMessage(
+                    content=f"Error reading config file '{config_file}': {e}",
+                    status="error",
+                    tool_call_id=runtime.tool_call_id,
+                )
+
+            tasks = config_data.get("tasks", [])
+            if not tasks:
+                return ToolMessage(
+                    content=f"Error file '{config_file}' contains no tasks!",
+                    status="error",
+                    tool_call_id=runtime.tool_call_id,
+                )
+
+            parent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
+
+            async def run_task(task_spec: dict[str, Any], idx: int) -> tuple[str, str]:
+                task_id = str(task_spec.get("id", idx))
+                desc = task_spec["description"]
+                subagent_type = task_spec["subagent_type"]
+
+                subagent = subagent_graphs.get(subagent_type)
+                if subagent is None:
+                    allowed = ", ".join(subagent_graphs.keys())
+                    return task_id, f"Error: unknown subagent_type '{subagent_type}'. Allowed: {allowed}"
+
+                subagent_state = dict(parent_state)
+                subagent_state["messages"] = [HumanMessage(content=desc)]
+
+                result = await subagent.ainvoke(subagent_state)
+                messages = result.get("messages", [])
+                if messages:
+                    text = messages[-1].text or ""
+                    return task_id, text.rstrip()
+                return task_id, ""
+
+            coros = [run_task(task_spec, idx) for idx, task_spec in enumerate(tasks)]
+            results = await asyncio.gather(*coros, return_exceptions=True)
+
+            output_dir_clean = output_dir.rstrip("/")
+            outputs: list[tuple[str, bytes]] = []
+            summaries: list[str] = []
+
+            for item in results:
+                if isinstance(item, Exception):
+                    summaries.append(f"Error: {item}")
+                    continue
+                task_id, result_text = item
+                output_path = f"{output_dir_clean}/{task_id}.txt"
+                outputs.append((output_path, result_text.encode("utf-8")))
+
+            upload_responses = await resolved_backend.aupload_files(outputs)
+            for upload in upload_responses:
+                if upload.error is not None:
+                    summaries.append(f"✗ {upload.path}: error writing result: {upload.error}")
+                else:
+                    result_len = next((len(b) for p, b in outputs if p == upload.path), 0)
+                    summaries.append(f"✓ {upload.path}: wrote {result_len} chars")
+
+            completed = sum(1 for s in summaries if s.startswith("✓"))
+            summary = f"{completed}/{len(tasks)} tasks completed. Results in {output_dir_clean}/\n"
+            summary += "\n".join(summaries)
+            return ToolMessage(
+                content=summary,
+                status="success",
+                tool_call_id=runtime.tool_call_id,
+            )
+
+        return StructuredTool.from_function(
+            name="swarm",
+            func=swarm,
+            coroutine=aswarm,
+            description=description,
+        )
 
     def _get_subagents(self) -> list[_SubagentSpec]:
         """Create runnable agents from specs.
@@ -913,3 +907,4 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             new_system_message = append_to_system_message(request.system_message, self.system_prompt)
             return await handler(request.override(system_message=new_system_message))
         return await handler(request)
+

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -507,11 +507,7 @@ def _build_task_tool(  # noqa: C901
 
 SWARM_TOOL_DESCRIPTION = """Launch many subagents in parallel from a JSON config file.
 
-Use this when you need to fan out the same (or similar) work across many chunks of data - for example:
-- processing sections of a large file
-- classifying batches of entries
-- querying multiple documents
-
+Use this when you need to fan out the same (or similar) work across many chunks of data — for example, processing sections of a large file, classifying batches of entries, or querying multiple documents.
 
 ## Workflow
 1. Write a Python script (via `execute`) that reads your data, chunks it, and generates a JSON config file.

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -542,7 +542,7 @@ Available subagent types:
 """
 
 
-def _build_swarm_tool(
+def _build_swarm_tool(  # noqa: C901, PLR0915
     subagents: list[_SubagentSpec],
     backend: "BackendProtocol | BackendFactory | None" = None,
 ) -> BaseTool:
@@ -558,6 +558,18 @@ def _build_swarm_tool(
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
     subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
     description = SWARM_TOOL_DESCRIPTION.format(available_agents=subagent_description_str)
+
+    def _get_backend(runtime: ToolRuntime) -> BackendProtocol:
+        resolved_backend = backend if backend is not None else runtime.state.get("__deepagents_backend")
+        if resolved_backend is None:
+            msg = "backend is required"
+            raise ValueError(msg)
+        if callable(resolved_backend):
+            resolved_backend = resolved_backend(runtime)  # ty: ignore[call-top-callable]
+        if not isinstance(resolved_backend, BackendProtocol):
+            msg = "backend must be a BackendProtocol instance"
+            raise TypeError(msg)
+        return resolved_backend
 
     async def _run_one_task(
         task_spec: dict,
@@ -583,7 +595,7 @@ def _build_swarm_tool(
             if messages:
                 text = messages[-1].text or ""
                 return task_id, text.rstrip()
-            return task_id, ""
+            return task_id, ""  # noqa: TRY300
         except Exception as e:
             return task_id, f"Error: {e}"
 
@@ -593,11 +605,18 @@ def _build_swarm_tool(
         runtime: ToolRuntime,
     ) -> str:
         """Core implementation of swarm."""
-        # Read config file from disk
+        # Read config file from backend
         try:
-            with open(config_file) as f:
-                config_data = json.load(f)
-        except Exception as e:
+            backend_ = _get_backend(runtime)
+        except (TypeError, ValueError) as e:
+            return f"Error: {e}"
+        try:
+            responses = await backend_.adownload_files([config_file])
+            response = responses[0]
+            if response.error is not None or response.content is None:
+                return f"Error reading config file '{config_file}': {response.error}"
+            config_data = json.loads(response.content.decode("utf-8"))
+        except (OSError, ValueError, TypeError, UnicodeDecodeError) as e:
             return f"Error reading config file '{config_file}': {e}"
 
         tasks = config_data.get("tasks", [])
@@ -612,22 +631,29 @@ def _build_swarm_tool(
         results = await asyncio.gather(*coros, return_exceptions=True)
 
         # Write results to output files
-        import os
         output_dir_clean = output_dir.rstrip("/")
-        os.makedirs(output_dir_clean, exist_ok=True)
-        summaries = []
+        try:
+            backend_ = _get_backend(runtime)
+        except (TypeError, ValueError) as e:
+            return f"Error: {e}"
+
+        outputs: list[tuple[str, bytes]] = []
+        summaries: list[str] = []
         for item in results:
             if isinstance(item, Exception):
                 summaries.append(f"Error: {item}")
                 continue
             task_id, result_text = item
             output_path = f"{output_dir_clean}/{task_id}.txt"
-            try:
-                with open(output_path, "w") as f:
-                    f.write(result_text)
-                summaries.append(f"✓ {task_id}: wrote {len(result_text)} chars to {output_path}")
-            except Exception as e:
-                summaries.append(f"✗ {task_id}: error writing result: {e}")
+            outputs.append((output_path, result_text.encode("utf-8")))
+
+        upload_responses = await backend_.aupload_files(outputs)
+        for upload in upload_responses:
+            if upload.error is not None:
+                summaries.append(f"✗ {upload.path}: error writing result: {upload.error}")
+            else:
+                result_len = next((len(b) for p, b in outputs if p == upload.path), 0)
+                summaries.append(f"✓ {upload.path}: wrote {result_len} chars")
 
         completed = sum(1 for s in summaries if s.startswith("✓"))
         summary = f"{completed}/{len(tasks)} tasks completed. Results in {output_dir_clean}/\n"
@@ -636,16 +662,18 @@ def _build_swarm_tool(
 
     def swarm(
         config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
-        output_dir: Annotated[str, "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt."],
+        output_dir: Annotated[
+            str, "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt."
+        ],
         runtime: ToolRuntime,
     ) -> str:
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor() as pool:
-            return pool.submit(asyncio.run, _execute_swarm(config_file, output_dir, runtime)).result()
+	raise NotImlementedError("No sync path yet")
 
     async def aswarm(
         config_file: Annotated[str, "Absolute path to the JSON config file containing the task definitions."],
-        output_dir: Annotated[str, "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt."],
+        output_dir: Annotated[
+            str, "Absolute path to the directory where result files will be written. Each task result is written to <output_dir>/<task_id>.txt."
+        ],
         runtime: ToolRuntime,
     ) -> str:
         return await _execute_swarm(config_file, output_dir, runtime)

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -3,8 +3,11 @@
 import asyncio
 import json
 import warnings
+from langgraph.types import Interrupt
+
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
+from langgraph.errors import GraphInterrupt
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
@@ -831,6 +834,24 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             parent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
 
             results = await _run_swarm_tasks(subagent_graphs, parent_state, tasks)
+
+            interrupts: list[Interrupt] = []
+            interrupt_excs: list[GraphInterrupt] = []
+
+            for item in results:
+                if isinstance(item, GraphInterrupt):
+                    interrupt_excs.append(item)
+                    if not item.args:
+                        continue
+                    seq = item.args[0]
+                    if isinstance(seq, tuple | list) and all(isinstance(x, Interrupt) for x in seq):
+                        interrupts.extend(seq)
+
+            if interrupt_excs:
+                if interrupts:
+                    raise GraphInterrupt(interrupts)
+                raise interrupt_excs[0]
+
             output_dir_clean = output_dir.rstrip("/")
 
             outputs: list[tuple[str, bytes]] = []

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -6,6 +6,7 @@ and child agents.
 """
 
 import json
+import os
 import warnings
 from pathlib import Path
 from typing import Any, TypedDict
@@ -25,7 +26,7 @@ from pydantic import BaseModel, Field
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.skills import SkillsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
+from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware, _sanitize_task_id
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
 
@@ -1749,3 +1750,46 @@ class TestSubAgentMiddlewareValidation:
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)
         assert "deprecated" in str(w[0].message).lower()
+
+
+@pytest.mark.parametrize(
+    ("task_id", "expected"),
+    [
+        ("simple", "simple"),
+        ("with spaces", "with spaces"),
+        ("0", "0"),
+    ],
+)
+def test_sanitize_task_id_allows_safe_ids(tmp_path: Path, task_id: str, expected: str) -> None:
+    assert _sanitize_task_id(task_id, str(tmp_path), fallback="0") == expected
+
+
+@pytest.mark.parametrize(
+    "task_id",
+    [
+        "../../etc/passwd",
+        "../escape",
+        "foo/../../etc/shadow",
+        "/absolute/path",
+    ],
+)
+def test_sanitize_task_id_strips_directory_components(tmp_path: Path, task_id: str) -> None:
+    result = _sanitize_task_id(task_id, str(tmp_path), fallback="0")
+    resolved = os.path.realpath(str(tmp_path / f"{result}.txt"))
+    assert resolved.startswith(os.path.realpath(str(tmp_path)) + os.sep)
+
+
+def test_sanitize_task_id_empty_after_basename(tmp_path: Path) -> None:
+    result = _sanitize_task_id("..", str(tmp_path), fallback="fallback")
+    assert result == "fallback"
+
+
+def test_sanitize_task_id_rejects_symlink_that_escapes(tmp_path: Path) -> None:
+    jail = tmp_path / "subdir"
+    jail.mkdir(parents=True)
+    escape_target = tmp_path / "escaped.txt"
+    escape_target.write_text("secret")
+    symlink = jail / "evil.txt"
+    symlink.symlink_to(escape_target)
+    with pytest.raises(ValueError, match="resolves outside output directory"):
+        _sanitize_task_id("evil", str(jail), fallback="0")

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -5,6 +5,7 @@ are invoked, how they return results, and how state is managed between parent
 and child agents.
 """
 
+import json
 import warnings
 from pathlib import Path
 from typing import Any, TypedDict
@@ -43,6 +44,65 @@ Instructions go here.
 
 class TestSubAgents:
     """Tests for sub-agent middleware functionality."""
+
+    async def test_swarm_tool_writes_results_via_backend(self, tmp_path: Path) -> None:
+        backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        config_path = str(tmp_path / "swarm_config.json")
+        output_dir = str(tmp_path / "results")
+        config = {
+            "tasks": [
+                {"id": "t0", "description": "Say hi", "subagent_type": "general-purpose"},
+                {"id": "t1", "description": "Say bye", "subagent_type": "general-purpose"},
+            ]
+        }
+        backend.upload_files([(config_path, json.dumps(config).encode("utf-8"))])
+
+        leader_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "swarm",
+                                "args": {"config_file": config_path, "output_dir": output_dir},
+                                "id": "call_swarm",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+
+        gp_model = GenericFakeChatModel(messages=iter([AIMessage(content="result"), AIMessage(content="result")]))
+
+        agent = create_deep_agent(
+            model=leader_model,
+            checkpointer=InMemorySaver(),
+            backend=backend,
+            subagents=[
+                SubAgent(
+                    name="general-purpose",
+                    description="gp",
+                    system_prompt="you are gp",
+                    model=gp_model,
+                    tools=[],
+                )
+            ],
+            enable_swarm=True,
+        )
+
+        await agent.ainvoke(
+            {"messages": [HumanMessage(content="run swarm")]},
+            config={"configurable": {"thread_id": "test_thread_swarm"}},
+        )
+
+        r0 = backend.download_files([f"{output_dir}/t0.txt"])[0]
+        r1 = backend.download_files([f"{output_dir}/t1.txt"])[0]
+        assert (r0.error, r0.content) == (None, b"result")
+        assert (r1.error, r1.content) == (None, b"result")
 
     def test_subagent_returns_final_message_as_tool_result(self) -> None:
         """Test that a subagent's final message is returned as a ToolMessage.

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -104,6 +104,50 @@ class TestSubAgents:
         assert (r0.error, r0.content) == (None, b"result")
         assert (r1.error, r1.content) == (None, b"result")
 
+    async def test_swarm_tool_surfaces_validation_error_as_tool_message(self, tmp_path: Path) -> None:
+        backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        config_path = str(tmp_path / "swarm_config.json")
+        output_dir = str(tmp_path / "results")
+        config = {"tasks": [{"id": "t0", "description": "Say hi"}]}
+        backend.upload_files([(config_path, json.dumps(config).encode("utf-8"))])
+
+        leader_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "swarm",
+                                "args": {"config_file": config_path, "output_dir": output_dir},
+                                "id": "call_swarm",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=leader_model,
+            checkpointer=InMemorySaver(),
+            backend=backend,
+            subagents=[],
+            enable_swarm=True,
+        )
+
+        result = await agent.ainvoke(
+            {"messages": [HumanMessage(content="run swarm")]},
+            config={"configurable": {"thread_id": "test_thread_swarm_validation_error"}},
+        )
+
+        assert [m.type for m in result["messages"]] == ["human", "ai", "tool", "ai"]
+        tool = result["messages"][2]
+        assert tool.status == "error"
+        assert json.loads(tool.content)[0]["type"] == "missing"
+
     def test_subagent_returns_final_message_as_tool_result(self) -> None:
         """Test that a subagent's final message is returned as a ToolMessage.
 


### PR DESCRIPTION
1. **Moves `_build_swarm_tool` from a standalone function to a method on `SubAgentMiddleware`** — it now has access to `self._backend` directly instead of receiving it as a parameter.

2. **Uses the backend for file I/O instead of raw `os`/`open`** — the old code used `open()` to read the config file and write results. The new code uses `resolved_backend.adownload_files()` and `resolved_backend.aupload_files()`, making it work with non-local backends (sandboxes, etc.).

3. **Adds structured parsing with validation** — extracts `SwarmTaskSpec` (TypedDict) and `ParsedSwarmConfig`, and validates the JSON config against them using Pydantic's `TypeAdapter`. Invalid configs now return a `ToolMessage` with `status="error"` instead of crashing.

4. **Returns `ToolMessage` instead of plain `str`** — `aswarm` now returns a `ToolMessage` directly, giving control over `status` and `tool_call_id`.

5. **Handles `GraphInterrupt` from subagents** — new logic collects `Interrupt` objects from subagent exceptions and re-raises them, enabling human-in-the-loop to work through swarm tasks.

6. **Removes the sync `swarm()` wrapper** — the old code had both sync (via `ThreadPoolExecutor`) and async versions. Now it's async-only via `coroutine=aswarm`.

7. **Defaults `enable_swarm=False`** in `create_deep_agent` (was `True`).

8. **Adds docstring for `enable_swarm`** in `create_deep_agent` and the CLI's `create_cli_agent`.
