### PR TITLE
feat(sdk): expose `summary_prompt` parameter in `create_deep_agent`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -119,6 +119,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     store: BaseStore | None = None,
     backend: BackendProtocol | BackendFactory | None = None,
     interrupt_on: dict[str, bool | InterruptOnConfig] | None = None,
+    summary_prompt: str | None = None,
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
@@ -200,6 +201,11 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             Pass to pause agent execution at specified tool calls for human approval or modification.
 
             Example: `interrupt_on={"edit_file": True}` pauses before every edit.
+        summary_prompt: Custom prompt template for generating conversation summaries.
+
+            When the agent's context window fills up, this prompt controls how the
+            conversation history is summarized. If `None`, uses the default summary prompt
+            from LangChain. Applied to the main agent and all subagents.
         debug: Whether to enable debug mode. Passed through to `create_agent`.
         name: The name of the agent. Passed through to `create_agent`.
         cache: The cache to use for the agent. Passed through to `create_agent`.
@@ -215,7 +221,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     gp_middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(),
         FilesystemMiddleware(backend=backend),
-        create_summarization_middleware(model, backend),
+        create_summarization_middleware(model, backend, summary_prompt=summary_prompt),
         AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
         PatchToolCallsMiddleware(),
     ]
@@ -246,7 +252,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
                 TodoListMiddleware(),
                 FilesystemMiddleware(backend=backend),
-                create_summarization_middleware(subagent_model, backend),
+                create_summarization_middleware(subagent_model, backend, summary_prompt=summary_prompt),
                 AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
                 PatchToolCallsMiddleware(),
             ]
@@ -281,7 +287,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
                 backend=backend,
                 subagents=all_subagents,
             ),
-            create_summarization_middleware(model, backend),
+            create_summarization_middleware(model, backend, summary_prompt=summary_prompt),
             AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
             PatchToolCallsMiddleware(),
         ]

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1077,6 +1077,8 @@ SummarizationMiddleware = _DeepAgentsSummarizationMiddleware
 def create_summarization_middleware(
     model: BaseChatModel,
     backend: BACKEND_TYPES,
+    *,
+    summary_prompt: str | None = None,
 ) -> _DeepAgentsSummarizationMiddleware:
     """Create a `SummarizationMiddleware` with model-aware defaults.
 
@@ -1086,6 +1088,10 @@ def create_summarization_middleware(
     Args:
         model: Resolved chat model instance.
         backend: Backend instance or factory for persisting conversation history.
+        summary_prompt: Custom prompt template for generating conversation summaries.
+
+            Controls how evicted messages are summarized. If `None`, uses the
+            default summary prompt from LangChain.
 
     Returns:
         Configured `SummarizationMiddleware` instance.
@@ -1097,6 +1103,7 @@ def create_summarization_middleware(
         raise TypeError(msg)
 
     defaults = compute_summarization_defaults(model)
+    resolved_summary_prompt = summary_prompt if summary_prompt is not None else DEFAULT_SUMMARY_PROMPT
     return SummarizationMiddleware(
         model=model,
         backend=backend,
@@ -1104,6 +1111,7 @@ def create_summarization_middleware(
         keep=defaults["keep"],
         trim_tokens_to_summarize=None,
         truncate_args_settings=defaults["truncate_args_settings"],
+        summary_prompt=resolved_summary_prompt,
     )
 
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
+from deepagents import graph as graph_module
 from deepagents.backends import FilesystemBackend, LocalShellBackend
 from deepagents.backends.utils import create_file_data
 from deepagents.graph import create_deep_agent
@@ -171,3 +173,24 @@ description: Systematic code review process following best practices and style g
         _system_message_as_text(system_messages[0]),
         update_snapshots=update_snapshots,
     )
+
+
+def test_summary_prompt_forwarded_to_factory() -> None:
+    """Verify that `summary_prompt` is forwarded to all `create_summarization_middleware` calls."""
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="hello!")]))
+    custom_prompt = "Summarize focusing on key decisions and code changes only."
+
+    factory_calls: list[dict] = []
+    original_factory = graph_module.create_summarization_middleware
+
+    def tracking_factory(*args: object, **kwargs: object) -> object:
+        factory_calls.append(dict(kwargs))
+        return original_factory(*args, **kwargs)
+
+    with patch.object(graph_module, "create_summarization_middleware", tracking_factory):
+        create_deep_agent(model=model, summary_prompt=custom_prompt)
+
+    # At least 2 calls: one for the main agent and one for the general-purpose subagent
+    assert len(factory_calls) >= 2
+    for call_kwargs in factory_calls:
+        assert call_kwargs.get("summary_prompt") == custom_prompt


### PR DESCRIPTION
## Summary

- Surfaces the `summary_prompt` parameter through `create_deep_agent()`, allowing users to customize how conversation history is summarized when the context window fills up
- The custom prompt is forwarded to all three internal `create_summarization_middleware` calls: main agent, general-purpose subagent, and user-provided subagents
- Zero-cost for existing users — defaults are unchanged

## Why `summary_prompt` instead of user-constructed `SummarizationMiddleware`

`create_deep_agent` internally constructs **3** `SummarizationMiddleware` instances (main agent, GP subagent, custom subagents). A user who wants to customize summarization currently has two options, both problematic:

1. **Pass their own via `middleware=`** — this *adds* a 4th instance on top of the 3 internal ones, causing double summarization. There's no way to replace the internal ones from outside.
2. **Skip `create_deep_agent` entirely** — build the full middleware stack manually with `create_agent()`, duplicating ~100 lines of assembly logic.

The `summary_prompt` parameter solves this by letting users customize all internal instances without replacing them or replicating the assembly logic.

## Test plan

- [x] New unit test verifies `summary_prompt` is forwarded to all `create_summarization_middleware` calls
- [x] All existing smoke tests pass (5/5, snapshot tests unchanged)
- [x] Full unit test suite passes (727 passed)
- [x] Ruff lint and `ty` type check pass

## Review notes

- The `summary_prompt` parameter is added to both `create_summarization_middleware` (factory) and `create_deep_agent` (public API)
- Uses keyword-only argument (`*`) to avoid breaking positional callers
- When `None` (default), resolves to `DEFAULT_SUMMARY_PROMPT` — existing behavior is unchanged

---

> This contribution was developed with AI assistance.