### PR TITLE
test(cli): remove duplicate import in `test_version`

### DIFF
--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -41,8 +41,6 @@ def test_cli_version_flag() -> None:
     # argparse exits with 0 for --version
     assert result.returncode == 0
     assert f"deepagents-cli {__version__}" in result.stdout
-    from importlib.metadata import version as pkg_version
-
     sdk_version = pkg_version("deepagents")
     assert f"deepagents (SDK) {sdk_version}" in result.stdout
 


### PR DESCRIPTION
## Summary

This PR removes a redundant `from importlib.metadata import version as pkg_version` inside `test_cli_version_flag` in `libs/cli/tests/unit_tests/test_version.py`; the module already imports `version as pkg_version` at the top (line 6), so the function-level import is unnecessary. Behavior is unchanged – the tests still use the same `pkg_version` helper, now only via the module-level import.

## Changes

- Removed duplicate import statement in `test_cli_version_flag()` function
- No functional changes, purely code cleanup

## Testing

- [x] `uv run --group test pytest tests/unit_tests/test_version.py -v` passes locally
- [x] The change is a single deleted import with no logic differences
- [x] CI will validate the full test suite

## AI Usage

This change was drafted with AI assistance (Cursor / GPT) and then reviewed and submitted by me.