### PR TITLE
feat(cli): add sort, branch filter, and verbose flags to threads list

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -265,6 +265,31 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Max number of threads to display (default: 20)",
     )
+    threads_list.add_argument(
+        "--sort",
+        choices=["created", "updated"],
+        default=None,
+        help="Sort threads by timestamp (default: from config, or updated)",
+    )
+    threads_list.add_argument(
+        "--branch",
+        default=None,
+        help="Filter by git branch name",
+    )
+    threads_list.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Show all columns (branch, created, prompt)",
+    )
+    threads_list.add_argument(
+        "-r",
+        "--relative",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Show timestamps as relative time (default: from config, or absolute)",
+    )
     threads_delete = threads_sub.add_parser(
         "delete",
         help="Delete a thread",
@@ -1209,6 +1234,10 @@ def cli_main() -> None:
                     list_threads_command(
                         agent_name=getattr(args, "agent", None),
                         limit=getattr(args, "limit", None),
+                        sort_by=getattr(args, "sort", None),
+                        branch=getattr(args, "branch", None),
+                        verbose=getattr(args, "verbose", False),
+                        relative=getattr(args, "relative", None),
                     )
                 )
             elif args.threads_command == "delete":

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -1210,6 +1210,75 @@ def save_thread_relative_time(enabled: bool, config_path: Path | None = None) ->
     return True
 
 
+def load_thread_sort_order(config_path: Path | None = None) -> str:
+    """Load the sort order preference for the thread selector.
+
+    Args:
+        config_path: Path to config file.
+
+    Returns:
+        `"updated_at"` or `"created_at"`.
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+    try:
+        if not config_path.exists():
+            return "updated_at"
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        value = data.get("threads", {}).get("sort_order")
+        if value in {"updated_at", "created_at"}:
+            return value
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.debug("Could not read thread sort_order config", exc_info=True)
+    return "updated_at"
+
+
+def save_thread_sort_order(sort_order: str, config_path: Path | None = None) -> bool:
+    """Save the sort order preference for the thread selector.
+
+    Args:
+        sort_order: `"updated_at"` or `"created_at"`.
+        config_path: Path to config file.
+
+    Returns:
+        True if save succeeded, False on I/O error.
+
+    Raises:
+        ValueError: If `sort_order` is not a recognised value.
+    """
+    if sort_order not in {"updated_at", "created_at"}:
+        msg = (
+            f"Invalid sort_order {sort_order!r}; expected 'updated_at' or 'created_at'"
+        )
+        raise ValueError(msg)
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        if config_path.exists():
+            with config_path.open("rb") as f:
+                data = tomllib.load(f)
+        else:
+            data = {}
+        if "threads" not in data:
+            data["threads"] = {}
+        data["threads"]["sort_order"] = sort_order
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except Exception:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.exception("Could not save thread sort_order preference")
+        return False
+    return True
+
+
 def save_recent_model(model_spec: str, config_path: Path | None = None) -> bool:
     """Update the recently used model in config file.
 

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -222,6 +222,8 @@ async def list_threads(
     agent_name: str | None = None,
     limit: int = 20,
     include_message_count: bool = False,
+    sort_by: str = "updated",
+    branch: str | None = None,
 ) -> list[ThreadInfo]:
     """List threads from checkpoints table.
 
@@ -229,45 +231,53 @@ async def list_threads(
         agent_name: Optional filter by agent name.
         limit: Maximum number of threads to return.
         include_message_count: Whether to include message counts.
+        sort_by: Sort field — `"updated"` or `"created"`.
+        branch: Optional filter by git branch name.
 
     Returns:
         List of `ThreadInfo` dicts with `thread_id`, `agent_name`,
-            `updated_at`, and optionally `message_count`.
+            `updated_at`, `created_at`, `latest_checkpoint_id`, `git_branch`,
+            and optionally `message_count`.
+
+    Raises:
+        ValueError: If `sort_by` is not `"updated"` or `"created"`.
     """
     async with _connect() as conn:
         # Return empty if table doesn't exist yet (fresh install)
         if not await _table_exists(conn, "checkpoints"):
             return []
 
+        if sort_by not in {"updated", "created"}:
+            msg = f"Invalid sort_by {sort_by!r}; expected 'updated' or 'created'"
+            raise ValueError(msg)
+        order_col = "created_at" if sort_by == "created" else "updated_at"
+
+        where_clauses: list[str] = []
+        params_list: list[str | int] = []
+
         if agent_name:
-            query = """
-                SELECT thread_id,
-                       json_extract(metadata, '$.agent_name') as agent_name,
-                       MAX(json_extract(metadata, '$.updated_at')) as updated_at,
-                       MAX(checkpoint_id) as latest_checkpoint_id,
-                       MIN(json_extract(metadata, '$.updated_at')) as created_at,
-                       MAX(json_extract(metadata, '$.git_branch')) as git_branch
-                FROM checkpoints
-                WHERE json_extract(metadata, '$.agent_name') = ?
-                GROUP BY thread_id
-                ORDER BY updated_at DESC
-                LIMIT ?
-            """
-            params: tuple = (agent_name, limit)
-        else:
-            query = """
-                SELECT thread_id,
-                       json_extract(metadata, '$.agent_name') as agent_name,
-                       MAX(json_extract(metadata, '$.updated_at')) as updated_at,
-                       MAX(checkpoint_id) as latest_checkpoint_id,
-                       MIN(json_extract(metadata, '$.updated_at')) as created_at,
-                       MAX(json_extract(metadata, '$.git_branch')) as git_branch
-                FROM checkpoints
-                GROUP BY thread_id
-                ORDER BY updated_at DESC
-                LIMIT ?
-            """
-            params = (limit,)
+            where_clauses.append("json_extract(metadata, '$.agent_name') = ?")
+            params_list.append(agent_name)
+        if branch:
+            where_clauses.append("json_extract(metadata, '$.git_branch') = ?")
+            params_list.append(branch)
+
+        where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+
+        query = f"""
+            SELECT thread_id,
+                   json_extract(metadata, '$.agent_name') as agent_name,
+                   MAX(json_extract(metadata, '$.updated_at')) as updated_at,
+                   MAX(checkpoint_id) as latest_checkpoint_id,
+                   MIN(json_extract(metadata, '$.updated_at')) as created_at,
+                   MAX(json_extract(metadata, '$.git_branch')) as git_branch
+            FROM checkpoints
+            {where_sql}
+            GROUP BY thread_id
+            ORDER BY {order_col} DESC
+            LIMIT ?
+        """  # noqa: S608  # where_sql/order_col derived from controlled internal values; user values use ? placeholders
+        params: tuple = (*params_list, limit)
 
         async with conn.execute(query, params) as cursor:
             rows = await cursor.fetchall()
@@ -287,7 +297,10 @@ async def list_threads(
         if include_message_count and threads:
             await _populate_message_counts(conn, threads)
 
-        _cache_recent_threads(agent_name, limit, threads)
+        # Only cache unfiltered results so the thread selector modal
+        # doesn't receive branch-filtered or differently-sorted data.
+        if sort_by == "updated" and branch is None:
+            _cache_recent_threads(agent_name, limit, threads)
         return threads
 
 
@@ -912,11 +925,15 @@ def get_thread_limit() -> int:
 async def list_threads_command(
     agent_name: str | None = None,
     limit: int | None = None,
+    sort_by: str | None = None,
+    branch: str | None = None,
+    verbose: bool = False,
+    relative: bool | None = None,
 ) -> None:
     """CLI handler for `deepagents threads list`.
 
     Fetches and displays a table of recent conversation threads, optionally
-    filtered by agent name.
+    filtered by agent name or git branch.
 
     Args:
         agent_name: Only show threads belonging to this agent.
@@ -926,30 +943,69 @@ async def list_threads_command(
 
             When `None`, reads from `DA_CLI_RECENT_THREADS` or falls back to
             the default.
+        sort_by: Sort field — `"updated"` or `"created"`.
+
+            When `None`, reads from config (`~/.deepagents/config.toml`).
+        branch: Only show threads from this git branch.
+        verbose: When `True`, show all columns (branch, created, prompt).
+        relative: Show timestamps as relative time (e.g., '5m ago').
+
+            When `None`, reads from config (`~/.deepagents/config.toml`).
     """
     from rich.table import Table
 
     from deepagents_cli.config import COLORS, console
+    from deepagents_cli.model_config import (
+        load_thread_relative_time,
+        load_thread_sort_order,
+    )
+
+    if sort_by is None:
+        raw = load_thread_sort_order()
+        sort_by = "created" if raw == "created_at" else "updated"
+    if relative is None:
+        relative = load_thread_relative_time()
+
+    fmt_ts = format_relative_timestamp if relative else format_timestamp
 
     limit = get_thread_limit() if limit is None else max(1, limit)
 
-    threads = await list_threads(agent_name, limit=limit, include_message_count=True)
+    threads = await list_threads(
+        agent_name,
+        limit=limit,
+        include_message_count=True,
+        sort_by=sort_by,
+        branch=branch,
+    )
+
+    if verbose and threads:
+        await populate_thread_checkpoint_details(
+            threads, include_message_count=False, include_initial_prompt=True
+        )
 
     if not threads:
+        filters = []
         if agent_name:
+            filters.append(f"agent '{agent_name}'")
+        if branch:
+            filters.append(f"branch '{branch}'")
+        if filters:
             console.print(
-                f"[yellow]No threads found for agent '{agent_name}'.[/yellow]"
+                f"[yellow]No threads found for {' and '.join(filters)}.[/yellow]"
             )
         else:
             console.print("[yellow]No threads found.[/yellow]")
         console.print("[dim]Start a conversation with: deepagents[/dim]")
         return
 
-    title = (
-        f"Recent threads for '{agent_name}' (last {limit})"
-        if agent_name
-        else f"Recent Threads (last {limit})"
-    )
+    title_parts = []
+    if agent_name:
+        title_parts.append(f"agent '{agent_name}'")
+    if branch:
+        title_parts.append(f"branch '{branch}'")
+    title_filter = f" for {' and '.join(title_parts)}" if title_parts else ""
+    sort_label = "created" if sort_by == "created" else "updated"
+    title = f"Recent Threads{title_filter} (last {limit}, by {sort_label})"
 
     table = Table(
         title=title, show_header=True, header_style=f"bold {COLORS['primary']}"
@@ -957,15 +1013,31 @@ async def list_threads_command(
     table.add_column("Thread ID", style="bold")
     table.add_column("Agent")
     table.add_column("Messages", justify="right")
-    table.add_column("Last Used")
+    if verbose:
+        table.add_column("Created")
+    table.add_column("Updated" if sort_by == "updated" else "Last Used")
+    if verbose:
+        table.add_column("Branch")
+        table.add_column("Prompt", max_width=40, no_wrap=True)
+
+    prompt_max = 40
 
     for t in threads:
-        table.add_row(
+        row: list[str] = [
             t["thread_id"],
             t["agent_name"] or "unknown",
             str(t.get("message_count", 0)),
-            format_timestamp(t.get("updated_at")),
-        )
+        ]
+        if verbose:
+            row.append(fmt_ts(t.get("created_at")))
+        row.append(fmt_ts(t.get("updated_at")))
+        if verbose:
+            row.append(t.get("git_branch") or "")
+            prompt = " ".join((t.get("initial_prompt") or "").split())
+            if len(prompt) > prompt_max:
+                prompt = prompt[: prompt_max - 3] + "..."
+            row.append(prompt)
+        table.add_row(*row)
 
     console.print()
     console.print(table)

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -344,13 +344,28 @@ def show_threads_list_help() -> None:
     console.print("  deepagents threads list [options]")
     console.print()
     console.print("[bold]Options:[/bold]", style=COLORS["primary"])
-    console.print("  --agent NAME      Filter by agent name")
-    console.print("  -n, --limit N     Maximum threads to display (default: 20)")
-    console.print("  -h, --help        Show this help message")
+    console.print("  --agent NAME              Filter by agent name")
+    console.print("  --branch TEXT             Filter by git branch name")
+    console.print(
+        "  --sort {created,updated}  Sort order (default: from config, or updated)"
+    )
+    console.print(
+        "  -n, --limit N             Maximum threads to display (default: 20)"
+    )
+    console.print(
+        "  -v, --verbose             Show all columns (branch, created, prompt)"
+    )
+    console.print(
+        "  -r, --relative/--no-relative"
+        "  Show relative timestamps (default: from config)"
+    )
+    console.print("  -h, --help                Show this help message")
     console.print()
     console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
     console.print("  deepagents threads list")
     console.print("  deepagents threads list -n 10")
     console.print("  deepagents threads list --agent mybot")
-    console.print("  deepagents threads list --limit 50")
+    console.print("  deepagents threads list --branch main -v")
+    console.print("  deepagents threads list --sort created --limit 50")
+    console.print("  deepagents threads list -r")
     console.print()

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -619,7 +619,6 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._selected_index = 0
         self._option_widgets: list[ThreadOption] = []
         self._filter_text = ""
-        self._sort_by_updated = True
         self._confirming_delete = False
         self._render_lock = asyncio.Lock()
         self._filter_input: Input | None = None
@@ -628,10 +627,12 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         from deepagents_cli.model_config import (
             load_thread_columns,
             load_thread_relative_time,
+            load_thread_sort_order,
         )
 
         self._columns = load_thread_columns()
         self._relative_time = load_thread_relative_time()
+        self._sort_by_updated = load_thread_sort_order() == "updated_at"
 
         self._sync_selected_index()
         self._column_widths = self._compute_column_widths()
@@ -918,6 +919,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             self._sync_selected_index()
             self._update_help_widgets()
             self._schedule_list_rebuild()
+
+            self._persist_sort_order("updated_at" if event.value else "created_at")
             return
 
         if event.checkbox.id == _RELATIVE_TIME_SWITCH_ID:
@@ -1609,6 +1612,22 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._sync_selected_index()
         self._update_help_widgets()
         self._schedule_list_rebuild()
+
+        self._persist_sort_order(
+            "updated_at" if self._sort_by_updated else "created_at"
+        )
+
+    def _persist_sort_order(self, order: str) -> None:
+        """Save sort-order preference to config, notifying on failure."""
+
+        async def _save() -> None:
+            from deepagents_cli.model_config import save_thread_sort_order
+
+            ok = await asyncio.to_thread(save_thread_sort_order, order)
+            if not ok:
+                self.app.notify("Could not save sort preference", severity="warning")
+
+        self.run_worker(_save(), group="thread-selector-save")
 
     def action_delete_thread(self) -> None:
         """Show delete confirmation for the highlighted thread."""

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -10,7 +10,7 @@ from rich.console import Console
 
 from deepagents_cli.agent import DEFAULT_AGENT_NAME
 from deepagents_cli.main import _DEFAULT_AGENT_NAME, parse_args
-from deepagents_cli.ui import show_help
+from deepagents_cli.ui import show_help, show_threads_list_help
 
 
 class TestInitialPromptArg:
@@ -343,4 +343,38 @@ class TestHelpScreenDrift:
         assert not missing, (
             f"Flags in argparse but missing from show_help(): {missing}\n"
             "Add them to the Options section in ui.show_help()."
+        )
+
+    def test_threads_list_flags_appear_in_help(self) -> None:
+        """Every `threads list`-specific --flag must appear in show_threads_list_help().
+
+        We capture the argparse -h output for the subcommand, then compare
+        only the optional-arguments section (after "options:") to avoid
+        matching inherited global flags in the usage line.
+        """
+        stdout_buf = io.StringIO()
+        with (
+            patch.object(sys, "argv", ["deepagents", "threads", "list", "-h"]),
+            patch("sys.stdout", stdout_buf),
+            patch("deepagents_cli.ui.console", Console(file=io.StringIO())),
+            pytest.raises(SystemExit),
+        ):
+            parse_args()
+        raw = stdout_buf.getvalue()
+
+        # Only look at the "options:" section to avoid inherited global flags
+        options_section = raw.split("options:")[-1] if "options:" in raw else raw
+        parser_flags = set(re.findall(r"--[\w][\w-]*", options_section))
+        parser_flags.discard("--help")
+
+        help_buf = io.StringIO()
+        test_console = Console(file=help_buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            show_threads_list_help()
+        help_flags = set(re.findall(r"--[\w][\w-]*", help_buf.getvalue()))
+
+        missing = parser_flags - help_flags
+        assert not missing, (
+            f"Flags in argparse but missing from show_threads_list_help(): {missing}\n"
+            "Add them to the Options section in ui.show_threads_list_help()."
         )

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -201,6 +201,55 @@ class TestThreadRelativeTimePersistence:
         assert data["threads"]["relative_time"] is False
 
 
+class TestThreadSortOrderPersistence:
+    """Tests for thread sort-order preference persistence."""
+
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        """Saved sort order should load back on the next session."""
+        from deepagents_cli.model_config import (
+            load_thread_sort_order,
+            save_thread_sort_order,
+        )
+
+        config_path = tmp_path / "config.toml"
+        assert save_thread_sort_order("created_at", config_path) is True
+        assert load_thread_sort_order(config_path) == "created_at"
+
+        assert save_thread_sort_order("updated_at", config_path) is True
+        assert load_thread_sort_order(config_path) == "updated_at"
+
+    def test_default_is_updated_at(self, tmp_path: Path) -> None:
+        """When no config file exists, sort order defaults to updated_at."""
+        from deepagents_cli.model_config import load_thread_sort_order
+
+        config_path = tmp_path / "config.toml"
+        assert load_thread_sort_order(config_path) == "updated_at"
+
+    def test_invalid_value_falls_back_to_default(self, tmp_path: Path) -> None:
+        """An unrecognized sort_order value should fall back to updated_at."""
+        from deepagents_cli.model_config import load_thread_sort_order
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[threads]\nsort_order = "bogus"\n')
+        assert load_thread_sort_order(config_path) == "updated_at"
+
+    def test_preserves_other_config_sections(self, tmp_path: Path) -> None:
+        """Saving sort order should not clobber other config sections."""
+        from deepagents_cli.model_config import save_thread_sort_order
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models]\ndefault = "anthropic:claude-sonnet-4-5"\n')
+
+        save_thread_sort_order("created_at", config_path)
+
+        import tomllib
+
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["models"]["default"] == "anthropic:claude-sonnet-4-5"
+        assert data["threads"]["sort_order"] == "created_at"
+
+
 class TestProviderApiKeyEnv:
     """Tests for PROVIDER_API_KEY_ENV constant."""
 

--- a/libs/cli/tests/unit_tests/test_sessions.py
+++ b/libs/cli/tests/unit_tests/test_sessions.py
@@ -5,7 +5,7 @@ import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1072,3 +1072,311 @@ class TestGetThreadLimit:
         """Returns 1 when DA_CLI_RECENT_THREADS is negative."""
         with patch.dict("os.environ", {"DA_CLI_RECENT_THREADS": "-5"}):
             assert get_thread_limit() == 1
+
+
+class TestListThreadsSortAndBranch:
+    """Tests for sort_by and branch params on list_threads."""
+
+    @pytest.fixture
+    def db_with_branches(self, tmp_path: Path) -> Path:
+        """Create a database with threads on different branches.
+
+        thread_a: created 2025-01-01, updated 2025-06-01 (on main)
+        thread_b: created 2025-03-01, updated 2025-05-15 (on feat)
+
+        sort_by="updated" → thread_a first (June > May)
+        sort_by="created" → thread_b first (March > January)
+        """
+        db_path = tmp_path / "branches.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE checkpoints (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                metadata BLOB,
+                PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE writes (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                idx INTEGER NOT NULL,
+                channel TEXT NOT NULL,
+                type TEXT,
+                value BLOB,
+                PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+            )
+        """)
+
+        ins = (
+            "INSERT INTO checkpoints"
+            " (thread_id, checkpoint_ns, checkpoint_id, metadata)"
+            " VALUES (?, '', ?, ?)"
+        )
+
+        # thread_a: created 2025-01-01, updated 2025-06-01, on main
+        conn.execute(
+            ins,
+            (
+                "thread_a",
+                "cp1a",
+                json.dumps(
+                    {
+                        "agent_name": "bot",
+                        "updated_at": "2025-01-01T12:00:00+00:00",
+                        "git_branch": "main",
+                    }
+                ),
+            ),
+        )
+        # Second checkpoint for thread_a with a later updated_at
+        conn.execute(
+            ins,
+            (
+                "thread_a",
+                "cp1b",
+                json.dumps(
+                    {
+                        "agent_name": "bot",
+                        "updated_at": "2025-06-01T12:00:00+00:00",
+                        "git_branch": "main",
+                    }
+                ),
+            ),
+        )
+        # thread_b: created 2025-03-01, updated 2025-05-15, on feat
+        conn.execute(
+            ins,
+            (
+                "thread_b",
+                "cp2",
+                json.dumps(
+                    {
+                        "agent_name": "bot",
+                        "updated_at": "2025-03-01T12:00:00+00:00",
+                        "git_branch": "feat",
+                    }
+                ),
+            ),
+        )
+        # Second checkpoint for thread_b with a later updated_at
+        conn.execute(
+            ins,
+            (
+                "thread_b",
+                "cp2b",
+                json.dumps(
+                    {
+                        "agent_name": "bot",
+                        "updated_at": "2025-05-15T12:00:00+00:00",
+                        "git_branch": "feat",
+                    }
+                ),
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_sort_by_updated(self, db_with_branches: Path) -> None:
+        """Default sort returns most recently updated first."""
+        with patch.object(sessions, "get_db_path", return_value=db_with_branches):
+            threads = asyncio.run(sessions.list_threads(sort_by="updated"))
+            assert threads[0]["thread_id"] == "thread_a"
+
+    def test_sort_by_created(self, db_with_branches: Path) -> None:
+        """Most recently created first (thread_b: March > thread_a: Jan)."""
+        with patch.object(sessions, "get_db_path", return_value=db_with_branches):
+            threads = asyncio.run(sessions.list_threads(sort_by="created"))
+            assert threads[0]["thread_id"] == "thread_b"
+
+    def test_filter_by_branch(self, db_with_branches: Path) -> None:
+        """Branch filter returns only matching threads."""
+        with patch.object(sessions, "get_db_path", return_value=db_with_branches):
+            threads = asyncio.run(sessions.list_threads(branch="feat"))
+            assert len(threads) == 1
+            assert threads[0]["thread_id"] == "thread_b"
+            assert threads[0]["git_branch"] == "feat"
+
+    def test_filter_by_branch_no_match(self, db_with_branches: Path) -> None:
+        """Branch filter returns empty list when no match."""
+        with patch.object(sessions, "get_db_path", return_value=db_with_branches):
+            threads = asyncio.run(sessions.list_threads(branch="nonexistent"))
+            assert threads == []
+
+    def test_combined_agent_and_branch_filter(self, db_with_branches: Path) -> None:
+        """Agent + branch filters combine with AND."""
+        with patch.object(sessions, "get_db_path", return_value=db_with_branches):
+            threads = asyncio.run(
+                sessions.list_threads(agent_name="bot", branch="main")
+            )
+            assert len(threads) == 1
+            assert threads[0]["thread_id"] == "thread_a"
+
+
+class TestListThreadsCommandConfigDefaults:
+    """Tests for list_threads_command reading config defaults."""
+
+    _THREAD: ClassVar[dict[str, str | int]] = {
+        "thread_id": "abc123",
+        "agent_name": "bot",
+        "message_count": 2,
+        "updated_at": "2025-06-01T12:00:00+00:00",
+        "created_at": "2025-05-30T10:00:00+00:00",
+    }
+
+    def test_sort_reads_config_when_not_specified(self) -> None:
+        """sort_by=None falls back to config value."""
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="created_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_relative_time",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.sessions.list_threads",
+                new_callable=AsyncMock,
+                return_value=[self._THREAD],
+            ) as mock_list,
+            patch("deepagents_cli.sessions.format_timestamp", side_effect=str),
+            patch("deepagents_cli.config.console"),
+        ):
+            asyncio.run(sessions.list_threads_command())
+            mock_list.assert_called_once()
+            assert mock_list.call_args.kwargs["sort_by"] == "created"
+
+    def test_sort_flag_overrides_config(self) -> None:
+        """Explicit sort_by overrides config."""
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="created_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_relative_time",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.sessions.list_threads",
+                new_callable=AsyncMock,
+                return_value=[self._THREAD],
+            ) as mock_list,
+            patch("deepagents_cli.sessions.format_timestamp", side_effect=str),
+            patch("deepagents_cli.config.console"),
+        ):
+            asyncio.run(sessions.list_threads_command(sort_by="updated"))
+            mock_list.assert_called_once()
+            assert mock_list.call_args.kwargs["sort_by"] == "updated"
+
+    def test_relative_reads_config_when_not_specified(self) -> None:
+        """relative=None falls back to config value."""
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="updated_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_relative_time",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.sessions.list_threads",
+                new_callable=AsyncMock,
+                return_value=[self._THREAD],
+            ),
+            patch(
+                "deepagents_cli.sessions.format_relative_timestamp",
+                side_effect=str,
+            ) as mock_rel,
+            patch("deepagents_cli.sessions.format_timestamp") as mock_abs,
+            patch("deepagents_cli.config.console"),
+        ):
+            asyncio.run(sessions.list_threads_command())
+            assert mock_rel.call_count > 0
+            assert mock_abs.call_count == 0
+
+    def test_relative_flag_overrides_config(self) -> None:
+        """Explicit relative=False overrides config True."""
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="updated_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_relative_time",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.sessions.list_threads",
+                new_callable=AsyncMock,
+                return_value=[self._THREAD],
+            ),
+            patch(
+                "deepagents_cli.sessions.format_relative_timestamp",
+            ) as mock_rel,
+            patch(
+                "deepagents_cli.sessions.format_timestamp",
+                side_effect=str,
+            ) as mock_abs,
+            patch("deepagents_cli.config.console"),
+        ):
+            asyncio.run(sessions.list_threads_command(relative=False))
+            assert mock_abs.call_count > 0
+            assert mock_rel.call_count == 0
+
+    def test_branch_forwarded_to_list_threads(self) -> None:
+        """Branch parameter is passed through to list_threads."""
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="updated_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_relative_time",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.sessions.list_threads",
+                new_callable=AsyncMock,
+                return_value=[self._THREAD],
+            ) as mock_list,
+            patch("deepagents_cli.sessions.format_timestamp", side_effect=str),
+            patch("deepagents_cli.config.console"),
+        ):
+            asyncio.run(sessions.list_threads_command(branch="main"))
+            mock_list.assert_called_once()
+            assert mock_list.call_args.kwargs["branch"] == "main"
+
+    def test_verbose_calls_populate_details(self) -> None:
+        """verbose=True triggers populate_thread_checkpoint_details."""
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="updated_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_relative_time",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.sessions.list_threads",
+                new_callable=AsyncMock,
+                return_value=[{**self._THREAD, "git_branch": "main"}],
+            ),
+            patch(
+                "deepagents_cli.sessions.populate_thread_checkpoint_details",
+                new_callable=AsyncMock,
+            ) as mock_populate,
+            patch("deepagents_cli.sessions.format_timestamp", side_effect=str),
+            patch("deepagents_cli.config.console"),
+        ):
+            asyncio.run(sessions.list_threads_command(verbose=True))
+            mock_populate.assert_called_once()
+            assert mock_populate.call_args.kwargs["include_initial_prompt"] is True

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -67,14 +67,28 @@ def _patch_list_threads(threads: list[ThreadInfo] | None = None) -> Any:  # noqa
 
 
 def _patch_columns(columns: dict[str, bool] | None = None) -> Any:  # noqa: ANN401
-    """Patch load_thread_columns to return given columns."""
+    """Patch load_thread_columns and load_thread_sort_order for tests."""
+    import contextlib
+
     from deepagents_cli.model_config import THREAD_COLUMN_DEFAULTS
 
     cols = columns if columns is not None else THREAD_COLUMN_DEFAULTS
-    return patch(
-        "deepagents_cli.model_config.load_thread_columns",
-        return_value=dict(cols),
-    )
+
+    @contextlib.contextmanager
+    def _ctx() -> Any:  # noqa: ANN401
+        with (
+            patch(
+                "deepagents_cli.model_config.load_thread_columns",
+                return_value=dict(cols),
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_sort_order",
+                return_value="updated_at",
+            ),
+        ):
+            yield
+
+    return _ctx()
 
 
 def _style_scalar_value(value: object) -> int:


### PR DESCRIPTION
Extend `deepagents threads list` with sorting, branch filtering, verbose output, and relative timestamps. The `/thread` selector modal already supported sort toggling and relative time, but those preferences weren't accessible from the CLI subcommand and the sort preference wasn't persisted across sessions.

## Changes
- Add `--sort`, `--branch`, `-v/--verbose`, and `-r/--relative` flags to `threads list` in `parse_args()` and wire them through `list_threads_command`
- Refactor `list_threads()` to accept `sort_by` and `branch` params, replacing the duplicated agent/no-agent SQL branches with dynamic `WHERE` clause construction
- Add `load_thread_sort_order` / `save_thread_sort_order` config helpers in `model_config.py`, following the existing `load_thread_relative_time` pattern
- Persist sort-order preference from `ThreadSelectorScreen` toggle via `_persist_sort_order`, and load it on modal init instead of hardcoding `_sort_by_updated = True`
- `list_threads_command` now reads sort and relative-time defaults from config when CLI flags are omitted, and only caches unfiltered results to avoid polluting the thread selector cache
- Verbose mode adds branch, created timestamp, and truncated initial prompt columns to the output table
- Update `show_threads_list_help()` and add drift-detection test for the `threads list` subcommand flags