### PR TITLE
fix(deepagents): restore full routed path in write/edit results

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -19,6 +19,7 @@ Examples:
 """
 
 from collections import defaultdict
+from dataclasses import replace
 from typing import cast
 
 from deepagents.backends.protocol import (
@@ -417,6 +418,8 @@ class CompositeBackend(BackendProtocol):
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = backend.write(stripped_key, content)
+        if res.path is not None:
+            res = replace(res, path=file_path)
         # If this is a state-backed update and default has state, merge so listings reflect changes
         if res.files_update:
             try:
@@ -438,6 +441,8 @@ class CompositeBackend(BackendProtocol):
         """Async version of write."""
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.awrite(stripped_key, content)
+        if res.path is not None:
+            res = replace(res, path=file_path)
         # If this is a state-backed update and default has state, merge so listings reflect changes
         if res.files_update:
             try:
@@ -471,6 +476,8 @@ class CompositeBackend(BackendProtocol):
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = backend.edit(stripped_key, old_string, new_string, replace_all=replace_all)
+        if res.path is not None:
+            res = replace(res, path=file_path)
         if res.files_update:
             try:
                 runtime = getattr(self.default, "runtime", None)
@@ -493,6 +500,8 @@ class CompositeBackend(BackendProtocol):
         """Async version of edit."""
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.aedit(stripped_key, old_string, new_string, replace_all=replace_all)
+        if res.path is not None:
+            res = replace(res, path=file_path)
         if res.files_update:
             try:
                 runtime = getattr(self.default, "runtime", None)

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -127,7 +127,7 @@ def test_composite_backend_store_to_store():
 
     # Write to routed store
     res2 = comp.write("/memories/important.txt", "routed store content")
-    assert isinstance(res2, WriteResult) and res2.error is None and res2.path == "/important.txt"
+    assert isinstance(res2, WriteResult) and res2.error is None and res2.path == "/memories/important.txt"
 
     # Read from both
     content1 = comp.read("/notes.txt")
@@ -172,17 +172,17 @@ def test_composite_backend_multiple_routes():
     # Write to /memories/ route
     res_mem = comp.write("/memories/important.md", "long-term memory")
     assert res_mem.files_update is None  # Store backend doesn't return files_update
-    assert res_mem.path == "/important.md"
+    assert res_mem.path == "/memories/important.md"
 
     # Write to /archive/ route
     res_arch = comp.write("/archive/old.log", "archived log")
     assert res_arch.files_update is None
-    assert res_arch.path == "/old.log"
+    assert res_arch.path == "/archive/old.log"
 
     # Write to /cache/ route
     res_cache = comp.write("/cache/session.json", "cached session")
     assert res_cache.files_update is None
-    assert res_cache.path == "/session.json"
+    assert res_cache.path == "/cache/session.json"
 
     # ls_info at root should aggregate all
     infos = comp.ls_info("/")
@@ -215,6 +215,7 @@ def test_composite_backend_multiple_routes():
     edit_res = comp.edit("/memories/important.md", "long-term", "persistent", replace_all=False)
     assert edit_res.error is None
     assert edit_res.occurrences == 1
+    assert edit_res.path == "/memories/important.md"
 
     updated_content = comp.read("/memories/important.md")
     assert "persistent memory" in updated_content
@@ -1306,3 +1307,26 @@ def test_route_for_path_no_trailing_slash_boundary() -> None:
         "/abcde/file.txt",
         None,
     )
+
+
+def test_write_result_path_restored_to_full_routed_path():
+    """CompositeBackend.write should return the full path, not the stripped key."""
+    rt = make_runtime()
+    comp = build_composite_state_backend(rt, routes={"/memories/": StoreBackend})
+
+    res = comp.write("/memories/site_context.md", "content")
+
+    assert res.error is None
+    assert res.path == "/memories/site_context.md"  # not "/site_context.md"
+
+
+def test_edit_result_path_restored_to_full_routed_path():
+    """CompositeBackend.edit should return the full path, not the stripped key."""
+    rt = make_runtime()
+    comp = build_composite_state_backend(rt, routes={"/memories/": StoreBackend})
+    comp.write("/memories/notes.md", "hello world")
+
+    res = comp.edit("/memories/notes.md", "hello", "goodbye")
+
+    assert res.error is None
+    assert res.path == "/memories/notes.md"  # not "/notes.md"

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -151,7 +151,7 @@ async def test_composite_backend_store_to_store_async():
 
     # Write to routed store
     res2 = await comp.awrite("/memories/important.txt", "routed store content")
-    assert isinstance(res2, WriteResult) and res2.error is None and res2.path == "/important.txt"
+    assert isinstance(res2, WriteResult) and res2.error is None and res2.path == "/memories/important.txt"
 
     # Read from both
     content1 = await comp.aread("/notes.txt")
@@ -195,17 +195,17 @@ async def test_composite_backend_multiple_routes_async():
     # Write to /memories/ route
     res_mem = await comp.awrite("/memories/important.md", "long-term memory")
     assert res_mem.files_update is None
-    assert res_mem.path == "/important.md"
+    assert res_mem.path == "/memories/important.md"
 
     # Write to /archive/ route
     res_arch = await comp.awrite("/archive/old.log", "archived log")
     assert res_arch.files_update is None
-    assert res_arch.path == "/old.log"
+    assert res_arch.path == "/archive/old.log"
 
     # Write to /cache/ route
     res_cache = await comp.awrite("/cache/session.json", "cached session")
     assert res_cache.files_update is None
-    assert res_cache.path == "/session.json"
+    assert res_cache.path == "/cache/session.json"
 
     # als_info at root should aggregate all
     infos = await comp.als_info("/")
@@ -238,6 +238,7 @@ async def test_composite_backend_multiple_routes_async():
     edit_res = await comp.aedit("/memories/important.md", "long-term", "persistent", replace_all=False)
     assert edit_res.error is None
     assert edit_res.occurrences == 1
+    assert edit_res.path == "/memories/important.md"
 
     updated_content = await comp.aread("/memories/important.md")
     assert "persistent memory" in updated_content
@@ -1034,3 +1035,26 @@ async def test_composite_aglob_info_nested_path_in_route_async() -> None:
     result_paths = sorted([fi["path"] for fi in results])
 
     assert result_paths == ["/archive/2024/feb.log", "/archive/2024/jan.log"]
+
+
+async def test_awrite_result_path_restored_to_full_routed_path():
+    """CompositeBackend.awrite should return the full path, not the stripped key."""
+    rt = make_runtime()
+    comp = build_composite_state_backend(rt, routes={"/memories/": StoreBackend})
+
+    res = await comp.awrite("/memories/site_context.md", "content")
+
+    assert res.error is None
+    assert res.path == "/memories/site_context.md"  # not "/site_context.md"
+
+
+async def test_aedit_result_path_restored_to_full_routed_path():
+    """CompositeBackend.aedit should return the full path, not the stripped key."""
+    rt = make_runtime()
+    comp = build_composite_state_backend(rt, routes={"/memories/": StoreBackend})
+    await comp.awrite("/memories/notes.md", "hello world")
+
+    res = await comp.aedit("/memories/notes.md", "hello", "goodbye")
+
+    assert res.error is None
+    assert res.path == "/memories/notes.md"  # not "/notes.md"


### PR DESCRIPTION
## Problem

`CompositeBackend.write`/`edit` return the stripped path (e.g. `/site_context.md`) instead of the full routed path (`/memories/site_context.md`). Agents see the wrong path and attempt unnecessary recovery operations.

Fixes #1680

## Fix

Apply `dataclasses.replace(res, path=file_path)` in `write`, `awrite`, `edit`, `aedit` — matching the precedent set by [`upload_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/deepagents/deepagents/backends/composite.py#L603-L607) which already restores original paths.

Existing tests that asserted the incorrect stripped paths are updated, plus 4 new regression tests (sync + async).

## Design note

This fix patches the path after the fact. Ideally, `write`/`edit` would construct their own response objects (like `upload_files` does) so the stripped path never leaks out in the first place. Happy to refactor it that way if you'd prefer.
