### PR TITLE
fix(cli): make langsmith URL lookups non-blocking

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -9,6 +9,7 @@ import os
 import re
 import shlex
 import sys
+import threading
 import uuid
 from dataclasses import dataclass
 from enum import StrEnum
@@ -71,7 +72,6 @@ MODE_PREFIXES: dict[str, str] = {
 """Maps each non-normal mode to its trigger character."""
 
 
-# Charset mode configuration
 class CharsetMode(StrEnum):
     """Character set mode for TUI display."""
 
@@ -169,14 +169,21 @@ ASCII_GLYPHS = Glyphs(
     tree_vertical="|   ",
 )
 
-# Module-level cache for detected glyphs
 _glyphs_cache: Glyphs | None = None
+"""Module-level cache for detected glyphs."""
 
-# Module-level cache for editable install detection
 _editable_cache: bool | None = None
+"""Module-level cache for editable install detection."""
 
-# Module-level cache for successful LangSmith project URL lookups
 _langsmith_url_cache: tuple[str, str] | None = None
+"""Module-level cache for successful LangSmith project URL lookups."""
+
+_LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS = 2.0
+"""
+Maximum time to wait for LangSmith project URL lookup.
+
+Keep this short so tracing metadata can never stall CLI flows.
+"""
 
 
 def _is_editable_install() -> bool:
@@ -946,8 +953,8 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
     Successful results are cached at module level so repeated calls do not
     make additional network requests.
 
-    This is a blocking network call on the first invocation. In async
-    contexts, run it in a thread (e.g. via `asyncio.to_thread`).
+    To prevent LangSmith outages from stalling the CLI, lookup runs in a
+    daemon thread with a hard timeout.
 
     Returns None (with a debug log) on any expected failure: missing
     `langsmith` package, network errors, invalid project names, or client
@@ -969,21 +976,54 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
 
     try:
         from langsmith import Client
-        from langsmith.utils import LangSmithError
-
-        project = Client().read_project(project_name=project_name)
-    except (ImportError, LangSmithError, OSError, ValueError, RuntimeError):
+    except ImportError:
         logger.debug(
             "Could not fetch LangSmith project URL for '%s'",
             project_name,
             exc_info=True,
         )
         return None
-    else:
-        url = project.url or None
-        if url is not None:
-            _langsmith_url_cache = (project_name, url)
-        return url
+
+    result: str | None = None
+    lookup_error: Exception | None = None
+    done = threading.Event()
+
+    def _lookup_url() -> None:
+        nonlocal result, lookup_error
+        try:
+            project = Client().read_project(project_name=project_name)
+            result = project.url or None
+        except Exception as exc:  # noqa: BLE001  # LangSmith SDK error types are not stable
+            lookup_error = exc
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=_lookup_url, daemon=True)
+    thread.start()
+
+    if not done.wait(_LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS):
+        logger.debug(
+            "Timed out fetching LangSmith project URL for '%s' after %.1fs",
+            project_name,
+            _LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS,
+        )
+        return None
+
+    if lookup_error is not None:
+        logger.debug(
+            "Could not fetch LangSmith project URL for '%s'",
+            project_name,
+            exc_info=(
+                type(lookup_error),
+                lookup_error,
+                lookup_error.__traceback__,
+            ),
+        )
+        return None
+
+    if result is not None:
+        _langsmith_url_cache = (project_name, result)
+    return result
 
 
 def build_langsmith_thread_url(thread_id: str) -> str | None:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -179,10 +179,9 @@ _langsmith_url_cache: tuple[str, str] | None = None
 """Module-level cache for successful LangSmith project URL lookups."""
 
 _LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS = 2.0
-"""
-Maximum time to wait for LangSmith project URL lookup.
+"""Max seconds to wait for LangSmith project URL lookup.
 
-Keep this short so tracing metadata can never stall CLI flows.
+Kept short so tracing metadata can never stall CLI flows.
 """
 
 
@@ -953,12 +952,13 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
     Successful results are cached at module level so repeated calls do not
     make additional network requests.
 
-    To prevent LangSmith outages from stalling the CLI, lookup runs in a
-    daemon thread with a hard timeout.
+    The network call runs in a daemon thread with a hard timeout of
+    `_LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS`, so this function blocks the
+    calling thread for at most that duration even if LangSmith is unreachable.
 
-    Returns None (with a debug log) on any expected failure: missing
-    `langsmith` package, network errors, invalid project names, or client
-    initialization issues.
+    Returns None (with a debug log) on any failure: missing `langsmith` package,
+    network errors, invalid project names, client initialization issues,
+    or timeouts.
 
     Args:
         project_name: LangSmith project name to look up.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import sys
+import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -131,6 +132,41 @@ class StreamState:
         default_factory=dict
     )
     interrupt_occurred: bool = False
+
+
+@dataclass
+class ThreadUrlLookupState:
+    """Best-effort background LangSmith thread URL lookup state."""
+
+    done: threading.Event = field(default_factory=threading.Event)
+    url: str | None = None
+
+
+def _start_langsmith_thread_url_lookup(thread_id: str) -> ThreadUrlLookupState:
+    """Start background LangSmith URL resolution without blocking.
+
+    Args:
+        thread_id: Thread identifier to resolve.
+
+    Returns:
+        Mutable lookup state that can be polled for completion.
+    """
+    state = ThreadUrlLookupState()
+
+    def _resolve() -> None:
+        try:
+            state.url = build_langsmith_thread_url(thread_id)
+        except Exception:
+            logger.debug(
+                "Could not resolve LangSmith thread URL for '%s'",
+                thread_id,
+                exc_info=True,
+            )
+        finally:
+            state.done.set()
+
+    threading.Thread(target=_resolve, daemon=True).start()
+    return state
 
 
 def _process_interrupts(
@@ -426,6 +462,7 @@ async def _run_agent_loop(
     *,
     quiet: bool = False,
     stream: bool = True,
+    thread_url_lookup: ThreadUrlLookupState | None = None,
 ) -> None:
     """Run the agent and handle HITL interrupts until the task completes.
 
@@ -443,6 +480,8 @@ async def _run_agent_loop(
 
             When `False`, the full response is buffered and flushed at
             the end.
+        thread_url_lookup: Optional non-blocking lookup state for rendering
+            a fast-follow LangSmith thread link.
 
     Raises:
         HITLIterationLimitError: If the HITL iteration limit is exceeded.
@@ -480,18 +519,36 @@ async def _run_agent_loop(
 
     if not quiet:
         console.print()
+        if (
+            thread_url_lookup is not None
+            and thread_url_lookup.done.is_set()
+            and thread_url_lookup.url
+        ):
+            link_text = Text("View in LangSmith: ", style="dim")
+            link_text.append(
+                thread_url_lookup.url,
+                style=Style(dim=True, link=thread_url_lookup.url),
+            )
+            console.print(link_text)
         console.print("[green]✓ Task completed[/green]")
 
 
-def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:
+def _build_non_interactive_header(
+    assistant_id: str,
+    thread_id: str,
+    *,
+    include_thread_link: bool = False,
+) -> Text:
     """Build the non-interactive mode header with model, agent, and thread info.
 
-    The thread ID is rendered as a clickable hyperlink when LangSmith tracing
-    is configured.
+    By default, this function avoids LangSmith network lookups and renders the
+    thread ID as plain text. Callers can opt in to hyperlink resolution.
 
     Args:
         assistant_id: Agent identifier.
         thread_id: Thread identifier.
+        include_thread_link: Whether to resolve and render a LangSmith link for
+            the thread ID.
 
     Returns:
         Rich Text object with the formatted header line.
@@ -506,8 +563,7 @@ def _build_non_interactive_header(assistant_id: str, thread_id: str) -> Text:
 
     parts.append((" | ", "dim"))
 
-    # Attempt to build a clickable thread link via LangSmith
-    thread_url = build_langsmith_thread_url(thread_id)
+    thread_url = build_langsmith_thread_url(thread_id) if include_thread_link else None
     if thread_url:
         parts.extend(
             [
@@ -541,9 +597,8 @@ async def run_non_interactive(
     list; commands not in the list are rejected with an error message sent
     back to the agent.
 
-    Note: when LangSmith tracing is configured, `_build_non_interactive_header`
-    makes a synchronous network call (via `fetch_langsmith_project_url`) to
-    resolve the thread URL. This blocks the event loop briefly at startup.
+    Note: startup header rendering avoids LangSmith URL lookups to keep startup
+    non-blocking.
 
     Args:
         message: The task/message to execute.
@@ -591,7 +646,9 @@ async def run_non_interactive(
         },
     }
 
+    thread_url_lookup: ThreadUrlLookupState | None = None
     if not quiet:
+        thread_url_lookup = _start_langsmith_thread_url_lookup(thread_id)
         console.print("[dim]Running task non-interactively...[/dim]")
         header = _build_non_interactive_header(assistant_id, thread_id)
         console.print(header)
@@ -664,6 +721,7 @@ async def run_non_interactive(
                 file_op_tracker,
                 quiet=quiet,
                 stream=stream,
+                thread_url_lookup=thread_url_lookup,
             )
             return 0
 

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -136,7 +136,11 @@ class StreamState:
 
 @dataclass
 class ThreadUrlLookupState:
-    """Best-effort background LangSmith thread URL lookup state."""
+    """Best-effort background LangSmith thread URL lookup state.
+
+    Thread safety: the background thread sets `url` then calls `done.set()`.
+    Consumers must check `done.is_set()` before reading `url`.
+    """
 
     done: threading.Event = field(default_factory=threading.Event)
     url: str | None = None
@@ -149,14 +153,14 @@ def _start_langsmith_thread_url_lookup(thread_id: str) -> ThreadUrlLookupState:
         thread_id: Thread identifier to resolve.
 
     Returns:
-        Mutable lookup state that can be polled for completion.
+        Mutable lookup state whose completion can be checked later.
     """
     state = ThreadUrlLookupState()
 
     def _resolve() -> None:
         try:
             state.url = build_langsmith_thread_url(thread_id)
-        except Exception:
+        except Exception:  # build_langsmith_thread_url already handles known errors
             logger.debug(
                 "Could not resolve LangSmith thread URL for '%s'",
                 thread_id,
@@ -597,8 +601,9 @@ async def run_non_interactive(
     list; commands not in the list are rejected with an error message sent
     back to the agent.
 
-    Note: startup header rendering avoids LangSmith URL lookups to keep startup
-    non-blocking.
+    Note: startup header rendering avoids synchronous LangSmith URL lookups.
+    A background thread resolves the thread URL concurrently and the result is
+    displayed after task completion if available.
 
     Args:
         message: The task/message to execute.

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for config module including project discovery utilities."""
 
+import time
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -604,6 +605,32 @@ class TestFetchLangsmithProjectUrl:
                 LangSmithNotFoundError("Project angus-dacli not found")
             )
             result = fetch_langsmith_project_url("angus-dacli")
+
+        assert result is None
+
+    def test_returns_none_on_unexpected_exception(self) -> None:
+        """Should return None on unexpected SDK exceptions."""
+        with patch("langsmith.Client") as mock_client_cls:
+            mock_client_cls.return_value.read_project.side_effect = TypeError(
+                "unexpected SDK type error"
+            )
+            result = fetch_langsmith_project_url("my-project")
+
+        assert result is None
+
+    def test_returns_none_when_lookup_times_out(self) -> None:
+        """Should return None when LangSmith lookup exceeds timeout."""
+        with (
+            patch(
+                "deepagents_cli.config._LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS",
+                0.01,
+            ),
+            patch("langsmith.Client") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.read_project.side_effect = lambda **_kwargs: (
+                time.sleep(0.1)
+            )
+            result = fetch_langsmith_project_url("my-project")
 
         assert result is None
 

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -4,6 +4,7 @@ import io
 import sys
 from collections.abc import AsyncIterator, Generator
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -132,11 +133,7 @@ class TestBuildNonInteractiveHeader:
         """Header should contain the agent identifier."""
         with patch("deepagents_cli.non_interactive.settings") as mock_settings:
             mock_settings.model_name = None
-            with patch(
-                "deepagents_cli.non_interactive.build_langsmith_thread_url",
-                return_value=None,
-            ):
-                header = _build_non_interactive_header("my-agent", "abc123")
+            header = _build_non_interactive_header("my-agent", "abc123")
         assert "Agent: my-agent" in header.plain
         # Non-default agent should not have "(default)" label
         assert "(default)" not in header.plain
@@ -145,44 +142,28 @@ class TestBuildNonInteractiveHeader:
         """Header should show '(default)' for the default agent name."""
         with patch("deepagents_cli.non_interactive.settings") as mock_settings:
             mock_settings.model_name = None
-            with patch(
-                "deepagents_cli.non_interactive.build_langsmith_thread_url",
-                return_value=None,
-            ):
-                header = _build_non_interactive_header("agent", "abc123")
+            header = _build_non_interactive_header("agent", "abc123")
         assert "Agent: agent (default)" in header.plain
 
     def test_includes_model_name(self) -> None:
         """Header should display model name when available."""
         with patch("deepagents_cli.non_interactive.settings") as mock_settings:
             mock_settings.model_name = "gpt-5"
-            with patch(
-                "deepagents_cli.non_interactive.build_langsmith_thread_url",
-                return_value=None,
-            ):
-                header = _build_non_interactive_header("agent", "abc123")
+            header = _build_non_interactive_header("agent", "abc123")
         assert "Model: gpt-5" in header.plain
 
     def test_omits_model_when_none(self) -> None:
         """Header should not include model section when model_name is None."""
         with patch("deepagents_cli.non_interactive.settings") as mock_settings:
             mock_settings.model_name = None
-            with patch(
-                "deepagents_cli.non_interactive.build_langsmith_thread_url",
-                return_value=None,
-            ):
-                header = _build_non_interactive_header("agent", "abc123")
+            header = _build_non_interactive_header("agent", "abc123")
         assert "Model:" not in header.plain
 
     def test_includes_thread_id(self) -> None:
         """Header should contain the thread ID."""
         with patch("deepagents_cli.non_interactive.settings") as mock_settings:
             mock_settings.model_name = None
-            with patch(
-                "deepagents_cli.non_interactive.build_langsmith_thread_url",
-                return_value=None,
-            ):
-                header = _build_non_interactive_header("agent", "deadbeef")
+            header = _build_non_interactive_header("agent", "deadbeef")
         assert "Thread: deadbeef" in header.plain
 
     def test_thread_clickable_when_url_available(self) -> None:
@@ -194,7 +175,11 @@ class TestBuildNonInteractiveHeader:
                 "deepagents_cli.non_interactive.build_langsmith_thread_url",
                 return_value=url,
             ):
-                header = _build_non_interactive_header("agent", "abc123")
+                header = _build_non_interactive_header(
+                    "agent",
+                    "abc123",
+                    include_thread_link=True,
+                )
         # Find the span containing the thread ID and verify it has a link
         for start, end, style in header._spans:
             text = header.plain[start:end]
@@ -203,6 +188,17 @@ class TestBuildNonInteractiveHeader:
                 break
         else:
             pytest.fail("Thread ID span with hyperlink not found")
+
+    def test_default_header_does_not_lookup_langsmith(self) -> None:
+        """Header should skip LangSmith lookup unless explicitly enabled."""
+        with patch("deepagents_cli.non_interactive.settings") as mock_settings:
+            mock_settings.model_name = None
+            with patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+            ) as mock_build_url:
+                _build_non_interactive_header("agent", "abc123")
+
+        mock_build_url.assert_not_called()
 
 
 class TestSandboxSetupForwarding:
@@ -586,6 +582,132 @@ class TestNoStreamMode:
         assert len(text_writes) == 2
         assert text_writes[0] == "Hello "
         assert text_writes[1] == "world"
+
+
+class TestFastFollowLangsmithLink:
+    """Tests for best-effort fast-follow LangSmith link output."""
+
+    @pytest.mark.asyncio
+    async def test_prints_link_when_lookup_ready(self) -> None:
+        """Should print LangSmith link before completion when ready."""
+        mock_console = MagicMock(spec=Console)
+        ready_state = SimpleNamespace(
+            done=SimpleNamespace(is_set=lambda: True),
+            url="https://smith.langchain.com/o/org/projects/p/proj/t/test-thread",
+        )
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.Console",
+                return_value=mock_console,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive._start_langsmith_thread_url_lookup",
+                return_value=ready_state,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+            ) as mock_checkpointer,
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_cp = MagicMock()
+            mock_checkpointer_cm = AsyncMock()
+            mock_checkpointer_cm.__aenter__.return_value = mock_cp
+            mock_checkpointer_cm.__aexit__.return_value = None
+            mock_checkpointer.return_value = mock_checkpointer_cm
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=False)
+
+        printed = [
+            str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+        ]
+        assert any("View in LangSmith:" in line for line in printed)
+
+    @pytest.mark.asyncio
+    async def test_skips_link_when_lookup_not_ready(self) -> None:
+        """Should not wait for or print link when lookup is still in flight."""
+        mock_console = MagicMock(spec=Console)
+        pending_state = SimpleNamespace(
+            done=SimpleNamespace(is_set=lambda: False),
+            url="https://smith.langchain.com/o/org/projects/p/proj/t/test-thread",
+        )
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.Console",
+                return_value=mock_console,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive._start_langsmith_thread_url_lookup",
+                return_value=pending_state,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+            ) as mock_checkpointer,
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_cp = MagicMock()
+            mock_checkpointer_cm = AsyncMock()
+            mock_checkpointer_cm.__aenter__.return_value = mock_cp
+            mock_checkpointer_cm.__aexit__.return_value = None
+            mock_checkpointer.return_value = mock_checkpointer_cm
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=False)
+
+        printed = [
+            str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+        ]
+        assert not any("View in LangSmith:" in line for line in printed)
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -4,7 +4,6 @@ import io
 import sys
 from collections.abc import AsyncIterator, Generator
 from contextlib import contextmanager
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,8 +14,10 @@ from rich.text import Text
 
 from deepagents_cli.config import ModelResult
 from deepagents_cli.non_interactive import (
+    ThreadUrlLookupState,
     _build_non_interactive_header,
     _make_hitl_decision,
+    _start_langsmith_thread_url_lookup,
     run_non_interactive,
 )
 
@@ -591,9 +592,10 @@ class TestFastFollowLangsmithLink:
     async def test_prints_link_when_lookup_ready(self) -> None:
         """Should print LangSmith link before completion when ready."""
         mock_console = MagicMock(spec=Console)
-        ready_state = SimpleNamespace(
-            done=SimpleNamespace(is_set=lambda: True),
-            url="https://smith.langchain.com/o/org/projects/p/proj/t/test-thread",
+        ready_state = ThreadUrlLookupState()
+        ready_state.done.set()
+        ready_state.url = (
+            "https://smith.langchain.com/o/org/projects/p/proj/t/test-thread"
         )
 
         with (
@@ -652,9 +654,9 @@ class TestFastFollowLangsmithLink:
     async def test_skips_link_when_lookup_not_ready(self) -> None:
         """Should not wait for or print link when lookup is still in flight."""
         mock_console = MagicMock(spec=Console)
-        pending_state = SimpleNamespace(
-            done=SimpleNamespace(is_set=lambda: False),
-            url="https://smith.langchain.com/o/org/projects/p/proj/t/test-thread",
+        pending_state = ThreadUrlLookupState()
+        pending_state.url = (
+            "https://smith.langchain.com/o/org/projects/p/proj/t/test-thread"
         )
 
         with (
@@ -708,6 +710,151 @@ class TestFastFollowLangsmithLink:
             str(call.args[0]) for call in mock_console.print.call_args_list if call.args
         ]
         assert not any("View in LangSmith:" in line for line in printed)
+
+    @pytest.mark.asyncio
+    async def test_skips_link_when_lookup_done_but_url_none(self) -> None:
+        """Should not print link when lookup completed but URL is None."""
+        mock_console = MagicMock(spec=Console)
+        done_no_url = ThreadUrlLookupState()
+        done_no_url.done.set()
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.Console",
+                return_value=mock_console,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive._start_langsmith_thread_url_lookup",
+                return_value=done_no_url,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+            ) as mock_checkpointer,
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_cp = MagicMock()
+            mock_checkpointer_cm = AsyncMock()
+            mock_checkpointer_cm.__aenter__.return_value = mock_cp
+            mock_checkpointer_cm.__aexit__.return_value = None
+            mock_checkpointer.return_value = mock_checkpointer_cm
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=False)
+
+        printed = [
+            str(call.args[0]) for call in mock_console.print.call_args_list if call.args
+        ]
+        assert not any("View in LangSmith:" in line for line in printed)
+
+    @pytest.mark.asyncio
+    async def test_quiet_mode_skips_thread_url_lookup(self) -> None:
+        """Should not start LangSmith URL lookup when quiet=True."""
+        with (
+            patch(
+                "deepagents_cli.non_interactive.Console",
+                return_value=MagicMock(spec=Console),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive._start_langsmith_thread_url_lookup",
+            ) as mock_lookup,
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+            ) as mock_checkpointer,
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_cp = MagicMock()
+            mock_checkpointer_cm = AsyncMock()
+            mock_checkpointer_cm.__aenter__.return_value = mock_cp
+            mock_checkpointer_cm.__aexit__.return_value = None
+            mock_checkpointer.return_value = mock_checkpointer_cm
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="test", quiet=True)
+
+        mock_lookup.assert_not_called()
+
+
+class TestStartLangsmithThreadUrlLookup:
+    """Tests for _start_langsmith_thread_url_lookup."""
+
+    def test_sets_url_on_success(self) -> None:
+        """Should populate state.url when build succeeds."""
+        url = "https://smith.langchain.com/o/org/projects/p/proj/t/tid"
+        with patch(
+            "deepagents_cli.non_interactive.build_langsmith_thread_url",
+            return_value=url,
+        ):
+            state = _start_langsmith_thread_url_lookup("tid")
+            assert state.done.wait(timeout=2.0)
+        assert state.url == url
+
+    def test_signals_done_on_exception(self) -> None:
+        """Should signal done and leave url as None when build raises."""
+        with patch(
+            "deepagents_cli.non_interactive.build_langsmith_thread_url",
+            side_effect=RuntimeError("boom"),
+        ):
+            state = _start_langsmith_thread_url_lookup("tid")
+            assert state.done.wait(timeout=2.0)
+        assert state.url is None
+
+    def test_signals_done_when_url_is_none(self) -> None:
+        """Should signal done when build returns None."""
+        with patch(
+            "deepagents_cli.non_interactive.build_langsmith_thread_url",
+            return_value=None,
+        ):
+            state = _start_langsmith_thread_url_lookup("tid")
+            assert state.done.wait(timeout=2.0)
+        assert state.url is None
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029


### PR DESCRIPTION
Make LangSmith URL lookups fully non-blocking in non-interactive mode. 

Previously, `_build_non_interactive_header` called `build_langsmith_thread_url` synchronously at startup — if LangSmith was slow or unreachable, the CLI would hang before the agent even started. Now the header renders immediately with plain text, a background thread resolves the URL concurrently with agent execution, and a "View in LangSmith" link prints at task completion if the lookup finished in time.