### PR TITLE
feat(cli): model detail footer + persist `--profile-override` on hot-swap

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -539,6 +539,7 @@ class DeepAgentsApp(App):
         sandbox: SandboxBackendProtocol | None = None,
         sandbox_type: str | None = None,
         mcp_server_info: list[MCPServerInfo] | None = None,
+        profile_override: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the Deep Agents application.
@@ -556,6 +557,8 @@ class DeepAgentsApp(App):
             sandbox: Sandbox backend (for model hot-swap)
             sandbox_type: Type of sandbox provider (for model hot-swap)
             mcp_server_info: MCP server metadata for the `/mcp` viewer.
+            profile_override: Extra profile fields from `--profile-override`,
+                retained for model hot-swap and footer display.
             **kwargs: Additional arguments passed to parent
         """
         super().__init__(**kwargs)
@@ -573,6 +576,7 @@ class DeepAgentsApp(App):
         self._sandbox = sandbox
         self._sandbox_type = sandbox_type
         self._mcp_server_info = mcp_server_info
+        self._profile_override = profile_override
         self._mcp_tool_count = sum(len(s.tools) for s in (mcp_server_info or []))
         self._status_bar: StatusBar | None = None
         self._chat_input: ChatInput | None = None
@@ -1649,7 +1653,10 @@ class DeepAgentsApp(App):
 
             try:
                 model_spec = f"{settings.model_provider}:{settings.model_name}"
-                result = create_model(model_spec)
+                result = create_model(
+                    model_spec,
+                    profile_overrides=self._profile_override,
+                )
                 model = result.model
             except Exception as exc:  # noqa: BLE001  # surface model config errors to user
                 await self._mount_message(
@@ -1659,10 +1666,10 @@ class DeepAgentsApp(App):
                 )
                 return
 
-            # create_model() applies config.toml overrides but not CLI
-            # --profile-override (the raw CLI dict isn't retained after
-            # startup). Patch settings.model_context_limit — which reflects
-            # both sources — into the fresh model
+            # create_model() receives --profile-override via self._profile_override,
+            # but settings.model_context_limit may have been set by additional
+            # runtime logic. Patch it into the fresh model when it differs from
+            # the profile value.
             ctx = settings.model_context_limit
             if ctx is not None:
                 # Guard against models that lack a profile dict
@@ -2733,6 +2740,7 @@ class DeepAgentsApp(App):
         screen = ModelSelectorScreen(
             current_model=settings.model_name,
             current_provider=settings.model_provider,
+            cli_profile_override=self._profile_override,
         )
         self.push_screen(screen, handle_result)
 
@@ -2982,7 +2990,11 @@ class DeepAgentsApp(App):
             return
 
         try:
-            result = create_model(model_spec, extra_kwargs=extra_kwargs)
+            result = create_model(
+                model_spec,
+                extra_kwargs=extra_kwargs,
+                profile_overrides=self._profile_override,
+            )
         except ModelConfigError as e:
             await self._mount_message(ErrorMessage(str(e)))
             return
@@ -3140,6 +3152,7 @@ async def run_textual_app(
     sandbox: SandboxBackendProtocol | None = None,
     sandbox_type: str | None = None,
     mcp_server_info: list[MCPServerInfo] | None = None,
+    profile_override: dict[str, Any] | None = None,
 ) -> AppResult:
     """Run the Textual application.
 
@@ -3156,6 +3169,8 @@ async def run_textual_app(
         sandbox: Sandbox backend (for model hot-swap)
         sandbox_type: Type of sandbox provider (for model hot-swap)
         mcp_server_info: MCP server metadata for the `/mcp` viewer.
+        profile_override: Extra profile fields from `--profile-override`,
+            retained for model hot-swap and footer display.
 
     Returns:
         An `AppResult` with the return code and final thread ID.
@@ -3173,6 +3188,7 @@ async def run_textual_app(
         sandbox=sandbox,
         sandbox_type=sandbox_type,
         mcp_server_info=mcp_server_info,
+        profile_override=profile_override,
     )
     await app.run_async()
     return AppResult(

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -635,6 +635,7 @@ async def run_textual_cli_async(
                 sandbox=sandbox_backend,
                 sandbox_type=sandbox_type if sandbox_type != "none" else None,
                 mcp_server_info=mcp_server_info,
+                profile_override=profile_override,
             )
         finally:
             # Clean up MCP session manager if initialized

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -400,6 +400,32 @@ def get_available_models() -> dict[str, list[str]]:
     return available
 
 
+def _build_entry(
+    base: dict[str, Any],
+    overrides: dict[str, Any],
+    cli_override: dict[str, Any] | None,
+) -> ModelProfileEntry:
+    """Build a profile entry by merging base, overrides, and CLI override.
+
+    Args:
+        base: Upstream profile dict (empty for config-only models).
+        overrides: `config.toml` profile overrides.
+        cli_override: Extra fields from `--profile-override`.
+
+    Returns:
+        Profile entry with merged data and override tracking.
+    """
+    merged = {**base, **overrides}
+    overridden_keys = set(overrides)
+    if cli_override:
+        merged = {**merged, **cli_override}
+        overridden_keys |= set(cli_override)
+    return ModelProfileEntry(
+        profile=merged,
+        overridden_keys=frozenset(overridden_keys),
+    )
+
+
 def get_model_profiles(
     *,
     cli_override: dict[str, Any] | None = None,
@@ -441,14 +467,16 @@ def get_model_profiles(
             profiles = _load_provider_profiles(module_path)
         except ImportError:
             logger.debug(
-                "Could not import profiles from %s for model profiles",
+                "Could not import profiles from %s for provider '%s'",
                 module_path,
+                provider,
             )
             continue
         except Exception:
             logger.warning(
-                "Failed to load profiles from %s for model profiles",
+                "Failed to load profiles from %s for provider '%s'",
                 module_path,
+                provider,
                 exc_info=True,
             )
             continue
@@ -457,15 +485,7 @@ def get_model_profiles(
             spec = f"{provider}:{model_name}"
             seen_specs.add(spec)
             overrides = config.get_profile_overrides(provider, model_name=model_name)
-            merged = {**upstream_profile, **overrides}
-            overridden_keys = set(overrides)
-            if cli_override:
-                merged = {**merged, **cli_override}
-                overridden_keys |= set(cli_override)
-            result[spec] = ModelProfileEntry(
-                profile=merged,
-                overridden_keys=frozenset(overridden_keys),
-            )
+            result[spec] = _build_entry(upstream_profile, overrides, cli_override)
 
     # Add config-only models that have no upstream profile.
     for provider_name, provider_config in config.providers.items():
@@ -476,15 +496,7 @@ def get_model_profiles(
                 overrides = config.get_profile_overrides(
                     provider_name, model_name=model_name
                 )
-                merged = dict(overrides)
-                overridden_keys = set(overrides)
-                if cli_override:
-                    merged = {**merged, **cli_override}
-                    overridden_keys |= set(cli_override)
-                result[spec] = ModelProfileEntry(
-                    profile=merged,
-                    overridden_keys=frozenset(overridden_keys),
-                )
+                result[spec] = _build_entry({}, overrides, cli_override)
 
     frozen = MappingProxyType(result)
     # Only populate cache for the static (no CLI override) path.

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -108,7 +108,14 @@ class ModelProfileEntry(TypedDict):
     """Profile data for a model with override tracking."""
 
     profile: dict[str, Any]
+    """Merged profile dict (upstream defaults + config.toml overrides).
+
+    Keys vary by provider (e.g., `max_input_tokens`, `tool_calling`).
+    """
+
     overridden_keys: frozenset[str]
+    """Keys in `profile` whose values came from config.toml rather than the
+    upstream provider package."""
 
 
 class ProviderConfig(TypedDict, total=False):
@@ -201,7 +208,7 @@ registry fallback.
 _available_models_cache: dict[str, list[str]] | None = None
 _builtin_providers_cache: dict[str, Any] | None = None
 _default_config_cache: ModelConfig | None = None
-_profiles_cache: dict[str, ModelProfileEntry] | None = None
+_profiles_cache: Mapping[str, ModelProfileEntry] | None = None
 
 
 def clear_caches() -> None:
@@ -393,16 +400,19 @@ def get_available_models() -> dict[str, list[str]]:
     return available
 
 
-def get_model_profiles() -> dict[str, ModelProfileEntry]:
+def get_model_profiles() -> Mapping[str, ModelProfileEntry]:
     """Load upstream profiles merged with config.toml overrides.
 
     Keyed by `provider:model` spec string. Each entry contains the
     merged profile dict and the set of keys overridden by config.toml.
 
+    Unlike `get_available_models()`, this includes all models from upstream
+    profiles regardless of capability filters (tool calling, text I/O).
+
     Results are cached; use `clear_caches()` to reset.
 
     Returns:
-        Dictionary mapping spec strings to profile entries.
+        Read-only mapping of spec strings to profile entries.
     """
     global _profiles_cache  # noqa: PLW0603  # Module-level cache requires global statement
     if _profiles_cache is not None:
@@ -455,8 +465,8 @@ def get_model_profiles() -> dict[str, ModelProfileEntry]:
                     overridden_keys=frozenset(overrides),
                 )
 
-    _profiles_cache = result
-    return result
+    _profiles_cache = MappingProxyType(result)
+    return _profiles_cache
 
 
 def _is_langchain_supported_provider(provider: str) -> bool:

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -104,6 +104,13 @@ class ModelSpec:
         return f"{self.provider}:{self.model}"
 
 
+class ModelProfileEntry(TypedDict):
+    """Profile data for a model with override tracking."""
+
+    profile: dict[str, Any]
+    overridden_keys: frozenset[str]
+
+
 class ProviderConfig(TypedDict, total=False):
     """Configuration for a model provider.
 
@@ -194,6 +201,7 @@ registry fallback.
 _available_models_cache: dict[str, list[str]] | None = None
 _builtin_providers_cache: dict[str, Any] | None = None
 _default_config_cache: ModelConfig | None = None
+_profiles_cache: dict[str, ModelProfileEntry] | None = None
 
 
 def clear_caches() -> None:
@@ -201,10 +209,11 @@ def clear_caches() -> None:
 
     Intended for tests and for a hypothetical "refresh models" UI action.
     """
-    global _available_models_cache, _builtin_providers_cache, _default_config_cache  # noqa: PLW0603  # Module-level caches require global statement
+    global _available_models_cache, _builtin_providers_cache, _default_config_cache, _profiles_cache  # noqa: PLW0603, E501  # Module-level caches require global statement
     _available_models_cache = None
     _builtin_providers_cache = None
     _default_config_cache = None
+    _profiles_cache = None
 
 
 def _get_builtin_providers() -> dict[str, Any]:
@@ -382,6 +391,72 @@ def get_available_models() -> dict[str, list[str]]:
 
     _available_models_cache = available
     return available
+
+
+def get_model_profiles() -> dict[str, ModelProfileEntry]:
+    """Load upstream profiles merged with config.toml overrides.
+
+    Keyed by `provider:model` spec string. Each entry contains the
+    merged profile dict and the set of keys overridden by config.toml.
+
+    Results are cached; use `clear_caches()` to reset.
+
+    Returns:
+        Dictionary mapping spec strings to profile entries.
+    """
+    global _profiles_cache  # noqa: PLW0603  # Module-level cache requires global statement
+    if _profiles_cache is not None:
+        return _profiles_cache
+
+    result: dict[str, ModelProfileEntry] = {}
+    config = ModelConfig.load()
+
+    # Collect upstream profiles from provider packages.
+    seen_specs: set[str] = set()
+    provider_modules = _get_provider_profile_modules()
+    for provider, module_path in provider_modules:
+        try:
+            profiles = _load_provider_profiles(module_path)
+        except ImportError:
+            logger.debug(
+                "Could not import profiles from %s for model profiles",
+                module_path,
+            )
+            continue
+        except Exception:
+            logger.warning(
+                "Failed to load profiles from %s for model profiles",
+                module_path,
+                exc_info=True,
+            )
+            continue
+
+        for model_name, upstream_profile in profiles.items():
+            spec = f"{provider}:{model_name}"
+            seen_specs.add(spec)
+            overrides = config.get_profile_overrides(provider, model_name=model_name)
+            merged = {**upstream_profile, **overrides}
+            result[spec] = ModelProfileEntry(
+                profile=merged,
+                overridden_keys=frozenset(overrides),
+            )
+
+    # Add config-only models that have no upstream profile.
+    for provider_name, provider_config in config.providers.items():
+        config_models = provider_config.get("models", [])
+        for model_name in config_models:
+            spec = f"{provider_name}:{model_name}"
+            if spec not in seen_specs:
+                overrides = config.get_profile_overrides(
+                    provider_name, model_name=model_name
+                )
+                result[spec] = ModelProfileEntry(
+                    profile=dict(overrides),
+                    overridden_keys=frozenset(overrides),
+                )
+
+    _profiles_cache = result
+    return result
 
 
 def _is_langchain_supported_provider(provider: str) -> bool:

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -400,7 +400,10 @@ def get_available_models() -> dict[str, list[str]]:
     return available
 
 
-def get_model_profiles() -> Mapping[str, ModelProfileEntry]:
+def get_model_profiles(
+    *,
+    cli_override: dict[str, Any] | None = None,
+) -> Mapping[str, ModelProfileEntry]:
     """Load upstream profiles merged with config.toml overrides.
 
     Keyed by `provider:model` spec string. Each entry contains the
@@ -409,13 +412,22 @@ def get_model_profiles() -> Mapping[str, ModelProfileEntry]:
     Unlike `get_available_models()`, this includes all models from upstream
     profiles regardless of capability filters (tool calling, text I/O).
 
-    Results are cached; use `clear_caches()` to reset.
+    Results are cached when `cli_override` is None; use `clear_caches()`
+    to reset. When `cli_override` is provided the cache is bypassed
+    because CLI overrides are session-specific.
+
+    Args:
+        cli_override: Extra profile fields from `--profile-override`.
+
+            When provided, these are merged on top of every profile entry
+            (after upstream + config.toml) and their keys are added to
+            `overridden_keys`.
 
     Returns:
         Read-only mapping of spec strings to profile entries.
     """
     global _profiles_cache  # noqa: PLW0603  # Module-level cache requires global statement
-    if _profiles_cache is not None:
+    if cli_override is None and _profiles_cache is not None:
         return _profiles_cache
 
     result: dict[str, ModelProfileEntry] = {}
@@ -446,9 +458,13 @@ def get_model_profiles() -> Mapping[str, ModelProfileEntry]:
             seen_specs.add(spec)
             overrides = config.get_profile_overrides(provider, model_name=model_name)
             merged = {**upstream_profile, **overrides}
+            overridden_keys = set(overrides)
+            if cli_override:
+                merged = {**merged, **cli_override}
+                overridden_keys |= set(cli_override)
             result[spec] = ModelProfileEntry(
                 profile=merged,
-                overridden_keys=frozenset(overrides),
+                overridden_keys=frozenset(overridden_keys),
             )
 
     # Add config-only models that have no upstream profile.
@@ -460,13 +476,21 @@ def get_model_profiles() -> Mapping[str, ModelProfileEntry]:
                 overrides = config.get_profile_overrides(
                     provider_name, model_name=model_name
                 )
+                merged = dict(overrides)
+                overridden_keys = set(overrides)
+                if cli_override:
+                    merged = {**merged, **cli_override}
+                    overridden_keys |= set(cli_override)
                 result[spec] = ModelProfileEntry(
-                    profile=dict(overrides),
-                    overridden_keys=frozenset(overrides),
+                    profile=merged,
+                    overridden_keys=frozenset(overridden_keys),
                 )
 
-    _profiles_cache = MappingProxyType(result)
-    return _profiles_cache
+    frozen = MappingProxyType(result)
+    # Only populate cache for the static (no CLI override) path.
+    if cli_override is None:
+        _profiles_cache = frozen
+    return frozen
 
 
 def _is_langchain_supported_provider(provider: str) -> bool:

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -530,7 +530,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         overridden = profile_entry["overridden_keys"]
 
         def _mark(key: str, text: str) -> str:
-            return f"*{text}" if key in overridden else text
+            return f"[yellow]*{text}[/yellow]" if key in overridden else text
 
         # Line 1: Context window
         parts_ctx: list[str] = []
@@ -598,7 +598,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             "structured_output",
         }
         has_visible_override = bool(overridden & displayed_keys)
-        line4 = "[dim]* = override[/dim]" if has_visible_override else ""
+        line4 = (
+            "[dim][yellow]*[/yellow] = override[/dim]" if has_visible_override else ""
+        )
 
         return f"{line1}\n{line2}\n{line3}\n{line4}"
 

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -18,11 +18,13 @@ from textual.widgets import Input, Static
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import CharsetMode, Glyphs, _detect_charset_mode, get_glyphs
 from deepagents_cli.model_config import (
     ModelConfig,
+    ModelProfileEntry,
     clear_default_model,
     get_available_models,
+    get_model_profiles,
     has_provider_credentials,
     save_default_model,
 )
@@ -187,6 +189,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         margin-top: 1;
         text-align: center;
     }
+
+    ModelSelectorScreen .model-detail-footer {
+        height: 4;
+        padding: 0 2;
+        border-top: solid $primary-lighten-2;
+    }
     """
 
     def __init__(
@@ -223,6 +231,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
         config = ModelConfig.load()
         self._default_spec: str | None = config.default_model
+        self._profiles = get_model_profiles()
 
     def _find_current_model_index(self) -> int:
         """Find the index of the current model in the filtered list.
@@ -269,6 +278,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 self._options_container = Container(id="model-options")
                 yield self._options_container
 
+            # Model detail footer
+            yield Static("", classes="model-detail-footer", id="model-detail-footer")
+
             # Help text
             help_text = (
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
@@ -285,6 +297,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             container.styles.border = ("ascii", "green")
 
         await self._update_display()
+        self._update_footer()
 
         # Focus the filter input
         filter_input = self.query_one("#model-filter", Input)
@@ -453,6 +466,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             else:
                 selected_widget.scroll_visible(animate=False)
 
+        self._update_footer()
+
     @staticmethod
     def _format_option_label(
         model_spec: str,
@@ -485,6 +500,105 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         suffix = " [dim](current)[/dim]" if current else ""
         default_suffix = " [cyan](default)[/cyan]" if is_default else ""
         return f"{cursor}{spec_text}{suffix}{default_suffix}"
+
+    @staticmethod
+    def _format_footer(
+        profile_entry: ModelProfileEntry | None,
+        glyphs: Glyphs,
+    ) -> str:
+        """Build the detail footer text for the highlighted model.
+
+        Args:
+            profile_entry: Profile data with override tracking, or None.
+            glyphs: Glyph set for display characters.
+
+        Returns:
+            Rich-markup string for the 4-line footer.
+        """
+        from deepagents_cli.textual_adapter import format_token_count
+
+        if profile_entry is None:
+            return "[dim]No profile data available[/dim]\n\n\n"
+
+        profile = profile_entry["profile"]
+        overridden = profile_entry["overridden_keys"]
+
+        def _mark(key: str, text: str) -> str:
+            return f"*{text}" if key in overridden else text
+
+        # Line 1: Context window
+        parts_ctx: list[str] = []
+        max_in = profile.get("max_input_tokens")
+        max_out = profile.get("max_output_tokens")
+        if max_in is not None:
+            formatted = f"{format_token_count(int(max_in))} in"
+            parts_ctx.append(_mark("max_input_tokens", formatted))
+        if max_out is not None:
+            formatted = f"{format_token_count(int(max_out))} out"
+            parts_ctx.append(_mark("max_output_tokens", formatted))
+        sep = f" {glyphs.bullet} "
+        if parts_ctx:
+            line1 = f"Context: {sep.join(parts_ctx)}"
+        else:
+            line1 = "[dim]Context: unknown[/dim]"
+
+        # Line 2: Input modalities
+        modality_keys = [
+            ("text_inputs", "text"),
+            ("image_inputs", "image"),
+            ("audio_inputs", "audio"),
+            ("pdf_inputs", "pdf"),
+            ("video_inputs", "video"),
+        ]
+        modality_parts: list[str] = []
+        for key, label in modality_keys:
+            if key in profile:
+                val = profile[key]
+                styled = f"[green]{label}[/green]" if val else f"[dim]{label}[/dim]"
+                modality_parts.append(_mark(key, styled))
+        line2 = f"Input: {' '.join(modality_parts)}" if modality_parts else ""
+
+        # Line 3: Capabilities
+        capability_keys = [
+            ("reasoning_output", "reasoning"),
+            ("tool_calling", "tool calling"),
+            ("structured_output", "structured output"),
+        ]
+        cap_parts: list[str] = []
+        for key, label in capability_keys:
+            if key in profile:
+                val = profile[key]
+                styled = f"[green]{label}[/green]" if val else f"[dim]{label}[/dim]"
+                cap_parts.append(_mark(key, styled))
+        line3 = f"Capabilities: {' '.join(cap_parts)}" if cap_parts else ""
+
+        # Line 4: Override notice
+        displayed_keys = {
+            "max_input_tokens",
+            "max_output_tokens",
+            "text_inputs",
+            "image_inputs",
+            "audio_inputs",
+            "pdf_inputs",
+            "video_inputs",
+            "reasoning_output",
+            "tool_calling",
+            "structured_output",
+        }
+        has_visible_override = bool(overridden & displayed_keys)
+        line4 = "[dim]* = config.toml override[/dim]" if has_visible_override else ""
+
+        return f"{line1}\n{line2}\n{line3}\n{line4}"
+
+    def _update_footer(self) -> None:
+        """Update the detail footer for the currently highlighted model."""
+        footer = self.query_one("#model-detail-footer", Static)
+        if not self._filtered_models:
+            footer.update("[dim]No model selected[/dim]")
+            return
+        spec, _ = self._filtered_models[self._selected_index]
+        entry = self._profiles.get(spec)
+        footer.update(self._format_footer(entry, get_glyphs()))
 
     def _move_selection(self, delta: int) -> None:
         """Move selection by delta, updating only the affected widgets.
@@ -532,6 +646,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             scroll_container.scroll_home(animate=False)
         else:
             new_widget.scroll_visible()
+
+        self._update_footer()
 
     def action_move_up(self) -> None:
         """Move selection up."""

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -532,27 +532,47 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         def _mark(key: str, text: str) -> str:
             return f"[yellow]*{text}[/yellow]" if key in overridden else text
 
+        def _format_token(key: str, suffix: str) -> str | None:
+            """Format a token-count profile key, falling back to the raw value.
+
+            Returns:
+                Formatted string with override marker, or None if key absent.
+            """
+            val = profile.get(key)
+            if val is None:
+                return None
+            try:
+                text = f"{format_token_count(int(val))} {suffix}"
+            except (ValueError, TypeError, OverflowError):
+                text = f"{val} {suffix}"
+            return _mark(key, text)
+
+        def _format_flags(keys: list[tuple[str, str]]) -> list[str]:
+            """Render boolean profile keys as green (on) or dim (off) labels.
+
+            Returns:
+                List of Rich-markup strings for present keys.
+            """
+            parts: list[str] = []
+            for key, label in keys:
+                if key in profile:
+                    styled = (
+                        f"[green]{label}[/green]"
+                        if profile[key]
+                        else f"[dim]{label}[/dim]"
+                    )
+                    parts.append(_mark(key, styled))
+            return parts
+
         # Line 1: Context window
-        parts_ctx: list[str] = []
-        max_in = profile.get("max_input_tokens")
-        max_out = profile.get("max_output_tokens")
-        if max_in is not None:
-            try:
-                formatted = f"{format_token_count(int(max_in))} in"
-            except (ValueError, TypeError, OverflowError):
-                formatted = f"{max_in} in"
-            parts_ctx.append(_mark("max_input_tokens", formatted))
-        if max_out is not None:
-            try:
-                formatted = f"{format_token_count(int(max_out))} out"
-            except (ValueError, TypeError, OverflowError):
-                formatted = f"{max_out} out"
-            parts_ctx.append(_mark("max_output_tokens", formatted))
+        token_keys = [("max_input_tokens", "in"), ("max_output_tokens", "out")]
+        ctx_parts = [p for k, s in token_keys if (p := _format_token(k, s)) is not None]
         sep = f" {glyphs.bullet} "
-        if parts_ctx:
-            line1 = f"Context: {sep.join(parts_ctx)}"
-        else:
-            line1 = "[dim]Context: unknown[/dim]"
+        line1 = (
+            f"Context: {sep.join(ctx_parts)}"
+            if ctx_parts
+            else "[dim]Context: unknown[/dim]"
+        )
 
         # Line 2: Input modalities
         modality_keys = [
@@ -562,12 +582,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             ("pdf_inputs", "pdf"),
             ("video_inputs", "video"),
         ]
-        modality_parts: list[str] = []
-        for key, label in modality_keys:
-            if key in profile:
-                val = profile[key]
-                styled = f"[green]{label}[/green]" if val else f"[dim]{label}[/dim]"
-                modality_parts.append(_mark(key, styled))
+        modality_parts = _format_flags(modality_keys)
         line2 = f"Input: {' '.join(modality_parts)}" if modality_parts else ""
 
         # Line 3: Capabilities
@@ -576,27 +591,11 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             ("tool_calling", "tool calling"),
             ("structured_output", "structured output"),
         ]
-        cap_parts: list[str] = []
-        for key, label in capability_keys:
-            if key in profile:
-                val = profile[key]
-                styled = f"[green]{label}[/green]" if val else f"[dim]{label}[/dim]"
-                cap_parts.append(_mark(key, styled))
+        cap_parts = _format_flags(capability_keys)
         line3 = f"Capabilities: {' '.join(cap_parts)}" if cap_parts else ""
 
         # Line 4: Override notice
-        displayed_keys = {
-            "max_input_tokens",
-            "max_output_tokens",
-            "text_inputs",
-            "image_inputs",
-            "audio_inputs",
-            "pdf_inputs",
-            "video_inputs",
-            "reasoning_output",
-            "tool_calling",
-            "structured_output",
-        }
+        displayed_keys = {k for k, _ in token_keys + modality_keys + capability_keys}
         has_visible_override = bool(overridden & displayed_keys)
         line4 = (
             "[dim][yellow]*[/yellow] = override[/dim]" if has_visible_override else ""

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -385,6 +385,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         if not self._filtered_models:
             no_matches = Static("[dim]No matching models[/dim]")
             await self._options_container.mount(no_matches)
+            self._update_footer()
             return
 
         # Group by provider
@@ -531,10 +532,16 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         max_in = profile.get("max_input_tokens")
         max_out = profile.get("max_output_tokens")
         if max_in is not None:
-            formatted = f"{format_token_count(int(max_in))} in"
+            try:
+                formatted = f"{format_token_count(int(max_in))} in"
+            except (ValueError, TypeError, OverflowError):
+                formatted = f"{max_in} in"
             parts_ctx.append(_mark("max_input_tokens", formatted))
         if max_out is not None:
-            formatted = f"{format_token_count(int(max_out))} out"
+            try:
+                formatted = f"{format_token_count(int(max_out))} out"
+            except (ValueError, TypeError, OverflowError):
+                formatted = f"{max_out} out"
             parts_ctx.append(_mark("max_output_tokens", formatted))
         sep = f" {glyphs.bullet} "
         if parts_ctx:
@@ -596,9 +603,15 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         if not self._filtered_models:
             footer.update("[dim]No model selected[/dim]")
             return
-        spec, _ = self._filtered_models[self._selected_index]
+        index = min(self._selected_index, len(self._filtered_models) - 1)
+        spec, _ = self._filtered_models[index]
         entry = self._profiles.get(spec)
-        footer.update(self._format_footer(entry, get_glyphs()))
+        try:
+            text = self._format_footer(entry, get_glyphs())
+        except Exception:  # Resilient footer rendering
+            logger.debug("Failed to format footer for %s", spec, exc_info=True)
+            text = "[dim]Could not load profile details[/dim]\n\n\n"
+        footer.update(text)
 
     def _move_selection(self, delta: int) -> None:
         """Move selection by delta, updating only the affected widgets.

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
@@ -201,12 +201,17 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self,
         current_model: str | None = None,
         current_provider: str | None = None,
+        cli_profile_override: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the ModelSelectorScreen.
 
         Args:
             current_model: The currently active model name (to highlight).
             current_provider: The provider of the current model.
+            cli_profile_override: Extra profile fields from `--profile-override`.
+
+                Merged on top of upstream + config.toml profiles so that CLI
+                overrides appear with `*` markers in the detail footer.
         """
         super().__init__()
         self._current_model = current_model
@@ -231,7 +236,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
         config = ModelConfig.load()
         self._default_spec: str | None = config.default_model
-        self._profiles = get_model_profiles()
+        self._profiles = get_model_profiles(cli_override=cli_profile_override)
 
     def _find_current_model_index(self) -> int:
         """Find the index of the current model in the filtered list.
@@ -593,7 +598,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             "structured_output",
         }
         has_visible_override = bool(overridden & displayed_keys)
-        line4 = "[dim]* = config.toml override[/dim]" if has_visible_override else ""
+        line4 = "[dim]* = override[/dim]" if has_visible_override else ""
 
         return f"{line1}\n{line2}\n{line3}\n{line4}"
 

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1914,3 +1914,75 @@ max_input_tokens = 100000
                 f"{spec}: overridden_keys {entry['overridden_keys']} "
                 f"not a subset of profile keys {set(entry['profile'].keys())}"
             )
+
+    def test_cli_override_merged_on_top(self) -> None:
+        """CLI override is merged on top of upstream + config.toml."""
+        fake_profiles = {
+            "claude-sonnet-4-5": {
+                "tool_calling": True,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 64000,
+            },
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with patch(
+            "deepagents_cli.model_config._load_provider_profiles",
+            side_effect=mock_load,
+        ):
+            profiles = get_model_profiles(cli_override={"max_input_tokens": 4096})
+
+        entry = profiles["anthropic:claude-sonnet-4-5"]
+        assert entry["profile"]["max_input_tokens"] == 4096
+        assert entry["profile"]["max_output_tokens"] == 64000
+        assert "max_input_tokens" in entry["overridden_keys"]
+
+    def test_cli_override_skips_cache(self) -> None:
+        """cli_override path does not populate module-level cache."""
+        fake_profiles = {
+            "test-model": {"tool_calling": True},
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with patch(
+            "deepagents_cli.model_config._load_provider_profiles",
+            side_effect=mock_load,
+        ):
+            get_model_profiles(cli_override={"max_input_tokens": 4096})
+
+        assert model_config._profiles_cache is None
+
+    def test_cli_override_on_config_only_model(self, tmp_path: Path) -> None:
+        """CLI override applies to config-only models with no upstream profile."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.custom]
+models = ["my-model"]
+[models.providers.custom.profile]
+max_input_tokens = 8192
+""")
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=ImportError("not installed"),
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles(cli_override={"max_output_tokens": 2048})
+
+        entry = profiles["custom:my-model"]
+        assert entry["profile"]["max_input_tokens"] == 8192
+        assert entry["profile"]["max_output_tokens"] == 2048
+        assert "max_output_tokens" in entry["overridden_keys"]
+        assert "max_input_tokens" in entry["overridden_keys"]

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1877,3 +1877,40 @@ max_input_tokens = 4096
         assert model_config._profiles_cache is not None
         clear_caches()
         assert model_config._profiles_cache is None
+
+    def test_overridden_keys_subset_of_profile(self, tmp_path: Path) -> None:
+        """overridden_keys is always a subset of profile keys."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+[models.providers.anthropic.profile]
+max_input_tokens = 100000
+""")
+        fake_profiles = {
+            "claude-sonnet-4-5": {
+                "tool_calling": True,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 64000,
+            },
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        for spec, entry in profiles.items():
+            assert entry["overridden_keys"] <= entry["profile"].keys(), (
+                f"{spec}: overridden_keys {entry['overridden_keys']} "
+                f"not a subset of profile keys {set(entry['profile'].keys())}"
+            )

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -13,6 +13,7 @@ from deepagents_cli.model_config import (
     PROVIDER_API_KEY_ENV,
     ModelConfig,
     ModelConfigError,
+    ModelProfileEntry,
     ModelSpec,
     _get_builtin_providers,
     _get_provider_profile_modules,
@@ -20,6 +21,7 @@ from deepagents_cli.model_config import (
     clear_caches,
     clear_default_model,
     get_available_models,
+    get_model_profiles,
     has_provider_credentials,
     is_warning_suppressed,
     save_recent_model,
@@ -1760,3 +1762,118 @@ class TestSuppressWarning:
             data = tomllib.load(f)
         assert data["models"]["default"] == "some:model"
         assert "ripgrep" in data["warnings"]["suppress"]
+
+
+class TestGetModelProfiles:
+    """Tests for get_model_profiles() function."""
+
+    def test_returns_upstream_profiles(self) -> None:
+        """Returns profiles keyed by provider:model spec."""
+        fake_profiles = {
+            "claude-sonnet-4-5": {
+                "tool_calling": True,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 64000,
+            },
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with patch(
+            "deepagents_cli.model_config._load_provider_profiles",
+            side_effect=mock_load,
+        ):
+            profiles = get_model_profiles()
+
+        assert "anthropic:claude-sonnet-4-5" in profiles
+        entry = profiles["anthropic:claude-sonnet-4-5"]
+        assert entry["profile"]["max_input_tokens"] == 200000
+        assert entry["profile"]["tool_calling"] is True
+        assert entry["overridden_keys"] == frozenset()
+
+    def test_merges_config_overrides(self, tmp_path: Path) -> None:
+        """Config.toml profile overrides are merged and tracked."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+[models.providers.anthropic.profile]
+max_input_tokens = 100000
+""")
+        fake_profiles = {
+            "claude-sonnet-4-5": {
+                "tool_calling": True,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 64000,
+            },
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        entry = profiles["anthropic:claude-sonnet-4-5"]
+        assert entry["profile"]["max_input_tokens"] == 100000
+        assert entry["profile"]["max_output_tokens"] == 64000
+        assert "max_input_tokens" in entry["overridden_keys"]
+        assert "max_output_tokens" not in entry["overridden_keys"]
+
+    def test_config_only_model_no_upstream(self, tmp_path: Path) -> None:
+        """Config-only model with no upstream profile creates an entry."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.custom]
+models = ["my-model"]
+[models.providers.custom.profile]
+max_input_tokens = 4096
+""")
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=ImportError("not installed"),
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        assert "custom:my-model" in profiles
+        entry = profiles["custom:my-model"]
+        assert entry["profile"]["max_input_tokens"] == 4096
+        assert "max_input_tokens" in entry["overridden_keys"]
+
+    def test_cache_cleared(self) -> None:
+        """clear_caches() resets the profiles cache."""
+        fake_profiles = {
+            "test-model": {"tool_calling": True},
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with patch(
+            "deepagents_cli.model_config._load_provider_profiles",
+            side_effect=mock_load,
+        ):
+            get_model_profiles()
+
+        assert model_config._profiles_cache is not None
+        clear_caches()
+        assert model_config._profiles_cache is None

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -673,7 +673,7 @@ class TestModelDetailFooter:
         assert "No profile data available" in result
 
     def test_format_footer_overridden_fields(self) -> None:
-        """Overridden fields show * marker and override notice."""
+        """Overridden fields show yellow * marker and override legend."""
         from deepagents_cli.config import UNICODE_GLYPHS
         from deepagents_cli.model_config import ModelProfileEntry
 
@@ -686,8 +686,8 @@ class TestModelDetailFooter:
             overridden_keys=frozenset({"max_input_tokens"}),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "*100.0K" in result
-        assert "* = override" in result
+        assert "[yellow]*" in result
+        assert "= override" in result
 
     def test_format_footer_partial_profile(self) -> None:
         """Profile with only token counts still renders without crash."""
@@ -717,7 +717,7 @@ class TestModelDetailFooter:
         assert "No profile data" not in result
 
     def test_format_footer_override_on_non_displayed_key(self) -> None:
-        """Override on a non-displayed key should not show notice."""
+        """Override on a non-displayed key should not show legend."""
         from deepagents_cli.config import UNICODE_GLYPHS
         from deepagents_cli.model_config import ModelProfileEntry
 
@@ -726,7 +726,7 @@ class TestModelDetailFooter:
             overridden_keys=frozenset({"supports_thinking"}),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "* = override" not in result
+        assert "= override" not in result
 
     def test_format_footer_non_numeric_tokens(self) -> None:
         """Non-numeric token values render gracefully instead of crashing."""
@@ -742,7 +742,7 @@ class TestModelDetailFooter:
         assert "64.0K" in result
 
     def test_format_footer_cli_override(self) -> None:
-        """CLI-overridden key shows * marker and override notice."""
+        """CLI-overridden key shows yellow * marker and override legend."""
         from deepagents_cli.config import UNICODE_GLYPHS
         from deepagents_cli.model_config import ModelProfileEntry
 
@@ -755,8 +755,8 @@ class TestModelDetailFooter:
             overridden_keys=frozenset({"max_input_tokens"}),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "*4096" in result or "*4.1K" in result or "*4.0K" in result
-        assert "* = override" in result
+        assert "[yellow]*" in result
+        assert "= override" in result
 
     async def test_footer_updates_on_navigation(self) -> None:
         """Footer content changes when navigating to a different model."""

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -687,7 +687,7 @@ class TestModelDetailFooter:
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
         assert "*100.0K" in result
-        assert "config.toml override" in result
+        assert "* = override" in result
 
     def test_format_footer_partial_profile(self) -> None:
         """Profile with only token counts still renders without crash."""
@@ -726,7 +726,7 @@ class TestModelDetailFooter:
             overridden_keys=frozenset({"supports_thinking"}),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "config.toml override" not in result
+        assert "* = override" not in result
 
     def test_format_footer_non_numeric_tokens(self) -> None:
         """Non-numeric token values render gracefully instead of crashing."""
@@ -740,6 +740,23 @@ class TestModelDetailFooter:
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
         assert "unlimited" in result
         assert "64.0K" in result
+
+    def test_format_footer_cli_override(self) -> None:
+        """CLI-overridden key shows * marker and override notice."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={
+                "max_input_tokens": 4096,
+                "max_output_tokens": 64000,
+                "tool_calling": True,
+            },
+            overridden_keys=frozenset({"max_input_tokens"}),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "*4096" in result or "*4.1K" in result or "*4.0K" in result
+        assert "* = override" in result
 
     async def test_footer_updates_on_navigation(self) -> None:
         """Footer content changes when navigating to a different model."""

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -741,23 +741,6 @@ class TestModelDetailFooter:
         assert "unlimited" in result
         assert "64.0K" in result
 
-    def test_format_footer_cli_override(self) -> None:
-        """CLI-overridden key shows yellow * marker and override legend."""
-        from deepagents_cli.config import UNICODE_GLYPHS
-        from deepagents_cli.model_config import ModelProfileEntry
-
-        entry = ModelProfileEntry(
-            profile={
-                "max_input_tokens": 4096,
-                "max_output_tokens": 64000,
-                "tool_calling": True,
-            },
-            overridden_keys=frozenset({"max_input_tokens"}),
-        )
-        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "[yellow]*" in result
-        assert "= override" in result
-
     async def test_footer_updates_on_navigation(self) -> None:
         """Footer content changes when navigating to a different model."""
         app = ModelSelectorTestApp()

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -6,7 +6,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container
 from textual.screen import ModalScreen
-from textual.widgets import Input
+from textual.widgets import Input, Static
 
 from deepagents_cli.widgets.model_selector import ModelSelectorScreen
 
@@ -632,3 +632,109 @@ class TestModelSelectorFuzzyMatching:
             await pilot.press("down")
             await pilot.pause()
             assert screen._selected_index == (initial + 1) % count
+
+
+class TestModelDetailFooter:
+    """Tests for the model detail footer in the selector."""
+
+    def test_format_footer_full_profile(self) -> None:
+        """Full profile renders token counts, modalities, and capabilities."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={
+                "max_input_tokens": 200000,
+                "max_output_tokens": 64000,
+                "text_inputs": True,
+                "image_inputs": True,
+                "pdf_inputs": False,
+                "reasoning_output": True,
+                "tool_calling": True,
+                "structured_output": False,
+            },
+            overridden_keys=frozenset(),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "200.0K" in result
+        assert "64.0K" in result
+        assert "text" in result
+        assert "image" in result
+        assert "tool calling" in result
+        assert "reasoning" in result
+        # No override marker
+        assert "* =" not in result
+
+    def test_format_footer_no_profile(self) -> None:
+        """None profile shows 'No profile data available'."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+
+        result = ModelSelectorScreen._format_footer(None, UNICODE_GLYPHS)
+        assert "No profile data available" in result
+
+    def test_format_footer_overridden_fields(self) -> None:
+        """Overridden fields show * marker and override notice."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={
+                "max_input_tokens": 100000,
+                "max_output_tokens": 64000,
+                "tool_calling": True,
+            },
+            overridden_keys=frozenset({"max_input_tokens"}),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "*100.0K" in result
+        assert "config.toml override" in result
+
+    def test_format_footer_partial_profile(self) -> None:
+        """Profile with only token counts still renders without crash."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={"max_input_tokens": 4096},
+            overridden_keys=frozenset(),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "4096" in result or "4.1K" in result or "4.0K" in result
+        # Should not crash and should have content
+        assert "No profile data" not in result
+
+    async def test_footer_updates_on_navigation(self) -> None:
+        """Footer content changes when navigating to a different model."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            footer = screen.query_one("#model-detail-footer", Static)
+            initial_content = str(footer.content)
+            assert len(initial_content) > 0
+
+            await pilot.press("down")
+            await pilot.pause()
+
+            updated_content = str(footer.content)
+            # Footer should still have content after navigation
+            assert len(updated_content) > 0
+
+    async def test_footer_shows_on_mount(self) -> None:
+        """Footer is populated (not empty) on initial mount."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            footer = screen.query_one("#model-detail-footer", Static)
+            content = str(footer.content)
+            # Footer should have some content after mount
+            assert len(content) > 0

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -703,6 +703,44 @@ class TestModelDetailFooter:
         # Should not crash and should have content
         assert "No profile data" not in result
 
+    def test_format_footer_empty_profile(self) -> None:
+        """Empty profile dict shows 'Context: unknown' fallback."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={},
+            overridden_keys=frozenset(),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "Context: unknown" in result
+        assert "No profile data" not in result
+
+    def test_format_footer_override_on_non_displayed_key(self) -> None:
+        """Override on a non-displayed key should not show notice."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={"max_input_tokens": 4096, "supports_thinking": True},
+            overridden_keys=frozenset({"supports_thinking"}),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "config.toml override" not in result
+
+    def test_format_footer_non_numeric_tokens(self) -> None:
+        """Non-numeric token values render gracefully instead of crashing."""
+        from deepagents_cli.config import UNICODE_GLYPHS
+        from deepagents_cli.model_config import ModelProfileEntry
+
+        entry = ModelProfileEntry(
+            profile={"max_input_tokens": "unlimited", "max_output_tokens": 64000},
+            overridden_keys=frozenset(),
+        )
+        result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
+        assert "unlimited" in result
+        assert "64.0K" in result
+
     async def test_footer_updates_on_navigation(self) -> None:
         """Footer content changes when navigating to a different model."""
         app = ModelSelectorTestApp()
@@ -715,17 +753,16 @@ class TestModelDetailFooter:
 
             footer = screen.query_one("#model-detail-footer", Static)
             initial_content = str(footer.content)
-            assert len(initial_content) > 0
+            assert "Context:" in initial_content or "No profile" in initial_content
 
             await pilot.press("down")
             await pilot.pause()
 
             updated_content = str(footer.content)
-            # Footer should still have content after navigation
-            assert len(updated_content) > 0
+            assert "Context:" in updated_content or "No profile" in updated_content
 
     async def test_footer_shows_on_mount(self) -> None:
-        """Footer is populated (not empty) on initial mount."""
+        """Footer is populated with structural content on initial mount."""
         app = ModelSelectorTestApp()
         async with app.run_test() as pilot:
             app.show_selector()
@@ -736,5 +773,24 @@ class TestModelDetailFooter:
 
             footer = screen.query_one("#model-detail-footer", Static)
             content = str(footer.content)
-            # Footer should have some content after mount
-            assert len(content) > 0
+            assert "Context:" in content or "No profile" in content
+
+    async def test_footer_no_model_when_filter_empty(self) -> None:
+        """Footer shows 'No model selected' when filter matches nothing."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+
+            for char in "xyz999qqq":
+                await pilot.press(char)
+            # Pump several frames so all deferred call_after_refresh
+            # callbacks complete after the last keystroke
+            for _ in range(5):
+                await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+            assert len(screen._filtered_models) == 0
+            footer = screen.query_one("#model-detail-footer", Static)
+            assert "No model selected" in str(footer.content)

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -768,6 +768,7 @@ class TestModelSwitchExtraKwargs:
         mock_create.assert_called_once_with(
             "anthropic:claude-sonnet-4-5",
             extra_kwargs={"temperature": 0.7},
+            profile_overrides=None,
         )
 
     async def test_no_extra_kwargs_by_default(self) -> None:
@@ -800,6 +801,7 @@ class TestModelSwitchExtraKwargs:
         mock_create.assert_called_once_with(
             "anthropic:claude-sonnet-4-5",
             extra_kwargs=None,
+            profile_overrides=None,
         )
 
 


### PR DESCRIPTION
- Add a detail footer to the `/model` selector showing context window size, input modalities, and capabilities for the highlighted model. Profile data comes from upstream provider packages merged with `config.toml` overrides.
- Wire `--profile-override` through the full session lifetime so it (1) re-applies on every `/model` hot-swap and (2) appears in the footer. Previously the CLI override was discarded after startup — switching models via `/model` silently dropped it.
- Overridden values (from `config.toml` or `--profile-override`) render in yellow with a `*` prefix so users can tell what they've customized.

<img width="593" height="195" alt="Screenshot 26" src="https://github.com/user-attachments/assets/6328ffe6-21d2-4104-babc-20703500a9cc" />

<img width="624" height="92" alt="Screenshot" src="https://github.com/user-attachments/assets/fdac12e9-c789-45be-8bcd-d375c7327de7" />


## Changes

- **`model_config.py`** — Add `get_model_profiles()` to load upstream profiles, merge `config.toml` overrides, and cache the result keyed by `provider:model`. Add optional `cli_override` param that merges on top of every entry without populating the cache (session-specific). Add `ModelProfileEntry` TypedDict pairing merged profiles with an `overridden_keys` frozenset.
- **`model_selector.py`** — Add a 4-line `model-detail-footer` widget showing context window (`format_token_count`), input modalities (text/image/audio/pdf/video), and capabilities (reasoning/tool calling/structured output). Accept `cli_profile_override` param and pass to `get_model_profiles()`. Override markers render as `[yellow]*value[/yellow]`.