### PR TITLE
fix(cli): support space-separated tokens in model fuzzy search

### DIFF
--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -330,12 +330,15 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             self._selected_index = self._find_current_model_index()
             return
 
+        tokens = query.split()
+
         try:
-            matcher = Matcher(query, case_sensitive=False)
-            scored = [
-                (matcher.match(spec), spec, provider)
-                for spec, provider in self._all_models
-            ]
+            matchers = [Matcher(token, case_sensitive=False) for token in tokens]
+            scored: list[tuple[float, str, str]] = []
+            for spec, provider in self._all_models:
+                scores = [m.match(spec) for m in matchers]
+                if all(s > 0 for s in scores):
+                    scored.append((min(scores), spec, provider))
         except Exception:
             # graceful fallback if Matcher fails on edge-case input
             logger.warning(
@@ -348,9 +351,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             return
 
         self._filtered_models = [
-            (spec, provider)
-            for score, spec, provider in sorted(scored, reverse=True)
-            if score > 0
+            (spec, provider) for score, spec, provider in sorted(scored, reverse=True)
         ]
         self._selected_index = 0
 

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -509,6 +509,26 @@ class TestModelSelectorFuzzyMatching:
             model_spec, _ = app.result
             assert "claude" in model_spec.lower()
 
+    async def test_fuzzy_space_separated_tokens(self) -> None:
+        """Space-separated tokens should each fuzzy-match independently."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            # "claude sonnet" should match models containing both subsequences
+            for char in "claude sonnet":
+                await pilot.press(char)
+            await pilot.pause()
+
+            specs = [spec for spec, _ in screen._filtered_models]
+            assert any("claude" in s and "sonnet" in s for s in specs), (
+                f"'claude sonnet' should match claude-sonnet models. Got: {specs}"
+            )
+
     async def test_navigation_after_fuzzy_filter(self) -> None:
         """Arrow keys should work correctly on fuzzy-filtered results."""
         app = ModelSelectorTestApp()


### PR DESCRIPTION
The model selector's fuzzy search treated the entire query as a single token, so spaces — which never appear in model names — caused zero matches. Now the query is split on whitespace and each token is fuzzy-matched independently; only models matching *all* tokens are shown, ranked by the weakest token's score.
