### PR TITLE
release(sdk): bump partner packages (daytona 0.0.3, modal 0.0.2, runloop 0.0.3)

### DIFF
--- a/libs/partners/daytona/pyproject.toml
+++ b/libs/partners/daytona/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "deepagents>=0.4.3",

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "langchain-daytona"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "daytona" },

--- a/libs/partners/modal/pyproject.toml
+++ b/libs/partners/modal/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "0.0.1"
+version = "0.0.2"
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "deepagents>=0.4.3",

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "langchain-modal"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "deepagents" },

--- a/libs/partners/runloop/pyproject.toml
+++ b/libs/partners/runloop/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "deepagents>=0.4.3",

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "langchain-runloop"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "deepagents" },


### PR DESCRIPTION
Patch releases for all partner sandbox packages to pick up changes since PR #1154 (per-command timeout override) and #1461 (timeout guard + deepagents>=0.4.3 floor).

- langchain-daytona: 0.0.2 -> 0.0.3
- langchain-modal: 0.0.1 -> 0.0.2
- langchain-runloop: 0.0.2 -> 0.0.3

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).