### PR TITLE
feat(cli): add background PyPI update check

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -568,6 +568,14 @@ class DeepAgentsApp(App):
                 group="startup-thread-prewarm",
             )
 
+        # Background update check (opt-out via DEEPAGENTS_NO_UPDATE_CHECK)
+        if not os.environ.get("DEEPAGENTS_NO_UPDATE_CHECK"):
+            self.run_worker(
+                self._check_for_updates,
+                exclusive=True,
+                group="startup-update-check",
+            )
+
         # Focus the input (autocomplete is now built into ChatInput)
         self._chat_input.focus_input()
 
@@ -630,6 +638,24 @@ class DeepAgentsApp(App):
         )
 
         await prewarm_thread_message_counts(limit=get_thread_limit())
+
+    async def _check_for_updates(self) -> None:
+        """Check PyPI for a newer deepagents-cli version and notify the user."""
+        try:
+            from deepagents_cli.update_check import is_update_available
+
+            available, latest = await asyncio.to_thread(is_update_available)
+            if available:
+                from deepagents_cli._version import __version__ as cli_version
+
+                self.notify(
+                    f"Update available: v{latest} (current: v{cli_version}). "
+                    "Run: uv tool upgrade deepagents-cli",
+                    severity="information",
+                    timeout=15,
+                )
+        except Exception:
+            logger.debug("Background update check failed", exc_info=True)
 
     def on_scroll_up(self, _event: ScrollUp) -> None:
         """Handle scroll up to check if we need to hydrate older messages."""

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -1,0 +1,102 @@
+"""Background update check for deepagents-cli.
+
+Compares the installed version against PyPI and caches the result
+(see `CACHE_TTL`). All errors are silently swallowed to avoid disrupting
+user experience.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from deepagents_cli._version import __version__
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from deepagents_cli.model_config import DEFAULT_CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+PYPI_URL = "https://pypi.org/pypi/deepagents-cli/json"
+CACHE_FILE: Path = DEFAULT_CONFIG_DIR / "latest_version.json"
+CACHE_TTL = 86_400  # 24 hours
+USER_AGENT = f"deepagents-cli/{__version__} update-check"
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a comparable integer tuple.
+
+    Args:
+        v: Version string like `'1.2.3'`.
+
+    Returns:
+        Tuple of integers, e.g. `(1, 2, 3)`.
+
+    """
+    return tuple(int(x) for x in v.strip().split("."))
+
+
+def get_latest_version() -> str | None:
+    """Fetch the latest deepagents-cli version from PyPI, with caching.
+
+    Results are cached to `CACHE_FILE` to avoid repeated network calls.
+
+    Returns:
+        The latest version string, or `None` on any failure.
+    """
+    try:
+        if CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            if time.time() - data.get("checked_at", 0) < CACHE_TTL:
+                return data["version"]
+    except Exception:
+        logger.debug("Failed to read update-check cache", exc_info=True)
+
+    try:
+        import requests
+
+        resp = requests.get(
+            PYPI_URL,
+            headers={"User-Agent": USER_AGENT},
+            timeout=3,
+        )
+        resp.raise_for_status()
+        latest: str = resp.json()["info"]["version"]
+    except Exception:
+        logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
+        return None
+
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(
+            json.dumps({"version": latest, "checked_at": time.time()}),
+            encoding="utf-8",
+        )
+    except Exception:
+        logger.debug("Failed to write update-check cache", exc_info=True)
+
+    return latest
+
+
+def is_update_available() -> tuple[bool, str | None]:
+    """Check whether a newer version of deepagents-cli is available.
+
+    Returns:
+        A `(available, latest)` tuple. `available` is `True` when
+        the PyPI version is strictly newer than the installed version;
+        `latest` is the version string (or `None` when the check fails).
+    """
+    latest = get_latest_version()
+    if latest is None:
+        return False, None
+
+    try:
+        if _parse_version(latest) > _parse_version(__version__):
+            return True, latest
+    except (ValueError, TypeError):
+        logger.debug("Failed to compare versions", exc_info=True)
+
+    return False, None

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -1,0 +1,170 @@
+"""Tests for the background update check module."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepagents_cli.update_check import (
+    CACHE_TTL,
+    _parse_version,
+    get_latest_version,
+    is_update_available,
+)
+
+
+@pytest.fixture
+def cache_file(tmp_path):
+    """Override CACHE_FILE to use a temporary directory."""
+    path = tmp_path / "latest_version.json"
+    with patch("deepagents_cli.update_check.CACHE_FILE", path):
+        yield path
+
+
+def _mock_pypi_response(version: str = "99.0.0") -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {"info": {"version": version}}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestParseVersion:
+    def test_basic(self) -> None:
+        assert _parse_version("1.2.3") == (1, 2, 3)
+
+    def test_single_digit(self) -> None:
+        assert _parse_version("0") == (0,)
+
+    def test_whitespace(self) -> None:
+        assert _parse_version("  1.0.0  ") == (1, 0, 0)
+
+    def test_prerelease_raises(self) -> None:
+        """Pre-release suffixes like rc1 are not parseable."""
+        with pytest.raises(ValueError, match="invalid literal"):
+            _parse_version("1.2.3rc1")
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="invalid literal"):
+            _parse_version("")
+
+
+class TestGetLatestVersion:
+    def test_fresh_fetch(self, cache_file) -> None:
+        """Successful PyPI fetch writes cache and returns version."""
+        with patch("requests.get", return_value=_mock_pypi_response("2.0.0")):
+            result = get_latest_version()
+
+        assert result == "2.0.0"
+        assert cache_file.exists()
+        data = json.loads(cache_file.read_text())
+        assert data["version"] == "2.0.0"
+        assert "checked_at" in data
+
+    def test_cached_hit(self, cache_file) -> None:
+        """Fresh cache returns version without HTTP call."""
+        cache_file.write_text(
+            json.dumps({"version": "1.5.0", "checked_at": time.time()})
+        )
+        with patch("requests.get") as mock_get:
+            result = get_latest_version()
+
+        assert result == "1.5.0"
+        mock_get.assert_not_called()
+
+    def test_stale_cache(self, cache_file) -> None:
+        """Expired cache triggers a new HTTP call."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "version": "1.0.0",
+                    "checked_at": time.time() - CACHE_TTL - 1,
+                }
+            )
+        )
+        with patch(
+            "requests.get", return_value=_mock_pypi_response("2.0.0")
+        ) as mock_get:
+            result = get_latest_version()
+
+        assert result == "2.0.0"
+        mock_get.assert_called_once()
+
+    def test_network_error(self, cache_file) -> None:  # noqa: ARG002  # fixture overrides CACHE_FILE
+        """Network failure returns None."""
+        with patch("requests.get", side_effect=OSError("no network")):
+            result = get_latest_version()
+
+        assert result is None
+
+    def test_corrupt_cache(self, cache_file) -> None:
+        """Malformed cache JSON triggers PyPI fetch instead of crashing."""
+        cache_file.write_text("not valid json")
+        with patch("requests.get", return_value=_mock_pypi_response("3.0.0")):
+            result = get_latest_version()
+
+        assert result == "3.0.0"
+
+    def test_cache_missing_version_key(self, cache_file) -> None:
+        """Cache with missing version key triggers PyPI fetch."""
+        cache_file.write_text(json.dumps({"checked_at": time.time()}))
+        with patch("requests.get", return_value=_mock_pypi_response("3.0.0")):
+            result = get_latest_version()
+
+        assert result == "3.0.0"
+
+
+class TestIsUpdateAvailable:
+    def test_newer_available(self) -> None:
+        with patch(
+            "deepagents_cli.update_check.get_latest_version", return_value="99.0.0"
+        ):
+            available, latest = is_update_available()
+
+        assert available is True
+        assert latest == "99.0.0"
+
+    def test_current_version(self) -> None:
+        with (
+            patch(
+                "deepagents_cli.update_check.get_latest_version", return_value="0.0.1"
+            ),
+            patch("deepagents_cli.update_check.__version__", "0.0.1"),
+        ):
+            available, latest = is_update_available()
+
+        assert available is False
+        assert latest is None
+
+    def test_ahead_of_pypi(self) -> None:
+        """Dev build ahead of PyPI should not flag an update."""
+        with (
+            patch(
+                "deepagents_cli.update_check.get_latest_version", return_value="0.0.1"
+            ),
+            patch("deepagents_cli.update_check.__version__", "99.0.0"),
+        ):
+            available, latest = is_update_available()
+
+        assert available is False
+        assert latest is None
+
+    def test_fetch_failure(self) -> None:
+        with patch("deepagents_cli.update_check.get_latest_version", return_value=None):
+            available, latest = is_update_available()
+
+        assert available is False
+        assert latest is None
+
+    def test_unparseable_pypi_version(self) -> None:
+        """Malformed PyPI version string does not crash."""
+        with patch(
+            "deepagents_cli.update_check.get_latest_version",
+            return_value="1.2.3rc1",
+        ):
+            available, latest = is_update_available()
+
+        assert available is False
+        assert latest is None


### PR DESCRIPTION
Closes #1343

---

Add background update check that compares the installed CLI version against PyPI on startup. 

Users running outdated versions currently have no way to know — this gives them a non-intrusive toast notification with upgrade instructions.

The check is cached for 24 hours, runs off the main thread via `asyncio.to_thread`, and silently no-ops on any failure.

## Changes
- Add `update_check` module with `get_latest_version()` (PyPI fetch + 24h file cache in `~/.deepagents/latest_version.json`) and `is_update_available()` (tuple-based version comparison)
- Spawn a `_check_for_updates` background worker in `DeepAgentsApp.on_mount` that shows a 15-second toast when a newer version exists — deferred import of `update_check` keeps the startup path clean
- Opt-out via `DEEPAGENTS_NO_UPDATE_CHECK` env var, checked before the worker is spawned