### PR TITLE
feat(cli): track and display working directory per thread

### DIFF
--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -1072,6 +1072,7 @@ THREAD_COLUMN_DEFAULTS: dict[str, bool] = {
     "created_at": True,
     "updated_at": True,
     "git_branch": False,
+    "cwd": False,
     "initial_prompt": True,
     "agent_name": False,
 }

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -743,12 +743,18 @@ async def run_non_interactive(
     result.apply_to_settings()
     thread_id = generate_thread_id()
 
+    try:
+        cwd = str(Path.cwd())
+    except OSError:
+        logger.warning("Could not determine working directory", exc_info=True)
+        cwd = ""
     metadata: dict[str, str] = {
         "assistant_id": assistant_id,
         "agent_name": assistant_id,
         "updated_at": datetime.now(UTC).isoformat(),
-        "cwd": str(Path.cwd()),
     }
+    if cwd:
+        metadata["cwd"] = cwd
     from deepagents_cli.textual_adapter import _get_git_branch
 
     branch = _get_git_branch()

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -23,6 +23,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain.agents.middleware.human_in_the_loop import ActionRequest, HITLRequest
@@ -746,6 +747,7 @@ async def run_non_interactive(
         "assistant_id": assistant_id,
         "agent_name": assistant_id,
         "updated_at": datetime.now(UTC).isoformat(),
+        "cwd": str(Path.cwd()),
     }
     from deepagents_cli.textual_adapter import _get_git_branch
 

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -211,7 +211,7 @@ def format_path(path: str | None) -> str:
         prefix = home + "/"
         if path.startswith(prefix):
             return "~/" + path[len(prefix) :]
-    except (RuntimeError, KeyError):
+    except (RuntimeError, KeyError, OSError):
         return path
     else:
         return path
@@ -267,7 +267,7 @@ async def list_threads(
     Returns:
         List of `ThreadInfo` dicts with `thread_id`, `agent_name`,
             `updated_at`, `created_at`, `latest_checkpoint_id`, `git_branch`,
-            and optionally `message_count`.
+            `cwd`, and optionally `message_count`.
 
     Raises:
         ValueError: If `sort_by` is not `"updated"` or `"created"`.
@@ -301,7 +301,7 @@ async def list_threads(
                    MAX(checkpoint_id) as latest_checkpoint_id,
                    MIN(json_extract(metadata, '$.updated_at')) as created_at,
                    MAX(json_extract(metadata, '$.git_branch')) as git_branch,
-                   json_extract(metadata, '$.cwd') as cwd
+                   MAX(json_extract(metadata, '$.cwd')) as cwd
             FROM checkpoints
             {where_sql}
             GROUP BY thread_id

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -105,6 +105,9 @@ class ThreadInfo(TypedDict):
     latest_checkpoint_id: NotRequired[str | None]
     """Most recent checkpoint ID for cache invalidation."""
 
+    cwd: NotRequired[str | None]
+    """Working directory where the thread was last used."""
+
 
 class _CheckpointSummary(NamedTuple):
     """Structured data extracted from a thread's latest checkpoint."""
@@ -185,6 +188,33 @@ def format_relative_timestamp(iso_timestamp: str | None) -> str:
         return f"{months}mo ago"
     years = days // 365
     return f"{years}y ago"
+
+
+def format_path(path: str | None) -> str:
+    """Format a filesystem path for display.
+
+    Paths under the user's home directory are shown relative to `~`.
+    All other paths are returned as-is.
+
+    Args:
+        path: Absolute filesystem path, or `None`.
+
+    Returns:
+        Formatted path string or empty string if `None`.
+    """
+    if not path:
+        return ""
+    try:
+        home = str(Path.home())
+        if path == home:
+            return "~"
+        prefix = home + "/"
+        if path.startswith(prefix):
+            return "~/" + path[len(prefix) :]
+    except (RuntimeError, KeyError):
+        return path
+    else:
+        return path
 
 
 def get_db_path() -> Path:
@@ -270,7 +300,8 @@ async def list_threads(
                    MAX(json_extract(metadata, '$.updated_at')) as updated_at,
                    MAX(checkpoint_id) as latest_checkpoint_id,
                    MIN(json_extract(metadata, '$.updated_at')) as created_at,
-                   MAX(json_extract(metadata, '$.git_branch')) as git_branch
+                   MAX(json_extract(metadata, '$.git_branch')) as git_branch,
+                   json_extract(metadata, '$.cwd') as cwd
             FROM checkpoints
             {where_sql}
             GROUP BY thread_id
@@ -289,6 +320,7 @@ async def list_threads(
                     latest_checkpoint_id=r[3],
                     created_at=r[4],
                     git_branch=r[5],
+                    cwd=r[6],
                 )
                 for r in rows
             ]
@@ -1018,6 +1050,7 @@ async def list_threads_command(
     table.add_column("Updated" if sort_by == "updated" else "Last Used")
     if verbose:
         table.add_column("Branch")
+        table.add_column("Location")
         table.add_column("Prompt", max_width=40, no_wrap=True)
 
     prompt_max = 40
@@ -1032,11 +1065,16 @@ async def list_threads_command(
             row.append(fmt_ts(t.get("created_at")))
         row.append(fmt_ts(t.get("updated_at")))
         if verbose:
-            row.append(t.get("git_branch") or "")
             prompt = " ".join((t.get("initial_prompt") or "").split())
             if len(prompt) > prompt_max:
                 prompt = prompt[: prompt_max - 3] + "..."
-            row.append(prompt)
+            row.extend(
+                [
+                    t.get("git_branch") or "",
+                    format_path(t.get("cwd")),
+                    prompt,
+                ]
+            )
         table.add_row(*row)
 
     console.print()

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -229,7 +229,10 @@ def _get_git_branch() -> str | None:
     """Return the current git branch name, or None if not in a repo."""
     import subprocess  # noqa: S404
 
-    cwd = str(Path.cwd())
+    try:
+        cwd = str(Path.cwd())
+    except OSError:
+        return None
     if cwd in _git_branch_cache:
         return _git_branch_cache[cwd]
 
@@ -268,7 +271,12 @@ def _build_stream_config(
     Returns:
         Config dict with `configurable` and `metadata` keys.
     """
-    metadata: dict[str, str] = {"cwd": str(Path.cwd())}
+    try:
+        cwd = str(Path.cwd())
+    except OSError:
+        logger.warning("Could not determine working directory", exc_info=True)
+        cwd = ""
+    metadata: dict[str, str] = {"cwd": cwd} if cwd else {}
     if assistant_id:
         metadata.update(
             {

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -268,7 +268,7 @@ def _build_stream_config(
     Returns:
         Config dict with `configurable` and `metadata` keys.
     """
-    metadata: dict[str, str] = {}
+    metadata: dict[str, str] = {"cwd": str(Path.cwd())}
     if assistant_id:
         metadata.update(
             {

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -81,7 +81,7 @@ _COLUMN_TOGGLE_LABELS = {
     "created_at": "Created At",
     "updated_at": "Updated At",
     "git_branch": "Git Branch",
-    "cwd": "Location",
+    "cwd": "Working Directory",
     "initial_prompt": "Initial Prompt",
 }
 # Reserved for future right-aligned columns (e.g., message counts).
@@ -175,7 +175,11 @@ def _format_column_value(
     Returns:
         Formatted display text for the column cell.
     """
-    from deepagents_cli.sessions import format_relative_timestamp, format_timestamp
+    from deepagents_cli.sessions import (
+        format_path,
+        format_relative_timestamp,
+        format_timestamp,
+    )
 
     fmt = format_relative_timestamp if relative_time else format_timestamp
 
@@ -196,8 +200,6 @@ def _format_column_value(
     elif key == "git_branch":
         value = thread.get("git_branch") or ""
     elif key == "cwd":
-        from deepagents_cli.sessions import format_path
-
         value = format_path(thread.get("cwd"))
     elif key == "initial_prompt":
         value = _collapse_whitespace(thread.get("initial_prompt") or "")

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -43,7 +43,7 @@ _COL_BRANCH = 16
 _COL_TIMESTAMP = None
 _MAX_SEARCH_TEXT_LEN = 200
 _COL_PROMPT = None
-_AUTO_WIDTH_COLUMNS = {"agent_name", "created_at", "updated_at"}
+_AUTO_WIDTH_COLUMNS = {"agent_name", "created_at", "updated_at", "cwd"}
 _COLUMN_ORDER = (
     "thread_id",
     "agent_name",
@@ -51,6 +51,7 @@ _COLUMN_ORDER = (
     "created_at",
     "updated_at",
     "git_branch",
+    "cwd",
     "initial_prompt",
 )
 _COLUMN_WIDTHS: dict[str, int | None] = {
@@ -60,6 +61,7 @@ _COLUMN_WIDTHS: dict[str, int | None] = {
     "created_at": _COL_TIMESTAMP,
     "updated_at": _COL_TIMESTAMP,
     "git_branch": _COL_BRANCH,
+    "cwd": None,
     "initial_prompt": _COL_PROMPT,
 }
 _COLUMN_LABELS = {
@@ -69,6 +71,7 @@ _COLUMN_LABELS = {
     "created_at": "Created",
     "updated_at": "Updated",
     "git_branch": "Branch",
+    "cwd": "Location",
     "initial_prompt": "Prompt",
 }
 _COLUMN_TOGGLE_LABELS = {
@@ -78,6 +81,7 @@ _COLUMN_TOGGLE_LABELS = {
     "created_at": "Created At",
     "updated_at": "Updated At",
     "git_branch": "Git Branch",
+    "cwd": "Location",
     "initial_prompt": "Initial Prompt",
 }
 # Reserved for future right-aligned columns (e.g., message counts).
@@ -191,6 +195,10 @@ def _format_column_value(
         value = fmt(thread.get("updated_at"))
     elif key == "git_branch":
         value = thread.get("git_branch") or ""
+    elif key == "cwd":
+        from deepagents_cli.sessions import format_path
+
+        value = format_path(thread.get("cwd"))
     elif key == "initial_prompt":
         value = _collapse_whitespace(thread.get("initial_prompt") or "")
     else:

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -135,6 +135,7 @@ class TestThreadColumnPersistence:
             "created_at": True,
             "updated_at": False,
             "git_branch": True,
+            "cwd": False,
             "initial_prompt": False,
             "agent_name": True,
         }

--- a/libs/cli/tests/unit_tests/test_sessions.py
+++ b/libs/cli/tests/unit_tests/test_sessions.py
@@ -80,13 +80,16 @@ class TestThreadFunctions:
         earlier = "2024-01-01T10:00:00+00:00"
 
         threads = [
-            ("thread1", "agent1", now),
-            ("thread2", "agent2", earlier),
-            ("thread3", "agent1", earlier),
+            ("thread1", "agent1", now, "/home/user/project-a"),
+            ("thread2", "agent2", earlier, "/tmp/workspace"),
+            ("thread3", "agent1", earlier, None),
         ]
 
-        for tid, agent, updated in threads:
-            metadata = json.dumps({"agent_name": agent, "updated_at": updated})
+        for tid, agent, updated, cwd in threads:
+            meta: dict[str, str] = {"agent_name": agent, "updated_at": updated}
+            if cwd is not None:
+                meta["cwd"] = cwd
+            metadata = json.dumps(meta)
             conn.execute(
                 "INSERT INTO checkpoints "
                 "(thread_id, checkpoint_ns, checkpoint_id, metadata) "
@@ -120,10 +123,14 @@ class TestThreadFunctions:
             assert threads == []
 
     def test_list_threads(self, temp_db):
-        """List returns all threads."""
+        """List returns all threads with cwd."""
         with patch.object(sessions, "get_db_path", return_value=temp_db):
             threads = asyncio.run(sessions.list_threads())
             assert len(threads) == 3
+            by_id = {t["thread_id"]: t for t in threads}
+            assert by_id["thread1"]["cwd"] == "/home/user/project-a"
+            assert by_id["thread2"]["cwd"] == "/tmp/workspace"
+            assert by_id["thread3"]["cwd"] is None
 
     def test_list_threads_filter_by_agent(self, temp_db):
         """List filters by agent name."""
@@ -308,6 +315,39 @@ class TestFormatRelativeTimestamp:
         ts = (datetime.now(tz=UTC) - timedelta(seconds=59)).isoformat()
         result = sessions.format_relative_timestamp(ts)
         assert result.endswith("s ago")
+
+
+class TestFormatPath:
+    """Tests for format_path helper."""
+
+    def test_none(self):
+        """Returns empty for None."""
+        assert sessions.format_path(None) == ""
+
+    def test_empty_string(self):
+        """Returns empty for empty string."""
+        assert sessions.format_path("") == ""
+
+    def test_home_directory(self):
+        """Home directory is shown as ~."""
+        home = str(Path.home())
+        assert sessions.format_path(home) == "~"
+
+    def test_path_under_home(self):
+        """Paths under home are shown relative to ~."""
+        home = str(Path.home())
+        path = home + "/projects/my-app"
+        assert sessions.format_path(path) == "~/projects/my-app"
+
+    def test_path_outside_home(self):
+        """Paths outside home are shown as-is."""
+        assert sessions.format_path("/tmp/workspace") == "/tmp/workspace"
+
+    def test_path_with_similar_prefix(self):
+        """Paths that start like home but aren't under it are shown as-is."""
+        home = str(Path.home())
+        path = home + "-other/projects"
+        assert sessions.format_path(path) == path
 
 
 class TestTextualSessionState:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -136,6 +136,7 @@ class TestBuildStreamConfig:
         assert config["metadata"]["assistant_id"] == "my-agent"
         assert config["metadata"]["agent_name"] == "my-agent"
         assert "updated_at" in config["metadata"]
+        assert "cwd" in config["metadata"]
 
     def test_updated_at_is_valid_iso_timestamp(self) -> None:
         """`updated_at` should be a valid timezone-aware ISO 8601 timestamp."""
@@ -152,6 +153,7 @@ class TestBuildStreamConfig:
         assert "assistant_id" not in metadata
         assert "agent_name" not in metadata
         assert "updated_at" not in metadata
+        assert "cwd" in metadata
 
     def test_no_assistant_fields_when_empty_string(self) -> None:
         """Empty-string `assistant_id` should be treated as absent."""
@@ -160,6 +162,7 @@ class TestBuildStreamConfig:
         assert "assistant_id" not in metadata
         assert "agent_name" not in metadata
         assert "updated_at" not in metadata
+        assert "cwd" in metadata
 
     def test_git_branch_included_when_available(self) -> None:
         """Git branch should be included in metadata when in a git repo."""

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -29,6 +29,7 @@ MOCK_THREADS: list[ThreadInfo] = [
         "message_count": 5,
         "created_at": "2025-01-15T09:00:00",
         "git_branch": "main",
+        "cwd": "/home/user/project-a",
         "initial_prompt": "Hello world",
     },
     {
@@ -38,6 +39,7 @@ MOCK_THREADS: list[ThreadInfo] = [
         "message_count": 12,
         "created_at": "2025-01-14T07:00:00",
         "git_branch": "feature-x",
+        "cwd": "/tmp/workspace",
         "initial_prompt": "Fix the bug",
     },
     {
@@ -47,6 +49,7 @@ MOCK_THREADS: list[ThreadInfo] = [
         "message_count": 3,
         "created_at": "2025-01-13T14:00:00",
         "git_branch": None,
+        "cwd": None,
         "initial_prompt": None,
     },
 ]

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -1035,6 +1035,7 @@ class TestThreadSelectorPromptOverflow:
             "created_at": False,
             "updated_at": True,
             "git_branch": False,
+            "cwd": False,
             "initial_prompt": True,
             "agent_name": False,
         }
@@ -1072,6 +1073,7 @@ class TestThreadSelectorBranchOverflow:
             "created_at": False,
             "updated_at": False,
             "git_branch": True,
+            "cwd": False,
             "initial_prompt": False,
             "agent_name": False,
         }
@@ -1111,6 +1113,7 @@ class TestThreadSelectorAutoWidthColumns:
             "created_at": False,
             "updated_at": False,
             "git_branch": False,
+            "cwd": False,
             "initial_prompt": False,
             "agent_name": True,
         }
@@ -1873,6 +1876,7 @@ class TestThreadSelectorColumnConfig:
             "created_at": True,
             "updated_at": True,
             "git_branch": True,
+            "cwd": False,
             "initial_prompt": False,
             "agent_name": True,
         }


### PR DESCRIPTION
Supersedes #1513

---

Track the working directory (`cwd`) where each thread was last used, storing it in checkpoint metadata and surfacing it in the thread list and `/thread` switcher. This makes it easier to identify threads when you work across multiple projects — especially when thread names or prompts aren't distinctive enough on their own.

## Changes
- Add `cwd` field to `ThreadInfo` and persist it in checkpoint metadata via `_build_stream_config` and `run_non_interactive`
- Query `cwd` from the checkpoints table in `list_threads` alongside existing fields like `git_branch`
- Add `format_path` helper in `sessions.py` that collapses paths under `$HOME` to `~/...` for display
- Surface `cwd` as a "Location" column in both `list_threads_command` (verbose mode) and the `ThreadSelector` widget, with auto-width sizing and column toggle support