### PR TITLE
feat(cli): add `--shell-allow-list all`

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -332,7 +332,16 @@ config: RunnableConfig = {"recursion_limit": 1000}
 console = Console(highlight=False)
 
 
-SHELL_ALLOW_ALL: list[str] = ["__ALL__"]
+class _ShellAllowAll(list):  # noqa: FURB189  # sentinel type, not a general-purpose list subclass
+    """Sentinel subclass for unrestricted shell access.
+
+    Using a dedicated type instead of a plain list lets consumers use
+    `isinstance` checks, which survive serialization/copy unlike identity
+    checks (`is`).
+    """
+
+
+SHELL_ALLOW_ALL: list[str] = _ShellAllowAll(["__ALL__"])
 """Sentinel value returned by `parse_shell_allow_list` for `--shell-allow-list=all`."""
 
 
@@ -343,12 +352,18 @@ def parse_shell_allow_list(allow_list_str: str | None) -> list[str] | None:
         allow_list_str: Comma-separated list of commands, `'recommended'` for
             safe defaults, or `'all'` to allow any command.
 
+            `'all'` must be the sole value — it is not recognized inside a
+            comma-separated list (unlike `'recommended'`).
+
             Can also include `'recommended'` in the list to merge with custom
             commands.
 
     Returns:
         List of allowed commands, `SHELL_ALLOW_ALL` if `'all'` was specified,
         or `None` if no allow-list configured.
+
+    Raises:
+        ValueError: If `'all'` is combined with other commands.
     """
     if not allow_list_str:
         return None
@@ -363,6 +378,14 @@ def parse_shell_allow_list(allow_list_str: str | None) -> list[str] | None:
 
     # Split by comma and strip whitespace
     commands = [cmd.strip() for cmd in allow_list_str.split(",") if cmd.strip()]
+
+    # Reject ambiguous input: 'all' mixed with other commands
+    if any(cmd.lower() == "all" for cmd in commands):
+        msg = (
+            "Cannot combine 'all' with other commands in --shell-allow-list. "
+            "Use '--shell-allow-list all' alone to allow any command."
+        )
+        raise ValueError(msg)
 
     # If "recommended" is in the list, merge with recommended commands
     result = []
@@ -884,25 +907,31 @@ def contains_dangerous_patterns(command: str) -> bool:
 def is_shell_command_allowed(command: str, allow_list: list[str] | None) -> bool:
     """Check if a shell command is in the allow-list.
 
-    The allow-list matches against the first token of the command (the executable name).
-    This allows read-only commands like ls, cat, grep, etc. to be auto-approved.
+    The allow-list matches against the first token of the command (the executable
+    name). This allows read-only commands like ls, cat, grep, etc. to be
+    auto-approved.
 
-    SECURITY: This function rejects commands containing dangerous shell patterns
-    (command substitution, redirects, process substitution, etc.) BEFORE parsing,
-    to prevent injection attacks that could bypass the allow-list.
+    When `allow_list` is the `SHELL_ALLOW_ALL` sentinel, all non-empty commands
+    are approved unconditionally — dangerous pattern checks are skipped.
+
+    SECURITY: For regular allow-lists, this function rejects commands containing
+    dangerous shell patterns (command substitution, redirects, process
+    substitution, etc.) BEFORE parsing, to prevent injection attacks that could
+    bypass the allow-list.
 
     Args:
-        command: The full shell command to check
-        allow_list: List of allowed command names (e.g., ["ls", "cat", "grep"])
+        command: The full shell command to check.
+        allow_list: List of allowed command names (e.g., `["ls", "cat", "grep"]`),
+            the `SHELL_ALLOW_ALL` sentinel to allow any command, or `None`.
 
     Returns:
-        True if the command is allowed, False otherwise.
+        `True` if the command is allowed, `False` otherwise.
     """
     if not allow_list or not command or not command.strip():
         return False
 
     # SHELL_ALLOW_ALL sentinel — skip pattern and token checks
-    if allow_list is SHELL_ALLOW_ALL:
+    if isinstance(allow_list, _ShellAllowAll):
         return True
 
     # SECURITY: Check for dangerous patterns BEFORE any parsing

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -360,7 +360,7 @@ def parse_shell_allow_list(allow_list_str: str | None) -> list[str] | None:
 
     Returns:
         List of allowed commands, `SHELL_ALLOW_ALL` if `'all'` was specified,
-        or `None` if no allow-list configured.
+            or `None` if no allow-list configured.
 
     Raises:
         ValueError: If `'all'` is combined with other commands.

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -332,22 +332,32 @@ config: RunnableConfig = {"recursion_limit": 1000}
 console = Console(highlight=False)
 
 
+SHELL_ALLOW_ALL: list[str] = ["__ALL__"]
+"""Sentinel value returned by `parse_shell_allow_list` for `--shell-allow-list=all`."""
+
+
 def parse_shell_allow_list(allow_list_str: str | None) -> list[str] | None:
     """Parse shell allow-list from string.
 
     Args:
-        allow_list_str: Comma-separated list of commands, or "recommended" for
-            safe defaults.
+        allow_list_str: Comma-separated list of commands, `'recommended'` for
+            safe defaults, or `'all'` to allow any command.
 
-            Can also include "recommended" in the list to merge with custom commands.
+            Can also include `'recommended'` in the list to merge with custom
+            commands.
 
     Returns:
-        List of allowed commands, or None if no allow-list configured.
+        List of allowed commands, `SHELL_ALLOW_ALL` if `'all'` was specified,
+        or `None` if no allow-list configured.
     """
     if not allow_list_str:
         return None
 
-    # Special value "recommended" uses our curated safe list
+    # Special value 'all' allows any shell command
+    if allow_list_str.strip().lower() == "all":
+        return SHELL_ALLOW_ALL
+
+    # Special value 'recommended' uses our curated safe list
     if allow_list_str.strip().lower() == "recommended":
         return list(RECOMMENDED_SAFE_SHELL_COMMANDS)
 
@@ -890,6 +900,10 @@ def is_shell_command_allowed(command: str, allow_list: list[str] | None) -> bool
     """
     if not allow_list or not command or not command.strip():
         return False
+
+    # SHELL_ALLOW_ALL sentinel — skip pattern and token checks
+    if allow_list is SHELL_ALLOW_ALL:
+        return True
 
     # SECURITY: Check for dangerous patterns BEFORE any parsing
     # This prevents injection attacks like: ls "$(rm -rf /)"

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1088,6 +1088,7 @@ def cli_main() -> None:
                     mcp_config_path=getattr(args, "mcp_config", None),
                     no_mcp=getattr(args, "no_mcp", False),
                     trust_project_mcp=getattr(args, "trust_project_mcp", False),
+                    auto_approve=args.auto_approve,
                 )
             )
             sys.exit(exit_code)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -350,7 +350,8 @@ def parse_args() -> argparse.Namespace:
         dest="non_interactive_message",
         metavar="TEXT",
         help="Run a single task non-interactively and exit "
-        "(shell disabled unless --shell-allow-list is set)",
+        "(shell disabled unless --shell-allow-list is set). "
+        "Use --auto-approve to also skip HITL prompts",
     )
 
     parser.add_argument(
@@ -403,7 +404,7 @@ def parse_args() -> argparse.Namespace:
         "--shell-allow-list",
         metavar="LIST",
         help="Comma-separated list of shell commands to auto-approve, "
-        "or 'recommended' for safe defaults. "
+        "'recommended' for safe defaults, or 'all' to allow any command. "
         "Applies to both -n and interactive modes.",
     )
     parser.add_argument(

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -350,8 +350,7 @@ def parse_args() -> argparse.Namespace:
         dest="non_interactive_message",
         metavar="TEXT",
         help="Run a single task non-interactively and exit "
-        "(shell disabled unless --shell-allow-list is set). "
-        "Use --auto-approve to also skip HITL prompts",
+        "(shell disabled unless --shell-allow-list is set)",
     )
 
     parser.add_argument(
@@ -1089,7 +1088,6 @@ def cli_main() -> None:
                     mcp_config_path=getattr(args, "mcp_config", None),
                     no_mcp=getattr(args, "no_mcp", False),
                     trust_project_mcp=getattr(args, "trust_project_mcp", False),
-                    auto_approve=args.auto_approve,
                 )
             )
             sys.exit(exit_code)

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -3,18 +3,12 @@
 Provides `run_non_interactive` which runs a single user task against the
 agent graph, streams results to stdout, and exits with an appropriate code.
 
-Shell/auto-approve behaviour is determined by a two-axis decision:
+Shell commands are gated by an optional allow-list (`--shell-allow-list`):
 
-1. **Shell access** — controlled exclusively by `--shell-allow-list`:
-   - Not set → shell disabled.
-   - `--shell-allow-list=recommended` or explicit list → shell enabled,
-     commands gated by HITL against the list.
-   - `--shell-allow-list=all` → shell enabled, any command allowed.
-
-2. **HITL gating** — controlled by `--auto-approve`:
-   - Not set → HITL active when a `--shell-allow-list` (other than `all`)
-     is configured; auto-approved otherwise.
-   - `--auto-approve` → all tool calls (including shell) skip HITL.
+- Not set → shell disabled, all other tool calls auto-approved.
+- `recommended` or explicit list → shell enabled, commands validated
+    against the list; non-shell tools approved unconditionally.
+- `all` → shell enabled, any command allowed, all tools auto-approved.
 
 An optional quiet mode (`--quiet` / `-q`) redirects all console output to
 stderr, leaving stdout exclusively for the agent's response text.
@@ -41,6 +35,7 @@ from rich.text import Text
 
 from deepagents_cli.agent import DEFAULT_AGENT_NAME, create_cli_agent
 from deepagents_cli.config import (
+    SHELL_ALLOW_ALL,
     SHELL_TOOL_NAMES,
     build_langsmith_thread_url,
     create_model,
@@ -385,16 +380,15 @@ def _make_hitl_decision(
 ) -> dict[str, str]:
     """Decide whether to approve or reject a single action request.
 
-    This function is only invoked when HITL is active (`auto_approve=False`).
-    When `--auto-approve` is set, `interrupt_on` is empty and this function
-    is bypassed entirely.
+    This function is only invoked when a restrictive shell allow-list is
+    configured (not `all`). When shell is disabled or unrestricted,
+    `interrupt_on` is empty and this function is bypassed entirely.
 
     Shell tools are always gated: if an allow-list is configured, the command
-    is validated against it (including `SHELL_ALLOW_ALL` which approves
-    everything); if no allow-list is configured, shell commands are rejected
-    outright (defense-in-depth — the caller should disable shell tools when
-    no allow-list is present, but this function fails closed regardless).
-    Non-shell tools are approved unconditionally.
+    is validated against it; if no allow-list is configured, shell commands
+    are rejected outright (defense-in-depth — the caller should disable
+    shell tools when no allow-list is present, but this function fails
+    closed regardless). Non-shell tools are approved unconditionally.
 
     Args:
         action_request: The action-request dict emitted by the HITL middleware.
@@ -684,19 +678,15 @@ async def run_non_interactive(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool = False,
-    auto_approve: bool = False,
 ) -> int:
     """Run a single task non-interactively and exit.
 
-    Shell access is controlled by `--shell-allow-list`:
+    Shell access and auto-approval are controlled by `--shell-allow-list`:
 
     - Not set → shell disabled, all other tools auto-approved.
-    - `recommended` or explicit list → shell enabled, gated by allow-list
-        via HITL; non-shell tools approved unconditionally.
-    - `all` → shell enabled, any command allowed.
-
-    `--auto-approve` is orthogonal: when set it disables all HITL prompts
-    regardless of the shell configuration.
+    - `recommended` or explicit list → shell enabled, commands gated by
+        allow-list; non-shell tools approved unconditionally.
+    - `all` → shell enabled, any command allowed, all tools auto-approved.
 
     Note: startup header rendering avoids synchronous LangSmith URL lookups.
     A background thread resolves the thread URL concurrently and the result is
@@ -731,9 +721,6 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
-        auto_approve: When `True`, skip all HITL prompts. Orthogonal to shell
-            access — shell must still be enabled via `--shell-allow-list` for
-            shell commands to run.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
@@ -837,17 +824,14 @@ async def run_non_interactive(
                 return 1
 
             # Shell access is controlled by --shell-allow-list:
-            #   not set        → shell disabled
+            #   not set        → shell disabled, auto-approve all other tools
             #   recommended/…  → shell enabled, gated by list
-            #   all            → shell enabled, any command
-            # --auto-approve is orthogonal: skips all HITL prompts.
-            from deepagents_cli.config import SHELL_ALLOW_ALL
-
+            #   all            → shell enabled, any command, auto-approve
             enable_shell = bool(settings.shell_allow_list)
-            shell_is_unrestricted = settings.shell_allow_list is SHELL_ALLOW_ALL
-            # HITL is needed only when shell has a restrictive allow-list
-            # and --auto-approve was not passed.
-            use_auto_approve = auto_approve or not enable_shell or shell_is_unrestricted
+            shell_is_unrestricted = isinstance(
+                settings.shell_allow_list, type(SHELL_ALLOW_ALL)
+            )
+            use_auto_approve = not enable_shell or shell_is_unrestricted
 
             agent, composite_backend = create_cli_agent(
                 model=model,

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -720,6 +720,8 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
+        auto_approve: When `True`, auto-approve all tool calls without
+            human-in-the-loop prompts.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -3,19 +3,18 @@
 Provides `run_non_interactive` which runs a single user task against the
 agent graph, streams results to stdout, and exits with an appropriate code.
 
-Shell commands are gated by an optional allow-list. When no allow-list is
-set, shell is disabled and all other tool calls are auto-approved via the
-`auto_approve` flag. When an allow-list is provided, shell is enabled and
-all tool calls (shell and non-shell) pass through HITL, where non-shell
-tools are approved unconditionally and shell commands are validated against
-the list.
+Shell/auto-approve behaviour is determined by a three-way decision:
+
+1. `--auto-approve` — shell is enabled **and** all tool calls (including
+   shell) are auto-approved with no human-in-the-loop gating.
+2. `--shell-allow-list` (without `--auto-approve`) — shell is enabled but
+   every command is validated against the allow-list via HITL; non-shell
+   tools are approved unconditionally.
+3. Neither flag — shell is disabled entirely and all other tool calls are
+   auto-approved.
 
 An optional quiet mode (`--quiet` / `-q`) redirects all console output to
 stderr, leaving stdout exclusively for the agent's response text.
-
-Note: in non-interactive mode (`-n`), auto-approval is determined solely by
-whether a `--shell-allow-list` is present, not by the `--auto-approve` CLI
-flag. See `run_non_interactive` for details.
 """
 
 from __future__ import annotations
@@ -383,6 +382,10 @@ def _make_hitl_decision(
 ) -> dict[str, str]:
     """Decide whether to approve or reject a single action request.
 
+    This function is only invoked when HITL is active (`auto_approve=False`).
+    When `--auto-approve` is set, `interrupt_on` is empty and this function
+    is bypassed entirely.
+
     Shell tools are always gated: if an allow-list is configured, the command
     is validated against it; if no allow-list is configured, shell commands
     are rejected outright (defense-in-depth -- the caller should disable
@@ -681,11 +684,12 @@ async def run_non_interactive(
 ) -> int:
     """Run a single task non-interactively and exit.
 
-    When no `shell_allow_list` is configured, shell execution is disabled
-    and all other tool calls are auto-approved (no HITL prompts). When an
-    allow-list **is** provided, shell execution is enabled but gated by the
-    list; commands not in the list are rejected with an error message sent
-    back to the agent.
+    When `auto_approve` is `True`, shell execution is enabled and all tool
+    calls are auto-approved with no HITL gating. When `auto_approve` is `False`
+    and a `shell_allow_list` is configured, shell execution is enabled but gated
+    by the list; commands not in the list are rejected with an error message
+    sent back to the agent. When neither flag is set, shell execution is
+    disabled and all other tool calls are auto-approved.
 
     Note: startup header rendering avoids synchronous LangSmith URL lookups.
     A background thread resolves the thread URL concurrently and the result is
@@ -720,8 +724,9 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
-        auto_approve: When `True`, auto-approve all tool calls without
-            human-in-the-loop prompts.
+        auto_approve: When `True`, shell is enabled and all tool calls
+            (including shell commands) are auto-approved without HITL prompts.
+            Overrides `shell_allow_list` behaviour when both are set.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
@@ -831,6 +836,16 @@ async def run_non_interactive(
             if auto_approve:
                 enable_shell = True
                 use_auto_approve = True
+                logger.info(
+                    "Auto-approve enabled: shell commands will execute "
+                    "without HITL gating"
+                )
+                if settings.shell_allow_list:
+                    console.print(
+                        "[yellow]Warning: --auto-approve overrides "
+                        "--shell-allow-list. All shell commands will be "
+                        "auto-approved regardless of the allow-list.[/yellow]"
+                    )
             elif settings.shell_allow_list:
                 enable_shell = True
                 use_auto_approve = False

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -631,6 +631,7 @@ async def run_non_interactive(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool = False,
+    auto_approve: bool = False,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -775,11 +776,19 @@ async def run_non_interactive(
                 console.print(f"[red]✗ Failed to load MCP tools: {e}[/red]")
                 return 1
 
-            # If an allow-list is provided, enable shell but disable
-            # auto-approve so HITL can gate commands. If no allow-list, disable
-            # shell entirely and auto-approve all other tools.
-            enable_shell = bool(settings.shell_allow_list)
-            use_auto_approve = not enable_shell
+            # If --auto-approve is set, enable shell with no gating at all.
+            # If an allow-list is provided (without --auto-approve), enable
+            # shell but gate commands via HITL.
+            # Otherwise, disable shell and auto-approve all other tools.
+            if auto_approve:
+                enable_shell = True
+                use_auto_approve = True
+            elif settings.shell_allow_list:
+                enable_shell = True
+                use_auto_approve = False
+            else:
+                enable_shell = False
+                use_auto_approve = True
 
             agent, composite_backend = create_cli_agent(
                 model=model,

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -3,15 +3,18 @@
 Provides `run_non_interactive` which runs a single user task against the
 agent graph, streams results to stdout, and exits with an appropriate code.
 
-Shell/auto-approve behaviour is determined by a three-way decision:
+Shell/auto-approve behaviour is determined by a two-axis decision:
 
-1. `--auto-approve` — shell is enabled **and** all tool calls (including
-   shell) are auto-approved with no human-in-the-loop gating.
-2. `--shell-allow-list` (without `--auto-approve`) — shell is enabled but
-   every command is validated against the allow-list via HITL; non-shell
-   tools are approved unconditionally.
-3. Neither flag — shell is disabled entirely and all other tool calls are
-   auto-approved.
+1. **Shell access** — controlled exclusively by `--shell-allow-list`:
+   - Not set → shell disabled.
+   - `--shell-allow-list=recommended` or explicit list → shell enabled,
+     commands gated by HITL against the list.
+   - `--shell-allow-list=all` → shell enabled, any command allowed.
+
+2. **HITL gating** — controlled by `--auto-approve`:
+   - Not set → HITL active when a `--shell-allow-list` (other than `all`)
+     is configured; auto-approved otherwise.
+   - `--auto-approve` → all tool calls (including shell) skip HITL.
 
 An optional quiet mode (`--quiet` / `-q`) redirects all console output to
 stderr, leaving stdout exclusively for the agent's response text.
@@ -387,10 +390,11 @@ def _make_hitl_decision(
     is bypassed entirely.
 
     Shell tools are always gated: if an allow-list is configured, the command
-    is validated against it; if no allow-list is configured, shell commands
-    are rejected outright (defense-in-depth -- the caller should disable
-    shell tools when no allow-list is present, but this function fails
-    closed regardless). Non-shell tools are approved unconditionally.
+    is validated against it (including `SHELL_ALLOW_ALL` which approves
+    everything); if no allow-list is configured, shell commands are rejected
+    outright (defense-in-depth — the caller should disable shell tools when
+    no allow-list is present, but this function fails closed regardless).
+    Non-shell tools are approved unconditionally.
 
     Args:
         action_request: The action-request dict emitted by the HITL middleware.
@@ -684,12 +688,15 @@ async def run_non_interactive(
 ) -> int:
     """Run a single task non-interactively and exit.
 
-    When `auto_approve` is `True`, shell execution is enabled and all tool
-    calls are auto-approved with no HITL gating. When `auto_approve` is `False`
-    and a `shell_allow_list` is configured, shell execution is enabled but gated
-    by the list; commands not in the list are rejected with an error message
-    sent back to the agent. When neither flag is set, shell execution is
-    disabled and all other tool calls are auto-approved.
+    Shell access is controlled by `--shell-allow-list`:
+
+    - Not set → shell disabled, all other tools auto-approved.
+    - `recommended` or explicit list → shell enabled, gated by allow-list
+        via HITL; non-shell tools approved unconditionally.
+    - `all` → shell enabled, any command allowed.
+
+    `--auto-approve` is orthogonal: when set it disables all HITL prompts
+    regardless of the shell configuration.
 
     Note: startup header rendering avoids synchronous LangSmith URL lookups.
     A background thread resolves the thread URL concurrently and the result is
@@ -724,9 +731,9 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
-        auto_approve: When `True`, shell is enabled and all tool calls
-            (including shell commands) are auto-approved without HITL prompts.
-            Overrides `shell_allow_list` behaviour when both are set.
+        auto_approve: When `True`, skip all HITL prompts. Orthogonal to shell
+            access — shell must still be enabled via `--shell-allow-list` for
+            shell commands to run.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
@@ -829,29 +836,18 @@ async def run_non_interactive(
                 console.print(f"[red]✗ Failed to load MCP tools: {e}[/red]")
                 return 1
 
-            # If --auto-approve is set, enable shell with no gating at all.
-            # If an allow-list is provided (without --auto-approve), enable
-            # shell but gate commands via HITL.
-            # Otherwise, disable shell and auto-approve all other tools.
-            if auto_approve:
-                enable_shell = True
-                use_auto_approve = True
-                logger.info(
-                    "Auto-approve enabled: shell commands will execute "
-                    "without HITL gating"
-                )
-                if settings.shell_allow_list:
-                    console.print(
-                        "[yellow]Warning: --auto-approve overrides "
-                        "--shell-allow-list. All shell commands will be "
-                        "auto-approved regardless of the allow-list.[/yellow]"
-                    )
-            elif settings.shell_allow_list:
-                enable_shell = True
-                use_auto_approve = False
-            else:
-                enable_shell = False
-                use_auto_approve = True
+            # Shell access is controlled by --shell-allow-list:
+            #   not set        → shell disabled
+            #   recommended/…  → shell enabled, gated by list
+            #   all            → shell enabled, any command
+            # --auto-approve is orthogonal: skips all HITL prompts.
+            from deepagents_cli.config import SHELL_ALLOW_ALL
+
+            enable_shell = bool(settings.shell_allow_list)
+            shell_is_unrestricted = settings.shell_allow_list is SHELL_ALLOW_ALL
+            # HITL is needed only when shell has a restrictive allow-list
+            # and --auto-approve was not passed.
+            use_auto_approve = auto_approve or not enable_shell or shell_is_unrestricted
 
             agent, composite_backend = create_cli_agent(
                 model=model,

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -110,7 +110,7 @@ def show_help() -> None:
         "  --no-stream                Buffer full response instead of streaming"
     )
     console.print(
-        "  --shell-allow-list CMDS    Comma-separated local shell commands to allow"
+        "  --shell-allow-list CMDS    Comma-separated commands, 'recommended', or 'all'"
     )
     console.print("  --default-model [MODEL]    Set, show, or manage the default model")
     console.print("  --clear-default-model      Clear the default model")
@@ -129,6 +129,10 @@ def show_help() -> None:
     )
     console.print(
         "  deepagents -n 'Search logs' --shell-allow-list ls,cat,grep # Specify list",
+        style=COLORS["dim"],
+    )
+    console.print(
+        "  deepagents -n 'Fix tests' --shell-allow-list all           # Any command",
         style=COLORS["dim"],
     )
     console.print()

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -766,6 +766,16 @@ class TestParseShellAllowList:
             result = parse_shell_allow_list(variant)
             assert result is SHELL_ALLOW_ALL
 
+    def test_all_mixed_with_commands_raises(self) -> None:
+        """Combining 'all' with other commands should raise ValueError."""
+        with pytest.raises(ValueError, match="Cannot combine 'all'"):
+            parse_shell_allow_list("all,ls")
+
+    def test_all_mixed_case_insensitive_raises(self) -> None:
+        """Combining 'ALL' with other commands should also raise."""
+        with pytest.raises(ValueError, match="Cannot combine 'all'"):
+            parse_shell_allow_list("ls,ALL,cat")
+
     def test_empty_commands_ignored(self) -> None:
         """Test that empty strings from split are ignored."""
         result = parse_shell_allow_list("ls,,cat,,,grep,")

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -10,6 +10,7 @@ import pytest
 from deepagents_cli import model_config
 from deepagents_cli.config import (
     RECOMMENDED_SAFE_SHELL_COMMANDS,
+    SHELL_ALLOW_ALL,
     ModelResult,
     Settings,
     _create_model_from_class,
@@ -753,6 +754,17 @@ class TestParseShellAllowList:
         # Total should be: 1 (ls) + len(recommended) - 1 (duplicate ls) + 1 (mycmd)
         # Which simplifies to: len(recommended) + 1
         assert len(result) == len(RECOMMENDED_SAFE_SHELL_COMMANDS) + 1
+
+    def test_all_returns_sentinel(self) -> None:
+        """Test that 'all' returns SHELL_ALLOW_ALL sentinel."""
+        result = parse_shell_allow_list("all")
+        assert result is SHELL_ALLOW_ALL
+
+    def test_all_case_insensitive(self) -> None:
+        """Test that 'ALL', 'All', etc. all return sentinel."""
+        for variant in ["ALL", "All", "aLl", "  all  "]:
+            result = parse_shell_allow_list(variant)
+            assert result is SHELL_ALLOW_ALL
 
     def test_empty_commands_ignored(self) -> None:
         """Test that empty strings from split are ignored."""

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from rich.style import Style
 from rich.text import Text
 
-from deepagents_cli.config import ModelResult
+from deepagents_cli.config import SHELL_ALLOW_ALL, ModelResult
 from deepagents_cli.non_interactive import (
     ThreadUrlLookupState,
     _build_non_interactive_header,
@@ -913,7 +913,7 @@ class TestStartLangsmithThreadUrlLookup:
 
 
 class TestAutoApproveShellLogic:
-    """Tests for the 3-branch auto_approve + shell_allow_list decision."""
+    """Tests for the two-axis auto_approve x shell_allow_list decision."""
 
     @pytest.mark.parametrize(
         ("auto_approve", "shell_allow_list", "expected_enable_shell", "expected_auto"),
@@ -921,30 +921,44 @@ class TestAutoApproveShellLogic:
             pytest.param(
                 True,
                 None,
+                False,
                 True,
-                True,
-                id="auto-approve-enables-shell-and-auto-approve",
+                id="auto-approve-alone-no-shell",
             ),
             pytest.param(
                 True,
                 ["ls", "cat"],
                 True,
                 True,
-                id="auto-approve-overrides-allow-list",
+                id="auto-approve-with-allow-list",
             ),
             pytest.param(
                 False,
                 ["ls", "cat"],
                 True,
                 False,
-                id="allow-list-enables-shell-without-auto-approve",
+                id="allow-list-enables-shell-with-hitl",
             ),
             pytest.param(
                 False,
                 None,
                 False,
                 True,
-                id="no-flags-disables-shell-with-auto-approve",
+                id="no-flags-disables-shell-auto-approves",
+            ),
+            pytest.param(
+                False,
+                SHELL_ALLOW_ALL,
+                True,
+                True,
+                id="shell-allow-all-enables-shell-auto-approves",
+            ),
+            pytest.param(
+                True,
+                SHELL_ALLOW_ALL,
+                True,
+                True,
+                id="shell-allow-all-with-auto-approve",
             ),
         ],
     )

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -912,6 +912,105 @@ class TestStartLangsmithThreadUrlLookup:
         assert state.url is None
 
 
+class TestAutoApproveShellLogic:
+    """Tests for the 3-branch auto_approve + shell_allow_list decision."""
+
+    @pytest.mark.parametrize(
+        ("auto_approve", "shell_allow_list", "expected_enable_shell", "expected_auto"),
+        [
+            pytest.param(
+                True,
+                None,
+                True,
+                True,
+                id="auto-approve-enables-shell-and-auto-approve",
+            ),
+            pytest.param(
+                True,
+                ["ls", "cat"],
+                True,
+                True,
+                id="auto-approve-overrides-allow-list",
+            ),
+            pytest.param(
+                False,
+                ["ls", "cat"],
+                True,
+                False,
+                id="allow-list-enables-shell-without-auto-approve",
+            ),
+            pytest.param(
+                False,
+                None,
+                False,
+                True,
+                id="no-flags-disables-shell-with-auto-approve",
+            ),
+        ],
+    )
+    async def test_shell_auto_approve_branches(
+        self,
+        auto_approve: bool,
+        shell_allow_list: list[str] | None,
+        expected_enable_shell: bool,
+        expected_auto: bool,
+    ) -> None:
+        """Verify create_cli_agent receives correct enable_shell and auto_approve."""
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch(
+                "deepagents_cli.mcp_tools.resolve_and_load_mcp_tools",
+                return_value=([], None, []),
+            ),
+        ):
+            mock_settings.shell_allow_list = shell_allow_list
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(
+                message="test task",
+                auto_approve=auto_approve,
+            )
+
+        _, kwargs = mock_create_agent.call_args
+        assert kwargs["enable_shell"] is expected_enable_shell
+        assert kwargs["auto_approve"] is expected_auto
+
+
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029
     """Create an async iterator from a list for testing."""
     for item in items:

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -115,6 +115,15 @@ class TestMakeHitlDecision:
             )
             assert result["type"] == "reject"
 
+    def test_shell_with_allow_all_approved(self, console: Console) -> None:
+        """Shell commands should be approved when SHELL_ALLOW_ALL is set."""
+        with patch("deepagents_cli.non_interactive.settings") as mock_settings:
+            mock_settings.shell_allow_list = SHELL_ALLOW_ALL
+            result = _make_hitl_decision(
+                {"name": "execute", "args": {"command": "rm -rf /"}}, console
+            )
+            assert result == {"type": "approve"}
+
     @pytest.mark.parametrize("tool_name", ["bash", "shell", "execute"])
     def test_all_shell_tool_names_recognised(
         self, tool_name: str, console: Console
@@ -912,59 +921,34 @@ class TestStartLangsmithThreadUrlLookup:
         assert state.url is None
 
 
-class TestAutoApproveShellLogic:
-    """Tests for the two-axis auto_approve x shell_allow_list decision."""
+class TestShellAllowListDecisionLogic:
+    """Tests for shell allow-list → enable_shell + auto_approve derivation."""
 
     @pytest.mark.parametrize(
-        ("auto_approve", "shell_allow_list", "expected_enable_shell", "expected_auto"),
+        ("shell_allow_list", "expected_enable_shell", "expected_auto"),
         [
             pytest.param(
-                True,
                 None,
                 False,
                 True,
-                id="auto-approve-alone-no-shell",
+                id="no-allow-list-disables-shell-auto-approves",
             ),
             pytest.param(
-                True,
-                ["ls", "cat"],
-                True,
-                True,
-                id="auto-approve-with-allow-list",
-            ),
-            pytest.param(
-                False,
                 ["ls", "cat"],
                 True,
                 False,
-                id="allow-list-enables-shell-with-hitl",
+                id="restrictive-list-enables-shell-with-gating",
             ),
             pytest.param(
-                False,
-                None,
-                False,
-                True,
-                id="no-flags-disables-shell-auto-approves",
-            ),
-            pytest.param(
-                False,
                 SHELL_ALLOW_ALL,
                 True,
                 True,
-                id="shell-allow-all-enables-shell-auto-approves",
-            ),
-            pytest.param(
-                True,
-                SHELL_ALLOW_ALL,
-                True,
-                True,
-                id="shell-allow-all-with-auto-approve",
+                id="allow-all-enables-shell-auto-approves",
             ),
         ],
     )
     async def test_shell_auto_approve_branches(
         self,
-        auto_approve: bool,
         shell_allow_list: list[str] | None,
         expected_enable_shell: bool,
         expected_auto: bool,
@@ -1015,10 +999,7 @@ class TestAutoApproveShellLogic:
             mock_agent.astream = MagicMock(return_value=_async_iter([]))
             mock_create_agent.return_value = (mock_agent, MagicMock())
 
-            await run_non_interactive(
-                message="test task",
-                auto_approve=auto_approve,
-            )
+            await run_non_interactive(message="test task")
 
         _, kwargs = mock_create_agent.call_args
         assert kwargs["enable_shell"] is expected_enable_shell

--- a/libs/cli/tests/unit_tests/test_shell_allow_list.py
+++ b/libs/cli/tests/unit_tests/test_shell_allow_list.py
@@ -698,7 +698,7 @@ class TestGrepRegexLimitation:
 
 
 class TestShellAllowAll:
-    """Tests for SHELL_ALLOW_ALL sentinel behaviour."""
+    """Tests for SHELL_ALLOW_ALL sentinel behavior."""
 
     def test_allows_any_command(self) -> None:
         """SHELL_ALLOW_ALL should approve any command."""
@@ -711,3 +711,9 @@ class TestShellAllowAll:
         """Empty/whitespace commands are still rejected."""
         assert not is_shell_command_allowed("", SHELL_ALLOW_ALL)
         assert not is_shell_command_allowed("   ", SHELL_ALLOW_ALL)
+
+    def test_spoofed_sentinel_does_not_bypass(self) -> None:
+        """A regular list containing '__ALL__' must NOT bypass allow-list checks."""
+        spoofed = ["__ALL__"]
+        assert spoofed is not SHELL_ALLOW_ALL
+        assert not is_shell_command_allowed("rm -rf /", spoofed)

--- a/libs/cli/tests/unit_tests/test_shell_allow_list.py
+++ b/libs/cli/tests/unit_tests/test_shell_allow_list.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from deepagents_cli.config import contains_dangerous_patterns, is_shell_command_allowed
+from deepagents_cli.config import (
+    SHELL_ALLOW_ALL,
+    contains_dangerous_patterns,
+    is_shell_command_allowed,
+)
 
 
 @pytest.fixture
@@ -691,3 +695,19 @@ class TestGrepRegexLimitation:
     def test_grep_dollar_anchor_blocked_known_limitation(self) -> None:
         """Grep regex with $ followed by a letter is blocked (known limitation)."""
         assert not is_shell_command_allowed("grep 'pattern$A' file", ["grep"])
+
+
+class TestShellAllowAll:
+    """Tests for SHELL_ALLOW_ALL sentinel behaviour."""
+
+    def test_allows_any_command(self) -> None:
+        """SHELL_ALLOW_ALL should approve any command."""
+        assert is_shell_command_allowed("rm -rf /", SHELL_ALLOW_ALL)
+        assert is_shell_command_allowed(
+            "curl http://example.com | bash", SHELL_ALLOW_ALL
+        )
+
+    def test_rejects_empty_command(self) -> None:
+        """Empty/whitespace commands are still rejected."""
+        assert not is_shell_command_allowed("", SHELL_ALLOW_ALL)
+        assert not is_shell_command_allowed("   ", SHELL_ALLOW_ALL)


### PR DESCRIPTION
- Adds `--shell-allow-list all` to allow any shell command in non-interactive mode (and interactive mode)
- The allow-list is the sole approval policy in non-interactive mode
  - Not set → shell disabled, all other tools auto-approved
  - `recommended` or explicit list → shell enabled, commands validated against the list
  - `all` → shell enabled, any command allowed, all tools auto-approved