### PR TITLE
fix(cli): work around VS Code 1.110 space key regression

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -457,6 +457,24 @@ class ChatTextArea(TextArea):
 
     async def _on_key(self, event: events.Key) -> None:
         """Handle key events."""
+        # VS Code 1.110 incorrectly sends space as a CSI u escape code
+        # (`\x1b[32u`) instead of a plain ` ` character.  Textual parses
+        # this as Key(key='space', character=None, is_printable=False), so
+        # the TextArea never inserts the space.  Per the kitty keyboard
+        # protocol spec, keys that generate text (like space) should NOT
+        # use CSI u encoding — VS Code is the outlier here.
+        #
+        # This workaround should be safe to keep indefinitely: once VS Code or
+        # Textual fixes the issue upstream, `character` will be `' '` and
+        # this branch simply won't match.
+        #
+        # Upstream: https://github.com/Textualize/textual/issues/6408
+        if event.key == "space" and event.character is None:
+            event.prevent_default()
+            event.stop()
+            self.insert(" ")
+            return
+
         now = time.monotonic()
         if self._paste_burst_buffer:
             if event.key == "enter":

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -1948,3 +1948,44 @@ class TestBackslashEnterNewline:
 
             # Should have submitted (backslash included in text)
             assert len(app.submitted) == 1
+
+
+class TestVSCodeSpaceWorkaround:
+    """VS Code 1.110 sends space as CSI u (character=None, is_printable=False).
+
+    Our workaround in _on_key detects this and manually inserts a space.
+    See https://github.com/Textualize/textual/issues/6408.
+    """
+
+    async def test_space_with_none_character_inserts_space(self) -> None:
+        """A space key event with character=None should still insert a space."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello")
+            await pilot.pause()
+
+            # Simulate VS Code 1.110 CSI u space: key='space', character=None
+            await ta._on_key(events.Key("space", None))
+            await pilot.pause()
+
+            assert ta.text == "hello "
+
+    async def test_normal_space_still_works(self) -> None:
+        """A normal space key event (character=' ') should still work."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello")
+            await pilot.pause()
+
+            await pilot.press("space")
+            await pilot.pause()
+
+            assert ta.text == "hello "


### PR DESCRIPTION
VS Code 1.110 added kitty keyboard protocol support but incorrectly encodes the space key as a CSI u escape sequence (`\x1b[32u`). Textual parses this as `Key(key='space', character=None, is_printable=False)`, which means the `TextArea` silently drops it — space literally does nothing. This is a VS Code bug (the kitty spec says text-generating keys like space should not use CSI u), but we work around it here so users don't need to toggle VS Code settings. The workaround becomes a no-op once either side fixes upstream.

## Changes
- Detect the broken space event (`event.key == "space" and event.character is None`) at the top of `ChatTextArea._on_key` and manually insert `" "` — upstream tracked at [Textualize/textual#6408](https://github.com/Textualize/textual/issues/6408)