### PR TITLE
fix(cli): retry langsmith project url lookup until project exists

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1021,9 +1021,10 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
 
     try:
         from langsmith import Client
+        from langsmith.utils import LangSmithError
 
         project = Client().read_project(project_name=project_name)
-    except (ImportError, OSError, ValueError, RuntimeError):
+    except (ImportError, LangSmithError, OSError, ValueError, RuntimeError):
         logger.debug(
             "Could not fetch LangSmith project URL for '%s'",
             project_name,

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -171,8 +171,8 @@ _glyphs_cache: Glyphs | None = None
 # Module-level cache for editable install detection
 _editable_cache: bool | None = None
 
-# Module-level cache for LangSmith project URL (None means "not yet fetched")
-_langsmith_url_cache: tuple[str, str | None] | None = None
+# Module-level cache for successful LangSmith project URL lookups
+_langsmith_url_cache: tuple[str, str] | None = None
 
 
 def _is_editable_install() -> bool:
@@ -995,8 +995,8 @@ def get_langsmith_project_name() -> str | None:
 def fetch_langsmith_project_url(project_name: str) -> str | None:
     """Fetch the LangSmith project URL via the LangSmith client.
 
-    Results are cached at module level so repeated calls do not make additional
-    network requests. Failed lookups are also cached to avoid retries.
+    Successful results are cached at module level so repeated calls do not
+    make additional network requests.
 
     This is a blocking network call on the first invocation. In async
     contexts, run it in a thread (e.g. via `asyncio.to_thread`).
@@ -1030,11 +1030,11 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
             project_name,
             exc_info=True,
         )
-        _langsmith_url_cache = (project_name, None)
         return None
     else:
         url = project.url or None
-        _langsmith_url_cache = (project_name, url)
+        if url is not None:
+            _langsmith_url_cache = (project_name, url)
         return url
 
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -632,8 +632,8 @@ class TestFetchLangsmithProjectUrl:
         assert second == first
         mock_client_cls.assert_called_once()
 
-    def test_caches_none_on_failure(self) -> None:
-        """Should cache None on failure so retries don't make network calls."""
+    def test_retries_after_failure(self) -> None:
+        """Should retry after failure instead of caching None."""
         with patch("langsmith.Client") as mock_client_cls:
             mock_client_cls.return_value.read_project.side_effect = OSError("timeout")
             first = fetch_langsmith_project_url("my-project")
@@ -641,7 +641,22 @@ class TestFetchLangsmithProjectUrl:
 
         assert first is None
         assert second is None
-        mock_client_cls.assert_called_once()
+        assert mock_client_cls.return_value.read_project.call_count == 2
+
+    def test_retries_when_url_is_none(self) -> None:
+        """Should retry when the project URL is missing instead of caching None."""
+
+        class FakeProject:
+            url = None
+
+        with patch("langsmith.Client") as mock_client_cls:
+            mock_client_cls.return_value.read_project.return_value = FakeProject()
+            first = fetch_langsmith_project_url("my-project")
+            second = fetch_langsmith_project_url("my-project")
+
+        assert first is None
+        assert second is None
+        assert mock_client_cls.return_value.read_project.call_count == 2
 
     def test_different_project_name_fetches_again(self) -> None:
         """Should fetch again when called with a different project name."""

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -593,6 +593,18 @@ class TestFetchLangsmithProjectUrl:
 
         assert result is None
 
+    def test_returns_none_on_project_not_found(self) -> None:
+        """Should return None when the project does not exist yet."""
+        from langsmith.utils import LangSmithNotFoundError
+
+        with patch("langsmith.Client") as mock_client_cls:
+            mock_client_cls.return_value.read_project.side_effect = (
+                LangSmithNotFoundError("Project angus-dacli not found")
+            )
+            result = fetch_langsmith_project_url("angus-dacli")
+
+        assert result is None
+
     def test_returns_none_when_url_is_none(self) -> None:
         """Should return None when the project has no URL."""
 


### PR DESCRIPTION
`read_project` is a lookup-only API. For a new `LANGSMITH_PROJECT`, it can return `LangSmithNotFoundError` until the first trace creates the project.

The CLI handled this incompletely: it could raise on LangSmith errors, and after returning `None` once it cached that `None` for the rest of the session.

## Why
Users tracing to a brand-new LangSmith project could lose clickable LangSmith links for the entire first CLI session.

## What changed
- Catch `LangSmithError` in `fetch_langsmith_project_url` so LangSmith SDK errors return `None` gracefully.
- Change URL cache semantics to cache only successful, non-`None` project URLs.
- Remove failure/`None` cache writes so later calls retry and can succeed after first trace submission auto-creates the project.