### PR TITLE
fix(cli): expire `ctrl+c` quit window when toast disappears

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2485,7 +2485,9 @@ class DeepAgentsApp(App):
             self.exit()
         else:
             self._quit_pending = True
-            self.notify("Press Ctrl+C again to quit", timeout=3)
+            quit_timeout = 3
+            self.notify("Press Ctrl+C again to quit", timeout=quit_timeout)
+            self.set_timer(quit_timeout, lambda: setattr(self, "_quit_pending", False))
 
     def action_interrupt(self) -> None:
         """Handle escape key.


### PR DESCRIPTION
The `ctrl+c` double-press quit mechanism had no expiry — `_quit_pending` stayed `True` indefinitely after the first press, even though the toast notification disappeared after 3 seconds. A user could press `ctrl+c` once, wait arbitrarily long, then accidentally quit the app on a second press long after the visual hint was gone. Add a `set_timer` to reset `_quit_pending` after the same duration as the toast.