### PR TITLE
perf(sdk): conditionally add AnthropicPromptCachingMiddleware only for Anthropic models

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -82,7 +82,7 @@ def get_default_model() -> ChatAnthropic:
     )
 
 
-def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic with many conditional branches
+def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
     model: str | BaseChatModel | None = None,
     tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
     *,
@@ -291,14 +291,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
                 backend=backend,
                 subagents=all_subagents,
             ),
-            SummarizationMiddleware(
-                model=model,
-                backend=backend,
-                trigger=summarization_defaults["trigger"],
-                keep=summarization_defaults["keep"],
-                trim_tokens_to_summarize=None,
-                truncate_args_settings=summarization_defaults["truncate_args_settings"],
-            ),
+            summarization_middleware,
             PatchToolCallsMiddleware(),
         ]
     )


### PR DESCRIPTION
## Summary

- Only add `AnthropicPromptCachingMiddleware` to middleware stacks when the resolved model is a `ChatAnthropic` instance, avoiding unnecessary processing for non-Anthropic providers
- Removes the `unsupported_model_behavior="ignore"` workaround since the middleware is now only added when applicable
- Applies to all 3 middleware stacks: main agent, general-purpose subagent, and custom subagents
- Custom subagents correctly check their own `subagent_model`, not the parent model
- Updates `create_deep_agent` docstring to reflect the conditional behavior

Closes #1554