### PR TITLE
feat(sdk): add structured output support for subagents

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -1,5 +1,6 @@
 """Middleware for providing subagents to an agent via a `task` tool."""
 
+import json
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
@@ -7,6 +8,7 @@ from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
 from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, ModelResponse, ResponseT
+from langchain.agents.structured_output import ResponseFormat
 from langchain.chat_models import init_chat_model
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
@@ -14,6 +16,7 @@ from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
+from pydantic import BaseModel
 
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
@@ -76,6 +79,34 @@ class SubAgent(TypedDict):
 
     skills: NotRequired[list[str]]
     """Skill source paths for SkillsMiddleware."""
+
+    response_format: NotRequired[ResponseFormat]
+    """Structured output response format for the subagent.
+
+    When specified, the subagent will produce a `structured_response` conforming to the
+    given schema. The structured response is JSON-serialized and returned as the
+    ToolMessage content to the parent agent, replacing the default last-message extraction.
+
+    Accepts any format supported by `create_agent`: Pydantic models,
+    `ToolStrategy(schema=...)`, `ProviderStrategy(schema=...)`, etc.
+
+    Example:
+        ```python
+        from pydantic import BaseModel
+        from langchain.agents.structured_output import ToolStrategy
+
+        class AnalysisResult(BaseModel):
+            findings: str
+            confidence: float
+
+        analyzer: SubAgent = {
+            "name": "analyzer",
+            "description": "Analyzes data and returns structured findings",
+            "system_prompt": "Analyze the data and return your findings.",
+            "response_format": ToolStrategy(schema=AnalysisResult),
+        }
+        ```
+    """
 
 
 class CompiledSubAgent(TypedDict):
@@ -354,21 +385,55 @@ def _get_subagents_legacy(
         if interrupt_on:
             _middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
 
+        create_agent_kwargs: dict[str, Any] = {
+            "system_prompt": agent_["system_prompt"],
+            "tools": _tools,
+            "middleware": _middleware,
+            "name": agent_["name"],
+        }
+        if agent_.get("response_format") is not None:
+            create_agent_kwargs["response_format"] = agent_["response_format"]
+
         specs.append(
             {
                 "name": agent_["name"],
                 "description": agent_["description"],
-                "runnable": create_agent(
-                    subagent_model,
-                    system_prompt=agent_["system_prompt"],
-                    tools=_tools,
-                    middleware=_middleware,
-                    name=agent_["name"],
-                ),
+                "runnable": create_agent(subagent_model, **create_agent_kwargs),
             }
         )
 
     return specs
+
+
+def _serialize_structured_response(response: BaseModel | dict | list | str | float) -> str:
+    """Serialize a structured response to JSON string.
+
+    Args:
+        response: The structured response, typically a Pydantic model or dict.
+
+    Returns:
+        JSON string representation of the response.
+    """
+    if isinstance(response, BaseModel):
+        return response.model_dump_json()
+    return json.dumps(response)
+
+
+def _extract_subagent_content(result: dict) -> str:
+    """Extract content from a subagent result, preferring structured_response.
+
+    When a subagent produces a `structured_response`, it is JSON-serialized and
+    returned as the content. Otherwise, falls back to the last message text.
+
+    Args:
+        result: The subagent invocation result dict.
+
+    Returns:
+        String content for the ToolMessage.
+    """
+    if result.get("structured_response") is not None:
+        return _serialize_structured_response(result["structured_response"])
+    return result["messages"][-1].text.rstrip() if result["messages"][-1].text else ""
 
 
 def _build_task_tool(  # noqa: C901
@@ -410,12 +475,12 @@ def _build_task_tool(  # noqa: C901
             raise ValueError(error_msg)
 
         state_update = {k: v for k, v in result.items() if k not in _EXCLUDED_STATE_KEYS}
-        # Strip trailing whitespace to prevent API errors with Anthropic
-        message_text = result["messages"][-1].text.rstrip() if result["messages"][-1].text else ""
+
+        content = _extract_subagent_content(result)
         return Command(
             update={
                 **state_update,
-                "messages": [ToolMessage(message_text, tool_call_id=tool_call_id)],
+                "messages": [ToolMessage(content, tool_call_id=tool_call_id)],
             }
         )
 
@@ -653,17 +718,20 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             if interrupt_on:
                 middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
 
+            create_agent_kwargs: dict[str, Any] = {
+                "system_prompt": spec["system_prompt"],
+                "tools": spec["tools"],
+                "middleware": middleware,
+                "name": spec["name"],
+            }
+            if spec.get("response_format") is not None:
+                create_agent_kwargs["response_format"] = spec["response_format"]
+
             specs.append(
                 {
                     "name": spec["name"],
                     "description": spec["description"],
-                    "runnable": create_agent(
-                        model,
-                        system_prompt=spec["system_prompt"],
-                        tools=spec["tools"],
-                        middleware=middleware,
-                        name=spec["name"],
-                    ),
+                    "runnable": create_agent(model, **create_agent_kwargs),
                 }
             )
 

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -5,6 +5,7 @@ are invoked, how they return results, and how state is managed between parent
 and child agents.
 """
 
+import json
 import warnings
 from pathlib import Path
 from typing import Any, TypedDict
@@ -685,19 +686,15 @@ class TestSubAgents:
         )
 
         # Verify the exact content of the ToolMessages
-        # When a subagent uses ToolStrategy for structured output, the default tool message
-        # content shows the structured response using the Pydantic model's string representation
+        # When a subagent produces a structured_response, it is JSON-serialized
+        # as the ToolMessage content for predictable, parseable data
         weather_tool_message = tool_messages_by_id["call_weather"]
-        expected_weather_content = "Returning structured response: city='Tokyo' temperature_celsius=22.5 humidity_percent=65"
-        assert weather_tool_message.content == expected_weather_content, (
-            f"Expected weather ToolMessage content:\n{expected_weather_content}\nGot:\n{weather_tool_message.content}"
-        )
+        weather_parsed = json.loads(weather_tool_message.content)
+        assert weather_parsed == {"city": "Tokyo", "temperature_celsius": 22.5, "humidity_percent": 65}
 
         population_tool_message = tool_messages_by_id["call_population"]
-        expected_population_content = "Returning structured response: city='Tokyo' population=14000000 metro_area_population=37400000"
-        assert population_tool_message.content == expected_population_content, (
-            f"Expected population ToolMessage content:\n{expected_population_content}\nGot:\n{population_tool_message.content}"
-        )
+        population_parsed = json.loads(population_tool_message.content)
+        assert population_parsed == {"city": "Tokyo", "population": 14000000, "metro_area_population": 37400000}
 
     def test_lc_agent_name_and_tags_in_streaming_metadata(self) -> None:
         """Test that lc_agent_name and tags are correctly set in streaming metadata.
@@ -1549,6 +1546,234 @@ class TestSubAgents:
         # Verify skills_metadata is NOT in the subagent state
         subagent_state = captured_subagent_states[0]
         assert "skills_metadata" not in subagent_state, "Subagent without skills parameter should NOT have skills_metadata"
+
+    def test_subagent_structured_response_serialized_as_json(self) -> None:
+        """Test that a subagent's structured_response is JSON-serialized as ToolMessage content.
+
+        When a subagent produces a `structured_response` (via `response_format`),
+        the middleware should JSON-serialize it as the ToolMessage content instead
+        of extracting the last message text. This gives the supervisor predictable,
+        parseable data.
+        """
+
+        class AnalysisResult(BaseModel):
+            findings: str = Field(description="Analysis findings")
+            confidence: float = Field(description="Confidence score")
+            sources: int = Field(description="Number of sources")
+
+        subagent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "AnalysisResult",
+                                "args": {
+                                    "findings": "Renewable energy adoption is accelerating",
+                                    "confidence": 0.92,
+                                    "sources": 3,
+                                },
+                                "id": "call_analysis",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        subagent = create_agent(
+            model=subagent_model,
+            response_format=ToolStrategy(schema=AnalysisResult),
+        )
+
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Analyze renewable energy trends",
+                                    "subagent_type": "analyzer",
+                                },
+                                "id": "call_task",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done"),
+                ]
+            )
+        )
+
+        parent_agent = create_deep_agent(
+            model=parent_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                CompiledSubAgent(
+                    name="analyzer",
+                    description="An analysis agent",
+                    runnable=subagent,
+                )
+            ],
+        )
+
+        result = parent_agent.invoke(
+            {"messages": [HumanMessage(content="Analyze renewable energy")]},
+            config={"configurable": {"thread_id": "test_structured_json"}},
+        )
+
+        tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+        assert len(tool_messages) == 1
+        parsed = json.loads(tool_messages[0].content)
+        assert parsed == {
+            "findings": "Renewable energy adoption is accelerating",
+            "confidence": 0.92,
+            "sources": 3,
+        }
+
+    def test_subagent_falls_back_to_last_message_without_structured_response(self) -> None:
+        """Test that without structured_response, the last message text is used.
+
+        When a subagent does NOT produce a `structured_response`, the middleware
+        should fall back to extracting the last message text as the ToolMessage content.
+        """
+        subagent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(content="Plain text result without structured response"),
+                ]
+            )
+        )
+
+        subagent = create_agent(model=subagent_model)
+
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Do work",
+                                    "subagent_type": "worker",
+                                },
+                                "id": "call_task",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done"),
+                ]
+            )
+        )
+
+        parent_agent = create_deep_agent(
+            model=parent_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                CompiledSubAgent(
+                    name="worker",
+                    description="A worker agent",
+                    runnable=subagent,
+                )
+            ],
+        )
+
+        result = parent_agent.invoke(
+            {"messages": [HumanMessage(content="Test")]},
+            config={"configurable": {"thread_id": "test_no_structured"}},
+        )
+
+        tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].content == "Plain text result without structured response"
+
+    def test_subagent_spec_with_response_format(self) -> None:
+        """Test that SubAgent spec with response_format produces JSON-serialized output.
+
+        When a SubAgent (not CompiledSubAgent) specifies `response_format`, the
+        subagent should be created with structured output support and the
+        structured_response should be JSON-serialized in the ToolMessage.
+        """
+
+        class TaskResult(BaseModel):
+            summary: str = Field(description="Task summary")
+            status: str = Field(description="Task status")
+
+        subagent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "TaskResult",
+                                "args": {
+                                    "summary": "Completed analysis",
+                                    "status": "success",
+                                },
+                                "id": "call_result",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Analyze data",
+                                    "subagent_type": "structured-worker",
+                                },
+                                "id": "call_task",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done"),
+                ]
+            )
+        )
+
+        parent_agent = create_deep_agent(
+            model=parent_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                SubAgent(
+                    name="structured-worker",
+                    description="A worker that returns structured output",
+                    system_prompt="Return structured results.",
+                    model=subagent_model,
+                    tools=[],
+                    response_format=ToolStrategy(schema=TaskResult),
+                )
+            ],
+        )
+
+        result = parent_agent.invoke(
+            {"messages": [HumanMessage(content="Analyze")]},
+            config={"configurable": {"thread_id": "test_subagent_spec_response_format"}},
+        )
+
+        tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+        assert len(tool_messages) == 1
+        parsed = json.loads(tool_messages[0].content)
+        assert parsed == {"summary": "Completed analysis", "status": "success"}
 
 
 class TestSubAgentMiddlewareValidation:


### PR DESCRIPTION
## Description
Ports [deepagentsjs#290](https://github.com/langchain-ai/deepagentsjs/pull/290) to Python. When a subagent produces a `structured_response` (via `response_format`), the middleware now JSON-serializes it as the ToolMessage content instead of extracting the last message text. This gives the supervisor predictable, parseable data from subagents. Also adds `response_format` as an optional field on the `SubAgent` TypedDict so users can configure structured output directly on subagent specs.

> This PR was authored by an AI agent.

## Test Plan
- [ ] Verify subagent with `response_format` returns JSON-serialized structured output as ToolMessage content
- [ ] Verify subagent without `response_format` falls back to last message text
- [ ] Verify `SubAgent` spec with `response_format` passes it through to `create_agent`