### PR TITLE
feat(cli): tailor system prompt for non-interactive mode

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -49,6 +51,8 @@ from deepagents_cli.unicode_security import (
     strip_dangerous_unicode,
     summarize_issues,
 )
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_AGENT_NAME = "agent"
 """The default agent name used when no `-a` flag is provided."""
@@ -144,7 +148,7 @@ def get_system_prompt(
 ) -> str:
     """Get the base system prompt for the agent.
 
-    Loads the immutable system prompt from `system_prompt.md` and
+    Loads the base system prompt template from `system_prompt.md` and
     interpolates dynamic sections (model identity, working directory,
     skills path, execution mode).
 
@@ -232,7 +236,14 @@ def get_system_prompt(
             f"- Use `{working_dir}` as your working directory for all operations\n\n"
         )
     else:
-        cwd = Path.cwd()
+        try:
+            cwd = Path.cwd()
+        except OSError:
+            logger.warning(
+                "Could not determine working directory for system prompt",
+                exc_info=True,
+            )
+            cwd = Path()
         working_dir_section = (
             f"### Current Working Directory\n\n"
             f"The filesystem backend is currently operating in: `{cwd}`\n\n"
@@ -245,7 +256,7 @@ def get_system_prompt(
             f"- Never use relative paths - always construct full absolute paths\n\n"
         )
 
-    return (
+    result = (
         template.replace("{mode_description}", mode_description)
         .replace("{interactive_preamble}", interactive_preamble)
         .replace("{ambiguity_guidance}", ambiguity_guidance)
@@ -253,6 +264,13 @@ def get_system_prompt(
         .replace("{working_dir_section}", working_dir_section)
         .replace("{skills_path}", skills_path)
     )
+
+    # Detect unreplaced placeholders (defense-in-depth for template typos)
+    unreplaced = re.findall(r"\{[a-z_]+\}", result)
+    if unreplaced:
+        logger.warning("System prompt contains unreplaced placeholders: %s", unreplaced)
+
+    return result
 
 
 def _format_write_file_description(

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -204,7 +204,12 @@ def get_system_prompt(
             "- Do NOT ask clarifying questions — there is no human to answer "
             "them. Make reasonable assumptions and proceed.\n"
             "- If you encounter ambiguity, choose the most reasonable "
-            "interpretation and note your assumption briefly."
+            "interpretation and note your assumption briefly.\n"
+            "- Always use non-interactive command variants — no human is "
+            "available to respond to prompts. Examples: `npm init -y` not "
+            "`npm init`, `apt-get install -y` not `apt-get install`, "
+            "`yes |` or `--no-input`/`--non-interactive` flags where "
+            "available. Never run commands that block waiting for stdin."
         )
 
     # Build model identity section

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -136,12 +136,17 @@ def reset_agent(agent_name: str, source_agent: str | None = None) -> None:
     console.print(f"Location: {agent_dir}\n", style=COLORS["dim"])
 
 
-def get_system_prompt(assistant_id: str, sandbox_type: str | None = None) -> str:
+def get_system_prompt(
+    assistant_id: str,
+    sandbox_type: str | None = None,
+    *,
+    interactive: bool = True,
+) -> str:
     """Get the base system prompt for the agent.
 
     Loads the immutable system prompt from `system_prompt.md` and
     interpolates dynamic sections (model identity, working directory,
-    skills path).
+    skills path, execution mode).
 
     Args:
         assistant_id: The agent identifier for path references
@@ -149,6 +154,8 @@ def get_system_prompt(assistant_id: str, sandbox_type: str | None = None) -> str
             (`'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
 
             If `None`, agent is operating in local mode.
+        interactive: When `False`, the prompt is tailored for headless
+            non-interactive execution (no human in the loop).
 
     Returns:
         The system prompt string
@@ -165,6 +172,36 @@ def get_system_prompt(assistant_id: str, sandbox_type: str | None = None) -> str
     template = (Path(__file__).parent / "system_prompt.md").read_text()
 
     skills_path = f"~/.deepagents/{assistant_id}/skills/"
+
+    if interactive:
+        mode_description = "an interactive CLI on the user's computer"
+        interactive_preamble = (
+            "The user sends you messages and you respond with text and tool "
+            "calls. Your tools run on the user's machine. The user can see "
+            "your responses and tool outputs in real time, so keep them "
+            "informed — but don't over-explain."
+        )
+        ambiguity_guidance = (
+            "- If the request is ambiguous, ask questions before acting.\n"
+            "- If asked how to approach something, explain first, then act."
+        )
+    else:
+        mode_description = (
+            "non-interactive (headless) mode — there is no human operator "
+            "monitoring your output in real time"
+        )
+        interactive_preamble = (
+            "You received a single task and must complete it fully and "
+            "autonomously. There is no human available to answer follow-up "
+            "questions, so do NOT ask for clarification — make reasonable "
+            "assumptions and proceed."
+        )
+        ambiguity_guidance = (
+            "- Do NOT ask clarifying questions — there is no human to answer "
+            "them. Make reasonable assumptions and proceed.\n"
+            "- If you encounter ambiguity, choose the most reasonable "
+            "interpretation and note your assumption briefly."
+        )
 
     # Build model identity section
     model_identity_section = ""
@@ -209,7 +246,10 @@ def get_system_prompt(assistant_id: str, sandbox_type: str | None = None) -> str
         )
 
     return (
-        template.replace("{model_identity_section}", model_identity_section)
+        template.replace("{mode_description}", mode_description)
+        .replace("{interactive_preamble}", interactive_preamble)
+        .replace("{ambiguity_guidance}", ambiguity_guidance)
+        .replace("{model_identity_section}", model_identity_section)
         .replace("{working_dir_section}", working_dir_section)
         .replace("{skills_path}", skills_path)
     )
@@ -431,6 +471,7 @@ def create_cli_agent(
     sandbox: SandboxBackendProtocol | None = None,
     sandbox_type: str | None = None,
     system_prompt: str | None = None,
+    interactive: bool = True,
     auto_approve: bool = False,
     enable_memory: bool = True,
     enable_skills: bool = True,
@@ -457,7 +498,11 @@ def create_cli_agent(
             Used for system prompt generation.
         system_prompt: Override the default system prompt.
 
-            If `None`, generates one based on `sandbox_type` and `assistant_id`.
+            If `None`, generates one based on `sandbox_type`, `assistant_id`,
+            and `interactive`.
+        interactive: When `False`, the auto-generated system prompt is
+            tailored for headless non-interactive execution. Ignored when
+            `system_prompt` is provided explicitly.
         auto_approve: If `True`, no tools trigger human-in-the-loop
             interrupts — all calls (shell execution, file writes/edits,
             web search, URL fetch) run automatically.
@@ -600,7 +645,9 @@ def create_cli_agent(
     # Get or use custom system prompt
     if system_prompt is None:
         system_prompt = get_system_prompt(
-            assistant_id=assistant_id, sandbox_type=sandbox_type
+            assistant_id=assistant_id,
+            sandbox_type=sandbox_type,
+            interactive=interactive,
         )
 
     # Configure interrupt_on based on auto_approve setting

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -682,6 +682,10 @@ async def run_non_interactive(
 ) -> int:
     """Run a single task non-interactively and exit.
 
+    The agent is created with `interactive=False`, which tailors the system
+    prompt for autonomous headless execution (no clarification questions,
+    reasonable assumptions).
+
     Shell access and auto-approval are controlled by `--shell-allow-list`:
 
     - Not set → shell disabled, all other tools auto-approved.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -839,6 +839,7 @@ async def run_non_interactive(
                 tools=tools,
                 sandbox=sandbox_backend,
                 sandbox_type=sandbox_type if sandbox_type != "none" else None,
+                interactive=False,
                 auto_approve=use_auto_approve,
                 enable_shell=enable_shell,
                 checkpointer=checkpointer,

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -200,7 +200,7 @@ def format_path(path: str | None) -> str:
         path: Absolute filesystem path, or `None`.
 
     Returns:
-        Formatted path string or empty string if `None`.
+        Formatted path string, or empty string if path is falsy.
     """
     if not path:
         return ""
@@ -212,6 +212,9 @@ def format_path(path: str | None) -> str:
         if path.startswith(prefix):
             return "~/" + path[len(prefix) :]
     except (RuntimeError, KeyError, OSError):
+        logger.debug(
+            "Could not resolve home directory for path formatting", exc_info=True
+        )
         return path
     else:
         return path

--- a/libs/cli/deepagents_cli/system_prompt.md
+++ b/libs/cli/deepagents_cli/system_prompt.md
@@ -1,8 +1,8 @@
 # Deep Agents CLI
 
-You are a Deep Agent, an AI assistant running in an interactive CLI on the user's computer. You help with tasks like coding, debugging, research, analysis, and more.
+You are a Deep Agent, an AI assistant running in {mode_description}. You help with tasks like coding, debugging, research, analysis, and more.
 
-The user sends you messages and you respond with text and tool calls. Your tools run on the user's machine. The user can see your responses and tool outputs in real time, so keep them informed — but don't over-explain.
+{interactive_preamble}
 
 # Core Behavior
 
@@ -11,8 +11,7 @@ The user sends you messages and you respond with text and tool calls. Your tools
 - NEVER add unnecessary preamble ("Sure!", "Great question!", "I'll now...").
 - Don't say "I'll now do X" — just do it.
 - No time estimates. Focus on what needs to be done, not how long.
-- If the request is ambiguous, ask questions before acting.
-- If asked how to approach something, explain first, then act.
+{ambiguity_guidance}
 - When you run non-trivial bash commands, briefly explain what they do.
 - For longer tasks, give brief progress updates — what you've done, what's next.
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -232,6 +232,7 @@ def _get_git_branch() -> str | None:
     try:
         cwd = str(Path.cwd())
     except OSError:
+        logger.debug("Could not determine cwd for git branch lookup", exc_info=True)
         return None
     if cwd in _git_branch_cache:
         return _git_branch_cache[cwd]
@@ -262,7 +263,8 @@ def _build_stream_config(
 
     The `thread_id` in `configurable` is automatically propagated as run
     metadata by LangGraph, so it can be used for LangSmith filtering without
-    a separate metadata key.
+    a separate metadata key. Includes the current working directory (`cwd`)
+    and git branch in metadata when available.
 
     Args:
         thread_id: The CLI session thread identifier.

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -475,6 +475,159 @@ class TestGetSystemPromptNonInteractive:
         assert "interactive CLI" in prompt
 
 
+class TestGetSystemPromptCwdOSError:
+    """Tests for Path.cwd() OSError handling in get_system_prompt."""
+
+    def test_falls_back_on_cwd_oserror(self) -> None:
+        """get_system_prompt should not crash when Path.cwd() raises OSError."""
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.Path.cwd", side_effect=OSError("deleted")),
+        ):
+            prompt = get_system_prompt("test-agent")
+
+        assert "Current Working Directory" in prompt
+
+
+class TestGetSystemPromptPlaceholderValidation:
+    """Tests for unreplaced placeholder detection."""
+
+    def test_no_unreplaced_placeholders_in_interactive(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=True)
+
+        # No raw {placeholder} patterns should remain
+        import re
+
+        assert not re.findall(r"\{[a-z_]+\}", prompt)
+
+    def test_no_unreplaced_placeholders_in_non_interactive(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        import re
+
+        assert not re.findall(r"\{[a-z_]+\}", prompt)
+
+
+class TestCreateCliAgentInteractiveForwarding:
+    """Tests for interactive parameter forwarding in create_cli_agent."""
+
+    def test_forwards_interactive_false_to_get_system_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        """create_cli_agent should forward interactive=False to get_system_prompt."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+
+        fake_model = _make_fake_chat_model()
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware"),
+            patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
+            patch(
+                "deepagents.graph.init_chat_model",
+                return_value=fake_model,
+            ),
+            patch("deepagents_cli.agent.get_system_prompt") as mock_get_prompt,
+        ):
+            mock_get_prompt.return_value = "mocked prompt"
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=False,
+                interactive=False,
+            )
+
+        mock_get_prompt.assert_called_once()
+        _, kwargs = mock_get_prompt.call_args
+        assert kwargs["interactive"] is False
+
+    def test_explicit_system_prompt_ignores_interactive(self, tmp_path: Path) -> None:
+        """Explicit system_prompt should be used verbatim, ignoring interactive."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+
+        fake_model = _make_fake_chat_model()
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware"),
+            patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
+            patch(
+                "deepagents.graph.init_chat_model",
+                return_value=fake_model,
+            ),
+            patch("deepagents_cli.agent.get_system_prompt") as mock_get_prompt,
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=False,
+                system_prompt="custom prompt",
+                interactive=False,
+            )
+
+        # get_system_prompt should NOT be called when system_prompt is provided
+        mock_get_prompt.assert_not_called()
+
+
 class TestDefaultAgentName:
     """Tests for the DEFAULT_AGENT_NAME constant."""
 

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -423,6 +423,58 @@ class TestGetSystemPromptModelIdentity:
         assert "context window" not in prompt
 
 
+class TestGetSystemPromptNonInteractive:
+    """Tests for interactive vs non-interactive system prompt."""
+
+    def test_interactive_prompt_mentions_interactive_cli(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=True)
+
+        assert "interactive CLI" in prompt
+        assert "ask questions before acting" in prompt
+
+    def test_non_interactive_prompt_mentions_headless(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert "non-interactive" in prompt
+        assert "no human" in prompt.lower()
+
+    def test_non_interactive_prompt_does_not_ask_questions(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert "ask questions before acting" not in prompt
+
+    def test_non_interactive_prompt_instructs_autonomous_execution(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert "Do NOT ask clarifying questions" in prompt
+        assert "reasonable assumptions" in prompt
+
+    def test_default_is_interactive(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent")
+
+        assert "interactive CLI" in prompt
+
+
 class TestDefaultAgentName:
     """Tests for the DEFAULT_AGENT_NAME constant."""
 

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -465,6 +465,16 @@ class TestGetSystemPromptNonInteractive:
         assert "Do NOT ask clarifying questions" in prompt
         assert "reasonable assumptions" in prompt
 
+    def test_non_interactive_prompt_requires_non_interactive_commands(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert "non-interactive command variants" in prompt
+        assert "npm init -y" in prompt
+
     def test_default_is_interactive(self) -> None:
         mock_settings = Mock()
         mock_settings.model_name = None

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -1006,6 +1006,61 @@ class TestShellAllowListDecisionLogic:
         assert kwargs["auto_approve"] is expected_auto
 
 
+class TestNonInteractivePrompt:
+    """Tests that run_non_interactive passes interactive=False to create_cli_agent."""
+
+    async def test_passes_interactive_false(self) -> None:
+        mock_cp = MagicMock()
+        mock_checkpointer_cm = AsyncMock()
+        mock_checkpointer_cm.__aenter__.return_value = mock_cp
+        mock_checkpointer_cm.__aexit__.return_value = None
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.get_checkpointer",
+                return_value=mock_checkpointer_cm,
+            ),
+            patch(
+                "deepagents_cli.non_interactive.create_cli_agent",
+            ) as mock_create_agent,
+            patch(
+                "deepagents_cli.mcp_tools.resolve_and_load_mcp_tools",
+                return_value=([], None, []),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            mock_agent = MagicMock()
+            mock_agent.astream = MagicMock(return_value=_async_iter([]))
+            mock_create_agent.return_value = (mock_agent, MagicMock())
+
+            await run_non_interactive(message="do the thing")
+
+        _, kwargs = mock_create_agent.call_args
+        assert kwargs["interactive"] is False
+
+
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029
     """Create an async iterator from a list for testing."""
     for item in items:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -212,6 +212,39 @@ class TestGetGitBranch:
         assert mock_run.call_count == 1
 
 
+class TestGetGitBranchOSError:
+    """Tests for _get_git_branch when Path.cwd() raises OSError."""
+
+    def setup_method(self) -> None:
+        """Clear the git-branch cache between tests."""
+        textual_adapter._git_branch_cache.clear()
+
+    def test_returns_none_on_cwd_oserror(self) -> None:
+        """_get_git_branch should return None when cwd is inaccessible."""
+        with patch(
+            "deepagents_cli.textual_adapter.Path.cwd",
+            side_effect=OSError("deleted"),
+        ):
+            assert textual_adapter._get_git_branch() is None
+
+
+class TestBuildStreamConfigOSError:
+    """Tests for _build_stream_config when Path.cwd() raises OSError."""
+
+    def setup_method(self) -> None:
+        """Clear the git-branch cache between tests."""
+        textual_adapter._git_branch_cache.clear()
+
+    def test_cwd_absent_on_oserror(self) -> None:
+        """Cwd should be absent from metadata when Path.cwd() raises."""
+        with patch(
+            "deepagents_cli.textual_adapter.Path.cwd",
+            side_effect=OSError("deleted"),
+        ):
+            config = _build_stream_config("t-err", assistant_id="agent")
+        assert "cwd" not in config["metadata"]
+
+
 class TestIsSummarizationChunk:
     """Tests for `_is_summarization_chunk` detection."""
 


### PR DESCRIPTION
Closes #1250

---

When running in non-interactive mode (`-n`), the agent previously received the same system prompt as interactive mode — including instructions to `"ask questions before acting"` which is counterproductive for headless execution. This adds an `interactive` parameter to `get_system_prompt()` and `create_cli_agent()` so that non-interactive runs get a prompt tailored for autonomous execution: no clarifying questions, make reasonable assumptions, complete the task fully.