### PR TITLE
chore(sdk): add LANGSMITH_EXPERIMENT env var to evals workflow

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -87,6 +87,7 @@ jobs:
       PYTEST_ADDOPTS: "--model ${{ matrix.model }} --evals-report-file evals_report.json"
       LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
       LANGSMITH_TRACING_V2: "true"
+      LANGSMITH_EXPERIMENT: ${{ matrix.model }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
Sets `LANGSMITH_EXPERIMENT` to the matrix model name so each eval run registers as a named experiment in LangSmith.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).