### PR TITLE
release(sdk): bump deepagents to 0.4.6

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.4.5",
+    "deepagents==0.4.6",
     "langchain>=1.2.10,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",
 

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -855,7 +855,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "../deepagents" }
 dependencies = [
     { name = "langchain" },

--- a/libs/deepagents/deepagents/_version.py
+++ b/libs/deepagents/deepagents/_version.py
@@ -1,3 +1,3 @@
 """Version information for `deepagents` (SDK)."""
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 
 description = "General purpose 'deep agent' with sub-agent spawning, todo list capabilities, and mock file system. Built on LangGraph."
 readme = "README.md"

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "langchain" },

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -687,7 +687,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "../deepagents" }
 dependencies = [
     { name = "langchain" },

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "../../deepagents" }
 dependencies = [
     { name = "langchain" },

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "../../deepagents" }
 dependencies = [
     { name = "langchain" },

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "../../deepagents" }
 dependencies = [
     { name = "langchain" },


### PR DESCRIPTION
Patch version bump for deepagents SDK from 0.4.5 to 0.4.6. Also updates the CLI's pinned SDK version to match.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).