### PR TITLE
fix(cli): add missing flags to help screen

### DIFF
--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -81,6 +81,10 @@ def show_help() -> None:
     )
     console.print("  -a, --agent NAME           Agent to use (e.g., coder, researcher)")
     console.print("  -M, --model MODEL          Model to use (e.g., gpt-4o)")
+    console.print(
+        "  --model-params JSON        Extra model kwargs (e.g., '{\"temperature\": 0.7}')"  # noqa: E501
+    )
+    console.print("  --profile-override JSON    Override model profile fields as JSON")
     console.print("  -m, --message TEXT         Initial prompt to auto-submit on start")
     console.print(
         "  --auto-approve             Auto-approve all tool calls (toggle: Shift+Tab)"
@@ -93,6 +97,10 @@ def show_help() -> None:
         "  --sandbox-setup PATH       Setup script to run in sandbox after creation"
     )
     console.print("  -n, --non-interactive MSG  Run a single task and exit")
+    console.print("  -q, --quiet                Clean output for piping (needs -n)")
+    console.print(
+        "  --no-stream                Buffer full response instead of streaming"
+    )
     console.print(
         "  --shell-allow-list CMDS    Comma-separated local shell commands to allow"
     )


### PR DESCRIPTION
Four CLI flags (`--model-params`, `--profile-override`, `-q/--quiet`, `--no-stream`) were registered in argparse but never added to the hand-written Rich help screen in `show_help()`. Running `deepagents --help` omitted them entirely, making them undiscoverable.

## Changes
- Add `--model-params` and `--profile-override` entries to the Options block in `show_help()`, positioned after `--model` where they logically belong
- Add `-q, --quiet` and `--no-stream` entries after `-n, --non-interactive`, matching the non-interactive grouping they belong to