### PR TITLE
chore(sdk): expand eval matrix and fix model name access for groq

### DIFF
--- a/.github/scripts/aggregate_evals.py
+++ b/.github/scripts/aggregate_evals.py
@@ -17,7 +17,7 @@ def main() -> None:
         payload = json.loads(Path(file).read_text(encoding="utf-8"))
         rows.append(payload)
 
-    rows.sort(key=lambda r: str(r.get("model", "")))
+    rows.sort(key=lambda r: (str(r.get("model", "")).split(":")[0], -float(r.get("accuracy", 0.0))))
 
     headers = [
         "model",

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -12,6 +12,7 @@
 #   MISTRAL_API_KEY    — needed for Mistral models
 #   DEEPSEEK_API_KEY   — needed for DeepSeek models
 #   GROQ_API_KEY       — needed for Groq-hosted models
+#   OLLAMA_API_KEY     — needed for Ollama Cloud models
 
 name: "📊 Evals"
 
@@ -70,6 +71,13 @@ jobs:
           - "groq:openai/gpt-oss-120b"
           - "groq:qwen/qwen3-32b"
           - "groq:moonshotai/kimi-k2-instruct"
+          # Ollama Cloud
+          - "ollama-cloud:glm-5"
+          - "ollama-cloud:minimax-m2.5"
+          - "ollama-cloud:nemotron-3-nano:30b"
+          - "ollama-cloud:cogito-2.1:671b"
+          - "ollama-cloud:devstral-2:123b"
+          - "ollama-cloud:ministral-3:14b"
     defaults:
       run:
         working-directory: libs/deepagents
@@ -84,6 +92,7 @@ jobs:
       MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -13,6 +13,7 @@
 #   DEEPSEEK_API_KEY   — needed for DeepSeek models
 #   GROQ_API_KEY       — needed for Groq-hosted models
 #   OLLAMA_API_KEY     — needed for Ollama Cloud models
+#   OLLAMA_HOST        — set to https://ollama.com for cloud inference
 
 name: "📊 Evals"
 
@@ -72,12 +73,12 @@ jobs:
           - "groq:qwen/qwen3-32b"
           - "groq:moonshotai/kimi-k2-instruct"
           # Ollama Cloud
-          - "ollama-cloud:glm-5"
-          - "ollama-cloud:minimax-m2.5"
-          - "ollama-cloud:nemotron-3-nano:30b"
-          - "ollama-cloud:cogito-2.1:671b"
-          - "ollama-cloud:devstral-2:123b"
-          - "ollama-cloud:ministral-3:14b"
+          - "ollama:glm-5"
+          - "ollama:minimax-m2.5"
+          - "ollama:nemotron-3-nano:30b"
+          - "ollama:cogito-2.1:671b"
+          - "ollama:devstral-2:123b"
+          - "ollama:ministral-3:14b"
     defaults:
       run:
         working-directory: libs/deepagents
@@ -93,6 +94,7 @@ jobs:
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+      OLLAMA_HOST: "https://ollama.com"
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -38,30 +38,30 @@ jobs:
       matrix:
         model:
           # Anthropic
-#          - "anthropic:claude-haiku-4-5-20251001"
-#          - "anthropic:claude-sonnet-4-20250514"
-#          - "anthropic:claude-sonnet-4-5-20250929"
-#          - "anthropic:claude-sonnet-4-6"
-#          - "anthropic:claude-opus-4-1"
-#          - "anthropic:claude-opus-4-5-20251101"
-#          - "anthropic:claude-opus-4-6"
-#          # OpenAI
-#          - "openai:gpt-4o"
-#          - "openai:gpt-4o-mini"
-#          - "openai:gpt-4.1"
-#          - "openai:o3"
-#          - "openai:o4-mini"
-#          - "openai:gpt-5"
-#          - "openai:gpt-5.1-codex"
-#          - "openai:gpt-5.2-codex"
+          - "anthropic:claude-haiku-4-5-20251001"
+          - "anthropic:claude-sonnet-4-20250514"
+          - "anthropic:claude-sonnet-4-5-20250929"
+          - "anthropic:claude-sonnet-4-6"
+          - "anthropic:claude-opus-4-1"
+          - "anthropic:claude-opus-4-5-20251101"
+          - "anthropic:claude-opus-4-6"
+          # OpenAI
+          - "openai:gpt-4o"
+          - "openai:gpt-4o-mini"
+          - "openai:gpt-4.1"
+          - "openai:o3"
+          - "openai:o4-mini"
+          - "openai:gpt-5"
+          - "openai:gpt-5.1-codex"
+          - "openai:gpt-5.2-codex"
           # Google
           - "google_genai:gemini-2.5-flash"
           - "google_genai:gemini-2.5-pro"
           - "google_genai:gemini-3-flash-preview"
           - "google_genai:gemini-3.1-pro-preview"
-#          # xAI
-#          - "xai:grok-4"
-#          - "xai:grok-3-mini-fast"
+          # xAI
+          - "xai:grok-4"
+          - "xai:grok-3-mini-fast"
           # Mistral (API key not configured yet)
           # - "mistral:mistral-large-2512"
           # - "mistral:mistral-medium-2508"
@@ -69,17 +69,17 @@ jobs:
           # DeepSeek (API key not configured yet)
           # - "deepseek:deepseek-chat"
           # - "deepseek:deepseek-reasoner"
-#          # Groq
-#          - "groq:openai/gpt-oss-120b"
-#          - "groq:qwen/qwen3-32b"
-#          - "groq:moonshotai/kimi-k2-instruct"
-#          # Ollama Cloud
-#          - "ollama:glm-5"
-#          - "ollama:minimax-m2.5"
-#          - "ollama:nemotron-3-nano:30b"
-#          - "ollama:cogito-2.1:671b"
-#          - "ollama:devstral-2:123b"
-#          - "ollama:ministral-3:14b"
+          # Groq
+          - "groq:openai/gpt-oss-120b"
+          - "groq:qwen/qwen3-32b"
+          - "groq:moonshotai/kimi-k2-instruct"
+          # Ollama Cloud
+          - "ollama:glm-5"
+          - "ollama:minimax-m2.5"
+          - "ollama:nemotron-3-nano:30b"
+          - "ollama:cogito-2.1:671b"
+          - "ollama:devstral-2:123b"
+          - "ollama:ministral-3:14b"
     defaults:
       run:
         working-directory: libs/deepagents

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -69,17 +69,17 @@ jobs:
           # DeepSeek (API key not configured yet)
           # - "deepseek:deepseek-chat"
           # - "deepseek:deepseek-reasoner"
-          # Groq
-          - "groq:openai/gpt-oss-120b"
-          - "groq:qwen/qwen3-32b"
-          - "groq:moonshotai/kimi-k2-instruct"
-          # Ollama Cloud
-          - "ollama:glm-5"
-          - "ollama:minimax-m2.5"
-          - "ollama:nemotron-3-nano:30b"
-          - "ollama:cogito-2.1:671b"
-          - "ollama:devstral-2:123b"
-          - "ollama:ministral-3:14b"
+#          # Groq
+#          - "groq:openai/gpt-oss-120b"
+#          - "groq:qwen/qwen3-32b"
+#          - "groq:moonshotai/kimi-k2-instruct"
+#          # Ollama Cloud
+#          - "ollama:glm-5"
+#          - "ollama:minimax-m2.5"
+#          - "ollama:nemotron-3-nano:30b"
+#          - "ollama:cogito-2.1:671b"
+#          - "ollama:devstral-2:123b"
+#          - "ollama:ministral-3:14b"
     defaults:
       run:
         working-directory: libs/deepagents

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -36,29 +36,29 @@ jobs:
       matrix:
         model:
           # Anthropic
-          - "anthropic:claude-haiku-4-5-20251001"
-          - "anthropic:claude-sonnet-4-20250514"
-          - "anthropic:claude-sonnet-4-5-20250929"
-          - "anthropic:claude-sonnet-4-6"
-          - "anthropic:claude-opus-4-1"
-          - "anthropic:claude-opus-4-5-20251101"
-          - "anthropic:claude-opus-4-6"
-          # OpenAI
-          - "openai:gpt-4o"
-          - "openai:gpt-4o-mini"
-          - "openai:gpt-4.1"
-          - "openai:o3"
-          - "openai:o4-mini"
-          - "openai:gpt-5"
-          - "openai:gpt-5.1-codex"
-          - "openai:gpt-5.2-codex"
-          # Google (API key not configured yet)
-          # - "google:gemini-2.5-flash"
-          # - "google:gemini-2.5-pro"
-          # - "google:gemini-3-pro-preview"
-          # xAI
-          - "xai:grok-4"
-          - "xai:grok-3-mini-fast"
+#          - "anthropic:claude-haiku-4-5-20251001"
+#          - "anthropic:claude-sonnet-4-20250514"
+#          - "anthropic:claude-sonnet-4-5-20250929"
+#          - "anthropic:claude-sonnet-4-6"
+#          - "anthropic:claude-opus-4-1"
+#          - "anthropic:claude-opus-4-5-20251101"
+#          - "anthropic:claude-opus-4-6"
+#          # OpenAI
+#          - "openai:gpt-4o"
+#          - "openai:gpt-4o-mini"
+#          - "openai:gpt-4.1"
+#          - "openai:o3"
+#          - "openai:o4-mini"
+#          - "openai:gpt-5"
+#          - "openai:gpt-5.1-codex"
+#          - "openai:gpt-5.2-codex"
+#          # Google (API key not configured yet)
+#          # - "google:gemini-2.5-flash"
+#          # - "google:gemini-2.5-pro"
+#          # - "google:gemini-3-pro-preview"
+#          # xAI
+#          - "xai:grok-4"
+#          - "xai:grok-3-mini-fast"
           # Mistral (API key not configured yet)
           # - "mistral:mistral-large-2512"
           # - "mistral:mistral-medium-2508"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -54,10 +54,11 @@ jobs:
 #          - "openai:gpt-5"
 #          - "openai:gpt-5.1-codex"
 #          - "openai:gpt-5.2-codex"
-#          # Google (API key not configured yet)
-#          # - "google:gemini-2.5-flash"
-#          # - "google:gemini-2.5-pro"
-#          # - "google:gemini-3-pro-preview"
+          # Google
+          - "google_genai:gemini-2.5-flash"
+          - "google_genai:gemini-2.5-pro"
+          - "google_genai:gemini-3-flash-preview"
+          - "google_genai:gemini-3.1-pro-preview"
 #          # xAI
 #          - "xai:grok-4"
 #          - "xai:grok-3-mini-fast"

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -879,6 +879,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -59,6 +59,7 @@ evals = [
   "langchain-mistralai",
   "langchain-deepseek",
   "langchain-groq",
+  "langchain-ollama",
 ]
 
 [build-system]

--- a/libs/deepagents/tests/evals/utils.py
+++ b/libs/deepagents/tests/evals/utils.py
@@ -308,7 +308,7 @@ def run_agent(
     config = {"configurable": {"thread_id": thread_id}}
 
     logged_inputs = dict(invoke_inputs)
-    logged_inputs["model"] = str(model.model)
+    logged_inputs["model"] = str(getattr(model, "model", None) or getattr(model, "model_name", ""))
 
     t.log_inputs(logged_inputs)
     result = agent.invoke(invoke_inputs, config)

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -570,6 +570,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [
@@ -601,6 +602,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [
@@ -1257,6 +1259,19 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-ollama"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ollama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/51/72cd04d74278f3575f921084f34280e2f837211dc008c9671c268c578afe/langchain_ollama-1.0.1.tar.gz", hash = "sha256:e37880c2f41cdb0895e863b1cfd0c2c840a117868b3f32e44fef42569e367443", size = 153850, upload-time = "2025-12-12T21:48:28.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/46/f2907da16dc5a5a6c679f83b7de21176178afad8d2ca635a581429580ef6/langchain_ollama-1.0.1-py3-none-any.whl", hash = "sha256:37eb939a4718a0255fe31e19fbb0def044746c717b01b97d397606ebc3e9b440", size = 29207, upload-time = "2025-12-12T21:48:27.832Z" },
+]
+
+[[package]]
 name = "langchain-openai"
 version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1539,6 +1554,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/95/2d6fc6461687d7a171f087995247dec33e8749a562bfadd85fb5dbf37a11/nh3-0.3.2-cp38-abi3-win32.whl", hash = "sha256:169db03df90da63286e0560ea0efa9b6f3b59844a9735514a1d47e6bb2c8c61b", size = 589826, upload-time = "2025-10-30T11:17:42.239Z" },
     { url = "https://files.pythonhosted.org/packages/64/9a/1a1c154f10a575d20dd634e5697805e589bbdb7673a0ad00e8da90044ba7/nh3-0.3.2-cp38-abi3-win_amd64.whl", hash = "sha256:562da3dca7a17f9077593214a9781a94b8d76de4f158f8c895e62f09573945fe", size = 596406, upload-time = "2025-10-30T11:17:43.773Z" },
     { url = "https://files.pythonhosted.org/packages/9e/7e/a96255f63b7aef032cbee8fc4d6e37def72e3aaedc1f72759235e8f13cb1/nh3-0.3.2-cp38-abi3-win_arm64.whl", hash = "sha256:cf5964d54edd405e68583114a7cba929468bcd7db5e676ae38ee954de1cfc104", size = 584162, upload-time = "2025-10-30T11:17:44.96Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
 ]
 
 [[package]]

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -711,6 +711,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -655,6 +655,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -601,6 +601,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -409,6 +409,7 @@ evals = [
     { name = "langchain-deepseek" },
     { name = "langchain-groq" },
     { name = "langchain-mistralai" },
+    { name = "langchain-ollama" },
     { name = "langchain-xai" },
 ]
 test = [


### PR DESCRIPTION
Fixes model name logging in eval utils to handle ChatGroq (which exposes `model_name` instead of `model`) via a `getattr` fallback. Adds Google (`google_genai`) and Ollama Cloud models to the eval CI matrix, adds `langchain-ollama` to the evals dependency group, and improves the aggregation script to sort by provider then descending accuracy.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).