### PR TITLE
feat: GitHub Action with skills, memory, and security hardening

### DIFF
--- a/.github/workflows/deepagents-example.yml
+++ b/.github/workflows/deepagents-example.yml
@@ -1,0 +1,31 @@
+name: Deep Agents Example
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt for the agent'
+        required: true
+
+jobs:
+  deepagents:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.comment.body, '@deepagents')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Deep Agents
+        uses: langchain-ai/deepagents@v1
+        with:
+          prompt: ${{ github.event.inputs.prompt || github.event.comment.body }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Or: openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/deepagents-example.yml
+++ b/.github/workflows/deepagents-example.yml
@@ -3,6 +3,8 @@ name: Deep Agents Example
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       prompt:
@@ -15,11 +17,14 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         contains(github.event.comment.body, '@deepagents') &&
-        github.event.issue.pull_request &&
         (
           github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        (
+          github.event_name == 'pull_request_review_comment' ||
+          github.event.issue.pull_request
         )
       )
     runs-on: ubuntu-latest
@@ -29,25 +34,39 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Resolve PR number
+        if: github.event_name != 'workflow_dispatch'
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # issue_comment uses event.issue.number; review_comment uses event.pull_request.number
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
       - name: Acknowledge trigger
-        if: github.event_name == 'issue_comment'
+        if: github.event_name != 'workflow_dispatch'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          gh api \
-            --method POST \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-            -f content='rocket'
+          # issue_comment reactions use issues/comments; review_comment uses pulls/comments
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            API_PATH="repos/${{ github.repository }}/pulls/comments/${COMMENT_ID}/reactions"
+          else
+            API_PATH="repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions"
+          fi
+          gh api --method POST "$API_PATH" -f content='rocket'
 
       - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
+        if: github.event_name != 'workflow_dispatch'
         id: pr-sha
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ steps.pr-info.outputs.number }}
         run: |
-          PR_DATA=$(gh pr view "$PR_NUMBER" --json headRefOid,headRefName)
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName)
           PR_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
           PR_BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
           echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
@@ -56,16 +75,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # Use the PR branch name so the agent can commit and push to the PR directly.
-          ref: ${{ github.event_name == 'issue_comment' && steps.pr-sha.outputs.branch || '' }}
+          ref: ${{ github.event_name != 'workflow_dispatch' && steps.pr-sha.outputs.branch || '' }}
 
       - name: Build PR context prompt
-        if: github.event_name == 'issue_comment'
+        if: github.event_name != 'workflow_dispatch'
         id: build-prompt
         env:
           GH_TOKEN: ${{ github.token }}
           TRIGGER_COMMENT_BODY: ${{ github.event.comment.body }}
           TRIGGER_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ steps.pr-info.outputs.number }}
         run: |
           PROMPT_FILE=$(mktemp)
 
@@ -170,7 +189,7 @@ jobs:
       - name: Run Deep Agents
         uses: langchain-ai/deepagents@main
         with:
-          prompt: ${{ github.event_name == 'issue_comment' && steps.build-prompt.outputs.prompt || github.event.inputs.prompt }}
+          prompt: ${{ github.event_name != 'workflow_dispatch' && steps.build-prompt.outputs.prompt || github.event.inputs.prompt }}
           model: claude-sonnet-4-6
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or: openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/deepagents-example.yml
+++ b/.github/workflows/deepagents-example.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       prompt:
-        description: 'Prompt for the agent'
+        description: "Prompt for the agent"
         required: true
 
 jobs:
@@ -37,6 +37,7 @@ jobs:
       - name: Resolve PR number
         if: github.event_name != 'workflow_dispatch'
         id: pr-info
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           # issue_comment uses event.issue.number; review_comment uses event.pull_request.number
@@ -47,21 +48,27 @@ jobs:
       - name: Acknowledge trigger
         if: github.event_name != 'workflow_dispatch'
         continue-on-error: true
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
         run: |
           # issue_comment reactions use issues/comments; review_comment uses pulls/comments
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            API_PATH="repos/${{ github.repository }}/pulls/comments/${COMMENT_ID}/reactions"
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            API_PATH="repos/${REPO}/pulls/comments/${COMMENT_ID}/reactions"
           else
-            API_PATH="repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions"
+            API_PATH="repos/${REPO}/issues/comments/${COMMENT_ID}/reactions"
           fi
-          gh api --method POST "$API_PATH" -f content='rocket'
+          if ! gh api --method POST "$API_PATH" -f content='rocket'; then
+            echo "::warning::Failed to add reaction to comment ${COMMENT_ID} — comment may have been deleted or token may lack permissions"
+          fi
 
       - name: Get PR head SHA
         if: github.event_name != 'workflow_dispatch'
         id: pr-sha
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr-info.outputs.number }}
@@ -69,10 +76,16 @@ jobs:
           PR_DATA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName)
           PR_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
           PR_BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
+
+          if [ -z "$PR_SHA" ] || [ "$PR_SHA" = "null" ] || [ -z "$PR_BRANCH" ] || [ "$PR_BRANCH" = "null" ]; then
+            echo "::error::Failed to resolve PR head for #${PR_NUMBER}. API response: ${PR_DATA}"
+            exit 1
+          fi
+
           echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
           echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Use the PR branch name so the agent can commit and push to the PR directly.
           ref: ${{ github.event_name != 'workflow_dispatch' && steps.pr-sha.outputs.branch || '' }}
@@ -80,6 +93,7 @@ jobs:
       - name: Build PR context prompt
         if: github.event_name != 'workflow_dispatch'
         id: build-prompt
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TRIGGER_COMMENT_BODY: ${{ github.event.comment.body }}
@@ -87,34 +101,54 @@ jobs:
           PR_NUMBER: ${{ steps.pr-info.outputs.number }}
         run: |
           PROMPT_FILE=$(mktemp)
+          GH_STDERR=$(mktemp)
+          trap 'rm -f "$PROMPT_FILE" "$GH_STDERR"' EXIT
 
           # Fetch PR data
-          PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,author,state,headRefName,baseRefName)
-          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          if ! PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,author,state,headRefName,baseRefName 2>"$GH_STDERR"); then
+            echo "::error::Failed to fetch PR #${PR_NUMBER} data: $(cat "$GH_STDERR"). Check that the PR exists and the token has 'pull-requests: read' permission."
+            exit 1
+          fi
+
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // "Untitled"')
           PR_BODY=$(echo "$PR_DATA" | jq -r '.body // "No description"')
-          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
-          PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
-          PR_HEAD=$(echo "$PR_DATA" | jq -r '.headRefName')
-          PR_BASE=$(echo "$PR_DATA" | jq -r '.baseRefName')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // "unknown"')
+          PR_STATE=$(echo "$PR_DATA" | jq -r '.state // "unknown"')
+          PR_HEAD=$(echo "$PR_DATA" | jq -r '.headRefName // "unknown"')
+          PR_BASE=$(echo "$PR_DATA" | jq -r '.baseRefName // "unknown"')
 
-          # Fetch PR diff stats
-          DIFF_STAT=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "Unable to fetch diff")
+          # Fetch PR diff stats (first page)
+          if ! DIFF_STAT=$(gh pr diff "$PR_NUMBER" --name-only 2>"$GH_STDERR"); then
+            echo "::warning::Failed to fetch PR diff: $(cat "$GH_STDERR")"
+            DIFF_STAT="[Error fetching diff — see workflow logs]"
+          fi
 
-          # Fetch PR comments (last 20)
-          PR_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=20" \
-            --jq '.[] | "<comment author=\"\(.user.login)\">\(.body)</comment>"' 2>/dev/null || echo "No comments")
+          # Fetch PR comments (first 20 — older ones omitted)
+          if ! PR_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=20" \
+            --jq '.[] | "<comment author=\"\(.user.login)\">\(.body)</comment>"' 2>"$GH_STDERR"); then
+            echo "::warning::Failed to fetch PR comments: $(cat "$GH_STDERR")"
+            PR_COMMENTS="[Error fetching comments — see workflow logs]"
+          fi
 
-          # Fetch PR reviews
-          PR_REVIEWS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=10" \
-            --jq '.[] | "<review author=\"\(.user.login)\" state=\"\(.state)\">\(.body // "No review body")</review>"' 2>/dev/null || echo "No reviews")
+          # Fetch PR reviews (first 10)
+          if ! PR_REVIEWS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=10" \
+            --jq '.[] | "<review author=\"\(.user.login)\" state=\"\(.state)\">\(.body // "No review body")</review>"' 2>"$GH_STDERR"); then
+            echo "::warning::Failed to fetch PR reviews: $(cat "$GH_STDERR")"
+            PR_REVIEWS="[Error fetching reviews — see workflow logs]"
+          fi
 
-          # Fetch review comments (inline code comments)
-          REVIEW_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments?per_page=30" \
-            --jq '.[] | "<review-comment author=\"\(.user.login)\" path=\"\(.path)\" line=\"\(.line // .original_line)\">\(.body)</review-comment>"' 2>/dev/null || echo "No review comments")
+          # Fetch review comments / inline code comments (first 30)
+          if ! REVIEW_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments?per_page=30" \
+            --jq '.[] | "<review-comment author=\"\(.user.login)\" path=\"\(.path)\" line=\"\(.line // .original_line)\">\(.body)</review-comment>"' 2>"$GH_STDERR"); then
+            echo "::warning::Failed to fetch review comments: $(cat "$GH_STDERR")"
+            REVIEW_COMMENTS="[Error fetching review comments — see workflow logs]"
+          fi
 
           cat > "$PROMPT_FILE" << 'PROMPT_HEADER'
           <instructions>
           The user has tagged @deepagents in a comment on this pull request. Your task is to resolve their request in the simplest way possible.
+
+          You have shell access with git and gh available. The repository is checked out on the PR branch.
 
           Determine whether the comment requires code changes, and if so implement them directly.
           - Make only the changes requested. Do not make unrelated changes.
@@ -134,57 +168,39 @@ jobs:
 
           PROMPT_HEADER
 
-          # Append structured context (random delimiter prevents user content from terminating the heredoc)
-          CONTEXT_DELIM="CONTEXT_$(openssl rand -hex 16)"
-          cat >> "$PROMPT_FILE" << $CONTEXT_DELIM
-          <pull-request>
-          <title>${PR_TITLE}</title>
-          <author>${PR_AUTHOR}</author>
-          <state>${PR_STATE}</state>
-          <base>${PR_BASE}</base>
-          <head>${PR_HEAD}</head>
-          <body>
-          ${PR_BODY}
-          </body>
-          </pull-request>
+          # Write PR context using printf to avoid shell expansion of user-controlled content
+          {
+            printf '<pull-request>\n'
+            printf '<title>%s</title>\n' "$PR_TITLE"
+            printf '<author>%s</author>\n' "$PR_AUTHOR"
+            printf '<state>%s</state>\n' "$PR_STATE"
+            printf '<base>%s</base>\n' "$PR_BASE"
+            printf '<head>%s</head>\n' "$PR_HEAD"
+            printf '<body>\n%s\n</body>\n' "$PR_BODY"
+            printf '</pull-request>\n\n'
 
-          <changed-files>
-          ${DIFF_STAT}
-          </changed-files>
+            printf '<changed-files>\n%s\n</changed-files>\n\n' "$DIFF_STAT"
+            printf '<pull-request-comments>\n%s\n</pull-request-comments>\n\n' "$PR_COMMENTS"
+            printf '<pull-request-reviews>\n%s\n</pull-request-reviews>\n\n' "$PR_REVIEWS"
+            printf '<review-comments>\n%s\n</review-comments>\n\n' "$REVIEW_COMMENTS"
 
-          <pull-request-comments>
-          ${PR_COMMENTS}
-          </pull-request-comments>
+            printf '<trigger-comment>\n'
+            printf 'This is the comment that triggered this workflow. Focus on resolving this request.\n'
+            printf '<author>%s</author>\n' "$TRIGGER_COMMENT_AUTHOR"
+            printf '<body>\n%s\n</body>\n' "$TRIGGER_COMMENT_BODY"
+            printf '</trigger-comment>\n\n'
 
-          <pull-request-reviews>
-          ${PR_REVIEWS}
-          </pull-request-reviews>
+            printf 'Given all of this context, resolve the trigger comment in the simplest way possible.\n'
+            printf 'IMPORTANT: The trigger comment takes precedence. Focus on what was asked, using the PR context to inform your approach.\n'
+          } >> "$PROMPT_FILE"
 
-          <review-comments>
-          ${REVIEW_COMMENTS}
-          </review-comments>
-
-          <trigger-comment>
-          This is the comment that triggered this workflow. Focus on resolving this request.
-          <author>${TRIGGER_COMMENT_AUTHOR}</author>
-          <body>
-          ${TRIGGER_COMMENT_BODY}
-          </body>
-          </trigger-comment>
-
-          Given all of this context, resolve the trigger comment in the simplest way possible.
-          IMPORTANT: The trigger comment takes precedence. Focus on what was asked, using the PR context to inform your approach.
-          $CONTEXT_DELIM
-
-          # Set output
+          # Set output using heredoc with random delimiter
           DELIMITER="PROMPT_$(openssl rand -hex 16)"
           {
             echo "prompt<<${DELIMITER}"
             cat "$PROMPT_FILE"
             echo "${DELIMITER}"
           } >> "$GITHUB_OUTPUT"
-
-          rm -f "$PROMPT_FILE"
 
       - name: Run Deep Agents
         uses: langchain-ai/deepagents@main
@@ -193,4 +209,5 @@ jobs:
           model: claude-sonnet-4-6
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or: openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # Or: google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           skills_repo: langchain-ai/langchain-skills

--- a/.github/workflows/deepagents-example.yml
+++ b/.github/workflows/deepagents-example.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - name: Acknowledge trigger
         if: github.event_name == 'issue_comment'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/deepagents-example.yml
+++ b/.github/workflows/deepagents-example.yml
@@ -13,7 +13,15 @@ jobs:
   deepagents:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.comment.body, '@deepagents')
+      (
+        contains(github.event.comment.body, '@deepagents') &&
+        github.event.issue.pull_request &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,11 +29,148 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Acknowledge trigger
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='rocket'
+
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: pr-sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json headRefOid,headRefName)
+          PR_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
+          PR_BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
+          echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
+          echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
+        with:
+          # Use the PR branch name so the agent can commit and push to the PR directly.
+          ref: ${{ github.event_name == 'issue_comment' && steps.pr-sha.outputs.branch || '' }}
+
+      - name: Build PR context prompt
+        if: github.event_name == 'issue_comment'
+        id: build-prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_COMMENT_BODY: ${{ github.event.comment.body }}
+          TRIGGER_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          PROMPT_FILE=$(mktemp)
+
+          # Fetch PR data
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,author,state,headRefName,baseRefName)
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          PR_BODY=$(echo "$PR_DATA" | jq -r '.body // "No description"')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+          PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
+          PR_HEAD=$(echo "$PR_DATA" | jq -r '.headRefName')
+          PR_BASE=$(echo "$PR_DATA" | jq -r '.baseRefName')
+
+          # Fetch PR diff stats
+          DIFF_STAT=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "Unable to fetch diff")
+
+          # Fetch PR comments (last 20)
+          PR_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=20" \
+            --jq '.[] | "<comment author=\"\(.user.login)\">\(.body)</comment>"' 2>/dev/null || echo "No comments")
+
+          # Fetch PR reviews
+          PR_REVIEWS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=10" \
+            --jq '.[] | "<review author=\"\(.user.login)\" state=\"\(.state)\">\(.body // "No review body")</review>"' 2>/dev/null || echo "No reviews")
+
+          # Fetch review comments (inline code comments)
+          REVIEW_COMMENTS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments?per_page=30" \
+            --jq '.[] | "<review-comment author=\"\(.user.login)\" path=\"\(.path)\" line=\"\(.line // .original_line)\">\(.body)</review-comment>"' 2>/dev/null || echo "No review comments")
+
+          cat > "$PROMPT_FILE" << 'PROMPT_HEADER'
+          <instructions>
+          The user has tagged @deepagents in a comment on this pull request. Your task is to resolve their request in the simplest way possible.
+
+          Determine whether the comment requires code changes, and if so implement them directly.
+          - Make only the changes requested. Do not make unrelated changes.
+          - Do not leave comments in your code about the request or changes you're making.
+          - Keep changes minimal and focused.
+
+          If the comment does not require code changes (e.g. a question), respond by creating a comment on the PR with your answer.
+
+          After making changes, commit them to the current branch.
+
+          IMPORTANT: When you are finished, you MUST post a brief summary comment on the PR using `gh pr comment`. The comment should:
+          - Briefly describe what you did (1-3 sentences)
+          - List any files changed or commits made
+          - Note if you were unable to complete any part of the request
+          Always post this summary, even if the task was simple or no code changes were needed.
+          </instructions>
+
+          PROMPT_HEADER
+
+          # Append structured context (random delimiter prevents user content from terminating the heredoc)
+          CONTEXT_DELIM="CONTEXT_$(openssl rand -hex 16)"
+          cat >> "$PROMPT_FILE" << $CONTEXT_DELIM
+          <pull-request>
+          <title>${PR_TITLE}</title>
+          <author>${PR_AUTHOR}</author>
+          <state>${PR_STATE}</state>
+          <base>${PR_BASE}</base>
+          <head>${PR_HEAD}</head>
+          <body>
+          ${PR_BODY}
+          </body>
+          </pull-request>
+
+          <changed-files>
+          ${DIFF_STAT}
+          </changed-files>
+
+          <pull-request-comments>
+          ${PR_COMMENTS}
+          </pull-request-comments>
+
+          <pull-request-reviews>
+          ${PR_REVIEWS}
+          </pull-request-reviews>
+
+          <review-comments>
+          ${REVIEW_COMMENTS}
+          </review-comments>
+
+          <trigger-comment>
+          This is the comment that triggered this workflow. Focus on resolving this request.
+          <author>${TRIGGER_COMMENT_AUTHOR}</author>
+          <body>
+          ${TRIGGER_COMMENT_BODY}
+          </body>
+          </trigger-comment>
+
+          Given all of this context, resolve the trigger comment in the simplest way possible.
+          IMPORTANT: The trigger comment takes precedence. Focus on what was asked, using the PR context to inform your approach.
+          $CONTEXT_DELIM
+
+          # Set output
+          DELIMITER="PROMPT_$(openssl rand -hex 16)"
+          {
+            echo "prompt<<${DELIMITER}"
+            cat "$PROMPT_FILE"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_OUTPUT"
+
+          rm -f "$PROMPT_FILE"
 
       - name: Run Deep Agents
-        uses: langchain-ai/deepagents@v1
+        uses: langchain-ai/deepagents@main
         with:
-          prompt: ${{ github.event.inputs.prompt || github.event.comment.body }}
+          prompt: ${{ github.event_name == 'issue_comment' && steps.build-prompt.outputs.prompt || github.event.inputs.prompt }}
+          model: claude-sonnet-4-6
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or: openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          skills_repo: langchain-ai/langchain-skills

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,111 @@
+name: 'Deep Agents'
+description: 'Run Deep Agents AI coding assistant in GitHub workflows'
+author: 'LangChain AI'
+branding:
+  icon: 'cpu'
+  color: 'blue'
+
+inputs:
+  prompt:
+    description: 'The prompt/instruction to send to the agent'
+    required: true
+  model:
+    description: 'Model to use (claude-*, gpt-*, gemini-*). Auto-detects provider.'
+    required: false
+  anthropic_api_key:
+    description: 'Anthropic API key'
+    required: false
+  openai_api_key:
+    description: 'OpenAI API key'
+    required: false
+  google_api_key:
+    description: 'Google API key'
+    required: false
+  github_token:
+    description: 'GitHub token for API access'
+    required: false
+    default: ${{ github.token }}
+  auto_approve:
+    description: 'Auto-approve tool usage (default: true for CI)'
+    required: false
+    default: 'true'
+  working_directory:
+    description: 'Working directory for the agent'
+    required: false
+    default: '.'
+  timeout:
+    description: 'Timeout in minutes'
+    required: false
+    default: '30'
+  cli_version:
+    description: 'deepagents-cli version (empty = latest)'
+    required: false
+    default: ''
+
+outputs:
+  response:
+    description: 'Full text response from the agent'
+    value: ${{ steps.run-agent.outputs.response }}
+  exit_code:
+    description: 'Exit code from the agent'
+    value: ${{ steps.run-agent.outputs.exit_code }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python and uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        python-version: '3.11'
+        enable-cache: true
+
+    - name: Install deepagents-cli
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.cli_version }}" ]; then
+          uvx --from deepagents-cli==${{ inputs.cli_version }} deepagents --version
+        else
+          uvx --from deepagents-cli deepagents --version
+        fi
+
+    - name: Run Deep Agents
+      id: run-agent
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      timeout-minutes: ${{ fromJSON(inputs.timeout) }}
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        GOOGLE_API_KEY: ${{ inputs.google_api_key }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      run: |
+        # Build command
+        CMD="uvx --from deepagents-cli deepagents"
+
+        if [ -n "${{ inputs.model }}" ]; then
+          CMD="$CMD --model ${{ inputs.model }}"
+        fi
+
+        if [ "${{ inputs.auto_approve }}" == "true" ]; then
+          CMD="$CMD --auto-approve"
+        fi
+
+        # Create temp file for output
+        OUTPUT_FILE=$(mktemp)
+
+        # Run with prompt via -m flag
+        set +e
+        $CMD -m "${{ inputs.prompt }}" 2>&1 | tee "$OUTPUT_FILE"
+        EXIT_CODE=$?
+        set -e
+
+        # Set outputs using heredoc for multiline
+        {
+          echo "exit_code=$EXIT_CODE"
+          echo "response<<DEEPAGENTS_EOF"
+          cat "$OUTPUT_FILE"
+          echo "DEEPAGENTS_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        rm -f "$OUTPUT_FILE"
+        exit $EXIT_CODE

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python and uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@0ca8f610542aa7f4acaf39e65cf4eb3c35091883 # v7
       with:
         enable-cache: true
 

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,6 @@ inputs:
     description: 'GitHub token for API access'
     required: false
     default: ${{ github.token }}
-  auto_approve:
-    description: 'Auto-approve tool usage (default: true for CI)'
-    required: false
-    default: 'true'
   working_directory:
     description: 'Working directory for the agent'
     required: false
@@ -42,7 +38,7 @@ inputs:
     required: false
     default: ''
   enable_memory:
-    description: 'Cache agent memory (AGENTS.md, sessions) across workflow runs (default: true)'
+    description: 'Persist agent memory (AGENTS.md, sessions) across workflow runs using actions/cache. When enabled, memory is keyed by agent_name + memory_scope so the agent can recall prior context.'
     required: false
     default: 'true'
   memory_scope:
@@ -53,6 +49,10 @@ inputs:
     description: 'Agent identity name — controls memory namespace (default: agent)'
     required: false
     default: 'agent'
+  shell_allow_list:
+    description: 'Comma-separated shell allow list passed to --shell-allow-list (default: recommended,git,gh)'
+    required: false
+    default: 'recommended,git,gh'
   timeout:
     description: 'Maximum agent runtime in minutes (default: 30)'
     required: false
@@ -73,9 +73,8 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python and uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
-        python-version: '3.11'
         enable-cache: true
 
     - name: Resolve cache key
@@ -120,7 +119,7 @@ runs:
     - name: Restore agent memory
       if: inputs.enable_memory == 'true'
       id: restore-memory
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           ~/.deepagents/${{ inputs.agent_name }}/
@@ -195,11 +194,11 @@ runs:
         GOOGLE_API_KEY: ${{ inputs.google_api_key }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_MODEL: ${{ inputs.model }}
-        INPUT_AUTO_APPROVE: ${{ inputs.auto_approve }}
         INPUT_PROMPT: ${{ inputs.prompt }}
         INPUT_AGENT_NAME: ${{ inputs.agent_name }}
         INPUT_CLI_VERSION: ${{ inputs.cli_version }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_SHELL_ALLOW_LIST: ${{ inputs.shell_allow_list }}
       run: |
         # Build command (pin version if specified, matching the install step)
         if [ -n "$INPUT_CLI_VERSION" ]; then
@@ -209,14 +208,11 @@ runs:
         fi
 
         CMD+=(--agent "$INPUT_AGENT_NAME")
-        CMD+=(--shell-allow-list "recommended,git,gh")
+        CMD+=(--shell-allow-list "$INPUT_SHELL_ALLOW_LIST")
+        CMD+=(--auto-approve)
 
         if [ -n "$INPUT_MODEL" ]; then
           CMD+=(--model "$INPUT_MODEL")
-        fi
-
-        if [ "$INPUT_AUTO_APPROVE" == "true" ]; then
-          CMD+=(--auto-approve)
         fi
 
         # Create temp file for output
@@ -245,7 +241,7 @@ runs:
 
     - name: Save agent memory
       if: inputs.enable_memory == 'true' && always()
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: |
           ~/.deepagents/${{ inputs.agent_name }}/

--- a/action.yml
+++ b/action.yml
@@ -1,78 +1,78 @@
-name: 'Deep Agents'
-description: 'Run Deep Agents AI coding assistant in GitHub workflows'
-author: 'LangChain AI'
+name: "Deep Agents"
+description: "Run Deep Agents CLI coding assistant in GitHub workflows"
+author: "LangChain AI"
 branding:
-  icon: 'cpu'
-  color: 'blue'
+  icon: "cpu"
+  color: "blue"
 
 inputs:
   prompt:
-    description: 'The prompt/instruction to send to the agent'
+    description: "The prompt/instruction to send to the agent"
     required: true
   model:
-    description: 'Model to use (claude-*, gpt-*, gemini-*). Auto-detects provider.'
+    description: "Model to use (claude-*, gpt-*, gemini-*). Auto-detects provider."
     required: false
   anthropic_api_key:
-    description: 'Anthropic API key'
+    description: "Anthropic API key"
     required: false
   openai_api_key:
-    description: 'OpenAI API key'
+    description: "OpenAI API key"
     required: false
   google_api_key:
-    description: 'Google API key'
+    description: "Google API key"
     required: false
   github_token:
-    description: 'GitHub token for API access'
+    description: "GitHub token for API access"
     required: false
     default: ${{ github.token }}
   working_directory:
-    description: 'Working directory for the agent'
+    description: "Working directory for the agent"
     required: false
-    default: '.'
+    default: "."
   cli_version:
-    description: 'deepagents-cli version (empty = latest)'
+    description: "deepagents-cli version (empty = latest)"
     required: false
-    default: ''
+    default: ""
   skills_repo:
-    description: 'GitHub repo of skills to clone (e.g. owner/repo, owner/repo@ref, or full URL)'
+    description: "GitHub repo of skills to clone (e.g. owner/repo, owner/repo@ref, or full URL)"
     required: false
-    default: ''
+    default: ""
   enable_memory:
-    description: 'Persist agent memory (AGENTS.md, sessions) across workflow runs using actions/cache. When enabled, memory is keyed by agent_name + memory_scope so the agent can recall prior context.'
+    description: "Persist agent memory across workflow runs using actions/cache. When enabled, memory is keyed by agent_name + memory_scope so the agent can recall prior context."
     required: false
-    default: 'true'
+    default: "true"
   memory_scope:
-    description: 'Cache scope: pr (shared per PR), branch (shared per branch), repo (shared across repo)'
+    description: "Cache scope: pr (shared per PR), branch (shared per branch), repo (shared across repo)"
     required: false
-    default: 'repo'
+    default: "repo"
   agent_name:
-    description: 'Agent identity name — controls memory namespace (default: agent)'
+    description: "Agent identity name — controls memory namespace (default: agent)"
     required: false
-    default: 'agent'
+    default: "agent"
   shell_allow_list:
-    description: 'Comma-separated shell allow list passed to --shell-allow-list (default: recommended,git,gh)'
+    description: "Comma-separated shell allow list passed to --shell-allow-list (default: recommended,git,gh)"
     required: false
-    default: 'recommended,git,gh'
+    default: "recommended,git,gh"
   timeout:
-    description: 'Maximum agent runtime in minutes (default: 30)'
+    description: "Maximum agent runtime in minutes (default: 30)"
     required: false
-    default: '30'
+    default: "30"
 
 outputs:
   response:
-    description: 'Full text response from the agent'
+    description: "Full text response from the agent"
     value: ${{ steps.run-agent.outputs.response }}
   exit_code:
-    description: 'Exit code from the agent'
+    description: "Exit code from the agent"
     value: ${{ steps.run-agent.outputs.exit_code }}
   cache_hit:
-    description: 'Whether agent memory was restored from cache'
+    description: "Whether agent memory was restored from cache (empty if enable_memory is false)"
     value: ${{ steps.restore-memory.outputs.cache-hit }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Set up Python and uv
+    - name: Set up uv
       uses: astral-sh/setup-uv@0ca8f610542aa7f4acaf39e65cf4eb3c35091883 # v7
       with:
         enable-cache: true
@@ -84,31 +84,32 @@ runs:
       env:
         INPUT_MEMORY_SCOPE: ${{ inputs.memory_scope }}
         INPUT_AGENT_NAME: ${{ inputs.agent_name }}
+        REF_NAME: ${{ github.ref_name }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || '' }}
       run: |
         PREFIX="deepagents-memory-${INPUT_AGENT_NAME}"
         case "$INPUT_MEMORY_SCOPE" in
           pr)
             # Use PR number if available, fall back to ref
-            PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number || '' }}"
-            if [ -n "$PR_NUMBER" ]; then
-              SCOPE_KEY="pr-${PR_NUMBER}"
+            if [ -n "$EVENT_PR_NUMBER" ]; then
+              SCOPE_KEY="pr-${EVENT_PR_NUMBER}"
             else
-              SCOPE_KEY="ref-${{ github.ref_name }}"
+              SCOPE_KEY="ref-${REF_NAME}"
             fi
             ;;
           branch)
-            SCOPE_KEY="ref-${{ github.ref_name }}"
+            SCOPE_KEY="ref-${REF_NAME}"
             ;;
           repo)
             SCOPE_KEY="repo"
             ;;
           *)
+            # Fallback to pr-scoped (most conservative) rather than repo-scoped to limit blast radius
             echo "::warning::Unknown memory_scope '${INPUT_MEMORY_SCOPE}', defaulting to 'pr'"
-            PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number || '' }}"
-            if [ -n "$PR_NUMBER" ]; then
-              SCOPE_KEY="pr-${PR_NUMBER}"
+            if [ -n "$EVENT_PR_NUMBER" ]; then
+              SCOPE_KEY="pr-${EVENT_PR_NUMBER}"
             else
-              SCOPE_KEY="ref-${{ github.ref_name }}"
+              SCOPE_KEY="ref-${REF_NAME}"
             fi
             ;;
         esac
@@ -166,23 +167,33 @@ runs:
         mkdir -p "$SKILLS_DIR"
 
         CLONE_DIR=$(mktemp -d)
+        trap 'rm -rf "$CLONE_DIR"' EXIT
+
         CLONE_ARGS=(gh repo clone "$CLONE_URL" "$CLONE_DIR" --)
         CLONE_ARGS+=(--depth 1)
         if [ -n "$REF" ]; then
           CLONE_ARGS+=(--branch "$REF")
         fi
 
-        "${CLONE_ARGS[@]}"
+        if ! "${CLONE_ARGS[@]}"; then
+          echo "::error::Failed to clone skills repository '${INPUT_SKILLS_REPO}'. Verify the repo exists and your github_token has access."
+          exit 1
+        fi
 
         # Copy skill directories (those containing SKILL.md) into the skills dir
-        find "$CLONE_DIR" -name "SKILL.md" -type f | while read -r skill_file; do
+        SKILL_COUNT=0
+        while IFS= read -r skill_file; do
           skill_dir=$(dirname "$skill_file")
           skill_name=$(basename "$skill_dir")
           cp -r "$skill_dir" "$SKILLS_DIR/$skill_name"
           echo "Installed skill: $skill_name"
-        done
+          ((SKILL_COUNT++))
+        done < <(find "$CLONE_DIR" -name "SKILL.md" -type f)
 
-        rm -rf "$CLONE_DIR"
+        if [ "$SKILL_COUNT" -eq 0 ]; then
+          echo "::error::No skills found in ${INPUT_SKILLS_REPO} — expected at least one directory containing SKILL.md"
+          exit 1
+        fi
 
     - name: Run Deep Agents
       id: run-agent
@@ -209,16 +220,21 @@ runs:
 
         CMD+=(--agent "$INPUT_AGENT_NAME")
         CMD+=(--shell-allow-list "$INPUT_SHELL_ALLOW_LIST")
-        CMD+=(--auto-approve)
 
         if [ -n "$INPUT_MODEL" ]; then
           CMD+=(--model "$INPUT_MODEL")
         fi
 
-        # Create temp file for output
-        OUTPUT_FILE=$(mktemp)
+        # Validate timeout is a positive integer
+        if ! [[ "$INPUT_TIMEOUT" =~ ^[0-9]+$ ]] || [ "$INPUT_TIMEOUT" -eq 0 ]; then
+          echo "::error::Invalid timeout '${INPUT_TIMEOUT}' — must be a positive integer (minutes)"
+          exit 1
+        fi
 
-        # Run in non-interactive mode with timeout (pipefail ensures we capture the agent's exit code, not tee's)
+        OUTPUT_FILE=$(mktemp)
+        trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+        # set +e: allow non-zero exit so we can capture the code; pipefail: propagate the agent's exit code through tee
         TIMEOUT_SECS=$((INPUT_TIMEOUT * 60))
         set +e
         set -o pipefail
@@ -236,11 +252,10 @@ runs:
           echo "${DELIMITER}"
         } >> "$GITHUB_OUTPUT"
 
-        rm -f "$OUTPUT_FILE"
         exit $EXIT_CODE
 
     - name: Save agent memory
-      if: inputs.enable_memory == 'true' && always()
+      if: inputs.enable_memory == 'true' && steps.cache-key.outputs.key != '' && always()
       uses: actions/cache/save@v5
       with:
         path: |

--- a/action.yml
+++ b/action.yml
@@ -33,14 +33,30 @@ inputs:
     description: 'Working directory for the agent'
     required: false
     default: '.'
-  timeout:
-    description: 'Timeout in minutes'
-    required: false
-    default: '30'
   cli_version:
     description: 'deepagents-cli version (empty = latest)'
     required: false
     default: ''
+  skills_repo:
+    description: 'GitHub repo of skills to clone (e.g. owner/repo, owner/repo@ref, or full URL)'
+    required: false
+    default: ''
+  enable_memory:
+    description: 'Cache agent memory (AGENTS.md, sessions) across workflow runs (default: true)'
+    required: false
+    default: 'true'
+  memory_scope:
+    description: 'Cache scope: pr (shared per PR), branch (shared per branch), repo (shared across repo)'
+    required: false
+    default: 'repo'
+  agent_name:
+    description: 'Agent identity name — controls memory namespace (default: agent)'
+    required: false
+    default: 'agent'
+  timeout:
+    description: 'Maximum agent runtime in minutes (default: 30)'
+    required: false
+    default: '30'
 
 outputs:
   response:
@@ -49,6 +65,9 @@ outputs:
   exit_code:
     description: 'Exit code from the agent'
     value: ${{ steps.run-agent.outputs.exit_code }}
+  cache_hit:
+    description: 'Whether agent memory was restored from cache'
+    value: ${{ steps.restore-memory.outputs.cache-hit }}
 
 runs:
   using: 'composite'
@@ -59,53 +78,177 @@ runs:
         python-version: '3.11'
         enable-cache: true
 
+    - name: Resolve cache key
+      if: inputs.enable_memory == 'true'
+      id: cache-key
+      shell: bash
+      env:
+        INPUT_MEMORY_SCOPE: ${{ inputs.memory_scope }}
+        INPUT_AGENT_NAME: ${{ inputs.agent_name }}
+      run: |
+        PREFIX="deepagents-memory-${INPUT_AGENT_NAME}"
+        case "$INPUT_MEMORY_SCOPE" in
+          pr)
+            # Use PR number if available, fall back to ref
+            PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number || '' }}"
+            if [ -n "$PR_NUMBER" ]; then
+              SCOPE_KEY="pr-${PR_NUMBER}"
+            else
+              SCOPE_KEY="ref-${{ github.ref_name }}"
+            fi
+            ;;
+          branch)
+            SCOPE_KEY="ref-${{ github.ref_name }}"
+            ;;
+          repo)
+            SCOPE_KEY="repo"
+            ;;
+          *)
+            echo "::warning::Unknown memory_scope '${INPUT_MEMORY_SCOPE}', defaulting to 'pr'"
+            PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number || '' }}"
+            if [ -n "$PR_NUMBER" ]; then
+              SCOPE_KEY="pr-${PR_NUMBER}"
+            else
+              SCOPE_KEY="ref-${{ github.ref_name }}"
+            fi
+            ;;
+        esac
+
+        echo "key=${PREFIX}-${SCOPE_KEY}" >> "$GITHUB_OUTPUT"
+        echo "restore-keys=${PREFIX}-" >> "$GITHUB_OUTPUT"
+
+    - name: Restore agent memory
+      if: inputs.enable_memory == 'true'
+      id: restore-memory
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.deepagents/${{ inputs.agent_name }}/
+          ~/.deepagents/sessions.db
+          ${{ inputs.working_directory }}/.deepagents/AGENTS.md
+        key: ${{ steps.cache-key.outputs.key }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ steps.cache-key.outputs.key }}-
+          ${{ steps.cache-key.outputs.restore-keys }}
+
     - name: Install deepagents-cli
       shell: bash
+      env:
+        INPUT_CLI_VERSION: ${{ inputs.cli_version }}
       run: |
-        if [ -n "${{ inputs.cli_version }}" ]; then
-          uvx --from deepagents-cli==${{ inputs.cli_version }} deepagents --version
+        if [ -n "$INPUT_CLI_VERSION" ]; then
+          uvx --from "deepagents-cli==${INPUT_CLI_VERSION}" deepagents --version
         else
           uvx --from deepagents-cli deepagents --version
         fi
+
+    - name: Install skills
+      if: inputs.skills_repo != ''
+      shell: bash
+      env:
+        INPUT_SKILLS_REPO: ${{ inputs.skills_repo }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        # Build clone URL — check for full URLs first to avoid misinterpreting @ in git@... URLs
+        if [[ "$INPUT_SKILLS_REPO" == https://* || "$INPUT_SKILLS_REPO" == git@* ]]; then
+          CLONE_URL="$INPUT_SKILLS_REPO"
+          REF=""
+        elif [[ "$INPUT_SKILLS_REPO" == *"@"* ]]; then
+          REPO="${INPUT_SKILLS_REPO%%@*}"
+          REF="${INPUT_SKILLS_REPO##*@}"
+          CLONE_URL="https://github.com/${REPO}.git"
+        else
+          CLONE_URL="https://github.com/${INPUT_SKILLS_REPO}.git"
+          REF=""
+        fi
+
+        SKILLS_DIR=".deepagents/skills"
+        mkdir -p "$SKILLS_DIR"
+
+        CLONE_DIR=$(mktemp -d)
+        CLONE_ARGS=(gh repo clone "$CLONE_URL" "$CLONE_DIR" --)
+        CLONE_ARGS+=(--depth 1)
+        if [ -n "$REF" ]; then
+          CLONE_ARGS+=(--branch "$REF")
+        fi
+
+        "${CLONE_ARGS[@]}"
+
+        # Copy skill directories (those containing SKILL.md) into the skills dir
+        find "$CLONE_DIR" -name "SKILL.md" -type f | while read -r skill_file; do
+          skill_dir=$(dirname "$skill_file")
+          skill_name=$(basename "$skill_dir")
+          cp -r "$skill_dir" "$SKILLS_DIR/$skill_name"
+          echo "Installed skill: $skill_name"
+        done
+
+        rm -rf "$CLONE_DIR"
 
     - name: Run Deep Agents
       id: run-agent
       shell: bash
       working-directory: ${{ inputs.working_directory }}
-      timeout-minutes: ${{ fromJSON(inputs.timeout) }}
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         GOOGLE_API_KEY: ${{ inputs.google_api_key }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_MODEL: ${{ inputs.model }}
+        INPUT_AUTO_APPROVE: ${{ inputs.auto_approve }}
+        INPUT_PROMPT: ${{ inputs.prompt }}
+        INPUT_AGENT_NAME: ${{ inputs.agent_name }}
+        INPUT_CLI_VERSION: ${{ inputs.cli_version }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
       run: |
-        # Build command
-        CMD="uvx --from deepagents-cli deepagents"
-
-        if [ -n "${{ inputs.model }}" ]; then
-          CMD="$CMD --model ${{ inputs.model }}"
+        # Build command (pin version if specified, matching the install step)
+        if [ -n "$INPUT_CLI_VERSION" ]; then
+          CMD=(uvx --from "deepagents-cli==${INPUT_CLI_VERSION}" deepagents)
+        else
+          CMD=(uvx --from deepagents-cli deepagents)
         fi
 
-        if [ "${{ inputs.auto_approve }}" == "true" ]; then
-          CMD="$CMD --auto-approve"
+        CMD+=(--agent "$INPUT_AGENT_NAME")
+        CMD+=(--shell-allow-list "recommended,git,gh")
+
+        if [ -n "$INPUT_MODEL" ]; then
+          CMD+=(--model "$INPUT_MODEL")
+        fi
+
+        if [ "$INPUT_AUTO_APPROVE" == "true" ]; then
+          CMD+=(--auto-approve)
         fi
 
         # Create temp file for output
         OUTPUT_FILE=$(mktemp)
 
-        # Run with prompt via -m flag
+        # Run in non-interactive mode with timeout (pipefail ensures we capture the agent's exit code, not tee's)
+        TIMEOUT_SECS=$((INPUT_TIMEOUT * 60))
         set +e
-        $CMD -m "${{ inputs.prompt }}" 2>&1 | tee "$OUTPUT_FILE"
+        set -o pipefail
+        timeout "${TIMEOUT_SECS}" "${CMD[@]}" -n "$INPUT_PROMPT" 2>&1 | tee "$OUTPUT_FILE"
         EXIT_CODE=$?
+        set +o pipefail
         set -e
 
-        # Set outputs using heredoc for multiline
+        # Set outputs using heredoc with random delimiter
+        DELIMITER="DEEPAGENTS_$(openssl rand -hex 16)"
         {
           echo "exit_code=$EXIT_CODE"
-          echo "response<<DEEPAGENTS_EOF"
+          echo "response<<${DELIMITER}"
           cat "$OUTPUT_FILE"
-          echo "DEEPAGENTS_EOF"
+          echo "${DELIMITER}"
         } >> "$GITHUB_OUTPUT"
 
         rm -f "$OUTPUT_FILE"
         exit $EXIT_CODE
+
+    - name: Save agent memory
+      if: inputs.enable_memory == 'true' && always()
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.deepagents/${{ inputs.agent_name }}/
+          ~/.deepagents/sessions.db
+          ${{ inputs.working_directory }}/.deepagents/AGENTS.md
+        key: ${{ steps.cache-key.outputs.key }}-${{ github.run_id }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,7 +52,7 @@
   "pull-request-title-pattern": "release(${component}): ${version}",
   "component-no-space": true,
   "pull-request-header": "> [!CAUTION]\n> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.\n\nFor the full release process, see [`.github/RELEASING.md`](.github/RELEASING.md).\n\n---\n\n_Everything below this line will be the GitHub release body._\n",
-  "pull-request-footer": "\n_Everything above this line will be the GitHub release body._\n\n---\n\n> [!NOTE]\n> A **New Contributors** section is appended to the GitHub release notes automatically at publish time (see [Release Pipeline](.github/RELEASING.md#release-pipeline), step 2).\n> For the full release process, see [`.github/RELEASING.md`](.github/RELEASING.md).",
+  "pull-request-footer": "\n_Everything above this line will be the GitHub release body._\n\n---\n\n> [!NOTE]\n> A **New Contributors** section is appended to the GitHub release notes automatically at publish time (see [Release Pipeline](.github/RELEASING.md#release-pipeline), step 2).",
   "packages": {
     "libs/cli": {
       "release-type": "python",


### PR DESCRIPTION
Adds a composite GitHub Action (`action.yml`) for running Deep Agents in CI workflows, superseding #937 with security hardening and new features.

## Changes

- **Core action** — runs `deepagents-cli` via `uvx` with support for multiple LLM providers (Anthropic, OpenAI, Google), configurable model/timeout/version. Exposes `response`, `exit_code`, and `cache_hit` outputs for downstream steps.
- **Security hardening** — all `${{ inputs.* }}` moved to `env:` mappings to prevent shell injection, bash arrays for safe command construction, randomized `GITHUB_OUTPUT` delimiter, authorization gate on `author_association` in the example workflow. Auto-approve is always enabled in CI (no input toggle).
- **Skills loading** (`skills_repo`) — clone an external repo of skills into `.deepagents/skills/` before the agent runs. Supports `owner/repo`, `owner/repo@ref`, and full URLs.
- **Agent memory** (`enable_memory`, `memory_scope`, `agent_name`) — cache `AGENTS.md`, `sessions.db`, and project memory across runs using `actions/cache`. Scoped per repo (default), PR, or branch, namespaced by `agent_name`. Memory is saved with `always()` so it persists even when the agent fails.
- **Non-interactive mode** — uses `-n` instead of `-m` so the agent runs and exits cleanly in CI.
- **Shell allow-list** (`shell_allow_list`) — configurable input (default: `recommended,git,gh`) for safe read-only commands, git, and GitHub CLI operations.
- **Example workflow** (`.github/workflows/deepagents-example.yml`) — triggers on `@deepagents` mentions in PR comments or `workflow_dispatch`. Builds a structured prompt with PR metadata, diff stats, comments, reviews, and inline review comments so the agent has full context.
