### PR TITLE
perf(cli): optimize thread resume path with prefetch and batched hydration

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1768,7 +1768,82 @@ class DeepAgentsApp(App):
 
         return result
 
-    async def _load_thread_history(self) -> None:
+    async def _fetch_thread_history_data(self, thread_id: str) -> list[MessageData]:
+        """Fetch and convert stored messages for a thread.
+
+        Args:
+            thread_id: Thread ID to fetch from checkpoint storage.
+
+        Returns:
+            Converted message data ready for bulk loading.
+        """
+        if not self._agent:
+            return []
+
+        config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
+        state = await self._agent.aget_state(config)
+        if not state or not state.values:
+            return []
+
+        messages = state.values.get("messages", [])
+        if not messages:
+            return []
+
+        # Offload conversion so large histories don't block the UI loop.
+        return await asyncio.to_thread(self._convert_messages_to_data, messages)
+
+    async def _upgrade_thread_message_link(
+        self,
+        widget: AppMessage,
+        *,
+        prefix: str,
+        thread_id: str,
+    ) -> None:
+        """Upgrade a plain thread message to a linked one when URL resolves.
+
+        Args:
+            widget: The already-mounted app message.
+            prefix: Text prefix before thread ID.
+            thread_id: Thread ID to resolve.
+        """
+        thread_msg = await self._build_thread_message(prefix, thread_id)
+        if not isinstance(thread_msg, Text):
+            return
+        if widget.parent is None:
+            return
+        # Keep serialized content in sync with the rendered content.
+        widget._content = thread_msg
+        widget.update(thread_msg)
+
+    def _schedule_thread_message_link(
+        self,
+        widget: AppMessage,
+        *,
+        prefix: str,
+        thread_id: str,
+    ) -> None:
+        """Resolve and apply thread URL link in the background.
+
+        Args:
+            widget: The message widget to update.
+            prefix: Text prefix before thread ID.
+            thread_id: Thread ID to resolve.
+        """
+        self.run_worker(
+            self._upgrade_thread_message_link(
+                widget,
+                prefix=prefix,
+                thread_id=thread_id,
+            ),
+            exclusive=False,
+        )
+
+    async def _load_thread_history(
+        self,
+        *,
+        thread_id: str | None = None,
+        preloaded_data: list[MessageData] | None = None,
+    ) -> None:
         """Load and render message history when resuming a thread.
 
         This retrieves the checkpoint state from the agent and converts stored
@@ -1776,24 +1851,26 @@ class DeepAgentsApp(App):
         into the `MessageStore`. Only the last `WINDOW_SIZE` messages are
         mounted as widgets, drastically reducing DOM operations for large
         threads.
+
+        Args:
+            thread_id: Optional explicit thread ID to load.
+
+                Defaults to current.
+            preloaded_data: Optional pre-fetched history data for the thread.
         """
-        if not self._agent or not self._lc_thread_id:
+        history_thread_id = thread_id or self._lc_thread_id
+        if not history_thread_id:
+            return
+        if preloaded_data is None and not self._agent:
             return
 
-        config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
-
         try:
-            # 1. Fetch state (single network call)
-            state = await self._agent.aget_state(config)
-            if not state or not state.values:
-                return
-
-            messages = state.values.get("messages", [])
-            if not messages:
-                return
-
-            # 2. Convert to data (pure computation, no DOM)
-            all_data = self._convert_messages_to_data(messages)
+            # 1-2. Fetch + convert (reuse preloaded payload on thread switch)
+            all_data = (
+                preloaded_data
+                if preloaded_data is not None
+                else await self._fetch_thread_history_data(history_thread_id)
+            )
             if not all_data:
                 return
 
@@ -1810,18 +1887,27 @@ class DeepAgentsApp(App):
                 return
 
             # 6-7. Create and mount only visible widgets (max WINDOW_SIZE)
-            for msg_data in visible:
-                widget = msg_data.to_widget()
-                await messages_container.mount(widget)
-                # 8. Render content for AssistantMessage after mount
-                if isinstance(widget, AssistantMessage) and msg_data.content:
-                    await widget.set_content(msg_data.content)
+            widgets = [msg_data.to_widget() for msg_data in visible]
+            if widgets:
+                await messages_container.mount(*widgets)
 
-            # 9. Add footer — "Resumed thread" message
-            thread_msg = await self._build_thread_message(
-                "Resumed thread", self._lc_thread_id
+            # 8. Render content for AssistantMessage after mount
+            assistant_updates = [
+                widget.set_content(msg_data.content)
+                for widget, msg_data in zip(widgets, visible, strict=False)
+                if isinstance(widget, AssistantMessage) and msg_data.content
+            ]
+            if assistant_updates:
+                await asyncio.gather(*assistant_updates)
+
+            # 9. Add footer immediately and resolve link asynchronously
+            thread_msg_widget = AppMessage(f"Resumed thread: {history_thread_id}")
+            await self._mount_message(thread_msg_widget)
+            self._schedule_thread_message_link(
+                thread_msg_widget,
+                prefix="Resumed thread",
+                thread_id=history_thread_id,
             )
-            await self._mount_message(AppMessage(thread_msg))
 
             # 10. Scroll once
             def scroll_to_end() -> None:
@@ -1832,7 +1918,10 @@ class DeepAgentsApp(App):
             self.set_timer(0.1, scroll_to_end)
 
         except Exception as e:  # Resilient history loading
-            logger.exception("Failed to load thread history for %s", self._lc_thread_id)
+            logger.exception(
+                "Failed to load thread history for %s",
+                history_thread_id,
+            )
             await self._mount_message(AppMessage(f"Could not load history: {e}"))
 
     async def _mount_message(
@@ -2201,8 +2290,9 @@ class DeepAgentsApp(App):
     async def _resume_thread(self, thread_id: str) -> None:
         """Resume a previously saved thread.
 
-        Clears the current conversation, switches to the selected thread,
-        updates the welcome banner, and loads its message history.
+        Fetches the selected thread history, then atomically switches UI state.
+        Prefetching first avoids clearing the active chat when history loading
+        fails.
 
         Args:
             thread_id: The thread ID to resume.
@@ -2229,6 +2319,20 @@ class DeepAgentsApp(App):
         prev_session_thread = self._session_state.thread_id
 
         try:
+            self._update_status(f"Loading thread: {thread_id}")
+            prefetched_history = await self._fetch_thread_history_data(thread_id)
+        except Exception as exc:
+            logger.exception("Failed to prefetch history for thread %s", thread_id)
+            self._update_status("")
+            await self._mount_message(
+                AppMessage(
+                    f"Failed to switch to thread {thread_id}: {exc}. "
+                    "Use /threads to try again."
+                )
+            )
+            return
+
+        try:
             # Clear conversation (similar to /clear, without creating a new thread)
             self._pending_messages.clear()
             self._queued_widgets.clear()
@@ -2252,7 +2356,10 @@ class DeepAgentsApp(App):
                 )
 
             # Load thread history
-            await self._load_thread_history()
+            await self._load_thread_history(
+                thread_id=thread_id,
+                preloaded_data=prefetched_history,
+            )
 
         except Exception as exc:
             logger.exception("Failed to switch to thread %s", thread_id)
@@ -2270,7 +2377,8 @@ class DeepAgentsApp(App):
                 )
             # Attempt to restore the previous thread's visible history
             try:
-                await self._load_thread_history()
+                await self._clear_messages()
+                await self._load_thread_history(thread_id=prev_session_thread)
             except Exception:  # noqa: BLE001  # Resilient session state saving
                 logger.debug(
                     "Could not restore previous thread history after "

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -463,6 +463,7 @@ class DeepAgentsApp(App):
         self._pending_messages: deque[QueuedMessage] = deque()
         self._queued_widgets: deque[QueuedUserMessage] = deque()
         self._processing_pending = False
+        self._thread_switching = False
         # Message virtualization store
         self._message_store = MessageStore()
         # Lazily imported here to avoid pulling image dependencies into
@@ -951,6 +952,15 @@ class DeepAgentsApp(App):
 
         # Reset quit pending state on any input
         self._quit_pending = False
+
+        # Prevent message handling while a thread switch is in-flight.
+        if self._thread_switching:
+            self.notify(
+                "Thread switch in progress. Please wait.",
+                severity="warning",
+                timeout=3,
+            )
+            return
 
         # If agent is running, enqueue message instead of processing immediately
         if self._agent_running:
@@ -1806,14 +1816,29 @@ class DeepAgentsApp(App):
             prefix: Text prefix before thread ID.
             thread_id: Thread ID to resolve.
         """
-        thread_msg = await self._build_thread_message(prefix, thread_id)
-        if not isinstance(thread_msg, Text):
-            return
-        if widget.parent is None:
-            return
-        # Keep serialized content in sync with the rendered content.
-        widget._content = thread_msg
-        widget.update(thread_msg)
+        try:
+            thread_msg = await self._build_thread_message(prefix, thread_id)
+            if not isinstance(thread_msg, Text):
+                logger.debug(
+                    "Skipping thread link upgrade for %s: URL did not resolve",
+                    thread_id,
+                )
+                return
+            if widget.parent is None:
+                logger.debug(
+                    "Skipping thread link upgrade for %s: widget no longer mounted",
+                    thread_id,
+                )
+                return
+            # Keep serialized content in sync with the rendered content.
+            widget._content = thread_msg
+            widget.update(thread_msg)
+        except Exception:
+            logger.warning(
+                "Failed to upgrade thread message link for %s",
+                thread_id,
+                exc_info=True,
+            )
 
     def _schedule_thread_message_link(
         self,
@@ -1822,7 +1847,7 @@ class DeepAgentsApp(App):
         prefix: str,
         thread_id: str,
     ) -> None:
-        """Resolve and apply thread URL link in the background.
+        """Schedule thread URL link resolution and apply updates in the background.
 
         Args:
             widget: The message widget to update.
@@ -1846,10 +1871,11 @@ class DeepAgentsApp(App):
     ) -> None:
         """Load and render message history when resuming a thread.
 
-        This retrieves the checkpoint state from the agent and converts stored
-        messages into lightweight `MessageData` objects, then bulk-loads them
-        into the `MessageStore`. Only the last `WINDOW_SIZE` messages are
-        mounted as widgets, drastically reducing DOM operations for large
+        When `preloaded_data` is provided (e.g., from `_resume_thread`), this
+        reuses that payload. Otherwise, it fetches checkpoint state from the
+        agent and converts stored messages into lightweight `MessageData`
+        objects. The method then bulk-loads into the `MessageStore` and mounts
+        only the last `WINDOW_SIZE` widgets to reduce DOM operations on large
         threads.
 
         Args:
@@ -1860,12 +1886,17 @@ class DeepAgentsApp(App):
         """
         history_thread_id = thread_id or self._lc_thread_id
         if not history_thread_id:
+            logger.debug("Skipping history load: no thread ID available")
             return
         if preloaded_data is None and not self._agent:
+            logger.debug(
+                "Skipping history load for %s: no active agent and no preloaded data",
+                history_thread_id,
+            )
             return
 
         try:
-            # 1-2. Fetch + convert (reuse preloaded payload on thread switch)
+            # Fetch + convert, or reuse preloaded payload on thread switch.
             all_data = (
                 preloaded_data
                 if preloaded_data is not None
@@ -1898,7 +1929,17 @@ class DeepAgentsApp(App):
                 if isinstance(widget, AssistantMessage) and msg_data.content
             ]
             if assistant_updates:
-                await asyncio.gather(*assistant_updates)
+                assistant_results = await asyncio.gather(
+                    *assistant_updates,
+                    return_exceptions=True,
+                )
+                for error in assistant_results:
+                    if isinstance(error, Exception):
+                        logger.warning(
+                            "Failed to render assistant history message for %s: %s",
+                            history_thread_id,
+                            error,
+                        )
 
             # 9. Add footer immediately and resolve link asynchronously
             thread_msg_widget = AppMessage(f"Resumed thread: {history_thread_id}")
@@ -2314,83 +2355,97 @@ class DeepAgentsApp(App):
             await self._mount_message(AppMessage(f"Already on thread: {thread_id}"))
             return
 
+        if self._thread_switching:
+            await self._mount_message(AppMessage("Thread switch already in progress."))
+            return
+
         # Save previous state for rollback on failure
         prev_thread_id = self._lc_thread_id
         prev_session_thread = self._session_state.thread_id
+        self._thread_switching = True
+        if self._chat_input:
+            self._chat_input.set_cursor_active(active=False)
 
         try:
-            self._update_status(f"Loading thread: {thread_id}")
-            prefetched_history = await self._fetch_thread_history_data(thread_id)
-        except Exception as exc:
-            logger.exception("Failed to prefetch history for thread %s", thread_id)
-            self._update_status("")
-            await self._mount_message(
-                AppMessage(
-                    f"Failed to switch to thread {thread_id}: {exc}. "
-                    "Use /threads to try again."
-                )
-            )
-            return
-
-        try:
-            # Clear conversation (similar to /clear, without creating a new thread)
-            self._pending_messages.clear()
-            self._queued_widgets.clear()
-            await self._clear_messages()
-            if self._token_tracker:
-                self._token_tracker.reset()
-            self._update_status("")
-
-            # Switch to the selected thread
-            self._session_state.thread_id = thread_id
-            self._lc_thread_id = thread_id
-
-            # Update welcome banner
             try:
-                banner = self.query_one("#welcome-banner", WelcomeBanner)
-                banner.update_thread_id(thread_id)
-            except NoMatches:
-                logger.debug(
-                    "Welcome banner not found during thread switch to %s",
-                    thread_id,
+                self._update_status(f"Loading thread: {thread_id}")
+                prefetched_history = await self._fetch_thread_history_data(thread_id)
+            except Exception as exc:
+                logger.exception("Failed to prefetch history for thread %s", thread_id)
+                await self._mount_message(
+                    AppMessage(
+                        f"Failed to switch to thread {thread_id}: {exc}. "
+                        "Use /threads to try again."
+                    )
                 )
+                return
 
-            # Load thread history
-            await self._load_thread_history(
-                thread_id=thread_id,
-                preloaded_data=prefetched_history,
-            )
-
-        except Exception as exc:
-            logger.exception("Failed to switch to thread %s", thread_id)
-            # Restore previous thread IDs so the user can retry
-            self._session_state.thread_id = prev_session_thread
-            self._lc_thread_id = prev_thread_id
             try:
-                banner = self.query_one("#welcome-banner", WelcomeBanner)
-                banner.update_thread_id(prev_session_thread)
-            except NoMatches:
-                logger.warning(
-                    "Welcome banner not found during rollback to thread %s; "
-                    "banner may display stale thread ID",
-                    prev_session_thread,
-                )
-            # Attempt to restore the previous thread's visible history
-            try:
+                # Clear conversation (similar to /clear, without creating a new thread)
+                self._pending_messages.clear()
+                self._queued_widgets.clear()
                 await self._clear_messages()
-                await self._load_thread_history(thread_id=prev_session_thread)
-            except Exception:  # noqa: BLE001  # Resilient session state saving
-                logger.debug(
-                    "Could not restore previous thread history after "
-                    "failed switch to %s",
-                    thread_id,
+                if self._token_tracker:
+                    self._token_tracker.reset()
+                self._update_status("")
+
+                # Switch to the selected thread
+                self._session_state.thread_id = thread_id
+                self._lc_thread_id = thread_id
+
+                # Update welcome banner
+                try:
+                    banner = self.query_one("#welcome-banner", WelcomeBanner)
+                    banner.update_thread_id(thread_id)
+                except NoMatches:
+                    logger.debug(
+                        "Welcome banner not found during thread switch to %s",
+                        thread_id,
+                    )
+
+                # Load thread history
+                await self._load_thread_history(
+                    thread_id=thread_id,
+                    preloaded_data=prefetched_history,
                 )
-            await self._mount_message(
-                AppMessage(
-                    f"Failed to switch to thread {thread_id}: {exc}. "
-                    "Use /threads to try again."
-                )
-            )
+
+            except Exception as exc:
+                logger.exception("Failed to switch to thread %s", thread_id)
+                # Restore previous thread IDs so the user can retry
+                self._session_state.thread_id = prev_session_thread
+                self._lc_thread_id = prev_thread_id
+                try:
+                    banner = self.query_one("#welcome-banner", WelcomeBanner)
+                    banner.update_thread_id(prev_session_thread)
+                except NoMatches:
+                    logger.warning(
+                        "Welcome banner not found during rollback to thread %s; "
+                        "banner may display stale thread ID",
+                        prev_session_thread,
+                    )
+                rollback_restore_failed = False
+                # Attempt to restore the previous thread's visible history
+                try:
+                    await self._clear_messages()
+                    await self._load_thread_history(thread_id=prev_session_thread)
+                except Exception:  # Resilient session state saving
+                    rollback_restore_failed = True
+                    logger.warning(
+                        "Could not restore previous thread history after "
+                        "failed switch to %s",
+                        thread_id,
+                        exc_info=True,
+                    )
+                error_message = f"Failed to switch to thread {thread_id}: {exc}."
+                if rollback_restore_failed:
+                    error_message += " Previous thread history could not be restored."
+                error_message += " Use /threads to try again."
+                await self._mount_message(AppMessage(error_message))
+        finally:
+            self._thread_switching = False
+            self._update_status("")
+            if self._chat_input:
+                self._chat_input.set_cursor_active(active=not self._agent_running)
 
     async def _switch_model(self, model_spec: str) -> None:
         """Switch to a new model, preserving conversation history.

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -361,6 +361,26 @@ class TestMessageQueue:
             assert app._pending_messages[0].mode == "normal"
 
     @pytest.mark.asyncio
+    async def test_message_blocked_while_thread_switching(self) -> None:
+        """Submissions should be ignored while thread switching is in-flight."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._thread_switching = True
+            with patch.object(app, "notify") as notify_mock:
+                app.post_message(ChatInput.Submitted("blocked msg", "normal"))
+                await pilot.pause()
+
+                assert len(app._pending_messages) == 0
+                user_msgs = app.query(UserMessage)
+                assert not any(w._content == "blocked msg" for w in user_msgs)
+                notify_mock.assert_called_once_with(
+                    "Thread switch in progress. Please wait.",
+                    severity="warning",
+                    timeout=3,
+                )
+
+    @pytest.mark.asyncio
     async def test_queued_widget_mounted(self) -> None:
         """Queued messages should produce a QueuedUserMessage widget."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -904,6 +904,22 @@ class TestResumeThread:
         assert "no active session" in _get_widget_text(mounted[0])
 
     @pytest.mark.asyncio
+    async def test_already_switching_shows_message(self) -> None:
+        """_resume_thread should reject concurrent thread switches."""
+        app = DeepAgentsApp()
+        mounted: list[Static] = []
+        app._mount_message = AsyncMock(side_effect=lambda w: mounted.append(w))  # type: ignore[assignment]
+        app._agent = MagicMock()
+        app._session_state = MagicMock()
+        app._session_state.thread_id = "thread-123"
+        app._thread_switching = True
+
+        await app._resume_thread("thread-999")
+
+        assert len(mounted) == 1
+        assert "already in progress" in _get_widget_text(mounted[0])
+
+    @pytest.mark.asyncio
     async def test_already_on_thread_shows_message(self) -> None:
         """_resume_thread when already on the thread should show info message."""
         app = DeepAgentsApp()
@@ -964,6 +980,7 @@ class TestResumeThread:
         app._queued_widgets = MagicMock()
         app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
         app._clear_messages = AsyncMock(side_effect=RuntimeError("UI gone"))  # type: ignore[assignment]
+        app._update_status = MagicMock()  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
         app.query_one = MagicMock(side_effect=_NoMatches())  # type: ignore[assignment]
 
@@ -977,6 +994,7 @@ class TestResumeThread:
             "Failed to switch" in _get_widget_text(call.args[0])
             for call in app._mount_message.call_args_list  # type: ignore[union-attr]
         )
+        app._update_status.assert_any_call("")  # type: ignore[union-attr]
 
     @pytest.mark.asyncio
     async def test_failure_during_load_history_restores_ids(self) -> None:
@@ -1035,6 +1053,125 @@ class TestResumeThread:
             for call in mount_message_mock.call_args_list
         )
 
+    @pytest.mark.asyncio
+    async def test_prefetch_failure_clears_switch_lock_and_restores_input(self) -> None:
+        """Prefetch failures should release switch lock and restore input state."""
+        app = DeepAgentsApp(thread_id="old-thread")
+        app._agent = MagicMock()
+        app._session_state = MagicMock()
+        app._session_state.thread_id = "old-thread"
+        app._chat_input = MagicMock()
+        app._mount_message = AsyncMock()  # type: ignore[assignment]
+
+        with patch.object(
+            app,
+            "_fetch_thread_history_data",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("checkpoint read failed"),
+        ):
+            await app._resume_thread("new-thread")
+
+        assert app._thread_switching is False
+        app._chat_input.set_cursor_active.assert_any_call(active=False)
+        app._chat_input.set_cursor_active.assert_any_call(active=True)
+
+    @pytest.mark.asyncio
+    async def test_double_failure_surfaces_restore_failure_hint(self) -> None:
+        """If rollback restore fails, user-facing error should mention it."""
+        from textual.css.query import NoMatches as _NoMatches
+
+        app = DeepAgentsApp(thread_id="old-thread")
+        app._agent = MagicMock()
+        app._session_state = MagicMock()
+        app._session_state.thread_id = "old-thread"
+        app._pending_messages = MagicMock()
+        app._queued_widgets = MagicMock()
+        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
+        app._clear_messages = AsyncMock()  # type: ignore[assignment]
+        app._load_thread_history = AsyncMock(  # type: ignore[assignment]
+            side_effect=RuntimeError("checkpoint corrupt")
+        )
+        mount_message_mock = AsyncMock()
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+        app.query_one = MagicMock(side_effect=_NoMatches())  # type: ignore[assignment]
+
+        with patch.object(app, "_update_status") as update_status_mock:
+            await app._resume_thread("new-thread")
+
+        assert any(
+            "Previous thread history could not be restored"
+            in _get_widget_text(call.args[0])
+            for call in mount_message_mock.call_args_list
+        )
+        update_status_mock.assert_any_call("")
+
+
+class TestFetchThreadHistoryData:
+    """Tests for DeepAgentsApp._fetch_thread_history_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_agent_missing(self) -> None:
+        """No active agent should return an empty history payload."""
+        app = DeepAgentsApp()
+        app._agent = None
+
+        result = await app._fetch_thread_history_data("tid-1")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_state_missing(self) -> None:
+        """Missing checkpoint state should return an empty history payload."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aget_state = AsyncMock(return_value=None)
+
+        result = await app._fetch_thread_history_data("tid-1")
+
+        assert result == []
+        app._agent.aget_state.assert_awaited_once_with(
+            {"configurable": {"thread_id": "tid-1"}}
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_messages_missing(self) -> None:
+        """State with no messages should return an empty history payload."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        state = MagicMock()
+        state.values = {}
+        app._agent.aget_state = AsyncMock(return_value=state)
+
+        result = await app._fetch_thread_history_data("tid-1")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_offloads_conversion_to_thread(self) -> None:
+        """Message conversion should be offloaded via `asyncio.to_thread`."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        raw_messages = [object()]
+        state = MagicMock()
+        state.values = {"messages": raw_messages}
+        app._agent.aget_state = AsyncMock(return_value=state)
+        converted = [MessageData(type=MessageType.USER, content="hello")]
+
+        with patch(
+            "deepagents_cli.app.asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=converted,
+        ) as to_thread_mock:
+            result = await app._fetch_thread_history_data("tid-1")
+
+        assert result == converted
+        to_thread_mock.assert_awaited_once()
+        await_args = to_thread_mock.await_args
+        assert await_args is not None
+        assert await_args.args[1] == raw_messages
+
 
 class TestLoadThreadHistory:
     """Tests for DeepAgentsApp._load_thread_history."""
@@ -1066,6 +1203,167 @@ class TestLoadThreadHistory:
         messages_container.mount.assert_awaited_once()
         mount_message_mock.assert_awaited_once()
         schedule_link_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_fetch_path_used_without_preloaded_data(self) -> None:
+        """History should be fetched when preloaded data is not provided."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp(thread_id="tid-1")
+        app._agent = MagicMock()
+        fetched = [MessageData(type=MessageType.USER, content="hello")]
+        fetch_history_mock = AsyncMock(return_value=fetched)
+        mount_message_mock = AsyncMock()
+        schedule_link_mock = MagicMock()
+        app._fetch_thread_history_data = fetch_history_mock  # type: ignore[assignment]
+        app._remove_spacer = AsyncMock()  # type: ignore[assignment]
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+        app._schedule_thread_message_link = schedule_link_mock  # type: ignore[assignment]
+        app.set_timer = MagicMock()  # type: ignore[assignment]
+
+        messages_container = MagicMock()
+        messages_container.mount = AsyncMock()
+        app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
+
+        await app._load_thread_history(thread_id="tid-1")
+
+        fetch_history_mock.assert_awaited_once_with("tid-1")
+        messages_container.mount.assert_awaited_once()
+        mount_message_mock.assert_awaited_once()
+        schedule_link_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_assistant_render_failure_does_not_abort_history_load(self) -> None:
+        """A single assistant render failure should not abort history loading."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+        from deepagents_cli.widgets.messages import AssistantMessage
+
+        app = DeepAgentsApp(thread_id="tid-1")
+        app._agent = MagicMock()
+        mount_message_mock = AsyncMock()
+        schedule_link_mock = MagicMock()
+        app._remove_spacer = AsyncMock()  # type: ignore[assignment]
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+        app._schedule_thread_message_link = schedule_link_mock  # type: ignore[assignment]
+        app.set_timer = MagicMock()  # type: ignore[assignment]
+
+        messages_container = MagicMock()
+        messages_container.mount = AsyncMock()
+        app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
+
+        preloaded = [
+            MessageData(type=MessageType.ASSISTANT, content="ok"),
+            MessageData(type=MessageType.ASSISTANT, content="fail"),
+        ]
+
+        def _set_content_side_effect(content: str) -> None:
+            if content == "fail":
+                msg = "markdown update failed"
+                raise RuntimeError(msg)
+
+        with patch.object(
+            AssistantMessage,
+            "set_content",
+            new_callable=AsyncMock,
+            side_effect=_set_content_side_effect,
+        ) as set_content_mock:
+            await app._load_thread_history(thread_id="tid-1", preloaded_data=preloaded)
+
+        assert set_content_mock.await_count == 2
+        mount_message_mock.assert_awaited_once()
+        schedule_link_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_early_return_without_thread_id_logs_debug(self) -> None:
+        """Missing thread ID should early-return with a debug log entry."""
+        app = DeepAgentsApp()
+        app._lc_thread_id = None
+        app._agent = MagicMock()
+
+        with patch("deepagents_cli.app.logger.debug") as debug_mock:
+            await app._load_thread_history()
+
+        debug_mock.assert_called_once_with(
+            "Skipping history load: no thread ID available"
+        )
+
+    @pytest.mark.asyncio
+    async def test_early_return_without_agent_logs_debug(self) -> None:
+        """No agent and no preloaded payload should early-return with debug log."""
+        app = DeepAgentsApp(thread_id="tid-1")
+        app._agent = None
+
+        with patch("deepagents_cli.app.logger.debug") as debug_mock:
+            await app._load_thread_history(thread_id="tid-1")
+
+        debug_mock.assert_called_once_with(
+            "Skipping history load for %s: no active agent and no preloaded data",
+            "tid-1",
+        )
+
+
+class TestUpgradeThreadMessageLink:
+    """Tests for DeepAgentsApp._upgrade_thread_message_link."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_link_does_not_resolve(self) -> None:
+        """Plain-string result should leave widget content unchanged."""
+        app = DeepAgentsApp()
+        app._build_thread_message = AsyncMock(return_value="Resumed thread: tid-1")  # type: ignore[assignment]
+        widget = MagicMock()
+        widget.parent = object()
+        widget._content = "Resumed thread: tid-1"
+
+        await app._upgrade_thread_message_link(
+            widget,
+            prefix="Resumed thread",
+            thread_id="tid-1",
+        )
+
+        widget.update.assert_not_called()
+        assert widget._content == "Resumed thread: tid-1"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_widget_unmounted(self) -> None:
+        """Unmounted widget should not be updated even when link resolves."""
+        from rich.text import Text
+
+        app = DeepAgentsApp()
+        app._build_thread_message = AsyncMock(  # type: ignore[assignment]
+            return_value=Text("Resumed thread: tid-1")
+        )
+        widget = MagicMock()
+        widget.parent = None
+        widget._content = "Resumed thread: tid-1"
+
+        await app._upgrade_thread_message_link(
+            widget,
+            prefix="Resumed thread",
+            thread_id="tid-1",
+        )
+
+        widget.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_updates_widget_when_link_resolves(self) -> None:
+        """Resolved Rich text should replace widget content."""
+        from rich.text import Text
+
+        app = DeepAgentsApp()
+        linked = Text("Resumed thread: tid-1")
+        app._build_thread_message = AsyncMock(return_value=linked)  # type: ignore[assignment]
+        widget = MagicMock()
+        widget.parent = object()
+        widget._content = "Resumed thread: tid-1"
+
+        await app._upgrade_thread_message_link(
+            widget,
+            prefix="Resumed thread",
+            thread_id="tid-1",
+        )
+
+        assert widget._content == linked
+        widget.update.assert_called_once_with(linked)
 
 
 class TestBuildThreadMessage:

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -932,6 +932,7 @@ class TestResumeThread:
         app._clear_messages = AsyncMock()  # type: ignore[assignment]
         app._token_tracker = MagicMock()
         app._update_status = MagicMock()  # type: ignore[assignment]
+        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
         app._load_thread_history = AsyncMock()  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
         app.query_one = MagicMock(side_effect=_NoMatches())  # type: ignore[assignment]
@@ -944,7 +945,11 @@ class TestResumeThread:
         app._queued_widgets.clear.assert_called_once()
         app._clear_messages.assert_awaited_once()
         app._token_tracker.reset.assert_called_once()
-        app._load_thread_history.assert_awaited_once()
+        app._fetch_thread_history_data.assert_awaited_once_with("new-thread")
+        app._load_thread_history.assert_awaited_once_with(
+            thread_id="new-thread",
+            preloaded_data=[],
+        )
 
     @pytest.mark.asyncio
     async def test_failure_restores_previous_thread_ids(self) -> None:
@@ -957,6 +962,7 @@ class TestResumeThread:
         app._session_state.thread_id = "old-thread"
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
+        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
         app._clear_messages = AsyncMock(side_effect=RuntimeError("UI gone"))  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
         app.query_one = MagicMock(side_effect=_NoMatches())  # type: ignore[assignment]
@@ -983,6 +989,7 @@ class TestResumeThread:
         app._session_state.thread_id = "old-thread"
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
+        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
         app._clear_messages = AsyncMock()  # type: ignore[assignment]
         app._token_tracker = MagicMock()
         app._update_status = MagicMock()  # type: ignore[assignment]
@@ -1001,6 +1008,64 @@ class TestResumeThread:
             "Failed to switch" in _get_widget_text(call.args[0])
             for call in app._mount_message.call_args_list  # type: ignore[union-attr]
         )
+
+    @pytest.mark.asyncio
+    async def test_prefetch_failure_keeps_current_thread_visible(self) -> None:
+        """Failed prefetch should not clear current conversation state."""
+        app = DeepAgentsApp(thread_id="old-thread")
+        app._agent = MagicMock()
+        app._session_state = MagicMock()
+        app._session_state.thread_id = "old-thread"
+        fetch_history_mock = AsyncMock(
+            side_effect=RuntimeError("checkpoint read failed")
+        )
+        clear_messages_mock = AsyncMock()
+        mount_message_mock = AsyncMock()
+        app._fetch_thread_history_data = fetch_history_mock  # type: ignore[assignment]
+        app._clear_messages = clear_messages_mock  # type: ignore[assignment]
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+
+        await app._resume_thread("new-thread")
+
+        assert app._session_state.thread_id == "old-thread"
+        assert app._lc_thread_id == "old-thread"
+        clear_messages_mock.assert_not_awaited()
+        assert any(
+            "Failed to switch" in _get_widget_text(call.args[0])
+            for call in mount_message_mock.call_args_list
+        )
+
+
+class TestLoadThreadHistory:
+    """Tests for DeepAgentsApp._load_thread_history."""
+
+    @pytest.mark.asyncio
+    async def test_preloaded_history_skips_fetch_and_schedules_link(self) -> None:
+        """Preloaded history should render without state fetch round-trip."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp(thread_id="tid-1")
+        app._agent = MagicMock()
+        fetch_history_mock = AsyncMock()
+        mount_message_mock = AsyncMock()
+        schedule_link_mock = MagicMock()
+        app._fetch_thread_history_data = fetch_history_mock  # type: ignore[assignment]
+        app._remove_spacer = AsyncMock()  # type: ignore[assignment]
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+        app._schedule_thread_message_link = schedule_link_mock  # type: ignore[assignment]
+        app.set_timer = MagicMock()  # type: ignore[assignment]
+
+        messages_container = MagicMock()
+        messages_container.mount = AsyncMock()
+        app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
+
+        preloaded = [MessageData(type=MessageType.USER, content="hello")]
+        await app._load_thread_history(thread_id="tid-1", preloaded_data=preloaded)
+
+        fetch_history_mock.assert_not_awaited()
+        messages_container.mount.assert_awaited_once()
+        mount_message_mock.assert_awaited_once()
+        schedule_link_mock.assert_called_once()
 
 
 class TestBuildThreadMessage:


### PR DESCRIPTION
Selecting a thread to resume had visible stutter and a blank-chat window while history loaded. This PR reduces both actual latency and perceived latency in the resume path.

- Adds prefetch-first resume flow:
  - Fetch/convert target thread history before clearing current UI
  - Only switch UI/thread state after prefetch succeeds
- Reduced DOM work during resume
- Made "Resumed thread: <id>" link resolution non-blocking
- On switch failure, clear and restore previous thread history to avoid mixed UI state