### PR TITLE
feat(sdk): expose `summary_prompt` parameter in `create_deep_agent`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -31,6 +31,7 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import (
+    DEFAULT_SUMMARY_PROMPT,
     SummarizationMiddleware,
     compute_summarization_defaults,
 )
@@ -82,7 +83,7 @@ def get_default_model() -> ChatAnthropic:
     )
 
 
-def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic with many conditional branches
+def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
     model: str | BaseChatModel | None = None,
     tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
     *,
@@ -97,6 +98,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     store: BaseStore | None = None,
     backend: BackendProtocol | BackendFactory | None = None,
     interrupt_on: dict[str, bool | InterruptOnConfig] | None = None,
+    summary_prompt: str | None = None,
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
@@ -169,6 +171,11 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             Pass to pause agent execution at specified tool calls for human approval or modification.
 
             Example: `interrupt_on={"edit_file": True}` pauses before every edit.
+        summary_prompt: Custom prompt template for generating conversation summaries.
+
+            When the agent's context window fills up, this prompt controls how the
+            conversation history is summarized. If `None`, uses the default summary prompt
+            from LangChain. Applied to the main agent and all subagents.
         debug: Whether to enable debug mode. Passed through to `create_agent`.
         name: The name of the agent. Passed through to `create_agent`.
         cache: The cache to use for the agent. Passed through to `create_agent`.
@@ -195,6 +202,9 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
 
     backend = backend if backend is not None else (StateBackend)
 
+    # Resolve summary prompt for SummarizationMiddleware instances
+    resolved_summary_prompt = summary_prompt if summary_prompt is not None else DEFAULT_SUMMARY_PROMPT
+
     # Build general-purpose subagent with default middleware stack
     gp_middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(),
@@ -206,6 +216,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             keep=summarization_defaults["keep"],
             trim_tokens_to_summarize=None,
             truncate_args_settings=summarization_defaults["truncate_args_settings"],
+            summary_prompt=resolved_summary_prompt,
         ),
         AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
         PatchToolCallsMiddleware(),
@@ -246,6 +257,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
                     keep=subagent_summarization_defaults["keep"],
                     trim_tokens_to_summarize=None,
                     truncate_args_settings=subagent_summarization_defaults["truncate_args_settings"],
+                    summary_prompt=resolved_summary_prompt,
                 ),
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                 PatchToolCallsMiddleware(),
@@ -281,6 +293,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         keep=summarization_defaults["keep"],
         trim_tokens_to_summarize=None,
         truncate_args_settings=summarization_defaults["truncate_args_settings"],
+        summary_prompt=resolved_summary_prompt,
     )
     deepagent_middleware.extend(
         [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from deepagents.backends import FilesystemBackend, LocalShellBackend
 from deepagents.backends.utils import create_file_data
 from deepagents.graph import create_deep_agent
+from deepagents.middleware.summarization import SummarizationMiddleware
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
 
@@ -171,3 +173,25 @@ description: Systematic code review process following best practices and style g
         _system_message_as_text(system_messages[0]),
         update_snapshots=update_snapshots,
     )
+
+
+def test_summary_prompt_forwarded_to_middleware() -> None:
+    """Verify that `summary_prompt` is forwarded to all SummarizationMiddleware instances."""
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="hello!")]))
+    custom_prompt = "Summarize focusing on key decisions and code changes only."
+
+    init_calls: list[dict] = []
+    original_init = SummarizationMiddleware.__init__
+
+    def tracking_init(self: SummarizationMiddleware, *args: object, **kwargs: object) -> None:
+        init_calls.append(dict(kwargs))
+        original_init(self, *args, **kwargs)
+
+    with patch.object(SummarizationMiddleware, "__init__", tracking_init):
+        create_deep_agent(model=model, summary_prompt=custom_prompt)
+
+    # There should be at least 2 SummarizationMiddleware instances:
+    # one for the main agent and one for the general-purpose subagent
+    assert len(init_calls) >= 2
+    for call_kwargs in init_calls:
+        assert call_kwargs.get("summary_prompt") == custom_prompt


### PR DESCRIPTION
## Summary

- Surfaces the `summary_prompt` parameter through `create_deep_agent()`, allowing users to customize how conversation history is summarized when the context window fills up
- `SummarizationMiddleware` already accepted this parameter, but `create_deep_agent` constructed the middleware internally without forwarding it
- The custom prompt is forwarded to all three `SummarizationMiddleware` instances: main agent, general-purpose subagent, and user-provided subagents

## Why

Different agent domains need different summary styles. A coding agent should preserve file paths and function names in summaries. A research agent should preserve citations. The default LangChain summary prompt is generic and doesn't serve all use cases well. This is a zero-cost change for existing users (defaults unchanged) that unlocks meaningful customization.

## Test plan

- [x] New unit test verifies `summary_prompt` is forwarded to all `SummarizationMiddleware` instances
- [x] All existing smoke tests pass (snapshot tests unchanged)
- [x] Full unit test suite passes (706 passed)
- [x] Ruff lint passes
- [x] `ty` type check passes

## Review notes

The `PLR0915` (too many statements) suppression was added to the existing `# noqa` on `create_deep_agent` — the function already suppressed `C901` and `PLR0912`. The 2 new statements pushed it from 51 to 53 (limit 50).

---

This contribution was developed with assistance from an AI agent (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)