### PR TITLE
fix(cli): make escape reject pending HITL approval first

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2323,8 +2323,8 @@ class DeepAgentsApp(App):
 
         Priority order:
         1. If bash process is running, kill it
-        2. If agent is running, interrupt it (preserve input)
-        3. If approval menu is active, reject it
+        2. If approval menu is active, reject it
+        3. If agent is running, interrupt it (preserve input)
         4. If double press (quit_pending), quit
         5. Otherwise show quit hint
         """
@@ -2338,6 +2338,15 @@ class DeepAgentsApp(App):
             self._quit_pending = False
             return
 
+        # If approval menu is active, reject it before cancelling the worker.
+        # During HITL the agent worker remains active while awaiting approval,
+        # so this must be checked before the worker cancellation branch to
+        # avoid leaving a stale approval widget interactive after interruption.
+        if self._pending_approval_widget:
+            self._pending_approval_widget.action_select_reject()
+            self._quit_pending = False
+            return
+
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
             self._pending_messages.clear()
@@ -2345,12 +2354,6 @@ class DeepAgentsApp(App):
                 w.remove()
             self._queued_widgets.clear()
             self._agent_worker.cancel()
-            self._quit_pending = False
-            return
-
-        # If approval menu is active, reject it
-        if self._pending_approval_widget:
-            self._pending_approval_widget.action_select_reject()
             self._quit_pending = False
             return
 
@@ -2393,10 +2396,10 @@ class DeepAgentsApp(App):
             self._bash_worker.cancel()
             return
 
-        # If approval menu is active, reject it first. During HITL the agent
-        # worker remains active while awaiting approval, so this must be
-        # checked before the worker cancellation branch to avoid leaving a
-        # stale approval widget interactive after interruption.
+        # If approval menu is active, reject it before cancelling the worker.
+        # During HITL the agent worker remains active while awaiting approval,
+        # so this must be checked before the worker cancellation branch to
+        # avoid leaving a stale approval widget interactive after interruption.
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_reject()
             return

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2338,7 +2338,7 @@ class DeepAgentsApp(App):
             self._quit_pending = False
             return
 
-        # If approval menu is active, reject it before cancelling the worker.
+        # If approval menu is active, reject it before cancelling the agent worker.
         # During HITL the agent worker remains active while awaiting approval,
         # so this must be checked before the worker cancellation branch to
         # avoid leaving a stale approval widget interactive after interruption.
@@ -2396,7 +2396,7 @@ class DeepAgentsApp(App):
             self._bash_worker.cancel()
             return
 
-        # If approval menu is active, reject it before cancelling the worker.
+        # If approval menu is active, reject it before cancelling the agent worker.
         # During HITL the agent worker remains active while awaiting approval,
         # so this must be checked before the worker cancellation branch to
         # avoid leaving a stale approval widget interactive after interruption.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2369,8 +2369,8 @@ class DeepAgentsApp(App):
         2. If completion popup is open, dismiss it
         3. If input is in command/bash mode, exit to normal mode
         4. If bash process is running, kill it
-        5. If agent is running, interrupt it
-        6. If approval menu is active, reject it
+        5. If approval menu is active, reject it
+        6. If agent is running, interrupt it
         """
         # If a modal screen is active, dismiss it
         if isinstance(self.screen, ModalScreen):
@@ -2393,6 +2393,14 @@ class DeepAgentsApp(App):
             self._bash_worker.cancel()
             return
 
+        # If approval menu is active, reject it first. During HITL the agent
+        # worker remains active while awaiting approval, so this must be
+        # checked before the worker cancellation branch to avoid leaving a
+        # stale approval widget interactive after interruption.
+        if self._pending_approval_widget:
+            self._pending_approval_widget.action_select_reject()
+            return
+
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
             self._pending_messages.clear()
@@ -2401,10 +2409,6 @@ class DeepAgentsApp(App):
             self._queued_widgets.clear()
             self._agent_worker.cancel()
             return
-
-        # If approval menu is active, reject it
-        if self._pending_approval_widget:
-            self._pending_approval_widget.action_select_reject()
 
     def action_quit_app(self) -> None:
         """Handle quit action (Ctrl+D)."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -476,7 +476,7 @@ class DeepAgentsApp(App):
         self._quit_pending = False
         self._session_state: TextualSessionState | None = None
         self._ui_adapter: TextualUIAdapter | None = None
-        self._pending_approval_widget: Any = None
+        self._pending_approval_widget: ApprovalMenu | None = None
         # Agent task tracking for interruption
         self._agent_worker: Worker[None] | None = None
         self._agent_running = False

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1154,3 +1154,50 @@ class TestBashCommandInterrupt:
             await pilot.pause()
 
             mock_worker.cancel.assert_called_once()
+
+
+class TestInterruptApprovalPriority:
+    """Tests for escape interrupt priority when HITL approval is pending."""
+
+    async def test_escape_rejects_approval_before_canceling_worker(self) -> None:
+        """When both HITL approval and worker are active, reject approval first."""
+        app = DeepAgentsApp()
+        approval = MagicMock()
+        worker = MagicMock()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._pending_approval_widget = approval
+            app._agent_running = True
+            app._agent_worker = worker
+
+            app.action_interrupt()
+
+        approval.action_select_reject.assert_called_once()
+        worker.cancel.assert_not_called()
+
+    async def test_escape_cancels_worker_when_no_approval_pending(self) -> None:
+        """Escape cancels active worker and clears queued messages when no approval."""
+        app = DeepAgentsApp()
+        worker = MagicMock()
+        queued_w1 = MagicMock()
+        queued_w2 = MagicMock()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._pending_approval_widget = None
+            app._agent_running = True
+            app._agent_worker = worker
+            app._pending_messages.append(QueuedMessage(text="q", mode="normal"))
+            app._queued_widgets.append(queued_w1)
+            app._queued_widgets.append(queued_w2)
+
+            app.action_interrupt()
+
+        worker.cancel.assert_called_once()
+        queued_w1.remove.assert_called_once()
+        queued_w2.remove.assert_called_once()
+        assert len(app._pending_messages) == 0
+        assert len(app._queued_widgets) == 0

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1201,3 +1201,38 @@ class TestInterruptApprovalPriority:
         queued_w2.remove.assert_called_once()
         assert len(app._pending_messages) == 0
         assert len(app._queued_widgets) == 0
+
+    async def test_escape_rejects_approval_when_no_worker(self) -> None:
+        """Approval rejection works even without an active agent worker."""
+        app = DeepAgentsApp()
+        approval = MagicMock()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._pending_approval_widget = approval
+            app._agent_running = False
+            app._agent_worker = None
+
+            app.action_interrupt()
+
+        approval.action_select_reject.assert_called_once()
+
+    async def test_ctrl_c_rejects_approval_before_canceling_worker(self) -> None:
+        """Ctrl+C should also reject approval before canceling worker."""
+        app = DeepAgentsApp()
+        approval = MagicMock()
+        worker = MagicMock()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._pending_approval_widget = approval
+            app._agent_running = True
+            app._agent_worker = worker
+
+            app.action_quit_or_interrupt()
+
+        approval.action_select_reject.assert_called_once()
+        worker.cancel.assert_not_called()
+        assert app._quit_pending is False


### PR DESCRIPTION
During HITL, the agent worker remains active while awaiting approval. Previously, `Esc` hit the worker cancellation branch first, leaving a stale approval widget interactive after interruption. Swap the priority so the approval check runs before worker cancellation.

Closes #1090, supersedes #1272

Co-Authored-By: weiguang li <OiPunk@users.noreply.github.com>