### PR TITLE
test(sdk): reuse model fixture in summarization evals

### DIFF
--- a/libs/deepagents/tests/evals/test_summarization.py
+++ b/libs/deepagents/tests/evals/test_summarization.py
@@ -9,7 +9,6 @@ import pytest
 import requests
 from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
-from langchain.chat_models import init_chat_model
 from langchain_core.language_models import BaseChatModel
 from langchain_core.load import load
 from langchain_core.messages import AnyMessage, HumanMessage
@@ -61,7 +60,7 @@ def _write_file(p: Path, content: str) -> None:
 
 def _setup_summarization_test(
     tmp_path: Path,
-    model_name: str,
+    model: BaseChatModel,
     max_input_tokens: int,
     middleware: Sequence[AgentMiddleware] = (),
     *,
@@ -82,10 +81,8 @@ def _setup_summarization_test(
     backend = FilesystemBackend(root_dir=str(root), virtual_mode=True)
     checkpointer = InMemorySaver()
 
-    model = init_chat_model(model_name)
     if model.profile is None:
         model.profile = {}
-    # Lower artificially to trigger summarization more easily
     model.profile["max_input_tokens"] = max_input_tokens
 
     all_middleware: list[AgentMiddleware] = list(middleware)
@@ -114,9 +111,9 @@ def _setup_summarization_test(
 
 
 @pytest.mark.langsmith
-def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel, model_name: str) -> None:
+def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel) -> None:
     """Test that summarization triggers and the agent can continue reading a large file."""
-    agent, _, _ = _setup_summarization_test(tmp_path, model_name, 15_000)
+    agent, _, _ = _setup_summarization_test(tmp_path, model, 15_000)
     thread_id = uuid.uuid4().hex[:8]
 
     trajectory = run_agent(
@@ -153,13 +150,13 @@ def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel, model_na
 
 
 @pytest.mark.langsmith
-def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatModel, model_name: str) -> None:
+def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatModel) -> None:
     """Test that conversation history is offloaded to filesystem during summarization.
 
     This verifies the summarization middleware correctly writes conversation history
     as markdown to the backend at /conversation_history/{thread_id}.md.
     """
-    agent, _, root = _setup_summarization_test(tmp_path, model_name, 15_000)
+    agent, _, root = _setup_summarization_test(tmp_path, model, 15_000)
     thread_id = uuid.uuid4().hex[:8]
 
     _ = run_agent(
@@ -230,9 +227,9 @@ def _load_seed_messages() -> list[AnyMessage]:
 
 @pytest.mark.skip(reason="Requires permissions to read ls_client.read_run")
 @pytest.mark.langsmith
-def test_compact_tool_new_task(tmp_path: Path, model: BaseChatModel, model_name: str) -> None:
+def test_compact_tool_new_task(tmp_path: Path, model: BaseChatModel) -> None:
 
-    agent, _, _ = _setup_summarization_test(tmp_path, model_name, 35_000, include_compact_tool=True)
+    agent, _, _ = _setup_summarization_test(tmp_path, model, 35_000, include_compact_tool=True)
 
     seed = _load_seed_messages()
     query = "Thanks. Let's move on to a completely new task. To prepare, first spec out how to upgrade a web app to Typescript 5.5"
@@ -246,9 +243,9 @@ def test_compact_tool_new_task(tmp_path: Path, model: BaseChatModel, model_name:
 
 @pytest.mark.skip(reason="Requires permissions to read ls_client.read_run")
 @pytest.mark.langsmith
-def test_compact_tool_not_overly_sensitive(tmp_path: Path, model: BaseChatModel, model_name: str) -> None:
+def test_compact_tool_not_overly_sensitive(tmp_path: Path, model: BaseChatModel) -> None:
 
-    agent, _, _ = _setup_summarization_test(tmp_path, model_name, 35_000, include_compact_tool=True)
+    agent, _, _ = _setup_summarization_test(tmp_path, model, 35_000, include_compact_tool=True)
 
     seed = _load_seed_messages()
     query = "Moving on, what are the two primary OpenAI APIs supported?"
@@ -262,7 +259,7 @@ def test_compact_tool_not_overly_sensitive(tmp_path: Path, model: BaseChatModel,
 
 @pytest.mark.skip(reason="Requires permissions to read ls_client.read_run")
 @pytest.mark.langsmith
-def test_compact_tool_large_reads(tmp_path: Path, model: BaseChatModel, model_name: str) -> None:
+def test_compact_tool_large_reads(tmp_path: Path, model: BaseChatModel) -> None:
     another_large_file = "https://raw.githubusercontent.com/langchain-ai/deepagents/5c90376c02754c67d448908e55d1e953f54b8acd/libs/deepagents/deepagents/middleware/filesystem.py"
 
     response = requests.get(another_large_file, timeout=30)
@@ -270,7 +267,7 @@ def test_compact_tool_large_reads(tmp_path: Path, model: BaseChatModel, model_na
 
     agent, backend, _ = _setup_summarization_test(
         tmp_path,
-        model_name,
+        model,
         35_000,
         middleware=[ModelCallLimitMiddleware(run_limit=3)],
         include_compact_tool=True,


### PR DESCRIPTION
Summarization eval tests were calling `init_chat_model(model_name)` independently inside `_setup_summarization_test` instead of using the `model` fixture from conftest. This meant special provider handling (NVIDIA, Baseten, etc.) was bypassed, and a redundant model instance was created.

Now `_setup_summarization_test` accepts a `BaseChatModel` directly, matching how every other eval test works.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).