### PR TITLE
chore: remove unnecessary `@pytest.mark.asyncio` decorators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ deepagents/
 - `make` – Task runner for common development commands. Feel free to look at the `Makefile` for available commands and usage patterns.
 - `ruff` – Fast Python linter and formatter
 - `ty` – Static type checking
+- Do NOT use Sphinx-style double backtick formatting (` ``code`` `). Use single backticks (`code`) for inline code references in docstrings and comments.
 
 #### Suppressing ruff lint rules
 
@@ -87,6 +88,8 @@ fix(cli): resolve type hinting issue
 chore(harbor): update infrastructure dependencies
 ```
 
+- Do NOT use Sphinx-style double backtick formatting (` ``code`` `). Use single backticks (`code`) for inline code references in docstrings and comments.
+
 #### Pull request guidelines
 
 - Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
@@ -142,6 +145,7 @@ Every new feature or bugfix MUST be covered by unit tests.
 - Unit tests: `tests/unit_tests/` (no network calls allowed)
 - Integration tests: `tests/integration_tests/` (network calls permitted)
 - We use `pytest` as the testing framework; if in doubt, check other existing tests for examples.
+- Do NOT add `@pytest.mark.asyncio` to async tests — every package sets `asyncio_mode = "auto"` in `pyproject.toml`, so pytest-asyncio discovers them automatically.
 - The testing file structure should mirror the source code structure.
 - Avoid mocks as much as possible
 - Test actual implementation, do not duplicate logic into tests
@@ -190,7 +194,7 @@ def send_email(to: str, msg: str, *, priority: str = "normal") -> bool:
 - Document all parameters, return values, and exceptions
 - Keep descriptions concise but clear
 - Ensure American English spelling (e.g., "behavior", not "behaviour")
-- Do NOT use Sphinx-style double backtick formatting (` ``code`` `). Use single backticks (`` `code` ``) for inline code references in docstrings and comments.
+- Do NOT use Sphinx-style double backtick formatting (` ``code`` `). Use single backticks (`code`) for inline code references in docstrings and comments.
 
 ## Package-specific guidance
 
@@ -233,3 +237,5 @@ The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents
 - **Documentation:** https://docs.langchain.com/oss/python/deepagents/overview and source at https://github.com/langchain-ai/docs or `../docs/`. Prefer the local install and use file search tools for best results. If needed, use the docs MCP server as defined in `.mcp.json` for programmatic access.
 - **Contributing Guide:** [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview)
 - **CLI Release Process:** See `.github/RELEASING.md` for the full CLI release workflow (release-please, version bumping, troubleshooting failed releases, and label management).
+
+- Do NOT use Sphinx-style double backtick formatting (` ``code`` `). Use single backticks (`code`) for inline code references in docstrings and comments.

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -35,7 +35,6 @@ from deepagents_cli.widgets.messages import (
 class TestInitialPromptOnMount:
     """Test that -m initial prompt is submitted on mount."""
 
-    @pytest.mark.asyncio
     async def test_initial_prompt_triggers_handle_user_message(self) -> None:
         """When initial_prompt is set, the prompt should be auto-submitted."""
         mock_agent = MagicMock()
@@ -63,7 +62,6 @@ class TestInitialPromptOnMount:
 class TestAppCSSValidation:
     """Test that app CSS is valid and doesn't cause runtime errors."""
 
-    @pytest.mark.asyncio
     async def test_app_css_validates_on_mount(self) -> None:
         """App should mount without CSS validation errors.
 
@@ -81,7 +79,6 @@ class TestAppCSSValidation:
 class TestThreadCachePrewarm:
     """Tests for startup thread-cache prewarming."""
 
-    @pytest.mark.asyncio
     async def test_prewarm_uses_current_thread_limit(self) -> None:
         """Prewarm helper should pass the resolved thread limit through."""
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
@@ -97,7 +94,6 @@ class TestThreadCachePrewarm:
 
         mock_prewarm.assert_awaited_once_with(limit=7)
 
-    @pytest.mark.asyncio
     async def test_show_thread_selector_uses_cached_rows(self) -> None:
         """Thread selector should receive prefetched rows when available."""
         cached_threads = [
@@ -271,7 +267,6 @@ class TestModalScreenEscapeDismissal:
     """Test that escape key dismisses modal screens."""
 
     @staticmethod
-    @pytest.mark.asyncio
     async def test_escape_dismisses_modal_screen() -> None:
         """Escape should dismiss any active ModalScreen.
 
@@ -339,7 +334,6 @@ class TestMountMessageNoMatches:
     (e.g. #messages container no longer exists), this should not crash.
     """
 
-    @pytest.mark.asyncio
     async def test_mount_message_no_crash_when_messages_missing(self) -> None:
         """_mount_message should not raise NoMatches when #messages is absent."""
         app = DeepAgentsApp()
@@ -361,7 +355,6 @@ class TestMountMessageNoMatches:
             # Before the fix, this raises NoMatches
             await app._mount_message(AppMessage("Interrupted by user"))
 
-    @pytest.mark.asyncio
     async def test_mount_error_message_no_crash_when_messages_missing(
         self,
     ) -> None:
@@ -401,7 +394,6 @@ class TestQueuedMessage:
 class TestMessageQueue:
     """Test message queue behavior in DeepAgentsApp."""
 
-    @pytest.mark.asyncio
     async def test_message_queued_when_agent_running(self) -> None:
         """Messages should be queued when agent is running."""
         app = DeepAgentsApp()
@@ -416,7 +408,6 @@ class TestMessageQueue:
             assert app._pending_messages[0].text == "queued msg"
             assert app._pending_messages[0].mode == "normal"
 
-    @pytest.mark.asyncio
     async def test_message_blocked_while_thread_switching(self) -> None:
         """Submissions should be ignored while thread switching is in-flight."""
         app = DeepAgentsApp()
@@ -436,7 +427,6 @@ class TestMessageQueue:
                     timeout=3,
                 )
 
-    @pytest.mark.asyncio
     async def test_queued_widget_mounted(self) -> None:
         """Queued messages should produce a QueuedUserMessage widget."""
         app = DeepAgentsApp()
@@ -451,7 +441,6 @@ class TestMessageQueue:
             assert len(widgets) == 1
             assert len(app._queued_widgets) == 1
 
-    @pytest.mark.asyncio
     async def test_immediate_processing_when_agent_idle(self) -> None:
         """Messages should process immediately when agent is not running."""
         app = DeepAgentsApp()
@@ -468,7 +457,6 @@ class TestMessageQueue:
             user_msgs = app.query(UserMessage)
             assert any(w._content == "direct msg" for w in user_msgs)
 
-    @pytest.mark.asyncio
     async def test_fifo_order(self) -> None:
         """Queued messages should process in FIFO order."""
         app = DeepAgentsApp()
@@ -485,7 +473,6 @@ class TestMessageQueue:
             assert app._pending_messages[0].text == "first"
             assert app._pending_messages[1].text == "second"
 
-    @pytest.mark.asyncio
     async def test_queue_cleared_on_interrupt(self) -> None:
         """Interrupt should clear the message queue."""
         app = DeepAgentsApp()
@@ -510,7 +497,6 @@ class TestMessageQueue:
             assert len(app._queued_widgets) == 0
             mock_worker.cancel.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_interrupt_dismisses_completion_without_stopping_agent(self) -> None:
         """Esc should dismiss completion popup without interrupting the agent."""
         app = DeepAgentsApp()
@@ -535,7 +521,6 @@ class TestMessageQueue:
             mock_worker.cancel.assert_not_called()
             assert app._agent_running is True
 
-    @pytest.mark.asyncio
     async def test_interrupt_falls_through_when_no_completion(self) -> None:
         """Esc should interrupt the agent when completion is not active."""
         app = DeepAgentsApp()
@@ -554,7 +539,6 @@ class TestMessageQueue:
 
             mock_worker.cancel.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_queue_cleared_on_ctrl_c(self) -> None:
         """Ctrl+C should clear the message queue."""
         app = DeepAgentsApp()
@@ -572,7 +556,6 @@ class TestMessageQueue:
             assert len(app._pending_messages) == 0
             assert len(app._queued_widgets) == 0
 
-    @pytest.mark.asyncio
     async def test_process_next_from_queue_removes_widget(self) -> None:
         """Processing a queued message should remove its ephemeral widget."""
         app = DeepAgentsApp()
@@ -591,7 +574,6 @@ class TestMessageQueue:
 
             assert len(app._queued_widgets) == 0
 
-    @pytest.mark.asyncio
     async def test_bash_command_continues_chain(self) -> None:
         """Bash/command messages should not break the queue processing chain."""
         app = DeepAgentsApp()
@@ -617,7 +599,6 @@ class TestMessageQueue:
 class TestTraceCommand:
     """Test /trace slash command."""
 
-    @pytest.mark.asyncio
     async def test_trace_opens_browser_when_configured(self) -> None:
         """Should open the LangSmith thread URL in the browser."""
         app = DeepAgentsApp()
@@ -645,7 +626,6 @@ class TestTraceCommand:
                 for w in app_msgs
             )
 
-    @pytest.mark.asyncio
     async def test_trace_shows_error_when_not_configured(self) -> None:
         """Should show configuration hint when LangSmith is not set up."""
         app = DeepAgentsApp()
@@ -663,7 +643,6 @@ class TestTraceCommand:
             app_msgs = app.query(AppMessage)
             assert any("LANGSMITH_API_KEY" in str(w._content) for w in app_msgs)
 
-    @pytest.mark.asyncio
     async def test_trace_shows_error_when_no_session(self) -> None:
         """Should show error when there is no active session."""
         app = DeepAgentsApp()
@@ -677,7 +656,6 @@ class TestTraceCommand:
             app_msgs = app.query(AppMessage)
             assert any("No active session" in str(w._content) for w in app_msgs)
 
-    @pytest.mark.asyncio
     async def test_trace_shows_link_when_browser_fails(self) -> None:
         """Should still display the URL link even if the browser cannot open."""
         app = DeepAgentsApp()
@@ -704,7 +682,6 @@ class TestTraceCommand:
                 for w in app_msgs
             )
 
-    @pytest.mark.asyncio
     async def test_trace_shows_error_when_url_build_raises(self) -> None:
         """Should show error message when build_langsmith_thread_url raises."""
         app = DeepAgentsApp()
@@ -722,7 +699,6 @@ class TestTraceCommand:
             app_msgs = app.query(AppMessage)
             assert any("Failed to resolve" in str(w._content) for w in app_msgs)
 
-    @pytest.mark.asyncio
     async def test_trace_routed_from_handle_command(self) -> None:
         """'/trace' should be correctly routed through _handle_command."""
         app = DeepAgentsApp()
@@ -740,7 +716,6 @@ class TestTraceCommand:
 class TestRunAgentTaskImageTracker:
     """Tests image tracker wiring from app into textual execution."""
 
-    @pytest.mark.asyncio
     async def test_run_agent_task_passes_image_tracker(self) -> None:
         """`_run_agent_task` should forward the shared image tracker."""
         app = DeepAgentsApp(agent=MagicMock())
@@ -757,7 +732,6 @@ class TestRunAgentTaskImageTracker:
             assert mock_execute.await_args is not None
             assert mock_execute.await_args.kwargs["image_tracker"] is app._image_tracker
 
-    @pytest.mark.asyncio
     async def test_run_agent_task_finalizes_pending_tools_on_error(self) -> None:
         """Unexpected agent errors should stop/clear in-flight tool widgets."""
         app = DeepAgentsApp(agent=MagicMock())
@@ -786,7 +760,6 @@ class TestRunAgentTaskImageTracker:
 class TestAppFocusRestoresChatInput:
     """Test `on_app_focus` restores chat input focus after terminal regains focus."""
 
-    @pytest.mark.asyncio
     async def test_app_focus_restores_chat_input(self) -> None:
         """Regaining terminal focus should re-focus the chat input."""
         app = DeepAgentsApp()
@@ -805,7 +778,6 @@ class TestAppFocusRestoresChatInput:
             # chat_input.focus_input should have been called
             assert app._chat_input._text_area.has_focus
 
-    @pytest.mark.asyncio
     async def test_app_focus_skips_when_modal_open(self) -> None:
         """Regaining focus should not steal focus from an open modal."""
         app = DeepAgentsApp()
@@ -827,7 +799,6 @@ class TestAppFocusRestoresChatInput:
 
             mock_focus.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_app_focus_skips_when_approval_pending(self) -> None:
         """Regaining focus should not steal focus from the approval widget."""
         app = DeepAgentsApp()
@@ -847,7 +818,6 @@ class TestAppFocusRestoresChatInput:
 class TestPasteRouting:
     """Tests app-level paste routing when chat input focus lags."""
 
-    @pytest.mark.asyncio
     async def test_on_paste_routes_unfocused_event_to_chat_input(self) -> None:
         """Unfocused paste events should be forwarded to chat input handler."""
         app = DeepAgentsApp()
@@ -870,7 +840,6 @@ class TestPasteRouting:
             mock_prevent.assert_called_once()
             mock_stop.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_on_paste_does_not_route_when_input_already_focused(self) -> None:
         """Focused input should keep normal TextArea paste handling path."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Container
@@ -20,6 +19,7 @@ from deepagents_cli.widgets.chat_input import (
 )
 
 if TYPE_CHECKING:
+    import pytest
     from textual.pilot import Pilot
 
 
@@ -80,7 +80,6 @@ class TestCompletionPopup:
 class TestCompletionPopupIntegration:
     """Integration tests for CompletionPopup with Textual."""
 
-    @pytest.mark.asyncio
     async def test_update_suggestions_shows_popup(self) -> None:
         """update_suggestions should show the popup when given suggestions."""
 
@@ -105,7 +104,6 @@ class TestCompletionPopupIntegration:
             # Should be visible
             assert popup.styles.display == "block"
 
-    @pytest.mark.asyncio
     async def test_update_suggestions_creates_option_widgets(self) -> None:
         """update_suggestions should create CompletionOption widgets."""
 
@@ -128,7 +126,6 @@ class TestCompletionPopupIntegration:
             options = popup.query(CompletionOption)
             assert len(options) == 2
 
-    @pytest.mark.asyncio
     async def test_empty_suggestions_hides_popup(self) -> None:
         """Empty suggestions should hide the popup."""
 
@@ -158,7 +155,6 @@ class TestCompletionPopupIntegration:
 class TestCompletionOptionClick:
     """Test click handling on CompletionOption."""
 
-    @pytest.mark.asyncio
     async def test_click_on_option_posts_message(self) -> None:
         """Clicking on an option should post a Clicked message."""
 
@@ -263,7 +259,6 @@ def _prompt_text(prompt: Static) -> str:
 class TestPromptIndicator:
     """Test that the prompt indicator reflects the current input mode."""
 
-    @pytest.mark.asyncio
     async def test_prompt_shows_bang_in_bash_mode(self) -> None:
         """Setting mode to 'bash' should change prompt to '!' and apply bash styling."""
         app = _ChatInputTestApp()
@@ -279,7 +274,6 @@ class TestPromptIndicator:
             assert _prompt_text(prompt) == "!"
             assert chat_input.has_class("mode-bash")
 
-    @pytest.mark.asyncio
     async def test_prompt_shows_slash_in_command_mode(self) -> None:
         """Setting mode to 'command' should change prompt and styling."""
         app = _ChatInputTestApp()
@@ -292,7 +286,6 @@ class TestPromptIndicator:
             assert _prompt_text(prompt) == "/"
             assert chat_input.has_class("mode-command")
 
-    @pytest.mark.asyncio
     async def test_prompt_reverts_to_default_on_normal_mode(self) -> None:
         """Resetting mode to 'normal' should revert indicator and classes."""
         app = _ChatInputTestApp()
@@ -311,7 +304,6 @@ class TestPromptIndicator:
             assert not chat_input.has_class("mode-bash")
             assert not chat_input.has_class("mode-command")
 
-    @pytest.mark.asyncio
     async def test_mode_change_posts_message(self) -> None:
         """Setting mode should post a ModeChanged message."""
         messages: list[ChatInput.ModeChanged] = []
@@ -335,7 +327,6 @@ class TestPromptIndicator:
 class TestHistoryNavigationFlag:
     """Test that _navigating_history resets when history is exhausted."""
 
-    @pytest.mark.asyncio
     async def test_down_arrow_at_bottom_resets_navigating_flag(self) -> None:
         """Pressing down with no history should not leave _navigating_history stuck."""
         app = _ChatInputTestApp()
@@ -351,7 +342,6 @@ class TestHistoryNavigationFlag:
 
             assert not text_area._navigating_history
 
-    @pytest.mark.asyncio
     async def test_autocomplete_works_after_down_arrow(self) -> None:
         """Typing '/' after pressing down should still trigger completions."""
         app = _ChatInputTestApp()
@@ -378,7 +368,6 @@ class TestHistoryNavigationFlag:
 class TestHistoryBoundaryNavigation:
     """Test that history navigation only triggers at input boundaries."""
 
-    @pytest.mark.asyncio
     async def test_up_arrow_only_triggers_at_cursor_start(self) -> None:
         """Up arrow should only navigate history when cursor is at (0, 0)."""
         app = _ChatInputTestApp()
@@ -398,7 +387,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == "hello"
 
-    @pytest.mark.asyncio
     async def test_up_arrow_triggers_at_cursor_zero(self) -> None:
         """Up arrow should navigate history when cursor is at (0, 0)."""
         app = _ChatInputTestApp()
@@ -419,7 +407,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == "previous entry"
 
-    @pytest.mark.asyncio
     async def test_down_arrow_navigates_from_start_when_in_history(self) -> None:
         """Down arrow at start navigates history when `_in_history` is True."""
         app = _ChatInputTestApp()
@@ -443,7 +430,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == ""
 
-    @pytest.mark.asyncio
     async def test_down_arrow_does_not_trigger_at_non_end(self) -> None:
         """Down arrow should not navigate history when cursor is not at end."""
         app = _ChatInputTestApp()
@@ -466,7 +452,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == "hello world"
 
-    @pytest.mark.asyncio
     async def test_down_arrow_at_end_triggers_history(self) -> None:
         """Down arrow at end of text should navigate history forward."""
         app = _ChatInputTestApp()
@@ -489,7 +474,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == "second"
 
-    @pytest.mark.asyncio
     async def test_up_at_middle_of_multiline_does_not_trigger(self) -> None:
         """Up arrow on a middle line should not navigate history."""
         app = _ChatInputTestApp()
@@ -510,7 +494,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == "line one\nline two\nline three"
 
-    @pytest.mark.asyncio
     async def test_in_history_allows_up_from_end(self) -> None:
         """When browsing history, up arrow at end should also navigate."""
         app = _ChatInputTestApp()
@@ -532,7 +515,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area.text == "first"
 
-    @pytest.mark.asyncio
     async def test_in_history_resets_after_submission(self) -> None:
         """Submitting should clear the _in_history flag."""
         app = _RecordingApp()
@@ -550,7 +532,6 @@ class TestHistoryBoundaryNavigation:
             await pilot.pause()
             assert chat._text_area._in_history is False
 
-    @pytest.mark.asyncio
     async def test_in_history_resets_after_navigating_past_end(self) -> None:
         """Pressing down past history end should set `_in_history` to False."""
         app = _ChatInputTestApp()
@@ -576,7 +557,6 @@ class TestHistoryBoundaryNavigation:
 class TestCompletionPopupClickBubbling:
     """Test that clicks on options bubble up through the popup."""
 
-    @pytest.mark.asyncio
     async def test_popup_receives_option_click_and_posts_message(self) -> None:
         """Popup should receive option clicks and post OptionClicked message."""
 
@@ -618,7 +598,6 @@ class TestCompletionPopupClickBubbling:
 class TestDismissCompletion:
     """Test ChatInput.dismiss_completion edge cases."""
 
-    @pytest.mark.asyncio
     async def test_dismiss_returns_false_when_no_suggestions(self) -> None:
         """dismiss_completion returns False when nothing is shown."""
         app = _ChatInputTestApp()
@@ -626,7 +605,6 @@ class TestDismissCompletion:
             chat = app.query_one("#chat-input", ChatInput)
             assert chat.dismiss_completion() is False
 
-    @pytest.mark.asyncio
     async def test_dismiss_clears_popup_and_state(self) -> None:
         """dismiss_completion hides popup and resets all state."""
         app = _ChatInputTestApp()
@@ -654,7 +632,6 @@ class TestDismissCompletion:
             assert popup.styles.display == "none"
             assert chat._text_area._completion_active is False
 
-    @pytest.mark.asyncio
     async def test_dismiss_is_idempotent(self) -> None:
         """Calling dismiss_completion twice is safe."""
         app = _ChatInputTestApp()
@@ -670,7 +647,6 @@ class TestDismissCompletion:
             # Second call is a no-op
             assert chat.dismiss_completion() is False
 
-    @pytest.mark.asyncio
     async def test_completion_reappears_after_dismiss(self) -> None:
         """Typing / after dismiss_completion re-opens the menu."""
         app = _ChatInputTestApp()
@@ -704,7 +680,6 @@ class TestDismissCompletion:
             assert len(chat._current_suggestions) == len(SLASH_COMMANDS)
             assert popup.styles.display == "block"
 
-    @pytest.mark.asyncio
     async def test_popup_hide_cancels_pending_rebuild(self) -> None:
         """Hiding the popup clears pending suggestions so a stale rebuild is a no-op."""
         app = _ChatInputTestApp()
@@ -727,7 +702,6 @@ class TestDismissCompletion:
 class TestModePrefixStripping:
     """Test that mode-trigger characters are stripped from text input."""
 
-    @pytest.mark.asyncio
     async def test_typing_bang_strips_prefix_and_sets_bash_mode(self) -> None:
         """Setting text to `'!ls'` should strip to `'ls'` and enter bash mode."""
         app = _ChatInputTestApp()
@@ -741,7 +715,6 @@ class TestModePrefixStripping:
             assert chat.mode == "bash"
             assert chat._text_area.text == "ls"
 
-    @pytest.mark.asyncio
     async def test_typing_slash_strips_prefix_and_sets_command_mode(self) -> None:
         """Setting text to `'/'` should strip to `''` and enter command mode."""
         app = _ChatInputTestApp()
@@ -755,7 +728,6 @@ class TestModePrefixStripping:
             assert chat.mode == "command"
             assert chat._text_area.text == ""
 
-    @pytest.mark.asyncio
     async def test_mode_stays_on_empty_text(self) -> None:
         """Clearing text after entering bash mode should stay in mode."""
         app = _ChatInputTestApp()
@@ -773,7 +745,6 @@ class TestModePrefixStripping:
             await pilot.pause()
             assert chat.mode == "bash"
 
-    @pytest.mark.asyncio
     async def test_backspace_on_empty_exits_mode(self) -> None:
         """Backspace on empty input in bash mode should reset to normal."""
         app = _ChatInputTestApp()
@@ -796,7 +767,6 @@ class TestModePrefixStripping:
             await pilot.pause()
             assert chat.mode == "normal"
 
-    @pytest.mark.asyncio
     async def test_backspace_on_single_char_stays_in_mode(self) -> None:
         """Deleting last char in command mode should stay in mode, not exit."""
         app = _ChatInputTestApp()
@@ -824,7 +794,6 @@ class TestModePrefixStripping:
             await pilot.pause()
             assert chat.mode == "normal"
 
-    @pytest.mark.asyncio
     async def test_backspace_exit_mode_dismisses_completion(self) -> None:
         """Exiting mode via backspace-on-empty should hide the completion popup."""
         app = _ChatInputTestApp()
@@ -846,7 +815,6 @@ class TestModePrefixStripping:
             assert chat._current_suggestions == []
             assert popup.styles.display == "none"
 
-    @pytest.mark.asyncio
     async def test_slash_completion_works_after_strip(self) -> None:
         """Entering command mode and typing `'h'` should trigger completions."""
         app = _ChatInputTestApp()
@@ -868,7 +836,6 @@ class TestModePrefixStripping:
             labels = [s[0] for s in chat._current_suggestions]
             assert "/help" in labels
 
-    @pytest.mark.asyncio
     async def test_submission_prepends_bash_prefix(self) -> None:
         """Submitting in bash mode should prepend `'!'` to the value."""
         app = _RecordingApp()
@@ -891,7 +858,6 @@ class TestModePrefixStripping:
             assert app.submitted[0].value == "!ls"
             assert app.submitted[0].mode == "bash"
 
-    @pytest.mark.asyncio
     async def test_submission_prepends_command_prefix(self) -> None:
         """Submitting in command mode should prepend `'/'` to the value."""
         app = _RecordingApp()
@@ -920,7 +886,6 @@ class TestModePrefixStripping:
             assert app.submitted[0].value == "/help"
             assert app.submitted[0].mode == "command"
 
-    @pytest.mark.asyncio
     async def test_mode_resets_after_submission(self) -> None:
         """Mode should reset to normal after submitting."""
         app = _ChatInputTestApp()
@@ -939,7 +904,6 @@ class TestModePrefixStripping:
             assert chat.mode == "normal"
             assert chat._text_area.text == ""
 
-    @pytest.mark.asyncio
     async def test_mode_sticky_during_typing(self) -> None:
         """Mode should persist while typing in bash/command mode."""
         app = _ChatInputTestApp()
@@ -958,7 +922,6 @@ class TestModePrefixStripping:
             await pilot.pause()
             assert chat.mode == "bash"
 
-    @pytest.mark.asyncio
     async def test_bash_mode_does_not_trigger_completions(self) -> None:
         """Typing in bash mode should not trigger completions."""
         app = _ChatInputTestApp()
@@ -971,7 +934,6 @@ class TestModePrefixStripping:
             assert chat.mode == "bash"
             assert chat._current_suggestions == []
 
-    @pytest.mark.asyncio
     async def test_submission_does_not_double_prefix(self) -> None:
         """If text already starts with prefix, submission should not add another."""
         app = _RecordingApp()
@@ -995,7 +957,6 @@ class TestModePrefixStripping:
 class TestHistoryRecallModeReset:
     """Regression: history recall must not inherit a stale bash/command mode."""
 
-    @pytest.mark.asyncio
     async def test_history_non_prefixed_entry_resets_bash_mode(self) -> None:
         """Recalling a normal-mode entry while in bash mode should reset to normal."""
         app = _RecordingApp()
@@ -1028,7 +989,6 @@ class TestHistoryRecallModeReset:
             assert app.submitted[0].value == "echo hello"
             assert app.submitted[0].mode == "normal"
 
-    @pytest.mark.asyncio
     async def test_history_prefixed_entry_keeps_mode(self) -> None:
         """Recalling a bash-prefixed entry should re-enter bash mode."""
         app = _RecordingApp()
@@ -1054,7 +1014,6 @@ class TestHistoryRecallModeReset:
             assert app.submitted[0].value == "!ls"
             assert app.submitted[0].mode == "bash"
 
-    @pytest.mark.asyncio
     async def test_history_non_prefixed_entry_resets_command_mode(self) -> None:
         """Recalling a normal entry while in command mode should reset to normal."""
         app = _RecordingApp()
@@ -1090,7 +1049,6 @@ class TestHistoryRecallModeReset:
 class TestSlashCompletionCursorMapping:
     """Regression: virtual-to-real index translation for slash replacement."""
 
-    @pytest.mark.asyncio
     async def test_tab_completion_mid_token_preserves_suffix(self) -> None:
         """Applying slash completion mid-token should keep text after cursor."""
         app = _ChatInputTestApp()
@@ -1114,7 +1072,6 @@ class TestSlashCompletionCursorMapping:
 
             assert chat._text_area.text == "help e"
 
-    @pytest.mark.asyncio
     async def test_click_completion_mid_token_preserves_suffix(self) -> None:
         """Click-selecting slash completion mid-token should keep suffix text."""
         app = _ChatInputTestApp()
@@ -1136,7 +1093,6 @@ class TestSlashCompletionCursorMapping:
 
             assert chat._text_area.text == "help e"
 
-    @pytest.mark.asyncio
     async def test_tab_completion_at_end_replaces_whole_token(self) -> None:
         """Tab-completing at end should replace all typed command text."""
         app = _ChatInputTestApp()
@@ -1157,7 +1113,6 @@ class TestSlashCompletionCursorMapping:
 
             assert chat._text_area.text == "help "
 
-    @pytest.mark.asyncio
     async def test_normal_mode_replace_is_unaffected(self) -> None:
         """In normal mode (no prefix), coordinates pass through unchanged."""
         app = _ChatInputTestApp()
@@ -1179,7 +1134,6 @@ class TestSlashCompletionCursorMapping:
 class TestHistorySlashPrefixRecall:
     """Test that recalling a slash-prefixed history entry enters command mode."""
 
-    @pytest.mark.asyncio
     async def test_history_slash_prefixed_entry_enters_command_mode(self) -> None:
         """Recalling a `/help` history entry should enter command mode."""
         app = _RecordingApp()
@@ -1207,7 +1161,6 @@ class TestHistorySlashPrefixRecall:
 class TestCompletionIndexToTextIndex:
     """Edge-case tests for _completion_index_to_text_index clamping."""
 
-    @pytest.mark.asyncio
     async def test_negative_mapped_index_clamps_to_zero(self) -> None:
         """A completion index below the prefix length should clamp to 0."""
         app = _ChatInputTestApp()
@@ -1223,7 +1176,6 @@ class TestCompletionIndexToTextIndex:
             # index=0 in completion space -> 0 - 1 = -1 -> clamped to 0
             assert chat._completion_index_to_text_index(0) == 0
 
-    @pytest.mark.asyncio
     async def test_overflow_index_clamps_to_text_length(self) -> None:
         """A completion index beyond text length should clamp to len(text)."""
         app = _ChatInputTestApp()
@@ -1237,7 +1189,6 @@ class TestCompletionIndexToTextIndex:
             # index=100 -> 100 - 1 = 99 -> clamped to 2
             assert chat._completion_index_to_text_index(100) == 2
 
-    @pytest.mark.asyncio
     async def test_normal_mode_passes_through(self) -> None:
         """In normal mode (prefix_len=0), index maps 1:1."""
         app = _ChatInputTestApp()
@@ -1253,7 +1204,6 @@ class TestCompletionIndexToTextIndex:
 class TestHistoryRecallSuppressesCompletions:
     """Test that history navigation does not trigger completions."""
 
-    @pytest.mark.asyncio
     async def test_history_recall_does_not_trigger_completions(self) -> None:
         """Recalling a history entry with '@' should not open file completions."""
         app = _ChatInputTestApp()
@@ -1273,7 +1223,6 @@ class TestHistoryRecallSuppressesCompletions:
 class TestDroppedImagePaste:
     """Tests for drag/drop image-path handling via paste events."""
 
-    @pytest.mark.asyncio
     async def test_forward_delete_removes_placeholder(self, tmp_path) -> None:
         """Forward-delete should remove `[image N]` as a single token."""
         img_path = tmp_path / "fwddelete.png"
@@ -1303,7 +1252,6 @@ class TestDroppedImagePaste:
             assert app.tracker.get_images() == []
             assert app.tracker.next_id == 1
 
-    @pytest.mark.asyncio
     async def test_backspace_removes_full_image_placeholder(self, tmp_path) -> None:
         """Backspace should remove `[image N]` as a single token."""
         img_path = tmp_path / "backspace.png"
@@ -1328,7 +1276,6 @@ class TestDroppedImagePaste:
             assert app.tracker.get_images() == []
             assert app.tracker.next_id == 1
 
-    @pytest.mark.asyncio
     async def test_readding_after_delete_restarts_image_counter(self, tmp_path) -> None:
         """Re-adding after deleting all placeholders should restart at `[image 1]`."""
         img_path = tmp_path / "readd.png"
@@ -1356,7 +1303,6 @@ class TestDroppedImagePaste:
             assert len(app.tracker.get_images()) == 1
             assert app.tracker.next_id == 2
 
-    @pytest.mark.asyncio
     async def test_handle_external_paste_attaches_dropped_image(self, tmp_path) -> None:
         """External paste routing should attach dropped images."""
         img_path = tmp_path / "external.png"
@@ -1376,7 +1322,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text.strip() == "[image 1]"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_handle_external_paste_attaches_unquoted_path_with_spaces(
         self, tmp_path
     ) -> None:
@@ -1398,7 +1343,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text.strip() == "[image 1]"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_handle_external_paste_inserts_plain_text(self) -> None:
         """External paste should insert text when payload is not a file path."""
         app = _ImagePasteApp()
@@ -1412,7 +1356,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text == "hello world"
             assert app.tracker.get_images() == []
 
-    @pytest.mark.asyncio
     async def test_paste_image_path_attaches_image_and_inserts_placeholder(
         self, tmp_path
     ) -> None:
@@ -1434,7 +1377,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text.strip() == "[image 1]"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_paste_non_image_path_keeps_original_text(self, tmp_path) -> None:
         """Non-image dropped paths should keep the default path paste behavior."""
         file_path = tmp_path / "notes.txt"
@@ -1451,7 +1393,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text.endswith(str(file_path).lstrip("/"))
             assert app.tracker.get_images() == []
 
-    @pytest.mark.asyncio
     async def test_inline_quoted_path_payload_rewrites_to_placeholder(
         self, tmp_path
     ) -> None:
@@ -1474,7 +1415,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text == "[image 1] "
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_key_burst_quoted_path_rewrites_without_showing_raw_path(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1508,7 +1448,6 @@ class TestDroppedImagePaste:
             assert chat._text_area.text == "[image 1] "
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_submit_absolute_path_without_paste_event_attaches_image(
         self, tmp_path
     ) -> None:
@@ -1537,7 +1476,6 @@ class TestDroppedImagePaste:
             assert app.submitted[0].mode == "normal"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_submit_absolute_path_with_spaces_stays_normal_mode(
         self, tmp_path
     ) -> None:
@@ -1566,7 +1504,6 @@ class TestDroppedImagePaste:
             assert app.submitted[0].mode == "normal"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_submit_absolute_path_with_spaces_and_trailing_text(
         self, tmp_path
     ) -> None:
@@ -1620,7 +1557,6 @@ class TestDroppedImagePaste:
             assert app.submitted[0].mode == "normal"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_submit_falls_back_to_leading_image_when_full_path_non_image(
         self, tmp_path
     ) -> None:
@@ -1650,7 +1586,6 @@ class TestDroppedImagePaste:
             assert app.submitted[0].mode == "normal"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_submit_leading_path_handles_unicode_space_variants(
         self, tmp_path
     ) -> None:
@@ -1679,7 +1614,6 @@ class TestDroppedImagePaste:
             assert app.submitted[0].mode == "normal"
             assert len(app.tracker.get_images()) == 1
 
-    @pytest.mark.asyncio
     async def test_sync_resumes_after_submit_skip(self, tmp_path) -> None:
         """Image tracker sync should resume after the post-submit skip event."""
         img_path = tmp_path / "sync_resume.png"
@@ -1711,7 +1645,6 @@ class TestDroppedImagePaste:
             assert app.tracker.get_images() == []
             assert app.tracker.next_id == 1
 
-    @pytest.mark.asyncio
     async def test_submit_recovers_if_command_mode_already_stripped_path(
         self, tmp_path
     ) -> None:

--- a/libs/cli/tests/unit_tests/test_compact.py
+++ b/libs/cli/tests/unit_tests/test_compact.py
@@ -924,7 +924,6 @@ class TestCompactProfileOverride:
     profile — when computing the retention budget and cutoff index.
     """
 
-    @pytest.mark.asyncio
     async def test_compact_applies_context_limit_to_model_profile(self) -> None:
         """Model profile should be patched to settings.model_context_limit."""
         app = DeepAgentsApp()
@@ -960,7 +959,6 @@ class TestCompactProfileOverride:
             assert len(captured_models) == 1
             assert captured_models[0].profile["max_input_tokens"] == 4096
 
-    @pytest.mark.asyncio
     async def test_compact_matching_override_preserves_original_profile(self) -> None:
         """When override matches native profile value, no mutation occurs."""
         app = DeepAgentsApp()
@@ -995,7 +993,6 @@ class TestCompactProfileOverride:
 
             assert captured_models[0].profile["max_input_tokens"] == 200_000
 
-    @pytest.mark.asyncio
     async def test_compact_override_triggers_compaction(self) -> None:
         """With a small override, conversation 'within budget' should compact."""
         app = DeepAgentsApp()
@@ -1042,7 +1039,6 @@ class TestCompactProfileOverride:
             # State should have been updated (compaction happened)
             app._agent.aupdate_state.assert_called_once()  # type: ignore[union-attr]
 
-    @pytest.mark.asyncio
     async def test_compact_override_none_uses_model_profile(self) -> None:
         """When model_context_limit is None, model profile is untouched."""
         app = DeepAgentsApp()
@@ -1076,7 +1072,6 @@ class TestCompactProfileOverride:
 
             assert captured_models[0].profile["max_input_tokens"] == 200_000
 
-    @pytest.mark.asyncio
     async def test_compact_override_with_no_model_profile(self) -> None:
         """When model.profile is None, override creates a new profile dict."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_compact.py
+++ b/libs/cli/tests/unit_tests/test_compact.py
@@ -123,7 +123,6 @@ class TestCompactInAutocomplete:
 class TestCompactGuards:
     """Test guard conditions that prevent compaction."""
 
-    @pytest.mark.asyncio
     async def test_no_agent_shows_error(self) -> None:
         """Should show error when there is no active agent."""
         app = DeepAgentsApp()
@@ -138,7 +137,6 @@ class TestCompactGuards:
             msgs = app.query(AppMessage)
             assert any("Nothing to compact" in str(w._content) for w in msgs)
 
-    @pytest.mark.asyncio
     async def test_agent_running_shows_error(self) -> None:
         """Should show error when agent is currently running."""
         app = DeepAgentsApp()
@@ -157,7 +155,6 @@ class TestCompactGuards:
                 "Cannot compact while agent is running" in str(w._content) for w in msgs
             )
 
-    @pytest.mark.asyncio
     async def test_cutoff_zero_shows_not_enough(self) -> None:
         """Should show error when middleware cutoff is zero."""
         app = DeepAgentsApp()
@@ -175,7 +172,6 @@ class TestCompactGuards:
             msgs = app.query(AppMessage)
             assert any("within the token budget" in str(w._content) for w in msgs)
 
-    @pytest.mark.asyncio
     async def test_empty_state_shows_error(self) -> None:
         """Should show error when state has no values."""
         app = DeepAgentsApp()
@@ -196,7 +192,6 @@ class TestCompactGuards:
             msgs = app.query(AppMessage)
             assert any("Nothing to compact" in str(w._content) for w in msgs)
 
-    @pytest.mark.asyncio
     async def test_state_read_failure_shows_error(self) -> None:
         """Should show error when reading state raises an exception."""
         app = DeepAgentsApp()
@@ -265,7 +260,6 @@ def _setup_compact_app(
 class TestCompactSuccess:
     """Test successful compaction flow."""
 
-    @pytest.mark.asyncio
     async def test_successful_compaction_sets_event(self) -> None:
         """Should set _summarization_event with cutoff and summary message."""
         app = DeepAgentsApp()
@@ -303,7 +297,6 @@ class TestCompactSuccess:
             assert "<summary>" in summary_msg.content
             assert "Summary of the conversation." in summary_msg.content
 
-    @pytest.mark.asyncio
     async def test_compaction_shows_feedback_message(self) -> None:
         """Should display feedback with message count and token change."""
         app = DeepAgentsApp()
@@ -330,7 +323,6 @@ class TestCompactSuccess:
                 for w in msgs
             )
 
-    @pytest.mark.asyncio
     async def test_compaction_updates_token_tracker(self) -> None:
         """Should update token tracker after compaction."""
         app = DeepAgentsApp()
@@ -354,7 +346,6 @@ class TestCompactSuccess:
 
             app._token_tracker.add.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_no_ui_clear_reload(self) -> None:
         """Should NOT clear/reload UI since messages stay in state."""
         app = DeepAgentsApp()
@@ -388,7 +379,6 @@ class TestCompactSuccess:
 class TestCompactEdgeCases:
     """Test edge cases in the compaction logic."""
 
-    @pytest.mark.asyncio
     async def test_cutoff_zero_does_not_update_state(self) -> None:
         """When middleware returns cutoff=0, state should not be modified."""
         app = DeepAgentsApp()
@@ -407,7 +397,6 @@ class TestCompactEdgeCases:
             assert any("within the token budget" in str(w._content) for w in msgs)
             app._agent.aupdate_state.assert_not_called()  # type: ignore[union-attr]
 
-    @pytest.mark.asyncio
     async def test_cutoff_one_compacts_single_message(self) -> None:
         """With cutoff=1, event should have cutoff_index=1."""
         app = DeepAgentsApp()
@@ -433,7 +422,6 @@ class TestCompactEdgeCases:
             event = update_values["_summarization_event"]
             assert event["cutoff_index"] == 1
 
-    @pytest.mark.asyncio
     async def test_middleware_cutoff_called_with_effective_messages(self) -> None:
         """Should pass effective messages to middleware cutoff logic."""
         app = DeepAgentsApp()
@@ -464,7 +452,6 @@ class TestCompactEdgeCases:
 class TestReCompaction:
     """Test compaction when a prior _summarization_event already exists."""
 
-    @pytest.mark.asyncio
     async def test_recompact_calculates_absolute_cutoff(self) -> None:
         """Re-compaction should compute state_cutoff = old_cutoff + new_cutoff - 1."""
         app = DeepAgentsApp()
@@ -506,7 +493,6 @@ class TestReCompaction:
 class TestAgentRunningGuard:
     """Test that _handle_compact sets _agent_running to prevent races."""
 
-    @pytest.mark.asyncio
     async def test_agent_running_set_during_compaction(self) -> None:
         """Should set _agent_running=True during compaction and reset after."""
         app = DeepAgentsApp()
@@ -541,7 +527,6 @@ class TestAgentRunningGuard:
             # And reset after completion
             assert app._agent_running is False
 
-    @pytest.mark.asyncio
     async def test_agent_running_reset_after_failure(self) -> None:
         """Should reset _agent_running=False even when compaction fails."""
         app = DeepAgentsApp()
@@ -562,7 +547,6 @@ class TestAgentRunningGuard:
 class TestCompactErrorHandling:
     """Test error handling during compaction."""
 
-    @pytest.mark.asyncio
     async def test_offload_failure_proceeds_without_path(self) -> None:
         """Should proceed with compaction even if offload fails."""
         app = DeepAgentsApp()
@@ -594,7 +578,6 @@ class TestCompactErrorHandling:
             summary_content = event["summary_message"].content
             assert "conversation history has been saved" not in summary_content
 
-    @pytest.mark.asyncio
     async def test_summary_generation_failure_shows_error(self) -> None:
         """Should show error and leave state untouched when summary fails."""
         app = DeepAgentsApp()
@@ -615,7 +598,6 @@ class TestCompactErrorHandling:
             error_msgs = app.query(ErrorMessage)
             assert any("Compaction failed" in str(w._content) for w in error_msgs)
 
-    @pytest.mark.asyncio
     async def test_state_update_failure_shows_error(self) -> None:
         """Should show error when aupdate_state raises."""
         app = DeepAgentsApp()
@@ -642,7 +624,6 @@ class TestCompactErrorHandling:
             error_msgs = app.query(ErrorMessage)
             assert any("Compaction failed" in str(w._content) for w in error_msgs)
 
-    @pytest.mark.asyncio
     async def test_spinner_hidden_after_failure(self) -> None:
         """Should hide spinner even when compaction fails."""
         app = DeepAgentsApp()
@@ -674,7 +655,6 @@ class TestCompactErrorHandling:
 class TestCreateModelFailure:
     """Test that _handle_compact handles create_model() failures."""
 
-    @pytest.mark.asyncio
     async def test_create_model_failure_shows_error(self) -> None:
         """Should show error when create_model() raises."""
         app = DeepAgentsApp()
@@ -699,7 +679,6 @@ class TestCreateModelFailure:
 class TestOffloadMessagesForCompact:
     """Test _offload_messages_for_compact code paths."""
 
-    @pytest.mark.asyncio
     async def test_filters_summary_messages(self) -> None:
         """Should use middleware._filter_summary_messages to exclude summaries."""
         app = DeepAgentsApp()
@@ -729,7 +708,6 @@ class TestOffloadMessagesForCompact:
             assert result is not None
             assert result != ""
 
-    @pytest.mark.asyncio
     async def test_all_summary_messages_returns_empty(self) -> None:
         """Should return empty string when all messages are summaries."""
         app = DeepAgentsApp()
@@ -744,7 +722,6 @@ class TestOffloadMessagesForCompact:
 
             assert result == ""
 
-    @pytest.mark.asyncio
     async def test_appends_to_existing_content(self) -> None:
         """Should append new section to existing history file."""
         app = DeepAgentsApp()
@@ -774,7 +751,6 @@ class TestOffloadMessagesForCompact:
             # Should have called aedit (not awrite) since existing content exists
             mock_backend.aedit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_creates_new_file_when_none_exists(self) -> None:
         """Should call awrite when no existing file is found."""
         app = DeepAgentsApp()
@@ -802,7 +778,6 @@ class TestOffloadMessagesForCompact:
             assert result is not None
             mock_backend.awrite.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_read_failure_returns_none(self) -> None:
         """Should return None when reading existing file fails."""
         app = DeepAgentsApp()
@@ -826,7 +801,6 @@ class TestOffloadMessagesForCompact:
 
             assert result is None
 
-    @pytest.mark.asyncio
     async def test_write_failure_returns_none(self) -> None:
         """Should return None when writing to backend fails."""
         app = DeepAgentsApp()
@@ -852,7 +826,6 @@ class TestOffloadMessagesForCompact:
 
             assert result is None
 
-    @pytest.mark.asyncio
     async def test_write_error_result_returns_none(self) -> None:
         """Should return None when write result contains an error."""
         app = DeepAgentsApp()
@@ -884,7 +857,6 @@ class TestOffloadMessagesForCompact:
 class TestCompactRouting:
     """Test that /compact is routed through _handle_command."""
 
-    @pytest.mark.asyncio
     async def test_compact_routed_from_handle_command(self) -> None:
         """'/compact' should be correctly routed through _handle_command."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_local_context.py
+++ b/libs/cli/tests/unit_tests/test_local_context.py
@@ -223,7 +223,6 @@ class TestLocalContextMiddleware:
         handler.assert_called_once_with(request)
         assert result == "response"
 
-    @pytest.mark.asyncio
     async def test_awrap_model_call_with_local_context(self) -> None:
         """Test that awrap_model_call appends local context to system prompt."""
         backend = _make_backend()
@@ -249,7 +248,6 @@ class TestLocalContextMiddleware:
         handler.assert_called_once_with(overridden_request)
         assert result == "async response"
 
-    @pytest.mark.asyncio
     async def test_awrap_model_call_without_local_context(self) -> None:
         """Test that awrap_model_call passes through when no local context."""
         backend = _make_backend()

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -125,7 +125,6 @@ class TestAppResult:
 class TestRunTextualAppReturnType:
     """Test that run_textual_app returns AppResult."""
 
-    @pytest.mark.asyncio
     async def test_run_textual_app_returns_app_result(self) -> None:
         """run_textual_app should return an AppResult."""
         sig = inspect.signature(run_textual_app)

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -80,7 +80,6 @@ class AppWithEscapeBinding(App):
 class TestModelSelectorEscapeKey:
     """Tests for ESC key dismissing the modal."""
 
-    @pytest.mark.asyncio
     async def test_escape_dismisses_modal(self) -> None:
         """Pressing ESC should dismiss the modal with None result."""
         app = ModelSelectorTestApp()
@@ -95,7 +94,6 @@ class TestModelSelectorEscapeKey:
             assert app.dismissed is True
             assert app.result is None
 
-    @pytest.mark.asyncio
     async def test_escape_works_when_input_focused(self) -> None:
         """ESC should work even when the filter input is focused."""
         app = ModelSelectorTestApp()
@@ -114,7 +112,6 @@ class TestModelSelectorEscapeKey:
             assert app.dismissed is True
             assert app.result is None
 
-    @pytest.mark.asyncio
     async def test_escape_with_conflicting_app_binding(self) -> None:
         """ESC should dismiss modal even when app has its own escape binding.
 
@@ -140,7 +137,6 @@ class TestModelSelectorEscapeKey:
 class TestModelSelectorKeyboardNavigation:
     """Tests for keyboard navigation in the modal."""
 
-    @pytest.mark.asyncio
     async def test_down_arrow_moves_selection(self) -> None:
         """Down arrow should move selection down."""
         app = ModelSelectorTestApp()
@@ -157,7 +153,6 @@ class TestModelSelectorKeyboardNavigation:
 
             assert screen._selected_index == initial_index + 1
 
-    @pytest.mark.asyncio
     async def test_up_arrow_moves_selection(self) -> None:
         """Up arrow should move selection up (wrapping to end if at 0)."""
         app = ModelSelectorTestApp()
@@ -177,7 +172,6 @@ class TestModelSelectorKeyboardNavigation:
             expected = (initial_index - 1) % count
             assert screen._selected_index == expected
 
-    @pytest.mark.asyncio
     async def test_enter_selects_model(self) -> None:
         """Enter should select the current model and dismiss."""
         app = ModelSelectorTestApp()
@@ -197,7 +191,6 @@ class TestModelSelectorKeyboardNavigation:
 class TestModelSelectorFiltering:
     """Tests for search filtering."""
 
-    @pytest.mark.asyncio
     async def test_typing_filters_models(self) -> None:
         """Typing in the filter input should filter models."""
         app = ModelSelectorTestApp()
@@ -214,7 +207,6 @@ class TestModelSelectorFiltering:
 
             assert screen._filter_text == "claude"
 
-    @pytest.mark.asyncio
     async def test_custom_model_spec_entry(self) -> None:
         """User can enter a custom provider:model spec."""
         app = ModelSelectorTestApp()
@@ -234,7 +226,6 @@ class TestModelSelectorFiltering:
             assert app.dismissed is True
             assert app.result == ("custom:my-model", "custom")
 
-    @pytest.mark.asyncio
     async def test_enter_selects_highlighted_model_not_filter_text(self) -> None:
         """Enter selects highlighted model, not raw filter text."""
         app = ModelSelectorTestApp()
@@ -268,7 +259,6 @@ class TestModelSelectorFiltering:
 class TestModelSelectorCurrentModelPreselection:
     """Tests for pre-selecting the current model when opening the selector."""
 
-    @pytest.mark.asyncio
     async def test_current_model_is_preselected(self) -> None:
         """Opening the selector should pre-select the current model, not first."""
         app = ModelSelectorTestApp()
@@ -294,7 +284,6 @@ class TestModelSelectorCurrentModelPreselection:
                 f"but index {screen._selected_index} was selected instead"
             )
 
-    @pytest.mark.asyncio
     async def test_clearing_filter_reselects_current_model(self) -> None:
         """Clearing the filter should re-select the current model."""
         app = ModelSelectorTestApp()

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -27,7 +27,6 @@ def _restore_settings() -> Iterator[None]:
 class TestModelSwitchNoOp:
     """Tests for no-op when switching to the same model."""
 
-    @pytest.mark.asyncio
     async def test_no_message_when_switching_to_same_model(self) -> None:
         """Switching to the already-active model should not print 'Switched to'.
 
@@ -72,7 +71,6 @@ class TestModelSwitchNoOp:
 class TestModelSwitchErrorHandling:
     """Tests for error handling in _switch_model."""
 
-    @pytest.mark.asyncio
     async def test_missing_credentials_shows_error(self) -> None:
         """_switch_model shows error when provider credentials are missing."""
         app = DeepAgentsApp()
@@ -108,7 +106,6 @@ class TestModelSwitchErrorHandling:
         assert "Missing credentials" in captured_errors[0]
         assert "ANTHROPIC_API_KEY" in captured_errors[0]
 
-    @pytest.mark.asyncio
     async def test_create_model_config_error_shows_error(self) -> None:
         """_switch_model shows error when create_model raises ModelConfigError."""
         app = DeepAgentsApp()
@@ -141,7 +138,6 @@ class TestModelSwitchErrorHandling:
         assert len(captured_errors) == 1
         assert "Missing package" in captured_errors[0]
 
-    @pytest.mark.asyncio
     async def test_create_model_exception_shows_error(self) -> None:
         """_switch_model shows error when create_model raises an exception."""
         app = DeepAgentsApp()
@@ -175,7 +171,6 @@ class TestModelSwitchErrorHandling:
         assert "Failed to create model" in captured_errors[0]
         assert "Invalid model" in captured_errors[0]
 
-    @pytest.mark.asyncio
     async def test_agent_recreation_failure_shows_error_and_preserves_settings(
         self,
     ) -> None:
@@ -226,7 +221,6 @@ class TestModelSwitchErrorHandling:
         assert settings.model_provider == "openai"
         assert settings.model_context_limit == 128_000
 
-    @pytest.mark.asyncio
     async def test_context_limit_cleared_when_new_model_has_none(self) -> None:
         """Switching to a model without a context limit clears the old value."""
         app = DeepAgentsApp()
@@ -262,7 +256,6 @@ class TestModelSwitchErrorHandling:
 
         assert settings.model_context_limit is None
 
-    @pytest.mark.asyncio
     async def test_agent_failure_rollback_with_none_context_limit(self) -> None:
         """Rollback restores previous context limit when new model has None."""
         app = DeepAgentsApp()
@@ -295,7 +288,6 @@ class TestModelSwitchErrorHandling:
 
         assert settings.model_context_limit == 128_000
 
-    @pytest.mark.asyncio
     async def test_no_checkpointer_saves_preference(self) -> None:
         """_switch_model without checkpointer saves preference but doesn't hot-swap."""
         app = DeepAgentsApp()
@@ -328,7 +320,6 @@ class TestModelSwitchErrorHandling:
         assert "Model preference set" in captured_messages[0]
         assert "Restart" in captured_messages[0]
 
-    @pytest.mark.asyncio
     async def test_no_checkpointer_save_failure_shows_error(self) -> None:
         """_switch_model without checkpointer shows error when save fails."""
         app = DeepAgentsApp()
@@ -359,7 +350,6 @@ class TestModelSwitchErrorHandling:
         assert len(captured_errors) == 1
         assert "Could not save model preference" in captured_errors[0]
 
-    @pytest.mark.asyncio
     async def test_hot_swap_save_failure_warns_in_message(self) -> None:
         """Successful hot-swap warns when save_recent_model fails."""
         app = DeepAgentsApp()
@@ -413,7 +403,6 @@ class TestModelSwitchConfigProvider:
         """Clear model config cache before each test."""
         clear_caches()
 
-    @pytest.mark.asyncio
     async def test_switch_to_config_provider_no_whitelist_error(self, tmp_path) -> None:
         """Switching to a provider not in PROVIDER_API_KEY_ENV succeeds.
 
@@ -466,7 +455,6 @@ api_key_env = "FIREWORKS_API_KEY"
         assert any("Switched to" in m for m in captured_messages)
         assert not any("Unknown provider" in m for m in captured_messages)
 
-    @pytest.mark.asyncio
     async def test_switch_config_provider_missing_credentials(self, tmp_path) -> None:
         """Config provider with missing credentials shows appropriate error."""
         config_path = tmp_path / "config.toml"
@@ -501,7 +489,6 @@ api_key_env = "FIREWORKS_API_KEY"
         assert "Missing credentials" in captured_errors[0]
         assert "FIREWORKS_API_KEY" in captured_errors[0]
 
-    @pytest.mark.asyncio
     async def test_switch_to_ollama_no_key_required(self, tmp_path) -> None:
         """Ollama (no api_key_env) passes credential check."""
         config_path = tmp_path / "config.toml"
@@ -550,7 +537,6 @@ models = ["llama3"]
 class TestModelSwitchBareModelName:
     """Tests for _switch_model with bare model names (no provider prefix)."""
 
-    @pytest.mark.asyncio
     async def test_bare_model_name_auto_detects_provider(self) -> None:
         """Bare model name like 'gpt-4o' auto-detects provider and succeeds."""
         app = DeepAgentsApp()
@@ -594,7 +580,6 @@ class TestModelSwitchBareModelName:
 
         assert any("Switched to" in m for m in captured_messages)
 
-    @pytest.mark.asyncio
     async def test_bare_model_name_missing_credentials(self) -> None:
         """Bare model name shows credential error when provider creds are missing."""
         app = DeepAgentsApp()
@@ -630,7 +615,6 @@ class TestModelSwitchBareModelName:
         assert "Missing credentials" in captured_errors[0]
         assert "OPENAI_API_KEY" in captured_errors[0]
 
-    @pytest.mark.asyncio
     async def test_bare_model_name_already_using(self) -> None:
         """Bare model name matching current model shows 'Already using'."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -205,7 +205,6 @@ class TestBuildNonInteractiveHeader:
 class TestSandboxSetupForwarding:
     """Test that sandbox_setup is forwarded to create_sandbox."""
 
-    @pytest.mark.asyncio
     async def test_sandbox_setup_passed_to_create_sandbox(self) -> None:
         """run_non_interactive should forward sandbox_setup to create_sandbox.
 
@@ -287,7 +286,6 @@ class TestSandboxSetupForwarding:
 class TestQuietMode:
     """Tests for --quiet flag in run_non_interactive."""
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("quiet", "expected_kwargs"),
         [
@@ -348,7 +346,6 @@ class TestQuietMode:
 
         mock_console_cls.assert_called_once_with(**expected_kwargs)
 
-    @pytest.mark.asyncio
     async def test_quiet_stdout_contains_only_agent_text(self) -> None:
         """In quiet mode, stdout should have only agent text."""
         # Build a fake AI message with a text block followed by a tool-call block
@@ -429,7 +426,6 @@ class TestQuietMode:
 class TestNoStreamMode:
     """Tests for --no-stream flag in run_non_interactive."""
 
-    @pytest.mark.asyncio
     async def test_no_stream_buffers_output(self) -> None:
         """In no-stream mode, stdout should receive text only after completion."""
         # Build two text chunks to verify buffering vs streaming
@@ -507,7 +503,6 @@ class TestNoStreamMode:
         assert len(text_writes) == 1
         assert text_writes[0] == "Hello world"
 
-    @pytest.mark.asyncio
     async def test_stream_mode_writes_incrementally(self) -> None:
         """Default stream mode should write text chunks as they arrive."""
         ai_msg1 = MagicMock(spec=AIMessage)
@@ -588,7 +583,6 @@ class TestNoStreamMode:
 class TestFastFollowLangsmithLink:
     """Tests for best-effort fast-follow LangSmith link output."""
 
-    @pytest.mark.asyncio
     async def test_prints_link_when_lookup_ready(self) -> None:
         """Should print LangSmith link before completion when ready."""
         mock_console = MagicMock(spec=Console)
@@ -650,7 +644,6 @@ class TestFastFollowLangsmithLink:
         ]
         assert any("View in LangSmith:" in line for line in printed)
 
-    @pytest.mark.asyncio
     async def test_skips_link_when_lookup_not_ready(self) -> None:
         """Should not wait for or print link when lookup is still in flight."""
         mock_console = MagicMock(spec=Console)
@@ -711,7 +704,6 @@ class TestFastFollowLangsmithLink:
         ]
         assert not any("View in LangSmith:" in line for line in printed)
 
-    @pytest.mark.asyncio
     async def test_skips_link_when_lookup_done_but_url_none(self) -> None:
         """Should not print link when lookup completed but URL is None."""
         mock_console = MagicMock(spec=Console)
@@ -770,7 +762,6 @@ class TestFastFollowLangsmithLink:
         ]
         assert not any("View in LangSmith:" in line for line in printed)
 
-    @pytest.mark.asyncio
     async def test_quiet_mode_skips_thread_url_lookup(self) -> None:
         """Should not start LangSmith URL lookup when quiet=True."""
         with (

--- a/libs/cli/tests/unit_tests/test_sessions.py
+++ b/libs/cli/tests/unit_tests/test_sessions.py
@@ -611,7 +611,6 @@ class TestGetCachedThreads:
 class TestPrewarmThreadMessageCounts:
     """Tests for prewarm_thread_message_counts error handling."""
 
-    @pytest.mark.asyncio
     async def test_unexpected_errors_log_warning(self) -> None:
         """Unexpected prewarm failures should be visible at warning level."""
         with (

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -192,7 +192,6 @@ class _FakeAgent:
 class TestExecuteTaskTextualSummarizationFeedback:
     """Tests for summarization spinner and notification feedback."""
 
-    @pytest.mark.asyncio
     async def test_spinner_transitions_for_summarization_stream(self) -> None:
         """Spinner should move Thinking -> Summarizing -> Thinking."""
         statuses: list[str | None] = []
@@ -232,7 +231,6 @@ class TestExecuteTaskTextualSummarizationFeedback:
         assert "Summarizing" in statuses
         assert statuses[-1] == "Thinking"
 
-    @pytest.mark.asyncio
     async def test_mounts_summarization_notification_on_regular_chunk(self) -> None:
         """Notification should render when regular chunks resume after summarization."""
         statuses: list[str | None] = []
@@ -278,8 +276,6 @@ class TestExecuteTaskTextualSummarizationFeedback:
         assert "Summarizing" in statuses
         assert statuses[-1] == "Thinking"
 
-    @pytest.mark.asyncio
-    @pytest.mark.asyncio
     async def test_mounts_notification_when_stream_ends_mid_summarization(self) -> None:
         """Notification should still render if stream exhausts during summarization."""
         mounted_widgets: list[object] = []

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -113,7 +113,6 @@ class AppWithEscapeBinding(App):
 class TestThreadSelectorEscapeKey:
     """Tests for ESC key dismissing the modal."""
 
-    @pytest.mark.asyncio
     async def test_escape_dismisses_modal(self) -> None:
         """Pressing ESC should dismiss the modal with None result."""
         with _patch_list_threads():
@@ -128,7 +127,6 @@ class TestThreadSelectorEscapeKey:
                 assert app.dismissed is True
                 assert app.result is None
 
-    @pytest.mark.asyncio
     async def test_escape_with_conflicting_app_binding(self) -> None:
         """ESC should dismiss modal even when app has its own escape binding."""
         with _patch_list_threads():
@@ -148,7 +146,6 @@ class TestThreadSelectorEscapeKey:
 class TestThreadSelectorKeyboardNavigation:
     """Tests for keyboard navigation in the modal."""
 
-    @pytest.mark.asyncio
     async def test_down_arrow_moves_selection(self) -> None:
         """Down arrow should move selection down."""
         with _patch_list_threads():
@@ -166,7 +163,6 @@ class TestThreadSelectorKeyboardNavigation:
 
                 assert screen._selected_index == initial_index + 1
 
-    @pytest.mark.asyncio
     async def test_up_arrow_wraps_from_top(self) -> None:
         """Up arrow at index 0 should wrap to last thread."""
         with _patch_list_threads():
@@ -185,7 +181,6 @@ class TestThreadSelectorKeyboardNavigation:
                 expected = (0 - 1) % count
                 assert screen._selected_index == expected
 
-    @pytest.mark.asyncio
     async def test_j_k_navigation(self) -> None:
         """j/k keys should navigate like down/up arrows."""
         with _patch_list_threads():
@@ -205,7 +200,6 @@ class TestThreadSelectorKeyboardNavigation:
                 await pilot.pause()
                 assert screen._selected_index == 0
 
-    @pytest.mark.asyncio
     async def test_enter_selects_thread(self) -> None:
         """Enter should select the current thread and dismiss."""
         with _patch_list_threads():
@@ -224,7 +218,6 @@ class TestThreadSelectorKeyboardNavigation:
 class TestThreadSelectorCurrentThread:
     """Tests for current thread highlighting and preselection."""
 
-    @pytest.mark.asyncio
     async def test_current_thread_is_preselected(self) -> None:
         """Opening the selector should pre-select the current thread."""
         with _patch_list_threads():
@@ -239,7 +232,6 @@ class TestThreadSelectorCurrentThread:
                 # def67890 is at index 1 in MOCK_THREADS
                 assert screen._selected_index == 1
 
-    @pytest.mark.asyncio
     async def test_unknown_current_thread_defaults_to_zero(self) -> None:
         """Unknown current thread should default to index 0."""
         with _patch_list_threads():
@@ -252,7 +244,6 @@ class TestThreadSelectorCurrentThread:
                 assert isinstance(screen, ThreadSelectorScreen)
                 assert screen._selected_index == 0
 
-    @pytest.mark.asyncio
     async def test_no_current_thread_defaults_to_zero(self) -> None:
         """No current thread should default to index 0."""
         with _patch_list_threads():
@@ -269,7 +260,6 @@ class TestThreadSelectorCurrentThread:
 class TestThreadSelectorEmptyState:
     """Tests for empty thread list."""
 
-    @pytest.mark.asyncio
     async def test_no_threads_shows_empty_message(self) -> None:
         """Empty thread list should show a message and escape still works."""
         with _patch_list_threads(threads=[]):
@@ -294,7 +284,6 @@ class TestThreadSelectorEmptyState:
                 assert app.dismissed is True
                 assert app.result is None
 
-    @pytest.mark.asyncio
     async def test_arrow_keys_on_empty_list_do_not_crash(self) -> None:
         """Arrow keys, j/k, and page keys on empty list should be no-ops."""
         with _patch_list_threads(threads=[]):
@@ -322,7 +311,6 @@ class TestThreadSelectorEmptyState:
 class TestThreadSelectorNavigateAndSelect:
     """Tests for navigating then selecting a specific thread."""
 
-    @pytest.mark.asyncio
     async def test_navigate_down_and_select(self) -> None:
         """Navigate to second thread and select it."""
         with _patch_list_threads():
@@ -344,7 +332,6 @@ class TestThreadSelectorNavigateAndSelect:
 class TestThreadSelectorTabNavigation:
     """Tests for tab/shift+tab navigation."""
 
-    @pytest.mark.asyncio
     async def test_tab_moves_down(self) -> None:
         """Tab should move selection down."""
         with _patch_list_threads():
@@ -360,7 +347,6 @@ class TestThreadSelectorTabNavigation:
                 await pilot.pause()
                 assert screen._selected_index == 1
 
-    @pytest.mark.asyncio
     async def test_shift_tab_moves_up(self) -> None:
         """Shift+tab should move selection up."""
         with _patch_list_threads():
@@ -385,7 +371,6 @@ class TestThreadSelectorTabNavigation:
 class TestThreadSelectorDownWrap:
     """Tests for wrapping from bottom to top."""
 
-    @pytest.mark.asyncio
     async def test_down_arrow_wraps_from_bottom(self) -> None:
         """Down arrow at last index should wrap to first thread."""
         with _patch_list_threads():
@@ -413,7 +398,6 @@ class TestThreadSelectorDownWrap:
 class TestThreadSelectorPageNavigation:
     """Tests for pageup/pagedown navigation."""
 
-    @pytest.mark.asyncio
     async def test_pagedown_moves_selection(self) -> None:
         """Pagedown should move selection forward."""
         with _patch_list_threads():
@@ -431,7 +415,6 @@ class TestThreadSelectorPageNavigation:
                 # Should move forward (clamped to last item with 3 threads)
                 assert screen._selected_index == len(MOCK_THREADS) - 1
 
-    @pytest.mark.asyncio
     async def test_pageup_at_top_is_noop(self) -> None:
         """Pageup at index 0 should be a no-op."""
         with _patch_list_threads():
@@ -452,7 +435,6 @@ class TestThreadSelectorPageNavigation:
 class TestThreadSelectorClickHandling:
     """Tests for mouse click handling."""
 
-    @pytest.mark.asyncio
     async def test_click_selects_thread(self) -> None:
         """Clicking a thread option should select and dismiss."""
         with _patch_list_threads():
@@ -641,7 +623,6 @@ class TestThreadSelectorBuildTitle:
         assert len(spans) > 0
         assert "cyan" in str(spans[0].style)
 
-    @pytest.mark.asyncio
     async def test_title_widget_has_id(self) -> None:
         """Title widget should be queryable by ID for URL updates."""
         with _patch_list_threads():
@@ -659,7 +640,6 @@ class TestThreadSelectorBuildTitle:
 class TestFetchThreadUrl:
     """Tests for _fetch_thread_url background worker."""
 
-    @pytest.mark.asyncio
     async def test_successful_url_updates_title(self) -> None:
         """Background worker should update the title with a clickable link."""
         from rich.text import Text
@@ -685,7 +665,6 @@ class TestFetchThreadUrl:
                 assert isinstance(content, Text)
                 assert "abc12345" in content.plain
 
-    @pytest.mark.asyncio
     async def test_timeout_leaves_title_unchanged(self) -> None:
         """Timeout during URL resolution should not crash or change the title."""
         import time
@@ -713,7 +692,6 @@ class TestFetchThreadUrl:
                 title_widget = screen.query_one("#thread-title", Static)
                 assert isinstance(title_widget._Static__content, str)
 
-    @pytest.mark.asyncio
     async def test_oserror_leaves_title_unchanged(self) -> None:
         """OSError during URL resolution should not crash or change the title."""
         with (
@@ -735,7 +713,6 @@ class TestFetchThreadUrl:
                 title_widget = screen.query_one("#thread-title", Static)
                 assert isinstance(title_widget._Static__content, str)
 
-    @pytest.mark.asyncio
     async def test_unexpected_exception_leaves_title_unchanged(self) -> None:
         """Unexpected exception should not crash the thread selector."""
         with (
@@ -757,7 +734,6 @@ class TestFetchThreadUrl:
                 title_widget = screen.query_one("#thread-title", Static)
                 assert isinstance(title_widget._Static__content, str)
 
-    @pytest.mark.asyncio
     async def test_none_url_leaves_title_unchanged(self) -> None:
         """When build returns None the title should remain a plain string."""
         with (
@@ -793,7 +769,6 @@ class TestThreadSelectorColumnHeader:
         assert "Msgs" in header
         assert "Updated" in header
 
-    @pytest.mark.asyncio
     async def test_header_widget_is_mounted(self) -> None:
         """Column header widget should be present in the mounted screen."""
         with _patch_list_threads():
@@ -806,7 +781,6 @@ class TestThreadSelectorColumnHeader:
                 assert isinstance(screen, ThreadSelectorScreen)
                 screen.query_one(".thread-list-header", Static)
 
-    @pytest.mark.asyncio
     async def test_header_stays_outside_scroll(self) -> None:
         """Header should be outside VerticalScroll (anchored, not scrollable)."""
         with _patch_list_threads():
@@ -826,7 +800,6 @@ class TestThreadSelectorColumnHeader:
 class TestThreadSelectorErrorHandling:
     """Tests for error handling when loading threads fails."""
 
-    @pytest.mark.asyncio
     async def test_list_threads_error_still_dismissable(self) -> None:
         """Database error should not crash; Escape still works."""
         with patch(
@@ -857,7 +830,6 @@ class TestThreadSelectorErrorHandling:
 class TestThreadSelectorLimit:
     """Tests for thread limit via get_thread_limit()."""
 
-    @pytest.mark.asyncio
     async def test_custom_limit_is_forwarded(self) -> None:
         """get_thread_limit() return value should be forwarded to list_threads."""
         with (
@@ -874,7 +846,6 @@ class TestThreadSelectorLimit:
 
                 mock_lt.assert_awaited_once_with(limit=5, include_message_count=False)
 
-    @pytest.mark.asyncio
     async def test_message_counts_are_loaded_in_background(self) -> None:
         """Missing counts should be populated asynchronously after list render."""
         threads_without_counts: list[ThreadInfo] = [
@@ -920,7 +891,6 @@ class TestThreadSelectorLimit:
                 assert isinstance(screen, ThreadSelectorScreen)
                 assert screen._threads[0]["message_count"] == 9
 
-    @pytest.mark.asyncio
     async def test_cached_counts_skip_background_population(self) -> None:
         """If cache fills counts before paint, background populate is skipped."""
         threads_without_counts: list[ThreadInfo] = [
@@ -968,7 +938,6 @@ class TestThreadSelectorLimit:
 class TestThreadSelectorMessageCountErrors:
     """Tests for thread selector message-count load error handling."""
 
-    @pytest.mark.asyncio
     async def test_unexpected_message_count_error_logs_warning(self) -> None:
         """Unexpected count-load errors should be visible at warning level."""
         screen = ThreadSelectorScreen(
@@ -999,7 +968,6 @@ class TestThreadSelectorMessageCountErrors:
 class TestThreadSelectorPrefetchedRows:
     """Tests for rendering with prefetched rows from startup cache."""
 
-    @pytest.mark.asyncio
     async def test_prefetched_rows_render_without_loading_state(self) -> None:
         """Prefetched rows should render immediately, then refresh from SQLite."""
         prefetched: list[ThreadInfo] = [
@@ -1070,7 +1038,6 @@ class TestThreadSelectorPrefetchedRows:
                 assert len(screen._threads) == 2
                 assert screen._threads[0]["thread_id"] == "new12345"
 
-    @pytest.mark.asyncio
     async def test_empty_prefetched_snapshot_still_refreshes(self) -> None:
         """An empty cached snapshot should still hydrate from SQLite in background."""
         refreshed: list[ThreadInfo] = [
@@ -1130,7 +1097,6 @@ def _get_widget_text(widget: Static) -> str:
 class TestResumeThread:
     """Tests for DeepAgentsApp._resume_thread."""
 
-    @pytest.mark.asyncio
     async def test_no_agent_shows_error(self) -> None:
         """_resume_thread with no agent should show an error message."""
         app = DeepAgentsApp()
@@ -1143,7 +1109,6 @@ class TestResumeThread:
         assert len(mounted) == 1
         assert "no active agent" in _get_widget_text(mounted[0])
 
-    @pytest.mark.asyncio
     async def test_no_session_state_shows_error(self) -> None:
         """_resume_thread with no session state should show an error message."""
         app = DeepAgentsApp()
@@ -1157,7 +1122,6 @@ class TestResumeThread:
         assert len(mounted) == 1
         assert "no active session" in _get_widget_text(mounted[0])
 
-    @pytest.mark.asyncio
     async def test_already_switching_shows_message(self) -> None:
         """_resume_thread should reject concurrent thread switches."""
         app = DeepAgentsApp()
@@ -1173,7 +1137,6 @@ class TestResumeThread:
         assert len(mounted) == 1
         assert "already in progress" in _get_widget_text(mounted[0])
 
-    @pytest.mark.asyncio
     async def test_already_on_thread_shows_message(self) -> None:
         """_resume_thread when already on the thread should show info message."""
         app = DeepAgentsApp()
@@ -1188,7 +1151,6 @@ class TestResumeThread:
         assert len(mounted) == 1
         assert "Already on thread" in _get_widget_text(mounted[0])
 
-    @pytest.mark.asyncio
     async def test_successful_switch_updates_ids(self) -> None:
         """Successful _resume_thread should update thread IDs and load history."""
         from textual.css.query import NoMatches as _NoMatches
@@ -1221,7 +1183,6 @@ class TestResumeThread:
             preloaded_data=[],
         )
 
-    @pytest.mark.asyncio
     async def test_failure_restores_previous_thread_ids(self) -> None:
         """If _clear_messages raises, thread IDs should be restored."""
         from textual.css.query import NoMatches as _NoMatches
@@ -1250,7 +1211,6 @@ class TestResumeThread:
         )
         app._update_status.assert_any_call("")  # type: ignore[union-attr]
 
-    @pytest.mark.asyncio
     async def test_failure_during_load_history_restores_ids(self) -> None:
         """If _load_thread_history raises, thread IDs should be rolled back."""
         from textual.css.query import NoMatches as _NoMatches
@@ -1281,7 +1241,6 @@ class TestResumeThread:
             for call in app._mount_message.call_args_list  # type: ignore[union-attr]
         )
 
-    @pytest.mark.asyncio
     async def test_prefetch_failure_keeps_current_thread_visible(self) -> None:
         """Failed prefetch should not clear current conversation state."""
         app = DeepAgentsApp(thread_id="old-thread")
@@ -1307,7 +1266,6 @@ class TestResumeThread:
             for call in mount_message_mock.call_args_list
         )
 
-    @pytest.mark.asyncio
     async def test_prefetch_failure_clears_switch_lock_and_restores_input(self) -> None:
         """Prefetch failures should release switch lock and restore input state."""
         app = DeepAgentsApp(thread_id="old-thread")
@@ -1329,7 +1287,6 @@ class TestResumeThread:
         app._chat_input.set_cursor_active.assert_any_call(active=False)
         app._chat_input.set_cursor_active.assert_any_call(active=True)
 
-    @pytest.mark.asyncio
     async def test_double_failure_surfaces_restore_failure_hint(self) -> None:
         """If rollback restore fails, user-facing error should mention it."""
         from textual.css.query import NoMatches as _NoMatches
@@ -1363,7 +1320,6 @@ class TestResumeThread:
 class TestFetchThreadHistoryData:
     """Tests for DeepAgentsApp._fetch_thread_history_data."""
 
-    @pytest.mark.asyncio
     async def test_returns_empty_when_agent_missing(self) -> None:
         """No active agent should return an empty history payload."""
         app = DeepAgentsApp()
@@ -1373,7 +1329,6 @@ class TestFetchThreadHistoryData:
 
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_returns_empty_when_state_missing(self) -> None:
         """Missing checkpoint state should return an empty history payload."""
         app = DeepAgentsApp()
@@ -1387,7 +1342,6 @@ class TestFetchThreadHistoryData:
             {"configurable": {"thread_id": "tid-1"}}
         )
 
-    @pytest.mark.asyncio
     async def test_returns_empty_when_messages_missing(self) -> None:
         """State with no messages should return an empty history payload."""
         app = DeepAgentsApp()
@@ -1400,7 +1354,6 @@ class TestFetchThreadHistoryData:
 
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_offloads_conversion_to_thread(self) -> None:
         """Message conversion should be offloaded via `asyncio.to_thread`."""
         from deepagents_cli.widgets.message_store import MessageData, MessageType
@@ -1430,7 +1383,6 @@ class TestFetchThreadHistoryData:
 class TestLoadThreadHistory:
     """Tests for DeepAgentsApp._load_thread_history."""
 
-    @pytest.mark.asyncio
     async def test_preloaded_history_skips_fetch_and_schedules_link(self) -> None:
         """Preloaded history should render without state fetch round-trip."""
         from deepagents_cli.widgets.message_store import MessageData, MessageType
@@ -1458,7 +1410,6 @@ class TestLoadThreadHistory:
         mount_message_mock.assert_awaited_once()
         schedule_link_mock.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_fallback_fetch_path_used_without_preloaded_data(self) -> None:
         """History should be fetched when preloaded data is not provided."""
         from deepagents_cli.widgets.message_store import MessageData, MessageType
@@ -1486,7 +1437,6 @@ class TestLoadThreadHistory:
         mount_message_mock.assert_awaited_once()
         schedule_link_mock.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_assistant_render_failure_does_not_abort_history_load(self) -> None:
         """A single assistant render failure should not abort history loading."""
         from deepagents_cli.widgets.message_store import MessageData, MessageType
@@ -1527,7 +1477,6 @@ class TestLoadThreadHistory:
         mount_message_mock.assert_awaited_once()
         schedule_link_mock.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_early_return_without_thread_id_logs_debug(self) -> None:
         """Missing thread ID should early-return with a debug log entry."""
         app = DeepAgentsApp()
@@ -1541,7 +1490,6 @@ class TestLoadThreadHistory:
             "Skipping history load: no thread ID available"
         )
 
-    @pytest.mark.asyncio
     async def test_early_return_without_agent_logs_debug(self) -> None:
         """No agent and no preloaded payload should early-return with debug log."""
         app = DeepAgentsApp(thread_id="tid-1")
@@ -1559,7 +1507,6 @@ class TestLoadThreadHistory:
 class TestUpgradeThreadMessageLink:
     """Tests for DeepAgentsApp._upgrade_thread_message_link."""
 
-    @pytest.mark.asyncio
     async def test_noop_when_link_does_not_resolve(self) -> None:
         """Plain-string result should leave widget content unchanged."""
         app = DeepAgentsApp()
@@ -1577,7 +1524,6 @@ class TestUpgradeThreadMessageLink:
         widget.update.assert_not_called()
         assert widget._content == "Resumed thread: tid-1"
 
-    @pytest.mark.asyncio
     async def test_noop_when_widget_unmounted(self) -> None:
         """Unmounted widget should not be updated even when link resolves."""
         from rich.text import Text
@@ -1598,7 +1544,6 @@ class TestUpgradeThreadMessageLink:
 
         widget.update.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_updates_widget_when_link_resolves(self) -> None:
         """Resolved Rich text should replace widget content."""
         from rich.text import Text
@@ -1623,7 +1568,6 @@ class TestUpgradeThreadMessageLink:
 class TestBuildThreadMessage:
     """Tests for DeepAgentsApp._build_thread_message."""
 
-    @pytest.mark.asyncio
     async def test_plain_text_when_tracing_not_configured(self) -> None:
         """Returns plain string when LangSmith URL is not available."""
         app = DeepAgentsApp()
@@ -1633,7 +1577,6 @@ class TestBuildThreadMessage:
         assert result == "Resumed thread: tid-123"
         assert isinstance(result, str)
 
-    @pytest.mark.asyncio
     async def test_hyperlinked_when_tracing_configured(self) -> None:
         """Returns Rich Text with hyperlink when LangSmith URL is available."""
         from rich.text import Text
@@ -1651,7 +1594,6 @@ class TestBuildThreadMessage:
         assert len(spans) == 1
         assert url in str(spans[0].style)
 
-    @pytest.mark.asyncio
     async def test_fallback_on_timeout(self) -> None:
         """Returns plain string when URL resolution times out."""
         app = DeepAgentsApp()
@@ -1664,7 +1606,6 @@ class TestBuildThreadMessage:
         assert isinstance(result, str)
         assert result == "Resumed thread: t-1"
 
-    @pytest.mark.asyncio
     async def test_fallback_on_exception(self) -> None:
         """Returns plain string when URL resolution raises an exception."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -47,7 +47,6 @@ def test_cli_version_flag() -> None:
     assert f"deepagents (SDK) {sdk_version}" in result.stdout
 
 
-@pytest.mark.asyncio
 async def test_version_slash_command_message_format() -> None:
     """Verify the `/version` slash command outputs both CLI and SDK versions."""
     from deepagents_cli.app import DeepAgentsApp
@@ -67,7 +66,6 @@ async def test_version_slash_command_message_format() -> None:
         assert f"deepagents (SDK) version: {sdk_version}" in content
 
 
-@pytest.mark.asyncio
 async def test_version_slash_command_sdk_unavailable() -> None:
     """Verify `/version` shows 'unknown' when SDK package metadata is missing."""
     from importlib.metadata import PackageNotFoundError
@@ -93,7 +91,6 @@ async def test_version_slash_command_sdk_unavailable() -> None:
         assert "deepagents (SDK) version: unknown" in content
 
 
-@pytest.mark.asyncio
 async def test_version_slash_command_cli_version_unavailable() -> None:
     """Verify `/version` shows 'unknown' when CLI _version module is missing."""
     from deepagents_cli.app import DeepAgentsApp

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -74,47 +74,38 @@ class TestSandboxBackendProtocolRaisesNotImplemented:
 class TestAsyncMethodsPropagateNotImplemented:
     """Async wrappers delegate to sync methods, so NotImplementedError propagates."""
 
-    @pytest.mark.asyncio
     async def test_als_info(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.als_info("/")
 
-    @pytest.mark.asyncio
     async def test_aread(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.aread("/file.txt")
 
-    @pytest.mark.asyncio
     async def test_agrep_raw(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.agrep_raw("pattern")
 
-    @pytest.mark.asyncio
     async def test_aglob_info(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.aglob_info("*.py")
 
-    @pytest.mark.asyncio
     async def test_awrite(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.awrite("/file.txt", "content")
 
-    @pytest.mark.asyncio
     async def test_aedit(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.aedit("/file.txt", "old", "new")
 
-    @pytest.mark.asyncio
     async def test_aupload_files(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.aupload_files([("/file.txt", b"data")])
 
-    @pytest.mark.asyncio
     async def test_adownload_files(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.adownload_files(["/file.txt"])
 
-    @pytest.mark.asyncio
     async def test_aexecute(self, sandbox_backend: BareSandboxBackend) -> None:
         with pytest.raises(NotImplementedError):
             await sandbox_backend.aexecute("ls")

--- a/libs/deepagents/tests/unit_tests/backends/test_timeout_compat.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_timeout_compat.py
@@ -103,7 +103,6 @@ class TestExecuteAcceptsTimeout:
 
 
 class TestAexecuteTimeoutGuard:
-    @pytest.mark.asyncio
     async def test_modern_backend_forwards_timeout(self) -> None:
         class RecordingBackend(SandboxBackendProtocol):
             received_timeout: int | None = None
@@ -121,7 +120,6 @@ class TestAexecuteTimeoutGuard:
         await backend.aexecute("ls", timeout=42)
         assert backend.received_timeout == 42
 
-    @pytest.mark.asyncio
     async def test_legacy_backend_drops_timeout_silently(self) -> None:
         """Timeout is silently dropped for legacy backends (middleware handles user-facing errors)."""
         execute_accepts_timeout.cache_clear()
@@ -129,7 +127,6 @@ class TestAexecuteTimeoutGuard:
         result = await backend.aexecute("ls", timeout=30)
         assert result.output == "ls"
 
-    @pytest.mark.asyncio
     async def test_no_timeout_skips_check(self) -> None:
         execute_accepts_timeout.cache_clear()
         backend = ModernBackend()
@@ -170,7 +167,6 @@ class TestCompositeTimeoutGuard:
         result = comp.execute("ls", timeout=60)
         assert result.output == "ls"
 
-    @pytest.mark.asyncio
     async def test_aexecute_forwards_timeout_to_modern(self) -> None:
         class RecordingModern(SandboxBackendProtocol):
             received_timeout: int | None = None
@@ -188,7 +184,6 @@ class TestCompositeTimeoutGuard:
         await comp.aexecute("ls", timeout=60)
         assert inner.received_timeout == 60
 
-    @pytest.mark.asyncio
     async def test_aexecute_omits_timeout_for_legacy(self) -> None:
         inner = LegacyBackend()
         comp = CompositeBackend(default=inner, routes={})

--- a/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
-import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.types import Command
 
@@ -167,7 +166,6 @@ class TestNotEnoughMessages:
         assert len(update_messages) == 1
         assert "Nothing to compact yet" in update_messages[0].content
 
-    @pytest.mark.asyncio
     async def test_not_enough_messages_async(self) -> None:
         """Async: return Command with a 'nothing to compact' ToolMessage when cutoff is 0."""
         mw = _make_middleware()
@@ -250,7 +248,6 @@ class TestCompactSuccess:
         # old_cutoff(5) + new_cutoff(3) - 1 = 7
         assert event["cutoff_index"] == 7
 
-    @pytest.mark.asyncio
     async def test_compact_success_async(self) -> None:
         """Async path should produce the same Command structure."""
         mw = _make_middleware()
@@ -376,7 +373,6 @@ class TestCompactErrorHandling:
         # Should NOT have a _summarization_event (state not modified)
         assert "_summarization_event" not in result.update
 
-    @pytest.mark.asyncio
     async def test_async_summary_failure_returns_error_tool_message(self) -> None:
         """Async: LLM failure should return an error ToolMessage, not raise."""
         mw = _make_middleware()
@@ -617,7 +613,6 @@ class TestIsEligibleForCompaction:
             result = mw._run_compact(runtime)
         assert "Nothing to compact" in result.update["messages"][0].content
 
-    @pytest.mark.asyncio
     async def test_under_50pct_async(self) -> None:
         """Async path: under 50% → nothing to compact."""
         mw = _make_middleware_with_trigger(("tokens", 100_000))

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -664,7 +664,6 @@ class TestDeepAgentEndToEnd:
             assert "AttributeError" not in glob_result
             assert "'list' object has no attribute 'items'" not in glob_result
 
-    @pytest.mark.asyncio
     async def test_deep_agent_two_turns_no_initial_files_async(self) -> None:
         """Async version: Test deepagent with two conversation turns without specifying files.
 
@@ -741,7 +740,6 @@ class TestDeepAgentEndToEnd:
         # Should either find files or return "No files found", not crash
         assert "AttributeError" not in glob_result
 
-    @pytest.mark.asyncio
     async def test_deep_agent_two_turns_state_backend_edge_case_async(self) -> None:
         """Async version: Test StateBackend with two turns to reproduce potential state corruption.
 
@@ -991,7 +989,6 @@ class TestDeepAgentEndToEnd:
         assert "Output was truncated due to size limits" in file_content
         assert "reformatting" in file_content.lower() or "reformat" in file_content.lower()
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("backend_factory", BACKEND_FACTORIES)
     async def test_deep_agent_read_file_truncation_async(self, tmp_path: Path, backend_factory: Callable[[Path], BackendProtocol]) -> None:
         """Test that read_file truncates large files in async mode."""

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -3,7 +3,6 @@
 import asyncio
 from unittest.mock import patch
 
-import pytest
 from langchain.tools import ToolRuntime
 from langgraph.store.memory import InMemoryStore
 from langgraph.types import Command
@@ -28,7 +27,6 @@ def build_composite_state_backend(runtime: ToolRuntime, *, routes):
 class TestFilesystemMiddlewareAsync:
     """Async tests for filesystem middleware tools."""
 
-    @pytest.mark.asyncio
     async def test_als_shortterm(self):
         """Test async ls tool with state backend."""
         state = FilesystemState(
@@ -53,7 +51,6 @@ class TestFilesystemMiddlewareAsync:
         )
         assert result == str(["/test.txt", "/test2.txt"])
 
-    @pytest.mark.asyncio
     async def test_als_shortterm_with_path(self):
         """Test async ls tool with specific path."""
         state = FilesystemState(
@@ -95,7 +92,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/pokemon/water/squirtle.txt" not in result  # In subdirectory
         assert "/pokemon/water/" in result
 
-    @pytest.mark.asyncio
     async def test_als_shortterm_lists_directories(self):
         """Test async ls lists directories with trailing /."""
         state = FilesystemState(
@@ -139,7 +135,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/pokemon/charmander.txt" not in result
         assert "/pokemon/water/squirtle.txt" not in result
 
-    @pytest.mark.asyncio
     async def test_aglob_search_shortterm_simple_pattern(self):
         """Test async glob with simple pattern."""
         state = FilesystemState(
@@ -178,7 +173,6 @@ class TestFilesystemMiddlewareAsync:
         # Standard glob: *.py only matches files in root directory, not subdirectories
         assert result == str(["/test.py"])
 
-    @pytest.mark.asyncio
     async def test_aglob_search_shortterm_wildcard_pattern(self):
         """Test async glob with wildcard pattern."""
         state = FilesystemState(
@@ -213,7 +207,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/src/utils/helper.py" in result
         assert "/tests/test_main.py" in result
 
-    @pytest.mark.asyncio
     async def test_aglob_search_shortterm_with_path(self):
         """Test async glob with specific path."""
         state = FilesystemState(
@@ -249,7 +242,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/src/utils/helper.py" not in result
         assert "/tests/test_main.py" not in result
 
-    @pytest.mark.asyncio
     async def test_aglob_search_shortterm_brace_expansion(self):
         """Test async glob with brace expansion."""
         state = FilesystemState(
@@ -284,7 +276,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/test.pyi" in result
         assert "/test.txt" not in result
 
-    @pytest.mark.asyncio
     async def test_aglob_search_shortterm_no_matches(self):
         """Test async glob with no matches."""
         state = FilesystemState(
@@ -332,7 +323,6 @@ class TestFilesystemMiddlewareAsync:
 
         assert result == "Error: glob timed out after 0.5s. Try a more specific pattern or a narrower path."
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_files_with_matches(self):
         """Test async grep with files_with_matches mode."""
         state = FilesystemState(
@@ -367,7 +357,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/helper.txt" in result
         assert "/main.py" not in result
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_content_mode(self):
         """Test async grep with content mode."""
         state = FilesystemState(
@@ -393,7 +382,6 @@ class TestFilesystemMiddlewareAsync:
         assert "2: import sys" in result
         assert "print" not in result
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_count_mode(self):
         """Test async grep with count mode."""
         state = FilesystemState(
@@ -423,7 +411,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/test.py:2" in result or "/test.py: 2" in result
         assert "/main.py:1" in result or "/main.py: 1" in result
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_with_include(self):
         """Test async grep with glob filter."""
         state = FilesystemState(
@@ -453,7 +440,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/test.py" in result
         assert "/test.txt" not in result
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_with_path(self):
         """Test async grep with specific path."""
         state = FilesystemState(
@@ -483,7 +469,6 @@ class TestFilesystemMiddlewareAsync:
         assert "/src/main.py" in result
         assert "/tests/test.py" not in result
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_regex_pattern(self):
         """Test async grep with literal pattern (not regex)."""
         state = FilesystemState(
@@ -510,7 +495,6 @@ class TestFilesystemMiddlewareAsync:
         assert "2: def world():" in result
         assert "x = 5" not in result
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_no_matches(self):
         """Test async grep with no matches."""
         state = FilesystemState(
@@ -533,7 +517,6 @@ class TestFilesystemMiddlewareAsync:
         )
         assert result == "No matches found"
 
-    @pytest.mark.asyncio
     async def test_agrep_search_shortterm_invalid_regex(self):
         """Test async grep with special characters (literal search, not regex)."""
         state = FilesystemState(
@@ -557,7 +540,6 @@ class TestFilesystemMiddlewareAsync:
         )
         assert "No matches found" in result
 
-    @pytest.mark.asyncio
     async def test_aread_file(self):
         """Test async read_file tool."""
         state = FilesystemState(
@@ -582,7 +564,6 @@ class TestFilesystemMiddlewareAsync:
         assert "Line 2" in result
         assert "Line 3" in result
 
-    @pytest.mark.asyncio
     async def test_aread_file_with_offset(self):
         """Test async read_file tool with offset."""
         state = FilesystemState(
@@ -610,7 +591,6 @@ class TestFilesystemMiddlewareAsync:
         assert "Line 1" not in result
         assert "Line 4" not in result
 
-    @pytest.mark.asyncio
     async def test_awrite_file(self):
         """Test async write_file tool."""
         state = FilesystemState(messages=[], files={})
@@ -627,7 +607,6 @@ class TestFilesystemMiddlewareAsync:
         assert isinstance(result, Command)
         assert "/test.txt" in result.update["files"]
 
-    @pytest.mark.asyncio
     async def test_aedit_file(self):
         """Test async edit_file tool."""
         state = FilesystemState(
@@ -654,7 +633,6 @@ class TestFilesystemMiddlewareAsync:
         assert isinstance(result, Command)
         assert "/test.txt" in result.update["files"]
 
-    @pytest.mark.asyncio
     async def test_aedit_file_replace_all(self):
         """Test async edit_file tool with replace_all."""
         state = FilesystemState(
@@ -681,7 +659,6 @@ class TestFilesystemMiddlewareAsync:
         assert isinstance(result, Command)
         assert "/test.txt" in result.update["files"]
 
-    @pytest.mark.asyncio
     async def test_aexecute_tool_returns_error_when_backend_doesnt_support(self):
         """Test async execute tool returns friendly error instead of raising exception."""
         state = FilesystemState(messages=[], files={})
@@ -707,7 +684,6 @@ class TestFilesystemMiddlewareAsync:
         assert "Error: Execution not available" in result
         assert "does not support command execution" in result
 
-    @pytest.mark.asyncio
     async def test_aexecute_tool_forwards_zero_timeout_to_backend(self):
         """Async execute tool should forward timeout=0 for no-timeout backends."""
         captured_timeout = {}
@@ -748,7 +724,6 @@ class TestFilesystemMiddlewareAsync:
         assert "async ok" in result
         assert captured_timeout["value"] == 0
 
-    @pytest.mark.asyncio
     async def test_aexecute_tool_output_formatting(self):
         """Test async execute tool formats output correctly."""
 
@@ -792,7 +767,6 @@ class TestFilesystemMiddlewareAsync:
         assert "succeeded" in result
         assert "exit code 0" in result
 
-    @pytest.mark.asyncio
     async def test_aexecute_tool_output_formatting_with_failure(self):
         """Test async execute tool formats failure output correctly."""
 
@@ -836,7 +810,6 @@ class TestFilesystemMiddlewareAsync:
         assert "failed" in result
         assert "exit code 127" in result
 
-    @pytest.mark.asyncio
     async def test_aexecute_tool_output_formatting_with_truncation(self):
         """Test async execute tool formats truncated output correctly."""
 


### PR DESCRIPTION
Every package in the monorepo sets `asyncio_mode = "auto"` in `pyproject.toml`, making `@pytest.mark.asyncio` decorators redundant on async test functions — pytest-asyncio discovers them automatically.