### PR TITLE
fix(cli): preserve input text when escaping shell/command mode

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1483,8 +1483,6 @@ class ChatInput(Vertical):
         if self._completion_manager:
             self._completion_manager.reset()
         self.clear_completion_suggestions()
-        if self._text_area:
-            self._text_area.clear()
         return True
 
     def dismiss_completion(self) -> bool:

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -983,6 +983,48 @@ class TestModePrefixStripping:
             assert app.submitted[0].value == "!already-prefixed"
 
 
+class TestExitModePreservesText:
+    """Exiting shell/command mode should preserve typed text."""
+
+    async def test_exit_shell_mode_keeps_text(self) -> None:
+        """Pressing Escape in shell mode should switch to normal but keep text."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            # Enter shell mode with some text
+            chat._text_area.text = "!ls -la"
+            await _pause_for_strip(pilot)
+            assert chat.mode == "shell"
+            assert chat._text_area.text == "ls -la"
+
+            # Exit mode — text should be preserved
+            assert chat.exit_mode() is True
+            assert chat.mode == "normal"
+            assert chat._text_area.text == "ls -la"
+
+    async def test_exit_command_mode_keeps_text(self) -> None:
+        """Pressing Escape in command mode should switch to normal but keep text."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.insert("/")
+            await _pause_for_strip(pilot)
+            assert chat.mode == "command"
+
+            chat.dismiss_completion()
+            chat._text_area.insert("help")
+            await pilot.pause()
+            assert chat._text_area.text == "help"
+
+            assert chat.exit_mode() is True
+            assert chat.mode == "normal"
+            assert chat._text_area.text == "help"
+
+
 class TestHistoryRecallModeReset:
     """Regression: history recall must not inherit a stale shell/command mode."""
 


### PR DESCRIPTION
Pressing Escape while in shell (`!`) or command (`/`) mode cleared the text input entirely. The expected behavior is that Escape exits the mode back to normal without discarding what was typed — the same way dismissing a completion popup preserves input.