### PR TITLE
fix(cli): load `.agents` skill alias directories at interactive startup

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -453,10 +453,14 @@ def create_cli_agent(
 
     # Skills directories (if enabled)
     skills_dir = None
+    user_agent_skills_dir = None
     project_skills_dir = None
+    project_agent_skills_dir = None
     if enable_skills:
         skills_dir = settings.ensure_user_skills_dir(assistant_id)
+        user_agent_skills_dir = settings.get_user_agent_skills_dir()
         project_skills_dir = settings.get_project_skills_dir()
+        project_agent_skills_dir = settings.get_project_agent_skills_dir()
 
     # Load custom subagents from filesystem
     custom_subagents: list[SubAgent | CompiledSubAgent] = []
@@ -493,11 +497,15 @@ def create_cli_agent(
 
     # Add skills middleware
     if enable_skills:
-        # Built-in first (lowest precedence), then user, then project (highest)
+        # Lowest to highest precedence:
+        # built-in -> user .deepagents -> user .agents
+        # -> project .deepagents -> project .agents
         sources = [str(settings.get_built_in_skills_dir())]
-        sources.append(str(skills_dir))
+        sources.extend([str(skills_dir), str(user_agent_skills_dir)])
         if project_skills_dir:
             sources.append(str(project_skills_dir))
+        if project_agent_skills_dir:
+            sources.append(str(project_agent_skills_dir))
 
         agent_middleware.append(
             SkillsMiddleware(

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -448,23 +448,33 @@ class TestListAgents:
 
 
 class TestCreateCliAgentSkillsSources:
-    """Test that `create_cli_agent` wires built-in skills as first source."""
+    """Test that `create_cli_agent` wires skills sources in precedence order."""
 
-    def test_built_in_dir_is_first_source(self, tmp_path: Path) -> None:
-        """Built-in skills dir should be the first (lowest-precedence) source.
+    def test_skills_source_precedence_order(self, tmp_path: Path) -> None:
+        """Skills sources should be wired from lowest to highest precedence.
 
-        SkillsMiddleware uses last-one-wins dedup, so first = lowest precedence.
+        SkillsMiddleware uses last-one-wins dedup, so source order matters.
         """
         agent_dir = tmp_path / "agent"
         agent_dir.mkdir()
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()
+        user_agent_skills_dir = tmp_path / "user-agent-skills"
+        user_agent_skills_dir.mkdir()
+        project_skills_dir = tmp_path / "project-skills"
+        project_skills_dir.mkdir()
+        project_agent_skills_dir = tmp_path / "project-agent-skills"
+        project_agent_skills_dir.mkdir()
         built_in_dir = Settings.get_built_in_skills_dir()
 
         mock_settings = Mock()
         mock_settings.ensure_agent_dir.return_value = agent_dir
         mock_settings.ensure_user_skills_dir.return_value = skills_dir
-        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_user_agent_skills_dir.return_value = user_agent_skills_dir
+        mock_settings.get_project_skills_dir.return_value = project_skills_dir
+        mock_settings.get_project_agent_skills_dir.return_value = (
+            project_agent_skills_dir
+        )
         mock_settings.get_built_in_skills_dir.return_value = built_in_dir
         mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
         mock_settings.get_project_agent_md_path.return_value = []
@@ -503,10 +513,13 @@ class TestCreateCliAgentSkillsSources:
 
         assert len(captured_sources) == 1
         sources = captured_sources[0]
-        # Built-in dir should be the first source
-        assert sources[0] == str(built_in_dir)
-        # User skills dir should follow
-        assert sources[1] == str(skills_dir)
+        assert sources == [
+            str(built_in_dir),
+            str(skills_dir),
+            str(user_agent_skills_dir),
+            str(project_skills_dir),
+            str(project_agent_skills_dir),
+        ]
 
 
 class TestCreateCliAgentMemorySources:


### PR DESCRIPTION
Fixes parity gap between interactive runtime skill loading and `deepagents skills` discovery.

Interactive startup previously loaded only (bundled) built-in + `.deepagents` skill paths (in agent or project-scoped directories) -- did not include `.agents` alias paths.

- Updated `create_cli_agent` to include alias skill directories in `SkillsMiddleware` sources:
  1. built-in
  2. `~/.deepagents/<agent>/skills`
  3. `~/.agents/skills`
  4. `.deepagents/skills`
  5. `.agents/skills`
