### PR TITLE
test(cli): add help screen drift-detection test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,10 @@ The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents
 - Defer heavy imports to the point where they are actually needed (inside functions/methods).
 - To read another package's version without importing it, use `importlib.metadata.version("package-name")`.
 
+**CLI help screen:**
+
+The `deepagents --help` screen is hand-maintained in `ui.show_help()`, separate from the argparse definitions in `main.parse_args()`. When adding a new CLI flag, update **both** files. A drift-detection test (`test_args.TestHelpScreenDrift`) fails if a flag is registered in argparse but missing from the help screen.
+
 **Building chat/streaming interfaces:**
 
 - Blog post: [Anatomy of a Textual User Interface](https://textual.textualize.io/blog/2024/09/15/anatomy-of-a-textual-user-interface/) - demonstrates building an AI chat interface with streaming responses

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -1,6 +1,7 @@
 """Tests for CLI argument parsing."""
 
 import io
+import re
 import sys
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ from rich.console import Console
 
 from deepagents_cli.agent import DEFAULT_AGENT_NAME
 from deepagents_cli.main import _DEFAULT_AGENT_NAME, parse_args
+from deepagents_cli.ui import show_help
 
 
 class TestInitialPromptArg:
@@ -267,3 +269,44 @@ class TestQuietArg:
 def test_default_agent_name_matches_canonical() -> None:
     """Ensure the duplicated constant in main.py stays in sync with agent.py."""
     assert _DEFAULT_AGENT_NAME == DEFAULT_AGENT_NAME
+
+
+class TestHelpScreenDrift:
+    """Ensure show_help() stays in sync with argparse flag definitions.
+
+    The help screen in `ui.show_help()` is hand-maintained separately from
+    the argparse definitions in `main.parse_args()`.  This test catches
+    drift — e.g. a new flag added to argparse but forgotten in the help screen.
+    """
+
+    def test_all_parser_flags_appear_in_help(self) -> None:
+        """Every top-level --flag in argparse must appear in show_help()."""
+        # 1. Trigger argparse usage line by passing an unrecognized flag.
+        #    argparse prints the full usage (all flags) to stderr, then exits.
+        stderr_buf = io.StringIO()
+        with (
+            patch.object(sys, "argv", ["deepagents", "--_x_"]),
+            patch("sys.stderr", stderr_buf),
+            pytest.raises(SystemExit),
+        ):
+            parse_args()
+        usage_text = stderr_buf.getvalue()
+
+        # 2. Render show_help() to a string.
+        help_buf = io.StringIO()
+        test_console = Console(file=help_buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            show_help()
+        help_text = help_buf.getvalue()
+
+        # 3. Extract --long-form flags from both and compare.
+        parser_flags = set(re.findall(r"--[\w][\w-]*", usage_text))
+        help_flags = set(re.findall(r"--[\w][\w-]*", help_text))
+
+        parser_flags.discard("--_x_")  # remove the fake trigger flag
+
+        missing = parser_flags - help_flags
+        assert not missing, (
+            f"Flags in argparse but missing from show_help(): {missing}\n"
+            "Add them to the Options section in ui.show_help()."
+        )


### PR DESCRIPTION
Add a drift-detection test in `TestHelpScreenDrift` that cross-references the argparse parser against `show_help()` output, so future flag additions that forget the help screen fail CI instead of shipping silently. Document the dual-maintenance requirement in `AGENTS.md`.