### PR TITLE
fix(sdk): normalize legacy store backend paths

### DIFF
--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -53,6 +53,13 @@ NamespaceFactory = Callable[[BackendContext[Any, Any]], tuple[str, ...]]
 _NAMESPACE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9\-_.@+:~]+$")
 
 
+def _normalize_store_path(path: str) -> str:
+    """Return a store path with a leading slash."""
+    if path.startswith("/"):
+        return path
+    return f"/{path}"
+
+
 def _validate_namespace(namespace: tuple[str, ...]) -> tuple[str, ...]:
     """Validate a namespace tuple returned by a NamespaceFactory.
 
@@ -198,6 +205,46 @@ class StoreBackend(BackendProtocol):
             return (assistant_id, namespace)
         return (namespace,)
 
+    def _get_store_item(
+        self,
+        store: BaseStore,
+        namespace: tuple[str, ...],
+        file_path: str,
+    ) -> tuple[str, Item | None]:
+        """Get a store item, tolerating legacy keys without a leading slash."""
+        normalized_path = _normalize_store_path(file_path)
+        item = store.get(namespace, normalized_path)
+        if item is not None:
+            return normalized_path, item
+
+        legacy_path = normalized_path.removeprefix("/")
+        if legacy_path:
+            item = store.get(namespace, legacy_path)
+            if item is not None:
+                return legacy_path, item
+
+        return normalized_path, None
+
+    async def _aget_store_item(
+        self,
+        store: BaseStore,
+        namespace: tuple[str, ...],
+        file_path: str,
+    ) -> tuple[str, Item | None]:
+        """Async version of `_get_store_item`."""
+        normalized_path = _normalize_store_path(file_path)
+        item = await store.aget(namespace, normalized_path)
+        if item is not None:
+            return normalized_path, item
+
+        legacy_path = normalized_path.removeprefix("/")
+        if legacy_path:
+            item = await store.aget(namespace, legacy_path)
+            if item is not None:
+                return legacy_path, item
+
+        return normalized_path, None
+
     def _convert_store_item_to_file_data(self, store_item: Item) -> dict[str, Any]:
         """Convert a store Item to FileData format.
 
@@ -305,17 +352,22 @@ class StoreBackend(BackendProtocol):
         items = self._search_store_paginated(store, namespace)
         infos: list[FileInfo] = []
         subdirs: set[str] = set()
+        seen_files: set[str] = set()
 
         # Normalize path to have trailing slash for proper prefix matching
-        normalized_path = path if path.endswith("/") else path + "/"
+        normalized_path = _normalize_store_path(path)
+        if not normalized_path.endswith("/"):
+            normalized_path += "/"
 
         for item in items:
+            item_path = _normalize_store_path(str(item.key))
+
             # Check if file is in the specified directory or a subdirectory
-            if not str(item.key).startswith(normalized_path):
+            if not item_path.startswith(normalized_path):
                 continue
 
             # Get the relative path after the directory
-            relative = str(item.key)[len(normalized_path) :]
+            relative = item_path[len(normalized_path) :]
 
             # If relative path contains '/', it's in a subdirectory
             if "/" in relative:
@@ -325,14 +377,19 @@ class StoreBackend(BackendProtocol):
                 continue
 
             # This is a file directly in the current directory
+            if item_path in seen_files:
+                continue
+
             try:
                 fd = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
+
+            seen_files.add(item_path)
             size = len("\n".join(fd.get("content", [])))
             infos.append(
                 {
-                    "path": item.key,
+                    "path": item_path,
                     "is_dir": False,
                     "size": int(size),
                     "modified_at": fd.get("modified_at", ""),
@@ -363,10 +420,10 @@ class StoreBackend(BackendProtocol):
         """
         store = self._get_store()
         namespace = self._get_namespace()
-        item: Item | None = store.get(namespace, file_path)
+        normalized_path, item = self._get_store_item(store, namespace, file_path)
 
         if item is None:
-            return f"Error: File '{file_path}' not found"
+            return f"Error: File '{normalized_path}' not found"
 
         try:
             file_data = self._convert_store_item_to_file_data(item)
@@ -387,10 +444,10 @@ class StoreBackend(BackendProtocol):
         """
         store = self._get_store()
         namespace = self._get_namespace()
-        item: Item | None = await store.aget(namespace, file_path)
+        normalized_path, item = await self._aget_store_item(store, namespace, file_path)
 
         if item is None:
-            return f"Error: File '{file_path}' not found"
+            return f"Error: File '{normalized_path}' not found"
 
         try:
             file_data = self._convert_store_item_to_file_data(item)
@@ -536,7 +593,7 @@ class StoreBackend(BackendProtocol):
         files: dict[str, Any] = {}
         for item in items:
             try:
-                files[item.key] = self._convert_store_item_to_file_data(item)
+                files[_normalize_store_path(str(item.key))] = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
         return grep_matches_from_files(files, pattern, path, glob)
@@ -549,7 +606,7 @@ class StoreBackend(BackendProtocol):
         files: dict[str, Any] = {}
         for item in items:
             try:
-                files[item.key] = self._convert_store_item_to_file_data(item)
+                files[_normalize_store_path(str(item.key))] = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
         result = _glob_search_files(files, pattern, path)
@@ -611,7 +668,7 @@ class StoreBackend(BackendProtocol):
         responses: list[FileDownloadResponse] = []
 
         for path in paths:
-            item = store.get(namespace, path)
+            _, item = self._get_store_item(store, namespace, path)
 
             if item is None:
                 responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -120,6 +120,35 @@ def test_store_backend_ls_trailing_slash():
     assert [fi["path"] for fi in listing1] == [fi["path"] for fi in listing2]
 
 
+def test_store_backend_handles_legacy_store_keys_without_leading_slash():
+    rt = make_runtime()
+    rt.store.put(
+        ("filesystem",),
+        "test.md",
+        {"content": ["hello legacy"], "created_at": "2023-01-01T00:00:00Z", "modified_at": "2023-01-01T00:00:00Z"},
+    )
+    rt.store.put(
+        ("filesystem",),
+        "subdir/file.txt",
+        {"content": ["nested legacy"], "created_at": "2023-01-01T00:00:00Z", "modified_at": "2023-01-01T00:00:00Z"},
+    )
+    be = StoreBackend(rt, namespace=lambda _ctx: ("filesystem",))
+
+    root_paths = [fi["path"] for fi in be.ls_info("/")]
+    assert "/test.md" in root_paths
+    assert "/subdir/" in root_paths
+
+    content = be.read("/test.md")
+    assert "hello legacy" in content
+
+    matches = be.grep_raw("hello", path="/")
+    assert isinstance(matches, list)
+    assert any(match["path"] == "/test.md" for match in matches)
+
+    glob_matches = be.glob_info("*.md", path="/")
+    assert any(match["path"] == "/test.md" for match in glob_matches)
+
+
 def test_store_backend_intercept_large_tool_result():
     """Test that StoreBackend properly handles large tool result interception."""
     rt = make_runtime()

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -120,6 +120,28 @@ async def test_store_backend_als_trailing_slash():
     assert [fi["path"] for fi in listing1] == [fi["path"] for fi in listing2]
 
 
+async def test_store_backend_async_handles_legacy_store_keys_without_leading_slash():
+    rt = make_runtime()
+    await rt.store.aput(
+        ("filesystem",),
+        "test.md",
+        {"content": ["hello legacy"], "created_at": "2023-01-01T00:00:00Z", "modified_at": "2023-01-01T00:00:00Z"},
+    )
+    await rt.store.aput(
+        ("filesystem",),
+        "subdir/file.txt",
+        {"content": ["nested legacy"], "created_at": "2023-01-01T00:00:00Z", "modified_at": "2023-01-01T00:00:00Z"},
+    )
+    be = StoreBackend(rt, namespace=lambda _ctx: ("filesystem",))
+
+    root_paths = [fi["path"] for fi in await be.als_info("/")]
+    assert "/test.md" in root_paths
+    assert "/subdir/" in root_paths
+
+    content = await be.aread("/test.md")
+    assert "hello legacy" in content
+
+
 async def test_store_backend_async_errors():
     """Test async error handling."""
     rt = make_runtime()


### PR DESCRIPTION
## Summary
- normalize `StoreBackend` path handling so legacy store keys without a leading slash are treated as absolute paths during listing and lookup
- fall back to legacy key lookups for `read`, `aread`, and downloads while returning normalized absolute paths from `ls_info`, `grep_raw`, and `glob_info`
- add sync and async regression tests covering legacy root listings and follow-up file access

## Why
Fixes #1655.

`StoreBackend.ls_info("/")` currently filters by a normalized `/` prefix, so entries stored as `test.md` instead of `/test.md` are invisible at the root. Once that happens, the data effectively becomes unreachable through normal listing and search flows even though it still exists in the store. This change keeps the backend tolerant of those legacy/non-canonical keys without changing the public file paths it returns.

## Review Notes
- The main behavior change is in `_get_store_item` / `_aget_store_item` and the key normalization used by `ls_info`, `grep_raw`, and `glob_info`.
- New writes are unchanged; this PR only makes lookup and listing robust when existing store data is missing the leading slash.

## Validation
- `uv run --group test pytest tests/unit_tests/backends/test_store_backend.py tests/unit_tests/backends/test_store_backend_async.py -q`
- `uv run --group test pytest tests/unit_tests/backends/test_composite_backend.py tests/unit_tests/backends/test_composite_backend_async.py -q`
- `uv run --group test ruff check deepagents/backends/store.py tests/unit_tests/backends/test_store_backend.py tests/unit_tests/backends/test_store_backend_async.py`

## AI Disclosure
- This contribution was prepared with help from an AI coding assistant and then validated locally before opening the PR.
