### PR TITLE
feat(cli): tab autocomplete in model selector

### DIFF
--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -100,8 +100,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         Binding("k", "move_up", "Up", show=False, priority=True),
         Binding("down", "move_down", "Down", show=False, priority=True),
         Binding("j", "move_down", "Down", show=False, priority=True),
-        Binding("tab", "move_down", "Down", show=False, priority=True),
-        Binding("shift+tab", "move_up", "Up", show=False, priority=True),
+        Binding("tab", "tab_complete", "Tab complete", show=False, priority=True),
         Binding("pageup", "page_up", "Page up", show=False, priority=True),
         Binding("pagedown", "page_down", "Page down", show=False, priority=True),
         Binding("enter", "select", "Select", show=False, priority=True),
@@ -272,9 +271,10 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
             # Help text
             help_text = (
-                f"{glyphs.arrow_up}/{glyphs.arrow_down}/tab navigate {glyphs.bullet} "
-                f"Enter select {glyphs.bullet} Ctrl+S set default "
-                f"{glyphs.bullet} Esc cancel"
+                f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
+                f" {glyphs.bullet} Enter select"
+                f" {glyphs.bullet} Ctrl+S set default"
+                f" {glyphs.bullet} Esc cancel"
             )
             yield Static(help_text, classes="model-selector-help")
 
@@ -541,6 +541,15 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         """Move selection down."""
         self._move_selection(1)
 
+    def action_tab_complete(self) -> None:
+        """Replace search text with the currently selected model spec."""
+        if not self._filtered_models:
+            return
+        model_spec, _ = self._filtered_models[self._selected_index]
+        filter_input = self.query_one("#model-filter", Input)
+        filter_input.value = model_spec
+        filter_input.cursor_position = len(model_spec)
+
     def _visible_page_size(self) -> int:
         """Return the number of model options that fit in one visual page.
 
@@ -642,9 +651,10 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         """Restore the default help text after a temporary message."""
         glyphs = get_glyphs()
         help_text = (
-            f"{glyphs.arrow_up}/{glyphs.arrow_down}/tab navigate {glyphs.bullet} "
-            f"Enter select {glyphs.bullet} Ctrl+S set default "
-            f"{glyphs.bullet} Esc cancel"
+            f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
+            f" {glyphs.bullet} Enter select"
+            f" {glyphs.bullet} Ctrl+S set default"
+            f" {glyphs.bullet} Esc cancel"
         )
         help_widget = self.query_one(".model-selector-help", Static)
         help_widget.update(help_text)

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -529,6 +529,94 @@ class TestModelSelectorFuzzyMatching:
                 f"'claude sonnet' should match claude-sonnet models. Got: {specs}"
             )
 
+    async def test_tab_noop_when_no_matches(self) -> None:
+        """Tab should do nothing when filter matches no models."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            # Type gibberish that matches nothing
+            for char in "xyz999qqq":
+                await pilot.press(char)
+            await pilot.pause()
+
+            assert len(screen._filtered_models) == 0
+
+            # Press tab - should not crash or change input
+            await pilot.press("tab")
+            await pilot.pause()
+
+            from textual.widgets import Input
+
+            filter_input = screen.query_one("#model-filter", Input)
+            assert filter_input.value == "xyz999qqq"
+
+    async def test_tab_autocompletes_after_navigation(self) -> None:
+        """Tab should autocomplete the model navigated to, not just index 0."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            # Type a partial filter
+            for char in "claude":
+                await pilot.press(char)
+            await pilot.pause()
+
+            assert len(screen._filtered_models) > 1, (
+                "Need multiple claude matches to test navigation"
+            )
+
+            # Navigate down to select a different model
+            await pilot.press("down")
+            await pilot.pause()
+
+            assert screen._selected_index == 1
+            expected_spec, _ = screen._filtered_models[1]
+
+            # Press tab - should autocomplete the navigated-to model
+            await pilot.press("tab")
+            await pilot.pause()
+
+            from textual.widgets import Input
+
+            filter_input = screen.query_one("#model-filter", Input)
+            assert filter_input.value == expected_spec
+
+    async def test_tab_autocompletes_selected_model(self) -> None:
+        """Tab should replace search text with the selected model spec."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            # Type a partial filter
+            for char in "claude":
+                await pilot.press(char)
+            await pilot.pause()
+
+            assert len(screen._filtered_models) > 0
+            expected_spec, _ = screen._filtered_models[screen._selected_index]
+
+            # Press tab - should replace filter text with selected model spec
+            await pilot.press("tab")
+            await pilot.pause()
+
+            from textual.widgets import Input
+
+            filter_input = screen.query_one("#model-filter", Input)
+            assert filter_input.value == expected_spec
+
     async def test_navigation_after_fuzzy_filter(self) -> None:
         """Arrow keys should work correctly on fuzzy-filtered results."""
         app = ModelSelectorTestApp()


### PR DESCRIPTION
Repurpose the Tab key in `ModelSelectorScreen` from navigation (duplicate of arrow keys) to autocomplete — pressing Tab fills the search input with the currently highlighted model spec, matching the standard shell-completion mental model.