### PR TITLE
feat(cli): add curl-pipe-bash install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,18 @@ Try Deep Agents instantly from the terminal:
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+
+# With model provider extras (OpenAI is included by default)
+DEEPAGENTS_EXTRAS="anthropic,groq" curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+
 deepagents
 ```
 
 Or install directly with `uv`:
 
 ```bash
-uv tool install deepagents-cli
+# Install with chosen model providers (OpenAI is included by default)
+uv tool install 'deepagents-cli[anthropic,groq]'
 deepagents
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ MCP is supported via [`langchain-mcp-adapters`](https://github.com/langchain-ai/
 Try Deep Agents instantly from the terminal:
 
 ```bash
+curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+deepagents
+```
+
+Or install directly with `uv`:
+
+```bash
 uv tool install deepagents-cli
 deepagents
 ```

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -12,6 +12,13 @@
 ## Quick Install
 
 ```bash
+curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+deepagents
+```
+
+Or install directly with `uv`:
+
+```bash
 uv tool install deepagents-cli
 deepagents
 ```

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -13,13 +13,18 @@
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+
+# With model provider extras (OpenAI is included by default)
+DEEPAGENTS_EXTRAS="anthropic,groq" curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+
 deepagents
 ```
 
 Or install directly with `uv`:
 
 ```bash
-uv tool install deepagents-cli
+# Install with chosen model providers (OpenAI is included by default)
+uv tool install 'deepagents-cli[anthropic,groq]'
 deepagents
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@
 #   curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
 #
 # Environment variables:
-#   DEEPAGENTS_EXTRAS  — optional pip extras in bracket format, e.g. "[anthropic]"
+#   DEEPAGENTS_EXTRAS  — comma-separated pip extras, e.g. "anthropic" or "anthropic,groq"
 #                        (see pyproject.toml for available extras)
 #   DEEPAGENTS_PYTHON  — Python version to use (default: 3.13)
 #   UV_BIN             — path to uv binary (auto-detected if unset)
@@ -14,10 +14,16 @@ set -euo pipefail
 EXTRAS="${DEEPAGENTS_EXTRAS:-}"
 PYTHON_VERSION="${DEEPAGENTS_PYTHON:-3.13}"
 
-# Validate extras format if provided (must be bracket-enclosed, e.g. [anthropic])
-if [[ -n "$EXTRAS" && ! "$EXTRAS" =~ ^\[[-a-zA-Z0-9,]+\]$ ]]; then
-  echo "Error: DEEPAGENTS_EXTRAS must be in pip extras format, e.g. '[anthropic]'" >&2
-  exit 1
+# Validate and normalize extras: accept bare CSV, wrap in brackets for pip
+if [[ -n "$EXTRAS" ]]; then
+  # Strip brackets if the user passed them anyway
+  EXTRAS="${EXTRAS#[}"
+  EXTRAS="${EXTRAS%]}"
+  if [[ ! "$EXTRAS" =~ ^[-a-zA-Z0-9,]+$ ]]; then
+    echo "Error: DEEPAGENTS_EXTRAS must be comma-separated extra names, e.g. 'anthropic,groq'" >&2
+    exit 1
+  fi
+  EXTRAS="[${EXTRAS}]"
 fi
 
 install_uv() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Install deepagents-cli via uv.
+#
+# Usage:
+#   curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/scripts/install.sh | bash
+#
+# Environment variables:
+#   DEEPAGENTS_EXTRAS  — optional pip extras in bracket format, e.g. "[anthropic]"
+#                        (see pyproject.toml for available extras)
+#   DEEPAGENTS_PYTHON  — Python version to use (default: 3.13)
+#   UV_BIN             — path to uv binary (auto-detected if unset)
+set -euo pipefail
+
+EXTRAS="${DEEPAGENTS_EXTRAS:-}"
+PYTHON_VERSION="${DEEPAGENTS_PYTHON:-3.13}"
+
+# Validate extras format if provided (must be bracket-enclosed, e.g. [anthropic])
+if [[ -n "$EXTRAS" && ! "$EXTRAS" =~ ^\[[-a-zA-Z0-9,]+\]$ ]]; then
+  echo "Error: DEEPAGENTS_EXTRAS must be in pip extras format, e.g. '[anthropic]'" >&2
+  exit 1
+fi
+
+install_uv() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL https://astral.sh/uv/install.sh | sh
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- https://astral.sh/uv/install.sh | sh
+  else
+    echo "Error: curl or wget is required to install uv." >&2
+    exit 1
+  fi
+}
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found — installing..." >&2
+  install_uv
+fi
+
+# Resolve uv binary: honor UV_BIN override, then PATH, then the default
+# install location (~/.local/bin). A fresh install may not have updated PATH
+# in the current session, so we source the env file the installer creates.
+if [ -z "${UV_BIN:-}" ]; then
+  UV_BIN="uv"
+  if ! command -v "$UV_BIN" >/dev/null 2>&1; then
+    if [ -f "${HOME}/.local/bin/env" ]; then
+      # shellcheck source=/dev/null
+      . "${HOME}/.local/bin/env"
+    fi
+  fi
+  if ! command -v uv >/dev/null 2>&1; then
+    UV_BIN="${HOME}/.local/bin/uv"
+    if [ ! -x "$UV_BIN" ]; then
+      echo "Error: uv not found after installation. Restart your shell or add ~/.local/bin to PATH." >&2
+      exit 1
+    fi
+  fi
+fi
+
+PACKAGE="deepagents-cli${EXTRAS}"
+echo "Installing ${PACKAGE}..." >&2
+"$UV_BIN" tool install --python "$PYTHON_VERSION" "$PACKAGE" 2>/dev/null \
+  || "$UV_BIN" tool upgrade --python "$PYTHON_VERSION" "$PACKAGE"
+
+echo ""
+echo "deepagents-cli installed successfully."
+echo "Run:  deepagents"
+echo ""
+echo "If the command is not found, restart your shell or run:"
+echo "  source ~/.zshrc   # (or ~/.bashrc)"


### PR DESCRIPTION
Add a `curl | bash` install script that bootstraps `uv` and installs `deepagents-cli` in one command. Users currently need to manually install `uv`, then run `uv tool install deepagents-cli` — this collapses both steps into a single line.

## Changes
- Add `scripts/install.sh` — detects whether `uv` is present, installs it via `astral.sh/uv/install.sh` if missing, then runs `uv tool install deepagents-cli`
- Support `DEEPAGENTS_EXTRAS` env var for optional provider extras (e.g. `[anthropic]`), with regex validation to reject malformed input
- Support `UV_BIN` env var for users with custom `uv` install locations; auto-detection tries PATH, then sources `~/.local/bin/env`, then falls back to `~/.local/bin/uv`
- Handle re-runs gracefully: falls back to `uv tool upgrade` if `uv tool install` fails (package already installed)
