### PR TITLE
docs(examples): improve skill scores across 8 skills

### DIFF
--- a/examples/content-builder-agent/skills/blog-post/SKILL.md
+++ b/examples/content-builder-agent/skills/blog-post/SKILL.md
@@ -1,19 +1,9 @@
 ---
 name: blog-post
-description: Use this skill when writing long-form blog posts, tutorials, or educational articles that require structure, depth, and SEO considerations
+description: Writes and structures long-form blog posts, creates tutorial outlines, and optimizes content for SEO with cover image generation. Use when the user asks to write a blog post, article, how-to guide, tutorial, technical writeup, thought leadership piece, or long-form content.
 ---
 
 # Blog Post Writing Skill
-
-This skill provides a structured workflow for creating high-quality blog posts that educate and engage readers.
-
-## When to Use This Skill
-
-Use this skill when asked to:
-- Write a blog post or article
-- Create a tutorial or how-to guide
-- Develop educational long-form content
-- Write thought leadership pieces
 
 ## Research First (Required)
 

--- a/examples/content-builder-agent/skills/social-media/SKILL.md
+++ b/examples/content-builder-agent/skills/social-media/SKILL.md
@@ -1,19 +1,9 @@
 ---
 name: social-media
-description: Use this skill when creating short-form social media content for LinkedIn, Twitter/X, or other platforms
+description: Drafts engaging social media posts, writes hooks, suggests hashtags, creates thread structures, and generates companion images. Use when the user asks to write a LinkedIn post, tweet, Twitter/X thread, social media caption, social post, or repurpose content for social platforms.
 ---
 
 # Social Media Content Skill
-
-This skill provides guidelines for creating engaging social media content that drives engagement and shares.
-
-## When to Use This Skill
-
-Use this skill when asked to:
-- Write a LinkedIn post
-- Create a Twitter/X thread
-- Draft social media announcements
-- Repurpose blog content for social
 
 ## Research First (Required)
 

--- a/examples/text-to-sql-agent/skills/query-writing/SKILL.md
+++ b/examples/text-to-sql-agent/skills/query-writing/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: query-writing
-description: For writing and executing SQL queries - from simple single-table queries to complex multi-table JOINs and aggregations
+description: Writes and executes SQL queries from simple SELECTs to complex multi-table JOINs, aggregations, and subqueries. Use when the user asks to query a database, write SQL, run a SELECT statement, retrieve data, filter records, or generate reports from database tables.
 ---
 
 # Query Writing Skill
-
-## When to Use This Skill
-
-Use this skill when you need to answer a question by writing and executing a SQL query.
 
 ## Workflow for Simple Queries
 
@@ -55,6 +51,13 @@ GROUP BY c.Country
 ORDER BY TotalRevenue DESC
 LIMIT 5;
 ```
+
+## Error Recovery
+
+If a query fails or returns unexpected results:
+1. **Empty results** — Verify column names and WHERE conditions against the schema; check for case sensitivity or NULL values
+2. **Syntax error** — Re-examine JOINs, GROUP BY completeness, and alias references
+3. **Timeout** — Add stricter WHERE filters or LIMIT to reduce result set, then refine
 
 ## Quality Guidelines
 

--- a/examples/text-to-sql-agent/skills/schema-exploration/SKILL.md
+++ b/examples/text-to-sql-agent/skills/schema-exploration/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: schema-exploration
-description: For discovering and understanding database structure, tables, columns, and relationships
+description: Lists tables, describes columns and data types, identifies foreign key relationships, and maps entity relationships in a database. Use when the user asks about database schema, table structure, column types, what tables exist, ERD, foreign keys, or how entities relate.
 ---
 
 # Schema Exploration Skill
-
-## When to Use This Skill
-
-Use this skill when you need to:
-- Understand the database structure
-- Find which tables contain certain types of data
-- Discover column names and data types
-- Map relationships between tables
-- Answer questions like "What tables are available?" or "What columns does the Customer table have?"
 
 ## Workflow
 
@@ -139,23 +130,3 @@ This requires the query-writing skill to execute.
 - Explain the relationship chain
 - Suggest next steps (use query-writing skill)
 
-## Common Exploration Patterns
-
-### Pattern 1: Find a Table
-"Which table has customer information?"
-→ Use list_tables, then describe Customer table
-
-### Pattern 2: Understand Structure
-"What's in the Invoice table?"
-→ Use schema tool to show columns and sample data
-
-### Pattern 3: Map Relationships
-"How are artists connected to sales?"
-→ Trace the foreign key chain: Artist → Album → Track → InvoiceLine → Invoice
-
-## Tips
-
-- Table names in Chinook are singular and capitalized (Customer, not customers)
-- Foreign keys typically have "Id" suffix and match a table name
-- Use sample data to understand what values look like
-- When unsure which table to use, list all tables first

--- a/libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md
+++ b/libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md
@@ -7,15 +7,6 @@ compatibility: designed for deepagents-cli
 
 # Skill Creator
 
-This skill provides guidance for creating effective skills.
-
-## About Skills
-
-Skills are modular, self-contained packages that extend agent capabilities by providing
-specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
-domains or tasks—they transform a general-purpose agent into a specialized agent
-equipped with procedural knowledge and domain expertise.
-
 ### Skill Location for Deepagents
 
 The deepagents CLI loads skills from five sources, listed here from lowest to highest precedence:
@@ -43,13 +34,6 @@ Example directory layout:
 │   └── SKILL.md
 └── ...
 ```
-
-### What Skills Provide
-
-1. Specialized workflows - Multi-step procedures for specific domains
-2. Tool integrations - Instructions for working with specific file formats or APIs
-3. Domain expertise - Company-specific knowledge, schemas, business logic
-4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
 
 ## Core Principles
 

--- a/libs/cli/examples/skills/arxiv-search/SKILL.md
+++ b/libs/cli/examples/skills/arxiv-search/SKILL.md
@@ -1,102 +1,33 @@
 ---
 name: arxiv-search
-description: Search arXiv preprint repository for papers in physics, mathematics, computer science, quantitative biology, and related fields
+description: Searches arXiv for preprints and academic papers, retrieves abstracts, and filters by topic. Use when the user asks to find research papers, search arXiv, look up preprints, find academic articles in physics, math, CS, biology, statistics, or related fields.
 ---
 
 # arXiv Search Skill
 
-This skill provides access to arXiv, a free distribution service and open-access archive for scholarly articles in physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering, systems science, and economics.
+## Usage
 
-## When to Use This Skill
+Run the bundled Python script using the absolute skills directory path from your system prompt:
 
-Use this skill when you need to:
-- Find preprints and recent research papers before journal publication
-- Search for papers in computational biology, bioinformatics, or systems biology
-- Access mathematical or statistical methods papers relevant to biology
-- Find machine learning papers applied to biological problems
-- Get the latest research that may not yet be in PubMed
-
-## How to Use
-
-The skill provides a Python script that searches arXiv and returns formatted results.
-
-### Basic Usage
-
-**Note:** Always use the absolute path from your skills directory (shown in the system prompt above).
-
-If running deepagents from a virtual environment:
 ```bash
 .venv/bin/python [YOUR_SKILLS_DIR]/arxiv-search/arxiv_search.py "your search query" [--max-papers N]
 ```
 
-Or for system Python:
-```bash
-python3 [YOUR_SKILLS_DIR]/arxiv-search/arxiv_search.py "your search query" [--max-papers N]
-```
+- `query` (required): Search query string
+- `--max-papers` (optional): Maximum results to retrieve (default: 10)
 
-Replace `[YOUR_SKILLS_DIR]` with the absolute skills directory path from your system prompt (e.g., `~/.deepagents/agent/skills` or the full absolute path).
+### Example
 
-**Arguments:**
-- `query` (required): The search query string (e.g., "neural networks protein structure", "single cell RNA-seq")
-- `--max-papers` (optional): Maximum number of papers to retrieve (default: 10)
-
-### Examples
-
-Search for machine learning papers:
 ```bash
 .venv/bin/python ~/.deepagents/agent/skills/arxiv-search/arxiv_search.py "deep learning drug discovery" --max-papers 5
 ```
 
-Search for computational biology papers:
-```bash
-.venv/bin/python ~/.deepagents/agent/skills/arxiv-search/arxiv_search.py "protein folding prediction"
-```
-
-Search for bioinformatics methods:
-```bash
-.venv/bin/python ~/.deepagents/agent/skills/arxiv-search/arxiv_search.py "genome assembly algorithms"
-```
-
-## Output Format
-
-The script returns formatted results with:
-- **Title**: Paper title
-- **Summary**: Abstract/summary text
-
-Each paper is separated by blank lines for readability.
-
-## Features
-
-- **Relevance sorting**: Results ordered by relevance to query
-- **Fast retrieval**: Direct API access with no authentication required
-- **Simple interface**: Clean, easy-to-parse output
-- **No API key required**: Free access to arXiv database
+Returns title and abstract for each matching paper, sorted by relevance.
 
 ## Dependencies
 
-This skill requires the `arxiv` Python package. The script will detect if it's missing and show an error.
+Requires the `arxiv` Python package. If missing, install with:
 
-**If you see "Error: arxiv package not installed":**
-
-If running deepagents from a virtual environment (recommended), use the venv's Python:
 ```bash
 .venv/bin/python -m pip install arxiv
 ```
-
-Or for system-wide install:
-```bash
-python3 -m pip install arxiv
-```
-
-The package is not included in deepagents by default since it's skill-specific. Install it on-demand when first using this skill.
-
-## Notes
-
-- arXiv is particularly strong for:
-  - Computer science (cs.LG, cs.AI, cs.CV)
-  - Quantitative biology (q-bio)
-  - Statistics (stat.ML)
-  - Physics and mathematics
-- Papers are preprints and may not be peer-reviewed
-- Results include both recent uploads and older papers
-- Best for computational/theoretical work in biology

--- a/libs/cli/examples/skills/langgraph-docs/SKILL.md
+++ b/libs/cli/examples/skills/langgraph-docs/SKILL.md
@@ -1,35 +1,28 @@
 ---
 name: langgraph-docs
-description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
+description: Fetches and references LangGraph Python documentation to build stateful agents, create multi-agent workflows, and implement human-in-the-loop patterns. Use when the user asks about LangGraph, graph agents, state machines, agent orchestration, LangGraph API, or needs LangGraph implementation guidance.
 ---
 
 # langgraph-docs
 
-## Overview
-
-This skill explains how to access LangGraph Python documentation to help answer questions and guide implementation.
-
-## Instructions
+## Workflow
 
 ### 1. Fetch the Documentation Index
 
-Use the fetch_url tool to read the following URL:
-https://docs.langchain.com/llms.txt
+Use `fetch_url` to read: https://docs.langchain.com/llms.txt
 
-This provides a structured list of all available documentation with descriptions.
+This returns a structured list of all available documentation with descriptions.
 
 ### 2. Select Relevant Documentation
 
-Based on the question, identify 2-4 most relevant documentation URLs from the index. Prioritize:
-- Specific how-to guides for implementation questions
-- Core concept pages for understanding questions
-- Tutorials for end-to-end examples
-- Reference docs for API details
+Identify 2-4 most relevant URLs from the index. Prioritize:
+- **Implementation questions** — specific how-to guides
+- **Conceptual questions** — core concept pages
+- **End-to-end examples** — tutorials
+- **API details** — reference docs
 
-### 3. Fetch Selected Documentation
+### 3. Fetch and Apply
 
-Use the fetch_url tool to read the selected documentation URLs.
+Use `fetch_url` on the selected URLs, then complete the user's request using the documentation content.
 
-### 4. Provide Accurate Guidance
-
-After reading the documentation, complete the users request.
+If `fetch_url` fails or returns empty content, retry once. If it fails again, inform the user and suggest checking https://langchain-ai.github.io/langgraph/ directly.

--- a/libs/cli/examples/skills/skill-creator/SKILL.md
+++ b/libs/cli/examples/skills/skill-creator/SKILL.md
@@ -5,15 +5,6 @@ description: "Guide for creating effective skills that extend agent capabilities
 
 # Skill Creator
 
-This skill provides guidance for creating effective skills.
-
-## About Skills
-
-Skills are modular, self-contained packages that extend agent capabilities by providing
-specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
-domains or tasks—they transform a general-purpose agent into a specialized agent
-equipped with procedural knowledge and domain expertise.
-
 ### Skill Location for Deepagents
 
 The deepagents CLI loads skills from four directories, listed here from lowest to highest precedence:
@@ -40,13 +31,6 @@ Example directory layout:
 │   └── SKILL.md
 └── ...
 ```
-
-### What Skills Provide
-
-1. Specialized workflows - Multi-step procedures for specific domains
-2. Tool integrations - Instructions for working with specific file formats or APIs
-3. Domain expertise - Company-specific knowledge, schemas, business logic
-4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
 
 ## Core Principles
 

--- a/libs/cli/examples/skills/web-research/SKILL.md
+++ b/libs/cli/examples/skills/web-research/SKILL.md
@@ -1,19 +1,9 @@
 ---
 name: web-research
-description: Use this skill for requests related to web research; it provides a structured approach to conducting comprehensive web research
+description: Searches multiple web sources, synthesizes findings, and produces cited research reports using delegated subagents. Use when the user asks to research a topic online, search the web, look something up, find current information, compare options, or produce a research report.
 ---
 
 # Web Research Skill
-
-This skill provides a structured approach to conducting comprehensive web research using the `task` tool to spawn research subagents. It emphasizes planning, efficient delegation, and systematic synthesis of findings.
-
-## When to Use This Skill
-
-Use this skill when you need to:
-- Research complex topics requiring multiple information sources
-- Gather and synthesize current information from the web
-- Conduct comparative analysis across multiple subjects
-- Produce well-sourced research reports with clear citations
 
 ## Research Process
 
@@ -77,21 +67,6 @@ After all subagents complete:
 3. **Write final report** (optional) - Use `write_file` to create `research_[topic_name]/research_report.md` if requested
 
 **Note**: If you need to fetch additional information from URLs, use the `fetch_url` tool, not `read_file`.
-
-## Available Tools
-
-You have access to:
-- **write_file**: Save research plans and findings to local files
-- **read_file**: Read local files (e.g., findings saved by subagents)
-- **list_files**: See what local files exist in a directory
-- **fetch_url**: Fetch content from URLs and convert to markdown (use this for web pages, not read_file)
-- **task**: Spawn research subagents with web_search access
-
-## Research Subagent Configuration
-
-Each subagent you spawn will have access to:
-- **web_search**: Search the web using Tavily (parameters: query, max_results, topic, include_raw_content)
-- **write_file**: Save their findings to the filesystem
 
 ## Best Practices
 


### PR DESCRIPTION
Hullo @mdrxy 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. The process was run by me, a human meatbag (yes, I am typing, and that's me (with shorter hair) in the avatar), with some assistance from a skill and claude, which feels fitting and somewhat meta, given it's measuring and updating some skills. So I would consider this a clear disclaimer that I have used AI, but I did human write this. This is done with good intent, not to land some slop, the goal is to improve the activation and use of the skills you're sharing here, that's all. 🙏 

<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->

<img width="1312" height="1214" alt="deepagents_score_card" src="https://github.com/user-attachments/assets/2fbd8b01-b73a-40d9-96b4-2047eb5c4004" />

Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| query-writing | 53% | 100% | +47% |
| arxiv-search | 52% | 94% | +42% |
| blog-post | 59% | 89% | +30% |
| social-media | 59% | 89% | +30% |
| langgraph-docs | 56% | 86% | +30% |
| web-research | 59% | 89% | +30% |
| schema-exploration | 55% | 83% | +28% |
| skill-creator (built-in) | 84% | 88% | +4% |

<details>
<summary>What changed</summary>

**Description improvements (all skills)**
- Added concrete action verbs to frontmatter descriptions (e.g. "Writes and structures long-form blog posts" instead of just "Use this skill when writing...")
- Added explicit "Use when..." clauses with natural trigger terms users would actually say
- Expanded trigger term coverage (e.g. "tweet", "thread", "caption" for social-media)

**Body conciseness (7 skills)**
- Removed redundant "When to Use This Skill" body sections — these are only read after triggering, so they waste context tokens
- Removed filler intro sentences ("This skill provides a structured workflow for...")
- Removed "Available Tools" and "Research Subagent Configuration" sections from web-research — the agent already knows its tools
- Removed verbose "Common Exploration Patterns" and "Tips" sections from schema-exploration that restated earlier content
- Trimmed "About Skills" and "What Skills Provide" sections from both skill-creator instances

**arxiv-search (52% → 94%)**
- Replaced 103 lines of verbose content with 34 focused lines
- Removed explanations of what arXiv is, "When to Use" section, "Features" list, and "Notes" section
- Kept only the essential: usage syntax, one example, and dependency install

**langgraph-docs (56% → 86%)**
- Added concrete capabilities to description (stateful agents, multi-agent workflows, human-in-the-loop)
- Added error recovery guidance for failed fetch_url calls
- Removed redundant "Overview" section

**query-writing (53% → 100%)**
- Added error recovery section for empty results, syntax errors, and timeouts

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏

> **Disclaimer**: This contribution was assisted by generative AI tooling (Claude Code + tessl skill review).

## make format

```
make format
🎨 Formatting libs/acp
[ "deepagents_acp/ tests/" = "" ] || uv run --group test ruff format deepagents_acp/ tests/
Using CPython 3.12.11
Creating virtual environment at: .venv
      Built deepagents-acp @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/acp
Installed 69 packages in 100ms
11 files left unchanged
[ "deepagents_acp/ tests/" = "" ] || uv run --group test ruff check --fix deepagents_acp/ tests/
All checks passed!
🎨 Formatting libs/cli
[ "." = "" ] || uv run --all-groups ruff format .
Using CPython 3.12.11
Creating virtual environment at: .venv
      Built deepagents-cli @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/cli
      Built deepagents @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/deepagents
Installed 177 packages in 213ms
125 files left unchanged
[ "." = "" ] || uv run --all-groups ruff check --fix .
All checks passed!
🎨 Formatting libs/deepagents
[ "." = "" ] || uv run --all-groups ruff format .
Using CPython 3.12.11
Creating virtual environment at: .venv
Installed 118 packages in 143ms
80 files left unchanged
[ "." = "" ] || uv run --all-groups ruff check --fix .
All checks passed!
🎨 Formatting libs/harbor
[ "deepagents_harbor/ tests/" = "" ] || uv run --group test ruff format deepagents_harbor/ tests/
Using CPython 3.12.11
Creating virtual environment at: .venv
      Built deepagents-cli @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/cli
      Built deepagents-harbor @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/harbor
Installed 198 packages in 390ms
7 files left unchanged
[ "deepagents_harbor/ tests/" = "" ] || uv run --group test ruff check --fix deepagents_harbor/ tests/
All checks passed!
🎨 Formatting libs/partners/daytona
[ "." = "" ] || uv run --all-groups ruff format .
Using CPython 3.12.11
Creating virtual environment at: .venv
      Built langchain-daytona @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/partners/daytona
Installed 115 packages in 133ms
8 files left unchanged
[ "." = "" ] || uv run --all-groups ruff check --fix .
All checks passed!
🎨 Formatting libs/partners/modal
[ "." = "" ] || uv run --all-groups ruff format .
Using CPython 3.12.11
Creating virtual environment at: .venv
      Built langchain-modal @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/partners/modal
Installed 102 packages in 97ms
8 files left unchanged
[ "." = "" ] || uv run --all-groups ruff check --fix .
All checks passed!
🎨 Formatting libs/partners/runloop
[ "." = "" ] || uv run --all-groups ruff format .
Using CPython 3.12.11
Creating virtual environment at: .venv
      Built langchain-runloop @ file:///Users/alan/Projects/auto-p-o/langchain-ai/deepagents/libs/partners/runloop
Installed 79 packages in 72ms
8 files left unchanged
[ "." = "" ] || uv run --all-groups ruff check --fix .
All checks passed!
✅ All packages formatted!
```

## make lint

```
make lint
🔍 Linting libs/acp
[ "deepagents_acp/ tests/" = "" ] ||    uv run --group test ruff format deepagents_acp/ tests/ --diff
11 files already formatted
[ "deepagents_acp/ tests/" = "" ] ||    uv run --group test ruff check deepagents_acp/ tests/
All checks passed!
/Library/Developer/CommandLineTools/usr/bin/make type
uv run --group test ty check deepagents_acp
All checks passed!
🔍 Linting libs/cli
[ "." = "" ] || uv run --all-groups ruff check .
All checks passed!
[ "." = "" ] || uv run --all-groups ruff format . --diff
125 files already formatted
/Library/Developer/CommandLineTools/usr/bin/make type PYTHON_FILES="."
uv run --all-groups ty check .
warning[possibly-missing-attribute]: Attribute `kwargs` may be missing on object of type `_Call | None | @Todo`
    --> tests/unit_tests/test_thread_selector.py:1409:22
     |
1408 |                 mock_list_threads.assert_awaited_once()
1409 |                 kw = mock_list_threads.await_args.kwargs
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1410 |                 assert kw["limit"] == 20
1411 |                 assert kw["include_message_count"] is False
     |
info: rule `possibly-missing-attribute` is enabled by default

warning[possibly-missing-attribute]: Attribute `kwargs` may be missing on object of type `_Call | None | @Todo`
    --> tests/unit_tests/test_thread_selector.py:1501:22
     |
1500 |                 mock_list_threads.assert_awaited_once()
1501 |                 kw = mock_list_threads.await_args.kwargs
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1502 |                 assert kw["limit"] == 20
1503 |                 assert kw["include_message_count"] is False
     |
info: rule `possibly-missing-attribute` is enabled by default

Found 2 diagnostics
🔍 Linting libs/deepagents
[ "." = "" ] || uv run --all-groups ruff check .
All checks passed!
[ "." = "" ] || uv run --all-groups ruff format . --diff
80 files already formatted
/Library/Developer/CommandLineTools/usr/bin/make type
uv run --all-groups ty check deepagents
All checks passed!
🔍 Linting libs/harbor
[ "deepagents_harbor/ tests/" = "" ] || uv run --group test ruff format deepagents_harbor/ tests/ --diff
7 files already formatted
/Library/Developer/CommandLineTools/usr/bin/make type PYTHON_FILES="deepagents_harbor/ tests/"
[ "deepagents_harbor/ tests/" = "" ] || uv run --group test ty check deepagents_harbor/ tests/
All checks passed!
🔍 Linting libs/partners/daytona
[ "." = "" ] || uv run --all-groups ruff check .
All checks passed!
[ "." = "" ] || uv run --all-groups ruff format . --diff
8 files already formatted
/Library/Developer/CommandLineTools/usr/bin/make type
uv run --all-groups ty check langchain_daytona
All checks passed!
🔍 Linting libs/partners/modal
[ "." = "" ] || uv run --all-groups ruff check .
All checks passed!
[ "." = "" ] || uv run --all-groups ruff format . --diff
8 files already formatted
/Library/Developer/CommandLineTools/usr/bin/make type
uv run --all-groups ty check langchain_modal
All checks passed!
🔍 Linting libs/partners/runloop
[ "." = "" ] || uv run --all-groups ruff check .
All checks passed!
[ "." = "" ] || uv run --all-groups ruff format . --diff
8 files already formatted
/Library/Developer/CommandLineTools/usr/bin/make type
uv run --all-groups ty check langchain_runloop
All checks passed!
✅ All packages linted!
```

