### PR TITLE
fix(daytona): use session-based execution to avoid 5-minute SDK timeout

### DIFF
--- a/libs/partners/daytona/langchain_daytona/sandbox.py
+++ b/libs/partners/daytona/langchain_daytona/sandbox.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import time
+import uuid
+
 import daytona
-from daytona import FileDownloadRequest, FileUpload
+from daytona import FileDownloadRequest, FileUpload, SessionExecuteRequest
 from deepagents.backends.protocol import (
     ExecuteResponse,
     FileDownloadResponse,
@@ -11,23 +14,41 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.sandbox import BaseSandbox
 
+_POLL_INTERVAL = 0.5
+_MAX_POLL_INTERVAL = 5.0
+
 
 class DaytonaSandbox(BaseSandbox):
     """Daytona sandbox implementation conforming to SandboxBackendProtocol.
 
     This implementation inherits all file operation methods from BaseSandbox
     and only implements the execute() method using Daytona's API.
+
+    Execution uses Daytona's session-based API (`execute_session_command` with
+    `run_async=True`) instead of `process.exec` to avoid the 5-minute HTTP
+    connection timeout in the Python SDK.  The command is dispatched
+    asynchronously and then polled for completion, so arbitrarily long-running
+    commands are supported without holding open a single HTTP connection.
     """
 
     def __init__(self, *, sandbox: daytona.Sandbox) -> None:
         """Create a backend wrapping an existing Daytona sandbox."""
         self._sandbox = sandbox
         self._default_timeout: int = 30 * 60
+        self._session_id: str | None = None
 
     @property
     def id(self) -> str:
         """Return the Daytona sandbox id."""
         return self._sandbox.id
+
+    def _ensure_session(self) -> str:
+        """Return an existing session id, creating one if needed."""
+        if self._session_id is None:
+            sid = f"da-exec-{uuid.uuid4().hex[:12]}"
+            self._sandbox.process.create_session(sid)
+            self._session_id = sid
+        return self._session_id
 
     def execute(
         self,
@@ -37,21 +58,52 @@ class DaytonaSandbox(BaseSandbox):
     ) -> ExecuteResponse:
         """Execute a shell command inside the sandbox.
 
+        Uses Daytona's session API with async dispatch and polling to avoid
+        the 5-minute HTTP connection timeout in the Python SDK.
+
         Args:
             command: Shell command string to execute.
             timeout: Maximum time in seconds to wait for the command to complete.
 
-                If None, uses the backend's default timeout.
-
-                Note that in Daytona's implementation, a timeout of 0 means
-                "wait indefinitely".
+                If None, uses the backend's default timeout (30 minutes).
+                A timeout of 0 means "wait indefinitely".
         """
         effective_timeout = timeout if timeout is not None else self._default_timeout
-        result = self._sandbox.process.exec(command, timeout=effective_timeout)
+        session_id = self._ensure_session()
+
+        resp = self._sandbox.process.execute_session_command(
+            session_id,
+            SessionExecuteRequest(command=command, run_async=True),
+        )
+        cmd_id = resp.cmd_id
+
+        deadline = time.monotonic() + effective_timeout if effective_timeout else None
+        interval = _POLL_INTERVAL
+
+        while True:
+            cmd = self._sandbox.process.get_session_command(session_id, cmd_id)
+            if cmd.exit_code is not None:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                return ExecuteResponse(
+                    output=f"Command timed out after {effective_timeout}s",
+                    exit_code=124,
+                    truncated=False,
+                )
+            time.sleep(interval)
+            interval = min(interval * 1.5, _MAX_POLL_INTERVAL)
+
+        logs = self._sandbox.process.get_session_command_logs(session_id, cmd_id)
+        output_parts: list[str] = []
+        if logs.stdout:
+            output_parts.append(logs.stdout)
+        if logs.stderr:
+            output_parts.append(logs.stderr)
+        output = "\n".join(output_parts) if output_parts else ""
 
         return ExecuteResponse(
-            output=result.result,
-            exit_code=result.exit_code,
+            output=output,
+            exit_code=cmd.exit_code,
             truncated=False,
         )
 

--- a/libs/partners/daytona/tests/unit_tests/test_sandbox.py
+++ b/libs/partners/daytona/tests/unit_tests/test_sandbox.py
@@ -1,0 +1,206 @@
+"""Tests for DaytonaSandbox session-based execution."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_daytona.sandbox import _MAX_POLL_INTERVAL, _POLL_INTERVAL, DaytonaSandbox
+
+
+def _make_sandbox() -> tuple[DaytonaSandbox, MagicMock]:
+    """Create a DaytonaSandbox with a mocked daytona.Sandbox."""
+    mock_sdk = MagicMock()
+    mock_sdk.id = "sb-123"
+    sb = DaytonaSandbox(sandbox=mock_sdk)
+    return sb, mock_sdk
+
+
+def test_execute_creates_session_once() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=0)
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="hello", stderr=""
+    )
+
+    sb.execute("echo hello")
+    sb.execute("echo world")
+
+    assert mock_sdk.process.create_session.call_count == 1
+
+
+def test_execute_returns_stdout() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=0)
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="hello world", stderr=""
+    )
+
+    result = sb.execute("echo hello world")
+
+    assert result.output == "hello world"
+    assert result.exit_code == 0
+    assert result.truncated is False
+
+
+def test_execute_returns_combined_stdout_stderr() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=1)
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="partial output", stderr="some error"
+    )
+
+    result = sb.execute("bad-command")
+
+    assert result.output == "partial output\nsome error"
+    assert result.exit_code == 1
+
+
+def test_execute_empty_output() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=0)
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="", stderr=""
+    )
+
+    result = sb.execute("true")
+
+    assert result.output == ""
+    assert result.exit_code == 0
+
+
+def test_execute_polls_until_exit_code() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.side_effect = [
+        SimpleNamespace(exit_code=None),
+        SimpleNamespace(exit_code=None),
+        SimpleNamespace(exit_code=0),
+    ]
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="done", stderr=""
+    )
+
+    with patch("langchain_daytona.sandbox.time.sleep") as mock_sleep:
+        result = sb.execute("sleep 5")
+
+    assert result.exit_code == 0
+    assert result.output == "done"
+    assert mock_sdk.process.get_session_command.call_count == 3  # noqa: PLR2004
+    assert mock_sleep.call_count == 2  # noqa: PLR2004
+
+
+def test_execute_timeout() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=None)
+
+    with (
+        patch("langchain_daytona.sandbox.time.sleep"),
+        patch("langchain_daytona.sandbox.time.monotonic", side_effect=[0.0, 0.0, 11.0]),
+    ):
+        result = sb.execute("sleep 999", timeout=10)
+
+    assert result.exit_code == 124  # noqa: PLR2004
+    assert "timed out" in result.output
+
+
+def test_execute_zero_timeout_waits_indefinitely() -> None:
+    """timeout=0 means no deadline; we just poll until done."""
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.side_effect = [
+        SimpleNamespace(exit_code=None),
+        SimpleNamespace(exit_code=0),
+    ]
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="ok", stderr=""
+    )
+
+    with patch("langchain_daytona.sandbox.time.sleep"):
+        result = sb.execute("long-command", timeout=0)
+
+    assert result.exit_code == 0
+    assert result.output == "ok"
+
+
+def test_execute_uses_run_async() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=0)
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="", stderr=""
+    )
+
+    sb.execute("echo hi")
+
+    req = mock_sdk.process.execute_session_command.call_args[0][1]
+    assert req.run_async is True
+
+
+def test_execute_uses_default_timeout() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=None)
+
+    with (
+        patch("langchain_daytona.sandbox.time.sleep"),
+        patch(
+            "langchain_daytona.sandbox.time.monotonic",
+            side_effect=[0.0, 0.0, 30 * 60 + 1.0],
+        ),
+    ):
+        result = sb.execute("sleep 999")
+
+    assert result.exit_code == 124  # noqa: PLR2004
+    assert "1800s" in result.output
+
+
+def test_poll_interval_backs_off() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+
+    poll_results = [SimpleNamespace(exit_code=None)] * 20 + [
+        SimpleNamespace(exit_code=0)
+    ]
+    mock_sdk.process.get_session_command.side_effect = poll_results
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout="", stderr=""
+    )
+
+    with (
+        patch("langchain_daytona.sandbox.time.sleep") as mock_sleep,
+        patch("langchain_daytona.sandbox.time.monotonic", return_value=0.0),
+    ):
+        sb.execute("long-thing", timeout=0)
+
+    sleep_args = [c.args[0] for c in mock_sleep.call_args_list]
+    assert sleep_args[0] == pytest.approx(_POLL_INTERVAL)
+    for val in sleep_args:
+        assert val <= _MAX_POLL_INTERVAL + 0.01
+
+
+def test_id_property() -> None:
+    sb, _ = _make_sandbox()
+    assert sb.id == "sb-123"
+
+
+def test_execute_none_logs() -> None:
+    """Logs fields may be None rather than empty string."""
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.process.execute_session_command.return_value = SimpleNamespace(cmd_id="c1")
+    mock_sdk.process.get_session_command.return_value = SimpleNamespace(exit_code=0)
+    mock_sdk.process.get_session_command_logs.return_value = SimpleNamespace(
+        stdout=None, stderr=None
+    )
+
+    result = sb.execute("true")
+
+    assert result.output == ""
+    assert result.exit_code == 0


### PR DESCRIPTION
Replaces `process.exec()` with Daytona's session-based API (`execute_session_command` with `run_async=True` + polling) to avoid the 5-minute HTTP connection timeout in the Python SDK. Commands are now dispatched asynchronously and polled for completion with exponential backoff, so arbitrarily long-running commands work without holding open a single HTTP connection. This also avoids the stale connection pool issue that caused `RemoteDisconnected` / `Connection aborted` errors.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).