### PR TITLE
fix(cli): use first-class OpenRouter attribution kwargs

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1144,14 +1144,43 @@ def _get_default_model_spec() -> str:
     raise ModelConfigError(msg)
 
 
-_OPENROUTER_DEFAULT_HEADERS: dict[str, str] = {
-    "HTTP-Referer": "https://github.com/langchain-ai/deepagents",
-    "X-Title": "Deep Agents CLI",
-}
-"""Default attribution headers sent with every OpenRouter request.
+_OPENROUTER_APP_URL = "https://github.com/langchain-ai/deepagents"
+"""Default `app_url` (maps to `HTTP-Referer`) for OpenRouter attribution.
 
 See https://openrouter.ai/docs/app-attribution for details.
 """
+
+_OPENROUTER_APP_TITLE = "Deep Agents CLI"
+"""Default `app_title` (maps to `X-Title`) for OpenRouter attribution."""
+
+
+def _apply_openrouter_defaults(kwargs: dict[str, Any]) -> None:
+    """Inject default OpenRouter attribution kwargs.
+
+    Sets `app_url` and `app_title` via `setdefault` so that user-supplied
+    values in config take precedence. These map to the `HTTP-Referer` and
+    `X-Title` headers that `ChatOpenRouter` sends for app attribution
+    (see https://openrouter.ai/docs/app-attribution).
+
+    Users can override either value provider-wide or per-model in
+    `~/.deepagents/config.toml`:
+
+    ```toml
+    # Provider-wide
+    [models.providers.openrouter.params]
+    app_url = "https://myapp.com"
+    app_title = "My App"
+
+    # Per-model (shallow-merges on top of provider-wide)
+    [models.providers.openrouter.params."openai/gpt-oss-120b"]
+    app_title = "My App (GPT)"
+    ```
+
+    Args:
+        kwargs: Mutable kwargs dict to update in place.
+    """
+    kwargs.setdefault("app_url", _OPENROUTER_APP_URL)
+    kwargs.setdefault("app_title", _OPENROUTER_APP_TITLE)
 
 
 def _get_provider_kwargs(
@@ -1164,10 +1193,6 @@ def _get_provider_kwargs(
 
     When `model_name` is provided, per-model overrides from the `params`
     sub-table are shallow-merged on top.
-
-    For the `openrouter` provider, default attribution headers (`HTTP-Referer`
-    and `X-Title`) are injected automatically. User-supplied `default_headers`
-    in config take precedence.
 
     Args:
         provider: Provider name (e.g., openai, anthropic, fireworks, ollama).
@@ -1188,8 +1213,7 @@ def _get_provider_kwargs(
             result["api_key"] = api_key
 
     if provider == "openrouter":
-        user_headers = result.get("default_headers") or {}
-        result["default_headers"] = {**_OPENROUTER_DEFAULT_HEADERS, **user_headers}
+        _apply_openrouter_defaults(result)
 
     return result
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1216,41 +1216,37 @@ class TestOpenRouterHeaders:
         """Clear model config cache before each test."""
         clear_caches()
 
-    def test_injects_default_headers(self) -> None:
-        """Injects HTTP-Referer and X-Title for openrouter provider."""
+    def test_injects_attribution_kwargs(self) -> None:
+        """Injects app_url and app_title for openrouter provider."""
         kwargs = _get_provider_kwargs("openrouter")
 
-        assert "default_headers" in kwargs
-        assert kwargs["default_headers"]["HTTP-Referer"] == (
-            "https://github.com/langchain-ai/deepagents"
-        )
-        assert kwargs["default_headers"]["X-Title"] == "Deep Agents CLI"
+        assert kwargs["app_url"] == "https://github.com/langchain-ai/deepagents"
+        assert kwargs["app_title"] == "Deep Agents CLI"
 
-    def test_per_model_headers_override_defaults(self, tmp_path: Path) -> None:
-        """Per-model default_headers override built-in defaults."""
+    def test_per_model_attribution_overrides_defaults(self, tmp_path: Path) -> None:
+        """Per-model app_title overrides built-in default."""
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
 [models.providers.openrouter]
 models = ["deepseek/deepseek-chat"]
 
 [models.providers.openrouter.params."deepseek/deepseek-chat"]
-default_headers = {X-Title = "My Custom App"}
+app_title = "My Custom App"
 """)
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
             kwargs = _get_provider_kwargs(
                 "openrouter", model_name="deepseek/deepseek-chat"
             )
 
-        assert kwargs["default_headers"]["X-Title"] == "My Custom App"
-        # Built-in HTTP-Referer should still be present
-        assert kwargs["default_headers"]["HTTP-Referer"] == (
-            "https://github.com/langchain-ai/deepagents"
-        )
+        assert kwargs["app_title"] == "My Custom App"
+        # Built-in app_url should still be present
+        assert kwargs["app_url"] == "https://github.com/langchain-ai/deepagents"
 
-    def test_no_headers_for_other_providers(self) -> None:
-        """Other providers do not get OpenRouter attribution headers."""
+    def test_no_attribution_for_other_providers(self) -> None:
+        """Other providers do not get OpenRouter attribution kwargs."""
         kwargs = _get_provider_kwargs("openai")
-        assert "default_headers" not in kwargs
+        assert "app_url" not in kwargs
+        assert "app_title" not in kwargs
 
 
 class TestCreateModelFromClass:


### PR DESCRIPTION
Switch OpenRouter attribution from raw `default_headers` (`HTTP-Referer` / `X-Title`) to the first-class `app_url` and `app_title` kwargs that `ChatOpenRouter` already supports. The old approach bypassed the SDK's own header-injection logic, which could lead to doubled or conflicting headers.