### PR TITLE
refactor(cli): rename bash input mode to shell

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -178,7 +178,7 @@ if _IS_ITERM:
     atexit.register(_restore_cursor_guide)
 
 
-InputMode = Literal["normal", "bash", "command"]
+InputMode = Literal["normal", "shell", "command"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -480,10 +480,10 @@ class DeepAgentsApp(App):
         # Agent task tracking for interruption
         self._agent_worker: Worker[None] | None = None
         self._agent_running = False
-        # Bash process tracking for interruption (! commands)
-        self._bash_process: asyncio.subprocess.Process | None = None
-        self._bash_worker: Worker[None] | None = None
-        self._bash_running = False
+        # Shell command process tracking for interruption (! commands)
+        self._shell_process: asyncio.subprocess.Process | None = None
+        self._shell_worker: Worker[None] | None = None
+        self._shell_running = False
         self._loading_widget: LoadingWidget | None = None
         self._token_tracker: TextualTokenTracker | None = None
         # Cumulative usage stats across all turns in this session
@@ -1006,8 +1006,8 @@ class DeepAgentsApp(App):
             value: The message text to process.
             mode: The input mode that determines message routing.
         """
-        if mode == "bash":
-            await self._handle_bash_command(value.removeprefix("!"))
+        if mode == "shell":
+            await self._handle_shell_command(value.removeprefix("!"))
         elif mode == "command":
             await self._handle_command(value)
         elif mode == "normal":
@@ -1033,8 +1033,8 @@ class DeepAgentsApp(App):
             )
             return
 
-        # If agent or bash command is running, enqueue instead of processing
-        if self._agent_running or self._bash_running:
+        # If agent or shell command is running, enqueue instead of processing
+        if self._agent_running or self._shell_running:
             self._pending_messages.append(QueuedMessage(text=value, mode=mode))
             queued_widget = QueuedUserMessage(value)
             self._queued_widgets.append(queued_widget)
@@ -1062,28 +1062,28 @@ class DeepAgentsApp(App):
         if self._chat_input:
             self.call_after_refresh(self._chat_input.focus_input)
 
-    async def _handle_bash_command(self, command: str) -> None:
-        """Handle a bash command (! prefix).
+    async def _handle_shell_command(self, command: str) -> None:
+        """Handle a shell command (! prefix).
 
         Thin dispatcher that mounts the user message and spawns a worker
         so the event loop stays free for key events (Esc/Ctrl+C).
 
         Args:
-            command: The bash command to execute.
+            command: The shell command to execute.
         """
         await self._mount_message(UserMessage(f"!{command}"))
-        self._bash_running = True
+        self._shell_running = True
 
         if self._chat_input:
             self._chat_input.set_cursor_active(active=False)
 
-        self._bash_worker = self.run_worker(
-            self._run_bash_task(command),
+        self._shell_worker = self.run_worker(
+            self._run_shell_task(command),
             exclusive=False,
         )
 
-    async def _run_bash_task(self, command: str) -> None:
-        """Run a bash command in a background worker.
+    async def _run_shell_task(self, command: str) -> None:
+        """Run a shell command in a background worker.
 
         This mirrors `_run_agent_task`: running in a worker keeps the event
         loop free so Esc/Ctrl+C can cancel the worker -> raise
@@ -1103,18 +1103,18 @@ class DeepAgentsApp(App):
                 cwd=self._cwd,
                 start_new_session=(sys.platform != "win32"),
             )
-            self._bash_process = proc
+            self._shell_process = proc
 
             try:
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(
                     proc.communicate(), timeout=60
                 )
             except TimeoutError:
-                await self._kill_bash_process()
+                await self._kill_shell_process()
                 await self._mount_message(ErrorMessage("Command timed out (60s limit)"))
                 return
             except asyncio.CancelledError:
-                await self._kill_bash_process()
+                await self._kill_shell_process()
                 raise
 
             output = (stdout_bytes or b"").decode(errors="replace").strip()
@@ -1137,35 +1137,35 @@ class DeepAgentsApp(App):
             chat.scroll_end(animate=False)
 
         except OSError as e:
-            logger.exception("Failed to execute bash command: %s", command)
+            logger.exception("Failed to execute shell command: %s", command)
             err_msg = f"Failed to run command: {e}"
             await self._mount_message(ErrorMessage(err_msg))
         finally:
-            await self._cleanup_bash_task()
+            await self._cleanup_shell_task()
 
-    async def _cleanup_bash_task(self) -> None:
-        """Clean up after bash task completes or is cancelled."""
-        was_interrupted = self._bash_process is not None and (
-            self._bash_worker is not None and self._bash_worker.is_cancelled
+    async def _cleanup_shell_task(self) -> None:
+        """Clean up after shell command task completes or is cancelled."""
+        was_interrupted = self._shell_process is not None and (
+            self._shell_worker is not None and self._shell_worker.is_cancelled
         )
-        self._bash_process = None
-        self._bash_running = False
-        self._bash_worker = None
+        self._shell_process = None
+        self._shell_running = False
+        self._shell_worker = None
         if was_interrupted:
             await self._mount_message(AppMessage("Command interrupted"))
         if self._chat_input:
             self._chat_input.set_cursor_active(active=True)
         await self._process_next_from_queue()
 
-    async def _kill_bash_process(self) -> None:
-        """Terminate the running bash process.
+    async def _kill_shell_process(self) -> None:
+        """Terminate the running shell command process.
 
         On POSIX, sends SIGTERM to the entire process group (killing children).
         On Windows, terminates only the root process. No-op if the process has
         already exited. Waits up to 5s for clean shutdown, then escalates
         to SIGKILL.
         """
-        proc = self._bash_process
+        proc = self._shell_process
         if proc is None or proc.returncode is not None:
             return
 
@@ -1178,7 +1178,7 @@ class DeepAgentsApp(App):
             return
         except OSError:
             logger.warning(
-                "Failed to terminate bash process (pid=%s)", proc.pid, exc_info=True
+                "Failed to terminate shell process (pid=%s)", proc.pid, exc_info=True
             )
             return
 
@@ -1186,7 +1186,7 @@ class DeepAgentsApp(App):
             await asyncio.wait_for(proc.wait(), timeout=5)
         except TimeoutError:
             logger.warning(
-                "Bash process (pid=%s) did not exit after SIGTERM; sending SIGKILL",
+                "Shell process (pid=%s) did not exit after SIGTERM; sending SIGKILL",
                 proc.pid,
             )
             with suppress(ProcessLookupError, OSError):
@@ -1303,7 +1303,7 @@ class DeepAgentsApp(App):
                 "  Shift+Tab       Toggle auto-approve mode\n"
                 "  @filename       Auto-complete files and inject content\n"
                 "  /command        Slash commands (/help, /clear, /quit)\n"
-                "  !command        Run bash commands directly\n\n"
+                "  !command        Run shell commands directly\n\n"
                 f"Docs: {DOCS_URL}",
                 style="dim italic",
             )
@@ -1920,7 +1920,7 @@ class DeepAgentsApp(App):
         # Command mode messages complete synchronously without spawning
         # a worker, so cleanup won't fire again. Continue draining the
         # queue if no worker was started.
-        busy = self._agent_running or self._bash_running
+        busy = self._agent_running or self._shell_running
         if not busy and self._pending_messages:
             await self._process_next_from_queue()
 
@@ -2344,23 +2344,36 @@ class DeepAgentsApp(App):
                 "UI may be out of sync with message store"
             )
 
+    def _discard_queue(self) -> None:
+        """Clear pending messages and remove queued widgets from the DOM."""
+        self._pending_messages.clear()
+        for w in self._queued_widgets:
+            w.remove()
+        self._queued_widgets.clear()
+
+    def _cancel_worker(self, worker: Worker[None] | None) -> None:
+        """Discard the message queue and cancel an active worker.
+
+        Args:
+            worker: The worker to cancel.
+        """
+        self._discard_queue()
+        if worker is not None:
+            worker.cancel()
+
     def action_quit_or_interrupt(self) -> None:
         """Handle Ctrl+C - interrupt agent, reject approval, or quit on double press.
 
         Priority order:
-        1. If bash process is running, kill it
+        1. If shell command is running, kill it
         2. If approval menu is active, reject it
         3. If agent is running, interrupt it (preserve input)
         4. If double press (quit_pending), quit
         5. Otherwise show quit hint
         """
-        # If bash command is running, cancel the worker
-        if self._bash_running and self._bash_worker:
-            self._pending_messages.clear()
-            for w in self._queued_widgets:
-                w.remove()
-            self._queued_widgets.clear()
-            self._bash_worker.cancel()
+        # If shell command is running, cancel the worker
+        if self._shell_running and self._shell_worker:
+            self._cancel_worker(self._shell_worker)
             self._quit_pending = False
             return
 
@@ -2375,11 +2388,7 @@ class DeepAgentsApp(App):
 
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
-            self._pending_messages.clear()
-            for w in self._queued_widgets:
-                w.remove()
-            self._queued_widgets.clear()
-            self._agent_worker.cancel()
+            self._cancel_worker(self._agent_worker)
             self._quit_pending = False
             return
 
@@ -2396,8 +2405,8 @@ class DeepAgentsApp(App):
         Priority order:
         1. If modal screen is active, dismiss it
         2. If completion popup is open, dismiss it
-        3. If input is in command/bash mode, exit to normal mode
-        4. If bash process is running, kill it
+        3. If input is in command/shell mode, exit to normal mode
+        4. If shell command is running, kill it
         5. If approval menu is active, reject it
         6. If agent is running, interrupt it
         """
@@ -2406,20 +2415,16 @@ class DeepAgentsApp(App):
             self.screen.dismiss(None)
             return
 
-        # Close completion popup or exit slash/bash mode
+        # Close completion popup or exit slash/shell command mode
         if self._chat_input:
             if self._chat_input.dismiss_completion():
                 return
             if self._chat_input.exit_mode():
                 return
 
-        # If bash command is running, cancel the worker
-        if self._bash_running and self._bash_worker:
-            self._pending_messages.clear()
-            for w in self._queued_widgets:
-                w.remove()
-            self._queued_widgets.clear()
-            self._bash_worker.cancel()
+        # If shell command is running, cancel the worker
+        if self._shell_running and self._shell_worker:
+            self._cancel_worker(self._shell_worker)
             return
 
         # If approval menu is active, reject it before cancelling the agent worker.
@@ -2432,11 +2437,7 @@ class DeepAgentsApp(App):
 
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
-            self._pending_messages.clear()
-            for w in self._queued_widgets:
-                w.remove()
-            self._queued_widgets.clear()
-            self._agent_worker.cancel()
+            self._cancel_worker(self._agent_worker)
             return
 
     def action_quit_app(self) -> None:
@@ -2461,16 +2462,12 @@ class DeepAgentsApp(App):
             message: Optional message to display on exit.
         """
         # Discard queued messages so _cleanup_agent_task won't try to
-        # process them after the event loop is torn down.
-        self._pending_messages.clear()
-        for w in self._queued_widgets:
-            w.remove()
-        self._queued_widgets.clear()
-
-        # Cancel active workers so their subprocesses are terminated
+        # process them after the event loop is torn down, and cancel
+        # active workers so their subprocesses are terminated
         # (SIGTERM → SIGKILL) instead of being orphaned.
-        if self._bash_running and self._bash_worker:
-            self._bash_worker.cancel()
+        self._discard_queue()
+        if self._shell_running and self._shell_worker:
+            self._shell_worker.cancel()
         if self._agent_running and self._agent_worker:
             self._agent_worker.cancel()
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -60,16 +60,19 @@ COLORS = {
     "agent": "#10b981",
     "thinking": "#34d399",
     "tool": "#fbbf24",
-    "mode_bash": "#ff1493",
+    "mode_shell": "#ff1493",
     "mode_command": "#8b5cf6",
 }
 """App color scheme."""
 
 MODE_PREFIXES: dict[str, str] = {
-    "bash": "!",
+    "shell": "!",
     "command": "/",
 }
 """Maps each non-normal mode to its trigger character."""
+
+PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
+"""Reverse lookup: trigger character -> mode name."""
 
 
 class CharsetMode(StrEnum):

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -18,6 +18,7 @@ from textual.widgets.text_area import Selection
 from deepagents_cli.config import (
     COLORS,
     MODE_PREFIXES,
+    PREFIX_TO_MODE,
     CharsetMode,
     _detect_charset_mode,
     get_glyphs,
@@ -34,8 +35,6 @@ from deepagents_cli.widgets.history import HistoryManager
 
 logger = logging.getLogger(__name__)
 
-_PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
-"""Reverse lookup: trigger character -> mode name."""
 
 _PASTE_BURST_CHAR_GAP_SECONDS = 0.03
 """Maximum time between chars to treat input as a paste-like burst."""
@@ -656,8 +655,8 @@ class ChatInput(Vertical):
         border: solid $primary;
     }
 
-    ChatInput.mode-bash {
-        border: solid __MODE_BASH__;
+    ChatInput.mode-shell {
+        border: solid __MODE_SHELL__;
     }
 
     ChatInput.mode-command {
@@ -677,8 +676,8 @@ class ChatInput(Vertical):
         text-style: bold;
     }
 
-    ChatInput.mode-bash .input-prompt {
-        color: __MODE_BASH__;
+    ChatInput.mode-shell .input-prompt {
+        color: __MODE_SHELL__;
     }
 
     ChatInput.mode-command .input-prompt {
@@ -698,7 +697,7 @@ class ChatInput(Vertical):
     ChatInput ChatTextArea:focus {
         border: none;
     }
-    """.replace("__MODE_BASH__", COLORS["mode_bash"]).replace(
+    """.replace("__MODE_SHELL__", COLORS["mode_shell"]).replace(
         "__MODE_CMD__", COLORS["mode_command"]
     )
 
@@ -758,7 +757,7 @@ class ChatInput(Vertical):
         self._skip_media_sync_events = 0
 
         # Number of virtual prefix characters currently injected for
-        # completion controller calls (0 for normal, 1 for bash/command).
+        # completion controller calls (0 for normal, 1 for shell/command).
         self._completion_prefix_len = 0
 
         # Guard flag: set while replacing a dropped path payload with an
@@ -834,7 +833,7 @@ class ChatInput(Vertical):
         # a prefix character.
         if self._stripping_prefix:
             self._stripping_prefix = False
-        elif text and text[0] in _PREFIX_TO_MODE:
+        elif text and text[0] in PREFIX_TO_MODE:
             if text[0] == "/" and is_path_payload:
                 # Absolute dropped paths stay normal input, not slash-command mode.
                 if self.mode != "normal":
@@ -846,7 +845,7 @@ class ChatInput(Vertical):
                 # text that re-includes the trigger character.  The
                 # _stripping_prefix guard prevents the resulting change event
                 # from looping back here.
-                detected = _PREFIX_TO_MODE[text[0]]
+                detected = PREFIX_TO_MODE[text[0]]
                 if self.mode != detected:
                     self.mode = detected
                 self._strip_mode_prefix()
@@ -1341,7 +1340,7 @@ class ChatInput(Vertical):
             Tuple of `(mode, display_text)` where mode-trigger prefixes are
                 removed from `display_text`.
         """
-        for prefix, mode in _PREFIX_TO_MODE.items():
+        for prefix, mode in PREFIX_TO_MODE.items():
             # Small dict; loop is fine. No need to over-engineer right now
             if entry.startswith(prefix):
                 return mode, entry[len(prefix) :]
@@ -1353,7 +1352,7 @@ class ChatInput(Vertical):
             return
 
         # Backspace at cursor position 0 (or on empty input) exits the
-        # current mode (e.g. command/bash).  When the cursor is at the very
+        # current mode (e.g. command/shell).  When the cursor is at the very
         # start of the text area, backspace is a no-op for the underlying
         # widget, so without this guard the user would be stuck in the mode.
         if (
@@ -1379,7 +1378,7 @@ class ChatInput(Vertical):
                 event.stop()
                 self._submit_value(self._text_area.text.strip())
             case CompletionResult.IGNORED if event.key == "enter":
-                # Handle Enter when completion is not active (bash/normal modes)
+                # Handle Enter when completion is not active (shell/normal modes)
                 value = self._text_area.text.strip()
                 if value:
                     event.prevent_default()
@@ -1414,7 +1413,7 @@ class ChatInput(Vertical):
             prompt = self.query_one("#prompt", Static)
         except NoMatches:
             return
-        self.remove_class("mode-bash", "mode-command")
+        self.remove_class("mode-shell", "mode-command")
         prefix = MODE_PREFIXES.get(mode)
         if prefix:
             prompt.update(prefix)
@@ -1473,7 +1472,7 @@ class ChatInput(Vertical):
             self._text_area.set_app_focus(has_focus=active)
 
     def exit_mode(self) -> bool:
-        """Exit the current input mode (command/bash) back to normal.
+        """Exit the current input mode (command/shell) back to normal.
 
         Returns:
             True if mode was non-normal and has been reset.

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -18,7 +18,7 @@ from textual.widgets import Markdown, Static
 
 from deepagents_cli.config import (
     COLORS,
-    MODE_PREFIXES,
+    PREFIX_TO_MODE,
     CharsetMode,
     _detect_charset_mode,
     get_glyphs,
@@ -36,15 +36,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
-"""Reverse lookup: trigger character -> mode name."""
-
 
 def _mode_color(mode: str | None) -> str:
     """Return the color string for a mode, falling back to primary.
 
     Args:
-        mode: Mode name (e.g. `'bash'`, `'command'`) or `None`.
+        mode: Mode name (e.g. `'shell'`, `'command'`) or `None`.
 
     Returns:
         Hex color string from `COLORS`.
@@ -129,7 +126,7 @@ class UserMessage(Static):
 
     def on_mount(self) -> None:
         """Set border style based on charset mode and content prefix."""
-        mode = _PREFIX_TO_MODE.get(self._content[:1]) if self._content else None
+        mode = PREFIX_TO_MODE.get(self._content[:1]) if self._content else None
         color = _mode_color(mode)
         border_type = "ascii" if _detect_charset_mode() == CharsetMode.ASCII else "wide"
         self.styles.border_left = (border_type, color)
@@ -144,8 +141,8 @@ class UserMessage(Static):
         content = self._content
 
         # Use mode-specific prefix indicator when content starts with a
-        # mode trigger character (e.g. "!" for bash, "/" for commands).
-        mode = _PREFIX_TO_MODE.get(content[:1]) if content else None
+        # mode trigger character (e.g. "!" for shell commands, "/" for commands).
+        mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
             text.append(f"{content[0]} ", style=f"bold {_mode_color(mode)}")
             content = content[1:]
@@ -224,7 +221,7 @@ class QueuedUserMessage(Static):
         """
         text = Text()
         content = self._content
-        mode = _PREFIX_TO_MODE.get(content[:1]) if content else None
+        mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
             text.append(f"{content[0]} ", style=f"bold {COLORS['dim']}")
             content = content[1:]

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -75,8 +75,8 @@ class StatusBar(Horizontal):
         display: none;
     }
 
-    StatusBar .status-mode.bash {
-        background: __MODE_BASH__;
+    StatusBar .status-mode.shell {
+        background: __MODE_SHELL__;
         color: white;
         text-style: bold;
     }
@@ -129,7 +129,7 @@ class StatusBar(Horizontal):
         color: $text-muted;
         text-align: right;
     }
-    """.replace("__MODE_BASH__", COLORS["mode_bash"]).replace(
+    """.replace("__MODE_SHELL__", COLORS["mode_shell"]).replace(
         "__MODE_CMD__", COLORS["mode_command"]
     )
 
@@ -181,11 +181,11 @@ class StatusBar(Horizontal):
             indicator = self.query_one("#mode-indicator", Static)
         except NoMatches:
             return
-        indicator.remove_class("normal", "bash", "command")
+        indicator.remove_class("normal", "shell", "command")
 
-        if mode == "bash":
-            indicator.update("BASH")
-            indicator.add_class("bash")
+        if mode == "shell":
+            indicator.update("SHELL")
+            indicator.add_class("shell")
         elif mode == "command":
             indicator.update("CMD")
             indicator.add_class("command")
@@ -251,7 +251,7 @@ class StatusBar(Horizontal):
         """Set the current input mode.
 
         Args:
-            mode: One of "normal", "bash", or "command"
+            mode: One of "normal", "shell", or "command"
         """
         self.mode = mode
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -388,9 +388,9 @@ class TestQueuedMessage:
 
     def test_fields(self) -> None:
         """QueuedMessage should store text and mode."""
-        msg = QueuedMessage(text="hello", mode="bash")
+        msg = QueuedMessage(text="hello", mode="shell")
         assert msg.text == "hello"
-        assert msg.mode == "bash"
+        assert msg.mode == "shell"
 
 
 class TestMessageQueue:
@@ -576,14 +576,14 @@ class TestMessageQueue:
 
             assert len(app._queued_widgets) == 0
 
-    async def test_bash_command_continues_chain(self) -> None:
-        """Bash/command messages should not break the queue processing chain."""
+    async def test_shell_command_continues_chain(self) -> None:
+        """Shell/command messages should not break the queue processing chain."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            # Queue a bash command followed by a normal message
-            app._pending_messages.append(QueuedMessage(text="!echo hi", mode="bash"))
+            # Queue a shell command followed by a normal message
+            app._pending_messages.append(QueuedMessage(text="!echo hi", mode="shell"))
             app._pending_messages.append(
                 QueuedMessage(text="hello agent", mode="normal")
             )
@@ -592,7 +592,7 @@ class TestMessageQueue:
             await pilot.pause()
             await pilot.pause()
 
-            # The bash command should have been processed and the normal
+            # The shell command should have been processed and the normal
             # message should also have been picked up (mounted as UserMessage)
             user_msgs = app.query(UserMessage)
             assert any(w._content == "hello agent" for w in user_msgs)
@@ -865,33 +865,33 @@ class TestPasteRouting:
             mock_stop.assert_not_called()
 
 
-class TestBashCommandInterrupt:
-    """Tests for interruptible bash commands (! prefix) using worker pattern."""
+class TestShellCommandInterrupt:
+    """Tests for interruptible shell commands (! prefix) using worker pattern."""
 
-    async def test_escape_cancels_bash_worker(self) -> None:
-        """Esc while bash is running should cancel the worker."""
+    async def test_escape_cancels_shell_worker(self) -> None:
+        """Esc while shell command is running should cancel the worker."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            app._bash_running = True
+            app._shell_running = True
             mock_worker = MagicMock()
-            app._bash_worker = mock_worker
+            app._shell_worker = mock_worker
 
             app.action_interrupt()
 
             mock_worker.cancel.assert_called_once()
             assert len(app._pending_messages) == 0
 
-    async def test_ctrl_c_cancels_bash_worker(self) -> None:
-        """Ctrl+C while bash is running should cancel the worker."""
+    async def test_ctrl_c_cancels_shell_worker(self) -> None:
+        """Ctrl+C while shell command is running should cancel the worker."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            app._bash_running = True
+            app._shell_running = True
             mock_worker = MagicMock()
-            app._bash_worker = mock_worker
+            app._shell_worker = mock_worker
 
             # Queue a message to verify it gets cleared
             app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
@@ -903,7 +903,7 @@ class TestBashCommandInterrupt:
             assert app._quit_pending is False
 
     async def test_process_killed_on_cancelled_error(self) -> None:
-        """CancelledError in _run_bash_task should kill the process."""
+        """CancelledError in _run_shell_task should kill the process."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -923,33 +923,33 @@ class TestBashCommandInterrupt:
                 patch("os.getpgid", return_value=12345),
                 pytest.raises(asyncio.CancelledError),
             ):
-                await app._run_bash_task("sleep 999")
+                await app._run_shell_task("sleep 999")
 
             mock_killpg.assert_called()
 
     async def test_cleanup_clears_state(self) -> None:
-        """_cleanup_bash_task should reset all bash state."""
+        """_cleanup_shell_task should reset all shell state."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            app._bash_running = True
-            app._bash_worker = MagicMock()
-            app._bash_worker.is_cancelled = False
-            app._bash_process = None
+            app._shell_running = True
+            app._shell_worker = MagicMock()
+            app._shell_worker.is_cancelled = False
+            app._shell_process = None
 
-            await app._cleanup_bash_task()
+            await app._cleanup_shell_task()
 
-            assert app._bash_process is None
-            assert app._bash_running is False
-            assert app._bash_worker is None
+            assert app._shell_process is None
+            assert app._shell_running is False
+            assert app._shell_worker is None
 
-    async def test_messages_queued_during_bash(self) -> None:
-        """Messages should be queued while bash command runs."""
+    async def test_messages_queued_during_shell(self) -> None:
+        """Messages should be queued while shell command runs."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            app._bash_running = True
+            app._shell_running = True
 
             app.post_message(ChatInput.Submitted("queued msg", "normal"))
             await pilot.pause()
@@ -957,28 +957,28 @@ class TestBashCommandInterrupt:
             assert len(app._pending_messages) == 1
             assert app._pending_messages[0].text == "queued msg"
 
-    async def test_queue_drains_after_bash_completes(self) -> None:
-        """Pending messages should drain after _cleanup_bash_task."""
+    async def test_queue_drains_after_shell_completes(self) -> None:
+        """Pending messages should drain after _cleanup_shell_task."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            app._bash_running = True
-            app._bash_worker = MagicMock()
-            app._bash_worker.is_cancelled = False
-            app._bash_process = None
+            app._shell_running = True
+            app._shell_worker = MagicMock()
+            app._shell_worker.is_cancelled = False
+            app._shell_process = None
 
             # Enqueue a message
             app._pending_messages.append(
-                QueuedMessage(text="after bash", mode="normal")
+                QueuedMessage(text="after shell", mode="normal")
             )
 
-            await app._cleanup_bash_task()
+            await app._cleanup_shell_task()
             await pilot.pause()
 
             # Message should have been processed (mounted as UserMessage)
             user_msgs = app.query(UserMessage)
-            assert any(w._content == "after bash" for w in user_msgs)
+            assert any(w._content == "after shell" for w in user_msgs)
 
     async def test_interrupted_shows_message(self) -> None:
         """Cancelled worker should show 'Command interrupted'."""
@@ -986,23 +986,23 @@ class TestBashCommandInterrupt:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            app._bash_running = True
+            app._shell_running = True
             mock_worker = MagicMock()
             mock_worker.is_cancelled = True
-            app._bash_worker = mock_worker
+            app._shell_worker = mock_worker
             # Process still set means it was interrupted mid-flight
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            app._bash_process = mock_proc
+            app._shell_process = mock_proc
 
-            await app._cleanup_bash_task()
+            await app._cleanup_shell_task()
             await pilot.pause()
 
             app_msgs = app.query(AppMessage)
             assert any("Command interrupted" in str(w._content) for w in app_msgs)
 
     async def test_timeout_kills_and_shows_error(self) -> None:
-        """Timeout in _run_bash_task should kill process and show error."""
+        """Timeout in _run_shell_task should kill process and show error."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -1021,15 +1021,15 @@ class TestBashCommandInterrupt:
                 patch("os.killpg"),
                 patch("os.getpgid", return_value=12345),
             ):
-                await app._run_bash_task("sleep 999")
+                await app._run_shell_task("sleep 999")
                 await pilot.pause()
 
-            assert app._bash_process is None
+            assert app._shell_process is None
             error_msgs = app.query(ErrorMessage)
             assert any("timed out" in w._content for w in error_msgs)
 
     async def test_posix_killpg_called(self) -> None:
-        """On POSIX, _kill_bash_process should use os.killpg with SIGTERM."""
+        """On POSIX, _kill_shell_process should use os.killpg with SIGTERM."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -1038,7 +1038,7 @@ class TestBashCommandInterrupt:
             mock_proc.returncode = None
             mock_proc.pid = 42
             mock_proc.wait = AsyncMock()
-            app._bash_process = mock_proc
+            app._shell_process = mock_proc
 
             with (
                 patch("deepagents_cli.app.sys") as mock_sys,
@@ -1046,7 +1046,7 @@ class TestBashCommandInterrupt:
                 patch("os.getpgid", return_value=42) as mock_getpgid,
             ):
                 mock_sys.platform = "linux"
-                await app._kill_bash_process()
+                await app._kill_shell_process()
 
             mock_getpgid.assert_called_once_with(42)
             mock_killpg.assert_called_once_with(42, signal.SIGTERM)
@@ -1062,7 +1062,7 @@ class TestBashCommandInterrupt:
             mock_proc.pid = 42
             mock_proc.wait = AsyncMock(side_effect=asyncio.TimeoutError)
             mock_proc.kill = MagicMock()
-            app._bash_process = mock_proc
+            app._shell_process = mock_proc
 
             with (
                 patch("deepagents_cli.app.sys") as mock_sys,
@@ -1070,20 +1070,20 @@ class TestBashCommandInterrupt:
                 patch("os.getpgid", return_value=42),
             ):
                 mock_sys.platform = "linux"
-                await app._kill_bash_process()
+                await app._kill_shell_process()
 
             # First call: SIGTERM, second call: SIGKILL
             assert mock_killpg.call_count == 2
             mock_killpg.assert_any_call(42, signal.SIGTERM)
             mock_killpg.assert_any_call(42, signal.SIGKILL)
 
-    async def test_no_op_when_no_bash_running(self) -> None:
-        """Ctrl+C with no bash running should fall through to quit hint."""
+    async def test_no_op_when_no_shell_running(self) -> None:
+        """Ctrl+C with no shell command running should fall through to quit hint."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            assert not app._bash_running
+            assert not app._shell_running
             app.action_quit_or_interrupt()
 
             assert app._quit_pending is True
@@ -1098,32 +1098,32 @@ class TestBashCommandInterrupt:
                 "asyncio.create_subprocess_shell",
                 side_effect=OSError("Permission denied"),
             ):
-                await app._run_bash_task("forbidden")
+                await app._run_shell_task("forbidden")
                 await pilot.pause()
 
-            assert app._bash_process is None
+            assert app._shell_process is None
             error_msgs = app.query(ErrorMessage)
             assert any("Permission denied" in w._content for w in error_msgs)
 
-    async def test_handle_bash_command_sets_running_state(self) -> None:
-        """_handle_bash_command should set _bash_running and spawn worker."""
+    async def test_handle_shell_command_sets_running_state(self) -> None:
+        """_handle_shell_command should set _shell_running and spawn worker."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
             with patch.object(app, "run_worker") as mock_rw:
                 mock_rw.return_value = MagicMock()
-                await app._handle_bash_command("echo hi")
+                await app._handle_shell_command("echo hi")
 
-            assert app._bash_running is True
-            assert app._bash_worker is not None
+            assert app._shell_running is True
+            assert app._shell_worker is not None
             mock_rw.assert_called_once()
             # Close the unawaited coroutine to suppress RuntimeWarning
             coro = mock_rw.call_args[0][0]
             coro.close()
 
     async def test_kill_noop_when_already_exited(self) -> None:
-        """_kill_bash_process should no-op if process already exited."""
+        """_kill_shell_process should no-op if process already exited."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -1131,24 +1131,24 @@ class TestBashCommandInterrupt:
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
             mock_proc.pid = 42
-            app._bash_process = mock_proc
+            app._shell_process = mock_proc
 
             with patch("os.killpg") as mock_killpg:
-                await app._kill_bash_process()
+                await app._kill_shell_process()
 
             mock_killpg.assert_not_called()
             mock_proc.terminate.assert_not_called()
 
-    async def test_end_to_end_escape_during_bash(self) -> None:
-        """Esc during a running bash worker should cancel execution."""
+    async def test_end_to_end_escape_during_shell(self) -> None:
+        """Esc during a running shell worker should cancel execution."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            # Simulate a running bash state with a mock worker
-            app._bash_running = True
+            # Simulate a running shell state with a mock worker
+            app._shell_running = True
             mock_worker = MagicMock()
-            app._bash_worker = mock_worker
+            app._shell_worker = mock_worker
 
             await pilot.press("escape")
             await pilot.pause()

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -261,20 +261,20 @@ def _prompt_text(prompt: Static) -> str:
 class TestPromptIndicator:
     """Test that the prompt indicator reflects the current input mode."""
 
-    async def test_prompt_shows_bang_in_bash_mode(self) -> None:
-        """Setting mode to 'bash' should change prompt to '!' and apply bash styling."""
+    async def test_prompt_shows_bang_in_shell_mode(self) -> None:
+        """Mode 'shell' should change prompt to '!' and apply styling."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat_input = app.query_one(ChatInput)
             prompt = chat_input.query_one("#prompt", Static)
 
             assert _prompt_text(prompt) == ">"
-            assert not chat_input.has_class("mode-bash")
+            assert not chat_input.has_class("mode-shell")
 
-            chat_input.mode = "bash"
+            chat_input.mode = "shell"
             await pilot.pause()
             assert _prompt_text(prompt) == "!"
-            assert chat_input.has_class("mode-bash")
+            assert chat_input.has_class("mode-shell")
 
     async def test_prompt_shows_slash_in_command_mode(self) -> None:
         """Setting mode to 'command' should change prompt and styling."""
@@ -295,15 +295,15 @@ class TestPromptIndicator:
             chat_input = app.query_one(ChatInput)
             prompt = chat_input.query_one("#prompt", Static)
 
-            chat_input.mode = "bash"
+            chat_input.mode = "shell"
             await pilot.pause()
             assert _prompt_text(prompt) == "!"
-            assert chat_input.has_class("mode-bash")
+            assert chat_input.has_class("mode-shell")
 
             chat_input.mode = "normal"
             await pilot.pause()
             assert _prompt_text(prompt) == ">"
-            assert not chat_input.has_class("mode-bash")
+            assert not chat_input.has_class("mode-shell")
             assert not chat_input.has_class("mode-command")
 
     async def test_mode_change_posts_message(self) -> None:
@@ -321,9 +321,9 @@ class TestPromptIndicator:
         async with app.run_test() as pilot:
             chat_input = app.query_one(ChatInput)
 
-            chat_input.mode = "bash"
+            chat_input.mode = "shell"
             await pilot.pause()
-            assert any(m.mode == "bash" for m in messages)
+            assert any(m.mode == "shell" for m in messages)
 
 
 class TestHistoryNavigationFlag:
@@ -706,8 +706,8 @@ class TestDismissCompletion:
 class TestModePrefixStripping:
     """Test that mode-trigger characters are stripped from text input."""
 
-    async def test_typing_bang_strips_prefix_and_sets_bash_mode(self) -> None:
-        """Setting text to `'!ls'` should strip to `'ls'` and enter bash mode."""
+    async def test_typing_bang_strips_prefix_and_sets_shell_mode(self) -> None:
+        """Setting text to `'!ls'` should strip to `'ls'` and enter shell mode."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -716,7 +716,7 @@ class TestModePrefixStripping:
             chat._text_area.text = "!ls"
             await _pause_for_strip(pilot)
 
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
             assert chat._text_area.text == "ls"
 
     async def test_typing_slash_strips_prefix_and_sets_command_mode(self) -> None:
@@ -733,38 +733,38 @@ class TestModePrefixStripping:
             assert chat._text_area.text == ""
 
     async def test_mode_stays_on_empty_text(self) -> None:
-        """Clearing text after entering bash mode should stay in mode."""
+        """Clearing text after entering shell mode should stay in mode."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            # Enter bash mode
+            # Enter shell mode
             chat._text_area.text = "!ls"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
 
             # Clear text — mode should persist (backspace on empty exits)
             chat._text_area.text = ""
             await pilot.pause()
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
 
     async def test_backspace_on_empty_exits_mode(self) -> None:
-        """Backspace on empty input in bash mode should reset to normal."""
+        """Backspace on empty input in shell mode should reset to normal."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            # Enter bash mode
+            # Enter shell mode
             chat._text_area.text = "!ls"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
 
-            # Clear text — still in bash mode
+            # Clear text — still in shell mode
             chat._text_area.text = ""
             await pilot.pause()
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
 
             # Backspace on empty — exits mode
             await pilot.press("backspace")
@@ -865,17 +865,17 @@ class TestModePrefixStripping:
             labels = [s[0] for s in chat._current_suggestions]
             assert "/help" in labels
 
-    async def test_submission_prepends_bash_prefix(self) -> None:
-        """Submitting in bash mode should prepend `'!'` to the value."""
+    async def test_submission_prepends_shell_prefix(self) -> None:
+        """Submitting in shell mode should prepend `'!'` to the value."""
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            # Enter bash mode
+            # Enter shell mode
             chat._text_area.text = "!ls"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
             assert chat._text_area.text == "ls"
 
             # Submit
@@ -885,7 +885,7 @@ class TestModePrefixStripping:
             # Should have received "!ls"
             assert len(app.submitted) == 1
             assert app.submitted[0].value == "!ls"
-            assert app.submitted[0].mode == "bash"
+            assert app.submitted[0].mode == "shell"
 
     async def test_submission_prepends_command_prefix(self) -> None:
         """Submitting in command mode should prepend `'/'` to the value."""
@@ -922,10 +922,10 @@ class TestModePrefixStripping:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            # Enter bash mode and submit
+            # Enter shell mode and submit
             chat._text_area.text = "!ls"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
 
             await pilot.press("enter")
             await pilot.pause()
@@ -934,25 +934,25 @@ class TestModePrefixStripping:
             assert chat._text_area.text == ""
 
     async def test_mode_sticky_during_typing(self) -> None:
-        """Mode should persist while typing in bash/command mode."""
+        """Mode should persist while typing in shell/command mode."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            # Enter bash mode
+            # Enter shell mode
             chat._text_area.text = "!echo hello"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
             assert chat._text_area.text == "echo hello"
 
-            # Continue typing — mode stays bash
+            # Continue typing — mode stays shell
             chat._text_area.text = "echo hello world"
             await pilot.pause()
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
 
-    async def test_bash_mode_does_not_trigger_completions(self) -> None:
-        """Typing in bash mode should not trigger completions."""
+    async def test_shell_mode_does_not_trigger_completions(self) -> None:
+        """Typing in shell mode should not trigger completions."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -960,7 +960,7 @@ class TestModePrefixStripping:
 
             chat._text_area.text = "!echo"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
             assert chat._current_suggestions == []
 
     async def test_submission_does_not_double_prefix(self) -> None:
@@ -971,7 +971,7 @@ class TestModePrefixStripping:
             assert chat._text_area is not None
 
             # Manually set mode and text that already has prefix
-            chat.mode = "bash"
+            chat.mode = "shell"
             chat._stripping_prefix = True  # prevent mode re-detection
             chat._text_area.text = "!already-prefixed"
             await pilot.pause()
@@ -984,10 +984,10 @@ class TestModePrefixStripping:
 
 
 class TestHistoryRecallModeReset:
-    """Regression: history recall must not inherit a stale bash/command mode."""
+    """Regression: history recall must not inherit a stale shell/command mode."""
 
-    async def test_history_non_prefixed_entry_resets_bash_mode(self) -> None:
-        """Recalling a normal-mode entry while in bash mode should reset to normal."""
+    async def test_history_non_prefixed_entry_resets_shell_mode(self) -> None:
+        """Recalling a normal-mode entry while in shell mode should reset to normal."""
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -996,12 +996,12 @@ class TestHistoryRecallModeReset:
             # Seed history with a normal-mode entry
             chat._history._entries.append("echo hello")
 
-            # Enter bash mode, then clear text so the history query is
+            # Enter shell mode, then clear text so the history query is
             # empty (matches all entries) — we're testing mode reset, not
             # substring filtering.
             chat._text_area.text = "!ls"
             await _pause_for_strip(pilot)
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
             chat._text_area.text = ""
             await pilot.pause()
 
@@ -1023,20 +1023,20 @@ class TestHistoryRecallModeReset:
             assert app.submitted[0].mode == "normal"
 
     async def test_history_prefixed_entry_keeps_mode(self) -> None:
-        """Recalling a bash-prefixed entry should re-enter bash mode."""
+        """Recalling a shell-prefixed entry should re-enter shell mode."""
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            # Seed history with a bash-mode entry
+            # Seed history with a shell-mode entry
             chat._history._entries.append("!ls")
 
             # Press up to recall the prefixed entry
             await pilot.press("up")
             await _pause_for_strip(pilot)
 
-            assert chat.mode == "bash"
+            assert chat.mode == "shell"
             assert chat._text_area.text == "ls"
 
             # Submit — should prepend "!"
@@ -1045,7 +1045,7 @@ class TestHistoryRecallModeReset:
 
             assert len(app.submitted) == 1
             assert app.submitted[0].value == "!ls"
-            assert app.submitted[0].mode == "bash"
+            assert app.submitted[0].mode == "shell"
 
     async def test_history_non_prefixed_entry_resets_command_mode(self) -> None:
         """Recalling a normal entry while in command mode should reset to normal."""

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -303,12 +303,12 @@ def _compose_text(widget: UserMessage | QueuedUserMessage) -> Text:
 class TestUserMessageModeRendering:
     """Test `UserMessage` renders mode-specific prefix indicators and colors."""
 
-    def test_bash_prefix_renders_bang_indicator(self) -> None:
-        """`UserMessage('!ls')` should render with `'! '` prefix and bash body."""
+    def test_shell_prefix_renders_bang_indicator(self) -> None:
+        """`UserMessage('!ls')` should render with `'! '` prefix and shell body."""
         text = _compose_text(UserMessage("!ls"))
         assert text.plain == "! ls"
         first_span = text._spans[0]
-        assert COLORS["mode_bash"] in str(first_span.style)
+        assert COLORS["mode_shell"] in str(first_span.style)
 
     def test_command_prefix_renders_slash_indicator(self) -> None:
         """`UserMessage('/help')` should render with `'/ '` prefix and body."""
@@ -333,7 +333,7 @@ class TestUserMessageModeRendering:
 class TestQueuedUserMessageModeRendering:
     """Test `QueuedUserMessage` renders mode-specific prefix indicators (dimmed)."""
 
-    def test_bash_prefix_renders_dimmed_bang(self) -> None:
+    def test_shell_prefix_renders_dimmed_bang(self) -> None:
         """`QueuedUserMessage('!ls')` should render dimmed `'! '` prefix."""
         text = _compose_text(QueuedUserMessage("!ls"))
         assert text.plain == "! ls"


### PR DESCRIPTION
Rename the `"bash"` input mode to `"shell"` throughout the CLI — the `!` prefix runs commands via the user's default shell, not necessarily bash. Also consolidates the duplicated `_PREFIX_TO_MODE` dict into a single `PREFIX_TO_MODE` export in `config.py`, and extracts repeated queue-discard-and-cancel logic into shared helpers.

## Changes
- Rename `InputMode` literal value `"bash"` → `"shell"` and rename all associated internal state (`_bash_process`, `_bash_worker`, `_bash_running` → `_shell_*`), methods (`_handle_bash_command` → `_handle_shell_command`, `_run_bash_task` → `_run_shell_task`, `_cleanup_bash_task` → `_cleanup_shell_task`, `_kill_bash_process` → `_kill_shell_process`), and CSS classes (`mode-bash` → `mode-shell`)
- Move the duplicated `_PREFIX_TO_MODE` reverse-lookup dict from `chat_input.py` and `messages.py` into `config.py` as the shared `PREFIX_TO_MODE` constant
- Extract `_discard_queue()` and `_cancel_worker()` helpers in `DeepAgentsApp` to eliminate four identical queue-clear-and-cancel blocks across `action_quit_or_interrupt`, `action_interrupt`, and `_quit`
- Update `StatusBar` mode indicator label from `"BASH"` to `"SHELL"` and config color key from `mode_bash` to `mode_shell`