### PR TITLE
feat(sdk): add async subagent middleware for remote LangGraph servers

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -599,6 +599,11 @@ def _add_interrupt_on() -> dict[str, InterruptOnConfig]:
         "description": _format_task_description,  # type: ignore[typeddict-item]  # Callable description narrower than TypedDict expects
     }
 
+    async_subagent_interrupt_config: InterruptOnConfig = {
+        "allowed_decisions": ["approve", "reject"],
+        "description": "Launch or send a follow-up to a remote async subagent.",
+    }
+
     interrupt_map: dict[str, InterruptOnConfig] = {
         "execute": execute_interrupt_config,
         "write_file": write_file_interrupt_config,
@@ -606,6 +611,8 @@ def _add_interrupt_on() -> dict[str, InterruptOnConfig]:
         "web_search": web_search_interrupt_config,
         "fetch_url": fetch_url_interrupt_config,
         "task": task_interrupt_config,
+        "launch_async_subagent": async_subagent_interrupt_config,
+        "update_async_subagent": async_subagent_interrupt_config,
     }
 
     if REQUIRE_COMPACT_TOOL_APPROVAL:

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -97,6 +97,10 @@ def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]
             data = tomllib.load(f)
     except (tomllib.TOMLDecodeError, PermissionError, OSError) as e:
         logger.warning("Could not read async subagents from %s: %s", config_path, e)
+        console.print(
+            f"[bold yellow]Warning:[/bold yellow] Could not read async subagents "
+            f"from {config_path}: {e}",
+        )
         return []
 
     section = data.get("async_subagents")
@@ -605,7 +609,7 @@ def _add_interrupt_on() -> dict[str, InterruptOnConfig]:
 
     async_subagent_interrupt_config: InterruptOnConfig = {
         "allowed_decisions": ["approve", "reject"],
-        "description": "Launch or send a follow-up to a remote async subagent.",
+        "description": "Launch, update, or cancel a remote async subagent.",
     }
 
     interrupt_map: dict[str, InterruptOnConfig] = {

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import tempfile
+import tomllib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -81,8 +82,6 @@ def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]
     Returns:
         List of `AsyncSubAgent` specs (empty if section is absent or invalid).
     """
-    import tomllib
-
     if config_path is None:
         config_path = Path.home() / ".deepagents" / "config.toml"
 
@@ -100,7 +99,7 @@ def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]
     if not isinstance(section, dict):
         return []
 
-    required = {"description", "url", "graph_id"}
+    required = {"description", "graph_id"}
     agents: list[AsyncSubAgent] = []
     for name, spec in section.items():
         if not isinstance(spec, dict):
@@ -115,9 +114,10 @@ def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]
         agent: AsyncSubAgent = {
             "name": name,
             "description": spec["description"],
-            "url": spec["url"],
             "graph_id": spec["graph_id"],
         }
+        if "url" in spec and isinstance(spec["url"], str):
+            agent["url"] = spec["url"]
         if "headers" in spec and isinstance(spec["headers"], dict):
             agent["headers"] = spec["headers"]
         agents.append(agent)

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from deepagents.backends.sandbox import SandboxBackendProtocol
+    from deepagents.middleware.async_subagents import AsyncSubAgent
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
     from langchain.agents.middleware import InterruptOnConfig
     from langchain.agents.middleware.types import AgentState
@@ -61,6 +62,67 @@ DEFAULT_AGENT_NAME = "agent"
 
 REQUIRE_COMPACT_TOOL_APPROVAL: bool = True
 """When `True`, `compact_conversation` requires HITL approval like other gated tools."""
+
+
+def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]:
+    """Load async subagent definitions from `config.toml`.
+
+    Reads the `[async_subagents]` section where each sub-table defines a
+    remote LangGraph deployment::
+
+        [async_subagents.researcher]
+        description = "Research agent"
+        url = "https://my-deployment.langsmith.dev"
+        graph_id = "agent"
+
+    Args:
+        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        List of `AsyncSubAgent` specs (empty if section is absent or invalid).
+    """
+    import tomllib
+
+    if config_path is None:
+        config_path = Path.home() / ".deepagents" / "config.toml"
+
+    if not config_path.exists():
+        return []
+
+    try:
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, PermissionError, OSError) as e:
+        logger.warning("Could not read async subagents from %s: %s", config_path, e)
+        return []
+
+    section = data.get("async_subagents")
+    if not isinstance(section, dict):
+        return []
+
+    required = {"description", "url", "graph_id"}
+    agents: list[AsyncSubAgent] = []
+    for name, spec in section.items():
+        if not isinstance(spec, dict):
+            logger.warning("Skipping async subagent '%s': expected a table", name)
+            continue
+        missing = required - spec.keys()
+        if missing:
+            logger.warning(
+                "Skipping async subagent '%s': missing fields %s", name, missing
+            )
+            continue
+        agent: AsyncSubAgent = {
+            "name": name,
+            "description": spec["description"],
+            "url": spec["url"],
+            "graph_id": spec["graph_id"],
+        }
+        if "headers" in spec and isinstance(spec["headers"], dict):
+            agent["headers"] = spec["headers"]
+        agents.append(agent)
+
+    return agents
 
 
 def list_agents(*, output_format: OutputFormat = "text") -> None:
@@ -577,6 +639,7 @@ def create_cli_agent(
     mcp_server_info: list[MCPServerInfo] | None = None,
     cwd: str | Path | None = None,
     project_context: ProjectContext | None = None,
+    async_subagents: list[AsyncSubAgent] | None = None,
 ) -> tuple[Pregel, CompositeBackend]:
     """Create a CLI-configured agent with flexible options.
 
@@ -619,6 +682,9 @@ def create_cli_agent(
         project_context: Explicit project path context for project-sensitive
             behavior such as project `AGENTS.md` files, skills, subagents, and
             MCP trust.
+        async_subagents: Remote LangGraph deployments to expose as async subagent tools.
+
+            Loaded from `[async_subagents]` in `config.toml` or passed directly.
 
     Returns:
         2-tuple of `(agent_graph, backend)`
@@ -826,5 +892,6 @@ def create_cli_agent(
         interrupt_on=interrupt_on,
         checkpointer=checkpointer,
         subagents=custom_subagents or None,
+        async_subagents=async_subagents or None,
     ).with_config(config)
     return agent, composite_backend

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -613,6 +613,7 @@ def _add_interrupt_on() -> dict[str, InterruptOnConfig]:
         "task": task_interrupt_config,
         "launch_async_subagent": async_subagent_interrupt_config,
         "update_async_subagent": async_subagent_interrupt_config,
+        "cancel_async_subagent": async_subagent_interrupt_config,
     }
 
     if REQUIRE_COMPACT_TOOL_APPROVAL:

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -68,16 +68,20 @@ REQUIRE_COMPACT_TOOL_APPROVAL: bool = True
 def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]:
     """Load async subagent definitions from `config.toml`.
 
-    Reads the `[async_subagents]` section where each sub-table defines a
-    remote LangGraph deployment::
+    Reads the `[async_subagents]` section where each sub-table defines a remote
+    LangGraph deployment:
 
-        [async_subagents.researcher]
-        description = "Research agent"
-        url = "https://my-deployment.langsmith.dev"
-        graph_id = "agent"
+    ```toml
+    [async_subagents.researcher]
+    description = "Research agent"
+    url = "https://my-deployment.langsmith.dev"
+    graph_id = "agent"
+    ```
 
     Args:
-        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
 
     Returns:
         List of `AsyncSubAgent` specs (empty if section is absent or invalid).

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -746,6 +746,10 @@ async def _run_acp_cli_async(
         sys.stderr.flush()
         return 1
 
+    from deepagents_cli.agent import load_async_subagents
+
+    async_subagents = load_async_subagents() or None
+
     try:
         from langgraph.checkpoint.memory import InMemorySaver
 
@@ -755,6 +759,7 @@ async def _run_acp_cli_async(
             tools=tools,
             mcp_server_info=mcp_server_info,
             checkpointer=InMemorySaver(),
+            async_subagents=async_subagents,
         )
     except Exception as exc:
         sys.stderr.write(f"Error: failed to create agent: {exc}\n")

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -696,7 +696,7 @@ async def _run_acp_cli_async(
     Returns:
         Exit code for ACP mode.
     """
-    from deepagents_cli.agent import create_cli_agent
+    from deepagents_cli.agent import create_cli_agent, load_async_subagents
     from deepagents_cli.config import create_model, settings
     from deepagents_cli.model_config import ModelConfigError, save_recent_model
     from deepagents_cli.tools import fetch_url, http_request, web_search
@@ -745,8 +745,6 @@ async def _run_acp_cli_async(
         sys.stderr.write(msg)
         sys.stderr.flush()
         return 1
-
-    from deepagents_cli.agent import load_async_subagents
 
     async_subagents = load_async_subagents() or None
 

--- a/libs/cli/deepagents_cli/server_graph.py
+++ b/libs/cli/deepagents_cli/server_graph.py
@@ -103,7 +103,7 @@ def make_graph() -> Any:  # noqa: ANN401
     config = ServerConfig.from_env()
     project_context = get_server_project_context()
 
-    from deepagents_cli.agent import create_cli_agent
+    from deepagents_cli.agent import create_cli_agent, load_async_subagents
     from deepagents_cli.config import create_model, settings
 
     if project_context is not None:
@@ -160,6 +160,8 @@ def make_graph() -> Any:  # noqa: ANN401
             )
             sys.exit(1)
 
+    async_subagents = load_async_subagents() or None
+
     agent, _ = create_cli_agent(
         model=result.model,
         assistant_id=config.assistant_id,
@@ -175,6 +177,7 @@ def make_graph() -> Any:  # noqa: ANN401
         mcp_server_info=mcp_server_info,
         cwd=project_context.user_cwd if project_context is not None else config.cwd,
         project_context=project_context,
+        async_subagents=async_subagents,
     )
     return agent
 

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any
 
+from rich.text import Text
 from textual.containers import Vertical
 from textual.content import Content
 from textual.widgets import Markdown, Static
@@ -35,6 +36,17 @@ if TYPE_CHECKING:
     from textual.widgets._markdown import MarkdownStream
 
 logger = logging.getLogger(__name__)
+
+
+def escape_markup(text: str) -> str:
+    """Escape text so Textual's markup parser won't interpret brackets as tags.
+
+    Unlike `rich.markup.escape` (which only escapes `[lowercase…]` patterns),
+    this escapes **every** unescaped `[` so that Textual's stricter parser
+    (which treats *any* `[` as a potential tag opener) cannot misinterpret
+    arbitrary tool output as markup.
+    """
+    return text.replace("\\[", "\x00").replace("[", "\\[").replace("\x00", "\\[")
 
 
 def _show_timestamp_toast(widget: Static | Vertical) -> None:

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any
 
-from rich.text import Text
 from textual.containers import Vertical
 from textual.content import Content
 from textual.widgets import Markdown, Static

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -38,17 +38,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def escape_markup(text: str) -> str:
-    """Escape text so Textual's markup parser won't interpret brackets as tags.
-
-    Unlike `rich.markup.escape` (which only escapes `[lowercase…]` patterns),
-    this escapes **every** unescaped `[` so that Textual's stricter parser
-    (which treats *any* `[` as a potential tag opener) cannot misinterpret
-    arbitrary tool output as markup.
-    """
-    return text.replace("\\[", "\x00").replace("[", "\\[").replace("\x00", "\\[")
-
-
 def _show_timestamp_toast(widget: Static | Vertical) -> None:
     """Show a toast with the message's creation timestamp.
 

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -23,6 +23,7 @@ from deepagents_cli.agent import (
     create_cli_agent,
     get_system_prompt,
     list_agents,
+    load_async_subagents,
 )
 from deepagents_cli.config import Settings, get_glyphs
 from deepagents_cli.project_utils import ProjectContext
@@ -1372,3 +1373,77 @@ class TestMiddlewareStackConformance:
             assert isinstance(mw, AgentMiddleware), (
                 f"{type(mw).__name__} does not inherit from AgentMiddleware"
             )
+
+
+class TestLoadAsyncSubagents:
+    def test_returns_empty_when_no_file(self, tmp_path: Path) -> None:
+        result = load_async_subagents(tmp_path / "nonexistent.toml")
+        assert result == []
+
+    def test_returns_empty_when_no_section(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text('[models]\ndefault = "gpt-4"\n')
+        result = load_async_subagents(config)
+        assert result == []
+
+    def test_loads_valid_async_subagent(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text(
+            "[async_subagents.researcher]\n"
+            'description = "Research agent"\n'
+            'url = "https://my-deployment.langsmith.dev"\n'
+            'graph_id = "agent"\n'
+        )
+        result = load_async_subagents(config)
+        assert len(result) == 1
+        assert result[0]["name"] == "researcher"
+        assert result[0]["description"] == "Research agent"
+        assert result[0]["url"] == "https://my-deployment.langsmith.dev"
+        assert result[0]["graph_id"] == "agent"
+
+    def test_loads_multiple_subagents(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text(
+            "[async_subagents.researcher]\n"
+            'description = "Research agent"\n'
+            'url = "https://research.langsmith.dev"\n'
+            'graph_id = "agent"\n'
+            "\n"
+            "[async_subagents.coder]\n"
+            'description = "Coding agent"\n'
+            'url = "https://coder.langsmith.dev"\n'
+            'graph_id = "coder"\n'
+        )
+        result = load_async_subagents(config)
+        assert len(result) == 2
+        names = {a["name"] for a in result}
+        assert names == {"researcher", "coder"}
+
+    def test_skips_entry_missing_required_fields(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[async_subagents.incomplete]\ndescription = "Missing url and graph_id"\n'
+        )
+        result = load_async_subagents(config)
+        assert result == []
+
+    def test_includes_optional_headers(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text(
+            "[async_subagents.custom]\n"
+            'description = "Custom agent"\n'
+            'url = "https://custom.langsmith.dev"\n'
+            'graph_id = "agent"\n'
+            "\n"
+            "[async_subagents.custom.headers]\n"
+            'x-custom = "value"\n'
+        )
+        result = load_async_subagents(config)
+        assert len(result) == 1
+        assert result[0]["headers"] == {"x-custom": "value"}
+
+    def test_handles_invalid_toml(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text("this is not valid toml [[[")
+        result = load_async_subagents(config)
+        assert result == []

--- a/libs/cli/tests/unit_tests/test_server_graph.py
+++ b/libs/cli/tests/unit_tests/test_server_graph.py
@@ -42,6 +42,7 @@ class TestServerGraph:
             "deepagents_cli.agent",
             DEFAULT_AGENT_NAME="agent",
             create_cli_agent=create_cli_agent,
+            load_async_subagents=MagicMock(return_value=None),
         )
 
         model_result = SimpleNamespace(
@@ -125,5 +126,6 @@ class TestServerGraph:
             mcp_server_info=mcp_server_info,
             cwd=None,
             project_context=None,
+            async_subagents=None,
         )
         assert module.graph is graph_obj

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -2,13 +2,14 @@
 
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
-from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentJob, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 
 __all__ = [
     "AsyncSubAgent",
+    "AsyncSubAgentJob",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
     "FilesystemMiddleware",

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -2,11 +2,14 @@
 
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 
 __all__ = [
+    "AsyncSubAgent",
+    "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
     "FilesystemMiddleware",
     "MemoryMiddleware",

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -153,9 +153,9 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         async_subagents: Optional list of async subagent specs for remote LangGraph servers.
 
             Each spec should be an `AsyncSubAgent` dict with `name`, `description`,
-            `url`, and `graph_id`. Async subagents run as background jobs that the
-            main agent can monitor and update via `launch_async_subagent`,
-            `check_async_subagent`, and `update_async_subagent` tools.
+            and `graph_id`. Optionally include `url` for remote deployments (omit
+            for ASGI transport). Async subagents run as background jobs with tools
+            for launching, checking, updating, cancelling, and listing jobs.
         skills: Optional list of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
 
             Paths must be specified using POSIX conventions (forward slashes) and are relative

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -20,6 +20,7 @@ from langgraph.types import Checkpointer
 from deepagents._models import resolve_model
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
@@ -85,6 +86,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     system_prompt: str | SystemMessage | None = None,
     middleware: Sequence[AgentMiddleware] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent] | None = None,
+    async_subagents: list[AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
     response_format: ResponseFormat | None = None,
@@ -148,6 +150,12 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             - (optional) `tools`
             - (optional) `model` (either a `LanguageModelLike` instance or `dict` settings)
             - (optional) `middleware` (list of `AgentMiddleware`)
+        async_subagents: Optional list of async subagent specs for remote LangGraph servers.
+
+            Each spec should be an `AsyncSubAgent` dict with `name`, `description`,
+            `url`, and `graph_id`. Async subagents run as background jobs that the
+            main agent can monitor and update via `launch_async_subagent`,
+            `check_async_subagent`, and `update_async_subagent` tools.
         skills: Optional list of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
 
             Paths must be specified using POSIX conventions (forward slashes) and are relative
@@ -265,6 +273,9 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             PatchToolCallsMiddleware(),
         ]
     )
+
+    if async_subagents:
+        deepagent_middleware.append(AsyncSubAgentMiddleware(async_subagents=async_subagents))
 
     if middleware:
         deepagent_middleware.extend(middleware)

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -47,7 +47,7 @@ Use a **plain tool** when:
 * The tool is specific to a single consumer (e.g. CLI-only)
 """
 
-from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentJob, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
@@ -60,6 +60,7 @@ from deepagents.middleware.summarization import (
 
 __all__ = [
     "AsyncSubAgent",
+    "AsyncSubAgentJob",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
     "FilesystemMiddleware",

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -47,6 +47,7 @@ Use a **plain tool** when:
 * The tool is specific to a single consumer (e.g. CLI-only)
 """
 
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
@@ -58,6 +59,8 @@ from deepagents.middleware.summarization import (
 )
 
 __all__ = [
+    "AsyncSubAgent",
+    "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
     "FilesystemMiddleware",
     "MemoryMiddleware",

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -121,8 +121,9 @@ You have access to async subagent tools that launch background jobs on remote La
 - After launching, ALWAYS return control to the user immediately. Never auto-check after launching.
 - Never poll `check_async_subagent` in a loop. Check once per user request, then stop.
 - If a check returns "running", tell the user and wait for them to ask again.
-- ALWAYS call `check_async_subagent` when the user asks for a status update — never answer from memory. Job statuses
-change over time and must be fetched fresh.
+- NEVER answer questions about job statuses from memory or conversation history. ALWAYS use a tool:
+  use `check_async_subagent` to get the live status of a specific job, or `list_async_subagent_jobs`
+  to see all tracked jobs. Job statuses change over time and must be fetched fresh.
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -296,12 +296,10 @@ def _build_launch_tool(
 
 def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -> str:
     """Resolve the client name from a parsed job_id agent_name field."""
-    if agent_name and agent_name in agent_map:
+    if agent_name in agent_map:
         return agent_name
-    if agent_name:
-        msg = f"Unknown agent '{agent_name}' in job_id. Available: {', '.join(agent_map)}"
-        raise ValueError(msg)
-    return next(iter(agent_map))
+    msg = f"Unknown agent '{agent_name}' in job_id. Available: {', '.join(agent_map)}"
+    raise ValueError(msg)
 
 
 def _build_check_result(
@@ -326,24 +324,15 @@ def _build_check_result(
 
 def _build_check_command(
     result: dict[str, Any],
-    job_id: str,
-    name: str,
-    thread_id: str,
-    run_id: str,
+    job: AsyncSubAgentJob,
     tool_call_id: str | None,
 ) -> Command:
     """Build the Command update for a check result."""
-    job: AsyncSubAgentJob = {
-        "job_id": job_id,
-        "agent_name": name,
-        "thread_id": thread_id,
-        "run_id": run_id,
-        "status": result["status"],
-    }
+    updated_job: AsyncSubAgentJob = {**job, "status": result["status"]}
     return Command(
         update={
             "messages": [ToolMessage(json.dumps(result), tool_call_id=tool_call_id)],
-            "async_subagent_jobs": {job_id: job},
+            "async_subagent_jobs": {job["job_id"]: updated_job},
         }
     )
 
@@ -368,11 +357,11 @@ def _resolve_tracked_job(
     job_id: str,
     agent_map: dict[str, AsyncSubAgent],
     runtime: ToolRuntime,
-) -> tuple[str, str, str, str] | str:
+) -> AsyncSubAgentJob | str:
     """Parse job_id, resolve agent, and look up the tracked job from state.
 
     Returns:
-        `(name, thread_id, run_id, canonical_job_id)` on success, or an error string.
+        The tracked `AsyncSubAgentJob` on success, or an error string.
     """
     parsed = _parse_and_resolve(job_id, agent_map)
     if isinstance(parsed, str):
@@ -383,7 +372,7 @@ def _resolve_tracked_job(
     tracked = jobs.get(canonical)
     if not tracked:
         return f"No tracked job found for job_id: {job_id}"
-    return name, thread_id, tracked["run_id"], canonical
+    return tracked
 
 
 def _build_check_tool(
@@ -399,21 +388,21 @@ def _build_check_tool(
         resolved = _resolve_tracked_job(job_id, agent_map, runtime)
         if isinstance(resolved, str):
             return resolved
-        name, thread_id, run_id, canonical = resolved
+        job = resolved
 
-        client = clients.get_sync(name)
+        client = clients.get_sync(job["agent_name"])
         try:
-            run = client.runs.get(thread_id=thread_id, run_id=run_id)
+            run = client.runs.get(thread_id=job["thread_id"], run_id=job["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to get run status: {e}"
 
         thread_values: dict[str, Any] = {}
         if run["status"] == "success":
-            thread = client.threads.get(thread_id=thread_id)
+            thread = client.threads.get(thread_id=job["thread_id"])
             thread_values = thread.get("values") or {}
 
-        result = _build_check_result(run, thread_id, thread_values)
-        return _build_check_command(result, canonical, name, thread_id, run_id, runtime.tool_call_id)
+        result = _build_check_result(run, job["thread_id"], thread_values)
+        return _build_check_command(result, job, runtime.tool_call_id)
 
     async def acheck_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
@@ -422,21 +411,21 @@ def _build_check_tool(
         resolved = _resolve_tracked_job(job_id, agent_map, runtime)
         if isinstance(resolved, str):
             return resolved
-        name, thread_id, run_id, canonical = resolved
+        job = resolved
 
-        client = clients.get_async(name)
+        client = clients.get_async(job["agent_name"])
         try:
-            run = await client.runs.get(thread_id=thread_id, run_id=run_id)
+            run = await client.runs.get(thread_id=job["thread_id"], run_id=job["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to get run status: {e}"
 
         thread_values: dict[str, Any] = {}
         if run["status"] == "success":
-            thread = await client.threads.get(thread_id=thread_id)
+            thread = await client.threads.get(thread_id=job["thread_id"])
             thread_values = thread.get("values") or {}
 
-        result = _build_check_result(run, thread_id, thread_values)
-        return _build_check_command(result, canonical, name, thread_id, run_id, runtime.tool_call_id)
+        result = _build_check_result(run, job["thread_id"], thread_values)
+        return _build_check_command(result, job, runtime.tool_call_id)
 
     return StructuredTool.from_function(
         name="check_async_subagent",
@@ -455,7 +444,7 @@ def _build_update_tool(
     Sends a follow-up message to an async subagent by creating a new run
     on the same thread. The subagent sees the full conversation history
     (including the original task and any prior results) plus the new message.
-    Returns a new job_id for the follow-up run.
+    The job_id remains the same; only the internal run_id is updated.
     """
 
     def update_async_subagent(
@@ -549,25 +538,19 @@ def _build_cancel_tool(
         resolved = _resolve_tracked_job(job_id, agent_map, runtime)
         if isinstance(resolved, str):
             return resolved
-        name, thread_id, run_id, canonical = resolved
+        tracked = resolved
 
-        client = clients.get_sync(name)
+        client = clients.get_sync(tracked["agent_name"])
         try:
-            client.runs.cancel(thread_id=thread_id, run_id=run_id)
+            client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        job: AsyncSubAgentJob = {
-            "job_id": canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
-            "run_id": run_id,
-            "status": "cancelled",
-        }
-        msg = f"Cancelled async subagent job: {canonical}"
+        updated: AsyncSubAgentJob = {**tracked, "status": "cancelled"}
+        msg = f"Cancelled async subagent job: {tracked['job_id']}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {canonical: job},
+                "async_subagent_jobs": {tracked["job_id"]: updated},
             }
         )
 
@@ -578,25 +561,19 @@ def _build_cancel_tool(
         resolved = _resolve_tracked_job(job_id, agent_map, runtime)
         if isinstance(resolved, str):
             return resolved
-        name, thread_id, run_id, canonical = resolved
+        tracked = resolved
 
-        client = clients.get_async(name)
+        client = clients.get_async(tracked["agent_name"])
         try:
-            await client.runs.cancel(thread_id=thread_id, run_id=run_id)
+            await client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        job: AsyncSubAgentJob = {
-            "job_id": canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
-            "run_id": run_id,
-            "status": "cancelled",
-        }
-        msg = f"Cancelled async subagent job: {canonical}"
+        updated: AsyncSubAgentJob = {**tracked, "status": "cancelled"}
+        msg = f"Cancelled async subagent job: {tracked['job_id']}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {canonical: job},
+                "async_subagent_jobs": {tracked["job_id"]: updated},
             }
         )
 
@@ -608,8 +585,7 @@ def _build_cancel_tool(
     )
 
 
-_TERMINAL_STATUSES = frozenset({"superseded", "cancelled"})
-_SKIP_IN_LIST = frozenset({"superseded"})
+_TERMINAL_STATUSES = frozenset({"cancelled"})
 
 
 def _fetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> str:
@@ -645,7 +621,7 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
 
     def list_async_subagent_jobs(runtime: ToolRuntime) -> str | Command:
         jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        active = [job for job in jobs.values() if job["status"] not in _SKIP_IN_LIST]
+        active = [job for job in jobs.values() if job["status"] not in _TERMINAL_STATUSES]
         if not active:
             return "No async subagent jobs tracked."
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
@@ -670,7 +646,7 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
 
     async def alist_async_subagent_jobs(runtime: ToolRuntime) -> str | Command:
         jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        active = [job for job in jobs.values() if job["status"] not in _SKIP_IN_LIST]
+        active = [job for job in jobs.values() if job["status"] not in _TERMINAL_STATUSES]
         if not active:
             return "No async subagent jobs tracked."
         updated_jobs: dict[str, AsyncSubAgentJob] = {}

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypedDict
 
-from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelResponse, ResponseT
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ModelResponse, ResponseT
+from langchain.tools import ToolRuntime  # noqa: TC002
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import StructuredTool
+from langgraph.types import Command
 from langgraph_sdk import get_client, get_sync_client
 
 from deepagents.middleware._utils import append_to_system_message
@@ -50,6 +53,32 @@ class AsyncSubAgent(TypedDict):
     url: str
     graph_id: str
     headers: NotRequired[dict[str, str]]
+
+
+class AsyncSubAgentJob(TypedDict):
+    """A tracked async subagent job persisted in agent state."""
+
+    job_id: str
+    agent_name: str
+    thread_id: str
+    run_id: str
+    status: str
+
+
+def _jobs_reducer(
+    existing: dict[str, AsyncSubAgentJob] | None,
+    update: dict[str, AsyncSubAgentJob],
+) -> dict[str, AsyncSubAgentJob]:
+    """Merge job updates into the existing jobs dict."""
+    merged = dict(existing or {})
+    merged.update(update)
+    return merged
+
+
+class AsyncSubAgentState(AgentState):
+    """State extension for async subagent job tracking."""
+
+    async_subagent_jobs: Annotated[NotRequired[dict[str, AsyncSubAgentJob]], _jobs_reducer]
 
 
 ASYNC_TASK_TOOL_DESCRIPTION = """Launch an async subagent on a remote LangGraph server. The subagent runs in the background and returns a job ID immediately.
@@ -178,7 +207,8 @@ def _build_launch_tool(
     def launch_async_subagent(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
         subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types."],
-    ) -> str:
+        runtime: ToolRuntime,
+    ) -> str | Command:
         error = _validate_agent_type(agent_map, subagent_type)
         if error:
             return error
@@ -191,12 +221,26 @@ def _build_launch_tool(
             input={"messages": [{"role": "user", "content": description}]},
         )
         job_id = _format_job_id(subagent_type, thread["thread_id"], run["run_id"])
-        return f"Launched async subagent. job_id: {job_id}"
+        job: AsyncSubAgentJob = {
+            "job_id": job_id,
+            "agent_name": subagent_type,
+            "thread_id": thread["thread_id"],
+            "run_id": run["run_id"],
+            "status": "running",
+        }
+        msg = f"Launched async subagent. job_id: {job_id}"
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {job_id: job},
+            }
+        )
 
     async def alaunch_async_subagent(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
         subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types."],
-    ) -> str:
+        runtime: ToolRuntime,
+    ) -> str | Command:
         error = _validate_agent_type(agent_map, subagent_type)
         if error:
             return error
@@ -209,7 +253,20 @@ def _build_launch_tool(
             input={"messages": [{"role": "user", "content": description}]},
         )
         job_id = _format_job_id(subagent_type, thread["thread_id"], run["run_id"])
-        return f"Launched async subagent. job_id: {job_id}"
+        job: AsyncSubAgentJob = {
+            "job_id": job_id,
+            "agent_name": subagent_type,
+            "thread_id": thread["thread_id"],
+            "run_id": run["run_id"],
+            "status": "running",
+        }
+        msg = f"Launched async subagent. job_id: {job_id}"
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {job_id: job},
+            }
+        )
 
     return StructuredTool.from_function(
         name="launch_async_subagent",
@@ -234,9 +291,11 @@ def _build_check_tool(
 
     def check_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
-    ) -> str:
+        runtime: ToolRuntime,
+    ) -> Command:
         agent_name, thread_id, run_id = _parse_job_id(job_id)
-        client = clients.sync(_resolve_client_name(agent_name, agent_map))
+        name = _resolve_client_name(agent_name, agent_map)
+        client = clients.sync(name)
         run = client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
@@ -248,13 +307,28 @@ def _build_check_tool(
                 result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
         elif run["status"] == "error":
             result["error"] = "The async subagent encountered an error."
-        return json.dumps(result)
+        canonical = _format_job_id(name, thread_id, run_id)
+        job: AsyncSubAgentJob = {
+            "job_id": canonical,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "status": run["status"],
+        }
+        return Command(
+            update={
+                "messages": [ToolMessage(json.dumps(result), tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {canonical: job},
+            }
+        )
 
     async def acheck_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
-    ) -> str:
+        runtime: ToolRuntime,
+    ) -> Command:
         agent_name, thread_id, run_id = _parse_job_id(job_id)
-        client = clients.async_(_resolve_client_name(agent_name, agent_map))
+        name = _resolve_client_name(agent_name, agent_map)
+        client = clients.async_(name)
         run = await client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
@@ -266,7 +340,20 @@ def _build_check_tool(
                 result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
         elif run["status"] == "error":
             result["error"] = "The async subagent encountered an error."
-        return json.dumps(result)
+        canonical = _format_job_id(name, thread_id, run_id)
+        job: AsyncSubAgentJob = {
+            "job_id": canonical,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "status": run["status"],
+        }
+        return Command(
+            update={
+                "messages": [ToolMessage(json.dumps(result), tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {canonical: job},
+            }
+        )
 
     return StructuredTool.from_function(
         name="check_async_subagent",
@@ -291,7 +378,8 @@ def _build_update_tool(
     def update_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent or a previous update. Pass it verbatim."],
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
-    ) -> str:
+        runtime: ToolRuntime,
+    ) -> str | Command:
         agent_name, thread_id, _run_id = _parse_job_id(job_id)
         name = _resolve_client_name(agent_name, agent_map)
         spec = agent_map[name]
@@ -303,12 +391,26 @@ def _build_update_tool(
             multitask_strategy="interrupt",
         )
         new_job_id = _format_job_id(name, thread_id, run["run_id"])
-        return f"Follow-up sent. New job_id: {new_job_id}"
+        job: AsyncSubAgentJob = {
+            "job_id": new_job_id,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": run["run_id"],
+            "status": "running",
+        }
+        msg = f"Follow-up sent. New job_id: {new_job_id}"
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {new_job_id: job},
+            }
+        )
 
     async def aupdate_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent or a previous update. Pass it verbatim."],
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
-    ) -> str:
+        runtime: ToolRuntime,
+    ) -> str | Command:
         agent_name, thread_id, _run_id = _parse_job_id(job_id)
         name = _resolve_client_name(agent_name, agent_map)
         spec = agent_map[name]
@@ -320,7 +422,20 @@ def _build_update_tool(
             multitask_strategy="interrupt",
         )
         new_job_id = _format_job_id(name, thread_id, run["run_id"])
-        return f"Follow-up sent. New job_id: {new_job_id}"
+        job: AsyncSubAgentJob = {
+            "job_id": new_job_id,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": run["run_id"],
+            "status": "running",
+        }
+        msg = f"Follow-up sent. New job_id: {new_job_id}"
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {new_job_id: job},
+            }
+        )
 
     return StructuredTool.from_function(
         name="update_async_subagent",
@@ -365,6 +480,9 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     `SubAgentMiddleware`, async subagents return immediately with a job ID,
     allowing the main agent to continue working while subagents execute.
 
+    Job IDs are persisted in the agent state under `async_subagent_jobs`
+    so they survive context compaction and can be accessed programmatically.
+
     Args:
         async_subagents: List of async subagent specifications. Each must
             include `name`, `description`, `url`, and `graph_id`.
@@ -387,6 +505,8 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         )
         ```
     """
+
+    state_schema = AsyncSubAgentState
 
     def __init__(
         self,

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -104,7 +104,7 @@ You have access to async subagent tools that launch background jobs on remote La
 - `check_async_subagent`: Check the status of a running job. Returns status and result if complete.
 - `update_async_subagent`: Send an update or new instructions to a running job.
 - `cancel_async_subagent`: Cancel a running job that is no longer needed.
-- `list_async_subagent_jobs`: List all tracked jobs and their last-known statuses. Use this to recall job IDs.
+- `list_async_subagent_jobs`: List all tracked jobs with live statuses. Use this to check all jobs at once.
 
 ### Workflow:
 1. **Launch** — Use `launch_async_subagent` to start a job. Report the job ID to the user and stop.
@@ -115,15 +115,16 @@ You have access to async subagent tools that launch background jobs on remote La
    the current run and starts a fresh one on the same thread. The job_id stays the same.
 4. **Cancel** (optional) — Use `cancel_async_subagent` to stop a job that is no longer needed.
 5. **Collect** — When `check_async_subagent` returns status "success", the result is included in the response.
-6. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
+6. **List** — Use `list_async_subagent_jobs` to see live statuses for all jobs at once, or to recall job IDs after context compaction.
 
 ### Critical rules:
 - After launching, ALWAYS return control to the user immediately. Never auto-check after launching.
 - Never poll `check_async_subagent` in a loop. Check once per user request, then stop.
 - If a check returns "running", tell the user and wait for them to ask again.
-- NEVER answer questions about job statuses from memory or conversation history. ALWAYS use a tool:
-  use `check_async_subagent` to get the live status of a specific job, or `list_async_subagent_jobs`
-  to see all tracked jobs. Job statuses change over time and must be fetched fresh.
+- Job statuses in conversation history are ALWAYS stale — a job that was "running" may now be done.
+  NEVER report a status from a previous tool result. ALWAYS call a tool to get the current status:
+  use `list_async_subagent_jobs` when the user asks about multiple jobs or "all jobs",
+  use `check_async_subagent` when the user asks about a specific job.
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent
@@ -607,26 +608,99 @@ def _build_cancel_tool(
     )
 
 
-def _build_list_jobs_tool() -> StructuredTool:
+_TERMINAL_STATUSES = frozenset({"superseded", "cancelled"})
+_SKIP_IN_LIST = frozenset({"superseded"})
+
+
+def _fetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> str:
+    """Fetch the current run status from the server, falling back to cached status on error."""
+    if job["status"] in _TERMINAL_STATUSES:
+        return job["status"]
+    try:
+        client = clients.get_sync(job["agent_name"])
+        run = client.runs.get(thread_id=job["thread_id"], run_id=job["run_id"])
+        return run["status"]
+    except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        return job["status"]
+
+
+async def _afetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> str:
+    """Async version of `_fetch_live_status`."""
+    if job["status"] in _TERMINAL_STATUSES:
+        return job["status"]
+    try:
+        client = clients.get_async(job["agent_name"])
+        run = await client.runs.get(thread_id=job["thread_id"], run_id=job["run_id"])
+        return run["status"]
+    except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        return job["status"]
+
+
+def _format_job_entry(job: AsyncSubAgentJob, status: str) -> str:
+    return f"- job_id: {job['job_id']}  agent: {job['agent_name']}  status: {status}"
+
+
+def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
     """Build the list_async_subagent_jobs tool."""
 
-    def list_async_subagent_jobs(runtime: ToolRuntime) -> str:
+    def list_async_subagent_jobs(runtime: ToolRuntime) -> str | Command:
         jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        if not jobs:
+        active = [job for job in jobs.values() if job["status"] not in _SKIP_IN_LIST]
+        if not active:
             return "No async subagent jobs tracked."
-        entries = [f"- job_id: {job['job_id']}  agent: {job['agent_name']}  status: {job['status']}" for job in jobs.values()]
-        return f"{len(entries)} tracked job(s):\n" + "\n".join(entries)
+        updated_jobs: dict[str, AsyncSubAgentJob] = {}
+        entries: list[str] = []
+        for job in active:
+            status = _fetch_live_status(clients, job)
+            entries.append(_format_job_entry(job, status))
+            updated_jobs[job["job_id"]] = AsyncSubAgentJob(
+                job_id=job["job_id"],
+                agent_name=job["agent_name"],
+                thread_id=job["thread_id"],
+                run_id=job["run_id"],
+                status=status,
+            )
+        msg = f"{len(entries)} tracked job(s):\n" + "\n".join(entries)
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": updated_jobs,
+            }
+        )
 
-    async def alist_async_subagent_jobs(runtime: ToolRuntime) -> str:
-        return list_async_subagent_jobs(runtime=runtime)
+    async def alist_async_subagent_jobs(runtime: ToolRuntime) -> str | Command:
+        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+        active = [job for job in jobs.values() if job["status"] not in _SKIP_IN_LIST]
+        if not active:
+            return "No async subagent jobs tracked."
+        updated_jobs: dict[str, AsyncSubAgentJob] = {}
+        entries: list[str] = []
+        for job in active:
+            status = await _afetch_live_status(clients, job)
+            entries.append(_format_job_entry(job, status))
+            updated_jobs[job["job_id"]] = AsyncSubAgentJob(
+                job_id=job["job_id"],
+                agent_name=job["agent_name"],
+                thread_id=job["thread_id"],
+                run_id=job["run_id"],
+                status=status,
+            )
+        msg = f"{len(entries)} tracked job(s):\n" + "\n".join(entries)
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": updated_jobs,
+            }
+        )
 
     return StructuredTool.from_function(
         name="list_async_subagent_jobs",
         func=list_async_subagent_jobs,
         coroutine=alist_async_subagent_jobs,
         description=(
-            "List all tracked async subagent jobs and their last-known statuses. "
-            "Use this to recall job IDs after context compaction or to see what jobs are in flight."
+            "List all tracked async subagent jobs with their current live statuses. "
+            "Use this to see the status of all jobs at once. "
+            "Use `check_async_subagent` to get the full result of a specific completed job."
         ),
     )
 
@@ -652,7 +726,7 @@ def _build_async_subagent_tools(
         _build_check_tool(agent_map, clients),
         _build_update_tool(agent_map, clients),
         _build_cancel_tool(agent_map, clients),
-        _build_list_jobs_tool(),
+        _build_list_jobs_tool(clients),
     ]
 
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -568,17 +568,42 @@ def _format_job_entry(job: AsyncSubAgentJob, status: str) -> str:
     return f"- job_id: {job['job_id']}  agent: {job['agent_name']}  status: {status}"
 
 
+def _filter_jobs(
+    jobs: dict[str, AsyncSubAgentJob],
+    status_filter: str | None,
+) -> list[AsyncSubAgentJob]:
+    """Filter jobs by status.
+
+    Args:
+        jobs: All tracked jobs from state.
+        status_filter: If `None` or `"all"`, return all jobs. Otherwise return only
+            jobs whose status matches the given value.
+
+    Returns:
+        Filtered list of jobs.
+    """
+    if not status_filter or status_filter == "all":
+        return list(jobs.values())
+    return [job for job in jobs.values() if job["status"] == status_filter]
+
+
 def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
     """Build the list_async_subagent_jobs tool."""
 
-    def list_async_subagent_jobs(runtime: ToolRuntime) -> str | Command:
+    def list_async_subagent_jobs(
+        runtime: ToolRuntime,
+        status_filter: Annotated[
+            str | None,
+            "Filter jobs by status. One of: 'running', 'success', 'error', 'cancelled', 'all'. Defaults to 'all'.",
+        ] = None,
+    ) -> str | Command:
         jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        active = [job for job in jobs.values() if job["status"] not in _TERMINAL_STATUSES]
-        if not active:
+        filtered = _filter_jobs(jobs, status_filter)
+        if not filtered:
             return "No async subagent jobs tracked."
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
         entries: list[str] = []
-        for job in active:
+        for job in filtered:
             status = _fetch_live_status(clients, job)
             entries.append(_format_job_entry(job, status))
             updated_jobs[job["job_id"]] = AsyncSubAgentJob(
@@ -596,15 +621,21 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
             }
         )
 
-    async def alist_async_subagent_jobs(runtime: ToolRuntime) -> str | Command:
+    async def alist_async_subagent_jobs(
+        runtime: ToolRuntime,
+        status_filter: Annotated[
+            str | None,
+            "Filter jobs by status. One of: 'running', 'success', 'error', 'cancelled', 'all'. Defaults to 'all'.",
+        ] = None,
+    ) -> str | Command:
         jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        active = [job for job in jobs.values() if job["status"] not in _TERMINAL_STATUSES]
-        if not active:
+        filtered = _filter_jobs(jobs, status_filter)
+        if not filtered:
             return "No async subagent jobs tracked."
-        statuses = await asyncio.gather(*(_afetch_live_status(clients, job) for job in active))
+        statuses = await asyncio.gather(*(_afetch_live_status(clients, job) for job in filtered))
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
         entries: list[str] = []
-        for job, status in zip(active, statuses, strict=True):
+        for job, status in zip(filtered, statuses, strict=True):
             entries.append(_format_job_entry(job, status))
             updated_jobs[job["job_id"]] = AsyncSubAgentJob(
                 job_id=job["job_id"],
@@ -626,8 +657,9 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
         func=list_async_subagent_jobs,
         coroutine=alist_async_subagent_jobs,
         description=(
-            "List all tracked async subagent jobs with their current live statuses. "
-            "Use this to see the status of all jobs at once. "
+            "List tracked async subagent jobs with their current live statuses. "
+            "By default shows all jobs. Use `status_filter` to narrow by status "
+            "(e.g. 'running', 'success', 'error', 'cancelled'). "
             "Use `check_async_subagent` to get the full result of a specific completed job."
         ),
     )

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -106,9 +106,12 @@ You have access to async subagent tools that launch background jobs on remote La
 - `list_async_subagent_jobs`: List all tracked jobs and their last-known statuses. Use this to recall job IDs.
 
 ### Workflow:
-1. **Launch** — Use `launch_async_subagent` to start a job. Report the job ID to the user and stop. Do NOT immediately check the status — the job runs in the background while you and the user continue other work.
-2. **Check (on request)** — Only use `check_async_subagent` when the user explicitly asks for a status update or result. If the status is "running", report that and stop — do not poll in a loop.
-3. **Update** (optional) — Use `update_async_subagent` to send new instructions to a running job. This interrupts the current run and starts a fresh one on the same thread. Use the new job_id it returns going forward.
+1. **Launch** — Use `launch_async_subagent` to start a job. Report the job ID to the user and stop.
+   Do NOT immediately check the status — the job runs in the background while you and the user continue other work.
+2. **Check (on request)** — Only use `check_async_subagent` when the user explicitly asks for a status update or
+   result. If the status is "running", report that and stop — do not poll in a loop.
+3. **Update** (optional) — Use `update_async_subagent` to send new instructions to a running job. This interrupts
+   the current run and starts a fresh one on the same thread. Use the new job_id it returns going forward.
 4. **Cancel** (optional) — Use `cancel_async_subagent` to stop a job that is no longer needed.
 5. **Collect** — When `check_async_subagent` returns status "success", the result is included in the response.
 6. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
@@ -308,6 +311,67 @@ def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -
     return next(iter(agent_map))
 
 
+def _build_check_result(
+    run: dict[str, Any],
+    thread_id: str,
+    thread_values: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the result dict from a completed run and its thread values."""
+    result: dict[str, Any] = {
+        "status": run["status"],
+        "run_id": run["run_id"],
+        "thread_id": thread_id,
+    }
+    if run["status"] == "success":
+        messages = thread_values.get("messages", []) if isinstance(thread_values, dict) else []
+        if messages:
+            last = messages[-1]
+            result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
+    elif run["status"] == "error":
+        result["error"] = "The async subagent encountered an error."
+    return result
+
+
+def _build_check_command(
+    result: dict[str, Any],
+    name: str,
+    thread_id: str,
+    run_id: str,
+    tool_call_id: str,
+) -> Command:
+    """Build the Command update for a check result."""
+    canonical = _format_job_id(name, thread_id, run_id)
+    job: AsyncSubAgentJob = {
+        "job_id": canonical,
+        "agent_name": name,
+        "thread_id": thread_id,
+        "run_id": run_id,
+        "status": result["status"],
+    }
+    return Command(
+        update={
+            "messages": [ToolMessage(json.dumps(result), tool_call_id=tool_call_id)],
+            "async_subagent_jobs": {canonical: job},
+        }
+    )
+
+
+def _parse_and_resolve(
+    job_id: str,
+    agent_map: dict[str, AsyncSubAgent],
+) -> tuple[str, str, str] | str:
+    """Parse a job_id and resolve the agent name. Returns (name, thread_id, run_id) or an error string."""
+    try:
+        agent_name, thread_id, run_id = _parse_job_id(job_id)
+    except ValueError as e:
+        return str(e)
+    try:
+        name = _resolve_client_name(agent_name, agent_map)
+    except ValueError as e:
+        return str(e)
+    return name, thread_id, run_id
+
+
 def _build_check_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
@@ -318,91 +382,47 @@ def _build_check_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        try:
-            agent_name, thread_id, run_id = _parse_job_id(job_id)
-        except ValueError as e:
-            return str(e)
-
-        try:
-            name = _resolve_client_name(agent_name, agent_map)
-        except ValueError as e:
-            return str(e)
+        parsed = _parse_and_resolve(job_id, agent_map)
+        if isinstance(parsed, str):
+            return parsed
+        name, thread_id, run_id = parsed
 
         client = clients.get_sync(name)
-
         try:
             run = client.runs.get(thread_id=thread_id, run_id=run_id)
         except Exception as e:
             return f"Failed to get run status: {e}"
-        result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
+
+        thread_values: dict[str, Any] = {}
         if run["status"] == "success":
             thread = client.threads.get(thread_id=thread_id)
-            values = thread.get("values") or {}
-            messages = values.get("messages", []) if isinstance(values, dict) else []
-            if messages:
-                last = messages[-1]
-                result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
-        elif run["status"] == "error":
-            result["error"] = "The async subagent encountered an error."
-        canonical = _format_job_id(name, thread_id, run_id)
-        job: AsyncSubAgentJob = {
-            "job_id": canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
-            "run_id": run_id,
-            "status": run["status"],
-        }
-        return Command(
-            update={
-                "messages": [ToolMessage(json.dumps(result), tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {canonical: job},
-            }
-        )
+            thread_values = thread.get("values") or {}
+
+        result = _build_check_result(run, thread_id, thread_values)
+        return _build_check_command(result, name, thread_id, run_id, runtime.tool_call_id)
 
     async def acheck_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        try:
-            agent_name, thread_id, run_id = _parse_job_id(job_id)
-        except ValueError as e:
-            return str(e)
-
-        try:
-            name = _resolve_client_name(agent_name, agent_map)
-        except ValueError as e:
-            return str(e)
+        parsed = _parse_and_resolve(job_id, agent_map)
+        if isinstance(parsed, str):
+            return parsed
+        name, thread_id, run_id = parsed
 
         client = clients.get_async(name)
-
         try:
             run = await client.runs.get(thread_id=thread_id, run_id=run_id)
         except Exception as e:
             return f"Failed to get run status: {e}"
-        result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
+
+        thread_values: dict[str, Any] = {}
         if run["status"] == "success":
             thread = await client.threads.get(thread_id=thread_id)
-            values = thread.get("values") or {}
-            messages = values.get("messages", []) if isinstance(values, dict) else []
-            if messages:
-                last = messages[-1]
-                result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
-        elif run["status"] == "error":
-            result["error"] = "The async subagent encountered an error."
-        canonical = _format_job_id(name, thread_id, run_id)
-        job: AsyncSubAgentJob = {
-            "job_id": canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
-            "run_id": run_id,
-            "status": run["status"],
-        }
-        return Command(
-            update={
-                "messages": [ToolMessage(json.dumps(result), tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {canonical: job},
-            }
-        )
+            thread_values = thread.get("values") or {}
+
+        result = _build_check_result(run, thread_id, thread_values)
+        return _build_check_command(result, name, thread_id, run_id, runtime.tool_call_id)
 
     return StructuredTool.from_function(
         name="check_async_subagent",

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -604,7 +604,7 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
         statuses = await asyncio.gather(*(_afetch_live_status(clients, job) for job in active))
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
         entries: list[str] = []
-        for job, status in zip(active, statuses):
+        for job, status in zip(active, statuses, strict=True):
             entries.append(_format_job_entry(job, status))
             updated_jobs[job["job_id"]] = AsyncSubAgentJob(
                 job_id=job["job_id"],

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -41,17 +41,18 @@ class AsyncSubAgent(TypedDict):
         name: Unique identifier for the async subagent.
         description: What this subagent does. The main agent uses this to decide
             when to delegate.
-        url: URL of the LangGraph server (e.g., `"https://my-deployment.langsmith.dev"`).
         graph_id: The graph name or assistant ID on the remote server.
 
     Optional fields:
+        url: URL of the LangGraph server (e.g., `"https://my-deployment.langsmith.dev"`).
+            Omit to use ASGI transport for local LangGraph servers.
         headers: Additional headers to include in requests to the remote server.
     """
 
     name: str
     description: str
-    url: str
     graph_id: str
+    url: NotRequired[str]
     headers: NotRequired[dict[str, str]]
 
 
@@ -137,7 +138,7 @@ class _ClientCache:
         if name not in self._sync:
             spec = self._agents[name]
             self._sync[name] = get_sync_client(
-                url=spec["url"],
+                url=spec.get("url"),
                 headers=_resolve_headers(spec),
             )
         return self._sync[name]
@@ -147,7 +148,7 @@ class _ClientCache:
         if name not in self._async:
             spec = self._agents[name]
             self._async[name] = get_client(
-                url=spec["url"],
+                url=spec.get("url"),
                 headers=_resolve_headers(spec),
             )
         return self._async[name]
@@ -512,7 +513,8 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
     Args:
         async_subagents: List of async subagent specifications. Each must
-            include `name`, `description`, `url`, and `graph_id`.
+            include `name`, `description`, and `graph_id`. `url` is optional —
+            omit it to use ASGI transport for local LangGraph servers.
         system_prompt: Instructions appended to the main agent's system prompt
             about how to use the async subagent tools.
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -121,6 +121,7 @@ You have access to async subagent tools that launch background jobs on remote La
 - After launching, ALWAYS return control to the user immediately. Never auto-check after launching.
 - Never poll `check_async_subagent` in a loop. Check once per user request, then stop.
 - If a check returns "running", tell the user and wait for them to ask again.
+- ALWAYS call `check_async_subagent` when the user asks for a status update — never answer from memory. Job statuses change over time and must be fetched fresh.
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -121,7 +121,8 @@ You have access to async subagent tools that launch background jobs on remote La
 - After launching, ALWAYS return control to the user immediately. Never auto-check after launching.
 - Never poll `check_async_subagent` in a loop. Check once per user request, then stop.
 - If a check returns "running", tell the user and wait for them to ask again.
-- ALWAYS call `check_async_subagent` when the user asks for a status update — never answer from memory. Job statuses change over time and must be fetched fresh.
+- ALWAYS call `check_async_subagent` when the user asks for a status update — never answer from memory. Job statuses
+change over time and must be fetched fresh.
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -88,10 +88,10 @@ Available async agent types:
 {available_agents}
 
 ## Usage notes:
-1. This tool launches a background job and returns immediately with a job ID (thread_id + run_id).
-2. Use `check_async_subagent` to poll for status and results.
-3. Use `update_async_subagent` to send updates or new instructions to a running job.
-4. Multiple async subagents can run concurrently — launch several and check them periodically.
+1. This tool launches a background job and returns immediately with a job ID. Report the job ID to the user and stop — do NOT immediately check status.
+2. Use `check_async_subagent` only when the user asks for a status update or result.
+3. Use `update_async_subagent` to send new instructions to a running job.
+4. Multiple async subagents can run concurrently — launch several and let them run in the background.
 5. The subagent runs on a remote LangGraph server, so it has its own tools and capabilities."""  # noqa: E501
 
 ASYNC_TASK_SYSTEM_PROMPT = """## Async subagents (remote LangGraph servers)
@@ -106,12 +106,17 @@ You have access to async subagent tools that launch background jobs on remote La
 - `list_async_subagent_jobs`: List all tracked jobs and their last-known statuses. Use this to recall job IDs.
 
 ### Workflow:
-1. **Launch** — Use `launch_async_subagent` to start a job. You get back a job ID.
-2. **Monitor** — Use `check_async_subagent` to poll for status. Jobs can be: pending, running, success, error, timeout, or interrupted.
+1. **Launch** — Use `launch_async_subagent` to start a job. Report the job ID to the user and stop. Do NOT immediately check the status — the job runs in the background while you and the user continue other work.
+2. **Check (on request)** — Only use `check_async_subagent` when the user explicitly asks for a status update or result. If the status is "running", report that and stop — do not poll in a loop.
 3. **Update** (optional) — Use `update_async_subagent` to send new context or instructions to a running job.
 4. **Cancel** (optional) — Use `cancel_async_subagent` to stop a job that is no longer needed.
-5. **Collect** — When status is "success", the result is included in the check response.
+5. **Collect** — When `check_async_subagent` returns status "success", the result is included in the response.
 6. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
+
+### Critical rules:
+- After launching, ALWAYS return control to the user immediately. Never auto-check after launching.
+- Never poll `check_async_subagent` in a loop. Check once per user request, then stop.
+- If a check returns "running", tell the user and wait for them to ask again.
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -534,7 +534,7 @@ def _build_cancel_tool(
     )
 
 
-_TERMINAL_STATUSES = frozenset({"cancelled"})
+_TERMINAL_STATUSES = frozenset({"cancelled", "success", "error"})
 
 
 def _fetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> str:

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -300,6 +300,7 @@ def _build_update_tool(
             thread_id=thread_id,
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": message}]},
+            multitask_strategy="interrupt",
         )
         new_job_id = _format_job_id(name, thread_id, run["run_id"])
         return f"Follow-up sent. New job_id: {new_job_id}"
@@ -316,6 +317,7 @@ def _build_update_tool(
             thread_id=thread_id,
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": message}]},
+            multitask_strategy="interrupt",
         )
         new_job_id = _format_job_id(name, thread_id, run["run_id"])
         return f"Follow-up sent. New job_id: {new_job_id}"

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -102,14 +102,16 @@ You have access to async subagent tools that launch background jobs on remote La
 - `launch_async_subagent`: Start a new background job. Returns a job ID immediately.
 - `check_async_subagent`: Check the status of a running job. Returns status and result if complete.
 - `update_async_subagent`: Send an update or new instructions to a running job.
+- `cancel_async_subagent`: Cancel a running job that is no longer needed.
 - `list_async_subagent_jobs`: List all tracked jobs and their last-known statuses. Use this to recall job IDs.
 
 ### Workflow:
 1. **Launch** — Use `launch_async_subagent` to start a job. You get back a job ID.
 2. **Monitor** — Use `check_async_subagent` to poll for status. Jobs can be: pending, running, success, error, timeout, or interrupted.
 3. **Update** (optional) — Use `update_async_subagent` to send new context or instructions to a running job.
-4. **Collect** — When status is "success", the result is included in the check response.
-5. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
+4. **Cancel** (optional) — Use `cancel_async_subagent` to stop a job that is no longer needed.
+5. **Collect** — When status is "success", the result is included in the check response.
+6. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent
@@ -503,6 +505,86 @@ def _build_update_tool(
     )
 
 
+def _build_cancel_tool(
+    agent_map: dict[str, AsyncSubAgent],
+    clients: _ClientCache,
+) -> StructuredTool:
+    """Build the cancel_async_subagent tool."""
+
+    def cancel_async_subagent(
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
+        runtime: ToolRuntime,
+    ) -> str | Command:
+        try:
+            agent_name, thread_id, run_id = _parse_job_id(job_id)
+        except ValueError as e:
+            return str(e)
+        try:
+            name = _resolve_client_name(agent_name, agent_map)
+        except ValueError as e:
+            return str(e)
+        client = clients.get_sync(name)
+        try:
+            client.runs.cancel(thread_id=thread_id, run_id=run_id)
+        except Exception as e:
+            return f"Failed to cancel run: {e}"
+        canonical = _format_job_id(name, thread_id, run_id)
+        job: AsyncSubAgentJob = {
+            "job_id": canonical,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "status": "cancelled",
+        }
+        msg = f"Cancelled async subagent job: {canonical}"
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {canonical: job},
+            }
+        )
+
+    async def acancel_async_subagent(
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
+        runtime: ToolRuntime,
+    ) -> str | Command:
+        try:
+            agent_name, thread_id, run_id = _parse_job_id(job_id)
+        except ValueError as e:
+            return str(e)
+        try:
+            name = _resolve_client_name(agent_name, agent_map)
+        except ValueError as e:
+            return str(e)
+        client = clients.get_async(name)
+        try:
+            await client.runs.cancel(thread_id=thread_id, run_id=run_id)
+        except Exception as e:
+            return f"Failed to cancel run: {e}"
+        canonical = _format_job_id(name, thread_id, run_id)
+        job: AsyncSubAgentJob = {
+            "job_id": canonical,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "status": "cancelled",
+        }
+        msg = f"Cancelled async subagent job: {canonical}"
+        return Command(
+            update={
+                "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
+                "async_subagent_jobs": {canonical: job},
+            }
+        )
+
+    return StructuredTool.from_function(
+        name="cancel_async_subagent",
+        func=cancel_async_subagent,
+        coroutine=acancel_async_subagent,
+        description="Cancel a running async subagent job. Use this to stop a job that is no longer needed.",
+    )
+
+
 def _build_list_jobs_tool() -> StructuredTool:
     """Build the list_async_subagent_jobs tool."""
 
@@ -547,6 +629,7 @@ def _build_async_subagent_tools(
         _build_launch_tool(agent_map, clients, launch_desc),
         _build_check_tool(agent_map, clients),
         _build_update_tool(agent_map, clients),
+        _build_cancel_tool(agent_map, clients),
         _build_list_jobs_tool(),
     ]
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -122,13 +122,39 @@ class _ClientCache:
         return self._async[name]
 
 
+_JOB_ID_SEP = "::"
+
+
 def _format_job_id(thread_id: str, run_id: str) -> str:
-    return json.dumps({"thread_id": thread_id, "run_id": run_id})
+    return f"{thread_id}{_JOB_ID_SEP}{run_id}"
+
+
+_JOB_ID_PREFIX = "job_id: "
 
 
 def _parse_job_id(job_id: str) -> tuple[str, str]:
-    data = json.loads(job_id)
-    return data["thread_id"], data["run_id"]
+    """Parse a job ID into (thread_id, run_id).
+
+    Handles multiple formats the LLM might pass:
+    - `thread_abc::run_xyz` (canonical)
+    - `Launched async subagent. job_id: thread_abc::run_xyz` (full launch output)
+    - `{"thread_id": "...", "run_id": "..."}` (legacy JSON)
+    """
+    raw = job_id.strip()
+    idx = raw.find(_JOB_ID_PREFIX)
+    if idx != -1:
+        raw = raw[idx + len(_JOB_ID_PREFIX) :].strip()
+    if _JOB_ID_SEP in raw:
+        parts = raw.split(_JOB_ID_SEP, maxsplit=1)
+        return parts[0], parts[1]
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data["thread_id"], data["run_id"]
+    except (json.JSONDecodeError, KeyError):
+        pass
+    msg = f"Invalid job_id format: {job_id!r}. Expected the exact job_id string returned by launch_async_subagent."
+    raise ValueError(msg)
 
 
 def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -> str | None:
@@ -160,7 +186,8 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        return _format_job_id(thread["thread_id"], run["run_id"])
+        job_id = _format_job_id(thread["thread_id"], run["run_id"])
+        return f"Launched async subagent. job_id: {job_id}"
 
     async def alaunch_async_subagent(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
@@ -177,7 +204,8 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        return _format_job_id(thread["thread_id"], run["run_id"])
+        job_id = _format_job_id(thread["thread_id"], run["run_id"])
+        return f"Launched async subagent. job_id: {job_id}"
 
     return StructuredTool.from_function(
         name="launch_async_subagent",
@@ -195,7 +223,7 @@ def _build_check_tool(
     first_name = next(iter(agent_map))
 
     def check_async_subagent(
-        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
     ) -> str:
         thread_id, run_id = _parse_job_id(job_id)
         client = clients.sync(first_name)
@@ -213,7 +241,7 @@ def _build_check_tool(
         return json.dumps(result)
 
     async def acheck_async_subagent(
-        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
     ) -> str:
         thread_id, run_id = _parse_job_id(job_id)
         client = clients.async_(first_name)
@@ -246,7 +274,7 @@ def _build_update_tool(
     first_name = next(iter(agent_map))
 
     def update_async_subagent(
-        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         update: Annotated[str, "New instructions or context to send to the running subagent."],
     ) -> str:
         thread_id, _run_id = _parse_job_id(job_id)
@@ -258,7 +286,7 @@ def _build_update_tool(
         return json.dumps({"status": "updated", "thread_id": thread_id})
 
     async def aupdate_async_subagent(
-        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         update: Annotated[str, "New instructions or context to send to the running subagent."],
     ) -> str:
         thread_id, _run_id = _parse_job_id(job_id)

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -363,6 +363,28 @@ def _parse_and_resolve(
     return name, thread_id
 
 
+def _resolve_tracked_job(
+    job_id: str,
+    agent_map: dict[str, AsyncSubAgent],
+    runtime: ToolRuntime,
+) -> tuple[str, str, str, str] | str:
+    """Parse job_id, resolve agent, and look up the tracked job from state.
+
+    Returns:
+        `(name, thread_id, run_id, canonical_job_id)` on success, or an error string.
+    """
+    parsed = _parse_and_resolve(job_id, agent_map)
+    if isinstance(parsed, str):
+        return parsed
+    name, thread_id = parsed
+    canonical = _format_job_id(name, thread_id)
+    jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+    tracked = jobs.get(canonical)
+    if not tracked:
+        return f"No tracked job found for job_id: {job_id}"
+    return name, thread_id, tracked["run_id"], canonical
+
+
 def _build_check_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
@@ -373,18 +395,10 @@ def _build_check_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        parsed = _parse_and_resolve(job_id, agent_map)
-        if isinstance(parsed, str):
-            return parsed
-        name, thread_id = parsed
-
-        # Look up the current run_id from state
-        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        canonical = _format_job_id(name, thread_id)
-        tracked = jobs.get(canonical)
-        if not tracked:
-            return f"No tracked job found for job_id: {job_id}"
-        run_id = tracked["run_id"]
+        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
+        if isinstance(resolved, str):
+            return resolved
+        name, thread_id, run_id, canonical = resolved
 
         client = clients.get_sync(name)
         try:
@@ -404,18 +418,10 @@ def _build_check_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        parsed = _parse_and_resolve(job_id, agent_map)
-        if isinstance(parsed, str):
-            return parsed
-        name, thread_id = parsed
-
-        # Look up the current run_id from state
-        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        canonical = _format_job_id(name, thread_id)
-        tracked = jobs.get(canonical)
-        if not tracked:
-            return f"No tracked job found for job_id: {job_id}"
-        run_id = tracked["run_id"]
+        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
+        if isinstance(resolved, str):
+            return resolved
+        name, thread_id, run_id, canonical = resolved
 
         client = clients.get_async(name)
         try:
@@ -539,17 +545,10 @@ def _build_cancel_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        parsed = _parse_and_resolve(job_id, agent_map)
-        if isinstance(parsed, str):
-            return parsed
-        name, thread_id = parsed
-
-        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        canonical = _format_job_id(name, thread_id)
-        tracked = jobs.get(canonical)
-        if not tracked:
-            return f"No tracked job found for job_id: {job_id}"
-        run_id = tracked["run_id"]
+        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
+        if isinstance(resolved, str):
+            return resolved
+        name, thread_id, run_id, canonical = resolved
 
         client = clients.get_sync(name)
         try:
@@ -575,17 +574,10 @@ def _build_cancel_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        parsed = _parse_and_resolve(job_id, agent_map)
-        if isinstance(parsed, str):
-            return parsed
-        name, thread_id = parsed
-
-        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-        canonical = _format_job_id(name, thread_id)
-        tracked = jobs.get(canonical)
-        if not tracked:
-            return f"No tracked job found for job_id: {job_id}"
-        run_id = tracked["run_id"]
+        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
+        if isinstance(resolved, str):
+            return resolved
+        name, thread_id, run_id, canonical = resolved
 
         client = clients.get_async(name)
         try:

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -85,6 +85,14 @@ You have access to async subagent tools that launch background jobs on remote La
 - When you want to run multiple tasks concurrently and collect results later"""
 
 
+def _resolve_headers(spec: AsyncSubAgent) -> dict[str, str]:
+    """Build headers for a remote LangGraph server, including auth scheme."""
+    headers: dict[str, str] = dict(spec.get("headers") or {})
+    if "x-auth-scheme" not in headers:
+        headers["x-auth-scheme"] = "langsmith"
+    return headers
+
+
 class _ClientCache:
     """Lazily-created, cached LangGraph SDK clients keyed by agent name."""
 
@@ -99,7 +107,7 @@ class _ClientCache:
             spec = self._agents[name]
             self._sync[name] = get_sync_client(
                 url=spec["url"],
-                headers=spec.get("headers"),
+                headers=_resolve_headers(spec),
             )
         return self._sync[name]
 
@@ -109,7 +117,7 @@ class _ClientCache:
             spec = self._agents[name]
             self._async[name] = get_client(
                 url=spec["url"],
-                headers=spec.get("headers"),
+                headers=_resolve_headers(spec),
             )
         return self._async[name]
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -151,10 +151,7 @@ class _ClientCache:
         """Get or create a sync client for the named agent."""
         spec = self._agents[name]
         if spec.get("url") is None:
-            msg = (
-                f"Async subagent '{name}' has no url configured. "
-                "ASGI transport (url=None) requires async invocation."
-            )
+            msg = f"Async subagent '{name}' has no url configured. ASGI transport (url=None) requires async invocation."
             raise ValueError(msg)
         key = self._cache_key(spec)
         if key not in self._sync:

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -126,32 +126,38 @@ def _resolve_headers(spec: AsyncSubAgent) -> dict[str, str]:
 
 
 class _ClientCache:
-    """Lazily-created, cached LangGraph SDK clients keyed by agent name."""
+    """Lazily-created, cached LangGraph SDK clients keyed by (url, headers)."""
 
     def __init__(self, agents: dict[str, AsyncSubAgent]) -> None:
         self._agents = agents
-        self._sync: dict[str, SyncLangGraphClient] = {}
-        self._async: dict[str, LangGraphClient] = {}
+        self._sync: dict[tuple[str | None, frozenset[tuple[str, str]]], SyncLangGraphClient] = {}
+        self._async: dict[tuple[str | None, frozenset[tuple[str, str]]], LangGraphClient] = {}
+
+    def _cache_key(self, spec: AsyncSubAgent) -> tuple[str | None, frozenset[tuple[str, str]]]:
+        """Build a cache key from the agent spec's url and resolved headers."""
+        return (spec.get("url"), frozenset(_resolve_headers(spec).items()))
 
     def get_sync(self, name: str) -> SyncLangGraphClient:
         """Get or create a sync client for the named agent."""
-        if name not in self._sync:
-            spec = self._agents[name]
-            self._sync[name] = get_sync_client(
+        spec = self._agents[name]
+        key = self._cache_key(spec)
+        if key not in self._sync:
+            self._sync[key] = get_sync_client(
                 url=spec.get("url"),
                 headers=_resolve_headers(spec),
             )
-        return self._sync[name]
+        return self._sync[key]
 
     def get_async(self, name: str) -> LangGraphClient:
         """Get or create an async client for the named agent."""
-        if name not in self._async:
-            spec = self._agents[name]
-            self._async[name] = get_client(
+        spec = self._agents[name]
+        key = self._cache_key(spec)
+        if key not in self._async:
+            self._async[key] = get_client(
                 url=spec.get("url"),
                 headers=_resolve_headers(spec),
             )
-        return self._async[name]
+        return self._async[key]
 
 
 _JOB_ID_SEP = "::"

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
     from langchain.agents.middleware.types import ModelRequest
     from langgraph_sdk.client import LangGraphClient, SyncLangGraphClient
+    from langgraph_sdk.schema import Run
 
 
 class AsyncSubAgent(TypedDict):
@@ -309,7 +310,7 @@ def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -
 
 
 def _build_check_result(
-    run: Any,
+    run: Run,
     thread_id: str,
     thread_values: dict[str, Any],
 ) -> dict[str, Any]:

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -30,6 +30,10 @@ class AsyncSubAgent(TypedDict):
     Async subagents connect to LangGraph deployments via the LangGraph SDK.
     They run as background jobs that the main agent can monitor and update.
 
+    Authentication is handled via environment variables (`LANGGRAPH_API_KEY`,
+    `LANGSMITH_API_KEY`, or `LANGCHAIN_API_KEY`), which the LangGraph SDK
+    reads automatically.
+
     Required fields:
         name: Unique identifier for the async subagent.
         description: What this subagent does. The main agent uses this to decide
@@ -38,7 +42,6 @@ class AsyncSubAgent(TypedDict):
         graph_id: The graph name or assistant ID on the remote server.
 
     Optional fields:
-        api_key: API key for authenticating with the remote server.
         headers: Additional headers to include in requests to the remote server.
     """
 
@@ -46,7 +49,6 @@ class AsyncSubAgent(TypedDict):
     description: str
     url: str
     graph_id: str
-    api_key: NotRequired[str]
     headers: NotRequired[dict[str, str]]
 
 
@@ -97,7 +99,6 @@ class _ClientCache:
             spec = self._agents[name]
             self._sync[name] = get_sync_client(
                 url=spec["url"],
-                api_key=spec.get("api_key"),
                 headers=spec.get("headers"),
             )
         return self._sync[name]
@@ -108,7 +109,6 @@ class _ClientCache:
             spec = self._agents[name]
             self._async[name] = get_client(
                 url=spec["url"],
-                api_key=spec.get("api_key"),
                 headers=spec.get("headers"),
             )
         return self._async[name]
@@ -317,7 +317,6 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                     "description": "Research agent for deep analysis",
                     "url": "https://my-deployment.langsmith.dev",
                     "graph_id": "research_agent",
-                    "api_key": "my-api-key",
                 }
             ],
         )

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -108,7 +108,7 @@ You have access to async subagent tools that launch background jobs on remote La
 ### Workflow:
 1. **Launch** — Use `launch_async_subagent` to start a job. Report the job ID to the user and stop. Do NOT immediately check the status — the job runs in the background while you and the user continue other work.
 2. **Check (on request)** — Only use `check_async_subagent` when the user explicitly asks for a status update or result. If the status is "running", report that and stop — do not poll in a loop.
-3. **Update** (optional) — Use `update_async_subagent` to send new context or instructions to a running job.
+3. **Update** (optional) — Use `update_async_subagent` to send new instructions to a running job. This interrupts the current run and starts a fresh one on the same thread. Use the new job_id it returns going forward.
 4. **Cancel** (optional) — Use `cancel_async_subagent` to stop a job that is no longer needed.
 5. **Collect** — When `check_async_subagent` returns status "success", the result is included in the response.
 6. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
@@ -503,9 +503,10 @@ def _build_update_tool(
         func=update_async_subagent,
         coroutine=aupdate_async_subagent,
         description=(
-            "Send a follow-up message to an async subagent. Creates a new run on the same thread "
-            "so the subagent sees the full conversation history plus your new message. "
-            "Returns a new job_id to track the follow-up."
+            "Send updated instructions to an async subagent. Interrupts the current run and starts "
+            "a new one on the same thread, so the subagent sees the full conversation history plus "
+            "your new message. The original job_id will show as 'interrupted'. "
+            "Returns a new job_id to track the updated run."
         ),
     )
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -422,8 +422,14 @@ def _build_update_tool(
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        agent_name, thread_id, _run_id = _parse_job_id(job_id)
-        name = _resolve_client_name(agent_name, agent_map)
+        try:
+            agent_name, thread_id, _run_id = _parse_job_id(job_id)
+        except ValueError as e:
+            return str(e)
+        try:
+            name = _resolve_client_name(agent_name, agent_map)
+        except ValueError as e:
+            return str(e)
         spec = agent_map[name]
         client = clients.get_sync(name)
         run = client.runs.create(
@@ -453,8 +459,14 @@ def _build_update_tool(
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        agent_name, thread_id, _run_id = _parse_job_id(job_id)
-        name = _resolve_client_name(agent_name, agent_map)
+        try:
+            agent_name, thread_id, _run_id = _parse_job_id(job_id)
+        except ValueError as e:
+            return str(e)
+        try:
+            name = _resolve_client_name(agent_name, agent_map)
+        except ValueError as e:
+            return str(e)
         spec = agent_map[name]
         client = clients.get_async(name)
         run = await client.runs.create(

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -304,11 +304,23 @@ def _build_check_tool(
     def check_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
-    ) -> Command:
-        agent_name, thread_id, run_id = _parse_job_id(job_id)
-        name = _resolve_client_name(agent_name, agent_map)
+    ) -> str | Command:
+        try:
+            agent_name, thread_id, run_id = _parse_job_id(job_id)
+        except ValueError as e:
+            return str(e)
+
+        try:
+            name = _resolve_client_name(agent_name, agent_map)
+        except ValueError as e:
+            return str(e)
+
         client = clients.get_sync(name)
-        run = client.runs.get(thread_id=thread_id, run_id=run_id)
+
+        try:
+            run = client.runs.get(thread_id=thread_id, run_id=run_id)
+        except Exception as e:
+            return f"Failed to get run status: {e}"
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
             thread = client.threads.get(thread_id=thread_id)
@@ -337,11 +349,23 @@ def _build_check_tool(
     async def acheck_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
-    ) -> Command:
-        agent_name, thread_id, run_id = _parse_job_id(job_id)
-        name = _resolve_client_name(agent_name, agent_map)
+    ) -> str | Command:
+        try:
+            agent_name, thread_id, run_id = _parse_job_id(job_id)
+        except ValueError as e:
+            return str(e)
+
+        try:
+            name = _resolve_client_name(agent_name, agent_map)
+        except ValueError as e:
+            return str(e)
+
         client = clients.get_async(name)
-        run = await client.runs.get(thread_id=thread_id, run_id=run_id)
+
+        try:
+            run = await client.runs.get(thread_id=thread_id, run_id=run_id)
+        except Exception as e:
+            return f"Failed to get run status: {e}"
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
             thread = await client.threads.get(thread_id=thread_id)

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -390,7 +390,7 @@ def _build_check_tool(
         client = clients.get_sync(name)
         try:
             run = client.runs.get(thread_id=thread_id, run_id=run_id)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to get run status: {e}"
 
         thread_values: dict[str, Any] = {}
@@ -413,7 +413,7 @@ def _build_check_tool(
         client = clients.get_async(name)
         try:
             run = await client.runs.get(thread_id=thread_id, run_id=run_id)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to get run status: {e}"
 
         thread_values: dict[str, Any] = {}
@@ -568,7 +568,7 @@ def _build_cancel_tool(
         client = clients.get_sync(name)
         try:
             client.runs.cancel(thread_id=thread_id, run_id=run_id)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
         canonical = _format_job_id(name, thread_id, run_id)
         job: AsyncSubAgentJob = {
@@ -601,7 +601,7 @@ def _build_cancel_tool(
         client = clients.get_async(name)
         try:
             await client.runs.cancel(thread_id=thread_id, run_id=run_id)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
         canonical = _format_job_id(name, thread_id, run_id)
         job: AsyncSubAgentJob = {

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -329,7 +329,13 @@ def _build_check_command(
     tool_call_id: str | None,
 ) -> Command:
     """Build the Command update for a check result."""
-    updated_job: AsyncSubAgentJob = {**job, "status": result["status"]}
+    updated_job = AsyncSubAgentJob(
+        job_id=job["job_id"],
+        agent_name=job["agent_name"],
+        thread_id=job["thread_id"],
+        run_id=job["run_id"],
+        status=result["status"],
+    )
     return Command(
         update={
             "messages": [ToolMessage(json.dumps(result), tool_call_id=tool_call_id)],
@@ -546,7 +552,13 @@ def _build_cancel_tool(
             client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        updated: AsyncSubAgentJob = {**tracked, "status": "cancelled"}
+        updated = AsyncSubAgentJob(
+            job_id=tracked["job_id"],
+            agent_name=tracked["agent_name"],
+            thread_id=tracked["thread_id"],
+            run_id=tracked["run_id"],
+            status="cancelled",
+        )
         msg = f"Cancelled async subagent job: {tracked['job_id']}"
         return Command(
             update={
@@ -569,7 +581,13 @@ def _build_cancel_tool(
             await client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        updated: AsyncSubAgentJob = {**tracked, "status": "cancelled"}
+        updated = AsyncSubAgentJob(
+            job_id=tracked["job_id"],
+            agent_name=tracked["agent_name"],
+            thread_id=tracked["thread_id"],
+            run_id=tracked["run_id"],
+            status="cancelled",
+        )
         msg = f"Cancelled async subagent job: {tracked['job_id']}"
         return Command(
             update={

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypedDict
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ModelResponse, ResponseT
@@ -20,6 +21,8 @@ from langgraph.types import Command
 from langgraph_sdk import get_client, get_sync_client
 
 from deepagents.middleware._utils import append_to_system_message
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -78,7 +81,12 @@ class AsyncSubAgentJob(TypedDict):
     """LangGraph run ID for the current execution on the thread."""
 
     status: str
-    """Current job status (e.g., `'running'`, `'success'`, `'error'`, `'cancelled'`)."""
+    """Current job status (e.g., `'running'`, `'success'`, `'error'`, `'cancelled'`).
+
+    Typed as `str` rather than a `Literal` because the LangGraph SDK's
+    `Run.status` is `str` — using a `Literal` here would require `cast` at every
+    SDK boundary.
+    """
 
 
 def _jobs_reducer(
@@ -217,13 +225,17 @@ def _build_launch_tool(
         if error:
             return error
         spec = agent_map[subagent_type]
-        client = clients.get_sync(subagent_type)
-        thread = client.threads.create()
-        run = client.runs.create(
-            thread_id=thread["thread_id"],
-            assistant_id=spec["graph_id"],
-            input={"messages": [{"role": "user", "content": description}]},
-        )
+        try:
+            client = clients.get_sync(subagent_type)
+            thread = client.threads.create()
+            run = client.runs.create(
+                thread_id=thread["thread_id"],
+                assistant_id=spec["graph_id"],
+                input={"messages": [{"role": "user", "content": description}]},
+            )
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+            logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
+            return f"Failed to launch async subagent '{subagent_type}': {e}"
         job_id = thread["thread_id"]
         job: AsyncSubAgentJob = {
             "job_id": job_id,
@@ -249,13 +261,17 @@ def _build_launch_tool(
         if error:
             return error
         spec = agent_map[subagent_type]
-        client = clients.get_async(subagent_type)
-        thread = await client.threads.create()
-        run = await client.runs.create(
-            thread_id=thread["thread_id"],
-            assistant_id=spec["graph_id"],
-            input={"messages": [{"role": "user", "content": description}]},
-        )
+        try:
+            client = clients.get_async(subagent_type)
+            thread = await client.threads.create()
+            run = await client.runs.create(
+                thread_id=thread["thread_id"],
+                assistant_id=spec["graph_id"],
+                input={"messages": [{"role": "user", "content": description}]},
+            )
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+            logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
+            return f"Failed to launch async subagent '{subagent_type}': {e}"
         job_id = thread["thread_id"]
         job: AsyncSubAgentJob = {
             "job_id": job_id,
@@ -285,7 +301,7 @@ def _build_check_result(
     thread_id: str,
     thread_values: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build the result dict from a completed run and its thread values."""
+    """Build the result dict from a run's current status and its thread values."""
     result: dict[str, Any] = {
         "status": run["status"],
         "thread_id": thread_id,
@@ -295,8 +311,11 @@ def _build_check_result(
         if messages:
             last = messages[-1]
             result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
+        else:
+            result["result"] = "(completed with no output messages)"
     elif run["status"] == "error":
-        result["error"] = "The async subagent encountered an error."
+        error_detail = run.get("error")
+        result["error"] = str(error_detail) if error_detail else "The async subagent encountered an error."
     return result
 
 
@@ -337,7 +356,7 @@ def _resolve_tracked_job(
     return tracked
 
 
-def _build_check_tool(
+def _build_check_tool(  # noqa: C901  # complexity from necessary error handling
     clients: _ClientCache,
 ) -> StructuredTool:
     """Build the `check_async_subagent` tool."""
@@ -358,8 +377,11 @@ def _build_check_tool(
 
         thread_values: dict[str, Any] = {}
         if run["status"] == "success":
-            thread = client.threads.get(thread_id=job["thread_id"])
-            thread_values = thread.get("values") or {}
+            try:
+                thread = client.threads.get(thread_id=job["thread_id"])
+                thread_values = thread.get("values") or {}
+            except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+                logger.warning("Failed to fetch thread values for job %s: %s", job["job_id"], e)
 
         result = _build_check_result(run, job["thread_id"], thread_values)
         return _build_check_command(result, job, runtime.tool_call_id)
@@ -380,8 +402,11 @@ def _build_check_tool(
 
         thread_values: dict[str, Any] = {}
         if run["status"] == "success":
-            thread = await client.threads.get(thread_id=job["thread_id"])
-            thread_values = thread.get("values") or {}
+            try:
+                thread = await client.threads.get(thread_id=job["thread_id"])
+                thread_values = thread.get("values") or {}
+            except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+                logger.warning("Failed to fetch thread values for job %s: %s", job["job_id"], e)
 
         result = _build_check_result(run, job["thread_id"], thread_values)
         return _build_check_command(result, job, runtime.tool_call_id)
@@ -415,13 +440,17 @@ def _build_update_tool(
         if isinstance(tracked, str):
             return tracked
         spec = agent_map[tracked["agent_name"]]
-        client = clients.get_sync(tracked["agent_name"])
-        run = client.runs.create(
-            thread_id=tracked["thread_id"],
-            assistant_id=spec["graph_id"],
-            input={"messages": [{"role": "user", "content": message}]},
-            multitask_strategy="interrupt",
-        )
+        try:
+            client = clients.get_sync(tracked["agent_name"])
+            run = client.runs.create(
+                thread_id=tracked["thread_id"],
+                assistant_id=spec["graph_id"],
+                input={"messages": [{"role": "user", "content": message}]},
+                multitask_strategy="interrupt",
+            )
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+            logger.warning("Failed to update async subagent '%s': %s", tracked["agent_name"], e)
+            return f"Failed to update async subagent: {e}"
         job: AsyncSubAgentJob = {
             "job_id": tracked["job_id"],
             "agent_name": tracked["agent_name"],
@@ -446,13 +475,17 @@ def _build_update_tool(
         if isinstance(tracked, str):
             return tracked
         spec = agent_map[tracked["agent_name"]]
-        client = clients.get_async(tracked["agent_name"])
-        run = await client.runs.create(
-            thread_id=tracked["thread_id"],
-            assistant_id=spec["graph_id"],
-            input={"messages": [{"role": "user", "content": message}]},
-            multitask_strategy="interrupt",
-        )
+        try:
+            client = clients.get_async(tracked["agent_name"])
+            run = await client.runs.create(
+                thread_id=tracked["thread_id"],
+                assistant_id=spec["graph_id"],
+                input={"messages": [{"role": "user", "content": message}]},
+                multitask_strategy="interrupt",
+            )
+        except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+            logger.warning("Failed to update async subagent '%s': %s", tracked["agent_name"], e)
+            return f"Failed to update async subagent: {e}"
         job: AsyncSubAgentJob = {
             "job_id": tracked["job_id"],
             "agent_name": tracked["agent_name"],
@@ -549,7 +582,8 @@ def _build_cancel_tool(
     )
 
 
-_TERMINAL_STATUSES = frozenset({"cancelled", "success", "error"})
+_TERMINAL_STATUSES = frozenset({"cancelled", "success", "error", "timeout", "interrupted"})
+"""Job statuses that will never change, so live-status fetches can be skipped."""
 
 
 def _fetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> str:
@@ -561,6 +595,13 @@ def _fetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> str:
         run = client.runs.get(thread_id=job["thread_id"], run_id=job["run_id"])
         return run["status"]
     except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        logger.warning(
+            "Failed to fetch live status for job %s (agent=%s), returning cached status %r",
+            job["job_id"],
+            job["agent_name"],
+            job["status"],
+            exc_info=True,
+        )
         return job["status"]
 
 
@@ -573,6 +614,13 @@ async def _afetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> s
         run = await client.runs.get(thread_id=job["thread_id"], run_id=job["run_id"])
         return run["status"]
     except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        logger.warning(
+            "Failed to fetch live status for job %s (agent=%s), returning cached status %r",
+            job["job_id"],
+            job["agent_name"],
+            job["status"],
+            exc_info=True,
+        )
         return job["status"]
 
 
@@ -585,13 +633,16 @@ def _filter_jobs(
     jobs: dict[str, AsyncSubAgentJob],
     status_filter: str | None,
 ) -> list[AsyncSubAgentJob]:
-    """Filter jobs by status.
+    """Filter jobs by cached status from agent state.
+
+    Filtering happens on the cached status, not live server status. Live
+    statuses are fetched after filtering by the calling tool.
 
     Args:
         jobs: All tracked jobs from state.
         status_filter: If `None` or `'all'`, return all jobs.
 
-            Otherwise return only jobs whose status matches the given value.
+            Otherwise return only jobs whose cached status matches.
 
     Returns:
         Filtered list of jobs.
@@ -688,7 +739,7 @@ def _build_async_subagent_tools(
         agents: List of async subagent specifications.
 
     Returns:
-        List of StructuredTools for launch, check, update, and list operations.
+        List of StructuredTools for launch, check, update, cancel, and list operations.
     """
     agent_map: dict[str, AsyncSubAgent] = {a["name"]: a for a in agents}
     clients = _ClientCache(agent_map)
@@ -753,6 +804,12 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         super().__init__()
         if not async_subagents:
             msg = "At least one async subagent must be specified"
+            raise ValueError(msg)
+
+        names = [a["name"] for a in async_subagents]
+        dupes = {n for n in names if names.count(n) > 1}
+        if dupes:
+            msg = f"Duplicate async subagent names: {dupes}"
             raise ValueError(msg)
 
         self.tools = _build_async_subagent_tools(async_subagents)

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -38,34 +38,47 @@ class AsyncSubAgent(TypedDict):
     Authentication is handled via environment variables (`LANGGRAPH_API_KEY`,
     `LANGSMITH_API_KEY`, or `LANGCHAIN_API_KEY`), which the LangGraph SDK
     reads automatically.
-
-    Required fields:
-        name: Unique identifier for the async subagent.
-        description: What this subagent does. The main agent uses this to decide
-            when to delegate.
-        graph_id: The graph name or assistant ID on the remote server.
-
-    Optional fields:
-        url: URL of the LangGraph server (e.g., `"https://my-deployment.langsmith.dev"`).
-            Omit to use ASGI transport for local LangGraph servers.
-        headers: Additional headers to include in requests to the remote server.
     """
 
     name: str
+    """Unique identifier for the async subagent."""
+
     description: str
+    """What this subagent does.
+
+    The main agent uses this to decide when to delegate.
+    """
+
     graph_id: str
+    """The graph name or assistant ID on the remote server."""
+
     url: NotRequired[str]
+    """URL of the LangGraph server (e.g., `"https://my-deployment.langsmith.dev"`).
+
+    Omit to use ASGI transport for local LangGraph servers.
+    """
+
     headers: NotRequired[dict[str, str]]
+    """Additional headers to include in requests to the remote server."""
 
 
 class AsyncSubAgentJob(TypedDict):
     """A tracked async subagent job persisted in agent state."""
 
     job_id: str
+    """Unique identifier for the job (same as `thread_id`)."""
+
     agent_name: str
+    """Name of the async subagent type that is running."""
+
     thread_id: str
+    """LangGraph thread ID for the remote run."""
+
     run_id: str
+    """LangGraph run ID for the current execution on the thread."""
+
     status: str
+    """Current job status (e.g., `'running'`, `'success'`, `'error'`, `'cancelled'`)."""
 
 
 def _jobs_reducer(
@@ -193,7 +206,7 @@ def _build_launch_tool(
     clients: _ClientCache,
     tool_description: str,
 ) -> StructuredTool:
-    """Build the launch_async_subagent tool."""
+    """Build the `launch_async_subagent` tool."""
 
     def launch_async_subagent(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
@@ -292,7 +305,7 @@ def _build_check_command(
     job: AsyncSubAgentJob,
     tool_call_id: str | None,
 ) -> Command:
-    """Build the Command update for a check result."""
+    """Build the `Command` update for a check result."""
     updated_job = AsyncSubAgentJob(
         job_id=job["job_id"],
         agent_name=job["agent_name"],
@@ -312,7 +325,7 @@ def _resolve_tracked_job(
     job_id: str,
     runtime: ToolRuntime,
 ) -> AsyncSubAgentJob | str:
-    """Look up a tracked job from state by its job_id (thread_id).
+    """Look up a tracked job from state by its `job_id` (`thread_id`).
 
     Returns:
         The tracked `AsyncSubAgentJob` on success, or an error string.
@@ -327,7 +340,7 @@ def _resolve_tracked_job(
 def _build_check_tool(
     clients: _ClientCache,
 ) -> StructuredTool:
-    """Build the check_async_subagent tool."""
+    """Build the `check_async_subagent` tool."""
 
     def check_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
@@ -385,12 +398,12 @@ def _build_update_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
 ) -> StructuredTool:
-    """Build the update_async_subagent tool.
+    """Build the `update_async_subagent` tool.
 
-    Sends a follow-up message to an async subagent by creating a new run
-    on the same thread. The subagent sees the full conversation history
-    (including the original task and any prior results) plus the new message.
-    The job_id remains the same; only the internal run_id is updated.
+    Sends a follow-up message to an async subagent by creating a new run on the
+    same thread. The subagent sees the full conversation history (including the
+    original task and any prior results) plus the new message. The `job_id`
+    remains the same; only the internal `run_id` is updated.
     """
 
     def update_async_subagent(
@@ -470,7 +483,7 @@ def _build_update_tool(
 def _build_cancel_tool(
     clients: _ClientCache,
 ) -> StructuredTool:
-    """Build the cancel_async_subagent tool."""
+    """Build the `cancel_async_subagent` tool."""
 
     def cancel_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
@@ -576,8 +589,9 @@ def _filter_jobs(
 
     Args:
         jobs: All tracked jobs from state.
-        status_filter: If `None` or `"all"`, return all jobs. Otherwise return only
-            jobs whose status matches the given value.
+        status_filter: If `None` or `'all'`, return all jobs.
+
+            Otherwise return only jobs whose status matches the given value.
 
     Returns:
         Filtered list of jobs.
@@ -698,13 +712,15 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     `SubAgentMiddleware`, async subagents return immediately with a job ID,
     allowing the main agent to continue working while subagents execute.
 
-    Job IDs are persisted in the agent state under `async_subagent_jobs`
-    so they survive context compaction and can be accessed programmatically.
+    Job IDs are persisted in the agent state under `async_subagent_jobs` so they
+    survive context compaction/offloading and can be accessed programmatically.
 
     Args:
-        async_subagents: List of async subagent specifications. Each must
-            include `name`, `description`, and `graph_id`. `url` is optional —
-            omit it to use ASGI transport for local LangGraph servers.
+        async_subagents: List of async subagent specifications.
+
+            Each must include `name`, `description`, and `graph_id`. `url` is
+            optional — omit it to use ASGI transport for local
+            LangGraph servers.
         system_prompt: Instructions appended to the main agent's system prompt
             about how to use the async subagent tools.
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -140,6 +140,12 @@ class _ClientCache:
     def get_sync(self, name: str) -> SyncLangGraphClient:
         """Get or create a sync client for the named agent."""
         spec = self._agents[name]
+        if spec.get("url") is None:
+            msg = (
+                f"Async subagent '{name}' has no url configured. "
+                "ASGI transport (url=None) requires async invocation."
+            )
+            raise ValueError(msg)
         key = self._cache_key(spec)
         if key not in self._sync:
             self._sync[key] = get_sync_client(

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -125,6 +125,7 @@ You have access to async subagent tools that launch background jobs on remote La
   NEVER report a status from a previous tool result. ALWAYS call a tool to get the current status:
   use `list_async_subagent_jobs` when the user asks about multiple jobs or "all jobs",
   use `check_async_subagent` when the user asks about a specific job.
+- Always show the full job_id — never truncate or abbreviate it.
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -1,0 +1,367 @@
+"""Middleware for async subagents running on remote LangGraph servers.
+
+Async subagents use the LangGraph SDK to launch background runs on remote
+LangGraph deployments. Unlike synchronous subagents (which block until
+completion), async subagents return a job ID immediately, allowing the main
+agent to monitor progress and send updates while the subagent works.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypedDict
+
+from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelResponse, ResponseT
+from langchain_core.tools import StructuredTool
+from langgraph_sdk import get_client, get_sync_client
+
+from deepagents.middleware._utils import append_to_system_message
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest
+    from langgraph_sdk.client import LangGraphClient, SyncLangGraphClient
+
+
+class AsyncSubAgent(TypedDict):
+    """Specification for an async subagent running on a remote LangGraph server.
+
+    Async subagents connect to LangGraph deployments via the LangGraph SDK.
+    They run as background jobs that the main agent can monitor and update.
+
+    Required fields:
+        name: Unique identifier for the async subagent.
+        description: What this subagent does. The main agent uses this to decide
+            when to delegate.
+        url: URL of the LangGraph server (e.g., `"https://my-deployment.langsmith.dev"`).
+        graph_id: The graph name or assistant ID on the remote server.
+
+    Optional fields:
+        api_key: API key for authenticating with the remote server.
+        headers: Additional headers to include in requests to the remote server.
+    """
+
+    name: str
+    description: str
+    url: str
+    graph_id: str
+    api_key: NotRequired[str]
+    headers: NotRequired[dict[str, str]]
+
+
+ASYNC_TASK_TOOL_DESCRIPTION = """Launch an async subagent on a remote LangGraph server. The subagent runs in the background and returns a job ID immediately.
+
+Available async agent types:
+{available_agents}
+
+## Usage notes:
+1. This tool launches a background job and returns immediately with a job ID (thread_id + run_id).
+2. Use `check_async_subagent` to poll for status and results.
+3. Use `update_async_subagent` to send updates or new instructions to a running job.
+4. Multiple async subagents can run concurrently — launch several and check them periodically.
+5. The subagent runs on a remote LangGraph server, so it has its own tools and capabilities."""  # noqa: E501
+
+ASYNC_TASK_SYSTEM_PROMPT = """## Async subagents (remote LangGraph servers)
+
+You have access to async subagent tools that launch background jobs on remote LangGraph servers.
+
+### Tools:
+- `launch_async_subagent`: Start a new background job. Returns a job ID immediately.
+- `check_async_subagent`: Check the status of a running job. Returns status and result if complete.
+- `update_async_subagent`: Send an update or new instructions to a running job.
+
+### Workflow:
+1. **Launch** — Use `launch_async_subagent` to start a job. You get back a job ID.
+2. **Monitor** — Use `check_async_subagent` to poll for status. Jobs can be: pending, running, success, error, timeout, or interrupted.
+3. **Update** (optional) — Use `update_async_subagent` to send new context or instructions to a running job.
+4. **Collect** — When status is "success", the result is included in the check response.
+
+### When to use async subagents:
+- Long-running tasks that would block the main agent
+- Tasks that benefit from running on specialized remote deployments
+- When you want to run multiple tasks concurrently and collect results later"""
+
+
+class _ClientCache:
+    """Lazily-created, cached LangGraph SDK clients keyed by agent name."""
+
+    def __init__(self, agents: dict[str, AsyncSubAgent]) -> None:
+        self._agents = agents
+        self._sync: dict[str, SyncLangGraphClient] = {}
+        self._async: dict[str, LangGraphClient] = {}
+
+    def sync(self, name: str) -> SyncLangGraphClient:
+        """Get or create a sync client for the named agent."""
+        if name not in self._sync:
+            spec = self._agents[name]
+            self._sync[name] = get_sync_client(
+                url=spec["url"],
+                api_key=spec.get("api_key"),
+                headers=spec.get("headers"),
+            )
+        return self._sync[name]
+
+    def async_(self, name: str) -> LangGraphClient:
+        """Get or create an async client for the named agent."""
+        if name not in self._async:
+            spec = self._agents[name]
+            self._async[name] = get_client(
+                url=spec["url"],
+                api_key=spec.get("api_key"),
+                headers=spec.get("headers"),
+            )
+        return self._async[name]
+
+
+def _format_job_id(thread_id: str, run_id: str) -> str:
+    return json.dumps({"thread_id": thread_id, "run_id": run_id})
+
+
+def _parse_job_id(job_id: str) -> tuple[str, str]:
+    data = json.loads(job_id)
+    return data["thread_id"], data["run_id"]
+
+
+def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -> str | None:
+    if agent_type not in agent_map:
+        allowed = ", ".join(f"`{k}`" for k in agent_map)
+        return f"Unknown async subagent type `{agent_type}`. Available types: {allowed}"
+    return None
+
+
+def _build_launch_tool(
+    agent_map: dict[str, AsyncSubAgent],
+    clients: _ClientCache,
+    description: str,
+) -> StructuredTool:
+    """Build the launch_async_subagent tool."""
+
+    def launch_async_subagent(
+        description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
+        subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types."],
+    ) -> str:
+        error = _validate_agent_type(agent_map, subagent_type)
+        if error:
+            return error
+        spec = agent_map[subagent_type]
+        client = clients.sync(subagent_type)
+        thread = client.threads.create()
+        run = client.runs.create(
+            thread_id=thread["thread_id"],
+            assistant_id=spec["graph_id"],
+            input={"messages": [{"role": "user", "content": description}]},
+        )
+        return _format_job_id(thread["thread_id"], run["run_id"])
+
+    async def alaunch_async_subagent(
+        description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
+        subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types."],
+    ) -> str:
+        error = _validate_agent_type(agent_map, subagent_type)
+        if error:
+            return error
+        spec = agent_map[subagent_type]
+        client = clients.async_(subagent_type)
+        thread = await client.threads.create()
+        run = await client.runs.create(
+            thread_id=thread["thread_id"],
+            assistant_id=spec["graph_id"],
+            input={"messages": [{"role": "user", "content": description}]},
+        )
+        return _format_job_id(thread["thread_id"], run["run_id"])
+
+    return StructuredTool.from_function(
+        name="launch_async_subagent",
+        func=launch_async_subagent,
+        coroutine=alaunch_async_subagent,
+        description=description,
+    )
+
+
+def _build_check_tool(
+    agent_map: dict[str, AsyncSubAgent],
+    clients: _ClientCache,
+) -> StructuredTool:
+    """Build the check_async_subagent tool."""
+    first_name = next(iter(agent_map))
+
+    def check_async_subagent(
+        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+    ) -> str:
+        thread_id, run_id = _parse_job_id(job_id)
+        client = clients.sync(first_name)
+        run = client.runs.get(thread_id=thread_id, run_id=run_id)
+        result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
+        if run["status"] == "success":
+            state = client.threads.get_state(thread_id=thread_id)
+            values = state.get("values", {})
+            messages = values.get("messages", []) if isinstance(values, dict) else []
+            if messages:
+                last = messages[-1]
+                result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
+        elif run["status"] == "error":
+            result["error"] = "The async subagent encountered an error."
+        return json.dumps(result)
+
+    async def acheck_async_subagent(
+        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+    ) -> str:
+        thread_id, run_id = _parse_job_id(job_id)
+        client = clients.async_(first_name)
+        run = await client.runs.get(thread_id=thread_id, run_id=run_id)
+        result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
+        if run["status"] == "success":
+            state = await client.threads.get_state(thread_id=thread_id)
+            values = state.get("values", {})
+            messages = values.get("messages", []) if isinstance(values, dict) else []
+            if messages:
+                last = messages[-1]
+                result["result"] = last.get("content", "") if isinstance(last, dict) else str(last)
+        elif run["status"] == "error":
+            result["error"] = "The async subagent encountered an error."
+        return json.dumps(result)
+
+    return StructuredTool.from_function(
+        name="check_async_subagent",
+        func=check_async_subagent,
+        coroutine=acheck_async_subagent,
+        description="Check the status of an async subagent job. Returns the current status and, if complete, the result.",
+    )
+
+
+def _build_update_tool(
+    agent_map: dict[str, AsyncSubAgent],
+    clients: _ClientCache,
+) -> StructuredTool:
+    """Build the update_async_subagent tool."""
+    first_name = next(iter(agent_map))
+
+    def update_async_subagent(
+        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+        update: Annotated[str, "New instructions or context to send to the running subagent."],
+    ) -> str:
+        thread_id, _run_id = _parse_job_id(job_id)
+        client = clients.sync(first_name)
+        client.threads.update_state(
+            thread_id=thread_id,
+            values={"messages": [{"role": "user", "content": update}]},
+        )
+        return json.dumps({"status": "updated", "thread_id": thread_id})
+
+    async def aupdate_async_subagent(
+        job_id: Annotated[str, "The job ID returned by launch_async_subagent."],
+        update: Annotated[str, "New instructions or context to send to the running subagent."],
+    ) -> str:
+        thread_id, _run_id = _parse_job_id(job_id)
+        client = clients.async_(first_name)
+        await client.threads.update_state(
+            thread_id=thread_id,
+            values={"messages": [{"role": "user", "content": update}]},
+        )
+        return json.dumps({"status": "updated", "thread_id": thread_id})
+
+    return StructuredTool.from_function(
+        name="update_async_subagent",
+        func=update_async_subagent,
+        coroutine=aupdate_async_subagent,
+        description="Send an update or new instructions to a running async subagent job.",
+    )
+
+
+def _build_async_subagent_tools(
+    agents: list[AsyncSubAgent],
+) -> list[StructuredTool]:
+    """Build the three async subagent tools from agent specs.
+
+    Args:
+        agents: List of async subagent specifications.
+
+    Returns:
+        List of StructuredTools for launch, check, and update operations.
+    """
+    agent_map: dict[str, AsyncSubAgent] = {a["name"]: a for a in agents}
+    clients = _ClientCache(agent_map)
+    agents_desc = "\n".join(f"- {a['name']}: {a['description']}" for a in agents)
+    launch_desc = ASYNC_TASK_TOOL_DESCRIPTION.format(available_agents=agents_desc)
+
+    return [
+        _build_launch_tool(agent_map, clients, launch_desc),
+        _build_check_tool(agent_map, clients),
+        _build_update_tool(agent_map, clients),
+    ]
+
+
+class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
+    """Middleware for async subagents running on remote LangGraph servers.
+
+    This middleware adds tools for launching, monitoring, and updating
+    background jobs on remote LangGraph deployments. Unlike the synchronous
+    `SubAgentMiddleware`, async subagents return immediately with a job ID,
+    allowing the main agent to continue working while subagents execute.
+
+    Args:
+        async_subagents: List of async subagent specifications. Each must
+            include `name`, `description`, `url`, and `graph_id`.
+        system_prompt: Instructions appended to the main agent's system prompt
+            about how to use the async subagent tools.
+
+    Example:
+        ```python
+        from deepagents.middleware.async_subagents import AsyncSubAgentMiddleware
+
+        middleware = AsyncSubAgentMiddleware(
+            async_subagents=[
+                {
+                    "name": "researcher",
+                    "description": "Research agent for deep analysis",
+                    "url": "https://my-deployment.langsmith.dev",
+                    "graph_id": "research_agent",
+                    "api_key": "my-api-key",
+                }
+            ],
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        async_subagents: list[AsyncSubAgent],
+        system_prompt: str | None = ASYNC_TASK_SYSTEM_PROMPT,
+    ) -> None:
+        """Initialize the `AsyncSubAgentMiddleware`."""
+        super().__init__()
+        if not async_subagents:
+            msg = "At least one async subagent must be specified"
+            raise ValueError(msg)
+
+        self.tools = _build_async_subagent_tools(async_subagents)
+
+        if system_prompt and async_subagents:
+            agents_desc = "\n".join(f"- {a['name']}: {a['description']}" for a in async_subagents)
+            self.system_prompt: str | None = system_prompt + "\n\nAvailable async subagent types:\n" + agents_desc
+        else:
+            self.system_prompt = system_prompt
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT]:
+        """Update the system message to include async subagent instructions."""
+        if self.system_prompt is not None:
+            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
+            return handler(request.override(system_message=new_system_message))
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """(async) Update the system message to include async subagent instructions."""
+        if self.system_prompt is not None:
+            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
+            return await handler(request.override(system_message=new_system_message))
+        return await handler(request)

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -133,7 +133,7 @@ class _ClientCache:
         self._sync: dict[str, SyncLangGraphClient] = {}
         self._async: dict[str, LangGraphClient] = {}
 
-    def sync(self, name: str) -> SyncLangGraphClient:
+    def get_sync(self, name: str) -> SyncLangGraphClient:
         """Get or create a sync client for the named agent."""
         if name not in self._sync:
             spec = self._agents[name]
@@ -143,7 +143,7 @@ class _ClientCache:
             )
         return self._sync[name]
 
-    def async_(self, name: str) -> LangGraphClient:
+    def get_async(self, name: str) -> LangGraphClient:
         """Get or create an async client for the named agent."""
         if name not in self._async:
             spec = self._agents[name]
@@ -209,14 +209,14 @@ def _build_launch_tool(
 
     def launch_async_subagent(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
-        subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types."],
+        subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types listed in the tool description."],
         runtime: ToolRuntime,
     ) -> str | Command:
         error = _validate_agent_type(agent_map, subagent_type)
         if error:
             return error
         spec = agent_map[subagent_type]
-        client = clients.sync(subagent_type)
+        client = clients.get_sync(subagent_type)
         thread = client.threads.create()
         run = client.runs.create(
             thread_id=thread["thread_id"],
@@ -241,14 +241,14 @@ def _build_launch_tool(
 
     async def alaunch_async_subagent(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
-        subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types."],
+        subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types listed in the tool description."],
         runtime: ToolRuntime,
     ) -> str | Command:
         error = _validate_agent_type(agent_map, subagent_type)
         if error:
             return error
         spec = agent_map[subagent_type]
-        client = clients.async_(subagent_type)
+        client = clients.get_async(subagent_type)
         thread = await client.threads.create()
         run = await client.runs.create(
             thread_id=thread["thread_id"],
@@ -283,6 +283,9 @@ def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -
     """Resolve the client name from a parsed job_id agent_name field."""
     if agent_name and agent_name in agent_map:
         return agent_name
+    if agent_name:
+        msg = f"Unknown agent '{agent_name}' in job_id. Available: {', '.join(agent_map)}"
+        raise ValueError(msg)
     return next(iter(agent_map))
 
 
@@ -298,7 +301,7 @@ def _build_check_tool(
     ) -> Command:
         agent_name, thread_id, run_id = _parse_job_id(job_id)
         name = _resolve_client_name(agent_name, agent_map)
-        client = clients.sync(name)
+        client = clients.get_sync(name)
         run = client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
@@ -331,7 +334,7 @@ def _build_check_tool(
     ) -> Command:
         agent_name, thread_id, run_id = _parse_job_id(job_id)
         name = _resolve_client_name(agent_name, agent_map)
-        client = clients.async_(name)
+        client = clients.get_async(name)
         run = await client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
@@ -386,7 +389,7 @@ def _build_update_tool(
         agent_name, thread_id, _run_id = _parse_job_id(job_id)
         name = _resolve_client_name(agent_name, agent_map)
         spec = agent_map[name]
-        client = clients.sync(name)
+        client = clients.get_sync(name)
         run = client.runs.create(
             thread_id=thread_id,
             assistant_id=spec["graph_id"],
@@ -417,7 +420,7 @@ def _build_update_tool(
         agent_name, thread_id, _run_id = _parse_job_id(job_id)
         name = _resolve_client_name(agent_name, agent_map)
         spec = agent_map[name]
-        client = clients.async_(name)
+        client = clients.get_async(name)
         run = await client.runs.create(
             thread_id=thread_id,
             assistant_id=spec["graph_id"],

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -101,12 +101,14 @@ You have access to async subagent tools that launch background jobs on remote La
 - `launch_async_subagent`: Start a new background job. Returns a job ID immediately.
 - `check_async_subagent`: Check the status of a running job. Returns status and result if complete.
 - `update_async_subagent`: Send an update or new instructions to a running job.
+- `list_async_subagent_jobs`: List all tracked jobs and their last-known statuses. Use this to recall job IDs.
 
 ### Workflow:
 1. **Launch** — Use `launch_async_subagent` to start a job. You get back a job ID.
 2. **Monitor** — Use `check_async_subagent` to poll for status. Jobs can be: pending, running, success, error, timeout, or interrupted.
 3. **Update** (optional) — Use `update_async_subagent` to send new context or instructions to a running job.
 4. **Collect** — When status is "success", the result is included in the check response.
+5. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
 
 ### When to use async subagents:
 - Long-running tasks that would block the main agent
@@ -449,16 +451,40 @@ def _build_update_tool(
     )
 
 
+def _build_list_jobs_tool() -> StructuredTool:
+    """Build the list_async_subagent_jobs tool."""
+
+    def list_async_subagent_jobs(runtime: ToolRuntime) -> str:
+        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+        if not jobs:
+            return "No async subagent jobs tracked."
+        entries = [f"- job_id: {job['job_id']}  agent: {job['agent_name']}  status: {job['status']}" for job in jobs.values()]
+        return f"{len(entries)} tracked job(s):\n" + "\n".join(entries)
+
+    async def alist_async_subagent_jobs(runtime: ToolRuntime) -> str:
+        return list_async_subagent_jobs(runtime=runtime)
+
+    return StructuredTool.from_function(
+        name="list_async_subagent_jobs",
+        func=list_async_subagent_jobs,
+        coroutine=alist_async_subagent_jobs,
+        description=(
+            "List all tracked async subagent jobs and their last-known statuses. "
+            "Use this to recall job IDs after context compaction or to see what jobs are in flight."
+        ),
+    )
+
+
 def _build_async_subagent_tools(
     agents: list[AsyncSubAgent],
 ) -> list[StructuredTool]:
-    """Build the three async subagent tools from agent specs.
+    """Build the async subagent tools from agent specs.
 
     Args:
         agents: List of async subagent specifications.
 
     Returns:
-        List of StructuredTools for launch, check, and update operations.
+        List of StructuredTools for launch, check, update, and list operations.
     """
     agent_map: dict[str, AsyncSubAgent] = {a["name"]: a for a in agents}
     clients = _ClientCache(agent_map)
@@ -469,6 +495,7 @@ def _build_async_subagent_tools(
         _build_launch_tool(agent_map, clients, launch_desc),
         _build_check_tool(agent_map, clients),
         _build_update_tool(agent_map, clients),
+        _build_list_jobs_tool(),
     ]
 
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -179,36 +179,6 @@ class _ClientCache:
         return self._async[key]
 
 
-_JOB_ID_SEP = "::"
-
-
-def _format_job_id(agent_name: str, thread_id: str) -> str:
-    return f"{agent_name}{_JOB_ID_SEP}{thread_id}"
-
-
-_JOB_ID_PREFIX = "job_id: "
-
-
-def _parse_job_id(job_id: str) -> tuple[str, str]:
-    """Parse a job ID into (agent_name, thread_id).
-
-    Handles multiple formats the LLM might pass:
-    - `agent::thread_abc` (canonical, 2-part)
-    - `Launched async subagent. job_id: agent::thread_abc` (full launch output)
-    - `agent::thread_abc::run_xyz` (legacy 3-part, run_id ignored)
-    """
-    raw = job_id.strip()
-    idx = raw.find(_JOB_ID_PREFIX)
-    if idx != -1:
-        raw = raw[idx + len(_JOB_ID_PREFIX) :].strip()
-    if _JOB_ID_SEP in raw:
-        parts = raw.split(_JOB_ID_SEP)
-        if len(parts) >= 2:  # noqa: PLR2004
-            return parts[0], parts[1]
-    msg = f"Invalid job_id format: {job_id!r}. Expected the exact job_id string returned by launch_async_subagent."
-    raise ValueError(msg)
-
-
 def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -> str | None:
     if agent_type not in agent_map:
         allowed = ", ".join(f"`{k}`" for k in agent_map)
@@ -239,11 +209,11 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        job_id = _format_job_id(subagent_type, thread["thread_id"])
+        job_id = thread["thread_id"]
         job: AsyncSubAgentJob = {
             "job_id": job_id,
             "agent_name": subagent_type,
-            "thread_id": thread["thread_id"],
+            "thread_id": job_id,
             "run_id": run["run_id"],
             "status": "running",
         }
@@ -271,11 +241,11 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        job_id = _format_job_id(subagent_type, thread["thread_id"])
+        job_id = thread["thread_id"]
         job: AsyncSubAgentJob = {
             "job_id": job_id,
             "agent_name": subagent_type,
-            "thread_id": thread["thread_id"],
+            "thread_id": job_id,
             "run_id": run["run_id"],
             "status": "running",
         }
@@ -293,14 +263,6 @@ def _build_launch_tool(
         coroutine=alaunch_async_subagent,
         description=description,
     )
-
-
-def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -> str:
-    """Resolve the client name from a parsed job_id agent_name field."""
-    if agent_name in agent_map:
-        return agent_name
-    msg = f"Unknown agent '{agent_name}' in job_id. Available: {', '.join(agent_map)}"
-    raise ValueError(msg)
 
 
 def _build_check_result(
@@ -344,46 +306,23 @@ def _build_check_command(
     )
 
 
-def _parse_and_resolve(
-    job_id: str,
-    agent_map: dict[str, AsyncSubAgent],
-) -> tuple[str, str] | str:
-    """Parse a job_id and resolve the agent name. Returns (name, thread_id) or an error string."""
-    try:
-        agent_name, thread_id = _parse_job_id(job_id)
-    except ValueError as e:
-        return str(e)
-    try:
-        name = _resolve_client_name(agent_name, agent_map)
-    except ValueError as e:
-        return str(e)
-    return name, thread_id
-
-
 def _resolve_tracked_job(
     job_id: str,
-    agent_map: dict[str, AsyncSubAgent],
     runtime: ToolRuntime,
 ) -> AsyncSubAgentJob | str:
-    """Parse job_id, resolve agent, and look up the tracked job from state.
+    """Look up a tracked job from state by its job_id (thread_id).
 
     Returns:
         The tracked `AsyncSubAgentJob` on success, or an error string.
     """
-    parsed = _parse_and_resolve(job_id, agent_map)
-    if isinstance(parsed, str):
-        return parsed
-    name, thread_id = parsed
-    canonical = _format_job_id(name, thread_id)
     jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
-    tracked = jobs.get(canonical)
+    tracked = jobs.get(job_id.strip())
     if not tracked:
-        return f"No tracked job found for job_id: {job_id}"
+        return f"No tracked job found for job_id: {job_id!r}"
     return tracked
 
 
 def _build_check_tool(
-    agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
 ) -> StructuredTool:
     """Build the check_async_subagent tool."""
@@ -392,10 +331,9 @@ def _build_check_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
-        if isinstance(resolved, str):
-            return resolved
-        job = resolved
+        job = _resolve_tracked_job(job_id, runtime)
+        if isinstance(job, str):
+            return job
 
         client = clients.get_sync(job["agent_name"])
         try:
@@ -415,10 +353,9 @@ def _build_check_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
-        if isinstance(resolved, str):
-            return resolved
-        job = resolved
+        job = _resolve_tracked_job(job_id, runtime)
+        if isinstance(job, str):
+            return job
 
         client = clients.get_async(job["agent_name"])
         try:
@@ -459,31 +396,29 @@ def _build_update_tool(
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        parsed = _parse_and_resolve(job_id, agent_map)
-        if isinstance(parsed, str):
-            return parsed
-        name, thread_id = parsed
-        spec = agent_map[name]
-        client = clients.get_sync(name)
+        tracked = _resolve_tracked_job(job_id, runtime)
+        if isinstance(tracked, str):
+            return tracked
+        spec = agent_map[tracked["agent_name"]]
+        client = clients.get_sync(tracked["agent_name"])
         run = client.runs.create(
-            thread_id=thread_id,
+            thread_id=tracked["thread_id"],
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": message}]},
             multitask_strategy="interrupt",
         )
-        canonical = _format_job_id(name, thread_id)
         job: AsyncSubAgentJob = {
-            "job_id": canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
+            "job_id": tracked["job_id"],
+            "agent_name": tracked["agent_name"],
+            "thread_id": tracked["thread_id"],
             "run_id": run["run_id"],
             "status": "running",
         }
-        msg = f"Updated async subagent. job_id: {canonical}"
+        msg = f"Updated async subagent. job_id: {tracked['job_id']}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {canonical: job},
+                "async_subagent_jobs": {tracked["job_id"]: job},
             }
         )
 
@@ -492,31 +427,29 @@ def _build_update_tool(
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        parsed = _parse_and_resolve(job_id, agent_map)
-        if isinstance(parsed, str):
-            return parsed
-        name, thread_id = parsed
-        spec = agent_map[name]
-        client = clients.get_async(name)
+        tracked = _resolve_tracked_job(job_id, runtime)
+        if isinstance(tracked, str):
+            return tracked
+        spec = agent_map[tracked["agent_name"]]
+        client = clients.get_async(tracked["agent_name"])
         run = await client.runs.create(
-            thread_id=thread_id,
+            thread_id=tracked["thread_id"],
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": message}]},
             multitask_strategy="interrupt",
         )
-        canonical = _format_job_id(name, thread_id)
         job: AsyncSubAgentJob = {
-            "job_id": canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
+            "job_id": tracked["job_id"],
+            "agent_name": tracked["agent_name"],
+            "thread_id": tracked["thread_id"],
             "run_id": run["run_id"],
             "status": "running",
         }
-        msg = f"Updated async subagent. job_id: {canonical}"
+        msg = f"Updated async subagent. job_id: {tracked['job_id']}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {canonical: job},
+                "async_subagent_jobs": {tracked["job_id"]: job},
             }
         )
 
@@ -533,7 +466,6 @@ def _build_update_tool(
 
 
 def _build_cancel_tool(
-    agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
 ) -> StructuredTool:
     """Build the cancel_async_subagent tool."""
@@ -542,10 +474,9 @@ def _build_cancel_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
-        if isinstance(resolved, str):
-            return resolved
-        tracked = resolved
+        tracked = _resolve_tracked_job(job_id, runtime)
+        if isinstance(tracked, str):
+            return tracked
 
         client = clients.get_sync(tracked["agent_name"])
         try:
@@ -571,10 +502,9 @@ def _build_cancel_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        resolved = _resolve_tracked_job(job_id, agent_map, runtime)
-        if isinstance(resolved, str):
-            return resolved
-        tracked = resolved
+        tracked = _resolve_tracked_job(job_id, runtime)
+        if isinstance(tracked, str):
+            return tracked
 
         client = clients.get_async(tracked["agent_name"])
         try:
@@ -718,9 +648,9 @@ def _build_async_subagent_tools(
 
     return [
         _build_launch_tool(agent_map, clients, launch_desc),
-        _build_check_tool(agent_map, clients),
+        _build_check_tool(clients),
         _build_update_tool(agent_map, clients),
-        _build_cancel_tool(agent_map, clients),
+        _build_cancel_tool(clients),
         _build_list_jobs_tool(clients),
     ]
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -430,7 +430,7 @@ def _build_update_tool(
         runtime: ToolRuntime,
     ) -> str | Command:
         try:
-            agent_name, thread_id, _run_id = _parse_job_id(job_id)
+            agent_name, thread_id, old_run_id = _parse_job_id(job_id)
         except ValueError as e:
             return str(e)
         try:
@@ -445,19 +445,27 @@ def _build_update_tool(
             input={"messages": [{"role": "user", "content": message}]},
             multitask_strategy="interrupt",
         )
+        old_canonical = _format_job_id(name, thread_id, old_run_id)
         new_job_id = _format_job_id(name, thread_id, run["run_id"])
-        job: AsyncSubAgentJob = {
+        old_job: AsyncSubAgentJob = {
+            "job_id": old_canonical,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": old_run_id,
+            "status": "superseded",
+        }
+        new_job: AsyncSubAgentJob = {
             "job_id": new_job_id,
             "agent_name": name,
             "thread_id": thread_id,
             "run_id": run["run_id"],
             "status": "running",
         }
-        msg = f"Follow-up sent. New job_id: {new_job_id}"
+        msg = f"Updated async subagent. Old job superseded. New job_id: {new_job_id}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {new_job_id: job},
+                "async_subagent_jobs": {old_canonical: old_job, new_job_id: new_job},
             }
         )
 
@@ -467,7 +475,7 @@ def _build_update_tool(
         runtime: ToolRuntime,
     ) -> str | Command:
         try:
-            agent_name, thread_id, _run_id = _parse_job_id(job_id)
+            agent_name, thread_id, old_run_id = _parse_job_id(job_id)
         except ValueError as e:
             return str(e)
         try:
@@ -482,19 +490,27 @@ def _build_update_tool(
             input={"messages": [{"role": "user", "content": message}]},
             multitask_strategy="interrupt",
         )
+        old_canonical = _format_job_id(name, thread_id, old_run_id)
         new_job_id = _format_job_id(name, thread_id, run["run_id"])
-        job: AsyncSubAgentJob = {
+        old_job: AsyncSubAgentJob = {
+            "job_id": old_canonical,
+            "agent_name": name,
+            "thread_id": thread_id,
+            "run_id": old_run_id,
+            "status": "superseded",
+        }
+        new_job: AsyncSubAgentJob = {
             "job_id": new_job_id,
             "agent_name": name,
             "thread_id": thread_id,
             "run_id": run["run_id"],
             "status": "running",
         }
-        msg = f"Follow-up sent. New job_id: {new_job_id}"
+        msg = f"Updated async subagent. Old job superseded. New job_id: {new_job_id}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {new_job_id: job},
+                "async_subagent_jobs": {old_canonical: old_job, new_job_id: new_job},
             }
         )
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -112,7 +112,7 @@ You have access to async subagent tools that launch background jobs on remote La
 2. **Check (on request)** — Only use `check_async_subagent` when the user explicitly asks for a status update or
    result. If the status is "running", report that and stop — do not poll in a loop.
 3. **Update** (optional) — Use `update_async_subagent` to send new instructions to a running job. This interrupts
-   the current run and starts a fresh one on the same thread. Use the new job_id it returns going forward.
+   the current run and starts a fresh one on the same thread. The job_id stays the same.
 4. **Cancel** (optional) — Use `cancel_async_subagent` to stop a job that is no longer needed.
 5. **Collect** — When `check_async_subagent` returns status "success", the result is included in the response.
 6. **Recall** — Use `list_async_subagent_jobs` if you need to recall job IDs (e.g., after context compaction).
@@ -179,21 +179,20 @@ class _ClientCache:
 _JOB_ID_SEP = "::"
 
 
-def _format_job_id(agent_name: str, thread_id: str, run_id: str) -> str:
-    return f"{agent_name}{_JOB_ID_SEP}{thread_id}{_JOB_ID_SEP}{run_id}"
+def _format_job_id(agent_name: str, thread_id: str) -> str:
+    return f"{agent_name}{_JOB_ID_SEP}{thread_id}"
 
 
 _JOB_ID_PREFIX = "job_id: "
 
 
-def _parse_job_id(job_id: str) -> tuple[str, str, str]:
-    """Parse a job ID into (agent_name, thread_id, run_id).
+def _parse_job_id(job_id: str) -> tuple[str, str]:
+    """Parse a job ID into (agent_name, thread_id).
 
     Handles multiple formats the LLM might pass:
-    - `agent::thread_abc::run_xyz` (canonical, 3-part)
-    - `Launched async subagent. job_id: agent::thread_abc::run_xyz` (full launch output)
-    - `thread_abc::run_xyz` (legacy 2-part, agent defaults to empty)
-    - `{"thread_id": "...", "run_id": "..."}` (legacy JSON)
+    - `agent::thread_abc` (canonical, 2-part)
+    - `Launched async subagent. job_id: agent::thread_abc` (full launch output)
+    - `agent::thread_abc::run_xyz` (legacy 3-part, run_id ignored)
     """
     raw = job_id.strip()
     idx = raw.find(_JOB_ID_PREFIX)
@@ -201,16 +200,8 @@ def _parse_job_id(job_id: str) -> tuple[str, str, str]:
         raw = raw[idx + len(_JOB_ID_PREFIX) :].strip()
     if _JOB_ID_SEP in raw:
         parts = raw.split(_JOB_ID_SEP)
-        if len(parts) >= 3:  # noqa: PLR2004
-            return parts[0], parts[1], parts[2]
-        if len(parts) == 2:  # noqa: PLR2004
-            return "", parts[0], parts[1]
-    try:
-        data = json.loads(raw)
-        if isinstance(data, dict):
-            return "", data["thread_id"], data["run_id"]
-    except (json.JSONDecodeError, KeyError):
-        pass
+        if len(parts) >= 2:  # noqa: PLR2004
+            return parts[0], parts[1]
     msg = f"Invalid job_id format: {job_id!r}. Expected the exact job_id string returned by launch_async_subagent."
     raise ValueError(msg)
 
@@ -245,7 +236,7 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        job_id = _format_job_id(subagent_type, thread["thread_id"], run["run_id"])
+        job_id = _format_job_id(subagent_type, thread["thread_id"])
         job: AsyncSubAgentJob = {
             "job_id": job_id,
             "agent_name": subagent_type,
@@ -277,7 +268,7 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        job_id = _format_job_id(subagent_type, thread["thread_id"], run["run_id"])
+        job_id = _format_job_id(subagent_type, thread["thread_id"])
         job: AsyncSubAgentJob = {
             "job_id": job_id,
             "agent_name": subagent_type,
@@ -319,7 +310,6 @@ def _build_check_result(
     """Build the result dict from a completed run and its thread values."""
     result: dict[str, Any] = {
         "status": run["status"],
-        "run_id": run["run_id"],
         "thread_id": thread_id,
     }
     if run["status"] == "success":
@@ -334,15 +324,15 @@ def _build_check_result(
 
 def _build_check_command(
     result: dict[str, Any],
+    job_id: str,
     name: str,
     thread_id: str,
     run_id: str,
     tool_call_id: str | None,
 ) -> Command:
     """Build the Command update for a check result."""
-    canonical = _format_job_id(name, thread_id, run_id)
     job: AsyncSubAgentJob = {
-        "job_id": canonical,
+        "job_id": job_id,
         "agent_name": name,
         "thread_id": thread_id,
         "run_id": run_id,
@@ -351,7 +341,7 @@ def _build_check_command(
     return Command(
         update={
             "messages": [ToolMessage(json.dumps(result), tool_call_id=tool_call_id)],
-            "async_subagent_jobs": {canonical: job},
+            "async_subagent_jobs": {job_id: job},
         }
     )
 
@@ -359,17 +349,17 @@ def _build_check_command(
 def _parse_and_resolve(
     job_id: str,
     agent_map: dict[str, AsyncSubAgent],
-) -> tuple[str, str, str] | str:
-    """Parse a job_id and resolve the agent name. Returns (name, thread_id, run_id) or an error string."""
+) -> tuple[str, str] | str:
+    """Parse a job_id and resolve the agent name. Returns (name, thread_id) or an error string."""
     try:
-        agent_name, thread_id, run_id = _parse_job_id(job_id)
+        agent_name, thread_id = _parse_job_id(job_id)
     except ValueError as e:
         return str(e)
     try:
         name = _resolve_client_name(agent_name, agent_map)
     except ValueError as e:
         return str(e)
-    return name, thread_id, run_id
+    return name, thread_id
 
 
 def _build_check_tool(
@@ -385,7 +375,15 @@ def _build_check_tool(
         parsed = _parse_and_resolve(job_id, agent_map)
         if isinstance(parsed, str):
             return parsed
-        name, thread_id, run_id = parsed
+        name, thread_id = parsed
+
+        # Look up the current run_id from state
+        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+        canonical = _format_job_id(name, thread_id)
+        tracked = jobs.get(canonical)
+        if not tracked:
+            return f"No tracked job found for job_id: {job_id}"
+        run_id = tracked["run_id"]
 
         client = clients.get_sync(name)
         try:
@@ -399,7 +397,7 @@ def _build_check_tool(
             thread_values = thread.get("values") or {}
 
         result = _build_check_result(run, thread_id, thread_values)
-        return _build_check_command(result, name, thread_id, run_id, runtime.tool_call_id)
+        return _build_check_command(result, canonical, name, thread_id, run_id, runtime.tool_call_id)
 
     async def acheck_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
@@ -408,7 +406,15 @@ def _build_check_tool(
         parsed = _parse_and_resolve(job_id, agent_map)
         if isinstance(parsed, str):
             return parsed
-        name, thread_id, run_id = parsed
+        name, thread_id = parsed
+
+        # Look up the current run_id from state
+        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+        canonical = _format_job_id(name, thread_id)
+        tracked = jobs.get(canonical)
+        if not tracked:
+            return f"No tracked job found for job_id: {job_id}"
+        run_id = tracked["run_id"]
 
         client = clients.get_async(name)
         try:
@@ -422,7 +428,7 @@ def _build_check_tool(
             thread_values = thread.get("values") or {}
 
         result = _build_check_result(run, thread_id, thread_values)
-        return _build_check_command(result, name, thread_id, run_id, runtime.tool_call_id)
+        return _build_check_command(result, canonical, name, thread_id, run_id, runtime.tool_call_id)
 
     return StructuredTool.from_function(
         name="check_async_subagent",
@@ -445,18 +451,14 @@ def _build_update_tool(
     """
 
     def update_async_subagent(
-        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent or a previous update. Pass it verbatim."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        try:
-            agent_name, thread_id, old_run_id = _parse_job_id(job_id)
-        except ValueError as e:
-            return str(e)
-        try:
-            name = _resolve_client_name(agent_name, agent_map)
-        except ValueError as e:
-            return str(e)
+        parsed = _parse_and_resolve(job_id, agent_map)
+        if isinstance(parsed, str):
+            return parsed
+        name, thread_id = parsed
         spec = agent_map[name]
         client = clients.get_sync(name)
         run = client.runs.create(
@@ -465,43 +467,31 @@ def _build_update_tool(
             input={"messages": [{"role": "user", "content": message}]},
             multitask_strategy="interrupt",
         )
-        old_canonical = _format_job_id(name, thread_id, old_run_id)
-        new_job_id = _format_job_id(name, thread_id, run["run_id"])
-        old_job: AsyncSubAgentJob = {
-            "job_id": old_canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
-            "run_id": old_run_id,
-            "status": "superseded",
-        }
-        new_job: AsyncSubAgentJob = {
-            "job_id": new_job_id,
+        canonical = _format_job_id(name, thread_id)
+        job: AsyncSubAgentJob = {
+            "job_id": canonical,
             "agent_name": name,
             "thread_id": thread_id,
             "run_id": run["run_id"],
             "status": "running",
         }
-        msg = f"Updated async subagent. Old job superseded. New job_id: {new_job_id}"
+        msg = f"Updated async subagent. job_id: {canonical}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {old_canonical: old_job, new_job_id: new_job},
+                "async_subagent_jobs": {canonical: job},
             }
         )
 
     async def aupdate_async_subagent(
-        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent or a previous update. Pass it verbatim."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        try:
-            agent_name, thread_id, old_run_id = _parse_job_id(job_id)
-        except ValueError as e:
-            return str(e)
-        try:
-            name = _resolve_client_name(agent_name, agent_map)
-        except ValueError as e:
-            return str(e)
+        parsed = _parse_and_resolve(job_id, agent_map)
+        if isinstance(parsed, str):
+            return parsed
+        name, thread_id = parsed
         spec = agent_map[name]
         client = clients.get_async(name)
         run = await client.runs.create(
@@ -510,27 +500,19 @@ def _build_update_tool(
             input={"messages": [{"role": "user", "content": message}]},
             multitask_strategy="interrupt",
         )
-        old_canonical = _format_job_id(name, thread_id, old_run_id)
-        new_job_id = _format_job_id(name, thread_id, run["run_id"])
-        old_job: AsyncSubAgentJob = {
-            "job_id": old_canonical,
-            "agent_name": name,
-            "thread_id": thread_id,
-            "run_id": old_run_id,
-            "status": "superseded",
-        }
-        new_job: AsyncSubAgentJob = {
-            "job_id": new_job_id,
+        canonical = _format_job_id(name, thread_id)
+        job: AsyncSubAgentJob = {
+            "job_id": canonical,
             "agent_name": name,
             "thread_id": thread_id,
             "run_id": run["run_id"],
             "status": "running",
         }
-        msg = f"Updated async subagent. Old job superseded. New job_id: {new_job_id}"
+        msg = f"Updated async subagent. job_id: {canonical}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_subagent_jobs": {old_canonical: old_job, new_job_id: new_job},
+                "async_subagent_jobs": {canonical: job},
             }
         )
 
@@ -541,8 +523,7 @@ def _build_update_tool(
         description=(
             "Send updated instructions to an async subagent. Interrupts the current run and starts "
             "a new one on the same thread, so the subagent sees the full conversation history plus "
-            "your new message. The original job_id will show as 'interrupted'. "
-            "Returns a new job_id to track the updated run."
+            "your new message. The job_id remains the same."
         ),
     )
 
@@ -557,20 +538,23 @@ def _build_cancel_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        try:
-            agent_name, thread_id, run_id = _parse_job_id(job_id)
-        except ValueError as e:
-            return str(e)
-        try:
-            name = _resolve_client_name(agent_name, agent_map)
-        except ValueError as e:
-            return str(e)
+        parsed = _parse_and_resolve(job_id, agent_map)
+        if isinstance(parsed, str):
+            return parsed
+        name, thread_id = parsed
+
+        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+        canonical = _format_job_id(name, thread_id)
+        tracked = jobs.get(canonical)
+        if not tracked:
+            return f"No tracked job found for job_id: {job_id}"
+        run_id = tracked["run_id"]
+
         client = clients.get_sync(name)
         try:
             client.runs.cancel(thread_id=thread_id, run_id=run_id)
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        canonical = _format_job_id(name, thread_id, run_id)
         job: AsyncSubAgentJob = {
             "job_id": canonical,
             "agent_name": name,
@@ -590,20 +574,23 @@ def _build_cancel_tool(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
         runtime: ToolRuntime,
     ) -> str | Command:
-        try:
-            agent_name, thread_id, run_id = _parse_job_id(job_id)
-        except ValueError as e:
-            return str(e)
-        try:
-            name = _resolve_client_name(agent_name, agent_map)
-        except ValueError as e:
-            return str(e)
+        parsed = _parse_and_resolve(job_id, agent_map)
+        if isinstance(parsed, str):
+            return parsed
+        name, thread_id = parsed
+
+        jobs: dict[str, AsyncSubAgentJob] = runtime.state.get("async_subagent_jobs") or {}
+        canonical = _format_job_id(name, thread_id)
+        tracked = jobs.get(canonical)
+        if not tracked:
+            return f"No tracked job found for job_id: {job_id}"
+        run_id = tracked["run_id"]
+
         client = clients.get_async(name)
         try:
             await client.runs.cancel(thread_id=thread_id, run_id=run_id)
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
-        canonical = _format_job_id(name, thread_id, run_id)
         job: AsyncSubAgentJob = {
             "job_id": canonical,
             "agent_name": name,

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -305,8 +305,8 @@ def _build_check_tool(
         run = client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
-            state = client.threads.get_state(thread_id=thread_id)
-            values = state.get("values", {})
+            thread = client.threads.get(thread_id=thread_id)
+            values = thread.get("values") or {}
             messages = values.get("messages", []) if isinstance(values, dict) else []
             if messages:
                 last = messages[-1]
@@ -338,8 +338,8 @@ def _build_check_tool(
         run = await client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
-            state = await client.threads.get_state(thread_id=thread_id)
-            values = state.get("values", {})
+            thread = await client.threads.get(thread_id=thread_id)
+            values = thread.get("values") or {}
             messages = values.get("messages", []) if isinstance(values, dict) else []
             if messages:
                 last = messages[-1]

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -125,19 +125,20 @@ class _ClientCache:
 _JOB_ID_SEP = "::"
 
 
-def _format_job_id(thread_id: str, run_id: str) -> str:
-    return f"{thread_id}{_JOB_ID_SEP}{run_id}"
+def _format_job_id(agent_name: str, thread_id: str, run_id: str) -> str:
+    return f"{agent_name}{_JOB_ID_SEP}{thread_id}{_JOB_ID_SEP}{run_id}"
 
 
 _JOB_ID_PREFIX = "job_id: "
 
 
-def _parse_job_id(job_id: str) -> tuple[str, str]:
-    """Parse a job ID into (thread_id, run_id).
+def _parse_job_id(job_id: str) -> tuple[str, str, str]:
+    """Parse a job ID into (agent_name, thread_id, run_id).
 
     Handles multiple formats the LLM might pass:
-    - `thread_abc::run_xyz` (canonical)
-    - `Launched async subagent. job_id: thread_abc::run_xyz` (full launch output)
+    - `agent::thread_abc::run_xyz` (canonical, 3-part)
+    - `Launched async subagent. job_id: agent::thread_abc::run_xyz` (full launch output)
+    - `thread_abc::run_xyz` (legacy 2-part, agent defaults to empty)
     - `{"thread_id": "...", "run_id": "..."}` (legacy JSON)
     """
     raw = job_id.strip()
@@ -145,12 +146,15 @@ def _parse_job_id(job_id: str) -> tuple[str, str]:
     if idx != -1:
         raw = raw[idx + len(_JOB_ID_PREFIX) :].strip()
     if _JOB_ID_SEP in raw:
-        parts = raw.split(_JOB_ID_SEP, maxsplit=1)
-        return parts[0], parts[1]
+        parts = raw.split(_JOB_ID_SEP)
+        if len(parts) >= 3:  # noqa: PLR2004
+            return parts[0], parts[1], parts[2]
+        if len(parts) == 2:  # noqa: PLR2004
+            return "", parts[0], parts[1]
     try:
         data = json.loads(raw)
         if isinstance(data, dict):
-            return data["thread_id"], data["run_id"]
+            return "", data["thread_id"], data["run_id"]
     except (json.JSONDecodeError, KeyError):
         pass
     msg = f"Invalid job_id format: {job_id!r}. Expected the exact job_id string returned by launch_async_subagent."
@@ -186,7 +190,7 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        job_id = _format_job_id(thread["thread_id"], run["run_id"])
+        job_id = _format_job_id(subagent_type, thread["thread_id"], run["run_id"])
         return f"Launched async subagent. job_id: {job_id}"
 
     async def alaunch_async_subagent(
@@ -204,7 +208,7 @@ def _build_launch_tool(
             assistant_id=spec["graph_id"],
             input={"messages": [{"role": "user", "content": description}]},
         )
-        job_id = _format_job_id(thread["thread_id"], run["run_id"])
+        job_id = _format_job_id(subagent_type, thread["thread_id"], run["run_id"])
         return f"Launched async subagent. job_id: {job_id}"
 
     return StructuredTool.from_function(
@@ -215,18 +219,24 @@ def _build_launch_tool(
     )
 
 
+def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -> str:
+    """Resolve the client name from a parsed job_id agent_name field."""
+    if agent_name and agent_name in agent_map:
+        return agent_name
+    return next(iter(agent_map))
+
+
 def _build_check_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
 ) -> StructuredTool:
     """Build the check_async_subagent tool."""
-    first_name = next(iter(agent_map))
 
     def check_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
     ) -> str:
-        thread_id, run_id = _parse_job_id(job_id)
-        client = clients.sync(first_name)
+        agent_name, thread_id, run_id = _parse_job_id(job_id)
+        client = clients.sync(_resolve_client_name(agent_name, agent_map))
         run = client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
@@ -243,8 +253,8 @@ def _build_check_tool(
     async def acheck_async_subagent(
         job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
     ) -> str:
-        thread_id, run_id = _parse_job_id(job_id)
-        client = clients.async_(first_name)
+        agent_name, thread_id, run_id = _parse_job_id(job_id)
+        client = clients.async_(_resolve_client_name(agent_name, agent_map))
         run = await client.runs.get(thread_id=thread_id, run_id=run_id)
         result: dict[str, Any] = {"status": run["status"], "run_id": run["run_id"], "thread_id": thread_id}
         if run["status"] == "success":
@@ -270,38 +280,55 @@ def _build_update_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
 ) -> StructuredTool:
-    """Build the update_async_subagent tool."""
-    first_name = next(iter(agent_map))
+    """Build the update_async_subagent tool.
+
+    Sends a follow-up message to an async subagent by creating a new run
+    on the same thread. The subagent sees the full conversation history
+    (including the original task and any prior results) plus the new message.
+    Returns a new job_id for the follow-up run.
+    """
 
     def update_async_subagent(
-        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
-        update: Annotated[str, "New instructions or context to send to the running subagent."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent or a previous update. Pass it verbatim."],
+        message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
     ) -> str:
-        thread_id, _run_id = _parse_job_id(job_id)
-        client = clients.sync(first_name)
-        client.threads.update_state(
+        agent_name, thread_id, _run_id = _parse_job_id(job_id)
+        name = _resolve_client_name(agent_name, agent_map)
+        spec = agent_map[name]
+        client = clients.sync(name)
+        run = client.runs.create(
             thread_id=thread_id,
-            values={"messages": [{"role": "user", "content": update}]},
+            assistant_id=spec["graph_id"],
+            input={"messages": [{"role": "user", "content": message}]},
         )
-        return json.dumps({"status": "updated", "thread_id": thread_id})
+        new_job_id = _format_job_id(name, thread_id, run["run_id"])
+        return f"Follow-up sent. New job_id: {new_job_id}"
 
     async def aupdate_async_subagent(
-        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent. Pass it verbatim."],
-        update: Annotated[str, "New instructions or context to send to the running subagent."],
+        job_id: Annotated[str, "The exact job_id string returned by launch_async_subagent or a previous update. Pass it verbatim."],
+        message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
     ) -> str:
-        thread_id, _run_id = _parse_job_id(job_id)
-        client = clients.async_(first_name)
-        await client.threads.update_state(
+        agent_name, thread_id, _run_id = _parse_job_id(job_id)
+        name = _resolve_client_name(agent_name, agent_map)
+        spec = agent_map[name]
+        client = clients.async_(name)
+        run = await client.runs.create(
             thread_id=thread_id,
-            values={"messages": [{"role": "user", "content": update}]},
+            assistant_id=spec["graph_id"],
+            input={"messages": [{"role": "user", "content": message}]},
         )
-        return json.dumps({"status": "updated", "thread_id": thread_id})
+        new_job_id = _format_job_id(name, thread_id, run["run_id"])
+        return f"Follow-up sent. New job_id: {new_job_id}"
 
     return StructuredTool.from_function(
         name="update_async_subagent",
         func=update_async_subagent,
         coroutine=aupdate_async_subagent,
-        description="Send an update or new instructions to a running async subagent job.",
+        description=(
+            "Send a follow-up message to an async subagent. Creates a new run on the same thread "
+            "so the subagent sees the full conversation history plus your new message. "
+            "Returns a new job_id to track the follow-up."
+        ),
     )
 
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -8,6 +8,7 @@ agent to monitor progress and send updates while the subagent works.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypedDict
 
@@ -180,6 +181,7 @@ class _ClientCache:
 
 
 def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -> str | None:
+    """Return an error message if `agent_type` is not in `agent_map`, or `None` if valid."""
     if agent_type not in agent_map:
         allowed = ", ".join(f"`{k}`" for k in agent_map)
         return f"Unknown async subagent type `{agent_type}`. Available types: {allowed}"
@@ -189,7 +191,7 @@ def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -
 def _build_launch_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
-    description: str,
+    tool_description: str,
 ) -> StructuredTool:
     """Build the launch_async_subagent tool."""
 
@@ -261,7 +263,7 @@ def _build_launch_tool(
         name="launch_async_subagent",
         func=launch_async_subagent,
         coroutine=alaunch_async_subagent,
-        description=description,
+        description=tool_description,
     )
 
 
@@ -562,6 +564,7 @@ async def _afetch_live_status(clients: _ClientCache, job: AsyncSubAgentJob) -> s
 
 
 def _format_job_entry(job: AsyncSubAgentJob, status: str) -> str:
+    """Format a single job as a display string for list output."""
     return f"- job_id: {job['job_id']}  agent: {job['agent_name']}  status: {status}"
 
 
@@ -598,10 +601,10 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
         active = [job for job in jobs.values() if job["status"] not in _TERMINAL_STATUSES]
         if not active:
             return "No async subagent jobs tracked."
+        statuses = await asyncio.gather(*(_afetch_live_status(clients, job) for job in active))
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
         entries: list[str] = []
-        for job in active:
-            status = await _afetch_live_status(clients, job)
+        for job, status in zip(active, statuses):
             entries.append(_format_job_entry(job, status))
             updated_jobs[job["job_id"]] = AsyncSubAgentJob(
                 job_id=job["job_id"],
@@ -706,7 +709,7 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         self.tools = _build_async_subagent_tools(async_subagents)
 
-        if system_prompt and async_subagents:
+        if system_prompt:
             agents_desc = "\n".join(f"- {a['name']}: {a['description']}" for a in async_subagents)
             self.system_prompt: str | None = system_prompt + "\n\nAvailable async subagent types:\n" + agents_desc
         else:

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -309,7 +309,7 @@ def _resolve_client_name(agent_name: str, agent_map: dict[str, AsyncSubAgent]) -
 
 
 def _build_check_result(
-    run: dict[str, Any],
+    run: Any,
     thread_id: str,
     thread_values: dict[str, Any],
 ) -> dict[str, Any]:
@@ -334,7 +334,7 @@ def _build_check_command(
     name: str,
     thread_id: str,
     run_id: str,
-    tool_call_id: str,
+    tool_call_id: str | None,
 ) -> Command:
     """Build the Command update for a check result."""
     canonical = _format_job_id(name, thread_id, run_id)

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -439,7 +439,14 @@ class TestListJobsTool:
                 "agent_name": "test-agent",
                 "thread_id": "t2",
                 "run_id": "r2",
-                "status": "cancelled",
+                "status": "success",
+            },
+            "t3": {
+                "job_id": "t3",
+                "agent_name": "test-agent",
+                "thread_id": "t3",
+                "run_id": "r3",
+                "status": "error",
             },
         }
         rt = ToolRuntime(

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -47,10 +47,15 @@ class TestAsyncSubAgentMiddleware:
         with pytest.raises(ValueError, match="At least one async subagent"):
             AsyncSubAgentMiddleware(async_subagents=[])
 
-    def test_init_creates_three_tools(self) -> None:
+    def test_init_creates_four_tools(self) -> None:
         mw = AsyncSubAgentMiddleware(async_subagents=[_make_spec()])
         tool_names = {t.name for t in mw.tools}
-        assert tool_names == {"launch_async_subagent", "check_async_subagent", "update_async_subagent"}
+        assert tool_names == {
+            "launch_async_subagent",
+            "check_async_subagent",
+            "update_async_subagent",
+            "list_async_subagent_jobs",
+        }
 
     def test_system_prompt_includes_agent_descriptions(self) -> None:
         mw = AsyncSubAgentMiddleware(
@@ -162,11 +167,16 @@ class TestJobsReducer:
 
 
 class TestBuildAsyncSubagentTools:
-    def test_returns_three_tools(self) -> None:
+    def test_returns_four_tools(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
-        assert len(tools) == 3
+        assert len(tools) == 4
         names = [t.name for t in tools]
-        assert names == ["launch_async_subagent", "check_async_subagent", "update_async_subagent"]
+        assert names == [
+            "launch_async_subagent",
+            "check_async_subagent",
+            "update_async_subagent",
+            "list_async_subagent_jobs",
+        ]
 
     def test_launch_description_includes_agent_info(self) -> None:
         tools = _build_async_subagent_tools([_make_spec("researcher", description="Research agent")])
@@ -336,6 +346,56 @@ class TestUpdateTool:
             input={"messages": [{"role": "user", "content": "Focus on security issues only"}]},
             multitask_strategy="interrupt",
         )
+
+
+class TestListJobsTool:
+    def test_empty_state_returns_no_jobs(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        list_tool = tools[3]
+        rt = _make_runtime()
+        result = list_tool.func(runtime=rt)
+        assert "No async subagent jobs tracked" in result
+
+    def test_returns_tracked_jobs(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        list_tool = tools[3]
+        jobs: dict[str, AsyncSubAgentJob] = {
+            "alpha::t1::r1": {
+                "job_id": "alpha::t1::r1",
+                "agent_name": "alpha",
+                "thread_id": "t1",
+                "run_id": "r1",
+                "status": "running",
+            },
+            "beta::t2::r2": {
+                "job_id": "beta::t2::r2",
+                "agent_name": "beta",
+                "thread_id": "t2",
+                "run_id": "r2",
+                "status": "success",
+            },
+        }
+        rt = ToolRuntime(
+            state={"async_subagent_jobs": jobs},
+            context=None,
+            tool_call_id="tc_list",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+        result = list_tool.func(runtime=rt)
+        assert "2 tracked job(s)" in result
+        assert "alpha::t1::r1" in result
+        assert "beta::t2::r2" in result
+        assert "running" in result
+        assert "success" in result
+
+    async def test_async_list_returns_same_result(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        list_tool = tools[3]
+        rt = _make_runtime()
+        result = await list_tool.coroutine(runtime=rt)
+        assert "No async subagent jobs tracked" in result
 
 
 def _async_return(value: Any) -> Any:  # noqa: ANN401

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -457,8 +457,53 @@ class TestListJobsTool:
             stream_writer=lambda _: None,
             config={},
         )
-        list_tool.func(runtime=rt)
+        result = list_tool.func(runtime=rt)
+        assert isinstance(result, Command)
         mock_client.runs.get.assert_not_called()
+        content = result.update["messages"][0].content
+        assert "3 tracked job(s)" in content
+        assert "cancelled" in content
+        assert "success" in content
+        assert "error" in content
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_status_filter_running(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {"run_id": "r1", "status": "running"}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("test-agent")])
+        list_tool = tools[4]
+        jobs: dict[str, AsyncSubAgentJob] = {
+            "t1": {
+                "job_id": "t1",
+                "agent_name": "test-agent",
+                "thread_id": "t1",
+                "run_id": "r1",
+                "status": "running",
+            },
+            "t2": {
+                "job_id": "t2",
+                "agent_name": "test-agent",
+                "thread_id": "t2",
+                "run_id": "r2",
+                "status": "success",
+            },
+        }
+        rt = ToolRuntime(
+            state={"async_subagent_jobs": jobs},
+            context=None,
+            tool_call_id="tc_list",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+        result = list_tool.func(runtime=rt, status_filter="running")
+        assert isinstance(result, Command)
+        content = result.update["messages"][0].content
+        assert "1 tracked job(s)" in content
+        assert "t1" in content
+        assert "t2" not in content
 
     async def test_async_list_returns_no_jobs(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -268,7 +268,7 @@ class TestCheckTool:
     def test_check_completed_job_returns_result(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "success"}
-        mock_client.threads.get_state.return_value = {
+        mock_client.threads.get.return_value = {
             "values": {
                 "messages": [
                     {"role": "assistant", "content": "Analysis complete: found 3 issues."},
@@ -433,7 +433,7 @@ class TestAsyncTools:
     async def test_async_check_returns_command(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.get = _async_return({"run_id": "run_xyz", "status": "success"})
-        mock_client.threads.get_state = _async_return({"values": {"messages": [{"role": "assistant", "content": "Done!"}]}})
+        mock_client.threads.get = _async_return({"values": {"messages": [{"role": "assistant", "content": "Done!"}]}})
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -1,7 +1,7 @@
 """Tests for async subagent middleware functionality."""
 
 import json
-from typing import Any
+from typing import Any, TypeVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -468,10 +468,13 @@ class TestListJobsTool:
         assert "No async subagent jobs tracked" in result
 
 
-def _async_return(value: Any) -> Any:  # noqa: ANN401
+_T = TypeVar("_T")
+
+
+def _async_return(value: _T) -> Any:  # noqa: ANN401
     """Create an async function that returns a fixed value."""
 
-    async def _inner(*_args: Any, **_kwargs: Any) -> Any:  # noqa: ANN401
+    async def _inner(*_args: Any, **_kwargs: Any) -> _T:
         return value
 
     return _inner

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -72,21 +72,25 @@ class TestResolveHeaders:
 
 
 class TestParseJobId:
-    def test_canonical_format(self) -> None:
-        assert _parse_job_id("thread_abc::run_xyz") == ("thread_abc", "run_xyz")
+    def test_canonical_three_part_format(self) -> None:
+        assert _parse_job_id("alpha::thread_abc::run_xyz") == ("alpha", "thread_abc", "run_xyz")
 
     def test_full_launch_output(self) -> None:
-        assert _parse_job_id("Launched async subagent. job_id: thread_abc::run_xyz") == (
+        assert _parse_job_id("Launched async subagent. job_id: alpha::thread_abc::run_xyz") == (
+            "alpha",
             "thread_abc",
             "run_xyz",
         )
 
+    def test_legacy_two_part_format(self) -> None:
+        assert _parse_job_id("thread_abc::run_xyz") == ("", "thread_abc", "run_xyz")
+
     def test_legacy_json_format(self) -> None:
         job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        assert _parse_job_id(job_id) == ("thread_abc", "run_xyz")
+        assert _parse_job_id(job_id) == ("", "thread_abc", "run_xyz")
 
     def test_whitespace_stripped(self) -> None:
-        assert _parse_job_id("  thread_abc::run_xyz  ") == ("thread_abc", "run_xyz")
+        assert _parse_job_id("  alpha::thread_abc::run_xyz  ") == ("alpha", "thread_abc", "run_xyz")
 
     def test_invalid_format_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid job_id format"):
@@ -131,7 +135,7 @@ class TestLaunchTool:
             headers={"x-auth-scheme": "langsmith"},
         )
 
-        assert "thread_abc::run_xyz" in result
+        assert "alpha::thread_abc::run_xyz" in result
         assert "job_id:" in result
 
         mock_client.threads.create.assert_called_once()
@@ -154,7 +158,7 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = check.invoke({"job_id": "thread_abc::run_xyz"})
+        result = check.invoke({"job_id": "test-agent::thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "running"
@@ -178,7 +182,7 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = check.invoke({"job_id": "thread_abc::run_xyz"})
+        result = check.invoke({"job_id": "test-agent::thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "success"
@@ -195,7 +199,7 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = check.invoke({"job_id": "thread_abc::run_xyz"})
+        result = check.invoke({"job_id": "test-agent::thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "error"
@@ -204,22 +208,27 @@ class TestCheckTool:
 
 class TestUpdateTool:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_update_sends_message(self, mock_get_client) -> None:
+    def test_update_creates_new_run(self, mock_get_client) -> None:
         mock_client = MagicMock()
-        mock_client.threads.update_state.return_value = None
+        mock_client.runs.create.return_value = {"run_id": "run_new"}
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
-        result = update.invoke({"job_id": "thread_abc::run_xyz", "update": "Focus on security issues only"})
+        result = update.invoke(
+            {
+                "job_id": "test-agent::thread_abc::run_xyz",
+                "message": "Focus on security issues only",
+            }
+        )
 
-        parsed = json.loads(result)
-        assert parsed["status"] == "updated"
-        assert parsed["thread_id"] == "thread_abc"
+        assert "test-agent::thread_abc::run_new" in result
+        assert "job_id:" in result.lower()
 
-        mock_client.threads.update_state.assert_called_once_with(
+        mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
-            values={"messages": [{"role": "user", "content": "Focus on security issues only"}]},
+            assistant_id="my_graph",
+            input={"messages": [{"role": "user", "content": "Focus on security issues only"}]},
         )
 
 
@@ -245,7 +254,7 @@ class TestAsyncTools:
         launch = tools[0]
         result = await launch.ainvoke({"description": "analyze data", "subagent_type": "alpha"})
 
-        assert "thread_abc::run_xyz" in result
+        assert "alpha::thread_abc::run_xyz" in result
         assert "job_id:" in result
 
     @patch("deepagents.middleware.async_subagents.get_client")
@@ -257,21 +266,25 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = await check.ainvoke({"job_id": "thread_abc::run_xyz"})
+        result = await check.ainvoke({"job_id": "test-agent::thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "success"
         assert parsed["result"] == "Done!"
 
     @patch("deepagents.middleware.async_subagents.get_client")
-    async def test_async_update_sends_message(self, mock_get_client) -> None:
+    async def test_async_update_creates_new_run(self, mock_get_client) -> None:
         mock_client = MagicMock()
-        mock_client.threads.update_state = _async_return(None)
+        mock_client.runs.create = _async_return({"run_id": "run_new"})
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
-        result = await update.ainvoke({"job_id": "thread_abc::run_xyz", "update": "New instructions"})
+        result = await update.ainvoke(
+            {
+                "job_id": "test-agent::thread_abc::run_xyz",
+                "message": "New instructions",
+            }
+        )
 
-        parsed = json.loads(result)
-        assert parsed["status"] == "updated"
+        assert "test-agent::thread_abc::run_new" in result

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -376,23 +376,31 @@ class TestListJobsTool:
         result = list_tool.func(runtime=rt)
         assert "No async subagent jobs tracked" in result
 
-    def test_returns_tracked_jobs(self) -> None:
-        tools = _build_async_subagent_tools([_make_spec()])
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_returns_live_statuses(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.side_effect = [
+            {"run_id": "r1", "status": "success"},
+            {"run_id": "r2", "status": "running"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("test-agent")])
         list_tool = tools[4]
         jobs: dict[str, AsyncSubAgentJob] = {
-            "alpha::t1": {
-                "job_id": "alpha::t1",
-                "agent_name": "alpha",
+            "test-agent::t1::r1": {
+                "job_id": "test-agent::t1::r1",
+                "agent_name": "test-agent",
                 "thread_id": "t1",
                 "run_id": "r1",
-                "status": "running",
+                "status": "running",  # stale — SDK will return "success"
             },
-            "beta::t2": {
-                "job_id": "beta::t2",
-                "agent_name": "beta",
+            "test-agent::t2::r2": {
+                "job_id": "test-agent::t2::r2",
+                "agent_name": "test-agent",
                 "thread_id": "t2",
                 "run_id": "r2",
-                "status": "success",
+                "status": "running",
             },
         }
         rt = ToolRuntime(
@@ -404,13 +412,53 @@ class TestListJobsTool:
             config={},
         )
         result = list_tool.func(runtime=rt)
-        assert "2 tracked job(s)" in result
-        assert "alpha::t1" in result
-        assert "beta::t2" in result
-        assert "running" in result
-        assert "success" in result
+        assert isinstance(result, Command)
+        content = result.update["messages"][0].content
+        assert "2 tracked job(s)" in content
+        assert "test-agent::t1::r1" in content
+        assert "test-agent::t2::r2" in content
+        assert "success" in content
+        assert "running" in content
+        # state should be updated with fresh statuses
+        updated = result.update["async_subagent_jobs"]
+        assert updated["test-agent::t1::r1"]["status"] == "success"
+        assert updated["test-agent::t2::r2"]["status"] == "running"
 
-    async def test_async_list_returns_same_result(self) -> None:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_skips_sdk_call_for_terminal_statuses(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("test-agent")])
+        list_tool = tools[4]
+        jobs: dict[str, AsyncSubAgentJob] = {
+            "test-agent::t1::r1": {
+                "job_id": "test-agent::t1::r1",
+                "agent_name": "test-agent",
+                "thread_id": "t1",
+                "run_id": "r1",
+                "status": "superseded",
+            },
+            "test-agent::t2::r2": {
+                "job_id": "test-agent::t2::r2",
+                "agent_name": "test-agent",
+                "thread_id": "t2",
+                "run_id": "r2",
+                "status": "cancelled",
+            },
+        }
+        rt = ToolRuntime(
+            state={"async_subagent_jobs": jobs},
+            context=None,
+            tool_call_id="tc_list",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+        list_tool.func(runtime=rt)
+        mock_client.runs.get.assert_not_called()
+
+    async def test_async_list_returns_no_jobs(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
         list_tool = tools[4]
         rt = _make_runtime()

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -432,15 +432,15 @@ class TestListJobsTool:
         tools = _build_async_subagent_tools([_make_spec("test-agent")])
         list_tool = tools[4]
         jobs: dict[str, AsyncSubAgentJob] = {
-            "test-agent::t1::r1": {
-                "job_id": "test-agent::t1::r1",
+            "test-agent::t1": {
+                "job_id": "test-agent::t1",
                 "agent_name": "test-agent",
                 "thread_id": "t1",
                 "run_id": "r1",
-                "status": "superseded",
+                "status": "cancelled",
             },
-            "test-agent::t2::r2": {
-                "job_id": "test-agent::t2::r2",
+            "test-agent::t2": {
+                "job_id": "test-agent::t2",
                 "agent_name": "test-agent",
                 "thread_id": "t2",
                 "run_id": "r2",

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -1,0 +1,238 @@
+"""Tests for async subagent middleware functionality."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepagents.middleware.async_subagents import (
+    AsyncSubAgent,
+    AsyncSubAgentMiddleware,
+    _build_async_subagent_tools,
+)
+
+
+def _make_spec(name: str = "test-agent", **overrides: Any) -> AsyncSubAgent:
+    base: dict[str, Any] = {
+        "name": name,
+        "description": f"A test agent named {name}",
+        "url": "http://localhost:8123",
+        "graph_id": "my_graph",
+    }
+    base.update(overrides)
+    return AsyncSubAgent(**base)  # type: ignore[typeddict-item]
+
+
+class TestAsyncSubAgentMiddleware:
+    def test_init_requires_at_least_one_agent(self) -> None:
+        with pytest.raises(ValueError, match="At least one async subagent"):
+            AsyncSubAgentMiddleware(async_subagents=[])
+
+    def test_init_creates_three_tools(self) -> None:
+        mw = AsyncSubAgentMiddleware(async_subagents=[_make_spec()])
+        tool_names = {t.name for t in mw.tools}
+        assert tool_names == {"launch_async_subagent", "check_async_subagent", "update_async_subagent"}
+
+    def test_system_prompt_includes_agent_descriptions(self) -> None:
+        mw = AsyncSubAgentMiddleware(
+            async_subagents=[
+                _make_spec("alpha", description="Alpha agent"),
+                _make_spec("beta", description="Beta agent"),
+            ]
+        )
+        assert "alpha" in mw.system_prompt
+        assert "beta" in mw.system_prompt
+        assert "Alpha agent" in mw.system_prompt
+        assert "Beta agent" in mw.system_prompt
+
+    def test_system_prompt_can_be_disabled(self) -> None:
+        mw = AsyncSubAgentMiddleware(async_subagents=[_make_spec()], system_prompt=None)
+        assert mw.system_prompt is None
+
+
+class TestBuildAsyncSubagentTools:
+    def test_returns_three_tools(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        assert len(tools) == 3
+        names = [t.name for t in tools]
+        assert names == ["launch_async_subagent", "check_async_subagent", "update_async_subagent"]
+
+    def test_launch_description_includes_agent_info(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec("researcher", description="Research agent")])
+        launch_tool = tools[0]
+        assert "researcher" in launch_tool.description
+        assert "Research agent" in launch_tool.description
+
+
+class TestLaunchTool:
+    def test_launch_invalid_type_returns_error(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec("alpha")])
+        launch = tools[0]
+        result = launch.invoke({"description": "do something", "subagent_type": "nonexistent"})
+        assert "Unknown async subagent type" in result
+        assert "`alpha`" in result
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_launch_creates_thread_and_run(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
+        mock_client.runs.create.return_value = {"run_id": "run_xyz"}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("alpha")])
+        launch = tools[0]
+        result = launch.invoke({"description": "analyze data", "subagent_type": "alpha"})
+
+        parsed = json.loads(result)
+        assert parsed["thread_id"] == "thread_abc"
+        assert parsed["run_id"] == "run_xyz"
+
+        mock_client.threads.create.assert_called_once()
+        mock_client.runs.create.assert_called_once_with(
+            thread_id="thread_abc",
+            assistant_id="my_graph",
+            input={"messages": [{"role": "user", "content": "analyze data"}]},
+        )
+
+
+class TestCheckTool:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_check_running_job(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {
+            "run_id": "run_xyz",
+            "status": "running",
+        }
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = tools[1]
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        result = check.invoke({"job_id": job_id})
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "running"
+        assert parsed["thread_id"] == "thread_abc"
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_check_completed_job_returns_result(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {
+            "run_id": "run_xyz",
+            "status": "success",
+        }
+        mock_client.threads.get_state.return_value = {
+            "values": {
+                "messages": [
+                    {"role": "assistant", "content": "Analysis complete: found 3 issues."},
+                ]
+            }
+        }
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = tools[1]
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        result = check.invoke({"job_id": job_id})
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+        assert parsed["result"] == "Analysis complete: found 3 issues."
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_check_errored_job(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {
+            "run_id": "run_xyz",
+            "status": "error",
+        }
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = tools[1]
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        result = check.invoke({"job_id": job_id})
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"
+        assert "error" in parsed
+
+
+class TestUpdateTool:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_update_sends_message(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.update_state.return_value = None
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        update = tools[2]
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        result = update.invoke({"job_id": job_id, "update": "Focus on security issues only"})
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "updated"
+        assert parsed["thread_id"] == "thread_abc"
+
+        mock_client.threads.update_state.assert_called_once_with(
+            thread_id="thread_abc",
+            values={"messages": [{"role": "user", "content": "Focus on security issues only"}]},
+        )
+
+
+def _async_return(value):
+    """Create an async function that returns a fixed value."""
+
+    async def _inner(*_args: Any, **_kwargs: Any) -> Any:  # noqa: ANN401
+        return value
+
+    return _inner
+
+
+@pytest.mark.allow_hosts(["127.0.0.1", "::1"])
+class TestAsyncTools:
+    @patch("deepagents.middleware.async_subagents.get_client")
+    async def test_async_launch_creates_thread_and_run(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.create = _async_return({"thread_id": "thread_abc"})
+        mock_client.runs.create = _async_return({"run_id": "run_xyz"})
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("alpha")])
+        launch = tools[0]
+        result = await launch.ainvoke({"description": "analyze data", "subagent_type": "alpha"})
+
+        parsed = json.loads(result)
+        assert parsed["thread_id"] == "thread_abc"
+        assert parsed["run_id"] == "run_xyz"
+
+    @patch("deepagents.middleware.async_subagents.get_client")
+    async def test_async_check_completed_job(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get = _async_return({"run_id": "run_xyz", "status": "success"})
+        mock_client.threads.get_state = _async_return({"values": {"messages": [{"role": "assistant", "content": "Done!"}]}})
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = tools[1]
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        result = await check.ainvoke({"job_id": job_id})
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+        assert parsed["result"] == "Done!"
+
+    @patch("deepagents.middleware.async_subagents.get_client")
+    async def test_async_update_sends_message(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.update_state = _async_return(None)
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        update = tools[2]
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        result = await update.ainvoke({"job_id": job_id, "update": "New instructions"})
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "updated"

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -229,6 +229,7 @@ class TestUpdateTool:
             thread_id="thread_abc",
             assistant_id="my_graph",
             input={"messages": [{"role": "user", "content": "Focus on security issues only"}]},
+            multitask_strategy="interrupt",
         )
 
 

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -10,6 +10,7 @@ from deepagents.middleware.async_subagents import (
     AsyncSubAgent,
     AsyncSubAgentMiddleware,
     _build_async_subagent_tools,
+    _parse_job_id,
     _resolve_headers,
 )
 
@@ -70,6 +71,28 @@ class TestResolveHeaders:
         assert headers["x-auth-scheme"] == "custom"
 
 
+class TestParseJobId:
+    def test_canonical_format(self) -> None:
+        assert _parse_job_id("thread_abc::run_xyz") == ("thread_abc", "run_xyz")
+
+    def test_full_launch_output(self) -> None:
+        assert _parse_job_id("Launched async subagent. job_id: thread_abc::run_xyz") == (
+            "thread_abc",
+            "run_xyz",
+        )
+
+    def test_legacy_json_format(self) -> None:
+        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
+        assert _parse_job_id(job_id) == ("thread_abc", "run_xyz")
+
+    def test_whitespace_stripped(self) -> None:
+        assert _parse_job_id("  thread_abc::run_xyz  ") == ("thread_abc", "run_xyz")
+
+    def test_invalid_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid job_id format"):
+            _parse_job_id("not-a-valid-job-id")
+
+
 class TestBuildAsyncSubagentTools:
     def test_returns_three_tools(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
@@ -108,9 +131,8 @@ class TestLaunchTool:
             headers={"x-auth-scheme": "langsmith"},
         )
 
-        parsed = json.loads(result)
-        assert parsed["thread_id"] == "thread_abc"
-        assert parsed["run_id"] == "run_xyz"
+        assert "thread_abc::run_xyz" in result
+        assert "job_id:" in result
 
         mock_client.threads.create.assert_called_once()
         mock_client.runs.create.assert_called_once_with(
@@ -132,8 +154,7 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        result = check.invoke({"job_id": job_id})
+        result = check.invoke({"job_id": "thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "running"
@@ -157,8 +178,7 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        result = check.invoke({"job_id": job_id})
+        result = check.invoke({"job_id": "thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "success"
@@ -175,8 +195,7 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        result = check.invoke({"job_id": job_id})
+        result = check.invoke({"job_id": "thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "error"
@@ -192,8 +211,7 @@ class TestUpdateTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        result = update.invoke({"job_id": job_id, "update": "Focus on security issues only"})
+        result = update.invoke({"job_id": "thread_abc::run_xyz", "update": "Focus on security issues only"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "updated"
@@ -227,9 +245,8 @@ class TestAsyncTools:
         launch = tools[0]
         result = await launch.ainvoke({"description": "analyze data", "subagent_type": "alpha"})
 
-        parsed = json.loads(result)
-        assert parsed["thread_id"] == "thread_abc"
-        assert parsed["run_id"] == "run_xyz"
+        assert "thread_abc::run_xyz" in result
+        assert "job_id:" in result
 
     @patch("deepagents.middleware.async_subagents.get_client")
     async def test_async_check_completed_job(self, mock_get_client) -> None:
@@ -240,8 +257,7 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        result = await check.ainvoke({"job_id": job_id})
+        result = await check.ainvoke({"job_id": "thread_abc::run_xyz"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "success"
@@ -255,8 +271,7 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        result = await update.ainvoke({"job_id": job_id, "update": "New instructions"})
+        result = await update.ainvoke({"job_id": "thread_abc::run_xyz", "update": "New instructions"})
 
         parsed = json.loads(result)
         assert parsed["status"] == "updated"

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -10,6 +10,7 @@ from deepagents.middleware.async_subagents import (
     AsyncSubAgent,
     AsyncSubAgentMiddleware,
     _build_async_subagent_tools,
+    _resolve_headers,
 )
 
 
@@ -51,6 +52,24 @@ class TestAsyncSubAgentMiddleware:
         assert mw.system_prompt is None
 
 
+class TestResolveHeaders:
+    def test_adds_auth_scheme_by_default(self) -> None:
+        spec = _make_spec()
+        headers = _resolve_headers(spec)
+        assert headers["x-auth-scheme"] == "langsmith"
+
+    def test_preserves_custom_headers(self) -> None:
+        spec = _make_spec(headers={"X-Custom": "value"})
+        headers = _resolve_headers(spec)
+        assert headers["x-auth-scheme"] == "langsmith"
+        assert headers["X-Custom"] == "value"
+
+    def test_does_not_override_explicit_auth_scheme(self) -> None:
+        spec = _make_spec(headers={"x-auth-scheme": "custom"})
+        headers = _resolve_headers(spec)
+        assert headers["x-auth-scheme"] == "custom"
+
+
 class TestBuildAsyncSubagentTools:
     def test_returns_three_tools(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
@@ -83,6 +102,11 @@ class TestLaunchTool:
         tools = _build_async_subagent_tools([_make_spec("alpha")])
         launch = tools[0]
         result = launch.invoke({"description": "analyze data", "subagent_type": "alpha"})
+
+        mock_get_client.assert_called_once_with(
+            url="http://localhost:8123",
+            headers={"x-auth-scheme": "langsmith"},
+        )
 
         parsed = json.loads(result)
         assert parsed["thread_id"] == "thread_abc"

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -15,7 +15,6 @@ from deepagents.middleware.async_subagents import (
     AsyncSubAgentState,
     _build_async_subagent_tools,
     _jobs_reducer,
-    _parse_job_id,
     _resolve_headers,
 )
 
@@ -96,70 +95,49 @@ class TestResolveHeaders:
         assert headers["x-auth-scheme"] == "custom"
 
 
-class TestParseJobId:
-    def test_canonical_two_part_format(self) -> None:
-        assert _parse_job_id("alpha::thread_abc") == ("alpha", "thread_abc")
-
-    def test_full_launch_output(self) -> None:
-        assert _parse_job_id("Launched async subagent. job_id: alpha::thread_abc") == (
-            "alpha",
-            "thread_abc",
-        )
-
-    def test_legacy_three_part_format_ignores_run_id(self) -> None:
-        assert _parse_job_id("alpha::thread_abc::run_xyz") == ("alpha", "thread_abc")
-
-    def test_whitespace_stripped(self) -> None:
-        assert _parse_job_id("  alpha::thread_abc  ") == ("alpha", "thread_abc")
-
-    def test_invalid_format_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid job_id format"):
-            _parse_job_id("not-a-valid-job-id")
-
-
 class TestJobsReducer:
     def test_merge_into_empty(self) -> None:
         job: AsyncSubAgentJob = {
-            "job_id": "a::t",
+            "job_id": "t",
             "agent_name": "a",
             "thread_id": "t",
             "run_id": "r",
             "status": "running",
         }
-        result = _jobs_reducer(None, {"a::t": job})
-        assert result == {"a::t": job}
+        result = _jobs_reducer(None, {"t": job})
+        assert result == {"t": job}
 
     def test_merge_updates_existing(self) -> None:
         old: AsyncSubAgentJob = {
-            "job_id": "a::t",
+            "job_id": "t",
             "agent_name": "a",
             "thread_id": "t",
             "run_id": "r",
             "status": "running",
         }
         updated: AsyncSubAgentJob = {**old, "status": "success"}
-        result = _jobs_reducer({"a::t": old}, {"a::t": updated})
-        assert result["a::t"]["status"] == "success"
+        result = _jobs_reducer({"t": old}, {"t": updated})
+        assert result["t"]["status"] == "success"
 
     def test_merge_preserves_other_keys(self) -> None:
         job1: AsyncSubAgentJob = {
-            "job_id": "a::t1",
+            "job_id": "t1",
             "agent_name": "a",
             "thread_id": "t1",
             "run_id": "r1",
             "status": "running",
         }
         job2: AsyncSubAgentJob = {
-            "job_id": "a::t2",
+            "job_id": "t2",
             "agent_name": "a",
             "thread_id": "t2",
             "run_id": "r2",
             "status": "running",
         }
-        result = _jobs_reducer({"a::t1": job1}, {"a::t2": job2})
+        result = _jobs_reducer({"t1": job1}, {"t2": job2})
         assert len(result) == 2
-        assert "a::t1" in result
-        assert "a::t2" in result
+        assert "t1" in result
+        assert "t2" in result
 
 
 class TestBuildAsyncSubagentTools:
@@ -214,8 +192,9 @@ class TestLaunchTool:
         update = result.update
         assert "async_subagent_jobs" in update
         jobs = update["async_subagent_jobs"]
-        assert "alpha::thread_abc" in jobs
-        job = jobs["alpha::thread_abc"]
+        assert "thread_abc" in jobs
+        job = jobs["thread_abc"]
+        assert job["job_id"] == "thread_abc"
         assert job["agent_name"] == "alpha"
         assert job["thread_id"] == "thread_abc"
         assert job["run_id"] == "run_xyz"
@@ -224,7 +203,7 @@ class TestLaunchTool:
         msgs = update["messages"]
         assert len(msgs) == 1
         assert msgs[0].tool_call_id == "tc_launch"
-        assert "alpha::thread_abc" in msgs[0].content
+        assert "thread_abc" in msgs[0].content
 
         mock_get_client.assert_called_once_with(
             url="http://localhost:8123",
@@ -242,8 +221,8 @@ class TestCheckTool:
     def _make_check_runtime(self, tool_call_id: str = "tc_check") -> ToolRuntime:
         """Create a runtime with a tracked job in state."""
         jobs: dict[str, AsyncSubAgentJob] = {
-            "test-agent::thread_abc": {
-                "job_id": "test-agent::thread_abc",
+            "thread_abc": {
+                "job_id": "thread_abc",
                 "agent_name": "test-agent",
                 "thread_id": "thread_abc",
                 "run_id": "run_xyz",
@@ -268,7 +247,7 @@ class TestCheckTool:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         result = check.func(
-            job_id="test-agent::thread_abc",
+            job_id="thread_abc",
             runtime=self._make_check_runtime("tc_check"),
         )
 
@@ -279,7 +258,7 @@ class TestCheckTool:
         assert parsed["thread_id"] == "thread_abc"
 
         jobs = result.update["async_subagent_jobs"]
-        assert jobs["test-agent::thread_abc"]["status"] == "running"
+        assert jobs["thread_abc"]["status"] == "running"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_completed_job_returns_result(self, mock_get_client: MagicMock) -> None:
@@ -297,7 +276,7 @@ class TestCheckTool:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         result = check.func(
-            job_id="test-agent::thread_abc",
+            job_id="thread_abc",
             runtime=self._make_check_runtime("tc_check"),
         )
 
@@ -307,7 +286,7 @@ class TestCheckTool:
         assert parsed["result"] == "Analysis complete: found 3 issues."
 
         jobs = result.update["async_subagent_jobs"]
-        assert jobs["test-agent::thread_abc"]["status"] == "success"
+        assert jobs["thread_abc"]["status"] == "success"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_errored_job(self, mock_get_client: MagicMock) -> None:
@@ -318,7 +297,7 @@ class TestCheckTool:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         result = check.func(
-            job_id="test-agent::thread_abc",
+            job_id="thread_abc",
             runtime=self._make_check_runtime("tc_check"),
         )
 
@@ -328,7 +307,7 @@ class TestCheckTool:
         assert "error" in parsed
 
         jobs = result.update["async_subagent_jobs"]
-        assert jobs["test-agent::thread_abc"]["status"] == "error"
+        assert jobs["thread_abc"]["status"] == "error"
 
 
 class TestUpdateTool:
@@ -340,25 +319,41 @@ class TestUpdateTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
+        jobs_state: dict[str, AsyncSubAgentJob] = {
+            "thread_abc": {
+                "job_id": "thread_abc",
+                "agent_name": "test-agent",
+                "thread_id": "thread_abc",
+                "run_id": "run_old",
+                "status": "running",
+            },
+        }
+        rt = ToolRuntime(
+            state={"async_subagent_jobs": jobs_state},
+            context=None,
+            tool_call_id="tc_update",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
         result = update.func(
-            job_id="test-agent::thread_abc",
+            job_id="thread_abc",
             message="Focus on security issues only",
-            runtime=_make_runtime("tc_update"),
+            runtime=rt,
         )
 
         assert isinstance(result, Command)
         jobs = result.update["async_subagent_jobs"]
 
         # Same job_id, updated run_id
-        key = "test-agent::thread_abc"
-        assert key in jobs
+        assert "thread_abc" in jobs
         assert len(jobs) == 1
-        assert jobs[key]["run_id"] == "run_new"
-        assert jobs[key]["status"] == "running"
+        assert jobs["thread_abc"]["run_id"] == "run_new"
+        assert jobs["thread_abc"]["status"] == "running"
 
         msgs = result.update["messages"]
         assert msgs[0].tool_call_id == "tc_update"
-        assert "test-agent::thread_abc" in msgs[0].content
+        assert "thread_abc" in msgs[0].content
 
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
@@ -388,15 +383,15 @@ class TestListJobsTool:
         tools = _build_async_subagent_tools([_make_spec("test-agent")])
         list_tool = tools[4]
         jobs: dict[str, AsyncSubAgentJob] = {
-            "test-agent::t1::r1": {
-                "job_id": "test-agent::t1::r1",
+            "t1": {
+                "job_id": "t1",
                 "agent_name": "test-agent",
                 "thread_id": "t1",
                 "run_id": "r1",
                 "status": "running",  # stale — SDK will return "success"
             },
-            "test-agent::t2::r2": {
-                "job_id": "test-agent::t2::r2",
+            "t2": {
+                "job_id": "t2",
                 "agent_name": "test-agent",
                 "thread_id": "t2",
                 "run_id": "r2",
@@ -415,14 +410,14 @@ class TestListJobsTool:
         assert isinstance(result, Command)
         content = result.update["messages"][0].content
         assert "2 tracked job(s)" in content
-        assert "test-agent::t1::r1" in content
-        assert "test-agent::t2::r2" in content
+        assert "t1" in content
+        assert "t2" in content
         assert "success" in content
         assert "running" in content
         # state should be updated with fresh statuses
         updated = result.update["async_subagent_jobs"]
-        assert updated["test-agent::t1::r1"]["status"] == "success"
-        assert updated["test-agent::t2::r2"]["status"] == "running"
+        assert updated["t1"]["status"] == "success"
+        assert updated["t2"]["status"] == "running"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_skips_sdk_call_for_terminal_statuses(self, mock_get_client: MagicMock) -> None:
@@ -432,15 +427,15 @@ class TestListJobsTool:
         tools = _build_async_subagent_tools([_make_spec("test-agent")])
         list_tool = tools[4]
         jobs: dict[str, AsyncSubAgentJob] = {
-            "test-agent::t1": {
-                "job_id": "test-agent::t1",
+            "t1": {
+                "job_id": "t1",
                 "agent_name": "test-agent",
                 "thread_id": "t1",
                 "run_id": "r1",
                 "status": "cancelled",
             },
-            "test-agent::t2": {
-                "job_id": "test-agent::t2",
+            "t2": {
+                "job_id": "t2",
                 "agent_name": "test-agent",
                 "thread_id": "t2",
                 "run_id": "r2",
@@ -493,9 +488,9 @@ class TestAsyncTools:
         )
 
         assert isinstance(result, Command)
-        assert "alpha::thread_abc" in result.update["messages"][0].content
+        assert "thread_abc" in result.update["messages"][0].content
         jobs = result.update["async_subagent_jobs"]
-        assert "alpha::thread_abc" in jobs
+        assert "thread_abc" in jobs
 
     @patch("deepagents.middleware.async_subagents.get_client")
     async def test_async_check_returns_command(self, mock_get_client: MagicMock) -> None:
@@ -507,8 +502,8 @@ class TestAsyncTools:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         tracked_jobs: dict[str, AsyncSubAgentJob] = {
-            "test-agent::thread_abc": {
-                "job_id": "test-agent::thread_abc",
+            "thread_abc": {
+                "job_id": "thread_abc",
                 "agent_name": "test-agent",
                 "thread_id": "thread_abc",
                 "run_id": "run_xyz",
@@ -524,7 +519,7 @@ class TestAsyncTools:
             config={},
         )
         result = await check.coroutine(
-            job_id="test-agent::thread_abc",
+            job_id="thread_abc",
             runtime=rt,
         )
 
@@ -532,7 +527,7 @@ class TestAsyncTools:
         parsed = json.loads(result.update["messages"][0].content)
         assert parsed["status"] == "success"
         assert parsed["result"] == "Done!"
-        assert result.update["async_subagent_jobs"]["test-agent::thread_abc"]["status"] == "success"
+        assert result.update["async_subagent_jobs"]["thread_abc"]["status"] == "success"
 
     @patch("deepagents.middleware.async_subagents.get_client")
     async def test_async_update_returns_command(self, mock_get_client: MagicMock) -> None:
@@ -542,13 +537,29 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
+        jobs_state: dict[str, AsyncSubAgentJob] = {
+            "thread_abc": {
+                "job_id": "thread_abc",
+                "agent_name": "test-agent",
+                "thread_id": "thread_abc",
+                "run_id": "run_old",
+                "status": "running",
+            },
+        }
+        rt = ToolRuntime(
+            state={"async_subagent_jobs": jobs_state},
+            context=None,
+            tool_call_id="tc_async_update",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
         result = await update.coroutine(
-            job_id="test-agent::thread_abc",
+            job_id="thread_abc",
             message="New instructions",
-            runtime=_make_runtime("tc_async_update"),
+            runtime=rt,
         )
 
         assert isinstance(result, Command)
-        key = "test-agent::thread_abc"
-        assert key in result.update["async_subagent_jobs"]
-        assert result.update["async_subagent_jobs"][key]["run_id"] == "run_new"
+        assert "thread_abc" in result.update["async_subagent_jobs"]
+        assert result.update["async_subagent_jobs"]["thread_abc"]["run_id"] == "run_new"

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -47,13 +47,14 @@ class TestAsyncSubAgentMiddleware:
         with pytest.raises(ValueError, match="At least one async subagent"):
             AsyncSubAgentMiddleware(async_subagents=[])
 
-    def test_init_creates_four_tools(self) -> None:
+    def test_init_creates_five_tools(self) -> None:
         mw = AsyncSubAgentMiddleware(async_subagents=[_make_spec()])
         tool_names = {t.name for t in mw.tools}
         assert tool_names == {
             "launch_async_subagent",
             "check_async_subagent",
             "update_async_subagent",
+            "cancel_async_subagent",
             "list_async_subagent_jobs",
         }
 
@@ -167,14 +168,15 @@ class TestJobsReducer:
 
 
 class TestBuildAsyncSubagentTools:
-    def test_returns_four_tools(self) -> None:
+    def test_returns_five_tools(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
-        assert len(tools) == 4
+        assert len(tools) == 5
         names = [t.name for t in tools]
         assert names == [
             "launch_async_subagent",
             "check_async_subagent",
             "update_async_subagent",
+            "cancel_async_subagent",
             "list_async_subagent_jobs",
         ]
 
@@ -331,10 +333,15 @@ class TestUpdateTool:
 
         assert isinstance(result, Command)
         jobs = result.update["async_subagent_jobs"]
+
         new_key = "test-agent::thread_abc::run_new"
         assert new_key in jobs
         assert jobs[new_key]["run_id"] == "run_new"
         assert jobs[new_key]["status"] == "running"
+
+        old_key = "test-agent::thread_abc::run_xyz"
+        assert old_key in jobs
+        assert jobs[old_key]["status"] == "superseded"
 
         msgs = result.update["messages"]
         assert msgs[0].tool_call_id == "tc_update"
@@ -351,14 +358,14 @@ class TestUpdateTool:
 class TestListJobsTool:
     def test_empty_state_returns_no_jobs(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
-        list_tool = tools[3]
+        list_tool = tools[4]
         rt = _make_runtime()
         result = list_tool.func(runtime=rt)
         assert "No async subagent jobs tracked" in result
 
     def test_returns_tracked_jobs(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
-        list_tool = tools[3]
+        list_tool = tools[4]
         jobs: dict[str, AsyncSubAgentJob] = {
             "alpha::t1::r1": {
                 "job_id": "alpha::t1::r1",
@@ -392,7 +399,7 @@ class TestListJobsTool:
 
     async def test_async_list_returns_same_result(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
-        list_tool = tools[3]
+        list_tool = tools[4]
         rt = _make_runtime()
         result = await list_tool.coroutine(runtime=rt)
         assert "No async subagent jobs tracked" in result

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -41,6 +41,42 @@ def _make_runtime(tool_call_id: str = "tc_test") -> ToolRuntime:
     )
 
 
+def _make_runtime_with_job(
+    job_id: str = "thread_abc",
+    agent_name: str = "test-agent",
+    run_id: str = "run_xyz",
+    status: str = "running",
+    tool_call_id: str = "tc_test",
+) -> ToolRuntime:
+    """Create a runtime with a single tracked job in state."""
+    jobs: dict[str, AsyncSubAgentJob] = {
+        job_id: {
+            "job_id": job_id,
+            "agent_name": agent_name,
+            "thread_id": job_id,
+            "run_id": run_id,
+            "status": status,
+        },
+    }
+    return ToolRuntime(
+        state={"async_subagent_jobs": jobs},
+        context=None,
+        tool_call_id=tool_call_id,
+        store=None,
+        stream_writer=lambda _: None,
+        config={},
+    )
+
+
+def _get_tool(tools: list, name: str) -> Any:  # noqa: ANN401
+    """Look up a tool by name from the built tools list."""
+    for t in tools:
+        if t.name == name:
+            return t
+    msg = f"Tool {name!r} not found"
+    raise KeyError(msg)
+
+
 class TestAsyncSubAgentMiddleware:
     def test_init_requires_at_least_one_agent(self) -> None:
         with pytest.raises(ValueError, match="At least one async subagent"):
@@ -72,6 +108,10 @@ class TestAsyncSubAgentMiddleware:
     def test_system_prompt_can_be_disabled(self) -> None:
         mw = AsyncSubAgentMiddleware(async_subagents=[_make_spec()], system_prompt=None)
         assert mw.system_prompt is None
+
+    def test_init_rejects_duplicate_names(self) -> None:
+        with pytest.raises(ValueError, match="Duplicate async subagent names"):
+            AsyncSubAgentMiddleware(async_subagents=[_make_spec("alpha"), _make_spec("alpha")])
 
     def test_state_schema_is_set(self) -> None:
         assert AsyncSubAgentMiddleware.state_schema is AsyncSubAgentState
@@ -618,3 +658,173 @@ class TestAsyncTools:
         assert isinstance(result, Command)
         assert "thread_abc" in result.update["async_subagent_jobs"]
         assert result.update["async_subagent_jobs"]["thread_abc"]["run_id"] == "run_new"
+
+    @patch("deepagents.middleware.async_subagents.get_client")
+    async def test_async_cancel_returns_command(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.cancel = _async_return(None)
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_async_cancel")
+        result = await cancel.coroutine(job_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        assert result.update["async_subagent_jobs"]["thread_abc"]["status"] == "cancelled"
+
+
+class TestCancelTool:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_cancel_returns_command_with_cancelled_status(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_cancel")
+        result = cancel.func(job_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        jobs = result.update["async_subagent_jobs"]
+        assert jobs["thread_abc"]["status"] == "cancelled"
+        assert jobs["thread_abc"]["job_id"] == "thread_abc"
+        msgs = result.update["messages"]
+        assert msgs[0].tool_call_id == "tc_cancel"
+        assert "thread_abc" in msgs[0].content
+        mock_client.runs.cancel.assert_called_once_with(
+            thread_id="thread_abc",
+            run_id="run_xyz",
+        )
+
+    def test_cancel_unknown_job_returns_error(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_subagent")
+        rt = _make_runtime("tc_cancel")
+        result = cancel.func(job_id="nonexistent", runtime=rt)
+        assert isinstance(result, str)
+        assert "No tracked job found" in result
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_cancel_sdk_error_returns_error_string(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.cancel.side_effect = RuntimeError("connection refused")
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        cancel = _get_tool(tools, "cancel_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_cancel")
+        result = cancel.func(job_id="thread_abc", runtime=rt)
+        assert isinstance(result, str)
+        assert "Failed to cancel run" in result
+        assert "connection refused" in result
+
+
+class TestUnknownJobId:
+    """Tests that check/update/cancel return error strings for unknown job IDs."""
+
+    def test_check_unknown_job_returns_error(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = _get_tool(tools, "check_async_subagent")
+        rt = _make_runtime()
+        result = check.func(job_id="nonexistent", runtime=rt)
+        assert isinstance(result, str)
+        assert "No tracked job found" in result
+
+    def test_update_unknown_job_returns_error(self) -> None:
+        tools = _build_async_subagent_tools([_make_spec()])
+        update = _get_tool(tools, "update_async_subagent")
+        rt = _make_runtime()
+        result = update.func(job_id="nonexistent", message="hello", runtime=rt)
+        assert isinstance(result, str)
+        assert "No tracked job found" in result
+
+
+class TestLaunchErrorHandling:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_launch_sdk_error_returns_error_string(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.create.side_effect = RuntimeError("connection refused")
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("alpha")])
+        launch = _get_tool(tools, "launch_async_subagent")
+        result = launch.func(
+            description="do stuff",
+            subagent_type="alpha",
+            runtime=_make_runtime(),
+        )
+        assert isinstance(result, str)
+        assert "Failed to launch" in result
+        assert "connection refused" in result
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_update_sdk_error_returns_error_string(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.create.side_effect = RuntimeError("timeout")
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        update = _get_tool(tools, "update_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_update")
+        result = update.func(job_id="thread_abc", message="hello", runtime=rt)
+        assert isinstance(result, str)
+        assert "Failed to update" in result
+        assert "timeout" in result
+
+
+class TestCheckEdgeCases:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_check_errored_job_includes_server_error(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {
+            "run_id": "run_xyz",
+            "status": "error",
+            "error": "Tool 'search' raised ValueError: invalid query",
+        }
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = _get_tool(tools, "check_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_check")
+        result = check.func(job_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        parsed = json.loads(result.update["messages"][0].content)
+        assert parsed["status"] == "error"
+        assert "ValueError" in parsed["error"]
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_check_success_empty_messages(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "success"}
+        mock_client.threads.get.return_value = {"values": {"messages": []}}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = _get_tool(tools, "check_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_check")
+        result = check.func(job_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        parsed = json.loads(result.update["messages"][0].content)
+        assert parsed["status"] == "success"
+        assert "no output" in parsed["result"].lower()
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_check_threads_get_failure_still_returns_status(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "success"}
+        mock_client.threads.get.side_effect = RuntimeError("network error")
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec()])
+        check = _get_tool(tools, "check_async_subagent")
+        rt = _make_runtime_with_job(tool_call_id="tc_check")
+        result = check.func(job_id="thread_abc", runtime=rt)
+
+        assert isinstance(result, Command)
+        parsed = json.loads(result.update["messages"][0].content)
+        assert parsed["status"] == "success"
+        # result should show empty-messages fallback since thread values couldn't be fetched
+        assert "no output" in parsed["result"].lower()

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -97,25 +97,20 @@ class TestResolveHeaders:
 
 
 class TestParseJobId:
-    def test_canonical_three_part_format(self) -> None:
-        assert _parse_job_id("alpha::thread_abc::run_xyz") == ("alpha", "thread_abc", "run_xyz")
+    def test_canonical_two_part_format(self) -> None:
+        assert _parse_job_id("alpha::thread_abc") == ("alpha", "thread_abc")
 
     def test_full_launch_output(self) -> None:
-        assert _parse_job_id("Launched async subagent. job_id: alpha::thread_abc::run_xyz") == (
+        assert _parse_job_id("Launched async subagent. job_id: alpha::thread_abc") == (
             "alpha",
             "thread_abc",
-            "run_xyz",
         )
 
-    def test_legacy_two_part_format(self) -> None:
-        assert _parse_job_id("thread_abc::run_xyz") == ("", "thread_abc", "run_xyz")
-
-    def test_legacy_json_format(self) -> None:
-        job_id = json.dumps({"thread_id": "thread_abc", "run_id": "run_xyz"})
-        assert _parse_job_id(job_id) == ("", "thread_abc", "run_xyz")
+    def test_legacy_three_part_format_ignores_run_id(self) -> None:
+        assert _parse_job_id("alpha::thread_abc::run_xyz") == ("alpha", "thread_abc")
 
     def test_whitespace_stripped(self) -> None:
-        assert _parse_job_id("  alpha::thread_abc::run_xyz  ") == ("alpha", "thread_abc", "run_xyz")
+        assert _parse_job_id("  alpha::thread_abc  ") == ("alpha", "thread_abc")
 
     def test_invalid_format_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid job_id format"):
@@ -125,46 +120,46 @@ class TestParseJobId:
 class TestJobsReducer:
     def test_merge_into_empty(self) -> None:
         job: AsyncSubAgentJob = {
-            "job_id": "a::t::r",
+            "job_id": "a::t",
             "agent_name": "a",
             "thread_id": "t",
             "run_id": "r",
             "status": "running",
         }
-        result = _jobs_reducer(None, {"a::t::r": job})
-        assert result == {"a::t::r": job}
+        result = _jobs_reducer(None, {"a::t": job})
+        assert result == {"a::t": job}
 
     def test_merge_updates_existing(self) -> None:
         old: AsyncSubAgentJob = {
-            "job_id": "a::t::r",
+            "job_id": "a::t",
             "agent_name": "a",
             "thread_id": "t",
             "run_id": "r",
             "status": "running",
         }
         updated: AsyncSubAgentJob = {**old, "status": "success"}
-        result = _jobs_reducer({"a::t::r": old}, {"a::t::r": updated})
-        assert result["a::t::r"]["status"] == "success"
+        result = _jobs_reducer({"a::t": old}, {"a::t": updated})
+        assert result["a::t"]["status"] == "success"
 
     def test_merge_preserves_other_keys(self) -> None:
         job1: AsyncSubAgentJob = {
-            "job_id": "a::t1::r1",
+            "job_id": "a::t1",
             "agent_name": "a",
             "thread_id": "t1",
             "run_id": "r1",
             "status": "running",
         }
         job2: AsyncSubAgentJob = {
-            "job_id": "a::t2::r2",
+            "job_id": "a::t2",
             "agent_name": "a",
             "thread_id": "t2",
             "run_id": "r2",
             "status": "running",
         }
-        result = _jobs_reducer({"a::t1::r1": job1}, {"a::t2::r2": job2})
+        result = _jobs_reducer({"a::t1": job1}, {"a::t2": job2})
         assert len(result) == 2
-        assert "a::t1::r1" in result
-        assert "a::t2::r2" in result
+        assert "a::t1" in result
+        assert "a::t2" in result
 
 
 class TestBuildAsyncSubagentTools:
@@ -219,8 +214,8 @@ class TestLaunchTool:
         update = result.update
         assert "async_subagent_jobs" in update
         jobs = update["async_subagent_jobs"]
-        assert "alpha::thread_abc::run_xyz" in jobs
-        job = jobs["alpha::thread_abc::run_xyz"]
+        assert "alpha::thread_abc" in jobs
+        job = jobs["alpha::thread_abc"]
         assert job["agent_name"] == "alpha"
         assert job["thread_id"] == "thread_abc"
         assert job["run_id"] == "run_xyz"
@@ -229,7 +224,7 @@ class TestLaunchTool:
         msgs = update["messages"]
         assert len(msgs) == 1
         assert msgs[0].tool_call_id == "tc_launch"
-        assert "alpha::thread_abc::run_xyz" in msgs[0].content
+        assert "alpha::thread_abc" in msgs[0].content
 
         mock_get_client.assert_called_once_with(
             url="http://localhost:8123",
@@ -244,6 +239,26 @@ class TestLaunchTool:
 
 
 class TestCheckTool:
+    def _make_check_runtime(self, tool_call_id: str = "tc_check") -> ToolRuntime:
+        """Create a runtime with a tracked job in state."""
+        jobs: dict[str, AsyncSubAgentJob] = {
+            "test-agent::thread_abc": {
+                "job_id": "test-agent::thread_abc",
+                "agent_name": "test-agent",
+                "thread_id": "thread_abc",
+                "run_id": "run_xyz",
+                "status": "running",
+            },
+        }
+        return ToolRuntime(
+            state={"async_subagent_jobs": jobs},
+            context=None,
+            tool_call_id=tool_call_id,
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_running_job(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
@@ -253,8 +268,8 @@ class TestCheckTool:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         result = check.func(
-            job_id="test-agent::thread_abc::run_xyz",
-            runtime=_make_runtime("tc_check"),
+            job_id="test-agent::thread_abc",
+            runtime=self._make_check_runtime("tc_check"),
         )
 
         assert isinstance(result, Command)
@@ -264,7 +279,7 @@ class TestCheckTool:
         assert parsed["thread_id"] == "thread_abc"
 
         jobs = result.update["async_subagent_jobs"]
-        assert jobs["test-agent::thread_abc::run_xyz"]["status"] == "running"
+        assert jobs["test-agent::thread_abc"]["status"] == "running"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_completed_job_returns_result(self, mock_get_client: MagicMock) -> None:
@@ -282,8 +297,8 @@ class TestCheckTool:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         result = check.func(
-            job_id="test-agent::thread_abc::run_xyz",
-            runtime=_make_runtime("tc_check"),
+            job_id="test-agent::thread_abc",
+            runtime=self._make_check_runtime("tc_check"),
         )
 
         assert isinstance(result, Command)
@@ -292,7 +307,7 @@ class TestCheckTool:
         assert parsed["result"] == "Analysis complete: found 3 issues."
 
         jobs = result.update["async_subagent_jobs"]
-        assert jobs["test-agent::thread_abc::run_xyz"]["status"] == "success"
+        assert jobs["test-agent::thread_abc"]["status"] == "success"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_errored_job(self, mock_get_client: MagicMock) -> None:
@@ -303,8 +318,8 @@ class TestCheckTool:
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
         result = check.func(
-            job_id="test-agent::thread_abc::run_xyz",
-            runtime=_make_runtime("tc_check"),
+            job_id="test-agent::thread_abc",
+            runtime=self._make_check_runtime("tc_check"),
         )
 
         assert isinstance(result, Command)
@@ -313,12 +328,12 @@ class TestCheckTool:
         assert "error" in parsed
 
         jobs = result.update["async_subagent_jobs"]
-        assert jobs["test-agent::thread_abc::run_xyz"]["status"] == "error"
+        assert jobs["test-agent::thread_abc"]["status"] == "error"
 
 
 class TestUpdateTool:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_update_returns_command_with_new_job(self, mock_get_client: MagicMock) -> None:
+    def test_update_returns_command_with_same_job_id(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.create.return_value = {"run_id": "run_new"}
         mock_get_client.return_value = mock_client
@@ -326,7 +341,7 @@ class TestUpdateTool:
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
         result = update.func(
-            job_id="test-agent::thread_abc::run_xyz",
+            job_id="test-agent::thread_abc",
             message="Focus on security issues only",
             runtime=_make_runtime("tc_update"),
         )
@@ -334,18 +349,16 @@ class TestUpdateTool:
         assert isinstance(result, Command)
         jobs = result.update["async_subagent_jobs"]
 
-        new_key = "test-agent::thread_abc::run_new"
-        assert new_key in jobs
-        assert jobs[new_key]["run_id"] == "run_new"
-        assert jobs[new_key]["status"] == "running"
-
-        old_key = "test-agent::thread_abc::run_xyz"
-        assert old_key in jobs
-        assert jobs[old_key]["status"] == "superseded"
+        # Same job_id, updated run_id
+        key = "test-agent::thread_abc"
+        assert key in jobs
+        assert len(jobs) == 1
+        assert jobs[key]["run_id"] == "run_new"
+        assert jobs[key]["status"] == "running"
 
         msgs = result.update["messages"]
         assert msgs[0].tool_call_id == "tc_update"
-        assert "run_new" in msgs[0].content
+        assert "test-agent::thread_abc" in msgs[0].content
 
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
@@ -367,15 +380,15 @@ class TestListJobsTool:
         tools = _build_async_subagent_tools([_make_spec()])
         list_tool = tools[4]
         jobs: dict[str, AsyncSubAgentJob] = {
-            "alpha::t1::r1": {
-                "job_id": "alpha::t1::r1",
+            "alpha::t1": {
+                "job_id": "alpha::t1",
                 "agent_name": "alpha",
                 "thread_id": "t1",
                 "run_id": "r1",
                 "status": "running",
             },
-            "beta::t2::r2": {
-                "job_id": "beta::t2::r2",
+            "beta::t2": {
+                "job_id": "beta::t2",
                 "agent_name": "beta",
                 "thread_id": "t2",
                 "run_id": "r2",
@@ -392,8 +405,8 @@ class TestListJobsTool:
         )
         result = list_tool.func(runtime=rt)
         assert "2 tracked job(s)" in result
-        assert "alpha::t1::r1" in result
-        assert "beta::t2::r2" in result
+        assert "alpha::t1" in result
+        assert "beta::t2" in result
         assert "running" in result
         assert "success" in result
 
@@ -432,9 +445,9 @@ class TestAsyncTools:
         )
 
         assert isinstance(result, Command)
-        assert "alpha::thread_abc::run_xyz" in result.update["messages"][0].content
+        assert "alpha::thread_abc" in result.update["messages"][0].content
         jobs = result.update["async_subagent_jobs"]
-        assert "alpha::thread_abc::run_xyz" in jobs
+        assert "alpha::thread_abc" in jobs
 
     @patch("deepagents.middleware.async_subagents.get_client")
     async def test_async_check_returns_command(self, mock_get_client: MagicMock) -> None:
@@ -445,16 +458,33 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
+        tracked_jobs: dict[str, AsyncSubAgentJob] = {
+            "test-agent::thread_abc": {
+                "job_id": "test-agent::thread_abc",
+                "agent_name": "test-agent",
+                "thread_id": "thread_abc",
+                "run_id": "run_xyz",
+                "status": "running",
+            },
+        }
+        rt = ToolRuntime(
+            state={"async_subagent_jobs": tracked_jobs},
+            context=None,
+            tool_call_id="tc_async_check",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
         result = await check.coroutine(
-            job_id="test-agent::thread_abc::run_xyz",
-            runtime=_make_runtime("tc_async_check"),
+            job_id="test-agent::thread_abc",
+            runtime=rt,
         )
 
         assert isinstance(result, Command)
         parsed = json.loads(result.update["messages"][0].content)
         assert parsed["status"] == "success"
         assert parsed["result"] == "Done!"
-        assert result.update["async_subagent_jobs"]["test-agent::thread_abc::run_xyz"]["status"] == "success"
+        assert result.update["async_subagent_jobs"]["test-agent::thread_abc"]["status"] == "success"
 
     @patch("deepagents.middleware.async_subagents.get_client")
     async def test_async_update_returns_command(self, mock_get_client: MagicMock) -> None:
@@ -465,12 +495,12 @@ class TestAsyncTools:
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
         result = await update.coroutine(
-            job_id="test-agent::thread_abc::run_xyz",
+            job_id="test-agent::thread_abc",
             message="New instructions",
             runtime=_make_runtime("tc_async_update"),
         )
 
         assert isinstance(result, Command)
-        new_key = "test-agent::thread_abc::run_new"
-        assert new_key in result.update["async_subagent_jobs"]
-        assert "run_new" in result.update["messages"][0].content
+        key = "test-agent::thread_abc"
+        assert key in result.update["async_subagent_jobs"]
+        assert result.update["async_subagent_jobs"][key]["run_id"] == "run_new"

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -5,11 +5,16 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain.tools import ToolRuntime
+from langgraph.types import Command
 
 from deepagents.middleware.async_subagents import (
     AsyncSubAgent,
+    AsyncSubAgentJob,
     AsyncSubAgentMiddleware,
+    AsyncSubAgentState,
     _build_async_subagent_tools,
+    _jobs_reducer,
     _parse_job_id,
     _resolve_headers,
 )
@@ -24,6 +29,17 @@ def _make_spec(name: str = "test-agent", **overrides: Any) -> AsyncSubAgent:
     }
     base.update(overrides)
     return AsyncSubAgent(**base)  # type: ignore[typeddict-item]
+
+
+def _make_runtime(tool_call_id: str = "tc_test") -> ToolRuntime:
+    return ToolRuntime(
+        state={},
+        context=None,
+        tool_call_id=tool_call_id,
+        store=None,
+        stream_writer=lambda _: None,
+        config={},
+    )
 
 
 class TestAsyncSubAgentMiddleware:
@@ -51,6 +67,9 @@ class TestAsyncSubAgentMiddleware:
     def test_system_prompt_can_be_disabled(self) -> None:
         mw = AsyncSubAgentMiddleware(async_subagents=[_make_spec()], system_prompt=None)
         assert mw.system_prompt is None
+
+    def test_state_schema_is_set(self) -> None:
+        assert AsyncSubAgentMiddleware.state_schema is AsyncSubAgentState
 
 
 class TestResolveHeaders:
@@ -97,6 +116,51 @@ class TestParseJobId:
             _parse_job_id("not-a-valid-job-id")
 
 
+class TestJobsReducer:
+    def test_merge_into_empty(self) -> None:
+        job: AsyncSubAgentJob = {
+            "job_id": "a::t::r",
+            "agent_name": "a",
+            "thread_id": "t",
+            "run_id": "r",
+            "status": "running",
+        }
+        result = _jobs_reducer(None, {"a::t::r": job})
+        assert result == {"a::t::r": job}
+
+    def test_merge_updates_existing(self) -> None:
+        old: AsyncSubAgentJob = {
+            "job_id": "a::t::r",
+            "agent_name": "a",
+            "thread_id": "t",
+            "run_id": "r",
+            "status": "running",
+        }
+        updated: AsyncSubAgentJob = {**old, "status": "success"}
+        result = _jobs_reducer({"a::t::r": old}, {"a::t::r": updated})
+        assert result["a::t::r"]["status"] == "success"
+
+    def test_merge_preserves_other_keys(self) -> None:
+        job1: AsyncSubAgentJob = {
+            "job_id": "a::t1::r1",
+            "agent_name": "a",
+            "thread_id": "t1",
+            "run_id": "r1",
+            "status": "running",
+        }
+        job2: AsyncSubAgentJob = {
+            "job_id": "a::t2::r2",
+            "agent_name": "a",
+            "thread_id": "t2",
+            "run_id": "r2",
+            "status": "running",
+        }
+        result = _jobs_reducer({"a::t1::r1": job1}, {"a::t2::r2": job2})
+        assert len(result) == 2
+        assert "a::t1::r1" in result
+        assert "a::t2::r2" in result
+
+
 class TestBuildAsyncSubagentTools:
     def test_returns_three_tools(self) -> None:
         tools = _build_async_subagent_tools([_make_spec()])
@@ -112,15 +176,20 @@ class TestBuildAsyncSubagentTools:
 
 
 class TestLaunchTool:
-    def test_launch_invalid_type_returns_error(self) -> None:
+    def test_launch_invalid_type_returns_error_string(self) -> None:
         tools = _build_async_subagent_tools([_make_spec("alpha")])
         launch = tools[0]
-        result = launch.invoke({"description": "do something", "subagent_type": "nonexistent"})
+        result = launch.func(
+            description="do something",
+            subagent_type="nonexistent",
+            runtime=_make_runtime(),
+        )
+        assert isinstance(result, str)
         assert "Unknown async subagent type" in result
         assert "`alpha`" in result
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_launch_creates_thread_and_run(self, mock_get_client) -> None:
+    def test_launch_returns_command_with_job(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
         mock_client.runs.create.return_value = {"run_id": "run_xyz"}
@@ -128,16 +197,32 @@ class TestLaunchTool:
 
         tools = _build_async_subagent_tools([_make_spec("alpha")])
         launch = tools[0]
-        result = launch.invoke({"description": "analyze data", "subagent_type": "alpha"})
+        result = launch.func(
+            description="analyze data",
+            subagent_type="alpha",
+            runtime=_make_runtime("tc_launch"),
+        )
+
+        assert isinstance(result, Command)
+        update = result.update
+        assert "async_subagent_jobs" in update
+        jobs = update["async_subagent_jobs"]
+        assert "alpha::thread_abc::run_xyz" in jobs
+        job = jobs["alpha::thread_abc::run_xyz"]
+        assert job["agent_name"] == "alpha"
+        assert job["thread_id"] == "thread_abc"
+        assert job["run_id"] == "run_xyz"
+        assert job["status"] == "running"
+
+        msgs = update["messages"]
+        assert len(msgs) == 1
+        assert msgs[0].tool_call_id == "tc_launch"
+        assert "alpha::thread_abc::run_xyz" in msgs[0].content
 
         mock_get_client.assert_called_once_with(
             url="http://localhost:8123",
             headers={"x-auth-scheme": "langsmith"},
         )
-
-        assert "alpha::thread_abc::run_xyz" in result
-        assert "job_id:" in result
-
         mock_client.threads.create.assert_called_once()
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
@@ -148,29 +233,31 @@ class TestLaunchTool:
 
 class TestCheckTool:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_check_running_job(self, mock_get_client) -> None:
+    def test_check_running_job(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
-        mock_client.runs.get.return_value = {
-            "run_id": "run_xyz",
-            "status": "running",
-        }
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "running"}
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = check.invoke({"job_id": "test-agent::thread_abc::run_xyz"})
+        result = check.func(
+            job_id="test-agent::thread_abc::run_xyz",
+            runtime=_make_runtime("tc_check"),
+        )
 
-        parsed = json.loads(result)
+        assert isinstance(result, Command)
+        msgs = result.update["messages"]
+        parsed = json.loads(msgs[0].content)
         assert parsed["status"] == "running"
         assert parsed["thread_id"] == "thread_abc"
 
+        jobs = result.update["async_subagent_jobs"]
+        assert jobs["test-agent::thread_abc::run_xyz"]["status"] == "running"
+
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_check_completed_job_returns_result(self, mock_get_client) -> None:
+    def test_check_completed_job_returns_result(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
-        mock_client.runs.get.return_value = {
-            "run_id": "run_xyz",
-            "status": "success",
-        }
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "success"}
         mock_client.threads.get_state.return_value = {
             "values": {
                 "messages": [
@@ -182,48 +269,66 @@ class TestCheckTool:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = check.invoke({"job_id": "test-agent::thread_abc::run_xyz"})
+        result = check.func(
+            job_id="test-agent::thread_abc::run_xyz",
+            runtime=_make_runtime("tc_check"),
+        )
 
-        parsed = json.loads(result)
+        assert isinstance(result, Command)
+        parsed = json.loads(result.update["messages"][0].content)
         assert parsed["status"] == "success"
         assert parsed["result"] == "Analysis complete: found 3 issues."
 
+        jobs = result.update["async_subagent_jobs"]
+        assert jobs["test-agent::thread_abc::run_xyz"]["status"] == "success"
+
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_check_errored_job(self, mock_get_client) -> None:
+    def test_check_errored_job(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
-        mock_client.runs.get.return_value = {
-            "run_id": "run_xyz",
-            "status": "error",
-        }
+        mock_client.runs.get.return_value = {"run_id": "run_xyz", "status": "error"}
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = check.invoke({"job_id": "test-agent::thread_abc::run_xyz"})
+        result = check.func(
+            job_id="test-agent::thread_abc::run_xyz",
+            runtime=_make_runtime("tc_check"),
+        )
 
-        parsed = json.loads(result)
+        assert isinstance(result, Command)
+        parsed = json.loads(result.update["messages"][0].content)
         assert parsed["status"] == "error"
         assert "error" in parsed
+
+        jobs = result.update["async_subagent_jobs"]
+        assert jobs["test-agent::thread_abc::run_xyz"]["status"] == "error"
 
 
 class TestUpdateTool:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_update_creates_new_run(self, mock_get_client) -> None:
+    def test_update_returns_command_with_new_job(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.create.return_value = {"run_id": "run_new"}
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
-        result = update.invoke(
-            {
-                "job_id": "test-agent::thread_abc::run_xyz",
-                "message": "Focus on security issues only",
-            }
+        result = update.func(
+            job_id="test-agent::thread_abc::run_xyz",
+            message="Focus on security issues only",
+            runtime=_make_runtime("tc_update"),
         )
 
-        assert "test-agent::thread_abc::run_new" in result
-        assert "job_id:" in result.lower()
+        assert isinstance(result, Command)
+        jobs = result.update["async_subagent_jobs"]
+        new_key = "test-agent::thread_abc::run_new"
+        assert new_key in jobs
+        assert jobs[new_key]["run_id"] == "run_new"
+        assert jobs[new_key]["status"] == "running"
+
+        msgs = result.update["messages"]
+        assert msgs[0].tool_call_id == "tc_update"
+        assert "run_new" in msgs[0].content
 
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
@@ -233,7 +338,7 @@ class TestUpdateTool:
         )
 
 
-def _async_return(value):
+def _async_return(value: Any) -> Any:  # noqa: ANN401
     """Create an async function that returns a fixed value."""
 
     async def _inner(*_args: Any, **_kwargs: Any) -> Any:  # noqa: ANN401
@@ -245,7 +350,7 @@ def _async_return(value):
 @pytest.mark.allow_hosts(["127.0.0.1", "::1"])
 class TestAsyncTools:
     @patch("deepagents.middleware.async_subagents.get_client")
-    async def test_async_launch_creates_thread_and_run(self, mock_get_client) -> None:
+    async def test_async_launch_returns_command(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.threads.create = _async_return({"thread_id": "thread_abc"})
         mock_client.runs.create = _async_return({"run_id": "run_xyz"})
@@ -253,13 +358,19 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec("alpha")])
         launch = tools[0]
-        result = await launch.ainvoke({"description": "analyze data", "subagent_type": "alpha"})
+        result = await launch.coroutine(
+            description="analyze data",
+            subagent_type="alpha",
+            runtime=_make_runtime("tc_async_launch"),
+        )
 
-        assert "alpha::thread_abc::run_xyz" in result
-        assert "job_id:" in result
+        assert isinstance(result, Command)
+        assert "alpha::thread_abc::run_xyz" in result.update["messages"][0].content
+        jobs = result.update["async_subagent_jobs"]
+        assert "alpha::thread_abc::run_xyz" in jobs
 
     @patch("deepagents.middleware.async_subagents.get_client")
-    async def test_async_check_completed_job(self, mock_get_client) -> None:
+    async def test_async_check_returns_command(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.get = _async_return({"run_id": "run_xyz", "status": "success"})
         mock_client.threads.get_state = _async_return({"values": {"messages": [{"role": "assistant", "content": "Done!"}]}})
@@ -267,25 +378,32 @@ class TestAsyncTools:
 
         tools = _build_async_subagent_tools([_make_spec()])
         check = tools[1]
-        result = await check.ainvoke({"job_id": "test-agent::thread_abc::run_xyz"})
+        result = await check.coroutine(
+            job_id="test-agent::thread_abc::run_xyz",
+            runtime=_make_runtime("tc_async_check"),
+        )
 
-        parsed = json.loads(result)
+        assert isinstance(result, Command)
+        parsed = json.loads(result.update["messages"][0].content)
         assert parsed["status"] == "success"
         assert parsed["result"] == "Done!"
+        assert result.update["async_subagent_jobs"]["test-agent::thread_abc::run_xyz"]["status"] == "success"
 
     @patch("deepagents.middleware.async_subagents.get_client")
-    async def test_async_update_creates_new_run(self, mock_get_client) -> None:
+    async def test_async_update_returns_command(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.runs.create = _async_return({"run_id": "run_new"})
         mock_get_client.return_value = mock_client
 
         tools = _build_async_subagent_tools([_make_spec()])
         update = tools[2]
-        result = await update.ainvoke(
-            {
-                "job_id": "test-agent::thread_abc::run_xyz",
-                "message": "New instructions",
-            }
+        result = await update.coroutine(
+            job_id="test-agent::thread_abc::run_xyz",
+            message="New instructions",
+            runtime=_make_runtime("tc_async_update"),
         )
 
-        assert "test-agent::thread_abc::run_new" in result
+        assert isinstance(result, Command)
+        new_key = "test-agent::thread_abc::run_new"
+        assert new_key in result.update["async_subagent_jobs"]
+        assert "run_new" in result.update["messages"][0].content


### PR DESCRIPTION
Adds `AsyncSubAgentMiddleware` to the SDK, enabling agents to launch background jobs on remote LangGraph deployments via the LangGraph SDK. Unlike synchronous subagents that block until completion, async subagents return a job ID immediately — the main agent can continue working, check progress on demand, send follow-up instructions, or cancel jobs. 

The CLI reads async subagent definitions from `[async_subagents]` in `~/.deepagents/config.toml` and wires them in automatically.

## Changes
- Add `AsyncSubAgentMiddleware` in `deepagents/middleware/async_subagents.py` with five tools: `launch_async_subagent`, `check_async_subagent`, `update_async_subagent`, `cancel_async_subagent`, and `list_async_subagent_jobs` — each with sync + async implementations that return `Command` objects to persist job state
- Track jobs via `AsyncSubAgentState` with a `_jobs_reducer` that merges updates into a `dict[str, AsyncSubAgentJob]`, surviving context compaction
- Cache LangGraph SDK clients per `(url, headers)` tuple in `_ClientCache` to avoid reconnecting on every tool call
- Add `async_subagents` parameter to `create_deep_agent` in `graph.py` — when provided, appends `AsyncSubAgentMiddleware` to the middleware stack
- Add `load_async_subagents()` in the CLI to parse `config.toml` and pass specs through to `create_cli_agent` in both interactive and server modes
- Wire HITL interrupt config for `launch_async_subagent`, `update_async_subagent`, and `cancel_async_subagent` in the CLI's approval system
- Export `AsyncSubAgent`, `AsyncSubAgentJob`, and `AsyncSubAgentMiddleware` from `deepagents` and `deepagents.middleware`