### PR TITLE
refactor(sdk): extract shared helpers from filesystem middleware sync/async pairs

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1016,8 +1016,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if not _supports_execution(resolved_backend):
                 return _EXECUTION_NOT_AVAILABLE_MSG
             try:
-                result = (  # ty: ignore[unresolved-attribute]
-                    await resolved_backend.aexecute(command, timeout=timeout) if timeout is not None else await resolved_backend.aexecute(command)
+                result = (
+                    await resolved_backend.aexecute(command, timeout=timeout) if timeout is not None else await resolved_backend.aexecute(command)  # ty: ignore[unresolved-attribute]
                 )
             except NotImplementedError as e:
                 return f"Error: Execution not available. {e}"


### PR DESCRIPTION
## Summary
- Part 3 of #1547 (sync/async deduplication)
- Extracts 11 shared helpers from `filesystem.py` so each sync/async pair shares a single implementation of its core logic
- Adds 26 unit tests for all new helpers
- Follows PRs #1548 (memory/skills) and #1549 (summarization)