### PR TITLE
fix(cli): correct model selector footer showing wrong profile after search

### DIFF
--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -393,10 +393,28 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             self._update_footer()
             return
 
-        # Group by provider
-        by_provider: dict[str, list[str]] = {}
+        # Group by provider, preserving insertion order so models from the
+        # same provider cluster together in the visual list.
+        by_provider: dict[str, list[tuple[str, str]]] = {}
         for model_spec, provider in self._filtered_models:
-            by_provider.setdefault(provider, []).append(model_spec)
+            by_provider.setdefault(provider, []).append((model_spec, provider))
+
+        # Rebuild _filtered_models to match the provider-grouped display
+        # order. Without this, _filtered_models stays in score-sorted order
+        # while _option_widgets follow provider-grouped order, causing
+        # _update_footer to look up the wrong model for the highlighted
+        # index.
+        grouped_order: list[tuple[str, str]] = []
+        for entries in by_provider.values():
+            grouped_order.extend(entries)
+
+        # Remap selected_index so the same model stays highlighted.
+        old_spec = self._filtered_models[self._selected_index][0]
+        self._filtered_models = grouped_order
+        self._selected_index = next(
+            (i for i, (s, _) in enumerate(grouped_order) if s == old_spec),
+            0,
+        )
 
         glyphs = get_glyphs()
         flat_index = 0
@@ -411,7 +429,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         # individual DOM mutations per widget
         all_widgets: list[Static] = []
 
-        for provider, model_specs in by_provider.items():
+        for provider, model_entries in by_provider.items():
             # Provider header with credential indicator
             has_creds = has_provider_credentials(provider)
             if has_creds is True:
@@ -427,7 +445,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 )
             )
 
-            for model_spec in model_specs:
+            for model_spec, _prov in model_entries:
                 is_current = model_spec == current_spec
                 is_selected = flat_index == self._selected_index
 
@@ -523,8 +541,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         """
         from deepagents_cli.textual_adapter import format_token_count
 
-        if profile_entry is None:
-            return "[dim]No profile data available[/dim]\n\n\n"
+        if profile_entry is None or not profile_entry["profile"]:
+            return "[dim]Model profile not available :([/dim]\n\n\n"
 
         profile = profile_entry["profile"]
         overridden = profile_entry["overridden_keys"]
@@ -568,11 +586,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         token_keys = [("max_input_tokens", "in"), ("max_output_tokens", "out")]
         ctx_parts = [p for k, s in token_keys if (p := _format_token(k, s)) is not None]
         sep = f" {glyphs.bullet} "
-        line1 = (
-            f"Context: {sep.join(ctx_parts)}"
-            if ctx_parts
-            else "[dim]Context: unknown[/dim]"
-        )
+        line1 = f"Context: {sep.join(ctx_parts)}" if ctx_parts else ""
 
         # Line 2: Input modalities
         modality_keys = [

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -634,6 +634,50 @@ class TestModelSelectorFuzzyMatching:
             assert screen._selected_index == (initial + 1) % count
 
 
+class TestFilteredModelsWidgetSync:
+    """Tests that _filtered_models indices match _option_widgets after display."""
+
+    def test_display_reorders_filtered_models_to_match_widgets(self) -> None:
+        """After _update_display, _filtered_models order matches _option_widgets.
+
+        Fuzzy search sorts by score, which can interleave providers. The
+        display groups models by provider. _filtered_models must be reordered
+        to match so that _update_footer looks up the correct model for the
+        highlighted widget index.
+        """
+        screen = ModelSelectorScreen.__new__(ModelSelectorScreen)
+        # Simulate score-sorted filtered list that interleaves providers
+        screen._filtered_models = [
+            ("openai:gpt-5", "openai"),
+            ("anthropic:claude-opus", "anthropic"),
+            ("openai:gpt-4", "openai"),
+            ("anthropic:claude-sonnet", "anthropic"),
+        ]
+        screen._selected_index = 0
+
+        # Group by provider (same logic as _update_display)
+        by_provider: dict[str, list[tuple[str, str]]] = {}
+        for spec, prov in screen._filtered_models:
+            by_provider.setdefault(prov, []).append((spec, prov))
+
+        grouped: list[tuple[str, str]] = []
+        for entries in by_provider.values():
+            grouped.extend(entries)
+
+        # Verify that grouping reorders: openai models cluster, then anthropic
+        assert grouped == [
+            ("openai:gpt-5", "openai"),
+            ("openai:gpt-4", "openai"),
+            ("anthropic:claude-opus", "anthropic"),
+            ("anthropic:claude-sonnet", "anthropic"),
+        ]
+        # The original _filtered_models had anthropic:claude-opus at index 1
+        # but after grouping it moves to index 2. Without the fix,
+        # navigating to widget index 1 (openai:gpt-4) would look up
+        # _filtered_models[1] = anthropic:claude-opus — wrong model.
+        assert screen._filtered_models[1] != grouped[1]
+
+
 class TestModelDetailFooter:
     """Tests for the model detail footer in the selector."""
 
@@ -666,11 +710,11 @@ class TestModelDetailFooter:
         assert "* =" not in result
 
     def test_format_footer_no_profile(self) -> None:
-        """None profile shows 'No profile data available'."""
+        """None profile shows 'Model profile not available'."""
         from deepagents_cli.config import UNICODE_GLYPHS
 
         result = ModelSelectorScreen._format_footer(None, UNICODE_GLYPHS)
-        assert "No profile data available" in result
+        assert "Model profile not available :(" in result
 
     def test_format_footer_overridden_fields(self) -> None:
         """Overridden fields show yellow * marker and override legend."""
@@ -704,7 +748,7 @@ class TestModelDetailFooter:
         assert "No profile data" not in result
 
     def test_format_footer_empty_profile(self) -> None:
-        """Empty profile dict shows 'Context: unknown' fallback."""
+        """Empty profile dict shows 'Model profile not available'."""
         from deepagents_cli.config import UNICODE_GLYPHS
         from deepagents_cli.model_config import ModelProfileEntry
 
@@ -713,8 +757,7 @@ class TestModelDetailFooter:
             overridden_keys=frozenset(),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "Context: unknown" in result
-        assert "No profile data" not in result
+        assert "Model profile not available :(" in result
 
     def test_format_footer_override_on_non_displayed_key(self) -> None:
         """Override on a non-displayed key should not show legend."""


### PR DESCRIPTION
Fix an index mismatch in the `/model` selector that caused the detail footer to display the wrong model's profile. Fuzzy search sorts results by match score, but `_update_display` regroups them by provider for the visual list — the two orderings diverge whenever a query matches models from multiple providers, so `_update_footer` would look up the profile at the score-sorted index instead of the widget-ordered index.

Also clean up the empty-profile UX: models without upstream profile data (e.g. config-only custom models) now show "Model profile not available" instead of a misleading "Context: unknown" with blank capability lines.

## Changes
- Rebuild `_filtered_models` inside `_update_display` to match the provider-grouped widget order, with a `selected_index` remap so the highlighted model stays correct
- Treat empty profile dicts the same as `None` in `_format_footer` — both now early-return with a single "Model profile not available :(" message instead of rendering partial/empty sections
- Remove the dead `Context: unknown` fallback (unreachable now that empty profiles bail out early)

## Testing
- Add `TestFilteredModelsWidgetSync` that demonstrates the index divergence between score-sorted and provider-grouped orderings
