### PR TITLE
docs(cli): document SDK version pin requirements

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -30,9 +30,13 @@ To release the CLI:
 1. Merge conventional commits to `main` (see [Commit Format](#commit-format))
 2. Wait for release-please to create/update the release PR
 3. Review the generated changelog in the PR
-4. Merge the release PR — this creates a **draft** GitHub release
-5. Review and edit the release notes in the GitHub UI
-6. Click "Publish release" — this triggers PyPI publication
+4. **Verify the SDK pin** — check that `deepagents==` in `libs/cli/pyproject.toml` is up to date. If the latest SDK version has been confirmed compatible, you should bump the pin on `main` and let release-please regenerate the PR before merging. See [Release Failed: CLI SDK Pin Mismatch](#release-failed-cli-sdk-pin-mismatch) for recovery if this is missed.
+5. Merge the release PR — this creates a **draft** GitHub release
+6. Review and edit the release notes in the GitHub UI
+7. Click "Publish release" — this triggers PyPI publication
+
+> [!IMPORTANT]
+> When developing CLI features that depend on new SDK functionality, bump the SDK pin as part of that work — don't defer it to release time. The pin should always reflect the minimum SDK version the CLI actually requires!
 
 ### Version Bumping
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,10 @@ def send_email(to: str, msg: str, *, priority: str = "normal") -> bool:
 - **Message passing** for widget communication - see [Events guide](https://textual.textualize.io/guide/events/)
 - **Reactive attributes** for state management - see [Reactivity guide](https://textual.textualize.io/guide/reactivity/)
 
+**SDK dependency pin:**
+
+The CLI pins an exact `deepagents==X.Y.Z` version in `libs/cli/pyproject.toml`. When developing CLI features that depend on new SDK functionality, bump this pin as part of the same PR. A CI check verifies the pin matches the current SDK version at release time (unless bypassed with `dangerous-skip-sdk-pin-check`).
+
 **Startup performance:**
 
 The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents`, LangChain, LangGraph) at module level or in the argument-parsing path. These imports pull in large dependency trees and add seconds to every invocation, including trivial commands like `deepagents -v`.


### PR DESCRIPTION
Document the CLI's SDK version pin requirement across release and development docs. The `deepagents==` pin in `libs/cli/pyproject.toml` has been a recurring source of release failures when it drifts behind the published SDK version — these changes make the expectation explicit in both the release checklist and the agent-facing coding guidelines.