### PR TITLE
fix(cli): image path pasting qualms

### DIFF
--- a/libs/cli/deepagents_cli/input.py
+++ b/libs/cli/deepagents_cli/input.py
@@ -3,6 +3,7 @@
 import logging
 import re
 import shlex
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -72,6 +73,22 @@ space code points that look identical to normal spaces when pasted.
 
 _WINDOWS_DRIVE_PATH_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
 """Pattern for Windows drive-letter paths like `C:\\Users\\...`."""
+
+
+@dataclass(frozen=True)
+class ParsedPastedPathPayload:
+    """Unified parse result for dropped-path payload detection.
+
+    Attributes:
+        paths: Resolved file paths parsed from the input payload.
+        token_end: End index (exclusive) of the parsed leading token when the
+            payload starts with a path followed by trailing text.
+
+            `None` means the entire payload was parsed as path-only content.
+    """
+
+    paths: list[Path]
+    token_end: int | None = None
 
 
 class ImageTracker:
@@ -242,6 +259,43 @@ def parse_pasted_file_paths(text: str) -> list[Path]:
         paths.append(resolved)
 
     return paths
+
+
+def parse_pasted_path_payload(
+    text: str, *, allow_leading_path: bool = False
+) -> ParsedPastedPathPayload | None:
+    """Parse dropped-path payload variants through one entrypoint.
+
+    Parsing order is:
+    1. strict multi-path payload parsing (`parse_pasted_file_paths`)
+    2. single-path normalization/parsing (`parse_single_pasted_file_path`)
+    3. optional leading-path extraction (`extract_leading_pasted_file_path`)
+
+    Args:
+        text: Input payload to parse.
+        allow_leading_path: Whether to parse a leading path token followed by
+            trailing prompt text.
+
+    Returns:
+        Parsed payload details, otherwise `None`.
+    """
+    paths = parse_pasted_file_paths(text)
+    if paths:
+        return ParsedPastedPathPayload(paths=paths)
+
+    single_path = parse_single_pasted_file_path(text)
+    if single_path is not None:
+        return ParsedPastedPathPayload(paths=[single_path])
+
+    if not allow_leading_path:
+        return None
+
+    leading = extract_leading_pasted_file_path(text)
+    if leading is None:
+        return None
+
+    path, token_end = leading
+    return ParsedPastedPathPayload(paths=[path], token_end=token_end)
 
 
 def parse_single_pasted_file_path(text: str) -> Path | None:

--- a/libs/cli/deepagents_cli/input.py
+++ b/libs/cli/deepagents_cli/input.py
@@ -58,6 +58,21 @@ Used to extract numeric IDs from placeholder tokens so the tracker can prune
 stale entries and compute the next available ID.
 """
 
+_UNICODE_SPACE_EQUIVALENTS = str.maketrans(
+    {
+        "\u00a0": " ",  # NO-BREAK SPACE
+        "\u202f": " ",  # NARROW NO-BREAK SPACE
+    }
+)
+"""Translation table used to normalize Unicode space variants.
+
+Some macOS-generated filenames (for example screenshots) may contain non-ASCII
+space code points that look identical to normal spaces when pasted.
+"""
+
+_WINDOWS_DRIVE_PATH_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+"""Pattern for Windows drive-letter paths like `C:\\Users\\...`."""
+
 
 class ImageTracker:
     """Track pasted images in the current conversation."""
@@ -221,16 +236,119 @@ def parse_pasted_file_paths(text: str) -> list[Path]:
         path = _token_to_path(token)
         if path is None:
             return []
-        try:
-            resolved = path.expanduser().resolve()
-        except (OSError, RuntimeError) as e:
-            logger.debug("Path resolution failed for token %r: %s", token, e)
-            return []
-        if not resolved.exists() or not resolved.is_file():
+        resolved = _resolve_existing_pasted_path(path)
+        if resolved is None:
             return []
         paths.append(resolved)
 
     return paths
+
+
+def parse_single_pasted_file_path(text: str) -> Path | None:
+    """Parse and resolve a single pasted path payload.
+
+    Unlike `parse_pasted_file_paths`, this helper only accepts one path token
+    and is intended for fallback handling when a paste event carries a
+    single path representation.
+
+    Args:
+        text: Raw pasted text payload.
+
+    Returns:
+        Resolved path when payload is a single existing file, otherwise `None`.
+    """
+    candidate = normalize_pasted_path(text)
+    if candidate is None:
+        return None
+    return _resolve_existing_pasted_path(candidate)
+
+
+def extract_leading_pasted_file_path(text: str) -> tuple[Path, int] | None:
+    """Extract and resolve a leading pasted path token from input text.
+
+    This is used for submit-time recovery when a user message starts with a
+    path token followed by additional prompt text.
+
+    Args:
+        text: Input text to inspect.
+
+    Returns:
+        Tuple of `(resolved_path, token_end_index)` or `None` when no valid
+        leading file path token exists.
+    """
+    if not text:
+        return None
+
+    start = len(text) - len(text.lstrip())
+    payload = text[start:]
+    token_end = _leading_token_end(payload)
+    if token_end is None:
+        return None
+
+    token_text = payload[:token_end]
+    path = parse_single_pasted_file_path(token_text)
+    if path is None:
+        spaced = _extract_unquoted_leading_path_with_spaces(payload)
+        if spaced is None:
+            return None
+        spaced_path, spaced_end = spaced
+        return spaced_path, start + spaced_end
+
+    return path, start + token_end
+
+
+def normalize_pasted_path(text: str) -> Path | None:
+    """Normalize pasted text that may represent a single filesystem path.
+
+    Supports:
+
+    - quoted and shell-escaped single paths
+    - `file://` URLs
+    - Windows drive-letter and UNC paths
+
+    Args:
+        text: Raw pasted text payload.
+
+    Returns:
+        Parsed `Path` if payload is a single path token, otherwise `None`.
+    """
+    payload = text.strip()
+    if not payload:
+        return None
+
+    unquoted = (
+        payload.removeprefix('"').removesuffix('"')
+        if payload.startswith('"') and payload.endswith('"')
+        else payload
+    )
+    unquoted = (
+        unquoted.removeprefix("'").removesuffix("'")
+        if unquoted.startswith("'") and unquoted.endswith("'")
+        else unquoted
+    )
+
+    if unquoted.startswith("file://"):
+        return _token_to_path(unquoted)
+
+    windows_path = _normalize_windows_pasted_path(unquoted)
+    if windows_path is not None:
+        return windows_path
+
+    posix_path = _normalize_posix_pasted_path(unquoted)
+    if posix_path is not None:
+        return posix_path
+
+    parts = _split_paste_line(payload)
+    if len(parts) != 1:
+        return None
+    token = parts[0]
+    path = _token_to_path(token)
+    if path is None:
+        return None
+    windows_token_path = _normalize_windows_pasted_path(str(path))
+    if windows_token_path is not None:
+        return windows_token_path
+    return path
 
 
 def _split_paste_line(line: str) -> list[str]:
@@ -285,3 +403,208 @@ def _token_to_path(token: str) -> Path | None:
         return Path(path_text)
 
     return Path(value)
+
+
+def _leading_token_end(text: str) -> int | None:
+    """Return the end index of the first shell-like token.
+
+    Args:
+        text: Input text beginning with a token.
+
+    Returns:
+        End index (exclusive), or `None` when token parsing fails.
+    """
+    if not text:
+        return None
+
+    if text[0] in {'"', "'"}:
+        quote = text[0]
+        escaped = False
+        for index in range(1, len(text)):
+            char = text[index]
+            if char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == quote and not escaped:
+                return index + 1
+            escaped = False
+        return None
+
+    escaped = False
+    for index, char in enumerate(text):
+        if char == "\\" and not escaped:
+            escaped = True
+            continue
+        if char.isspace() and not escaped:
+            return index
+        escaped = False
+    return len(text)
+
+
+def _extract_unquoted_leading_path_with_spaces(text: str) -> tuple[Path, int] | None:
+    """Extract a leading unquoted path that may contain spaces.
+
+    Args:
+        text: Input text beginning with a potential path.
+
+    Returns:
+        Tuple of `(resolved_path, token_end_index)` or `None` when no matching
+        leading path prefix resolves to an existing file.
+    """
+    if not text or ("\n" in text or "\r" in text):
+        return None
+    if not text.startswith(("/", "~/")):
+        return None
+    if " " not in text and "\u00a0" not in text and "\u202f" not in text:
+        return None
+
+    boundaries = [index for index, char in enumerate(text) if char.isspace()]
+    boundaries.append(len(text))
+    for end in reversed(boundaries):
+        candidate = text[:end].rstrip()
+        if not candidate:
+            continue
+        path = parse_single_pasted_file_path(candidate)
+        if path is not None:
+            return path, len(candidate)
+    return None
+
+
+def _normalize_windows_pasted_path(text: str) -> Path | None:
+    """Return a `Path` for unquoted Windows drive/UNC path inputs.
+
+    Args:
+        text: Potential Windows path input.
+
+    Returns:
+        Parsed `Path` when `text` is Windows drive-letter or UNC style,
+        otherwise `None`.
+    """
+    if _WINDOWS_DRIVE_PATH_PATTERN.match(text) or text.startswith("\\\\"):
+        return Path(text)
+    return None
+
+
+def _normalize_posix_pasted_path(text: str) -> Path | None:
+    """Return a `Path` for likely POSIX absolute/home path payloads.
+
+    Some terminals paste dropped absolute paths with spaces as raw text without
+    quoting/escaping. In that case shell tokenization splits on spaces even
+    though the full payload is intended to be a single path.
+
+    Args:
+        text: Potential POSIX path input.
+
+    Returns:
+        Parsed `Path` when `text` looks like a raw POSIX absolute/home path,
+        otherwise `None`.
+    """
+    if "\n" in text or "\r" in text:
+        return None
+    if text.startswith("~/"):
+        return Path(text)
+    if text.startswith("/") and "/" in text[1:]:
+        return Path(text)
+    return None
+
+
+def _resolve_existing_pasted_path(path: Path) -> Path | None:
+    """Resolve a pasted path candidate to an existing file.
+
+    Performs an exact resolution first, then a Unicode-space-tolerant lookup.
+
+    Args:
+        path: Parsed path candidate.
+
+    Returns:
+        Resolved existing file path, otherwise `None`.
+    """
+    try:
+        resolved = path.expanduser().resolve()
+    except (OSError, RuntimeError) as e:
+        logger.debug("Path resolution failed for %r: %s", path, e)
+        return None
+    if resolved.exists() and resolved.is_file():
+        return resolved
+
+    fuzzy = _resolve_with_unicode_space_variants(path)
+    if fuzzy is None:
+        return None
+    try:
+        resolved_fuzzy = fuzzy.resolve()
+    except (OSError, RuntimeError) as e:
+        logger.debug("Unicode-space resolution failed for %r: %s", fuzzy, e)
+        return None
+    if resolved_fuzzy.exists() and resolved_fuzzy.is_file():
+        return resolved_fuzzy
+    return None
+
+
+def _normalize_unicode_spaces(text: str) -> str:
+    """Normalize Unicode lookalike spaces to ASCII spaces.
+
+    Args:
+        text: Text to normalize.
+
+    Returns:
+        Normalized text with Unicode-space variants converted to ASCII spaces.
+    """
+    return text.translate(_UNICODE_SPACE_EQUIVALENTS)
+
+
+def _resolve_with_unicode_space_variants(path: Path) -> Path | None:
+    """Resolve path by matching filename segments with Unicode space variants.
+
+    Args:
+        path: Path candidate that may differ from disk by space code points.
+
+    Returns:
+        Matching filesystem path, or `None` when no variant match exists.
+    """
+    expanded = path.expanduser()
+    if expanded.is_absolute():
+        current = Path(expanded.anchor)
+        parts = expanded.parts[1:]
+    else:
+        current = Path.cwd()
+        parts = expanded.parts
+
+    for index, part in enumerate(parts):
+        candidate = current / part
+        if candidate.exists():
+            current = candidate
+            continue
+
+        if not current.exists() or not current.is_dir():
+            return None
+        if " " not in part and "\u00a0" not in part and "\u202f" not in part:
+            return None
+
+        normalized_part = _normalize_unicode_spaces(part)
+        try:
+            matches = [
+                entry
+                for entry in current.iterdir()
+                if _normalize_unicode_spaces(entry.name) == normalized_part
+            ]
+        except OSError as e:
+            logger.debug("Failed listing %s for Unicode-space lookup: %s", current, e)
+            return None
+
+        if not matches:
+            return None
+
+        is_last = index == len(parts) - 1
+        if is_last:
+            file_matches = [entry for entry in matches if entry.is_file()]
+            if file_matches:
+                matches = file_matches
+        else:
+            dir_matches = [entry for entry in matches if entry.is_dir()]
+            if dir_matches:
+                matches = dir_matches
+
+        matches.sort(key=lambda entry: entry.name)
+        current = matches[0]
+
+    return current

--- a/libs/cli/deepagents_cli/input.py
+++ b/libs/cli/deepagents_cli/input.py
@@ -498,6 +498,10 @@ def _leading_token_end(text: str) -> int | None:
 def _extract_unquoted_leading_path_with_spaces(text: str) -> tuple[Path, int] | None:
     """Extract a leading unquoted path that may contain spaces.
 
+    This fallback is intentionally POSIX-oriented (`/` and `~/`) because the
+    slash-command conflict it addresses is specific to inputs that begin with
+    `/`.
+
     Args:
         text: Input text beginning with a potential path.
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from textual.events import Click
     from textual.timer import Timer
 
-    from deepagents_cli.input import ImageTracker
+    from deepagents_cli.input import ImageTracker, ParsedPastedPathPayload
 
 
 class CompletionOption(Static):
@@ -404,19 +404,11 @@ class ChatTextArea(TextArea):
         if not payload:
             return
 
-        from deepagents_cli.input import (
-            parse_pasted_file_paths,
-            parse_single_pasted_file_path,
-        )
+        from deepagents_cli.input import parse_pasted_path_payload
 
-        paths = parse_pasted_file_paths(payload)
-        if not paths:
-            single_path = parse_single_pasted_file_path(payload)
-            if single_path is not None:
-                paths = [single_path]
-
-        if paths:
-            self.post_message(self.PastedPaths(payload, paths))
+        parsed = parse_pasted_path_payload(payload)
+        if parsed is not None:
+            self.post_message(self.PastedPaths(payload, parsed.paths))
             return
 
         self.insert(payload)
@@ -574,24 +566,18 @@ class ChatTextArea(TextArea):
         if self._paste_burst_buffer:
             self._flush_paste_burst()
 
-        from deepagents_cli.input import (
-            parse_pasted_file_paths,
-            parse_single_pasted_file_path,
-        )
+        from deepagents_cli.input import parse_pasted_path_payload
 
-        paths = parse_pasted_file_paths(event.text)
-        if not paths:
-            single_path = parse_single_pasted_file_path(event.text)
-            if single_path is None:
-                # Don't call super() here — Textual's MRO dispatch already calls
-                # TextArea._on_paste after this handler returns. Calling super()
-                # would insert the text a second time, duplicating the paste.
-                return
-            paths = [single_path]
+        parsed = parse_pasted_path_payload(event.text)
+        if parsed is None:
+            # Don't call super() here — Textual's MRO dispatch already calls
+            # TextArea._on_paste after this handler returns. Calling super()
+            # would insert the text a second time, duplicating the paste.
+            return
 
         event.prevent_default()
         event.stop()
-        self.post_message(self.PastedPaths(event.text, paths))
+        self.post_message(self.PastedPaths(event.text, parsed.paths))
 
     def set_text_from_history(self, text: str) -> None:
         """Set text from history navigation."""
@@ -870,21 +856,62 @@ class ChatInput(Vertical):
         self.scroll_visible()
 
     @staticmethod
+    def _parse_dropped_path_payload(
+        text: str, *, allow_leading_path: bool = False
+    ) -> ParsedPastedPathPayload | None:
+        """Parse dropped-path payload text through a single parser entrypoint.
+
+        Returns:
+            Parsed payload details, otherwise `None`.
+        """
+        from deepagents_cli.input import parse_pasted_path_payload
+
+        return parse_pasted_path_payload(text, allow_leading_path=allow_leading_path)
+
+    def _parse_dropped_path_payload_with_command_recovery(
+        self, text: str, *, allow_leading_path: bool = False
+    ) -> tuple[str, ParsedPastedPathPayload | None]:
+        """Parse payload and recover stripped leading slash in command mode.
+
+        Args:
+            text: Input text to parse.
+            allow_leading_path: Whether to parse leading path + suffix payloads.
+
+        Returns:
+            Tuple of `(candidate_text, parsed_payload)`.
+        """
+        candidate = text
+        parsed = self._parse_dropped_path_payload(
+            text, allow_leading_path=allow_leading_path
+        )
+        if parsed is not None:
+            return candidate, parsed
+
+        if self.mode != "command":
+            return candidate, None
+
+        prefixed = f"/{text.lstrip('/')}"
+        parsed = self._parse_dropped_path_payload(
+            prefixed, allow_leading_path=allow_leading_path
+        )
+        if parsed is None:
+            return candidate, None
+
+        logger.debug(
+            "Recovering stripped absolute path; resetting mode from "
+            "'command' to 'normal'"
+        )
+        self.mode = "normal"
+        return prefixed, parsed
+
+    @staticmethod
     def _is_existing_path_payload(text: str) -> bool:
         """Return whether text is a dropped-path payload for existing files."""
-        from deepagents_cli.input import (
-            extract_leading_pasted_file_path,
-            parse_pasted_file_paths,
-            parse_single_pasted_file_path,
-        )
+        from deepagents_cli.input import parse_pasted_path_payload
 
         if len(text) < 2:  # noqa: PLR2004  # Need at least '/' + one char
             return False
-        return (
-            bool(parse_pasted_file_paths(text))
-            or (parse_single_pasted_file_path(text) is not None)
-            or (extract_leading_pasted_file_path(text) is not None)
-        )
+        return parse_pasted_path_payload(text, allow_leading_path=True) is not None
 
     def _is_dropped_path_payload(self, text: str) -> bool:
         """Return whether current text looks like a dropped file-path payload."""
@@ -1083,20 +1110,11 @@ class ChatInput(Vertical):
         if not self._text_area:
             return False
 
-        from deepagents_cli.input import (
-            parse_pasted_file_paths,
-            parse_single_pasted_file_path,
-        )
-
-        paths = parse_pasted_file_paths(pasted)
-        if paths:
-            self._insert_pasted_paths(pasted, paths)
+        parsed = self._parse_dropped_path_payload(pasted)
+        if parsed is None:
+            self._text_area.insert(pasted)
         else:
-            single_path = parse_single_pasted_file_path(pasted)
-            if single_path is None:
-                self._text_area.insert(pasted)
-            else:
-                self._insert_pasted_paths(pasted, [single_path])
+            self._insert_pasted_paths(pasted, parsed.paths)
 
         self._text_area.focus()
         return True
@@ -1118,20 +1136,12 @@ class ChatInput(Vertical):
         if not self._text_area:
             return False
 
-        from deepagents_cli.input import (
-            parse_pasted_file_paths,
-            parse_single_pasted_file_path,
-        )
-
-        paths = parse_pasted_file_paths(text)
-        if not paths:
-            single_path = parse_single_pasted_file_path(text)
-            if single_path is None:
-                return False
-            paths = [single_path]
+        parsed = self._parse_dropped_path_payload(text)
+        if parsed is None:
+            return False
 
         replacement, attached = self._build_path_replacement(
-            text, paths, add_trailing_space=True
+            text, parsed.paths, add_trailing_space=True
         )
         if not attached or replacement == text:
             return False
@@ -1212,66 +1222,29 @@ class ChatInput(Vertical):
         Returns:
             Submitted text with image placeholders when attachment succeeded.
         """
-        from deepagents_cli.input import (
-            extract_leading_pasted_file_path,
-            parse_pasted_file_paths,
-            parse_single_pasted_file_path,
+        candidate, parsed = self._parse_dropped_path_payload_with_command_recovery(
+            value, allow_leading_path=True
         )
+        if parsed is None:
+            return value
 
-        paths = parse_pasted_file_paths(value)
-        candidate = value
-        if not paths:
-            single = parse_single_pasted_file_path(value)
-            if single is not None:
-                paths = [single]
-
-        # Recovery path: if command mode stripped the leading slash from an
-        # absolute dropped path, rehydrate it before resolving attachments.
-        if not paths and self.mode == "command":
-            prefixed = f"/{value.lstrip('/')}"
-            paths = parse_pasted_file_paths(prefixed)
-            if not paths:
-                single_prefixed = parse_single_pasted_file_path(prefixed)
-                if single_prefixed is not None:
-                    paths = [single_prefixed]
-            if paths:
-                candidate = prefixed
-                logger.debug(
-                    "Recovering stripped absolute path; resetting mode from "
-                    "'command' to 'normal'"
-                )
-                self.mode = "normal"
-
-        if paths:
+        if parsed.token_end is None:
             replacement, attached = self._build_path_replacement(
-                candidate, paths, add_trailing_space=False
+                candidate, parsed.paths, add_trailing_space=False
             )
             if attached:
                 return replacement.strip()
+            return value
 
-        leading_match = extract_leading_pasted_file_path(value)
-        leading_candidate = value
-        if leading_match is None and self.mode == "command":
-            prefixed = f"/{value.lstrip('/')}"
-            leading_match = extract_leading_pasted_file_path(prefixed)
-            if leading_match:
-                leading_candidate = prefixed
-                logger.debug(
-                    "Recovering stripped absolute leading path; resetting mode "
-                    "from 'command' to 'normal'"
-                )
-                self.mode = "normal"
-
-        if leading_match:
-            leading_path, token_end = leading_match
-            replacement, attached = self._build_path_replacement(
-                str(leading_path), [leading_path], add_trailing_space=False
-            )
-            if attached:
-                suffix = leading_candidate[token_end:].lstrip()
-                if suffix:
-                    return f"{replacement.strip()} {suffix}".strip()
-                return replacement.strip()
+        leading_path = parsed.paths[0]
+        replacement, attached = self._build_path_replacement(
+            str(leading_path), [leading_path], add_trailing_space=False
+        )
+        if attached:
+            suffix = candidate[parsed.token_end :].lstrip()
+            if suffix:
+                return f"{replacement.strip()} {suffix}".strip()
+            return replacement.strip()
         return value
 
     @staticmethod

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -462,14 +462,20 @@ class ChatTextArea(TextArea):
 
     async def _on_paste(self, event: events.Paste) -> None:
         """Handle paste events and detect dragged file paths."""
-        from deepagents_cli.input import parse_pasted_file_paths
+        from deepagents_cli.input import (
+            parse_pasted_file_paths,
+            parse_single_pasted_file_path,
+        )
 
         paths = parse_pasted_file_paths(event.text)
         if not paths:
-            # Don't call super() here — Textual's MRO dispatch already calls
-            # TextArea._on_paste after this handler returns. Calling super()
-            # would insert the text a second time, duplicating the paste.
-            return
+            single_path = parse_single_pasted_file_path(event.text)
+            if single_path is None:
+                # Don't call super() here — Textual's MRO dispatch already calls
+                # TextArea._on_paste after this handler returns. Calling super()
+                # would insert the text a second time, duplicating the paste.
+                return
+            paths = [single_path]
 
         event.prevent_default()
         event.stop()
@@ -738,11 +744,19 @@ class ChatInput(Vertical):
     @staticmethod
     def _is_existing_path_payload(text: str) -> bool:
         """Return whether text is a dropped-path payload for existing files."""
-        from deepagents_cli.input import parse_pasted_file_paths
+        from deepagents_cli.input import (
+            extract_leading_pasted_file_path,
+            parse_pasted_file_paths,
+            parse_single_pasted_file_path,
+        )
 
         if len(text) < 2:  # noqa: PLR2004  # Need at least '/' + one char
             return False
-        return bool(parse_pasted_file_paths(text))
+        return (
+            bool(parse_pasted_file_paths(text))
+            or (parse_single_pasted_file_path(text) is not None)
+            or (extract_leading_pasted_file_path(text) is not None)
+        )
 
     def _is_dropped_path_payload(self, text: str) -> bool:
         """Return whether current text looks like a dropped file-path payload."""
@@ -941,13 +955,20 @@ class ChatInput(Vertical):
         if not self._text_area:
             return False
 
-        from deepagents_cli.input import parse_pasted_file_paths
+        from deepagents_cli.input import (
+            parse_pasted_file_paths,
+            parse_single_pasted_file_path,
+        )
 
         paths = parse_pasted_file_paths(pasted)
         if paths:
             self._insert_pasted_paths(pasted, paths)
         else:
-            self._text_area.insert(pasted)
+            single_path = parse_single_pasted_file_path(pasted)
+            if single_path is None:
+                self._text_area.insert(pasted)
+            else:
+                self._insert_pasted_paths(pasted, [single_path])
 
         self._text_area.focus()
         return True
@@ -1022,16 +1043,28 @@ class ChatInput(Vertical):
         Returns:
             Submitted text with image placeholders when attachment succeeded.
         """
-        from deepagents_cli.input import parse_pasted_file_paths
+        from deepagents_cli.input import (
+            extract_leading_pasted_file_path,
+            parse_pasted_file_paths,
+            parse_single_pasted_file_path,
+        )
 
         paths = parse_pasted_file_paths(value)
         candidate = value
+        if not paths:
+            single = parse_single_pasted_file_path(value)
+            if single is not None:
+                paths = [single]
 
         # Recovery path: if command mode stripped the leading slash from an
         # absolute dropped path, rehydrate it before resolving attachments.
         if not paths and self.mode == "command":
             prefixed = f"/{value.lstrip('/')}"
             paths = parse_pasted_file_paths(prefixed)
+            if not paths:
+                single_prefixed = parse_single_pasted_file_path(prefixed)
+                if single_prefixed is not None:
+                    paths = [single_prefixed]
             if paths:
                 candidate = prefixed
                 logger.debug(
@@ -1045,6 +1078,30 @@ class ChatInput(Vertical):
                 candidate, paths, add_trailing_space=False
             )
             if attached:
+                return replacement.strip()
+
+        leading_match = extract_leading_pasted_file_path(value)
+        leading_candidate = value
+        if leading_match is None and self.mode == "command":
+            prefixed = f"/{value.lstrip('/')}"
+            leading_match = extract_leading_pasted_file_path(prefixed)
+            if leading_match:
+                leading_candidate = prefixed
+                logger.debug(
+                    "Recovering stripped absolute leading path; resetting mode "
+                    "from 'command' to 'normal'"
+                )
+                self.mode = "normal"
+
+        if leading_match:
+            leading_path, token_end = leading_match
+            replacement, attached = self._build_path_replacement(
+                str(leading_path), [leading_path], add_trailing_space=False
+            )
+            if attached:
+                suffix = leading_candidate[token_end:].lstrip()
+                if suffix:
+                    return f"{replacement.strip()} {suffix}".strip()
                 return replacement.strip()
         return value
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -324,6 +324,9 @@ class ChatTextArea(TextArea):
         self._in_history = False
         self._completion_active = False
         self._app_has_focus = True
+        # Buffer quote-prefixed high-frequency key bursts from terminals that
+        # emulate paste via rapid key events instead of dispatching a paste
+        # event.
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time: float | None = None
         self._paste_burst_timer: Timer | None = None
@@ -387,7 +390,11 @@ class ChatTextArea(TextArea):
         self._schedule_paste_burst_flush()
 
     def _should_start_paste_burst(self, char: str) -> bool:
-        """Return whether a keypress should start paste-burst buffering."""
+        """Return whether a keypress should start paste-burst buffering.
+
+        Restricting to quote-prefixed input at an empty cursor reduces false
+        positives for normal typing and slash-command entry.
+        """
         if char not in _PASTE_BURST_START_CHARS:
             return False
         if self.text or not self.selection.is_empty:
@@ -396,7 +403,11 @@ class ChatTextArea(TextArea):
         return row == 0 and col == 0
 
     def _flush_paste_burst(self) -> None:
-        """Flush buffered burst text through dropped-path parsing."""
+        """Flush buffered burst text through dropped-path parsing.
+
+        When parsing fails, the buffered text is inserted unchanged so regular
+        typing behavior is preserved.
+        """
         payload = self._paste_burst_buffer
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
@@ -1249,6 +1260,11 @@ class ChatInput(Vertical):
 
     def _replace_submitted_paths_with_images(self, value: str) -> str:
         """Replace dropped-path payloads in submitted text with image placeholders.
+
+        Handles both full-path payloads and leading-path-with-suffix payloads
+        (for example, `'<path>' what is this?`). When command mode previously
+        stripped a leading slash, this method also retries with the slash
+        restored before giving up.
 
         Args:
             value: Stripped submitted text (without mode prefix).

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -904,6 +904,40 @@ class ChatInput(Vertical):
         self.mode = "normal"
         return prefixed, parsed
 
+    def _extract_leading_dropped_path_with_command_recovery(
+        self, text: str
+    ) -> tuple[str, tuple[Path, int] | None]:
+        """Extract a leading dropped-path token with command-mode recovery.
+
+        Args:
+            text: Input text to parse.
+
+        Returns:
+            Tuple of `(candidate_text, leading_match)`, where `leading_match` is
+            `(path, token_end)` when extraction succeeds, otherwise `None`.
+        """
+        from deepagents_cli.input import extract_leading_pasted_file_path
+
+        leading_match = extract_leading_pasted_file_path(text)
+        candidate = text
+        if leading_match is not None:
+            return candidate, leading_match
+
+        if self.mode != "command":
+            return candidate, None
+
+        prefixed = f"/{text.lstrip('/')}"
+        leading_match = extract_leading_pasted_file_path(prefixed)
+        if leading_match is None:
+            return candidate, None
+
+        logger.debug(
+            "Recovering stripped absolute leading path; resetting mode "
+            "from 'command' to 'normal'"
+        )
+        self.mode = "normal"
+        return prefixed, leading_match
+
     @staticmethod
     def _is_existing_path_payload(text: str) -> bool:
         """Return whether text is a dropped-path payload for existing files."""
@@ -1234,14 +1268,23 @@ class ChatInput(Vertical):
             )
             if attached:
                 return replacement.strip()
-            return value
+            # Even when full-payload parsing resolves, still retry explicit
+            # leading-token extraction before giving up.
+            candidate, leading_match = (
+                self._extract_leading_dropped_path_with_command_recovery(value)
+            )
+            if leading_match is None:
+                return value
+            leading_path, token_end = leading_match
+        else:
+            leading_path = parsed.paths[0]
+            token_end = parsed.token_end
 
-        leading_path = parsed.paths[0]
         replacement, attached = self._build_path_replacement(
             str(leading_path), [leading_path], add_trailing_space=False
         )
         if attached:
-            suffix = candidate[parsed.token_end :].lstrip()
+            suffix = candidate[token_end:].lstrip()
             if suffix:
                 return f"{replacement.strip()} {suffix}".strip()
             return replacement.strip()

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -42,10 +43,20 @@ _IMAGE_PLACEHOLDER_PATTERN = re.compile(r"\[image \d+\]")
 Used to locate tokens for atomic backspace/delete handling.
 """
 
+_PASTE_BURST_CHAR_GAP_SECONDS = 0.03
+"""Maximum time between chars to treat input as a paste-like burst."""
+
+_PASTE_BURST_FLUSH_DELAY_SECONDS = 0.08
+"""Idle timeout before flushing buffered burst text."""
+
+_PASTE_BURST_START_CHARS = {"'", '"'}
+"""Characters that can start dropped-path payloads."""
+
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
     from textual.events import Click
+    from textual.timer import Timer
 
     from deepagents_cli.input import ImageTracker
 
@@ -313,6 +324,9 @@ class ChatTextArea(TextArea):
         self._in_history = False
         self._completion_active = False
         self._app_has_focus = True
+        self._paste_burst_buffer = ""
+        self._paste_burst_last_char_time: float | None = None
+        self._paste_burst_timer: Timer | None = None
 
     def set_app_focus(self, *, has_focus: bool) -> None:
         """Set whether the app should show the cursor as active.
@@ -343,8 +357,103 @@ class ChatTextArea(TextArea):
         end_col = len(lines[end_row])
         self.selection = Selection(start=(0, 0), end=(end_row, end_col))
 
+    def _cancel_paste_burst_timer(self) -> None:
+        """Cancel any scheduled paste-burst flush timer."""
+        if self._paste_burst_timer is None:
+            return
+        self._paste_burst_timer.stop()
+        self._paste_burst_timer = None
+
+    def _schedule_paste_burst_flush(self) -> None:
+        """Schedule idle-time flush for buffered paste-burst text."""
+        self._cancel_paste_burst_timer()
+        self._paste_burst_timer = self.set_timer(
+            _PASTE_BURST_FLUSH_DELAY_SECONDS, self._flush_paste_burst
+        )
+
+    def _start_paste_burst(self, char: str, now: float) -> None:
+        """Start buffering a paste-like keystroke burst."""
+        self._paste_burst_buffer = char
+        self._paste_burst_last_char_time = now
+        self._schedule_paste_burst_flush()
+
+    def _append_paste_burst(self, text: str, now: float) -> None:
+        """Append text to an active paste-burst buffer."""
+        if not self._paste_burst_buffer:
+            self._start_paste_burst(text, now)
+            return
+        self._paste_burst_buffer += text
+        self._paste_burst_last_char_time = now
+        self._schedule_paste_burst_flush()
+
+    def _should_start_paste_burst(self, char: str) -> bool:
+        """Return whether a keypress should start paste-burst buffering."""
+        if char not in _PASTE_BURST_START_CHARS:
+            return False
+        if self.text or not self.selection.is_empty:
+            return False
+        row, col = self.cursor_location
+        return row == 0 and col == 0
+
+    def _flush_paste_burst(self) -> None:
+        """Flush buffered burst text through dropped-path parsing."""
+        payload = self._paste_burst_buffer
+        self._paste_burst_buffer = ""
+        self._paste_burst_last_char_time = None
+        self._cancel_paste_burst_timer()
+        if not payload:
+            return
+
+        from deepagents_cli.input import (
+            parse_pasted_file_paths,
+            parse_single_pasted_file_path,
+        )
+
+        paths = parse_pasted_file_paths(payload)
+        if not paths:
+            single_path = parse_single_pasted_file_path(payload)
+            if single_path is not None:
+                paths = [single_path]
+
+        if paths:
+            self.post_message(self.PastedPaths(payload, paths))
+            return
+
+        self.insert(payload)
+
     async def _on_key(self, event: events.Key) -> None:
         """Handle key events."""
+        now = time.monotonic()
+        if self._paste_burst_buffer:
+            if event.key == "enter":
+                self._append_paste_burst("\n", now)
+                event.prevent_default()
+                event.stop()
+                return
+
+            if event.is_printable and event.character is not None:
+                last_time = self._paste_burst_last_char_time
+                if (
+                    last_time is not None
+                    and (now - last_time) <= _PASTE_BURST_CHAR_GAP_SECONDS
+                ):
+                    self._append_paste_burst(event.character, now)
+                    event.prevent_default()
+                    event.stop()
+                    return
+
+            self._flush_paste_burst()
+
+        if (
+            event.is_printable
+            and event.character is not None
+            and self._should_start_paste_burst(event.character)
+        ):
+            self._start_paste_burst(event.character, now)
+            event.prevent_default()
+            event.stop()
+            return
+
         # Modifier+Enter inserts newline (Ctrl+J is most reliable across terminals)
         if event.key in {"shift+enter", "ctrl+j", "alt+enter", "ctrl+enter"}:
             event.prevent_default()
@@ -462,6 +571,9 @@ class ChatTextArea(TextArea):
 
     async def _on_paste(self, event: events.Paste) -> None:
         """Handle paste events and detect dragged file paths."""
+        if self._paste_burst_buffer:
+            self._flush_paste_burst()
+
         from deepagents_cli.input import (
             parse_pasted_file_paths,
             parse_single_pasted_file_path,
@@ -483,6 +595,9 @@ class ChatTextArea(TextArea):
 
     def set_text_from_history(self, text: str) -> None:
         """Set text from history navigation."""
+        self._paste_burst_buffer = ""
+        self._paste_burst_last_char_time = None
+        self._cancel_paste_burst_timer()
         self._navigating_history = True
         self.text = text
         # Move cursor to end
@@ -495,6 +610,9 @@ class ChatTextArea(TextArea):
     def clear_text(self) -> None:
         """Clear the text area."""
         self._in_history = False
+        self._paste_burst_buffer = ""
+        self._paste_burst_last_char_time = None
+        self._cancel_paste_burst_timer()
         self.text = ""
         self.move_cursor((0, 0))
 
@@ -650,6 +768,11 @@ class ChatInput(Vertical):
         # completion controller calls (0 for normal, 1 for bash/command).
         self._completion_prefix_len = 0
 
+        # Guard flag: set while replacing a dropped path payload with an
+        # inline image placeholder so the resulting change event doesn't
+        # immediately recurse into the same replacement path.
+        self._applying_inline_path_replacement = False
+
         # Track current suggestions for click handling
         self._current_suggestions: list[tuple[str, str]] = []
         self._current_selected_index = 0
@@ -702,6 +825,11 @@ class ChatInput(Vertical):
             if self._completion_manager:
                 self._completion_manager.reset()
             self.scroll_visible()
+            return
+
+        if self._applying_inline_path_replacement:
+            self._applying_inline_path_replacement = False
+        elif self._apply_inline_dropped_path_replacement(text):
             return
 
         # Checked after the guards above so we skip the (potentially slow)
@@ -971,6 +1099,47 @@ class ChatInput(Vertical):
                 self._insert_pasted_paths(pasted, [single_path])
 
         self._text_area.focus()
+        return True
+
+    def _apply_inline_dropped_path_replacement(self, text: str) -> bool:
+        """Replace full dropped-path payload text with image placeholders.
+
+        Some terminals insert drag-and-drop payloads as plain text rather than
+        dispatching a dedicated paste event. When the current text resolves to
+        one or more file paths and at least one path is an image, rewrite the
+        text inline to `[image N]` placeholders.
+
+        Args:
+            text: Current text area content.
+
+        Returns:
+            `True` if text was rewritten inline, otherwise `False`.
+        """
+        if not self._text_area:
+            return False
+
+        from deepagents_cli.input import (
+            parse_pasted_file_paths,
+            parse_single_pasted_file_path,
+        )
+
+        paths = parse_pasted_file_paths(text)
+        if not paths:
+            single_path = parse_single_pasted_file_path(text)
+            if single_path is None:
+                return False
+            paths = [single_path]
+
+        replacement, attached = self._build_path_replacement(
+            text, paths, add_trailing_space=True
+        )
+        if not attached or replacement == text:
+            return False
+
+        self._applying_inline_path_replacement = True
+        self._text_area.text = replacement
+        lines = replacement.split("\n")
+        self._text_area.move_cursor((len(lines) - 1, len(lines[-1])))
         return True
 
     def _insert_pasted_paths(self, raw_text: str, paths: list[Path]) -> None:

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -1614,6 +1614,36 @@ class TestDroppedImagePaste:
             assert len(app.tracker.get_images()) == 1
 
     @pytest.mark.asyncio
+    async def test_submit_falls_back_to_leading_image_when_full_path_non_image(
+        self, tmp_path
+    ) -> None:
+        """Leading image token should win over full non-image payload resolution."""
+        img_path = tmp_path / "fallback.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (3, 3), color="green")
+        image.save(img_path, format="PNG")
+
+        payload_path = tmp_path / "fallback.png analyze"
+        payload_path.write_text("not an image")
+
+        app = _ImagePasteRecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.text = str(payload_path)
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "[image 1] analyze"
+            assert app.submitted[0].mode == "normal"
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
     async def test_submit_leading_path_handles_unicode_space_variants(
         self, tmp_path
     ) -> None:

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -1376,6 +1376,28 @@ class TestDroppedImagePaste:
             assert len(app.tracker.get_images()) == 1
 
     @pytest.mark.asyncio
+    async def test_handle_external_paste_attaches_unquoted_path_with_spaces(
+        self, tmp_path
+    ) -> None:
+        """External paste should attach raw absolute paths that include spaces."""
+        img_path = tmp_path / "Screenshot 1.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (4, 4), color="orange")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            assert chat.handle_external_paste(str(img_path))
+            await pilot.pause()
+
+            assert chat._text_area.text.strip() == "[image 1]"
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
     async def test_handle_external_paste_inserts_plain_text(self) -> None:
         """External paste should insert text when payload is not a file path."""
         app = _ImagePasteApp()
@@ -1454,6 +1476,118 @@ class TestDroppedImagePaste:
 
             assert len(app.submitted) == 1
             assert app.submitted[0].value == "[image 1]"
+            assert app.submitted[0].mode == "normal"
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
+    async def test_submit_absolute_path_with_spaces_stays_normal_mode(
+        self, tmp_path
+    ) -> None:
+        """Absolute paths with spaces should not trigger slash-command mode."""
+        img_path = tmp_path / "Screenshot 1.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (3, 3), color="green")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteRecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            # Simulate terminals that insert dropped paths as regular text.
+            chat._text_area.text = str(img_path)
+            await pilot.pause()
+
+            assert chat.mode == "normal"
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "[image 1]"
+            assert app.submitted[0].mode == "normal"
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
+    async def test_submit_absolute_path_with_spaces_and_trailing_text(
+        self, tmp_path
+    ) -> None:
+        """Path-with-spaces plus prompt text should stay normal and attach image."""
+        img_path = tmp_path / "Screenshot 1.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (3, 3), color="green")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteRecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.text = f"{img_path} what's in this"
+            await pilot.pause()
+
+            assert chat.mode == "normal"
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "[image 1] what's in this"
+            assert app.submitted[0].mode == "normal"
+            assert len(app.tracker.get_images()) == 1
+
+    async def test_submit_leading_path_with_trailing_text_attaches_image(
+        self, tmp_path
+    ) -> None:
+        """Leading pasted path should attach while preserving trailing prompt text."""
+        img_path = tmp_path / "leading-path.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (3, 3), color="green")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteRecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.text = f"'{img_path}' what's in this image?"
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "[image 1] what's in this image?"
+            assert app.submitted[0].mode == "normal"
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
+    async def test_submit_leading_path_handles_unicode_space_variants(
+        self, tmp_path
+    ) -> None:
+        """Submitted leading path should recover Unicode-space filename variants."""
+        from PIL import Image
+
+        img_path = tmp_path / "Screenshot 2026-02-26 at 2.02.42\u202fAM.png"
+        image = Image.new("RGB", (3, 3), color="green")
+        image.save(img_path, format="PNG")
+
+        pasted_with_ascii_space = str(img_path).replace("\u202f", " ")
+
+        app = _ImagePasteRecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.text = f"'{pasted_with_ascii_space}' analyze this"
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "[image 1] analyze this"
             assert app.submitted[0].mode == "normal"
             assert len(app.tracker.get_images()) == 1
 

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -1451,6 +1451,57 @@ class TestDroppedImagePaste:
             assert app.tracker.get_images() == []
 
     @pytest.mark.asyncio
+    async def test_inline_quoted_path_payload_rewrites_to_placeholder(
+        self, tmp_path
+    ) -> None:
+        """Quoted dropped path text should rewrite inline to `[image N]`."""
+        img_path = tmp_path / "vscode-drop.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (3, 3), color="teal")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            # Simulate terminals that drop paths as plain quoted text.
+            chat._text_area.text = f"'{img_path}'"
+            await pilot.pause()
+
+            assert chat._text_area.text == "[image 1] "
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
+    async def test_key_burst_quoted_path_rewrites_without_showing_raw_path(
+        self, tmp_path
+    ) -> None:
+        """Fast quoted-path key bursts should flush as `[image N]` placeholders."""
+        img_path = tmp_path / "vscode-burst.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (3, 3), color="navy")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            payload = f"'{img_path}'"
+            for char in payload:
+                await chat._text_area._on_key(events.Key(char, char))
+
+            # Burst text is buffered and should not be inserted verbatim.
+            assert chat._text_area.text == ""
+
+            await pilot.pause(0.2)
+
+            assert chat._text_area.text == "[image 1] "
+            assert len(app.tracker.get_images()) == 1
+
+    @pytest.mark.asyncio
     async def test_submit_absolute_path_without_paste_event_attaches_image(
         self, tmp_path
     ) -> None:

--- a/libs/cli/tests/unit_tests/test_input_parsing.py
+++ b/libs/cli/tests/unit_tests/test_input_parsing.py
@@ -9,6 +9,7 @@ from deepagents_cli.input import (
     normalize_pasted_path,
     parse_file_mentions,
     parse_pasted_file_paths,
+    parse_pasted_path_payload,
     parse_single_pasted_file_path,
 )
 
@@ -353,6 +354,34 @@ def test_parse_single_pasted_file_path_unquoted_posix_path_with_spaces(
     resolved = parse_single_pasted_file_path(str(img))
 
     assert resolved == img.resolve()
+
+
+def test_parse_pasted_path_payload_single_path(tmp_path: Path) -> None:
+    """Payload parser should resolve path-only payloads."""
+    img = tmp_path / "one.png"
+    img.write_bytes(b"img")
+
+    parsed = parse_pasted_path_payload(str(img))
+
+    assert parsed is not None
+    assert parsed.paths == [img.resolve()]
+    assert parsed.token_end is None
+
+
+def test_parse_pasted_path_payload_leading_path_with_suffix(tmp_path: Path) -> None:
+    """Payload parser should extract leading path when enabled."""
+    img = tmp_path / "my image.png"
+    img.write_bytes(b"img")
+    payload = f"'{img}' what's in this image?"
+
+    assert parse_pasted_path_payload(payload) is None
+
+    parsed = parse_pasted_path_payload(payload, allow_leading_path=True)
+
+    assert parsed is not None
+    assert parsed.paths == [img.resolve()]
+    assert parsed.token_end is not None
+    assert payload[parsed.token_end :] == " what's in this image?"
 
 
 def test_extract_leading_pasted_file_path_with_trailing_text(tmp_path: Path) -> None:

--- a/libs/cli/tests/unit_tests/test_input_parsing.py
+++ b/libs/cli/tests/unit_tests/test_input_parsing.py
@@ -5,8 +5,11 @@ from pathlib import Path
 import pytest
 
 from deepagents_cli.input import (
+    extract_leading_pasted_file_path,
+    normalize_pasted_path,
     parse_file_mentions,
     parse_pasted_file_paths,
+    parse_single_pasted_file_path,
 )
 
 
@@ -311,3 +314,72 @@ def test_parse_pasted_file_paths_handles_angle_bracket_wrapped_path(
     result = parse_pasted_file_paths(f"<{img}>")
 
     assert result == [img.resolve()]
+
+
+def test_normalize_pasted_path_rejects_mixed_payload() -> None:
+    """Single-path normalizer should reject path+prose mixed payloads."""
+    assert normalize_pasted_path("'/tmp/a.png' what's this") is None
+
+
+def test_normalize_pasted_path_accepts_windows_drive_payload() -> None:
+    """Unquoted Windows drive path with spaces should parse as one path token."""
+    payload = r"C:\Users\Alice\My Pictures\example image.png"
+    result = normalize_pasted_path(payload)
+    assert result == Path(payload)
+
+
+def test_parse_single_pasted_file_path_resolves_unicode_space_variant(
+    tmp_path: Path,
+) -> None:
+    """ASCII-space paste should resolve files with lookalike Unicode spaces."""
+    unicode_name = "Screenshot 2026-02-26 at 2.02.42\u202fAM.png"
+    img = tmp_path / unicode_name
+    img.write_bytes(b"img")
+
+    pasted_path = str(img).replace("\u202f", " ")
+    pasted = f"'{pasted_path}'"
+    resolved = parse_single_pasted_file_path(pasted)
+
+    assert resolved == img.resolve()
+
+
+def test_parse_single_pasted_file_path_unquoted_posix_path_with_spaces(
+    tmp_path: Path,
+) -> None:
+    """Raw POSIX absolute paths with spaces should resolve as one file path."""
+    img = tmp_path / "Screenshot 1.png"
+    img.write_bytes(b"img")
+
+    resolved = parse_single_pasted_file_path(str(img))
+
+    assert resolved == img.resolve()
+
+
+def test_extract_leading_pasted_file_path_with_trailing_text(tmp_path: Path) -> None:
+    """Leading path token should be extracted while preserving trailing text."""
+    img = tmp_path / "my image.png"
+    img.write_bytes(b"img")
+    payload = f"'{img}' what's in this image?"
+
+    result = extract_leading_pasted_file_path(payload)
+
+    assert result is not None
+    resolved, end = result
+    assert resolved == img.resolve()
+    assert payload[end:] == " what's in this image?"
+
+
+def test_extract_leading_pasted_file_path_unquoted_path_with_spaces(
+    tmp_path: Path,
+) -> None:
+    """Unquoted absolute paths with spaces should be extracted from leading text."""
+    img = tmp_path / "Screenshot 1.png"
+    img.write_bytes(b"img")
+    payload = f"{img} what's in this"
+
+    result = extract_leading_pasted_file_path(payload)
+
+    assert result is not None
+    resolved, end = result
+    assert resolved == img.resolve()
+    assert payload[end:] == " what's in this"


### PR DESCRIPTION
Fixes #1414
Fixes #1432

---

When users drag or paste an image path into the CLI, terminals can send that input in different formats. This PR makes image-path handling consistent across those formats.

## What users get

- Image paths are attached reliably, even when the path includes spaces.
- Absolute paths pasted as text are handled as file paths.
- If a message starts with a valid path and then includes text, the image is attached and the trailing text is preserved.
- If a terminal sends a dropped path as rapid key events (instead of a paste event), it is still detected and attached.
- Filenames with lookalike Unicode spaces (common in screenshot names) resolve correctly.

## Cases now handled

1. Path-only payloads (quoted, escaped, file URL, multi-line path lists).
2. Single raw absolute paths with spaces.
3. Leading path + prompt text (for example: `'<path>' what is this?`).
4. Recovery when a leading slash was stripped earlier.
5. Unicode-space filename variants pasted with normal spaces.

## Examples of handled cases

1. Path-only payloads  
   `'/Users/alex/Pictures/cat.png'` -> `[image 1]`  
   `file:///Users/alex/Pictures/cat%20photo.png` -> `[image 1]`  
   `/Users/alex/a.png\n/Users/alex/b.png` -> `[image 1]\n[image 2]` (if both are images)

2. Single raw absolute path with spaces  
   `/Users/alex/Desktop/Screenshot 1.png` -> `[image 1]`

3. Leading path + prompt text  
   `'/Users/alex/Pictures/chart.png' what does this show?` -> `[image 1] what does this show?`

4. Recovery when a leading slash was stripped earlier  
   `Users/alex/Pictures/recover.png` is recovered as `/Users/alex/Pictures/recover.png` on submit -> `[image 1]`

5. Unicode-space filename variants  
   File on disk uses Unicode space: `Screenshot 2026-02-26 at 2.02.42 AM.png`  
   Pasted text uses ASCII space: `'.../Screenshot 2026-02-26 at 2.02.42 AM.png' analyze this`  
   Result -> `[image 1] analyze this`

## Safety/behavior notes

- Non-image files keep normal text behavior (no forced attachment).
- Path parsing remains generic (no hardcoded machine-specific aliases).