### PR TITLE
feat(cli): show message timestamp toast on click

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2340,6 +2340,10 @@ class DeepAgentsApp(App):
 
         # Store message data for virtualization
         message_data = MessageData.from_widget(widget)
+        # Ensure the widget's DOM id matches the store id so that
+        # features like click-to-show-timestamp can look it up.
+        if not widget.id:
+            widget.id = message_data.id
         self._message_store.append(message_data)
 
         # Queued-message widgets must always stay at the bottom so they

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -38,18 +38,43 @@ logger = logging.getLogger(__name__)
 
 
 def _show_timestamp_toast(widget: Static | Vertical) -> None:
-    """Show a toast with the message's creation timestamp."""
+    """Show a toast with the message's creation timestamp.
+
+    No-ops silently if the widget is not mounted or has no associated message
+    data in the store.
+
+    Args:
+        widget: The message widget whose timestamp to display.
+    """
     from datetime import UTC, datetime
 
     try:
-        store = widget.app._message_store  # type: ignore[attr-defined]
-    except Exception:  # noqa: BLE001  # widget may not be mounted
+        app = widget.app
+    except Exception:  # noqa: BLE001  # Textual raises when widget has no app
         return
+    if not widget.id:
+        return
+    store = app._message_store  # type: ignore[attr-defined]
     data = store.get_message(widget.id)
     if not data:
         return
     dt = datetime.fromtimestamp(data.timestamp, tz=UTC).astimezone()
-    widget.app.notify(dt.strftime("%b %-d, %-I:%M:%S %p"), timeout=3)
+    label = f"{dt:%b} {dt.day}, {dt.hour % 12 or 12}:{dt:%M:%S} {dt:%p}"
+    app.notify(label, timeout=3)
+
+
+class _TimestampClickMixin:
+    """Mixin that shows a timestamp toast on click.
+
+    Add to any message widget that should display its creation timestamp when
+    clicked. Widgets needing additional click behavior (e.g. `ToolCallMessage`,
+    `AppMessage`) should override `on_click` and call `_show_timestamp_toast`
+    directly instead.
+    """
+
+    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
+        """Show timestamp toast on click."""
+        _show_timestamp_toast(self)  # type: ignore[arg-type]
 
 
 def _mode_color(mode: str | None) -> str:
@@ -116,7 +141,7 @@ _TOOLS_WITH_HEADER_INFO: set[str] = {
 }
 
 
-class UserMessage(Static):
+class UserMessage(_TimestampClickMixin, Static):
     """Widget displaying a user message."""
 
     DEFAULT_CSS = """
@@ -195,10 +220,6 @@ class UserMessage(Static):
 
         yield Static(text)
 
-    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
-        """Show timestamp toast on click."""
-        _show_timestamp_toast(self)
-
 
 class QueuedUserMessage(Static):
     """Widget displaying a queued (pending) user message in grey.
@@ -250,7 +271,7 @@ class QueuedUserMessage(Static):
         yield Static(text)
 
 
-class AssistantMessage(Vertical):
+class AssistantMessage(_TimestampClickMixin, Vertical):
     """Widget displaying an assistant message with markdown support.
 
     Uses MarkdownStream for smoother streaming instead of re-rendering
@@ -353,10 +374,6 @@ class AssistantMessage(Vertical):
         self._content = content
         if self._markdown:
             await self._markdown.update(content)
-
-    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
-        """Show timestamp toast on click."""
-        _show_timestamp_toast(self)
 
 
 class ToolCallMessage(Vertical):
@@ -675,10 +692,12 @@ class ToolCallMessage(Vertical):
         self._update_output_display()
 
     def on_click(self, event: Click) -> None:
-        """Handle click to toggle output expansion and show timestamp."""
+        """Toggle output expansion, or show timestamp if no output."""
         event.stop()  # Prevent click from bubbling up and scrolling
-        self.toggle_output()
-        _show_timestamp_toast(self)
+        if self._output:
+            self.toggle_output()
+        else:
+            _show_timestamp_toast(self)
 
     def _format_output(
         self, output: str, *, is_preview: bool = False
@@ -1192,7 +1211,7 @@ class ToolCallMessage(Vertical):
         return filtered
 
 
-class DiffMessage(Static):
+class DiffMessage(_TimestampClickMixin, Static):
     """Widget displaying a diff with syntax highlighting."""
 
     DEFAULT_CSS = """
@@ -1262,12 +1281,8 @@ class DiffMessage(Static):
         if _detect_charset_mode() == CharsetMode.ASCII:
             self.styles.border = ("ascii", "cyan")
 
-    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
-        """Show timestamp toast on click."""
-        _show_timestamp_toast(self)
 
-
-class ErrorMessage(Static):
+class ErrorMessage(_TimestampClickMixin, Static):
     """Widget displaying an error message."""
 
     DEFAULT_CSS = """
@@ -1299,10 +1314,6 @@ class ErrorMessage(Static):
         """Set border style based on charset mode."""
         if _detect_charset_mode() == CharsetMode.ASCII:
             self.styles.border_left = ("ascii", "red")
-
-    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
-        """Show timestamp toast on click."""
-        _show_timestamp_toast(self)
 
 
 class AppMessage(Static):

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -37,6 +37,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _show_timestamp_toast(widget: Static | Vertical) -> None:
+    """Show a toast with the message's creation timestamp."""
+    from datetime import UTC, datetime
+
+    try:
+        store = widget.app._message_store  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001  # widget may not be mounted
+        return
+    data = store.get_message(widget.id)
+    if not data:
+        return
+    dt = datetime.fromtimestamp(data.timestamp, tz=UTC).astimezone()
+    widget.app.notify(dt.strftime("%b %-d, %-I:%M:%S %p"), timeout=3)
+
+
 def _mode_color(mode: str | None) -> str:
     """Return the color string for a mode, falling back to primary.
 
@@ -179,6 +194,10 @@ class UserMessage(Static):
             text.append(content[last_end:])
 
         yield Static(text)
+
+    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
+        """Show timestamp toast on click."""
+        _show_timestamp_toast(self)
 
 
 class QueuedUserMessage(Static):
@@ -334,6 +353,10 @@ class AssistantMessage(Vertical):
         self._content = content
         if self._markdown:
             await self._markdown.update(content)
+
+    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
+        """Show timestamp toast on click."""
+        _show_timestamp_toast(self)
 
 
 class ToolCallMessage(Vertical):
@@ -652,9 +675,10 @@ class ToolCallMessage(Vertical):
         self._update_output_display()
 
     def on_click(self, event: Click) -> None:
-        """Handle click to toggle output expansion."""
+        """Handle click to toggle output expansion and show timestamp."""
         event.stop()  # Prevent click from bubbling up and scrolling
         self.toggle_output()
+        _show_timestamp_toast(self)
 
     def _format_output(
         self, output: str, *, is_preview: bool = False
@@ -1238,6 +1262,10 @@ class DiffMessage(Static):
         if _detect_charset_mode() == CharsetMode.ASCII:
             self.styles.border = ("ascii", "cyan")
 
+    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
+        """Show timestamp toast on click."""
+        _show_timestamp_toast(self)
+
 
 class ErrorMessage(Static):
     """Widget displaying an error message."""
@@ -1271,6 +1299,10 @@ class ErrorMessage(Static):
         """Set border style based on charset mode."""
         if _detect_charset_mode() == CharsetMode.ASCII:
             self.styles.border_left = ("ascii", "red")
+
+    def on_click(self, event: Click) -> None:  # noqa: ARG002  # Textual event handler
+        """Show timestamp toast on click."""
+        _show_timestamp_toast(self)
 
 
 class AppMessage(Static):
@@ -1307,9 +1339,10 @@ class AppMessage(Static):
         )
         super().__init__(content, **kwargs)
 
-    def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
-        """Open Rich-style hyperlinks on single click."""
+    def on_click(self, event: Click) -> None:
+        """Open Rich-style hyperlinks on single click and show timestamp."""
         open_style_link(event)
+        _show_timestamp_toast(self)
 
 
 class SummarizationMessage(AppMessage):

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -11,11 +11,14 @@ from deepagents_cli.config import COLORS
 from deepagents_cli.input import INPUT_HIGHLIGHT_PATTERN
 from deepagents_cli.widgets.messages import (
     AppMessage,
+    AssistantMessage,
+    DiffMessage,
     ErrorMessage,
     QueuedUserMessage,
     SummarizationMessage,
     ToolCallMessage,
     UserMessage,
+    _show_timestamp_toast,
 )
 
 # Content that previously caused MarkupError crashes
@@ -414,3 +417,150 @@ class TestAppMessageOnClickOpensLink:
 
         mock_open.assert_not_called()
         event.stop.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Timestamp toast tests
+# ---------------------------------------------------------------------------
+
+_MSG_STORE_PATH = "deepagents_cli.widgets.messages"
+
+
+class TestShowTimestampToast:
+    """Tests for `_show_timestamp_toast` helper."""
+
+    def test_noop_when_widget_not_mounted(self) -> None:
+        """Should not raise when widget has no app."""
+        widget = MagicMock(spec=["app", "id"])
+        # Simulate unmounted widget: .app property raises
+        type(widget).app = property(
+            lambda _: (_ for _ in ()).throw(RuntimeError("no app"))
+        )
+        widget.id = "msg-abc"
+        _show_timestamp_toast(widget)  # should not raise
+
+    def test_noop_when_widget_id_is_none(self) -> None:
+        """Should return early when widget.id is None."""
+        widget = MagicMock()
+        widget.id = None
+        widget.app = MagicMock()
+        _show_timestamp_toast(widget)
+        widget.app.notify.assert_not_called()
+
+    def test_noop_when_message_not_in_store(self) -> None:
+        """Should return early when message is not found in the store."""
+        widget = MagicMock()
+        widget.id = "msg-missing"
+        widget.app._message_store.get_message.return_value = None
+        _show_timestamp_toast(widget)
+        widget.app.notify.assert_not_called()
+
+    def test_shows_toast_with_formatted_timestamp(self) -> None:
+        """Should call notify with a human-readable timestamp."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        data = MessageData(
+            type=MessageType.USER,
+            content="hello",
+            id="msg-test123",
+            timestamp=1709744055.0,  # 2024-03-06 17:14:15 UTC
+        )
+        widget = MagicMock()
+        widget.id = "msg-test123"
+        widget.app._message_store.get_message.return_value = data
+
+        _show_timestamp_toast(widget)
+
+        widget.app.notify.assert_called_once()
+        call_args = widget.app.notify.call_args
+        label = call_args[0][0]
+        # Should contain month abbreviation and time components
+        assert "Mar" in label
+        assert ":" in label
+        assert call_args[1]["timeout"] == 3
+
+
+class TestTimestampClickMixin:
+    """Tests for `_TimestampClickMixin` on message widgets."""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [UserMessage, AssistantMessage, DiffMessage, ErrorMessage],
+        ids=["UserMessage", "AssistantMessage", "DiffMessage", "ErrorMessage"],
+    )
+    def test_mixin_classes_have_on_click(self, cls: type) -> None:
+        """Mixin widget classes should have an `on_click` handler."""
+        assert hasattr(cls, "on_click")
+
+    def test_tool_call_message_click_without_output_shows_toast(self) -> None:
+        """ToolCallMessage click with no output should show timestamp toast."""
+        msg = ToolCallMessage("test_tool", {})
+        msg._output = ""
+        event = MagicMock()
+
+        with patch(f"{_MSG_STORE_PATH}._show_timestamp_toast") as mock_toast:
+            msg.on_click(event)
+
+        event.stop.assert_called_once()
+        mock_toast.assert_called_once_with(msg)
+
+    def test_tool_call_message_click_with_output_toggles(self) -> None:
+        """ToolCallMessage click with output should toggle, not toast."""
+        msg = ToolCallMessage("test_tool", {})
+        msg._output = "some output"
+        event = MagicMock()
+
+        with (
+            patch.object(msg, "toggle_output") as mock_toggle,
+            patch(f"{_MSG_STORE_PATH}._show_timestamp_toast") as mock_toast,
+        ):
+            msg.on_click(event)
+
+        event.stop.assert_called_once()
+        mock_toggle.assert_called_once()
+        mock_toast.assert_not_called()
+
+    def test_app_message_click_shows_toast_alongside_link(self) -> None:
+        """AppMessage click should open link and show toast."""
+        msg = AppMessage("test")
+        event = MagicMock()
+        event.style = Style()
+
+        with (
+            patch(_WEBBROWSER_OPEN),
+            patch(f"{_MSG_STORE_PATH}._show_timestamp_toast") as mock_toast,
+        ):
+            msg.on_click(event)
+
+        mock_toast.assert_called_once_with(msg)
+
+
+class TestMountMessageIdSync:
+    """Tests for widget id sync in `_mount_message`."""
+
+    def test_widget_id_assigned_from_message_data(self) -> None:
+        """Widget with no id should get the MessageData id after from_widget."""
+        from deepagents_cli.widgets.message_store import MessageData
+
+        widget = UserMessage("hello")
+        assert widget.id is None
+
+        data = MessageData.from_widget(widget)
+        # Simulate what _mount_message does
+        if not widget.id:
+            widget.id = data.id
+
+        assert widget.id == data.id
+        assert widget.id is not None
+
+    def test_widget_with_existing_id_is_preserved(self) -> None:
+        """Widget with an explicit id should keep it."""
+        from deepagents_cli.widgets.message_store import MessageData
+
+        widget = UserMessage("hello", id="my-custom-id")
+        data = MessageData.from_widget(widget)
+
+        if not widget.id:
+            widget.id = data.id
+
+        assert widget.id == "my-custom-id"


### PR DESCRIPTION
Clicking any message widget in the CLI now shows a toast notification with its creation timestamp. `MessageData` already stores a `timestamp` field but it was never surfaced to the user — this wires it up via `on_click` handlers across all message widget types.

A prerequisite bug was also fixed: widgets created during normal message flow had `id=None`, so the store lookup would silently fail. `_mount_message` now syncs the widget's DOM id with the `MessageData.id` it just created.