### PR TITLE
ci(infra): port contributing workflows from langchain

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,101 @@
+name: "📋 Task"
+description: Create a task for project management and tracking by Deep Agents maintainers. If you are not a maintainer, please use other templates or the forum.
+labels: ["task"]
+type: task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for creating a task to help organize Deep Agents development.
+
+        This template is for **maintainer tasks** such as project management, development planning, refactoring, documentation updates, and other organizational work.
+
+        If you are not a Deep Agents maintainer or were not asked directly by a maintainer to create a task, then please start the conversation on the [Deep Agents Forum](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18) instead or use the appropriate bug report or feature request templates on the previous page.
+  - type: checkboxes
+    id: maintainer
+    attributes:
+      label: Maintainer task
+      description: Confirm that you are allowed to create a task here.
+      options:
+        - label: I am a Deep Agents maintainer, or was asked directly by a Deep Agents maintainer to create a task here.
+          required: true
+  - type: textarea
+    id: task-description
+    attributes:
+      label: Task Description
+      description: |
+        Provide a clear and detailed description of the task.
+
+        What needs to be done? Be specific about the scope and requirements.
+      placeholder: |
+        This task involves...
+
+        The goal is to...
+
+        Specific requirements:
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: |
+        Define the criteria that must be met for this task to be considered complete.
+
+        What are the specific deliverables or outcomes expected?
+      placeholder: |
+        This task will be complete when:
+        - [ ] ...
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and Background
+      description: |
+        Provide any relevant context, background information, or links to related issues/PRs.
+
+        Why is this task needed? What problem does it solve?
+      placeholder: |
+        Background:
+        - ...
+
+        Related issues/PRs:
+        - #...
+
+        Additional context:
+        - ...
+    validations:
+      required: false
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: |
+        List any dependencies or blockers for this task.
+
+        Are there other tasks, issues, or external factors that need to be completed first?
+      placeholder: |
+        This task depends on:
+        - [ ] Issue #...
+        - [ ] PR #...
+        - [ ] External dependency: ...
+
+        Blocked by:
+        - ...
+    validations:
+      required: false
+  - type: checkboxes
+    id: package
+    attributes:
+      label: Area (Required)
+      description: |
+        Please select area(s) that this task is related to.
+      options:
+        - label: deepagents (SDK)
+        - label: cli
+        - label: Other / not sure / general

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
-(Replace this entire block of text)
+Fixes #
+
+<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->
+
+Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview
 
 > **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).
 
-Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview
 If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!
 
 Thank you for contributing to Deep Agents! Follow these steps to have your pull request considered as ready for review.

--- a/.github/workflows/pr_size_labeler.yml
+++ b/.github/workflows/pr_size_labeler.yml
@@ -1,0 +1,174 @@
+# Label PRs by size (changed lines, excluding lockfiles and docs).
+#
+# Size thresholds:
+#   XS: < 50, S: < 200, M: < 500, L: < 1000, XL: >= 1000
+
+name: "📏 PR Size Labeler"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      max_items:
+        description: "Maximum number of open PRs to process"
+        default: "100"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  size-label:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Apply PR size label
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) return;
+
+            const sizeLabels = ['size: XS', 'size: S', 'size: M', 'size: L', 'size: XL'];
+            const labelColor = 'b76e79';
+
+            // Ensure labels exist
+            for (const name of sizeLabels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error?.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner, repo, name, color: labelColor,
+                });
+              }
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pullRequest.number, per_page: 100,
+            });
+
+            const excludedFiles = new Set(['poetry.lock', 'uv.lock']);
+            const totalChangedLines = files.reduce((total, file) => {
+              const path = file.filename ?? '';
+              if (path.startsWith('docs/') || excludedFiles.has(path)) return total;
+              return total + (file.additions ?? 0) + (file.deletions ?? 0);
+            }, 0);
+
+            let targetSizeLabel = 'size: XL';
+            if (totalChangedLines < 50) targetSizeLabel = 'size: XS';
+            else if (totalChangedLines < 200) targetSizeLabel = 'size: S';
+            else if (totalChangedLines < 500) targetSizeLabel = 'size: M';
+            else if (totalChangedLines < 1000) targetSizeLabel = 'size: L';
+
+            // Remove stale size labels
+            const currentLabels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              { owner, repo, issue_number: pullRequest.number, per_page: 100 },
+            );
+            for (const label of currentLabels) {
+              const name = label.name ?? '';
+              if (sizeLabels.includes(name) && name !== targetSizeLabel) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pullRequest.number, name,
+                });
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: pullRequest.number, labels: [targetSizeLabel],
+            });
+
+            console.log(`PR #${pullRequest.number}: ${totalChangedLines} changed lines → ${targetSizeLabel}`);
+
+  backfill:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Backfill size labels on open PRs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const maxItems = parseInt('${{ inputs.max_items }}') || 100;
+
+            const sizeLabels = ['size: XS', 'size: S', 'size: M', 'size: L', 'size: XL'];
+            const labelColor = 'b76e79';
+
+            // Ensure labels exist
+            for (const name of sizeLabels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error?.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner, repo, name, color: labelColor,
+                });
+                console.log(`Created label: ${name}`);
+              }
+            }
+
+            function getSizeLabel(totalChangedLines) {
+              if (totalChangedLines < 50) return 'size: XS';
+              if (totalChangedLines < 200) return 'size: S';
+              if (totalChangedLines < 500) return 'size: M';
+              if (totalChangedLines < 1000) return 'size: L';
+              return 'size: XL';
+            }
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+
+            let processed = 0;
+            for (const pr of prs) {
+              if (processed >= maxItems) break;
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: pr.number, per_page: 100,
+              });
+
+              const excludedFiles = new Set(['poetry.lock', 'uv.lock']);
+              const totalChangedLines = files.reduce((total, file) => {
+                const path = file.filename ?? '';
+                if (path.startsWith('docs/') || excludedFiles.has(path)) return total;
+                return total + (file.additions ?? 0) + (file.deletions ?? 0);
+              }, 0);
+
+              const targetSizeLabel = getSizeLabel(totalChangedLines);
+
+              // Remove stale size labels
+              const currentLabels = await github.paginate(
+                github.rest.issues.listLabelsOnIssue,
+                { owner, repo, issue_number: pr.number, per_page: 100 },
+              );
+              for (const label of currentLabels) {
+                const name = label.name ?? '';
+                if (sizeLabels.includes(name) && name !== targetSizeLabel) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: pr.number, name,
+                  });
+                }
+              }
+
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: [targetSizeLabel],
+              });
+
+              console.log(`PR #${pr.number}: ${totalChangedLines} changed lines → ${targetSizeLabel}`);
+              processed++;
+            }
+
+            console.log(`\nBackfill complete. Processed ${processed} PRs.`);

--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -1,0 +1,214 @@
+# Require external PRs to link to an approved issue or discussion using
+# GitHub auto-close keywords (Fixes #NNN, Closes #NNN, Resolves #NNN),
+# AND require that the PR author is assigned to the linked issue.
+#
+# - Reacts to the "external" label applied by tag-external-contributions.yml,
+#   avoiding a duplicate org membership check.
+# - Also re-checks on PR edits/reopens for PRs that already have the label.
+# - Validates the PR author is an assignee on at least one linked issue.
+# - Adds a "missing-issue-link" label on failure; removes it on pass.
+# - Automatically reopens PRs that were closed by this workflow once the
+#   check passes (e.g. author edits the body to add a valid issue link).
+# - Posts a comment explaining the requirement on failure.
+# - Deduplicates comments via an HTML marker so re-runs don't spam.
+#
+# Dependency: tag-external-contributions.yml must run first to apply the
+# "external" label on new PRs. Both workflows trigger on pull_request_target
+# opened events; this workflow additionally listens for the "labeled" event
+# to chain off the external classification.
+
+name: Require Issue Link
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, labeled]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Enforcement gate: set to 'true' to activate the issue link requirement.
+# When 'false', the workflow still runs the check logic (useful for dry-run
+# visibility) but will NOT label, comment, close, or fail PRs.
+# ──────────────────────────────────────────────────────────────────────────────
+env:
+  ENFORCE_ISSUE_LINK: 'false'
+
+permissions:
+  contents: read
+
+jobs:
+  check-issue-link:
+    # Run when the "external" label is added, or on edit/reopen if already labeled
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'external') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'external'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Check for issue link and assignee
+        id: check-link
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*#(\d+)/gi;
+            const matches = [...body.matchAll(pattern)];
+
+            if (matches.length === 0) {
+              console.log('No issue link found in PR body');
+              core.setOutput('has-link', 'false');
+              core.setOutput('is-assigned', 'false');
+              return;
+            }
+
+            const issues = matches.map(m => `#${m[1]}`).join(', ');
+            console.log(`Found issue link(s): ${issues}`);
+            core.setOutput('has-link', 'true');
+
+            // Check whether the PR author is assigned to at least one linked issue
+            const { owner, repo } = context.repo;
+            const prAuthor = context.payload.pull_request.user.login;
+            const issueNumbers = [...new Set(matches.map(m => parseInt(m[1], 10)))];
+
+            let assignedToAny = false;
+            for (const num of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner, repo, issue_number: num,
+                });
+                const assignees = issue.assignees.map(a => a.login.toLowerCase());
+                if (assignees.includes(prAuthor.toLowerCase())) {
+                  console.log(`PR author "${prAuthor}" is assigned to #${num}`);
+                  assignedToAny = true;
+                  break;
+                } else {
+                  console.log(`PR author "${prAuthor}" is NOT assigned to #${num} (assignees: ${assignees.join(', ') || 'none'})`);
+                }
+              } catch (error) {
+                console.log(`Could not fetch issue #${num}: ${error.message}`);
+              }
+            }
+
+            core.setOutput('is-assigned', assignedToAny ? 'true' : 'false');
+
+      - name: Add missing-issue-link label
+        if: >-
+          env.ENFORCE_ISSUE_LINK == 'true' &&
+          (steps.check-link.outputs.has-link != 'true' || steps.check-link.outputs.is-assigned != 'true')
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: prNumber, labels: ['missing-issue-link'],
+            });
+
+      - name: Remove missing-issue-link label and reopen PR
+        if: >-
+          env.ENFORCE_ISSUE_LINK == 'true' &&
+          steps.check-link.outputs.has-link == 'true' && steps.check-link.outputs.is-assigned == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: prNumber, name: 'missing-issue-link',
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            // Reopen PR only if it was previously closed by this workflow
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (context.payload.pull_request.state === 'closed' && labels.includes('missing-issue-link')) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                state: 'open',
+              });
+              console.log(`Reopened PR #${prNumber}`);
+            }
+
+      - name: Post comment, close PR, and fail
+        if: >-
+          env.ENFORCE_ISSUE_LINK == 'true' &&
+          (steps.check-link.outputs.has-link != 'true' || steps.check-link.outputs.is-assigned != 'true')
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const hasLink = '${{ steps.check-link.outputs.has-link }}' === 'true';
+            const isAssigned = '${{ steps.check-link.outputs.is-assigned }}' === 'true';
+            const marker = '<!-- require-issue-link -->';
+
+            let lines;
+            if (!hasLink) {
+              lines = [
+                marker,
+                '**This PR has been automatically closed** because it does not link to an approved issue.',
+                '',
+                'All external contributions must reference an approved issue or discussion. Please:',
+                '1. Find or [open an issue](https://github.com/' + owner + '/' + repo + '/issues/new/choose) describing the change',
+                '2. Wait for a maintainer to approve and assign you',
+                '3. Add `Fixes #<issue_number>`, `Closes #<issue_number>`, or `Resolves #<issue_number>` to your PR description and the PR will be reopened automatically',
+              ];
+            } else {
+              lines = [
+                marker,
+                '**This PR has been automatically closed** because you are not assigned to the linked issue.',
+                '',
+                'External contributors must be assigned to an issue before opening a PR for it. Please:',
+                '1. Comment on the linked issue to request assignment from a maintainer',
+                '2. Once assigned, edit your PR description and the PR will be reopened automatically',
+              ];
+            }
+
+            const body = lines.join('\n');
+
+            // Deduplicate: check for existing comment with the marker
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (!existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+              console.log('Posted requirement comment');
+            } else if (existing.body !== body) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              console.log('Updated existing comment with new message');
+            } else {
+              console.log('Comment already exists — skipping');
+            }
+
+            // Close the PR
+            if (context.payload.pull_request.state === 'open') {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                state: 'closed',
+              });
+              console.log(`Closed PR #${prNumber}`);
+            }
+
+            const reason = !hasLink
+              ? 'PR must reference an issue using auto-close keywords (e.g., "Fixes #123").'
+              : 'PR author must be assigned to the linked issue.';
+            core.setFailed(reason);

--- a/.github/workflows/tag-external-contributions.yml
+++ b/.github/workflows/tag-external-contributions.yml
@@ -1,9 +1,10 @@
 # Automatically tag issues and pull requests as "external" or "internal"
 # based on whether the author is a member of the langchain-ai
-# GitHub organization.
+# GitHub organization, and apply contributor tier labels to external
+# contributors based on their merged PR history.
 #
-# Setup instructions:
-# 1. Attach a GitHub App with the following permissions:
+# Setup Requirements:
+# 1. Create a GitHub App with permissions:
 #    - Repository: Issues (write), Pull requests (write)
 #    - Organization: Members (read)
 # 2. Install the app on your organization and this repository
@@ -13,6 +14,9 @@
 #
 # The GitHub App token is required to check private organization membership.
 # Without it, the workflow will fail.
+#
+# Contributor tier thresholds:
+#   - trusted-contributor: >= 5 merged PRs
 
 name: Tag External Contributions
 
@@ -21,9 +25,27 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      backfill_type:
+        description: "Backfill type (for initial run)"
+        default: "both"
+        type: choice
+        options:
+          - prs
+          - issues
+          - both
+      max_items:
+        description: "Maximum number of items to process"
+        default: "100"
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   tag-external:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -97,7 +119,10 @@ jobs:
         if: steps.check-membership.outputs.is-external == 'true' && github.event_name == 'pull_request_target'
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Use App token so the "labeled" event propagates to downstream
+          # workflows (e.g. require_issue_link.yml). Events created by the
+          # default GITHUB_TOKEN do not trigger additional workflow runs.
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
             const pull_number = context.payload.pull_request.number;
@@ -146,3 +171,230 @@ jobs:
             });
 
             console.log(`Added 'internal' label to pull request #${pull_number}`);
+
+      - name: Apply contributor tier label
+        if: steps.check-membership.outputs.is-external == 'true'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const isPR = context.eventName === 'pull_request_target';
+            const item = isPR
+              ? context.payload.pull_request
+              : context.payload.issue;
+            const author = item.user.login;
+            const issueNumber = item.number;
+
+            const TRUSTED_THRESHOLD = 5;
+
+            const mergedQuery = `repo:${owner}/${repo} is:pr is:merged author:"${author}"`;
+            let mergedCount = 0;
+            try {
+              const result = await github.rest.search.issuesAndPullRequests({
+                q: mergedQuery,
+                per_page: 1,
+              });
+              mergedCount = result?.data?.total_count ?? 0;
+            } catch (error) {
+              if (error?.status !== 422) throw error;
+              core.warning(`Search failed for ${author}; skipping tier label.`);
+              return;
+            }
+
+            const label = mergedCount >= TRUSTED_THRESHOLD ? 'trusted-contributor' : null;
+
+            if (label) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: [label],
+              });
+              console.log(`Applied '${label}' to #${issueNumber} (${mergedCount} merged PRs)`);
+            } else {
+              console.log(`No tier label for ${author} (${mergedCount} merged PRs)`);
+            }
+
+  backfill:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ORG_MEMBERSHIP_APP_ID }}
+          private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
+
+      - name: Backfill labels
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const maxItems = parseInt('${{ inputs.max_items }}') || 100;
+            const backfillType = '${{ inputs.backfill_type }}';
+
+            const TRUSTED_THRESHOLD = 5;
+            const LABEL_COLOR = 'b76e79';
+
+            const sizeLabels = ['size: XS', 'size: S', 'size: M', 'size: L', 'size: XL'];
+            const tierLabels = ['trusted-contributor'];
+
+            // Ensure tier and size labels exist
+            for (const name of [...tierLabels, ...sizeLabels]) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error?.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner, repo, name, color: LABEL_COLOR,
+                });
+                console.log(`Created label: ${name}`);
+              }
+            }
+
+            // Cache: author -> { isExternal, mergedCount }
+            const contributorCache = new Map();
+
+            async function getContributorInfo(author) {
+              if (contributorCache.has(author)) return contributorCache.get(author);
+
+              let isExternal = true;
+              try {
+                const membership = await github.rest.orgs.getMembershipForUser({
+                  org: 'langchain-ai',
+                  username: author,
+                });
+                isExternal = membership.data.state !== 'active';
+              } catch (error) {
+                if (error.status !== 404) {
+                  core.warning(`Membership check failed for ${author}: ${error.message}`);
+                }
+              }
+
+              let mergedCount = 0;
+              if (isExternal) {
+                try {
+                  const result = await github.rest.search.issuesAndPullRequests({
+                    q: `repo:${owner}/${repo} is:pr is:merged author:"${author}"`,
+                    per_page: 1,
+                  });
+                  mergedCount = result?.data?.total_count ?? 0;
+                } catch (error) {
+                  if (error?.status !== 422) throw error;
+                  core.warning(`Search failed for ${author}; skipping tier.`);
+                }
+              }
+
+              const info = { isExternal, mergedCount };
+              contributorCache.set(author, info);
+              return info;
+            }
+
+            function getTierLabel(mergedCount) {
+              return mergedCount >= TRUSTED_THRESHOLD ? 'trusted-contributor' : null;
+            }
+
+            function getSizeLabel(totalChangedLines) {
+              if (totalChangedLines < 50) return 'size: XS';
+              if (totalChangedLines < 200) return 'size: S';
+              if (totalChangedLines < 500) return 'size: M';
+              if (totalChangedLines < 1000) return 'size: L';
+              return 'size: XL';
+            }
+
+            async function removeStaleLabels(issueNumber, labelsToKeep, labelSets) {
+              const currentLabels = await github.paginate(
+                github.rest.issues.listLabelsOnIssue,
+                { owner, repo, issue_number: issueNumber, per_page: 100 },
+              );
+              for (const label of currentLabels) {
+                const name = label.name ?? '';
+                const inManagedSet = labelSets.some((s) => s.includes(name));
+                if (inManagedSet && !labelsToKeep.includes(name)) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: issueNumber, name,
+                  });
+                }
+              }
+            }
+
+            let processed = 0;
+
+            // Backfill PRs
+            if (backfillType === 'prs' || backfillType === 'both') {
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+
+              for (const pr of prs) {
+                if (processed >= maxItems) break;
+                const author = pr.user.login;
+                const info = await getContributorInfo(author);
+
+                const labels = [];
+                labels.push(info.isExternal ? 'external' : 'internal');
+
+                if (info.isExternal) {
+                  const tier = getTierLabel(info.mergedCount);
+                  if (tier) labels.push(tier);
+                }
+
+                // Compute size label
+                const files = await github.paginate(github.rest.pulls.listFiles, {
+                  owner, repo, pull_number: pr.number, per_page: 100,
+                });
+                const excludedFiles = new Set(['poetry.lock', 'uv.lock']);
+                const totalChangedLines = files.reduce((total, file) => {
+                  const path = file.filename ?? '';
+                  if (path.startsWith('docs/') || excludedFiles.has(path)) return total;
+                  return total + (file.additions ?? 0) + (file.deletions ?? 0);
+                }, 0);
+                labels.push(getSizeLabel(totalChangedLines));
+
+                await removeStaleLabels(pr.number, labels, [sizeLabels, tierLabels]);
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: pr.number, labels,
+                });
+                console.log(`PR #${pr.number} (${author}): ${labels.join(', ')}`);
+                processed++;
+              }
+            }
+
+            // Backfill issues
+            if (backfillType === 'issues' || backfillType === 'both') {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+
+              for (const issue of issues) {
+                if (processed >= maxItems) break;
+                if (issue.pull_request) continue;
+
+                const author = issue.user.login;
+                const info = await getContributorInfo(author);
+
+                const labels = [];
+                labels.push(info.isExternal ? 'external' : 'internal');
+
+                if (info.isExternal) {
+                  const tier = getTierLabel(info.mergedCount);
+                  if (tier) labels.push(tier);
+                }
+
+                await removeStaleLabels(issue.number, labels, [tierLabels]);
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: issue.number, labels,
+                });
+                console.log(`Issue #${issue.number} (${author}): ${labels.join(', ')}`);
+                processed++;
+              }
+            }
+
+            console.log(`\nBackfill complete. Processed ${processed} items. Cache hits: ${contributorCache.size} unique authors.`);


### PR DESCRIPTION
Port contributing infrastructure from the LangChain monorepo. Adds automated PR size labeling, contributor tier recognition, issue-link enforcement (gated off by default via `ENFORCE_ISSUE_LINK: 'false'`), and a maintainer task issue template. The existing external/internal tagger is upgraded with a `workflow_dispatch` backfill job, contributor tier labels, and an app token fix so `labeled` events propagate to downstream workflows.

## Changes

- **Contributor tiers + backfill** in `tag-external-contributions.yml`: add a `trusted-contributor` label (>= 5 merged PRs) for external contributors, a `workflow_dispatch` backfill job that retroactively labels open PRs/issues with external/internal + tier + size labels using a per-author cache, and switch the external PR label step to the App token so `labeled` events trigger `require_issue_link.yml`
- **PR size labeling** via new `pr_size_labeler.yml`: auto-applies `size: XS`/`S`/`M`/`L`/`XL` labels on `pull_request_target` events, excluding `docs/`, `poetry.lock`, and `uv.lock` from the line count — includes a `workflow_dispatch` backfill job
- **Issue link enforcement** via new `require_issue_link.yml`: checks external PRs for `Fixes #NNN`/`Closes #NNN`/`Resolves #NNN` keywords and validates the PR author is assigned to the linked issue — all enforcement steps (label, comment, close, `core.setFailed`) gated on `env.ENFORCE_ISSUE_LINK == 'true'`, currently set to `'false'`
- **PR template** updated with `Fixes #` placeholder at the top and reordered language policy blockquote
- **Task issue template** added as `task.yml` — maintainer-only, with task description, acceptance criteria, context, and dependency fields scoped to deepagents areas (SDK, CLI)
