### PR TITLE
style(cli): non-interactive output rendering issues

### DIFF
--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -773,10 +773,9 @@ async def run_non_interactive(
     thread_url_lookup: ThreadUrlLookupState | None = None
     if not quiet:
         thread_url_lookup = _start_langsmith_thread_url_lookup(thread_id)
-        console.print("[dim]Running task non-interactively...[/dim]")
+        console.print("[dim]Running task non-interactively...[/dim]", highlight=False)
         header = _build_non_interactive_header(assistant_id, thread_id)
         console.print(header)
-        console.print()
 
     sandbox_backend = None
     exit_stack = contextlib.ExitStack()
@@ -868,6 +867,9 @@ async def run_non_interactive(
             file_op_tracker = FileOpTracker(
                 assistant_id=assistant_id, backend=composite_backend
             )
+
+            if not quiet:
+                console.print()
 
             await _run_agent_loop(
                 agent,


### PR DESCRIPTION
Fix two rendering issues in non-interactive mode output. Rich's default `ReprHighlighter` was coloring the `...` in "Running task non-interactively..." as a Python Ellipsis literal, making it visually distinct from the rest of the dim text. Additionally, the MCP tools status line printed directly adjacent to the agent's response with no visual separation.