### PR TITLE
fix(cli): align compaction messaging across `/compact` and `compact_conversation`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1439,9 +1439,9 @@ class DeepAgentsApp(App):
             if cutoff == 0:
                 await self._mount_message(
                     AppMessage(
-                        "Nothing to compact yet"
-                        " \u2014 conversation is within the compact limit "
-                        f"({compact_limit})"
+                        "Nothing to compact yet \u2014 conversation is within "
+                        "the token budget.\n"
+                        f"Configured retention budget: {compact_limit}"
                     )
                 )
                 return
@@ -1507,11 +1507,12 @@ class DeepAgentsApp(App):
 
             await self._mount_message(
                 AppMessage(
-                    f"Compacted {len(to_summarize)} messages "
-                    f"({summarized_before} \u2192 {summarized_after} tokens)\n"
-                    f"  total context: {before} \u2192 {after} "
-                    f"({pct}% decrease) "
-                    f"\u00b7 {len(to_keep)} messages unchanged"
+                    "Conversation compacted. "
+                    f"Summarized {len(to_summarize)} messages into a concise summary.\n"
+                    f"Summarized context: {summarized_before} \u2192 "
+                    f"{summarized_after} tokens\n"
+                    f"Total context: {before} \u2192 {after} tokens "
+                    f"({pct}% decrease), {len(to_keep)} messages unchanged."
                 )
             )
 

--- a/libs/cli/tests/unit_tests/test_compact.py
+++ b/libs/cli/tests/unit_tests/test_compact.py
@@ -173,10 +173,7 @@ class TestCompactGuards:
                 await pilot.pause()
 
             msgs = app.query(AppMessage)
-            assert any(
-                "compact limit (20.0K tokens (10% of 200.0K))" in str(w._content)
-                for w in msgs
-            )
+            assert any("within the token budget" in str(w._content) for w in msgs)
 
     @pytest.mark.asyncio
     async def test_empty_state_shows_error(self) -> None:
@@ -328,7 +325,10 @@ class TestCompactSuccess:
                 await pilot.pause()
 
             msgs = app.query(AppMessage)
-            assert any("Compacted 4 messages" in str(w._content) for w in msgs)
+            assert any(
+                "Summarized 4 messages into a concise summary." in str(w._content)
+                for w in msgs
+            )
 
     @pytest.mark.asyncio
     async def test_compaction_updates_token_tracker(self) -> None:
@@ -404,10 +404,7 @@ class TestCompactEdgeCases:
                 await pilot.pause()
 
             msgs = app.query(AppMessage)
-            assert any(
-                "compact limit (20.0K tokens (10% of 200.0K))" in str(w._content)
-                for w in msgs
-            )
+            assert any("within the token budget" in str(w._content) for w in msgs)
             app._agent.aupdate_state.assert_not_called()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Aligns `/compact` user-facing copy with the `compact_conversation` tool result language so compaction feedback is consistent across invocation paths.