### PR TITLE
refactor(sdk): extract shared sync/async helpers in memory and skills

### DIFF
--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -302,7 +302,7 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         results = backend.download_files([path])
         return self._process_download_response(results, path)
 
-    def before_agent(self, state: MemoryState, runtime: Runtime, config: RunnableConfig) -> MemoryStateUpdate | None:
+    def before_agent(self, state: MemoryState, runtime: Runtime, config: RunnableConfig) -> MemoryStateUpdate | None:  # ty: ignore[invalid-method-override]
         """Load memory content before agent execution (synchronous).
 
         Loads memory from all configured sources and stores in state.

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -104,7 +104,7 @@ if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
     from langgraph.runtime import Runtime
 
-    from deepagents.backends.protocol import BACKEND_TYPES, BackendProtocol
+    from deepagents.backends.protocol import BACKEND_TYPES, BackendProtocol, FileInfo
 
 from typing import NotRequired, TypedDict
 
@@ -400,7 +400,7 @@ def _format_skill_annotations(skill: SkillMetadata) -> str:
     return ", ".join(parts)
 
 
-def _build_skill_md_paths(items: list[dict]) -> list[tuple[str, str]]:
+def _build_skill_md_paths(items: list[FileInfo]) -> list[tuple[str, str]]:
     """Build SKILL.md paths from directory listing items.
 
     Filters for directories and constructs the expected SKILL.md path


### PR DESCRIPTION
## Summary

- Extract `MemoryMiddleware._process_download_response()` to deduplicate response validation shared by `_load_memory_from_backend` and `_load_memory_from_backend_sync`
- Extract `_build_skill_md_paths()` and `_parse_skill_responses()` to deduplicate directory scanning and response parsing shared by `_list_skills` and `_alist_skills`
- Simplify `_list_skills` / `_alist_skills` from ~40 lines each to ~8 lines each
- Add 16 unit tests covering all new helpers

Intentionally skipped extracting `before_agent`/`abefore_agent` and `wrap_model_call`/`awrap_model_call` pairs — their loop bodies are too small (3-5 lines) to justify callback indirection.

`subagents.py` was also left unchanged since its duplication is already minimized by existing helpers.

Part 1 of #1547