### PR TITLE
fix(cli): skip auto-approve toggle when modal screen is open

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2484,6 +2484,8 @@ class DeepAgentsApp(App):
         web search, URL fetch) run without prompting. Updates the status
         bar indicator and session state.
         """
+        if isinstance(self.screen, ModalScreen):
+            return
         self._auto_approve = not self._auto_approve
         if self._status_bar:
             self._status_bar.set_auto_approve(enabled=self._auto_approve)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2484,6 +2484,8 @@ class DeepAgentsApp(App):
         web search, URL fetch) run without prompting. Updates the status
         bar indicator and session state.
         """
+        # shift+tab is reused for navigation inside modal screens (e.g.
+        # ModelSelectorScreen); skip the toggle so it doesn't fire through.
         if isinstance(self.screen, ModalScreen):
             return
         self._auto_approve = not self._auto_approve


### PR DESCRIPTION
Prevent `shift+tab` from toggling auto-approve mode while a modal screen (e.g., the model selector) is open. Both the app-level binding and `ModelSelectorScreen` bind `shift+tab` with `priority=True` — the app binding was firing through the modal, inadvertently flipping approval state.