### PR TITLE
fix(sdk,cli): accept YAML list format for allowed-tools in skill frontmatter

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -322,6 +322,9 @@ def _parse_skill_metadata(  # noqa: C901
             for t in raw_tools.split()
             if t.strip(",")
         ]
+    elif isinstance(raw_tools, list):
+        # Support YAML list format (e.g., `- Bash\n- Read`)
+        allowed_tools = [str(t).strip() for t in raw_tools if t is not None and str(t).strip()]
     else:
         if raw_tools is not None:
             logger.warning(

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -437,7 +437,7 @@ def test_validate_metadata_valid_dict_passthrough() -> None:
     assert result == {"author": "acme"}
 
 
-def test_parse_skill_metadata_allowed_tools_yaml_list_ignored() -> None:
+def test_parse_skill_metadata_allowed_tools_yaml_list_accepted() -> None:
     content = """---
 name: test-skill
 description: A test skill
@@ -452,10 +452,10 @@ Content
 
     result = _parse_skill_metadata(content, "/skills/test-skill/SKILL.md", "test-skill")
     assert result is not None
-    assert result["allowed_tools"] == []
+    assert result["allowed_tools"] == ["Bash", "Read", "Write"]
 
 
-def test_parse_skill_metadata_allowed_tools_yaml_list_non_strings_ignored() -> None:
+def test_parse_skill_metadata_allowed_tools_yaml_list_coerces_non_strings() -> None:
     content = """---
 name: test-skill
 description: A test skill
@@ -473,7 +473,7 @@ Content
 
     result = _parse_skill_metadata(content, "/skills/test-skill/SKILL.md", "test-skill")
     assert result is not None
-    assert result["allowed_tools"] == []
+    assert result["allowed_tools"] == ["Read", "123", "True", "Write"]
 
 
 def test_parse_skill_metadata_license_boolean_coerced() -> None:


### PR DESCRIPTION
## Summary
- Skills authored with YAML list syntax for `allowed-tools` (e.g., `- Bash\n- Read`) were silently ignored with a warning
- Now supports both string format (`allowed-tools: Bash Read Write`) and YAML list format (`allowed-tools:\n  - Bash\n  - Read`)
- Non-string list items are coerced via `str()`, `None`/whitespace-only entries are dropped

## Test plan
- [x] `test_parse_skill_metadata_allowed_tools_yaml_list_accepted` — verifies list format produces correct output
- [x] `test_parse_skill_metadata_allowed_tools_yaml_list_coerces_non_strings` — verifies mixed types are coerced and empty entries dropped
- [x] Existing string-format test (`test_parse_skill_metadata_allowed_tools_multiple_spaces`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)