### PR TITLE
fix(sdk): prevent commands from hanging waiting for stdin

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -301,6 +301,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 check=False,
                 shell=True,  # Intentional: designed for LLM-controlled shell execution
                 capture_output=True,
+                stdin=subprocess.DEVNULL,  # No stdin interaction
                 text=True,
                 timeout=effective_timeout,
                 env=self._env,

--- a/libs/deepagents/tests/unit_tests/test_local_shell.py
+++ b/libs/deepagents/tests/unit_tests/test_local_shell.py
@@ -1,6 +1,7 @@
 """Unit tests for LocalShellBackend per-command timeout features."""
 
 import subprocess
+import time
 from unittest.mock import patch
 
 import pytest
@@ -73,6 +74,22 @@ class TestPerCommandTimeout:
         backend = LocalShellBackend(inherit_env=True)
         with pytest.raises(ValueError, match="timeout must be positive"):
             backend.execute("echo hello", timeout=-5)
+
+
+class TestStdinBehavior:
+    """Tests for stdin behavior in execute()."""
+
+    def test_command_blocking_on_stdin_does_not_hang(self) -> None:
+        """Commands that block on stdin should not hang until timeout."""
+        backend = LocalShellBackend(timeout=60, inherit_env=True)
+        start = time.time()
+        # 'python' without arguments would normally hang waiting for stdin.
+        # With stdin=DEVNULL, it should exit immediately.
+        result = backend.execute("python", timeout=2)
+        elapsed = time.time() - start
+        # Should complete in well under 2 seconds
+        assert elapsed < 1
+        assert result.exit_code == 0
 
 
 class TestTimeoutErrorMessage:


### PR DESCRIPTION
Set `stdin=subprocess.DEVNULL` in LocalShellBackend.execute() so commands like python (without arguments) exit immediately instead of waiting for stdin until timeout.

Fixes #1766.

After the fix, the python command will exit immediately:

<img width="1846" height="1082" alt="image" src="https://github.com/user-attachments/assets/bbb82cce-3fc9-419c-a999-7add0484c57e" />
