### PR TITLE
feat(cli): support `~/.deepagents/.env` as global API key fallback

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -24,7 +24,8 @@ from deepagents_cli._version import __version__
 
 logger = logging.getLogger(__name__)
 
-dotenv.load_dotenv()
+dotenv.load_dotenv(Path.home() / ".deepagents" / ".env")
+dotenv.load_dotenv(override=True)
 
 # CRITICAL: Override LANGSMITH_PROJECT to route agent traces to separate project
 # LangSmith reads LANGSMITH_PROJECT at invocation time, so we override it here
@@ -557,6 +558,7 @@ class Settings:
         Returns:
             A list of human-readable change descriptions.
         """
+        dotenv.load_dotenv(Path.home() / ".deepagents" / ".env")
         dotenv.load_dotenv(override=True)
 
         api_key_fields = {

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -137,14 +137,25 @@ class TestReloadFromEnvironment:
     def test_calls_dotenv_load(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Reload should call dotenv with override enabled."""
+        """Reload should load global ~/.deepagents/.env then CWD .env with override."""
         settings = Settings.from_environment(start_path=tmp_path)
-        mock_load = MagicMock(return_value=False)
-        monkeypatch.setattr("deepagents_cli.config.dotenv.load_dotenv", mock_load)
+        calls: list[tuple[object, ...]] = []
+
+        def _capture_load(*args: object, **kwargs: object) -> bool:
+            calls.append((args, kwargs))
+            return False
+
+        monkeypatch.setattr("deepagents_cli.config.dotenv.load_dotenv", _capture_load)
 
         settings.reload_from_environment(start_path=tmp_path)
 
-        mock_load.assert_called_once_with(override=True)
+        assert len(calls) == 2
+        global_args, global_kwargs = calls[0][0], calls[0][1]
+        cwd_args, cwd_kwargs = calls[1][0], calls[1][1]
+        assert Path(global_args[0]) == Path.home() / ".deepagents" / ".env"
+        assert global_kwargs == {}
+        assert cwd_args == ()
+        assert cwd_kwargs == {"override": True}
 
     def test_multiple_simultaneous_changes(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -160,6 +171,25 @@ class TestReloadFromEnvironment:
         assert len(changes) == 3
         fields = {c.split(":")[0] for c in changes}
         assert fields == {"openai_api_key", "anthropic_api_key", "shell_allow_list"}
+
+    def test_global_env_loaded_before_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Global ~/.deepagents/.env is loaded before CWD .env (lower priority)."""
+        settings = Settings.from_environment(start_path=tmp_path)
+        load_order: list[str] = []
+
+        def _track_load(*args: object, **_kwargs: object) -> bool:
+            if args and ".deepagents" in str(args[0]):
+                load_order.append("global")
+            else:
+                load_order.append("cwd")
+            return False
+
+        monkeypatch.setattr("deepagents_cli.config.dotenv.load_dotenv", _track_load)
+        settings.reload_from_environment(start_path=tmp_path)
+
+        assert load_order == ["global", "cwd"]
 
 
 class TestReloadErrorPaths:


### PR DESCRIPTION
This pull request updates the environment variable loading logic in the CLI configuration to ensure that a global environment file (`~/.deepagents/.env`) is loaded before the local `.env` file, and that the local file can override the global settings. It also adds and updates tests to verify this behavior and the order of loading.

**Environment Variable Loading Improvements:**

* Changed `dotenv.load_dotenv` calls in `config.py` to first load the global `~/.deepagents/.env` file, followed by the local `.env` file with `override=True`, ensuring local settings take precedence. [[1]](diffhunk://#diff-ae79bb00939843f72b249990644f08fc857b2652279f4ddbeaecdef10ebe4f35L27-R28) [[2]](diffhunk://#diff-ae79bb00939843f72b249990644f08fc857b2652279f4ddbeaecdef10ebe4f35R561)

**Testing Enhancements:**

* Updated the test `test_calls_dotenv_load` to verify that both the global and local `.env` files are loaded in the correct order and with the correct arguments.
* Added a new test `test_global_env_loaded_before_cwd` to explicitly check that the global environment file is loaded before the local one.