### PR TITLE
fix(cli): coerce execute timeout to int before formatting tool display

### DIFF
--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -129,6 +129,8 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             command = truncate_value(command, 120)
             timeout = tool_args.get("timeout")
             if timeout is not None and timeout != DEFAULT_EXECUTE_TIMEOUT:
+                if not isinstance(timeout, int):
+                    timeout = int(timeout)
                 timeout_str = _format_timeout(timeout)
                 return f'{prefix} {tool_name}("{command}", timeout={timeout_str})'
             return f'{prefix} {tool_name}("{command}")'

--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -35,6 +35,31 @@ def _format_timeout(seconds: int) -> str:
     return f"{seconds}s"
 
 
+def _coerce_timeout_seconds(timeout: int | str | None) -> int | None:
+    """Normalize timeout values to seconds for display.
+
+    Accepts integer values and numeric strings. Returns `None` for invalid
+    values so display formatting never raises.
+
+    Args:
+        timeout: Raw timeout value from tool arguments.
+
+    Returns:
+        Integer timeout in seconds, or `None` if unavailable/invalid.
+    """
+    if type(timeout) is int:
+        return timeout
+    if isinstance(timeout, str):
+        stripped = timeout.strip()
+        if not stripped:
+            return None
+        try:
+            return int(stripped)
+        except ValueError:
+            return None
+    return None
+
+
 def truncate_value(value: str, max_length: int = MAX_ARG_LENGTH) -> str:
     """Truncate a string value if it exceeds max_length.
 
@@ -127,10 +152,8 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
         if "command" in tool_args:
             command = str(tool_args["command"])
             command = truncate_value(command, 120)
-            timeout = tool_args.get("timeout")
+            timeout = _coerce_timeout_seconds(tool_args.get("timeout"))
             if timeout is not None and timeout != DEFAULT_EXECUTE_TIMEOUT:
-                if not isinstance(timeout, int):
-                    timeout = int(timeout)
                 timeout_str = _format_timeout(timeout)
                 return f'{prefix} {tool_name}("{command}", timeout={timeout_str})'
             return f'{prefix} {tool_name}("{command}")'

--- a/libs/cli/tests/unit_tests/test_ui.py
+++ b/libs/cli/tests/unit_tests/test_ui.py
@@ -82,6 +82,14 @@ class TestFormatToolDisplayExecute:
         result = format_tool_display("execute", {"command": "make test", "timeout": 30})
         assert result == f'{prefix} execute("make test", timeout=30s)'
 
+    def test_execute_with_timeout_string_coerced(self) -> None:
+        """Test execute display coerces numeric timeout strings."""
+        prefix = get_glyphs().tool_prefix
+        result = format_tool_display(
+            "execute", {"command": "make test", "timeout": "300"}
+        )
+        assert result == f'{prefix} execute("make test", timeout=5m)'
+
     def test_execute_with_timeout_hours(self) -> None:
         """Test execute display formats timeout in hours when appropriate."""
         prefix = get_glyphs().tool_prefix
@@ -103,6 +111,22 @@ class TestFormatToolDisplayExecute:
         prefix = get_glyphs().tool_prefix
         result = format_tool_display(
             "execute", {"command": "echo hello", "timeout": 120}
+        )
+        assert result == f'{prefix} execute("echo hello")'
+
+    def test_execute_with_default_timeout_string_hidden(self) -> None:
+        """Test execute display excludes timeout when default arrives as a string."""
+        prefix = get_glyphs().tool_prefix
+        result = format_tool_display(
+            "execute", {"command": "echo hello", "timeout": "120"}
+        )
+        assert result == f'{prefix} execute("echo hello")'
+
+    def test_execute_with_invalid_timeout_string_hidden(self) -> None:
+        """Test execute display ignores invalid timeout strings instead of crashing."""
+        prefix = get_glyphs().tool_prefix
+        result = format_tool_display(
+            "execute", {"command": "echo hello", "timeout": "10s"}
         )
         assert result == f'{prefix} execute("echo hello")'
 


### PR DESCRIPTION
Description: This PR fixes a CLI rendering crash by coercing execute tool timeout values to int before calling _format_timeout, so tool calls no longer fail when timeout arrives as a string (for example, "10"). 

Minimal Code to Reproduce the Bug which this PR fixes:
```python
from deepagents_cli.tool_display import format_tool_display
format_tool_display("execute", {"command": "curl -s http://localhost:5000/ | head -50", "timeout": "10"})
```

Fixes: #1586