### PR TITLE
feat(cli): add `--model-params` flag to `/model` command

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import shlex
 import signal
 import sys
 import uuid
@@ -176,6 +178,99 @@ if _IS_ITERM:
         _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
 
     atexit.register(_restore_cursor_guide)
+
+
+def _extract_model_params_flag(raw_arg: str) -> tuple[str, dict[str, Any] | None]:
+    """Extract `--model-params` and its JSON value from a `/model` arg string.
+
+    Handles quoted (`'...'` / `"..."`) and bare `{...}` values with balanced
+    braces so that JSON containing spaces works without quoting.
+
+    Note:
+        The bare-brace mode counts `{` / `}` characters without awareness of
+        JSON string contents. Values that contain literal braces inside strings
+        (e.g., `{"stop": "end}here"}`) will mis-parse. Users should quote the
+        value in that case.
+
+    Args:
+        raw_arg: The argument string after `/model `.
+
+    Returns:
+        Tuple of `(remaining_args, parsed_dict | None)`. Returns `None` for the
+            dict when the flag is absent.
+
+    Raises:
+        ValueError: If the value is missing, has unclosed quotes,
+            unbalanced braces, or is not valid JSON.
+        TypeError: If the parsed JSON is not a dict.
+    """
+    flag = "--model-params"
+    idx = raw_arg.find(flag)
+    if idx == -1:
+        return raw_arg, None
+
+    before = raw_arg[:idx].rstrip()
+    after = raw_arg[idx + len(flag) :].lstrip()
+
+    if not after:
+        msg = "--model-params requires a JSON object value"
+        raise ValueError(msg)
+
+    # Determine the JSON string boundaries.
+    if after[0] in {"'", '"'}:
+        quote = after[0]
+        end = -1
+        backslash_count = 0
+        for i, ch in enumerate(after[1:], start=1):
+            if ch == "\\":
+                backslash_count += 1
+                continue
+            if ch == quote and backslash_count % 2 == 0:
+                end = i
+                break
+            backslash_count = 0
+        if end == -1:
+            msg = f"Unclosed {quote} in --model-params value"
+            raise ValueError(msg)
+        # Parse the quoted token with shlex so escaped quotes are unescaped.
+        json_str = shlex.split(after[: end + 1], posix=True)[0]
+        rest = after[end + 1 :].lstrip()
+    elif after[0] == "{":
+        # Walk forward to find the matching closing brace.
+        depth = 0
+        end = -1
+        for i, ch in enumerate(after):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        if end == -1:
+            msg = "Unbalanced braces in --model-params value"
+            raise ValueError(msg)
+        json_str = after[: end + 1]
+        rest = after[end + 1 :].lstrip()
+    else:
+        # Non-brace, non-quoted — take the next whitespace-delimited token.
+        parts = after.split(None, 1)
+        json_str = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+
+    remaining = f"{before} {rest}".strip()
+    try:
+        params = json.loads(json_str)
+    except json.JSONDecodeError:
+        msg = (
+            f"Invalid JSON in --model-params: {json_str!r}. "
+            'Expected format: --model-params \'{"key": "value"}\''
+        )
+        raise ValueError(msg) from None
+    if not isinstance(params, dict):
+        msg = "--model-params must be a JSON object, got " + type(params).__name__
+        raise TypeError(msg)
+    return remaining, params
 
 
 InputMode = Literal["normal", "bash", "command"]
@@ -1295,7 +1390,8 @@ class DeepAgentsApp(App):
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))
             help_text = Text(
-                "Commands: /quit, /clear, /compact, /model [--default], /remember, "
+                "Commands: /quit, /clear, /compact, "
+                "/model [--model-params JSON] [--default], /remember, "
                 "/tokens, /threads, /trace, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
@@ -1428,17 +1524,32 @@ class DeepAgentsApp(App):
         elif cmd == "/model" or cmd.startswith("/model "):
             model_arg = None
             set_default = False
+            extra_kwargs: dict[str, Any] | None = None
             if cmd.startswith("/model "):
                 raw_arg = command.strip()[len("/model ") :].strip()
+                try:
+                    raw_arg, extra_kwargs = _extract_model_params_flag(raw_arg)
+                except (ValueError, TypeError) as exc:
+                    await self._mount_message(UserMessage(command))
+                    await self._mount_message(ErrorMessage(str(exc)))
+                    return
                 if raw_arg.startswith("--default"):
                     set_default = True
                     model_arg = raw_arg[len("--default") :].strip() or None
                 else:
-                    model_arg = raw_arg
+                    model_arg = raw_arg or None
 
             if set_default:
                 await self._mount_message(UserMessage(command))
-                if model_arg == "--clear":
+                if extra_kwargs:
+                    await self._mount_message(
+                        ErrorMessage(
+                            "--model-params cannot be used with --default. "
+                            "Model params are applied per-session, not "
+                            "persisted."
+                        )
+                    )
+                elif model_arg == "--clear":
                     await self._clear_default_model()
                 elif model_arg:
                     await self._set_default_model(model_arg)
@@ -1452,9 +1563,9 @@ class DeepAgentsApp(App):
             elif model_arg:
                 # Direct switch: /model claude-sonnet-4-5
                 await self._mount_message(UserMessage(command))
-                await self._switch_model(model_arg)
+                await self._switch_model(model_arg, extra_kwargs=extra_kwargs)
             else:
-                await self._show_model_selector()
+                await self._show_model_selector(extra_kwargs=extra_kwargs)
         else:
             await self._mount_message(UserMessage(command))
             await self._mount_message(AppMessage(f"Unknown command: {cmd}"))
@@ -2604,14 +2715,29 @@ class DeepAgentsApp(App):
     # Model Switching
     # =========================================================================
 
-    async def _show_model_selector(self) -> None:
-        """Show interactive model selector as a modal screen."""
+    async def _show_model_selector(
+        self,
+        *,
+        extra_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Show interactive model selector as a modal screen.
+
+        Args:
+            extra_kwargs: Extra constructor kwargs from `--model-params`.
+        """
+        from functools import partial
 
         def handle_result(result: tuple[str, str] | None) -> None:
             """Handle the model selector result."""
             if result is not None:
                 model_spec, _ = result
-                self.call_later(self._switch_model, model_spec)
+                self.call_later(
+                    partial(
+                        self._switch_model,
+                        model_spec,
+                        extra_kwargs=extra_kwargs,
+                    )
+                )
             # Refocus input after modal closes
             if self._chat_input:
                 self._chat_input.focus_input()
@@ -2778,7 +2904,12 @@ class DeepAgentsApp(App):
             if self._chat_input:
                 self._chat_input.set_cursor_active(active=not self._agent_running)
 
-    async def _switch_model(self, model_spec: str) -> None:
+    async def _switch_model(
+        self,
+        model_spec: str,
+        *,
+        extra_kwargs: dict[str, Any] | None = None,
+    ) -> None:
         """Switch to a new model, preserving conversation history.
 
         Args:
@@ -2787,6 +2918,7 @@ class DeepAgentsApp(App):
                 Can be in `provider:model` format
                 (e.g., `'anthropic:claude-sonnet-4-5'`) or just the model name
                 for auto-detection.
+            extra_kwargs: Extra constructor kwargs from `--model-params`.
         """
         logger.info("Switching model to %s", model_spec)
 
@@ -2850,7 +2982,7 @@ class DeepAgentsApp(App):
             return
 
         try:
-            result = create_model(model_spec)
+            result = create_model(model_spec, extra_kwargs=extra_kwargs)
         except ModelConfigError as e:
             await self._mount_message(ErrorMessage(str(e)))
             return

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -101,7 +101,7 @@ SLASH_COMMANDS: list[tuple[str, str, str]] = [
     ("/compact", "Summarize conversation to reduce context usage", ""),
     ("/docs", "Open documentation in browser", ""),
     ("/feedback", "Submit a bug report or feature request", ""),
-    ("/model", "Switch model, show selector, or set default (--default)", ""),
+    ("/model", "Switch or configure model (--model-params, --default)", ""),
     ("/remember", "Update memory and skills from conversation", ""),
     ("/quit", "Exit app", "close leave"),
     ("/tokens", "Token usage", "cost"),

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from deepagents_cli import model_config
-from deepagents_cli.app import DeepAgentsApp
+from deepagents_cli.app import DeepAgentsApp, _extract_model_params_flag
 from deepagents_cli.config import ModelResult, settings
 from deepagents_cli.model_config import ModelConfigError, clear_caches
 from deepagents_cli.widgets.messages import AppMessage, ErrorMessage
@@ -644,3 +644,205 @@ class TestModelSwitchBareModelName:
         app._mount_message.assert_called_once()  # type: ignore[union-attr]
         assert len(captured_messages) == 1
         assert "Already using" in captured_messages[0]
+
+
+class TestExtractModelParamsFlag:
+    """Tests for _extract_model_params_flag helper."""
+
+    def test_no_flag(self) -> None:
+        """Returns original string and None when flag absent."""
+        remaining, params = _extract_model_params_flag("anthropic:claude-sonnet-4-5")
+        assert remaining == "anthropic:claude-sonnet-4-5"
+        assert params is None
+
+    def test_single_quoted_json(self) -> None:
+        """Extracts JSON from single-quoted value."""
+        raw = """--model-params '{"temperature": 0.7}' anthropic:claude-sonnet-4-5"""
+        remaining, params = _extract_model_params_flag(raw)
+        assert remaining == "anthropic:claude-sonnet-4-5"
+        assert params == {"temperature": 0.7}
+
+    def test_double_quoted_json_with_escaped_quotes(self) -> None:
+        """Extracts JSON from double-quoted value with escaped inner quotes."""
+        raw = '--model-params "{\\"temperature\\": 0.7}" anthropic:claude-sonnet-4-5'
+        remaining, params = _extract_model_params_flag(raw)
+        assert remaining == "anthropic:claude-sonnet-4-5"
+        assert params == {"temperature": 0.7}
+
+    def test_bare_braces(self) -> None:
+        """Extracts JSON from unquoted braces with balanced matching."""
+        raw = '--model-params {"temperature": 0.7, "max_tokens": 100}'
+        remaining, params = _extract_model_params_flag(raw)
+        assert remaining == ""
+        assert params == {"temperature": 0.7, "max_tokens": 100}
+
+    def test_bare_braces_with_model_after(self) -> None:
+        """Model arg after bare-brace JSON is preserved."""
+        raw = '--model-params {"temperature":0.7} anthropic:claude-sonnet-4-5'
+        remaining, params = _extract_model_params_flag(raw)
+        assert remaining == "anthropic:claude-sonnet-4-5"
+        assert params == {"temperature": 0.7}
+
+    def test_model_before_flag(self) -> None:
+        """Model arg before --model-params is preserved."""
+        raw = "anthropic:claude-sonnet-4-5 --model-params '{\"temperature\": 0.7}'"
+        remaining, params = _extract_model_params_flag(raw)
+        assert remaining == "anthropic:claude-sonnet-4-5"
+        assert params == {"temperature": 0.7}
+
+    def test_missing_value_raises(self) -> None:
+        """Raises ValueError when --model-params has no value."""
+        with pytest.raises(ValueError, match="requires a JSON object"):
+            _extract_model_params_flag("--model-params")
+
+    def test_invalid_json_raises(self) -> None:
+        """Raises ValueError with hint for malformed JSON."""
+        with pytest.raises(ValueError, match=r"Invalid JSON.*Expected format"):
+            _extract_model_params_flag("--model-params '{not json}'")
+
+    def test_non_dict_json_raises(self) -> None:
+        """Raises TypeError when JSON is not an object."""
+        with pytest.raises(TypeError, match="must be a JSON object"):
+            _extract_model_params_flag("--model-params '[1, 2, 3]'")
+
+    def test_unclosed_quote_raises(self) -> None:
+        """Raises ValueError for unclosed quote."""
+        with pytest.raises(ValueError, match="Unclosed"):
+            _extract_model_params_flag("""--model-params '{"temperature": 0.7}""")
+
+    def test_unbalanced_braces_raises(self) -> None:
+        """Raises ValueError for unbalanced braces."""
+        with pytest.raises(ValueError, match="Unbalanced"):
+            _extract_model_params_flag('--model-params {"temperature": 0.7')
+
+    def test_with_default_flag(self) -> None:
+        """Works alongside --default flag."""
+        raw = (
+            """--model-params '{"temperature": 0.7}' """
+            "--default anthropic:claude-sonnet-4-5"
+        )
+        remaining, params = _extract_model_params_flag(raw)
+        assert remaining == "--default anthropic:claude-sonnet-4-5"
+        assert params == {"temperature": 0.7}
+
+    def test_empty_object(self) -> None:
+        """Empty JSON object is valid."""
+        remaining, params = _extract_model_params_flag("--model-params '{}'")
+        assert remaining == ""
+        assert params == {}
+
+
+class TestModelSwitchExtraKwargs:
+    """Tests for extra_kwargs forwarding through _switch_model."""
+
+    async def test_extra_kwargs_forwarded_to_create_model(self) -> None:
+        """_switch_model passes extra_kwargs to create_model."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        mock_model = MagicMock()
+        mock_result = MagicMock(spec=ModelResult)
+        mock_result.model = mock_model
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.app.create_model", return_value=mock_result
+            ) as mock_create,
+            patch("deepagents_cli.app.save_recent_model", return_value=True),
+            patch("deepagents_cli.agent.create_cli_agent") as mock_agent,
+        ):
+            mock_agent.return_value = (MagicMock(), MagicMock())
+            await app._switch_model(
+                "anthropic:claude-sonnet-4-5",
+                extra_kwargs={"temperature": 0.7},
+            )
+
+        mock_create.assert_called_once_with(
+            "anthropic:claude-sonnet-4-5",
+            extra_kwargs={"temperature": 0.7},
+        )
+
+    async def test_no_extra_kwargs_by_default(self) -> None:
+        """_switch_model passes None extra_kwargs when not provided."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        mock_model = MagicMock()
+        mock_result = MagicMock(spec=ModelResult)
+        mock_result.model = mock_model
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.app.create_model", return_value=mock_result
+            ) as mock_create,
+            patch("deepagents_cli.app.save_recent_model", return_value=True),
+            patch("deepagents_cli.agent.create_cli_agent") as mock_agent,
+        ):
+            mock_agent.return_value = (MagicMock(), MagicMock())
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        mock_create.assert_called_once_with(
+            "anthropic:claude-sonnet-4-5",
+            extra_kwargs=None,
+        )
+
+
+class TestModelCommandIntegration:
+    """Tests for /model command handler integration."""
+
+    async def test_invalid_model_params_shows_error(self) -> None:
+        """/model with invalid --model-params JSON shows error."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+
+        captured_errors: list[str] = []
+        original_init = ErrorMessage.__init__
+
+        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+            captured_errors.append(message)
+            original_init(self, message, **kwargs)
+
+        with patch.object(ErrorMessage, "__init__", capture_init):
+            await app._handle_command("/model --model-params '{bad}'")
+
+        assert len(captured_errors) == 1
+        assert "Invalid JSON" in captured_errors[0]
+        assert "Expected format" in captured_errors[0]
+
+    async def test_model_params_with_default_rejected(self) -> None:
+        """/model --model-params with --default shows error."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+
+        captured_errors: list[str] = []
+        original_init = ErrorMessage.__init__
+
+        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+            captured_errors.append(message)
+            original_init(self, message, **kwargs)
+
+        cmd = (
+            """/model --model-params '{"temperature": 0.7}' """
+            "--default anthropic:claude-sonnet-4-5"
+        )
+        with patch.object(ErrorMessage, "__init__", capture_init):
+            await app._handle_command(cmd)
+
+        assert len(captured_errors) == 1
+        assert "cannot be used with --default" in captured_errors[0]


### PR DESCRIPTION
Add a `--model-params` flag to the `/model` slash command, allowing users to pass arbitrary model constructor kwargs (e.g., `temperature`, `max_tokens`) as a JSON object when switching models mid-session. The params are session-scoped and intentionally blocked from `--default` persistence.