### PR TITLE
chore(sdk,cli): switch `claude-sonnet-4-5-20250929` -> `claude-sonnet-4-6`

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -405,7 +405,7 @@ def create_cli_agent(
     both internally and from external code (e.g., benchmarking frameworks).
 
     Args:
-        model: LLM model to use (e.g., `'anthropic:claude-sonnet-4-5-20250929'`)
+        model: LLM model to use (e.g., `'anthropic:claude-sonnet-4-6'`)
         assistant_id: Agent identifier for memory/state storage
         tools: Additional tools to provide to agent
         sandbox: Optional sandbox backend for remote execution

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1090,7 +1090,7 @@ def _get_default_model_spec() -> str:
     if settings.has_openai:
         return "openai:gpt-5.2"
     if settings.has_anthropic:
-        return "anthropic:claude-sonnet-4-5-20250929"
+        return "anthropic:claude-sonnet-4-6"
     if settings.has_google:
         return "google_genai:gemini-3.1-pro-preview"
     if settings.has_vertex_ai:

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -295,7 +295,7 @@ def parse_args() -> argparse.Namespace:
         "-M",
         "--model",
         metavar="MODEL",
-        help="Model to use (e.g., claude-sonnet-4-5-20250929, gpt-5.2). "
+        help="Model to use (e.g., claude-sonnet-4-6, gpt-5.2). "
         "Provider is auto-detected from model name.",
     )
 

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -301,7 +301,7 @@ class TestGetSystemPromptModelIdentity:
     def test_includes_model_identity_when_all_settings_present(self) -> None:
         """Test that model identity section is included when all settings are set."""
         mock_settings = Mock()
-        mock_settings.model_name = "claude-sonnet-4-5-20250929"
+        mock_settings.model_name = "claude-sonnet-4-6"
         mock_settings.model_provider = "anthropic"
         mock_settings.model_context_limit = 200000
 
@@ -309,7 +309,7 @@ class TestGetSystemPromptModelIdentity:
             prompt = get_system_prompt("test-agent")
 
         assert "### Model Identity" in prompt
-        assert "claude-sonnet-4-5-20250929" in prompt
+        assert "claude-sonnet-4-6" in prompt
         assert "(provider: anthropic)" in prompt
         assert "Your context window is 200,000 tokens." in prompt
 

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1561,7 +1561,7 @@ recent = "openai:gpt-5.2"
         ):
             result = _get_default_model_spec()
 
-        assert result == "anthropic:claude-sonnet-4-5-20250929"
+        assert result == "anthropic:claude-sonnet-4-6"
 
 
 class TestIsWarningSuppressed:

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -71,11 +71,10 @@ def get_default_model() -> ChatAnthropic:
     """Get the default model for deep agents.
 
     Returns:
-        `ChatAnthropic` instance configured with Claude Sonnet 4.5.
+        `ChatAnthropic` instance configured with Claude Sonnet 4.6.
     """
     return ChatAnthropic(
-        model_name="claude-sonnet-4-5-20250929",
-        max_tokens=20000,
+        model_name="claude-sonnet-4-6",
     )
 
 
@@ -141,7 +140,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     Args:
         model: The model to use.
 
-            Defaults to `claude-sonnet-4-5-20250929`.
+            Defaults to `claude-sonnet-4-6`.
 
             Use the `provider:model` format (e.g., `openai:gpt-5`) to quickly switch between models.
 

--- a/libs/deepagents/tests/evals/test_subagents.py
+++ b/libs/deepagents/tests/evals/test_subagents.py
@@ -24,7 +24,7 @@ def test_task_calls_weather_subagent(model: str) -> None:
                 "description": "Use this agent to get the weather",
                 "system_prompt": "You are a weather agent.",
                 "tools": [get_weather_fake],
-                "model": "anthropic:claude-sonnet-4-5-20250929",
+                "model": "anthropic:claude-sonnet-4-6",
             }
         ],
     )

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -317,7 +317,7 @@ class TestDeepAgentEndToEnd:
 
         with patch("deepagents.graph.init_chat_model", return_value=fake_model):
             # This should not raise AttributeError: 'str' object has no attribute 'profile'
-            agent = create_deep_agent(model="claude-sonnet-4-5-20250929", tools=[sample_tool])
+            agent = create_deep_agent(model="claude-sonnet-4-6", tools=[sample_tool])
 
             # Verify agent was created successfully
             assert agent is not None


### PR DESCRIPTION
Technically breaking if someone wasn't setting `model` on `create_deep_agent()` and is expecting sonnet 4.5 behavior