### PR TITLE
feat(cli): add model profile overrides to config

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1411,13 +1411,36 @@ def create_model(
     resolved_provider = provider or getattr(model, "_model_provider", provider)
 
     # Apply profile overrides from config.toml (e.g., max_input_tokens)
-    profile_overrides = config.get_profile_overrides(provider, model_name=model_name)
-    if profile_overrides:
-        profile = getattr(model, "profile", None)
-        if isinstance(profile, dict):
-            profile.update(profile_overrides)
-        else:
-            model.profile = profile_overrides  # type: ignore[union-attr]
+    if provider:
+        profile_overrides = config.get_profile_overrides(
+            provider, model_name=model_name
+        )
+        if profile_overrides:
+            logger.debug(
+                "Applying profile overrides for '%s' (provider '%s'): %s",
+                model_name,
+                provider,
+                profile_overrides,
+            )
+            # Intentionally over-defensive
+            profile = getattr(model, "profile", None)
+            if isinstance(profile, dict):
+                # Copy original profile and overlay config overrides on top.
+                # Duplicate keys use the override value; keys only in the
+                # original (e.g., tool_calling) are preserved unchanged.
+                merged = {**profile, **profile_overrides}
+            else:
+                merged = profile_overrides
+            try:
+                model.profile = merged  # type: ignore[union-attr]
+            except (AttributeError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "Could not apply profile overrides to model '%s' "
+                    "(provider '%s'): %s. Overrides will be ignored.",
+                    model_name,
+                    provider,
+                    exc,
+                )
 
     # Extract context limit from model profile (if available)
     context_limit: int | None = None

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1410,6 +1410,15 @@ def create_model(
 
     resolved_provider = provider or getattr(model, "_model_provider", provider)
 
+    # Apply profile overrides from config.toml (e.g., max_input_tokens)
+    profile_overrides = config.get_profile_overrides(provider, model_name=model_name)
+    if profile_overrides:
+        profile = getattr(model, "profile", None)
+        if isinstance(profile, dict):
+            profile.update(profile_overrides)
+        else:
+            model.profile = profile_overrides  # type: ignore[union-attr]
+
     # Extract context limit from model profile (if available)
     context_limit: int | None = None
     profile = getattr(model, "profile", None)

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -577,8 +577,9 @@ class ModelConfig:
                     class_path,
                 )
 
-            params = provider.get("params", {})
             models = set(provider.get("models", []))
+
+            params = provider.get("params", {})
             for key, value in params.items():
                 if isinstance(value, dict) and key not in models:
                     logger.warning(
@@ -694,7 +695,6 @@ class ModelConfig:
         if not provider:
             return {}
         params = provider.get("params", {})
-        # Flat keys are provider-wide defaults; dict values are per-model overrides
         result = {k: v for k, v in params.items() if not isinstance(v, dict)}
         if model_name:
             overrides = params.get(model_name)

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -144,6 +144,14 @@ class ProviderConfig(TypedDict, total=False):
     the merge is shallow (model wins on conflict).
     """
 
+    profile: dict[str, Any]
+    """Overrides merged into the model's runtime profile dict.
+
+    Flat keys (e.g., `max_input_tokens = 4096`) are provider-wide defaults.
+    Model-keyed sub-tables (e.g., `[profile."claude-sonnet-4-5"]`) override
+    individual values for that model only; the merge is shallow.
+    """
+
 
 DEFAULT_CONFIG_DIR = Path.home() / ".deepagents"
 """Directory for user-level Deep Agents configuration (`~/.deepagents`)."""
@@ -690,6 +698,33 @@ class ModelConfig:
         result = {k: v for k, v in params.items() if not isinstance(v, dict)}
         if model_name:
             overrides = params.get(model_name)
+            if isinstance(overrides, dict):
+                result.update(overrides)
+        return result
+
+    def get_profile_overrides(
+        self, provider_name: str, *, model_name: str | None = None
+    ) -> dict[str, Any]:
+        """Get profile overrides for a provider.
+
+        Reads the `profile` table from the provider config. Flat keys are
+        provider-wide defaults; model-keyed sub-tables are per-model overrides
+        that shallow-merge on top (model wins on conflict).
+
+        Args:
+            provider_name: The provider to look up.
+            model_name: Optional model name for per-model overrides.
+
+        Returns:
+            Dictionary of profile overrides (empty if none configured).
+        """
+        provider = self.providers.get(provider_name)
+        if not provider:
+            return {}
+        profile = provider.get("profile", {})
+        result = {k: v for k, v in profile.items() if not isinstance(v, dict)}
+        if model_name:
+            overrides = profile.get(model_name)
             if isinstance(overrides, dict):
                 result.update(overrides)
         return result

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -416,6 +416,87 @@ class TestCreateModelProfileExtraction:
         assert result.context_limit is None
 
 
+class TestCreateModelProfileOverrides:
+    """Tests for profile overrides from config.toml in create_model."""
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_profile_override_sets_context_limit(
+        self, mock_init_chat_model: Mock, tmp_path: Path
+    ) -> None:
+        """Profile override for max_input_tokens flows to context_limit."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+""")
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 200000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            result = create_model("anthropic:claude-sonnet-4-5")
+
+        assert result.context_limit == 4096
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_per_model_profile_override_takes_precedence(
+        self, mock_init_chat_model: Mock, tmp_path: Path
+    ) -> None:
+        """Per-model profile override wins over provider-wide default."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+
+[models.providers.anthropic.profile."claude-sonnet-4-5"]
+max_input_tokens = 8192
+""")
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 200000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            result = create_model("anthropic:claude-sonnet-4-5")
+
+        assert result.context_limit == 8192
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_no_profile_override_preserves_original(
+        self, mock_init_chat_model: Mock, tmp_path: Path
+    ) -> None:
+        """Without config overrides, original profile value is used."""
+        config_path = tmp_path / "config.toml"  # Does not exist — empty config
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 200000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            result = create_model("anthropic:claude-sonnet-4-5")
+        assert result.context_limit == 200000
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_profile_override_on_model_without_profile(
+        self, mock_init_chat_model: Mock, tmp_path: Path
+    ) -> None:
+        """Profile override is applied even when model has no profile attr."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+""")
+        mock_model = Mock(spec=["invoke"])  # No profile attribute
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            result = create_model("anthropic:claude-sonnet-4-5")
+
+        assert result.context_limit == 4096
+
+
 class TestParseShellAllowList:
     """Test parsing shell allow-list strings."""
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for config module including project discovery utilities."""
 
+import logging
 import time
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -495,6 +496,80 @@ max_input_tokens = 4096
             result = create_model("anthropic:claude-sonnet-4-5")
 
         assert result.context_limit == 4096
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_profile_override_preserves_non_overridden_keys(
+        self, mock_init_chat_model: Mock, tmp_path: Path
+    ) -> None:
+        """Override merges into existing profile without dropping other keys."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+""")
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 200000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            create_model("anthropic:claude-sonnet-4-5")
+
+        assert mock_model.profile == {"max_input_tokens": 4096, "tool_calling": True}
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_profile_override_when_profile_is_none(
+        self, mock_init_chat_model: Mock, tmp_path: Path
+    ) -> None:
+        """Override is applied when model.profile is explicitly None."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+""")
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            result = create_model("anthropic:claude-sonnet-4-5")
+
+        assert result.context_limit == 4096
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_profile_override_logs_warning_on_frozen_model(
+        self,
+        mock_init_chat_model: Mock,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Graceful warning when model rejects attribute assignment."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+""")
+        mock_model = Mock()
+        # Make .profile read return a dict but assignment raises
+        type(mock_model).profile = property(
+            fget=lambda _: {"max_input_tokens": 200000},
+            fset=lambda _, __: (_ for _ in ()).throw(AttributeError("frozen")),
+        )
+        mock_init_chat_model.return_value = mock_model
+
+        clear_caches()
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            caplog.at_level(logging.WARNING, logger="deepagents_cli.config"),
+        ):
+            result = create_model("anthropic:claude-sonnet-4-5")
+
+        assert any(
+            "Could not apply profile overrides" in r.message for r in caplog.records
+        )
+        # Falls back to original profile extraction
+        assert result.context_limit == 200000
 
 
 class TestParseShellAllowList:

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1013,6 +1013,94 @@ temperature = 0.5
         assert kwargs == {"temperature": 0.5}
 
 
+class TestModelConfigGetProfileOverrides:
+    """Tests for ModelConfig.get_profile_overrides() method."""
+
+    def test_returns_empty_for_unknown_provider(self):
+        """Returns empty dict for unknown provider."""
+        config = ModelConfig()
+        assert config.get_profile_overrides("unknown") == {}
+
+    def test_returns_empty_when_no_profile(self, tmp_path):
+        """Returns empty dict when profile not in config."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.custom]
+models = ["my-model"]
+""")
+        config = ModelConfig.load(config_path)
+        assert config.get_profile_overrides("custom") == {}
+
+    def test_returns_provider_wide_overrides(self, tmp_path):
+        """Returns flat profile overrides."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5"]
+
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+""")
+        config = ModelConfig.load(config_path)
+        overrides = config.get_profile_overrides("anthropic")
+        assert overrides == {"max_input_tokens": 4096}
+
+    def test_per_model_override_takes_precedence(self, tmp_path):
+        """Per-model sub-table overrides provider-wide value."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5", "claude-opus-4-6"]
+
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+
+[models.providers.anthropic.profile."claude-sonnet-4-5"]
+max_input_tokens = 8192
+""")
+        config = ModelConfig.load(config_path)
+        overrides = config.get_profile_overrides(
+            "anthropic", model_name="claude-sonnet-4-5"
+        )
+        assert overrides == {"max_input_tokens": 8192}
+
+    def test_model_without_subtable_gets_provider_defaults(self, tmp_path):
+        """Model not in sub-table gets provider-level profile only."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5", "claude-opus-4-6"]
+
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+
+[models.providers.anthropic.profile."claude-sonnet-4-5"]
+max_input_tokens = 8192
+""")
+        config = ModelConfig.load(config_path)
+        overrides = config.get_profile_overrides(
+            "anthropic", model_name="claude-opus-4-6"
+        )
+        assert overrides == {"max_input_tokens": 4096}
+
+    def test_none_model_name_returns_provider_defaults(self, tmp_path):
+        """model_name=None returns provider-wide profile only."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5"]
+
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+
+[models.providers.anthropic.profile."claude-sonnet-4-5"]
+max_input_tokens = 8192
+""")
+        config = ModelConfig.load(config_path)
+        overrides = config.get_profile_overrides("anthropic", model_name=None)
+        assert overrides == {"max_input_tokens": 4096}
+
+
 class TestModelConfigValidateParams:
     """Tests for _validate() params warnings."""
 

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1100,6 +1100,26 @@ max_input_tokens = 8192
         overrides = config.get_profile_overrides("anthropic", model_name=None)
         assert overrides == {"max_input_tokens": 4096}
 
+    def test_multiple_flat_keys_with_model_subtable(self, tmp_path):
+        """Multiple flat keys returned; model sub-table merges on top."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5"]
+
+[models.providers.anthropic.profile]
+max_input_tokens = 4096
+supports_thinking = true
+
+[models.providers.anthropic.profile."claude-sonnet-4-5"]
+max_input_tokens = 8192
+""")
+        config = ModelConfig.load(config_path)
+        overrides = config.get_profile_overrides(
+            "anthropic", model_name="claude-sonnet-4-5"
+        )
+        assert overrides == {"max_input_tokens": 8192, "supports_thinking": True}
+
 
 class TestModelConfigValidateParams:
     """Tests for _validate() params warnings."""


### PR DESCRIPTION
Add a `profile` override table to `config.toml` so users can override model profile fields (like `max_input_tokens`) without touching provider packages. Follows the same flat-keys + model-keyed-subtable pattern as the existing `params` table.