### PR TITLE
fix(cli): allow Esc to exit command/bash input mode

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2367,18 +2367,22 @@ class DeepAgentsApp(App):
         Priority order:
         1. If modal screen is active, dismiss it
         2. If completion popup is open, dismiss it
-        3. If bash process is running, kill it
-        4. If agent is running, interrupt it
-        5. If approval menu is active, reject it
+        3. If input is in command/bash mode, exit to normal mode
+        4. If bash process is running, kill it
+        5. If agent is running, interrupt it
+        6. If approval menu is active, reject it
         """
         # If a modal screen is active, dismiss it
         if isinstance(self.screen, ModalScreen):
             self.screen.dismiss(None)
             return
 
-        # Close completion popup before interrupting the agent
-        if self._chat_input and self._chat_input.dismiss_completion():
-            return
+        # Close completion popup or exit slash/bash mode
+        if self._chat_input:
+            if self._chat_input.dismiss_completion():
+                return
+            if self._chat_input.exit_mode():
+                return
 
         # If bash command is running, cancel the worker
         if self._bash_running and self._bash_worker:

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1445,6 +1445,22 @@ class ChatInput(Vertical):
         if self._text_area:
             self._text_area.set_app_focus(has_focus=active)
 
+    def exit_mode(self) -> bool:
+        """Exit the current input mode (command/bash) back to normal.
+
+        Returns:
+            True if mode was non-normal and has been reset.
+        """
+        if self.mode == "normal":
+            return False
+        self.mode = "normal"
+        if self._completion_manager:
+            self._completion_manager.reset()
+        self.clear_completion_suggestions()
+        if self._text_area:
+            self._text_area.clear()
+        return True
+
     def dismiss_completion(self) -> bool:
         """Dismiss completion: clear view and reset controller state.
 


### PR DESCRIPTION
Fixes #1593

---

Allow `Esc` to exit slash-command (`/`) and bash (`\!`) input modes, returning to normal chat input. Previously, pressing `Esc` while in command or bash mode would skip straight to interrupting the agent — users had no way to back out of a mode change without submitting or clearing manually via backspace.