### PR TITLE
fix(cli): prevent `shift+enter` from sending `backslash+enter`

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -45,6 +45,16 @@ _PASTE_BURST_FLUSH_DELAY_SECONDS = 0.08
 _PASTE_BURST_START_CHARS = {"'", '"'}
 """Characters that can start dropped-path payloads."""
 
+_BACKSLASH_ENTER_GAP_SECONDS = 0.15
+"""Maximum gap between a `\\` key and a following `enter` key to treat the
+pair as a terminal-emitted shift+enter sequence.
+
+Some terminals (e.g. VSCode's built-in terminal) send a literal backslash
+followed by carriage-return when the user presses shift+enter.  The gap is
+generous (150 ms) because the terminal emits both characters nearly
+simultaneously; a human deliberately typing `\\` then pressing Enter would
+have a much larger gap."""
+
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
@@ -323,6 +333,7 @@ class ChatTextArea(TextArea):
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time: float | None = None
         self._paste_burst_timer: Timer | None = None
+        self._backslash_pending_time: float | None = None
 
     def set_app_focus(self, *, has_focus: bool) -> None:
         """Set whether the app should show the cursor as active.
@@ -417,6 +428,17 @@ class ChatTextArea(TextArea):
 
         self.insert(payload)
 
+    def _delete_preceding_backslash(self) -> None:
+        """Delete the backslash character immediately before the cursor."""
+        row, col = self.cursor_location
+        if col > 0:
+            start = (row, col - 1)
+            self.delete(start, self.cursor_location)
+        elif row > 0:
+            prev_line = self.document.get_line(row - 1)
+            start = (row - 1, len(prev_line))
+            self.delete(start, self.cursor_location)
+
     async def _on_key(self, event: events.Key) -> None:
         """Handle key events."""
         now = time.monotonic()
@@ -449,6 +471,25 @@ class ChatTextArea(TextArea):
             event.prevent_default()
             event.stop()
             return
+
+        # Some terminals (e.g. VSCode built-in) send a literal backslash
+        # followed by enter for shift+enter.  When enter arrives shortly
+        # after a backslash, delete the backslash and insert a newline.
+        if (
+            event.key == "enter"
+            and self._backslash_pending_time is not None
+            and (now - self._backslash_pending_time) <= _BACKSLASH_ENTER_GAP_SECONDS
+        ):
+            self._backslash_pending_time = None
+            event.prevent_default()
+            event.stop()
+            self._delete_preceding_backslash()
+            self.insert("\n")
+            return
+        self._backslash_pending_time = None
+
+        if event.key == "backslash" and event.character == "\\":
+            self._backslash_pending_time = now
 
         # Modifier+Enter inserts newline (Ctrl+J is most reliable across terminals)
         if event.key in {"shift+enter", "ctrl+j", "alt+enter", "ctrl+enter"}:
@@ -569,6 +610,7 @@ class ChatTextArea(TextArea):
 
     async def _on_paste(self, event: events.Paste) -> None:
         """Handle paste events and detect dragged file paths."""
+        self._backslash_pending_time = None
         if self._paste_burst_buffer:
             self._flush_paste_burst()
 
@@ -590,6 +632,7 @@ class ChatTextArea(TextArea):
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
+        self._backslash_pending_time = None
         self._navigating_history = True
         self.text = text
         # Move cursor to end
@@ -605,6 +648,7 @@ class ChatTextArea(TextArea):
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
+        self._backslash_pending_time = None
         self.text = ""
         self.move_cursor((0, 0))
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -51,7 +51,7 @@ _BACKSLASH_ENTER_GAP_SECONDS = 0.15
 pair as a terminal-emitted shift+enter sequence.
 
 Some terminals (e.g. VSCode's built-in terminal) send a literal backslash
-followed by carriage-return when the user presses shift+enter.  The gap is
+followed by enter when the user presses shift+enter.  The gap is
 generous (150 ms) because the terminal emits both characters nearly
 simultaneously; a human deliberately typing `\\` then pressing Enter would
 have a much larger gap."""
@@ -334,6 +334,7 @@ class ChatTextArea(TextArea):
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time: float | None = None
         self._paste_burst_timer: Timer | None = None
+        # See _BACKSLASH_ENTER_GAP_SECONDS for context.
         self._backslash_pending_time: float | None = None
 
     def set_app_focus(self, *, has_focus: bool) -> None:
@@ -343,6 +344,7 @@ class ChatTextArea(TextArea):
         so the cursor doesn't flash while waiting for a response.
         """
         self._app_has_focus = has_focus
+        self._backslash_pending_time = None
         self.cursor_blink = has_focus
         if has_focus and not self.has_focus:
             self.call_after_refresh(self.focus)
@@ -429,16 +431,29 @@ class ChatTextArea(TextArea):
 
         self.insert(payload)
 
-    def _delete_preceding_backslash(self) -> None:
-        """Delete the backslash character immediately before the cursor."""
+    def _delete_preceding_backslash(self) -> bool:
+        """Delete the backslash character immediately before the cursor.
+
+        Caller must ensure a backslash is expected at this position. The
+        method verifies the character before deleting it.
+
+        Returns:
+            `True` if a backslash was found and deleted, `False` otherwise.
+        """
         row, col = self.cursor_location
         if col > 0:
             start = (row, col - 1)
-            self.delete(start, self.cursor_location)
+            if self.document.get_text_range(start, self.cursor_location) == "\\":
+                self.delete(start, self.cursor_location)
+                return True
         elif row > 0:
             prev_line = self.document.get_line(row - 1)
-            start = (row - 1, len(prev_line))
-            self.delete(start, self.cursor_location)
+            start = (row - 1, len(prev_line) - 1)
+            end = (row - 1, len(prev_line))
+            if self.document.get_text_range(start, end) == "\\":
+                self.delete(start, self.cursor_location)
+                return True
+        return False
 
     async def _on_key(self, event: events.Key) -> None:
         """Handle key events."""
@@ -478,15 +493,16 @@ class ChatTextArea(TextArea):
         # after a backslash, delete the backslash and insert a newline.
         if (
             event.key == "enter"
+            and not self._completion_active
             and self._backslash_pending_time is not None
             and (now - self._backslash_pending_time) <= _BACKSLASH_ENTER_GAP_SECONDS
         ):
             self._backslash_pending_time = None
-            event.prevent_default()
-            event.stop()
-            self._delete_preceding_backslash()
-            self.insert("\n")
-            return
+            if self._delete_preceding_backslash():
+                event.prevent_default()
+                event.stop()
+                self.insert("\n")
+                return
         self._backslash_pending_time = None
 
         if event.key == "backslash" and event.character == "\\":

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -1851,3 +1851,73 @@ class TestDroppedVideoPaste:
             assert "[video 1]" in text
             assert len(app.tracker.get_images()) == 1
             assert len(app.tracker.get_videos()) == 1
+
+
+class TestBackslashEnterNewline:
+    """Test that backslash followed quickly by enter inserts a newline.
+
+    Some terminals (e.g. VSCode built-in) send a literal backslash followed
+    by enter when the user presses shift+enter.  The widget detects this
+    pair and collapses it into a newline.
+    """
+
+    async def test_backslash_then_enter_inserts_newline(self) -> None:
+        """Rapid backslash + enter should produce a newline, not submit."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello")
+            await pilot.pause()
+
+            await pilot.press("backslash")
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert "\n" in ta.text
+            assert "\\" not in ta.text
+            assert len(app.submitted) == 0
+
+    async def test_backslash_alone_inserts_normally(self) -> None:
+        """A lone backslash should be inserted immediately as normal text."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            await pilot.press("backslash")
+            await pilot.pause()
+
+            assert ta.text == "\\"
+
+    async def test_backslash_then_letter_inserts_both(self) -> None:
+        """Backslash followed by a letter should insert both characters."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            await pilot.press("backslash")
+            await pilot.press("a")
+            await pilot.pause()
+
+            assert "\\" in ta.text
+            assert "a" in ta.text
+
+    async def test_backslash_enter_on_empty_prompt_does_not_submit(self) -> None:
+        """Backslash + enter on empty prompt should not submit."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            await pilot.press("backslash")
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 0

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
+import pytest
 from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Container
@@ -1905,8 +1907,7 @@ class TestBackslashEnterNewline:
             await pilot.press("a")
             await pilot.pause()
 
-            assert "\\" in ta.text
-            assert "a" in ta.text
+            assert ta.text == "\\a"
 
     async def test_backslash_enter_on_empty_prompt_does_not_submit(self) -> None:
         """Backslash + enter on empty prompt should not submit."""
@@ -1921,3 +1922,29 @@ class TestBackslashEnterNewline:
             await pilot.pause()
 
             assert len(app.submitted) == 0
+            assert "\\" not in ta.text
+            assert ta.text == "\n"
+
+    async def test_backslash_then_slow_enter_submits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Backslash + enter beyond the timing gap should submit normally."""
+        # Set gap to 0 so any real delay exceeds it.
+        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 0.0)
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello")
+            await pilot.pause()
+
+            await pilot.press("backslash")
+            await asyncio.sleep(0.05)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # Should have submitted (backslash included in text)
+            assert len(app.submitted) == 1


### PR DESCRIPTION
Closes #757

---

Some terminals (e.g. VSCode's built-in terminal) send a literal backslash followed by enter when the user presses shift+enter, instead of a proper `shift+enter` key event. This caused the backslash to be inserted and the prompt to be submitted.