### PR TITLE
test(sdk): update eval model list with new providers and sets

### DIFF
--- a/.github/scripts/get_eval_models.py
+++ b/.github/scripts/get_eval_models.py
@@ -4,8 +4,10 @@ Prints a single line: matrix={"model":["provider:model-name", ...]}
 suitable for appending to $GITHUB_OUTPUT.
 
 Reads the EVAL_MODELS env var to determine which models to include:
-  - "all" (default): every model in MODELS
+  - "all" (default): every model across all sets (deduplicated)
+  - "set0": first-party API providers (Anthropic, OpenAI, Google)
   - "set1": a curated subset of flagship models
+  - "set2": slower third-party hosted models
   - any other value: treated as a single "provider:model" spec
 """
 
@@ -14,7 +16,7 @@ from __future__ import annotations
 import json
 import os
 
-MODELS: list[str] = [
+SET0: list[str] = [
     # Anthropic
     "anthropic:claude-haiku-4-5-20251001",
     "anthropic:claude-sonnet-4-20250514",
@@ -37,30 +39,19 @@ MODELS: list[str] = [
     "google_genai:gemini-2.5-pro",
     "google_genai:gemini-3-flash-preview",
     "google_genai:gemini-3.1-pro-preview",
-    # xAI
-    "xai:grok-4",
-    "xai:grok-3-mini-fast",
-    # Groq
-    "groq:openai/gpt-oss-120b",
-    "groq:qwen/qwen3-32b",
-    "groq:moonshotai/kimi-k2-instruct",
-    # Ollama Cloud
-    "ollama:glm-5",
-    "ollama:minimax-m2.5",
-    "ollama:nemotron-3-nano:30b",
-    "ollama:cogito-2.1:671b",
-    "ollama:devstral-2:123b",
-    "ollama:ministral-3:14b",
-    "ollama:qwen3-next:80b",
-    "ollama:qwen3-coder:480b-cloud",
-    "ollama:qwen3.5:397b-cloud",
-    "ollama:deepseek-v3.2:cloud",
     # Baseten
     "baseten:zai-org/GLM-5",
     "baseten:MiniMaxAI/MiniMax-M2.5",
+    "baseten:moonshotai/Kimi-K2.5",
+    "baseten:deepseek-ai/DeepSeek-V3.2",
+    "baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct",
     # Fireworks
     "fireworks:accounts/fireworks/models/qwen3-235b-a22b-instruct-2507",
     "fireworks:accounts/fireworks/models/deepseek-v3-0324",
+    "fireworks:accounts/fireworks/models/minimax-m2p1",
+    "fireworks:accounts/fireworks/models/kimi-k2p5",
+    "fireworks:accounts/fireworks/models/glm-5",
+    "fireworks:accounts/fireworks/models/minimax-m2p5",
 ]
 
 SET1: list[str] = [
@@ -80,17 +71,50 @@ SET1: list[str] = [
     "fireworks:accounts/fireworks/models/qwen3-235b-a22b-instruct-2507",
 ]
 
+# These are a bit slower
+SET2: list[str] = [
+    # Groq
+    "groq:openai/gpt-oss-120b",
+    "groq:qwen/qwen3-32b",
+    "groq:moonshotai/kimi-k2-instruct",
+    # xAI
+    "xai:grok-4",
+    "xai:grok-3-mini-fast",
+    # Ollama Cloud
+    "ollama:glm-5",
+    "ollama:minimax-m2.5",
+    "ollama:nemotron-3-nano:30b",
+    "ollama:cogito-2.1:671b",
+    "ollama:devstral-2:123b",
+    "ollama:ministral-3:14b",
+    "ollama:qwen3-next:80b",
+    "ollama:qwen3-coder:480b-cloud",
+    "ollama:qwen3.5:397b-cloud",
+    "ollama:deepseek-v3.2:cloud",
+]
+
 
 def _resolve_models(selection: str) -> list[str]:
     """Return the list of models for the given selection string.
 
-    Accepts "all", "set1", a single model spec, or comma-separated model specs.
+    Accepts "all", "set1", "set2", a single model spec, or comma-separated
+    model specs.
     """
     selection = selection.strip()
     if selection == "all":
-        return MODELS
+        seen: set[str] = set()
+        result: list[str] = []
+        for model in SET0 + SET1 + SET2:
+            if model not in seen:
+                seen.add(model)
+                result.append(model)
+        return result
+    if selection == "set0":
+        return SET0
     if selection == "set1":
         return SET1
+    if selection == "set2":
+        return SET2
     specs = [s.strip() for s in selection.split(",") if s.strip()]
     invalid = [s for s in specs if ":" not in s]
     if invalid:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -31,7 +31,9 @@ on:
         type: choice
         options:
           - all
+          - set0
           - set1
+          - set2
           - "anthropic:claude-haiku-4-5-20251001"
           - "anthropic:claude-sonnet-4-20250514"
           - "anthropic:claude-sonnet-4-5-20250929"
@@ -68,8 +70,15 @@ on:
           - "ollama:deepseek-v3.2:cloud"
           - "baseten:zai-org/GLM-5"
           - "baseten:MiniMaxAI/MiniMax-M2.5"
+          - "baseten:moonshotai/Kimi-K2.5"
+          - "baseten:deepseek-ai/DeepSeek-V3.2"
+          - "baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct"
           - "fireworks:accounts/fireworks/models/qwen3-235b-a22b-instruct-2507"
           - "fireworks:accounts/fireworks/models/deepseek-v3-0324"
+          - "fireworks:accounts/fireworks/models/minimax-m2p1"
+          - "fireworks:accounts/fireworks/models/kimi-k2p5"
+          - "fireworks:accounts/fireworks/models/glm-5"
+          - "fireworks:accounts/fireworks/models/minimax-m2p5"
       models_override:
         description: "Override: comma-separated models (e.g. 'openai:gpt-4.1,openai:o3'). Takes priority over dropdown when non-empty."
         required: false


### PR DESCRIPTION
Adds new models to the evals workflow across Baseten (Kimi-K2.5, DeepSeek-V3.2, Qwen3-Coder-480B), Fireworks (minimax-m2p1, kimi-k2p5, glm-5, minimax-m2p5), and reorganizes model sets. MODELS is now SET0 for first-party providers, SET2 added for slower third-party models (Groq, xAI, Ollama Cloud), and `all` returns the deduplicated union of all sets.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).