### PR TITLE
fix(cli): prevent cwd overflow in status bar when mode indicator is visible

### DIFF
--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -76,7 +76,7 @@ class StatusBar(Horizontal):
     }
 
     StatusBar .status-cwd {
-        width: 1fr;
+        width: auto;
         text-align: right;
         color: $text-muted;
     }


### PR DESCRIPTION
Related: #1209

The status bar CWD display used `width: 1fr`, splitting flexible space equally with the status message widget. When the BASH mode indicator appeared (transitioning from `display: none`), it consumed horizontal space, causing the CWD path to overflow its bounds and get clipped.

## Changes
- Change `StatusBar .status-cwd` from `width: 1fr` to `width: auto` so the path takes exactly the space it needs, letting `status-message` be the sole flex element that absorbs layout pressure