### PR TITLE
fix(cli): terminate active subprocesses on app quit

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2434,6 +2434,13 @@ class DeepAgentsApp(App):
             w.remove()
         self._queued_widgets.clear()
 
+        # Cancel active workers so their subprocesses are terminated
+        # (SIGTERM → SIGKILL) instead of being orphaned.
+        if self._bash_running and self._bash_worker:
+            self._bash_worker.cancel()
+        if self._agent_running and self._agent_worker:
+            self._agent_worker.cancel()
+
         _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
         super().exit(result=result, return_code=return_code, message=message)
 


### PR DESCRIPTION
Fixes #1309

---

Quitting the app via `Ctrl+D` while a bash command or agent task is running orphans the child process — the terminal hangs because `DeepAgentsApp.exit()` tears down the Textual event loop without cancelling active workers first. The interrupt paths (`Ctrl+C`, `Esc`) already handle this correctly; `exit()` just needed the same treatment.