### PR TITLE
fix(cli): backspace at cursor position 0 exits mode even with text

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1328,11 +1328,14 @@ class ChatInput(Vertical):
         if not self._completion_manager or not self._text_area:
             return
 
-        # Backspace on empty input exits the current mode (e.g. command/bash)
+        # Backspace at cursor position 0 (or on empty input) exits the
+        # current mode (e.g. command/bash).  When the cursor is at the very
+        # start of the text area, backspace is a no-op for the underlying
+        # widget, so without this guard the user would be stuck in the mode.
         if (
             event.key == "backspace"
-            and not self._text_area.text
             and self.mode != "normal"
+            and self._get_cursor_offset() == 0
         ):
             self._completion_manager.reset()
             self.mode = "normal"

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -11,7 +11,7 @@ from textual.widgets import Static
 
 from deepagents_cli.input import ImageTracker
 from deepagents_cli.widgets import chat_input as chat_input_module
-from deepagents_cli.widgets.autocomplete import SLASH_COMMANDS
+from deepagents_cli.widgets.autocomplete import MAX_SUGGESTIONS, SLASH_COMMANDS
 from deepagents_cli.widgets.chat_input import (
     ChatInput,
     CompletionOption,
@@ -677,7 +677,9 @@ class TestDismissCompletion:
             await _pause_for_strip(pilot)
 
             # Menu should reappear with all commands
-            assert len(chat._current_suggestions) == len(SLASH_COMMANDS)
+            assert len(chat._current_suggestions) == min(
+                len(SLASH_COMMANDS), MAX_SUGGESTIONS
+            )
             assert popup.styles.display == "block"
 
     async def test_popup_hide_cancels_pending_rebuild(self) -> None:
@@ -790,6 +792,31 @@ class TestModePrefixStripping:
             assert chat.mode == "command"
 
             # Second backspace on empty — exits mode
+            await pilot.press("backspace")
+            await pilot.pause()
+            assert chat.mode == "normal"
+
+    async def test_backspace_at_cursor_zero_with_text_exits_mode(self) -> None:
+        """Backspace at cursor position 0 with text after cursor exits mode."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            # Enter command mode and type some text
+            chat._text_area.insert("/")
+            await _pause_for_strip(pilot)
+            assert chat.mode == "command"
+
+            chat._text_area.insert("help")
+            await pilot.pause()
+            assert chat._text_area.text == "help"
+
+            # Move cursor to position 0 (beginning of field)
+            chat._text_area.move_cursor((0, 0))
+            await pilot.pause()
+
+            # Backspace at position 0 with text after cursor — should exit mode
             await pilot.press("backspace")
             await pilot.pause()
             assert chat.mode == "normal"


### PR DESCRIPTION
Backspace in a non-normal mode (command, bash) previously only exited the mode when the text area was completely empty. If a user typed `/help`, moved the cursor to position 0, and pressed backspace, nothing happened — the underlying Textual widget treats backspace at position 0 as a no-op, so the mode-exit guard never fired and the user was stuck.