### PR TITLE
fix(cli): show model info in `/tokens` before first usage

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1285,7 +1285,17 @@ class DeepAgentsApp(App):
 
                 await self._mount_message(AppMessage(msg))
             else:
-                await self._mount_message(AppMessage("No token usage yet"))
+                model_name = settings.model_name
+                context_limit = settings.model_context_limit
+
+                parts: list[str] = ["No token usage yet"]
+                if context_limit is not None:
+                    limit_str = _format_token_count(context_limit)
+                    parts.append(f"{limit_str} context window")
+                if model_name:
+                    parts.append(model_name)
+
+                await self._mount_message(AppMessage(" · ".join(parts)))
         elif cmd == "/remember" or cmd.startswith("/remember "):
             # Extract any additional context after /remember
             additional_context = ""


### PR DESCRIPTION
The `/tokens` slash command showed a bare "No token usage yet" message before any conversation started, dropping the model name and context window size that appear once usage is tracked. Now the zero-usage state mirrors the format of the active state, displaying context window size and model name so users can confirm their model configuration immediately.

## Changes
- Show context window size and model name in the `/tokens` zero-usage state, joining them with the existing `·` separator format (e.g., `No token usage yet · 200.0K context window · claude-opus-4-6`)
