### PR TITLE
feat(cli): fuzzy search for slash command autocomplete

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1290,7 +1290,7 @@ class DeepAgentsApp(App):
         """
         cmd = command.lower().strip()
 
-        if cmd in {"/quit", "/q"}:
+        if cmd == "/quit":
             self.exit()
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1290,7 +1290,7 @@ class DeepAgentsApp(App):
         """
         cmd = command.lower().strip()
 
-        if cmd == "/quit":
+        if cmd in {"/quit", "/q"}:
             self.exit()
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -114,8 +114,8 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
 MAX_SUGGESTIONS = 10
 """UI cap so the completion popup doesn't get unwieldy."""
 
-_MIN_FUZZY_SCORE = 25
-"""Minimum score to include in results (shared by slash + file completion)."""
+_MIN_SLASH_FUZZY_SCORE = 25
+"""Minimum score for slash-command fuzzy matches."""
 
 _MIN_DESC_SEARCH_LEN = 2
 """Minimum query length to search command descriptions (avoids single-char noise)."""
@@ -168,6 +168,8 @@ class SlashCommandController:
         Returns:
             Score value where higher indicates better match quality.
         """
+        if not search:
+            return 0.0
         name = cmd.lstrip("/").lower()
         lower_desc = desc.lower()
         # Prefix match on command name — highest priority
@@ -187,7 +189,7 @@ class SlashCommandController:
         name_ratio = SequenceMatcher(None, search, name).ratio()
         desc_ratio = SequenceMatcher(None, search, lower_desc).ratio()
         best = max(name_ratio * 60, desc_ratio * 30)
-        return best if best >= _MIN_FUZZY_SCORE else 0.0
+        return best if best >= _MIN_SLASH_FUZZY_SCORE else 0.0
 
     def on_text_changed(self, text: str, cursor_index: int) -> None:
         """Update suggestions when text changes."""
@@ -204,7 +206,7 @@ class SlashCommandController:
 
         if not search:
             # No search text — show all commands
-            suggestions = list(self._commands)
+            suggestions = list(self._commands)[:MAX_SUGGESTIONS]
         else:
             # Score and filter commands using fuzzy matching
             scored = [
@@ -289,6 +291,9 @@ class SlashCommandController:
 # Constants for fuzzy file completion
 _MAX_FALLBACK_FILES = 1000
 """Hard cap on files returned by the non-git glob fallback."""
+
+_MIN_FUZZY_SCORE = 15
+"""Minimum score to include in file-completion results."""
 
 _MIN_FUZZY_RATIO = 0.4
 """SequenceMatcher threshold for filename-only fuzzy matches."""

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -114,8 +114,11 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
 MAX_SUGGESTIONS = 10
 """UI cap so the completion popup doesn't get unwieldy."""
 
-_MIN_FUZZY_SCORE = 15
+_MIN_FUZZY_SCORE = 25
 """Minimum score to include in results (shared by slash + file completion)."""
+
+_MIN_DESC_SEARCH_LEN = 2
+"""Minimum query length to search command descriptions (avoids single-char noise)."""
 
 
 class SlashCommandController:
@@ -173,9 +176,13 @@ class SlashCommandController:
         # Substring match on command name
         if search in name:
             return 150.0
-        # Substring match on description
-        if search in lower_desc:
-            return 100.0
+        # Substring match on description (require ≥2 chars to avoid single-letter noise)
+        if len(search) >= _MIN_DESC_SEARCH_LEN and search in lower_desc:
+            idx = lower_desc.find(search)
+            # Word-boundary bonus: match at start of description or after a space
+            if idx == 0 or lower_desc[idx - 1] == " ":
+                return 110.0
+            return 90.0
         # Fuzzy match via SequenceMatcher on name + desc
         name_ratio = SequenceMatcher(None, search, name).ratio()
         desc_ratio = SequenceMatcher(None, search, lower_desc).ratio()

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -112,6 +112,10 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
 """Built-in slash commands with descriptions."""
 
 MAX_SUGGESTIONS = 10
+"""UI cap so the completion popup doesn't get unwieldy."""
+
+_MIN_FUZZY_SCORE = 15
+"""Minimum score to include in results (shared by slash + file completion)."""
 
 
 class SlashCommandController:
@@ -162,6 +166,7 @@ class SlashCommandController:
             Score value where higher indicates better match quality.
         """
         name = cmd.lstrip("/").lower()
+        lower_desc = desc.lower()
         # Prefix match on command name — highest priority
         if name.startswith(search):
             return 200.0
@@ -169,11 +174,11 @@ class SlashCommandController:
         if search in name:
             return 150.0
         # Substring match on description
-        if search in desc.lower():
+        if search in lower_desc:
             return 100.0
         # Fuzzy match via SequenceMatcher on name + desc
         name_ratio = SequenceMatcher(None, search, name).ratio()
-        desc_ratio = SequenceMatcher(None, search, desc.lower()).ratio()
+        desc_ratio = SequenceMatcher(None, search, lower_desc).ratio()
         best = max(name_ratio * 60, desc_ratio * 30)
         return best if best >= _MIN_FUZZY_SCORE else 0.0
 
@@ -196,10 +201,10 @@ class SlashCommandController:
         else:
             # Score and filter commands using fuzzy matching
             scored = [
-                (self._score_command(search, cmd, desc), cmd, desc)
+                (score, cmd, desc)
                 for cmd, desc in self._commands
+                if (score := self._score_command(search, cmd, desc)) > 0
             ]
-            scored = [(s, cmd, desc) for s, cmd, desc in scored if s > 0]
             scored.sort(key=lambda x: -x[0])
             suggestions = [(cmd, desc) for _, cmd, desc in scored[:MAX_SUGGESTIONS]]
 
@@ -276,8 +281,10 @@ class SlashCommandController:
 
 # Constants for fuzzy file completion
 _MAX_FALLBACK_FILES = 1000
+"""Hard cap on files returned by the non-git glob fallback."""
+
 _MIN_FUZZY_RATIO = 0.4
-_MIN_FUZZY_SCORE = 15  # Minimum score to include in results
+"""SequenceMatcher threshold for filename-only fuzzy matches."""
 
 
 def _get_project_files(root: Path) -> list[str]:

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -94,22 +94,26 @@ class CompletionController(Protocol):
 # Slash Command Completion
 # ============================================================================
 
-SLASH_COMMANDS: list[tuple[str, str]] = [
-    ("/help", "Show help"),
-    ("/changelog", "Open changelog in browser"),
-    ("/clear", "Clear chat and start new thread"),
-    ("/compact", "Summarize conversation to reduce context usage"),
-    ("/docs", "Open documentation in browser"),
-    ("/feedback", "Submit a bug report or feature request"),
-    ("/model", "Switch model, show selector, or set default (--default)"),
-    ("/remember", "Update memory and skills from conversation"),
-    ("/quit", "Exit app"),
-    ("/tokens", "Token usage"),
-    ("/threads", "Browse and resume previous threads"),
-    ("/trace", "Open current thread in LangSmith"),
-    ("/version", "Show version"),
+SLASH_COMMANDS: list[tuple[str, str, str]] = [
+    ("/help", "Show help", ""),
+    ("/changelog", "Open changelog in browser", ""),
+    ("/clear", "Clear chat and start new thread", "reset"),
+    ("/compact", "Summarize conversation to reduce context usage", ""),
+    ("/docs", "Open documentation in browser", ""),
+    ("/feedback", "Submit a bug report or feature request", ""),
+    ("/model", "Switch model, show selector, or set default (--default)", ""),
+    ("/remember", "Update memory and skills from conversation", ""),
+    ("/quit", "Exit app", "close leave"),
+    ("/tokens", "Token usage", "cost"),
+    ("/threads", "Browse and resume previous threads", "continue history"),
+    ("/trace", "Open current thread in LangSmith", ""),
+    ("/version", "Show version", ""),
 ]
-"""Built-in slash commands with descriptions."""
+"""Built-in slash commands: (name, description, hidden_keywords).
+
+Hidden keywords are space-separated terms that participate in fuzzy matching
+but are never displayed to the user.
+"""
 
 MAX_SUGGESTIONS = 10
 """UI cap so the completion popup doesn't get unwieldy."""
@@ -126,14 +130,14 @@ class SlashCommandController:
 
     def __init__(
         self,
-        commands: list[tuple[str, str]],
+        commands: list[tuple[str, str, str]],
         view: CompletionView,
     ) -> None:
         """Initialize the slash command controller.
 
         Args:
-            commands: List of (command, description) tuples
-            view: View to render suggestions to
+            commands: List of `(command, description, hidden_keywords)` tuples.
+            view: View to render suggestions to.
         """
         self._commands = commands
         self._view = view
@@ -157,13 +161,14 @@ class SlashCommandController:
             self._view.clear_completion_suggestions()
 
     @staticmethod
-    def _score_command(search: str, cmd: str, desc: str) -> float:
+    def _score_command(search: str, cmd: str, desc: str, keywords: str = "") -> float:
         """Score a command against a search string. Higher = better match.
 
         Args:
             search: Lowercase search string (without leading `/`).
             cmd: Command name (e.g. `'/help'`).
             desc: Command description text.
+            keywords: Space-separated hidden keywords for matching.
 
         Returns:
             Score value where higher indicates better match quality.
@@ -178,6 +183,11 @@ class SlashCommandController:
         # Substring match on command name
         if search in name:
             return 150.0
+        # Hidden keyword match — treated like a word-boundary description match
+        if keywords and len(search) >= _MIN_DESC_SEARCH_LEN:
+            for kw in keywords.lower().split():
+                if kw.startswith(search) or search in kw:
+                    return 120.0
         # Substring match on description (require ≥2 chars to avoid single-letter noise)
         if len(search) >= _MIN_DESC_SEARCH_LEN and search in lower_desc:
             idx = lower_desc.find(search)
@@ -205,14 +215,16 @@ class SlashCommandController:
         search = text[1:cursor_index].lower()
 
         if not search:
-            # No search text — show all commands
-            suggestions = list(self._commands)[:MAX_SUGGESTIONS]
+            # No search text — show all commands (display only cmd + desc)
+            suggestions = [(cmd, desc) for cmd, desc, _ in self._commands][
+                :MAX_SUGGESTIONS
+            ]
         else:
             # Score and filter commands using fuzzy matching
             scored = [
                 (score, cmd, desc)
-                for cmd, desc in self._commands
-                if (score := self._score_command(search, cmd, desc)) > 0
+                for cmd, desc, kw in self._commands
+                if (score := self._score_command(search, cmd, desc, kw)) > 0
             ]
             scored.sort(key=lambda x: -x[0])
             suggestions = [(cmd, desc) for _, cmd, desc in scored[:MAX_SUGGESTIONS]]

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -149,6 +149,34 @@ class SlashCommandController:
             self._selected_index = 0
             self._view.clear_completion_suggestions()
 
+    @staticmethod
+    def _score_command(search: str, cmd: str, desc: str) -> float:
+        """Score a command against a search string. Higher = better match.
+
+        Args:
+            search: Lowercase search string (without leading `/`).
+            cmd: Command name (e.g. `'/help'`).
+            desc: Command description text.
+
+        Returns:
+            Score value where higher indicates better match quality.
+        """
+        name = cmd.lstrip("/").lower()
+        # Prefix match on command name — highest priority
+        if name.startswith(search):
+            return 200.0
+        # Substring match on command name
+        if search in name:
+            return 150.0
+        # Substring match on description
+        if search in desc.lower():
+            return 100.0
+        # Fuzzy match via SequenceMatcher on name + desc
+        name_ratio = SequenceMatcher(None, search, name).ratio()
+        desc_ratio = SequenceMatcher(None, search, desc.lower()).ratio()
+        best = max(name_ratio * 60, desc_ratio * 30)
+        return best if best >= _MIN_FUZZY_SCORE else 0.0
+
     def on_text_changed(self, text: str, cursor_index: int) -> None:
         """Update suggestions when text changes."""
         if cursor_index < 0 or cursor_index > len(text):
@@ -162,12 +190,18 @@ class SlashCommandController:
         # Get the search string (text after /)
         search = text[1:cursor_index].lower()
 
-        # Filter commands that match
-        suggestions = [
-            (cmd, desc)
-            for cmd, desc in self._commands
-            if cmd.lower().startswith("/" + search)
-        ]
+        if not search:
+            # No search text — show all commands
+            suggestions = list(self._commands)
+        else:
+            # Score and filter commands using fuzzy matching
+            scored = [
+                (self._score_command(search, cmd, desc), cmd, desc)
+                for cmd, desc in self._commands
+            ]
+            scored = [(s, cmd, desc) for s, cmd, desc in scored if s > 0]
+            scored.sort(key=lambda x: -x[0])
+            suggestions = [(cmd, desc) for _, cmd, desc in scored[:MAX_SUGGESTIONS]]
 
         if suggestions:
             self._suggestions = suggestions

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -46,7 +46,7 @@ class TestFuzzyScore:
     def test_no_match_returns_low_score(self):
         """Completely unrelated strings get very low scores."""
         score = _fuzzy_score("xyz", "abc.py")
-        assert score < 15  # Below MIN_FUZZY_SCORE threshold
+        assert score < 25  # Below MIN_FUZZY_SCORE threshold
 
     def test_case_insensitive(self):
         """Matching is case insensitive."""
@@ -305,8 +305,12 @@ class TestScoreCommand:
     def test_substring_name_returns_150(self):
         assert self.score("omp", "/compact", "Summarize conversation") == 150
 
-    def test_substring_desc_returns_100(self):
-        assert self.score("exit", "/quit", "Exit app") == 100
+    def test_substring_desc_word_boundary_returns_110(self):
+        assert self.score("exit", "/quit", "Exit app") == 110
+
+    def test_substring_desc_mid_word_returns_90(self):
+        desc = "Summarize conversation to reduce context usage"
+        assert self.score("ex", "/compact", desc) == 90
 
     def test_no_match_returns_zero(self):
         assert self.score("zzzzz", "/help", "Show help") == 0
@@ -319,9 +323,11 @@ class TestScoreCommand:
         """Prefix > substring-name > substring-desc > fuzzy."""
         prefix = self.score("hel", "/help", "Show help")
         substr_name = self.score("omp", "/compact", "Summarize conversation")
-        substr_desc = self.score("exit", "/quit", "Exit app")
+        desc_boundary = self.score("exit", "/quit", "Exit app")
+        compact_desc = "Summarize conversation to reduce context usage"
+        desc_mid = self.score("ex", "/compact", compact_desc)
         fuzzy = self.score("hlep", "/help", "Show help")
-        assert prefix > substr_name > substr_desc > fuzzy > 0
+        assert prefix > substr_name > desc_boundary > desc_mid > fuzzy > 0
 
 
 class TestFuzzyFileControllerCanHandle:

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -236,21 +236,37 @@ class TestSlashCommandController:
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
         assert len(suggestions) == len(SLASH_COMMANDS)
 
-    def test_fuzzy_matches_description_exit(self, controller, mock_view):
-        """Typing 'exit' surfaces /quit via its description 'Exit app'."""
+    def test_substring_description_match_exit(self, controller, mock_view):
+        """Typing 'exit' surfaces /quit via substring match on 'Exit app'."""
         controller.on_text_changed("/exit", 5)
 
         mock_view.render_completion_suggestions.assert_called()
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
         assert any("/quit" in s[0] for s in suggestions)
 
-    def test_fuzzy_matches_description_new(self, controller, mock_view):
-        """Typing 'new' surfaces /clear via description containing 'new'."""
+    def test_substring_description_match_new(self, controller, mock_view):
+        """Typing 'new' surfaces /clear via substring on 'start new thread'."""
         controller.on_text_changed("/new", 4)
 
         mock_view.render_completion_suggestions.assert_called()
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
         assert any("/clear" in s[0] for s in suggestions)
+
+    def test_substring_name_match(self, controller, mock_view):
+        """Substring of command name (not prefix) surfaces the command."""
+        controller.on_text_changed("/omp", 4)
+
+        mock_view.render_completion_suggestions.assert_called()
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        assert any("/compact" in s[0] for s in suggestions)
+
+    def test_true_fuzzy_match_via_misspelling(self, controller, mock_view):
+        """Misspelled command surfaces via SequenceMatcher ratio."""
+        controller.on_text_changed("/hlep", 5)
+
+        mock_view.render_completion_suggestions.assert_called()
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        assert any("/help" in s[0] for s in suggestions)
 
     def test_prefix_match_ranks_first(self, controller, mock_view):
         """Prefix matches on command name rank above description matches."""
@@ -261,7 +277,7 @@ class TestSlashCommandController:
         # /help is a prefix match — should be first
         assert suggestions[0][0] == "/help"
 
-    def test_fuzzy_no_match_clears(self, controller, mock_view):
+    def test_no_match_clears(self, controller, mock_view):
         """Completely unrelated input clears suggestions."""
         controller.on_text_changed("/h", 2)
         mock_view.render_completion_suggestions.assert_called()
@@ -276,6 +292,36 @@ class TestSlashCommandController:
         controller.reset()
         # Second reset should be a no-op (suggestions already empty)
         controller.reset()
+
+
+class TestScoreCommand:
+    """Direct unit tests for SlashCommandController._score_command."""
+
+    score = staticmethod(SlashCommandController._score_command)
+
+    def test_prefix_returns_200(self):
+        assert self.score("hel", "/help", "Show help") == 200
+
+    def test_substring_name_returns_150(self):
+        assert self.score("omp", "/compact", "Summarize conversation") == 150
+
+    def test_substring_desc_returns_100(self):
+        assert self.score("exit", "/quit", "Exit app") == 100
+
+    def test_no_match_returns_zero(self):
+        assert self.score("zzzzz", "/help", "Show help") == 0
+
+    def test_fuzzy_above_threshold(self):
+        score = self.score("hlep", "/help", "Show help")
+        assert 0 < score < 100  # fuzzy tier, not substring/prefix
+
+    def test_tiers_ordering(self):
+        """Prefix > substring-name > substring-desc > fuzzy."""
+        prefix = self.score("hel", "/help", "Show help")
+        substr_name = self.score("omp", "/compact", "Summarize conversation")
+        substr_desc = self.score("exit", "/quit", "Exit app")
+        fuzzy = self.score("hlep", "/help", "Show help")
+        assert prefix > substr_name > substr_desc > fuzzy > 0
 
 
 class TestFuzzyFileControllerCanHandle:

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -236,6 +236,39 @@ class TestSlashCommandController:
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
         assert len(suggestions) == len(SLASH_COMMANDS)
 
+    def test_fuzzy_matches_description_exit(self, controller, mock_view):
+        """Typing 'exit' surfaces /quit via its description 'Exit app'."""
+        controller.on_text_changed("/exit", 5)
+
+        mock_view.render_completion_suggestions.assert_called()
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        assert any("/quit" in s[0] for s in suggestions)
+
+    def test_fuzzy_matches_description_new(self, controller, mock_view):
+        """Typing 'new' surfaces /clear via description containing 'new'."""
+        controller.on_text_changed("/new", 4)
+
+        mock_view.render_completion_suggestions.assert_called()
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        assert any("/clear" in s[0] for s in suggestions)
+
+    def test_prefix_match_ranks_first(self, controller, mock_view):
+        """Prefix matches on command name rank above description matches."""
+        controller.on_text_changed("/he", 3)
+
+        mock_view.render_completion_suggestions.assert_called()
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        # /help is a prefix match — should be first
+        assert suggestions[0][0] == "/help"
+
+    def test_fuzzy_no_match_clears(self, controller, mock_view):
+        """Completely unrelated input clears suggestions."""
+        controller.on_text_changed("/h", 2)
+        mock_view.render_completion_suggestions.assert_called()
+
+        controller.on_text_changed("/zzzzzzzzz", 10)
+        mock_view.clear_completion_suggestions.assert_called()
+
     @pytest.mark.usefixtures("mock_view")
     def test_double_reset_is_safe(self, controller):
         """Calling reset twice does not raise or double-clear."""

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from deepagents_cli.widgets.autocomplete import (
+    MAX_SUGGESTIONS,
     SLASH_COMMANDS,
     CompletionController,
     FuzzyFileController,
@@ -46,7 +47,7 @@ class TestFuzzyScore:
     def test_no_match_returns_low_score(self):
         """Completely unrelated strings get very low scores."""
         score = _fuzzy_score("xyz", "abc.py")
-        assert score < 25  # Below MIN_FUZZY_SCORE threshold
+        assert score < 15  # Below MIN_FUZZY_SCORE threshold
 
     def test_case_insensitive(self):
         """Matching is case insensitive."""
@@ -203,7 +204,7 @@ class TestSlashCommandController:
 
         mock_view.render_completion_suggestions.assert_called()
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
-        assert len(suggestions) == len(SLASH_COMMANDS)
+        assert len(suggestions) == min(len(SLASH_COMMANDS), MAX_SUGGESTIONS)
 
     def test_clears_on_no_match(self, controller, mock_view):
         """Clears suggestions when no commands match after having suggestions."""
@@ -234,7 +235,7 @@ class TestSlashCommandController:
         controller.on_text_changed("/", 1)
         mock_view.render_completion_suggestions.assert_called()
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
-        assert len(suggestions) == len(SLASH_COMMANDS)
+        assert len(suggestions) == min(len(SLASH_COMMANDS), MAX_SUGGESTIONS)
 
     def test_substring_description_match_exit(self, controller, mock_view):
         """Typing 'exit' surfaces /quit via substring match on 'Exit app'."""

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -237,6 +237,14 @@ class TestSlashCommandController:
         suggestions = mock_view.render_completion_suggestions.call_args[0][0]
         assert len(suggestions) == min(len(SLASH_COMMANDS), MAX_SUGGESTIONS)
 
+    def test_hidden_keyword_match_continue(self, controller, mock_view):
+        """Typing 'continue' surfaces /threads via hidden keyword."""
+        controller.on_text_changed("/continue", 9)
+
+        mock_view.render_completion_suggestions.assert_called()
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        assert any("/threads" in s[0] for s in suggestions)
+
     def test_substring_description_match_exit(self, controller, mock_view):
         """Typing 'exit' surfaces /quit via substring match on 'Exit app'."""
         controller.on_text_changed("/exit", 5)
@@ -320,15 +328,33 @@ class TestScoreCommand:
         score = self.score("hlep", "/help", "Show help")
         assert 0 < score < 100  # fuzzy tier, not substring/prefix
 
+    def test_hidden_keyword_prefix_match(self):
+        assert (
+            self.score("cont", "/threads", "Browse threads", "continue history") == 120
+        )
+
+    def test_hidden_keyword_substring_match(self):
+        assert (
+            self.score("hist", "/threads", "Browse threads", "continue history") == 120
+        )
+
+    def test_hidden_keyword_ignored_when_empty(self):
+        assert self.score("cont", "/threads", "Browse threads", "") == 0
+
+    def test_hidden_keyword_requires_min_length(self):
+        """Single-char queries do not match hidden keywords."""
+        assert self.score("c", "/threads", "Browse threads", "continue") == 0
+
     def test_tiers_ordering(self):
-        """Prefix > substring-name > substring-desc > fuzzy."""
+        """Prefix > substring-name > keyword > substring-desc > fuzzy."""
         prefix = self.score("hel", "/help", "Show help")
         substr_name = self.score("omp", "/compact", "Summarize conversation")
+        keyword = self.score("cont", "/threads", "Browse threads", "continue")
         desc_boundary = self.score("exit", "/quit", "Exit app")
         compact_desc = "Summarize conversation to reduce context usage"
         desc_mid = self.score("ex", "/compact", compact_desc)
         fuzzy = self.score("hlep", "/help", "Show help")
-        assert prefix > substr_name > desc_boundary > desc_mid > fuzzy > 0
+        assert prefix > substr_name > keyword > desc_boundary > desc_mid > fuzzy > 0
 
 
 class TestFuzzyFileControllerCanHandle:

--- a/libs/cli/tests/unit_tests/test_compact.py
+++ b/libs/cli/tests/unit_tests/test_compact.py
@@ -109,12 +109,12 @@ class TestCompactInAutocomplete:
 
     def test_compact_in_slash_commands(self) -> None:
         """The /compact command should be in the SLASH_COMMANDS list."""
-        labels = [label for label, _ in SLASH_COMMANDS]
+        labels = [label for label, *_ in SLASH_COMMANDS]
         assert "/compact" in labels
 
     def test_compact_sorted_alphabetically(self) -> None:
         """The /compact entry should appear between /clear and /docs."""
-        labels = [label for label, _ in SLASH_COMMANDS]
+        labels = [label for label, *_ in SLASH_COMMANDS]
         clear_idx = labels.index("/clear")
         compact_idx = labels.index("/compact")
         docs_idx = labels.index("/docs")


### PR DESCRIPTION
Closes #1290

Supersedes #1394 #1303

---

Replace prefix-only filtering with tiered fuzzy matching across both command names and descriptions.

Typing `/exit` now surfaces `/quit` (matched via its "Exit app" description), and `/new` surfaces `/clear` ("Clear chat and start **new** thread"). Prefix matches on the command name still rank highest, preserving existing behavior for exact-prefix input like `/he` → `/help`.

### Hidden keywords

Commands can now declare hidden keywords — space-separated terms that participate in fuzzy matching but are never shown to the user. For example, `/threads` declares `continue history`, so typing `/continue` surfaces `/threads` without polluting the visible description.

To add keywords to a command, set the third element of the tuple in `SLASH_COMMANDS`:

```python
("/threads", "Browse and resume previous threads", "continue history"),
```

### Noise reduction

- **Description matching requires ≥2 chars** — single-character queries like `/t` no longer match every command whose description contains that letter (10 results → 5)
- **Word-boundary awareness in descriptions** — `/ex` now ranks `/quit` ("**Ex**it app", 110) above `/compact` ("cont**ex**t usage", 90)

### Scoring tiers

| Tier | Score | Example |
|------|-------|---------|
| Prefix on name | 200 | `/hel` → `/help` |
| Substring in name | 150 | `/omp` → `/compact` |
| Hidden keyword | 120 | `/continue` → `/threads` |
| Description word-boundary | 110 | `/exit` → `/quit` |
| Description mid-word | 90 | `/ex` → `/compact` |
| Fuzzy (SequenceMatcher) | 25–60 | `/hlep` → `/help` |