### PR TITLE
feat(cli): surface mcp server/tool info in system prompt

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from langgraph.pregel import Pregel
     from langgraph.runtime import Runtime
 
+    from deepagents_cli.mcp_tools import MCPServerInfo
+
 from deepagents_cli.config import (
     COLORS,
     config,
@@ -398,6 +400,7 @@ def create_cli_agent(
     enable_skills: bool = True,
     enable_shell: bool = True,
     checkpointer: BaseCheckpointSaver | None = None,
+    mcp_server_info: list[MCPServerInfo] | None = None,
 ) -> tuple[Pregel, CompositeBackend]:
     """Create a CLI-configured agent with flexible options.
 
@@ -432,6 +435,7 @@ def create_cli_agent(
 
             If `None`, uses `InMemorySaver` (no persistence across
             CLI invocations).
+        mcp_server_info: MCP server metadata to surface in the system prompt.
 
     Returns:
         2-tuple of `(agent_graph, backend)`
@@ -545,7 +549,9 @@ def create_cli_agent(
     # Uses backend.execute() so it works in both local shell and remote sandbox modes.
     # Only enabled when the backend supports shell execution.
     if isinstance(backend, _ExecutableBackend):
-        agent_middleware.append(LocalContextMiddleware(backend=backend))
+        agent_middleware.append(
+            LocalContextMiddleware(backend=backend, mcp_server_info=mcp_server_info)
+        )
 
     # Get or use custom system prompt
     if system_prompt is None:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3011,6 +3011,7 @@ class DeepAgentsApp(App):
                 sandbox_type=self._sandbox_type,
                 auto_approve=self._auto_approve,
                 checkpointer=self._checkpointer,
+                mcp_server_info=self._mcp_server_info,
             )
         except Exception as e:
             # Roll back settings so the running agent isn't misrepresented.

--- a/libs/cli/deepagents_cli/local_context.py
+++ b/libs/cli/deepagents_cli/local_context.py
@@ -34,6 +34,47 @@ if TYPE_CHECKING:
     from deepagents.middleware.summarization import SummarizationEvent
     from langgraph.runtime import Runtime
 
+    from deepagents_cli.mcp_tools import MCPServerInfo
+
+
+_TOOL_NAME_DISPLAY_LIMIT = 10
+
+
+def _build_mcp_context(servers: list[MCPServerInfo]) -> str:
+    """Format MCP server/tool inventory for the system prompt.
+
+    Args:
+        servers: List of connected MCP server metadata.
+
+    Returns:
+        Formatted markdown string, or `""` if no servers.
+    """
+    if not servers:
+        return ""
+
+    total_tools = sum(len(s.tools) for s in servers)
+    lines = [f"**MCP Servers** ({len(servers)} servers, {total_tools} tools):"]
+
+    for server in servers:
+        if not server.tools:
+            lines.append(f"- **{server.name}** ({server.transport}): (no tools)")
+            continue
+
+        names = [t.name for t in server.tools]
+        if len(names) > _TOOL_NAME_DISPLAY_LIMIT:
+            shown = ", ".join(names[:_TOOL_NAME_DISPLAY_LIMIT])
+            remaining = len(names) - _TOOL_NAME_DISPLAY_LIMIT
+            lines.append(
+                f"- **{server.name}** ({server.transport}): "
+                f"{shown}, and {remaining} more"
+            )
+        else:
+            lines.append(
+                f"- **{server.name}** ({server.transport}): {', '.join(names)}"
+            )
+
+    return "\n".join(lines)
+
 
 @runtime_checkable
 class _ExecutableBackend(Protocol):
@@ -381,13 +422,20 @@ class LocalContextMiddleware(AgentMiddleware):
 
     state_schema = LocalContextState
 
-    def __init__(self, backend: _ExecutableBackend) -> None:
+    def __init__(
+        self,
+        backend: _ExecutableBackend,
+        *,
+        mcp_server_info: list[MCPServerInfo] | None = None,
+    ) -> None:
         """Initialize with a backend that supports shell execution.
 
         Args:
             backend: Backend instance that provides shell command execution.
+            mcp_server_info: MCP server metadata to include in the system prompt.
         """
         self.backend = backend
+        self._mcp_context = _build_mcp_context(mcp_server_info or [])
 
     def _run_detect_script(self) -> str | None:
         """Run the environment detection script.
@@ -480,9 +528,8 @@ class LocalContextMiddleware(AgentMiddleware):
             return {"local_context": output}
         return None
 
-    @staticmethod
-    def _get_modified_request(request: ModelRequest) -> ModelRequest | None:
-        """Append local context to the system prompt if available.
+    def _get_modified_request(self, request: ModelRequest) -> ModelRequest | None:
+        """Append local context and MCP info to the system prompt if available.
 
         Args:
             request: The model request to potentially modify.
@@ -493,11 +540,12 @@ class LocalContextMiddleware(AgentMiddleware):
         state = cast("LocalContextState", request.state)
         local_context = state.get("local_context", "")
 
-        if not local_context:
+        parts = [p for p in (local_context, self._mcp_context) if p]
+        if not parts:
             return None
 
         system_prompt = request.system_prompt or ""
-        new_prompt = system_prompt + "\n\n" + local_context
+        new_prompt = system_prompt + "\n\n" + "\n\n".join(parts)
         return request.override(system_prompt=new_prompt)
 
     def wrap_model_call(

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -600,6 +600,7 @@ async def run_textual_cli_async(
                 sandbox_type=sandbox_type if sandbox_type != "none" else None,
                 auto_approve=auto_approve,
                 checkpointer=checkpointer,
+                mcp_server_info=mcp_server_info,
             )
         except Exception as e:  # broad catch for friendly CLI errors
             logger.debug("Failed to create agent", exc_info=True)

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -744,6 +744,7 @@ async def run_non_interactive(
             return 1
 
     mcp_session_manager = None
+    mcp_server_info: list[Any] | None = None
     try:
         async with get_checkpointer() as checkpointer:
             tools = [http_request, fetch_url]
@@ -754,7 +755,11 @@ async def run_non_interactive(
             try:
                 from deepagents_cli.mcp_tools import resolve_and_load_mcp_tools
 
-                mcp_tools, mcp_session_manager, _ = await resolve_and_load_mcp_tools(
+                (
+                    mcp_tools,
+                    mcp_session_manager,
+                    mcp_server_info,
+                ) = await resolve_and_load_mcp_tools(
                     explicit_config_path=mcp_config_path,
                     no_mcp=no_mcp,
                     trust_project_mcp=trust_project_mcp,
@@ -785,6 +790,7 @@ async def run_non_interactive(
                 auto_approve=use_auto_approve,
                 enable_shell=enable_shell,
                 checkpointer=checkpointer,
+                mcp_server_info=mcp_server_info,
             )
 
             file_op_tracker = FileOpTracker(

--- a/libs/cli/tests/unit_tests/test_local_context.py
+++ b/libs/cli/tests/unit_tests/test_local_context.py
@@ -12,9 +12,11 @@ if TYPE_CHECKING:
 import pytest
 
 from deepagents_cli.local_context import (
+    _TOOL_NAME_DISPLAY_LIMIT,
     DETECT_CONTEXT_SCRIPT,
     LocalContextMiddleware,
     LocalContextState,
+    _build_mcp_context,
     _ExecutableBackend,
     _section_files,
     _section_git,
@@ -27,6 +29,7 @@ from deepagents_cli.local_context import (
     _section_tree,
     build_detect_script,
 )
+from deepagents_cli.mcp_tools import MCPServerInfo, MCPToolInfo
 
 
 def _make_backend(output: str = "", exit_code: int = 0) -> Mock:
@@ -911,3 +914,142 @@ class TestSectionGitExtended:
         out = _run_section(_section_git(), tmp_path, with_header=True)
         assert "`main`" in out
         assert "`master`" in out
+
+
+# ---------------------------------------------------------------------------
+# MCP context tests
+# ---------------------------------------------------------------------------
+
+
+def _make_server(
+    name: str, transport: str = "stdio", tool_names: list[str] | None = None
+) -> MCPServerInfo:
+    """Create an MCPServerInfo with the given tool names."""
+    tools = [MCPToolInfo(name=n, description=f"desc-{n}") for n in (tool_names or [])]
+    return MCPServerInfo(name=name, transport=transport, tools=tools)
+
+
+class TestBuildMcpContext:
+    """Tests for _build_mcp_context."""
+
+    def test_empty_servers(self) -> None:
+        assert _build_mcp_context([]) == ""
+
+    def test_single_server_with_tools(self) -> None:
+        server = _make_server("fs", "stdio", ["read_file", "write_file"])
+        result = _build_mcp_context([server])
+        assert "**MCP Servers** (1 servers, 2 tools):" in result
+        assert "- **fs** (stdio): read_file, write_file" in result
+
+    def test_multiple_servers(self) -> None:
+        servers = [
+            _make_server("fs", "stdio", ["read_file"]),
+            _make_server("docs", "http", ["search", "get_page", "list"]),
+        ]
+        result = _build_mcp_context(servers)
+        assert "(2 servers, 4 tools)" in result
+        assert "**fs** (stdio): read_file" in result
+        assert "**docs** (http): search, get_page, list" in result
+
+    def test_server_zero_tools(self) -> None:
+        server = _make_server("empty", "sse", [])
+        result = _build_mcp_context([server])
+        assert "(1 servers, 0 tools)" in result
+        assert "**empty** (sse): (no tools)" in result
+
+    def test_long_tool_list_truncated(self) -> None:
+        names = [f"tool_{i}" for i in range(15)]
+        server = _make_server("big", "stdio", names)
+        result = _build_mcp_context([server])
+        assert f"tool_{_TOOL_NAME_DISPLAY_LIMIT - 1}" in result
+        assert f"tool_{_TOOL_NAME_DISPLAY_LIMIT}" not in result
+        assert "and 5 more" in result
+
+
+class TestMcpContextInMiddleware:
+    """Tests for MCP context integration in LocalContextMiddleware."""
+
+    def test_mcp_context_appended_to_prompt(self) -> None:
+        """MCP info appears in system prompt via wrap_model_call."""
+        backend = _make_backend()
+        server = _make_server("myserver", "stdio", ["my_tool"])
+        middleware = LocalContextMiddleware(backend=backend, mcp_server_info=[server])
+
+        request = Mock()
+        request.system_prompt = "Base prompt"
+        request.state = {"local_context": SAMPLE_CONTEXT}
+
+        overridden = Mock()
+        request.override.return_value = overridden
+        handler = Mock(return_value="response")
+
+        middleware.wrap_model_call(request, handler)
+
+        call_args = request.override.call_args[1]
+        prompt = call_args["system_prompt"]
+        assert "Base prompt" in prompt
+        assert "## Local Context" in prompt
+        assert "**MCP Servers**" in prompt
+        assert "**myserver** (stdio): my_tool" in prompt
+
+    def test_no_mcp_context_when_none(self) -> None:
+        """No MCP section when mcp_server_info is None."""
+        backend = _make_backend()
+        middleware = LocalContextMiddleware(backend=backend, mcp_server_info=None)
+
+        request = Mock()
+        request.system_prompt = "Base prompt"
+        request.state = {"local_context": SAMPLE_CONTEXT}
+
+        overridden = Mock()
+        request.override.return_value = overridden
+        handler = Mock(return_value="response")
+
+        middleware.wrap_model_call(request, handler)
+
+        call_args = request.override.call_args[1]
+        prompt = call_args["system_prompt"]
+        assert "**MCP Servers**" not in prompt
+        assert "## Local Context" in prompt
+
+    def test_both_contexts_combined(self) -> None:
+        """Both bash context and MCP context appear in system prompt."""
+        backend = _make_backend()
+        server = _make_server("docs", "http", ["search"])
+        middleware = LocalContextMiddleware(backend=backend, mcp_server_info=[server])
+
+        request = Mock()
+        request.system_prompt = "Base"
+        request.state = {"local_context": SAMPLE_CONTEXT}
+
+        overridden = Mock()
+        request.override.return_value = overridden
+        handler = Mock(return_value="response")
+
+        middleware.wrap_model_call(request, handler)
+
+        call_args = request.override.call_args[1]
+        prompt = call_args["system_prompt"]
+        assert "## Local Context" in prompt
+        assert "**MCP Servers**" in prompt
+
+    def test_mcp_context_alone(self) -> None:
+        """MCP context still appended when no bash context is available."""
+        backend = _make_backend()
+        server = _make_server("fs", "stdio", ["read"])
+        middleware = LocalContextMiddleware(backend=backend, mcp_server_info=[server])
+
+        request = Mock()
+        request.system_prompt = "Base"
+        request.state = {}  # no local_context
+
+        overridden = Mock()
+        request.override.return_value = overridden
+        handler = Mock(return_value="response")
+
+        middleware.wrap_model_call(request, handler)
+
+        call_args = request.override.call_args[1]
+        prompt = call_args["system_prompt"]
+        assert "**MCP Servers**" in prompt
+        assert "**fs** (stdio): read" in prompt


### PR DESCRIPTION
Surface MCP server/tool metadata in the agent's system prompt so the model knows which tools come from which MCP servers, their transport type, and how they're grouped. Previously MCP tools appeared in the flat tool list via their schemas but the model had no system prompt context about their provenance or server-level organization.

Without this, MCP tools show up in the model's tool list as individual tool schemas — identical in appearance to built-in tools like `read_file` or `shell`. The model has no way to distinguish:

1. **Which tools are MCP tools vs built-in** — they're all flat entries in the same list
2. **Which server a tool belongs to** — `docs__search` and `fs__read_file` look unrelated even though they're grouped by server
3. **What transport/connection type backs them** — stdio vs HTTP vs SSE, which affects reliability expectations

By adding a grouped `**MCP Servers**` section to the system prompt, the model can reason about tools in context: "these 3 tools come from the `docs` server over HTTP" vs "this tool is a local stdio process." That helps with tool selection, error attribution (if a server is down, all its tools are affected), and understanding the environment it's operating in — which is exactly what `LocalContextMiddleware` already does for git state, runtimes, and package managers.

---

**Before** — MCP tools exist in the tool schema list but the system prompt has no mention of them:

```
...base system prompt content...

## Local Context

**Current Directory**: `/home/user/myproject`

**Project**:
- Language: python
- Monorepo: yes

**Package Manager**: Python: uv

**Git**: Current branch `feat/add-search`, main branch available: `main`, 2 uncommitted changes

**Files** (8 shown):
- libs/
- pyproject.toml
- README.md
...
```

The model sees tools like `mcp__docs_langchain__SearchDocsByLangChain`, `mcp__filesystem__read_file`, `mcp__filesystem__write_file` in the flat tool list — but has zero context about where they come from or how they relate to each other.

---

**After** — MCP server inventory appended alongside the local context:

```
...base system prompt content...

## Local Context

**Current Directory**: `/home/user/myproject`

**Project**:
- Language: python
- Monorepo: yes

**Package Manager**: Python: uv

**Git**: Current branch `feat/add-search`, main branch available: `main`, 2 uncommitted changes

**Files** (8 shown):
- libs/
- pyproject.toml
- README.md
...

**MCP Servers** (2 servers, 4 tools):
- **filesystem** (stdio): mcp__filesystem__read_file, mcp__filesystem__write_file, mcp__filesystem__list_directory
- **docs-langchain** (http): mcp__docs_langchain__SearchDocsByLangChain
```

Now the model knows: "there are 2 external MCP servers connected — `filesystem` is a local stdio process with 3 file tools, and `docs-langchain` is a remote HTTP service with a search tool." It can reason about grouping, provenance, and failure domains.
