### PR TITLE
style(cli): change shell mode display glyph from `!` to `$`

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -71,6 +71,12 @@ MODE_PREFIXES: dict[str, str] = {
 }
 """Maps each non-normal mode to its trigger character."""
 
+MODE_DISPLAY_GLYPHS: dict[str, str] = {
+    "shell": "$",
+    "command": "/",
+}
+"""Maps each non-normal mode to its display glyph shown in the prompt/UI."""
+
 PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
 """Reverse lookup: trigger character -> mode name."""
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -77,6 +77,15 @@ MODE_DISPLAY_GLYPHS: dict[str, str] = {
 }
 """Maps each non-normal mode to its display glyph shown in the prompt/UI."""
 
+if MODE_PREFIXES.keys() != MODE_DISPLAY_GLYPHS.keys():
+    _only_prefixes = MODE_PREFIXES.keys() - MODE_DISPLAY_GLYPHS.keys()
+    _only_glyphs = MODE_DISPLAY_GLYPHS.keys() - MODE_PREFIXES.keys()
+    msg = (
+        "MODE_PREFIXES and MODE_DISPLAY_GLYPHS have mismatched keys: "
+        f"only in PREFIXES={_only_prefixes}, only in GLYPHS={_only_glyphs}"
+    )
+    raise ValueError(msg)
+
 PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
 """Reverse lookup: trigger character -> mode name."""
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1413,6 +1413,8 @@ class ChatInput(Vertical):
         try:
             prompt = self.query_one("#prompt", Static)
         except NoMatches:
+            logger.warning("watch_mode: #prompt widget not found")
+            self.post_message(self.ModeChanged(mode))
             return
         self.remove_class("mode-shell", "mode-command")
         glyph = MODE_DISPLAY_GLYPHS.get(mode)
@@ -1420,6 +1422,11 @@ class ChatInput(Vertical):
             prompt.update(glyph)
             self.add_class(f"mode-{mode}")
         else:
+            if mode != "normal":
+                logger.warning(
+                    "No display glyph for mode %r; falling back to '>'",
+                    mode,
+                )
             prompt.update(">")
         self.post_message(self.ModeChanged(mode))
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -17,6 +17,7 @@ from textual.widgets.text_area import Selection
 
 from deepagents_cli.config import (
     COLORS,
+    MODE_DISPLAY_GLYPHS,
     MODE_PREFIXES,
     PREFIX_TO_MODE,
     CharsetMode,
@@ -1414,9 +1415,9 @@ class ChatInput(Vertical):
         except NoMatches:
             return
         self.remove_class("mode-shell", "mode-command")
-        prefix = MODE_PREFIXES.get(mode)
-        if prefix:
-            prompt.update(prefix)
+        glyph = MODE_DISPLAY_GLYPHS.get(mode)
+        if glyph:
+            prompt.update(glyph)
             self.add_class(f"mode-{mode}")
         else:
             prompt.update(">")

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -18,6 +18,7 @@ from textual.widgets import Markdown, Static
 
 from deepagents_cli.config import (
     COLORS,
+    MODE_DISPLAY_GLYPHS,
     PREFIX_TO_MODE,
     CharsetMode,
     _detect_charset_mode,
@@ -184,7 +185,8 @@ class UserMessage(_TimestampClickMixin, Static):
         # mode trigger character (e.g. "!" for shell commands, "/" for commands).
         mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
-            text.append(f"{content[0]} ", style=f"bold {_mode_color(mode)}")
+            glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
+            text.append(f"{glyph} ", style=f"bold {_mode_color(mode)}")
             content = content[1:]
         else:
             text.append("> ", style=f"bold {COLORS['primary']}")

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -182,7 +182,8 @@ class UserMessage(_TimestampClickMixin, Static):
         content = self._content
 
         # Use mode-specific prefix indicator when content starts with a
-        # mode trigger character (e.g. "!" for shell commands, "/" for commands).
+        # mode trigger character (e.g. "!" for shell, "/" for commands).
+        # The display glyph may differ from the trigger (e.g. "$" for shell).
         mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
             glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
@@ -265,7 +266,8 @@ class QueuedUserMessage(Static):
         content = self._content
         mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
-            text.append(f"{content[0]} ", style=f"bold {COLORS['dim']}")
+            glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
+            text.append(f"{glyph} ", style=f"bold {COLORS['dim']}")
             content = content[1:]
         else:
             text.append("> ", style=f"bold {COLORS['dim']}")

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -273,7 +273,7 @@ class TestPromptIndicator:
 
             chat_input.mode = "shell"
             await pilot.pause()
-            assert _prompt_text(prompt) == "!"
+            assert _prompt_text(prompt) == "$"
             assert chat_input.has_class("mode-shell")
 
     async def test_prompt_shows_slash_in_command_mode(self) -> None:
@@ -297,7 +297,7 @@ class TestPromptIndicator:
 
             chat_input.mode = "shell"
             await pilot.pause()
-            assert _prompt_text(prompt) == "!"
+            assert _prompt_text(prompt) == "$"
             assert chat_input.has_class("mode-shell")
 
             chat_input.mode = "normal"

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -336,10 +336,10 @@ class TestUserMessageModeRendering:
 class TestQueuedUserMessageModeRendering:
     """Test `QueuedUserMessage` renders mode-specific prefix indicators (dimmed)."""
 
-    def test_shell_prefix_renders_dimmed_bang(self) -> None:
-        """`QueuedUserMessage('!ls')` should render dimmed `'! '` prefix."""
+    def test_shell_prefix_renders_dimmed_dollar(self) -> None:
+        """`QueuedUserMessage('!ls')` should render dimmed `'$ '` prefix."""
         text = _compose_text(QueuedUserMessage("!ls"))
-        assert text.plain == "! ls"
+        assert text.plain == "$ ls"
 
     def test_command_prefix_renders_dimmed_slash(self) -> None:
         """`QueuedUserMessage('/help')` should render dimmed `'/ '` prefix."""

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -306,10 +306,10 @@ def _compose_text(widget: UserMessage | QueuedUserMessage) -> Text:
 class TestUserMessageModeRendering:
     """Test `UserMessage` renders mode-specific prefix indicators and colors."""
 
-    def test_shell_prefix_renders_bang_indicator(self) -> None:
-        """`UserMessage('!ls')` should render with `'! '` prefix and shell body."""
+    def test_shell_prefix_renders_dollar_indicator(self) -> None:
+        """`UserMessage('!ls')` should render with `'$ '` prefix and shell body."""
         text = _compose_text(UserMessage("!ls"))
-        assert text.plain == "! ls"
+        assert text.plain == "$ ls"
         first_span = text._spans[0]
         assert COLORS["mode_shell"] in str(first_span.style)
 


### PR DESCRIPTION
Decouples the shell mode display glyph from the trigger character. The `!` key still activates shell mode, but the prompt indicator and message history now show `$` instead. A new `MODE_DISPLAY_GLYPHS` mapping in `config.py` controls the UI-facing glyph independently from `MODE_PREFIXES` (which remains the trigger mapping).