### PR TITLE
fix(cli): remove double slash in skills path template

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -228,7 +228,7 @@ def get_system_prompt(
     """
     template = (Path(__file__).parent / "system_prompt.md").read_text()
 
-    skills_path = f"~/.deepagents/{assistant_id}/skills/"
+    skills_path = f"~/.deepagents/{assistant_id}/skills"
 
     if interactive:
         mode_description = "an interactive CLI on the user's computer"


### PR DESCRIPTION
Drop the trailing slash from `skills_path` in `get_system_prompt` to fix a double-slash in the rendered system prompt. The template at `system_prompt.md:200` already prepends `/` before the skill name, so the trailing slash on the variable produced paths like `~/.deepagents/agent/skills//web-research/script.py`.