### PR TITLE
fix(infra): checkout repo in evals aggregation job

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -86,6 +86,9 @@ jobs:
     needs: [eval]
     if: always()
     steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@v6
+
       - name: "📥 Download eval artifacts"
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
The evals aggregate job attempted to run .github/scripts/aggregate_evals.py without checking out the repository, causing the step to fail with a missing file error. This adds an explicit checkout step so the aggregation script is present when artifacts are downloaded and summarized.