### PR TITLE
fix(docs): markdown tree diagram formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ deepagents/
 │   ├── deepagents/  # SDK
 │   ├── cli/         # CLI tool
 │   ├── acp/         # Agent Context Protocol support
-│   └── harbor/      # Evaluation/benchmark framework
+│   ├── harbor/      # Evaluation/benchmark framework
 │   └── partners/    # Integration packages
 │       └── daytona/
 │       └── ...


### PR DESCRIPTION
Corrects tree diagram formatting in AGENTS.md where harbor and partners both used └──. Changed harbor to ├── since partners has child items.