### PR TITLE
fix(cli): write files with langsmith sandbox

### DIFF
--- a/libs/cli/deepagents_cli/integrations/langsmith.py
+++ b/libs/cli/deepagents_cli/integrations/langsmith.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import time
 from typing import TYPE_CHECKING, Any
@@ -14,8 +15,11 @@ from deepagents.backends.protocol import (
     SandboxBackendProtocol,
 )
 from deepagents.backends.sandbox import BaseSandbox
+from langsmith.sandbox import ResourceNotFoundError, SandboxClientError
 
 from deepagents_cli.integrations.sandbox_provider import SandboxProvider
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from langsmith.sandbox import Sandbox, SandboxClient, SandboxTemplate
@@ -88,18 +92,22 @@ class LangSmithBackend(BaseSandbox):
         Returns:
             List of FileDownloadResponse objects, one per input path.
             Response order matches input order.
-
-        TODO: Map LangSmith API error strings to standardized FileOperationError codes.
-        Currently only implements happy path.
         """
         responses: list[FileDownloadResponse] = []
 
         for path in paths:
-            # Use LangSmith's native file read API (returns bytes)
-            content = self._sandbox.read(path)
-            responses.append(
-                FileDownloadResponse(path=path, content=content, error=None)
-            )
+            try:
+                # Use LangSmith's native file read API (returns bytes)
+                content = self._sandbox.read(path)
+                responses.append(
+                    FileDownloadResponse(path=path, content=content, error=None)
+                )
+            except ResourceNotFoundError:
+                responses.append(
+                    FileDownloadResponse(
+                        path=path, content=None, error="file_not_found"
+                    )
+                )
 
         return responses
 
@@ -116,16 +124,19 @@ class LangSmithBackend(BaseSandbox):
         Returns:
             List of FileUploadResponse objects, one per input file.
             Response order matches input order.
-
-        TODO: Map LangSmith API error strings to standardized FileOperationError codes.
-        Currently only implements happy path.
         """
         responses: list[FileUploadResponse] = []
 
         for path, content in files:
-            # Use LangSmith's native file write API
-            self._sandbox.write(path, content)
-            responses.append(FileUploadResponse(path=path, error=None))
+            try:
+                # Use LangSmith's native file write API
+                self._sandbox.write(path, content)
+                responses.append(FileUploadResponse(path=path, error=None))
+            except SandboxClientError as e:
+                logger.debug("Failed to upload %s: %s", path, e)
+                responses.append(
+                    FileUploadResponse(path=path, error="permission_denied")
+                )
 
         return responses
 
@@ -266,8 +277,6 @@ class LangSmithProvider(SandboxProvider):
         Raises:
             RuntimeError: If template check or creation fails
         """
-        from langsmith.sandbox import ResourceNotFoundError
-
         try:
             self._client.get_template(template_name)
         except ResourceNotFoundError as e:


### PR DESCRIPTION
Langsmith sandbox is failing to write new files. 

This is because the cli tries to read the file first. 
The SDK raises an exception when reading files that don't exist.

This PR handles the exception for this case
