### PR TITLE
fix(cli): disambiguate `/tokens` vs `/compact` token reporting

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1277,11 +1277,19 @@ class DeepAgentsApp(App):
                 if context_limit is not None:
                     limit_str = _format_token_count(context_limit)
                     pct = count / context_limit * 100
-                    usage = f"{formatted} / {limit_str} tokens ({pct:.0f}%)"
+                    usage = (
+                        f"{formatted} / {limit_str} tokens "
+                        f"({pct:.0f}%, includes system prompt + tools)"
+                    )
                 else:
-                    usage = f"{formatted} tokens used"
+                    usage = f"{formatted} tokens used (includes system prompt + tools)"
 
                 msg = f"{usage} · {model_name}" if model_name else usage
+
+                # Append conversation-only token count when available
+                conv_line = await self._get_conversation_token_line()
+                if conv_line:
+                    msg = f"{msg}\n{conv_line}"
 
                 await self._mount_message(AppMessage(msg))
             else:
@@ -1360,6 +1368,34 @@ class DeepAgentsApp(App):
                 pass
 
         self.call_after_refresh(_scroll_after_command)
+
+    async def _get_conversation_token_line(self) -> str | None:
+        """Return a short string with the conversation-only token count.
+
+        Returns:
+            Formatted line like `"Conversation only: ~18 tokens"`, or
+            `None` if state is unavailable.
+        """
+        if not self._agent:
+            return None
+        try:
+            from langchain_core.messages.utils import (
+                count_tokens_approximately,
+            )
+
+            config: RunnableConfig = {
+                "configurable": {"thread_id": self._lc_thread_id},
+            }
+            state = await self._agent.aget_state(config)
+            if not state or not state.values:
+                return None
+            messages = state.values.get("messages", [])
+            if not messages:
+                return None
+            conv_tokens = count_tokens_approximately(messages)
+            return f"Conversation only: ~{_format_token_count(conv_tokens)} tokens"
+        except Exception:  # noqa: BLE001
+            return None
 
     async def _handle_compact(self) -> None:
         """Compact the conversation by summarizing old messages.
@@ -1470,13 +1506,41 @@ class DeepAgentsApp(App):
             )
 
             if cutoff == 0:
-                await self._mount_message(
-                    AppMessage(
-                        "Nothing to compact yet \u2014 conversation is within "
-                        "the token budget.\n"
-                        f"Configured retention budget: {compact_limit}"
-                    )
+                conv_tokens = count_tokens_approximately(effective)
+                conv_str = _format_token_count(conv_tokens)
+                total_context = (
+                    self._token_tracker.current_context if self._token_tracker else 0
                 )
+                context_limit = settings.model_context_limit
+
+                if (
+                    total_context > 0
+                    and context_limit is not None
+                    and total_context > context_limit
+                ):
+                    # Case A: overhead-dominated — total context exceeds
+                    # limit but conversation itself is small
+                    total_str = _format_token_count(total_context)
+                    await self._mount_message(
+                        AppMessage(
+                            f"Nothing to compact \u2014 conversation is only "
+                            f"~{conv_str} tokens.\n"
+                            f"Total context ({total_str}) is mostly system "
+                            f"prompt and tool overhead, which compaction "
+                            f"cannot reduce.\n"
+                            f"Retention budget: {compact_limit}"
+                        )
+                    )
+                else:
+                    # Case B: genuinely within budget
+                    await self._mount_message(
+                        AppMessage(
+                            "Nothing to compact yet \u2014 conversation is "
+                            "within the retention budget.\n"
+                            f"Conversation: ~{conv_str} tokens \u00b7 "
+                            f"Retention budget: {compact_limit}"
+                        )
+                    )
                 return
 
             to_summarize, to_keep = middleware._partition_messages(effective, cutoff)

--- a/libs/cli/tests/unit_tests/test_compact.py
+++ b/libs/cli/tests/unit_tests/test_compact.py
@@ -156,7 +156,7 @@ class TestCompactGuards:
             )
 
     async def test_cutoff_zero_shows_not_enough(self) -> None:
-        """Should show error when middleware cutoff is zero."""
+        """Should show info when middleware cutoff is zero (within budget)."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -165,12 +165,13 @@ class TestCompactGuards:
             with (
                 _mock_middleware(cutoff=0),
                 patch.object(settings, "model_context_limit", 200_000),
+                patch(_TOKEN_COUNT_PATH, return_value=45),
             ):
                 await app._handle_compact()
                 await pilot.pause()
 
             msgs = app.query(AppMessage)
-            assert any("within the token budget" in str(w._content) for w in msgs)
+            assert any("within the retention budget" in str(w._content) for w in msgs)
 
     async def test_empty_state_shows_error(self) -> None:
         """Should show error when state has no values."""
@@ -389,13 +390,38 @@ class TestCompactEdgeCases:
             with (
                 _mock_middleware(cutoff=0),
                 patch.object(settings, "model_context_limit", 200_000),
+                patch(_TOKEN_COUNT_PATH, return_value=45),
             ):
                 await app._handle_compact()
                 await pilot.pause()
 
             msgs = app.query(AppMessage)
-            assert any("within the token budget" in str(w._content) for w in msgs)
+            assert any("within the retention budget" in str(w._content) for w in msgs)
             app._agent.aupdate_state.assert_not_called()  # type: ignore[union-attr]
+
+    async def test_cutoff_zero_overhead_dominated(self) -> None:
+        """Show overhead message when context exceeds limit."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            _setup_compact_app(app, n_messages=3)
+
+            # Simulate total context (system prompt + tools) far exceeding
+            # the model limit while conversation tokens are tiny
+            tracker = MagicMock()
+            tracker.current_context = 14_000
+            app._token_tracker = tracker
+
+            with (
+                _mock_middleware(cutoff=0),
+                patch.object(settings, "model_context_limit", 4_096),
+                patch(_TOKEN_COUNT_PATH, return_value=45),
+            ):
+                await app._handle_compact()
+                await pilot.pause()
+
+            msgs = app.query(AppMessage)
+            assert any("compaction cannot reduce" in str(w._content) for w in msgs)
 
     async def test_cutoff_one_compacts_single_message(self) -> None:
         """With cutoff=1, event should have cutoff_index=1."""


### PR DESCRIPTION
`/tokens` and `/compact` both report token counts, but `/tokens` shows total model context (system prompt + tools + conversation) while `/compact` only looks at conversation messages. Both commands now explain what they measure and surface the conversation-only count so the discrepancy is immediately obvious.