### PR TITLE
fix(cli): persist models.recent on every session start

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -559,7 +559,7 @@ async def run_textual_cli_async(
     from deepagents_cli.agent import create_cli_agent
     from deepagents_cli.app import run_textual_app
     from deepagents_cli.config import console, create_model, settings
-    from deepagents_cli.model_config import ModelConfigError
+    from deepagents_cli.model_config import ModelConfigError, save_recent_model
     from deepagents_cli.sessions import get_checkpointer
     from deepagents_cli.tools import fetch_url, http_request, web_search
 
@@ -577,6 +577,10 @@ async def run_textual_cli_async(
 
     model = result.model
     result.apply_to_settings()
+
+    # Persist the resolved model so [models].recent is always populated,
+    # not only after an explicit /model switch.
+    save_recent_model(f"{result.provider}:{result.model_name}")
 
     # Show thread info
     if is_resumed:
@@ -735,7 +739,7 @@ async def _run_acp_cli_async(
     """
     from deepagents_cli.agent import create_cli_agent
     from deepagents_cli.config import create_model, settings
-    from deepagents_cli.model_config import ModelConfigError
+    from deepagents_cli.model_config import ModelConfigError, save_recent_model
     from deepagents_cli.tools import fetch_url, http_request, web_search
 
     try:
@@ -749,6 +753,9 @@ async def _run_acp_cli_async(
         sys.stderr.flush()
         return 1
     model_result.apply_to_settings()
+
+    # Persist the resolved model so [models].recent is always populated.
+    save_recent_model(f"{model_result.provider}:{model_result.model_name}")
 
     tools: list[Any] = [http_request, fetch_url]
     if settings.has_tavily:

--- a/libs/cli/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/cli/tests/unit_tests/test_main_acp_mode.py
@@ -38,6 +38,8 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
     model_obj = object()
     model_result = SimpleNamespace(
         model=model_obj,
+        provider="anthropic",
+        model_name="claude-sonnet-4-6",
         apply_to_settings=MagicMock(),
     )
     server = object()
@@ -78,6 +80,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
         ),
         patch("deepagents_cli.main.parse_args", return_value=args),
         patch("deepagents_cli.config.settings", new=SimpleNamespace(has_tavily=True)),
+        patch("deepagents_cli.model_config.save_recent_model", return_value=True),
         patch(
             "deepagents_cli.config.create_model", return_value=model_result
         ) as mock_create_model,
@@ -125,6 +128,8 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
     model_obj = object()
     model_result = SimpleNamespace(
         model=model_obj,
+        provider="anthropic",
+        model_name="claude-sonnet-4-6",
         apply_to_settings=MagicMock(),
     )
     server = object()
@@ -142,6 +147,7 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
         ),
         patch("deepagents_cli.main.parse_args", return_value=args),
         patch("deepagents_cli.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch("deepagents_cli.model_config.save_recent_model", return_value=True),
         patch("deepagents_cli.config.create_model", return_value=model_result),
         patch("deepagents_cli.mcp_tools.resolve_and_load_mcp_tools", resolve_mcp_tools),
         patch("deepagents_cli.tools.http_request", new=http_tool),


### PR DESCRIPTION
Call `save_recent_model` at startup in both `run_textual_cli_async` and `_run_acp_cli_async` so `[models].recent` is always written with the resolved `provider:model` spec, regardless of whether the user explicitly switches models via `/model`. Previously, `recent` was only populated on `/model` switch, so users who never changed models (or who cleared `[models].default`) would fall through to environment auto-detection on every launch instead of reusing the last session's model.