### PR TITLE
perf(cli): speed up `/threads` modal startup

### DIFF
--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -15,7 +15,7 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
 
 import tomli_w
 
@@ -221,6 +221,7 @@ def clear_caches() -> None:
     _builtin_providers_cache = None
     _default_config_cache = None
     _profiles_cache = None
+    invalidate_thread_config_cache()
 
 
 def _get_builtin_providers() -> dict[str, Any]:
@@ -1079,6 +1080,91 @@ THREAD_COLUMN_DEFAULTS: dict[str, bool] = {
 """Default visibility for thread selector columns."""
 
 
+class ThreadConfig(NamedTuple):
+    """Coalesced thread-selector configuration read from a single TOML parse."""
+
+    columns: dict[str, bool]
+    """Column visibility settings."""
+
+    relative_time: bool
+    """Whether to display timestamps as relative time."""
+
+    sort_order: str
+    """`'updated_at'` or `'created_at'`."""
+
+
+_thread_config_cache: ThreadConfig | None = None
+
+
+def load_thread_config(config_path: Path | None = None) -> ThreadConfig:
+    """Load all thread-selector settings from one config file read.
+
+    Returns a cached result when reading the default config path. The
+    prewarm worker calls this at startup so subsequent opens of the
+    `/threads` modal avoid disk I/O entirely.
+
+    Args:
+        config_path: Path to config file.
+
+    Returns:
+        Coalesced thread configuration.
+    """
+    global _thread_config_cache  # noqa: PLW0603  # Module-level cache requires global statement
+
+    if config_path is None:
+        if _thread_config_cache is not None:
+            return _thread_config_cache
+        config_path = DEFAULT_CONFIG_PATH
+    use_default = config_path == DEFAULT_CONFIG_PATH
+
+    columns = dict(THREAD_COLUMN_DEFAULTS)
+    relative_time = True
+    sort_order = "updated_at"
+
+    try:
+        if not config_path.exists():
+            result = ThreadConfig(columns, relative_time, sort_order)
+            if use_default:
+                _thread_config_cache = result
+            return result
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        threads_section = data.get("threads", {})
+
+        # columns
+        raw_columns = threads_section.get("columns", {})
+        if isinstance(raw_columns, dict):
+            for key in columns:
+                if key in raw_columns and isinstance(raw_columns[key], bool):
+                    columns[key] = raw_columns[key]
+
+        # relative_time
+        rt_value = threads_section.get("relative_time")
+        if isinstance(rt_value, bool):
+            relative_time = rt_value
+
+        # sort_order
+        so_value = threads_section.get("sort_order")
+        if so_value in {"updated_at", "created_at"}:
+            sort_order = so_value
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.warning("Could not read thread config; using defaults", exc_info=True)
+        # Do not cache on error — allow retry on next call in case the
+        # file is fixed or permissions are restored.
+        return ThreadConfig(columns, relative_time, sort_order)
+
+    result = ThreadConfig(columns, relative_time, sort_order)
+    if use_default:
+        _thread_config_cache = result
+    return result
+
+
+def invalidate_thread_config_cache() -> None:
+    """Clear the cached `ThreadConfig` so the next load re-reads disk."""
+    global _thread_config_cache  # noqa: PLW0603  # Module-level cache requires global statement
+    _thread_config_cache = None
+
+
 def load_thread_columns(config_path: Path | None = None) -> dict[str, bool]:
     """Load thread column visibility from config file.
 
@@ -1147,6 +1233,7 @@ def save_thread_columns(
     except (OSError, tomllib.TOMLDecodeError):
         logger.exception("Could not save thread column preferences")
         return False
+    invalidate_thread_config_cache()
     return True
 
 
@@ -1208,6 +1295,7 @@ def save_thread_relative_time(enabled: bool, config_path: Path | None = None) ->
     except (OSError, tomllib.TOMLDecodeError):
         logger.exception("Could not save thread relative_time preference")
         return False
+    invalidate_thread_config_cache()
     return True
 
 
@@ -1277,6 +1365,7 @@ def save_thread_sort_order(sort_order: str, config_path: Path | None = None) -> 
     except (OSError, tomllib.TOMLDecodeError):
         logger.exception("Could not save thread sort_order preference")
         return False
+    invalidate_thread_config_cache()
     return True
 
 

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -408,15 +408,15 @@ async def prewarm_thread_message_counts(limit: int | None = None) -> None:
         return
 
     try:
-        from deepagents_cli.model_config import load_thread_columns
+        from deepagents_cli.model_config import load_thread_config
 
-        columns = load_thread_columns()
+        cfg = load_thread_config()
         threads = await list_threads(limit=thread_limit, include_message_count=False)
         if threads:
             await populate_thread_checkpoint_details(
                 threads,
-                include_message_count=columns.get("messages", False),
-                include_initial_prompt=columns.get("initial_prompt", False),
+                include_message_count=cfg.columns.get("messages", False),
+                include_initial_prompt=cfg.columns.get("initial_prompt", False),
             )
         _cache_recent_threads(None, thread_limit, threads)
     except (OSError, sqlite3.Error):
@@ -665,37 +665,127 @@ async def _populate_checkpoint_fields(
     include_message_count: bool,
     include_initial_prompt: bool,
 ) -> None:
-    """Populate checkpoint-derived thread fields with a single latest-row pass."""
+    """Populate checkpoint-derived thread fields with a batched latest-row pass."""
     serde = await _get_jsonplus_serializer()
+
+    # Phase 1: apply cache hits, collect threads that need DB fetch.
+    uncached: list[ThreadInfo] = []
     for thread in threads:
         thread_id = thread["thread_id"]
         freshness = _thread_freshness(thread)
-        needs_message_count = False
-        needs_initial_prompt = False
+        needs_count = False
+        needs_prompt = False
 
         if include_message_count:
             cached = _message_count_cache.get(thread_id)
             if cached is not None and cached[0] == freshness:
                 thread["message_count"] = cached[1]
             else:
-                needs_message_count = True
+                needs_count = True
 
         if include_initial_prompt and "initial_prompt" not in thread:
             cached_prompt = _initial_prompt_cache.get(thread_id)
             if cached_prompt is not None and cached_prompt[0] == freshness:
                 thread["initial_prompt"] = cached_prompt[1]
             else:
-                needs_initial_prompt = True
-        if not needs_message_count and not needs_initial_prompt:
-            continue
+                needs_prompt = True
 
-        summary = await _load_latest_checkpoint_summary(conn, thread_id, serde)
-        if needs_message_count:
+        if needs_count or needs_prompt:
+            uncached.append(thread)
+
+    if not uncached:
+        return
+
+    # Phase 2: batch-fetch all uncached threads.
+    uncached_ids = [t["thread_id"] for t in uncached]
+    batch_results = await _load_latest_checkpoint_summaries_batch(
+        conn, uncached_ids, serde
+    )
+
+    # Phase 3: apply results and update caches.
+    for thread in uncached:
+        thread_id = thread["thread_id"]
+        freshness = _thread_freshness(thread)
+        summary = batch_results.get(thread_id, _CheckpointSummary(0, None))
+
+        if include_message_count and "message_count" not in thread:
             thread["message_count"] = summary.message_count
             _cache_message_count(thread_id, freshness, summary.message_count)
-        if needs_initial_prompt:
+        if include_initial_prompt and "initial_prompt" not in thread:
             thread["initial_prompt"] = summary.initial_prompt
             _cache_initial_prompt(thread_id, freshness, summary.initial_prompt)
+
+
+_SQLITE_MAX_VARIABLE_NUMBER = 500
+"""Max `?` placeholders per SQL query.
+
+SQLite limits how many `?` parameters a single query can have (default 999,
+lower on some builds). If a user accumulates hundreds of threads and the
+`/threads` modal fetches them all at once, the `IN (?, ?, ...)` clause could
+exceed that limit. We chunk to this size to stay safe.
+"""
+
+
+async def _load_latest_checkpoint_summaries_batch(
+    conn: aiosqlite.Connection,
+    thread_ids: list[str],
+    serde: JsonPlusSerializer,
+) -> dict[str, _CheckpointSummary]:
+    """Batch-load the latest checkpoint summary for multiple threads.
+
+    Uses a window function to fetch the latest checkpoint per thread, issuing
+    one query per chunk for SQLite variable-limit safety.
+
+    Args:
+        conn: Database connection.
+        thread_ids: Thread IDs to look up.
+        serde: Serializer for decoding checkpoint blobs.
+
+    Returns:
+        Dict mapping thread IDs to their checkpoint summaries.
+    """
+    if not thread_ids:
+        return {}
+
+    results: dict[str, _CheckpointSummary] = {}
+
+    for start in range(0, len(thread_ids), _SQLITE_MAX_VARIABLE_NUMBER):
+        chunk = thread_ids[start : start + _SQLITE_MAX_VARIABLE_NUMBER]
+        placeholders = ",".join("?" * len(chunk))
+        query = f"""
+            SELECT thread_id, type, checkpoint FROM (
+                SELECT thread_id, type, checkpoint,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY thread_id ORDER BY checkpoint_id DESC
+                       ) AS rn
+                FROM checkpoints
+                WHERE thread_id IN ({placeholders})
+            ) WHERE rn = 1
+        """  # noqa: S608  # placeholders built from len(chunk); user values use ? params
+        async with conn.execute(query, chunk) as cursor:
+            rows = await cursor.fetchall()
+
+        loop = asyncio.get_running_loop()
+        for row in rows:
+            tid, type_str, checkpoint_blob = row
+            if not type_str or not checkpoint_blob:
+                results[tid] = _CheckpointSummary(message_count=0, initial_prompt=None)
+                continue
+            try:
+                data = await loop.run_in_executor(
+                    None, serde.loads_typed, (type_str, checkpoint_blob)
+                )
+                results[tid] = _summarize_checkpoint(data)
+            except Exception:
+                logger.warning(
+                    "Failed to deserialize checkpoint for thread %s; "
+                    "message count and initial prompt may be incomplete",
+                    tid,
+                    exc_info=True,
+                )
+                results[tid] = _CheckpointSummary(message_count=0, initial_prompt=None)
+
+    return results
 
 
 async def _load_latest_checkpoint_summary(

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -36,6 +36,18 @@ from deepagents_cli.widgets._links import open_style_link
 
 logger = logging.getLogger(__name__)
 
+_column_widths_cache: (
+    tuple[
+        tuple[tuple[str, str | None], ...],  # (thread_id, checkpoint_id) fingerprint
+        frozenset[str],  # visible column keys
+        bool,  # relative_time
+        dict[str, int | None],  # computed widths
+    ]
+    | None
+) = None
+"""Module-level cache so repeated `/threads` opens skip column-width computation
+when the inputs (thread data + config) haven't changed."""
+
 _COL_TID = 10
 _COL_AGENT = 12
 _COL_MSGS = 4
@@ -634,17 +646,18 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._filter_input: Input | None = None
         self._filter_controls: list[Input | Checkbox] | None = None
 
-        from deepagents_cli.model_config import (
-            load_thread_columns,
-            load_thread_relative_time,
-            load_thread_sort_order,
-        )
+        from deepagents_cli.model_config import load_thread_config
 
-        self._columns = load_thread_columns()
-        self._relative_time = load_thread_relative_time()
-        self._sort_by_updated = load_thread_sort_order() == "updated_at"
+        cfg = load_thread_config()
+        self._columns = dict(cfg.columns)
+        self._relative_time = cfg.relative_time
+        self._sort_by_updated = cfg.sort_order == "updated_at"
 
-        self._apply_sort()
+        # Cached threads are pre-sorted by updated_at DESC (the only sort
+        # order the cache stores).  Skip the O(n log n) re-sort when that
+        # matches the user's preference.
+        if not (self._has_initial_threads and self._sort_by_updated):
+            self._apply_sort()
         self._sync_selected_index()
         self._column_widths = self._compute_column_widths()
 
@@ -1027,9 +1040,22 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         from the visible data instead.
 
         Returns:
-            Dict mapping column keys to their effective pixel widths, with
+            Dict mapping column keys to their effective cell widths, with
                 `None` for flex columns.
         """
+        global _column_widths_cache  # noqa: PLW0603  # Module-level cache requires global statement
+
+        visible = frozenset(_visible_column_keys(self._columns))
+        fingerprint = tuple(
+            (t["thread_id"], t.get("latest_checkpoint_id"))
+            for t in self._filtered_threads
+        )
+
+        if _column_widths_cache is not None:
+            fp, vis, rel, cached_widths = _column_widths_cache
+            if fp == fingerprint and vis == visible and rel == self._relative_time:
+                return dict(cached_widths)
+
         widths = dict(_COLUMN_WIDTHS)
 
         for key in _AUTO_WIDTH_COLUMNS:
@@ -1044,6 +1070,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 _CELL_PADDING_RIGHT
             )
 
+        _column_widths_cache = (fingerprint, visible, self._relative_time, widths)
         return widths
 
     @staticmethod
@@ -1199,6 +1226,26 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             group="thread-selector-checkpoints",
         )
 
+    @staticmethod
+    def _threads_match(old: list[ThreadInfo], new: list[ThreadInfo]) -> bool:
+        """Check whether two thread lists have the same IDs and checkpoints in order.
+
+        Args:
+            old: Previous thread list.
+            new: Fresh thread list.
+
+        Returns:
+            True if both lists have identical thread/checkpoint ID pairs.
+        """
+        if len(old) != len(new):
+            return False
+        for a, b in zip(old, new, strict=True):
+            if a["thread_id"] != b["thread_id"]:
+                return False
+            if a.get("latest_checkpoint_id") != b.get("latest_checkpoint_id"):
+                return False
+        return True
+
     async def _load_threads(self) -> None:
         """Load thread rows first, then kick off background enrichment."""
         from deepagents_cli.sessions import (
@@ -1206,6 +1253,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             apply_cached_thread_message_counts,
             list_threads,
         )
+
+        old_threads = list(self._threads)
 
         try:
             limit = self._thread_limit
@@ -1245,7 +1294,22 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._update_filtered_list()
         self._sync_selected_index()
 
-        await self._build_list()
+        # Short-circuit: when the fresh data matches what is already rendered,
+        # update widget references and cell labels without tearing down the DOM.
+        if (
+            self._has_initial_threads
+            and self._option_widgets
+            and self._threads_match(old_threads, self._filtered_threads)
+        ):
+            for widget, thread in zip(
+                self._option_widgets,
+                self._filtered_threads,
+                strict=True,
+            ):
+                widget.thread = thread
+            self._refresh_cell_labels()
+        else:
+            await self._build_list()
 
         self._schedule_checkpoint_enrichment()
 

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -251,6 +251,156 @@ class TestThreadSortOrderPersistence:
         assert data["threads"]["sort_order"] == "created_at"
 
 
+class TestThreadConfigCoalesced:
+    """Tests for the coalesced `load_thread_config()` helper."""
+
+    def test_defaults_when_no_file(self, tmp_path: Path) -> None:
+        """When the config file does not exist, defaults should be returned."""
+        from deepagents_cli.model_config import load_thread_config
+
+        config_path = tmp_path / "config.toml"
+        cfg = load_thread_config(config_path)
+        assert cfg.columns == THREAD_COLUMN_DEFAULTS
+        assert cfg.relative_time is True
+        assert cfg.sort_order == "updated_at"
+
+    def test_reads_all_sections_from_one_parse(self, tmp_path: Path) -> None:
+        """A single TOML read should populate columns, relative_time, and sort_order."""
+        from deepagents_cli.model_config import load_thread_config
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            """
+[threads]
+relative_time = false
+sort_order = "created_at"
+
+[threads.columns]
+thread_id = true
+messages = false
+"""
+        )
+        cfg = load_thread_config(config_path)
+        assert cfg.columns["thread_id"] is True
+        assert cfg.columns["messages"] is False
+        # unchanged defaults
+        assert cfg.columns["updated_at"] is True
+        assert cfg.relative_time is False
+        assert cfg.sort_order == "created_at"
+
+    def test_matches_individual_loaders(self, tmp_path: Path) -> None:
+        """Coalesced result should match the three individual loaders."""
+        from deepagents_cli.model_config import (
+            load_thread_columns,
+            load_thread_config,
+            load_thread_relative_time,
+            load_thread_sort_order,
+        )
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            """
+[threads]
+relative_time = false
+sort_order = "created_at"
+
+[threads.columns]
+git_branch = true
+cwd = true
+"""
+        )
+        cfg = load_thread_config(config_path)
+        assert cfg.columns == load_thread_columns(config_path)
+        assert cfg.relative_time == load_thread_relative_time(config_path)
+        assert cfg.sort_order == load_thread_sort_order(config_path)
+
+    def test_corrupt_toml_returns_defaults(self, tmp_path: Path) -> None:
+        """A corrupt config file should return defaults without crashing."""
+        from deepagents_cli.model_config import load_thread_config
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("this is not valid TOML {{{{")
+        cfg = load_thread_config(config_path)
+        assert cfg.columns == THREAD_COLUMN_DEFAULTS
+        assert cfg.relative_time is True
+        assert cfg.sort_order == "updated_at"
+
+    def test_default_path_uses_cache(self) -> None:
+        """Second call with default path should return cached result."""
+        from deepagents_cli.model_config import (
+            _thread_config_cache,
+            invalidate_thread_config_cache,
+            load_thread_config,
+        )
+
+        invalidate_thread_config_cache()
+        try:
+            first = load_thread_config()
+            second = load_thread_config()
+            assert first is second
+        finally:
+            invalidate_thread_config_cache()
+
+    def test_save_invalidates_cache(self, tmp_path: Path) -> None:
+        """Saving thread config should invalidate the cached value."""
+        from deepagents_cli.model_config import (
+            invalidate_thread_config_cache,
+            load_thread_config,
+            save_thread_columns,
+        )
+
+        invalidate_thread_config_cache()
+        try:
+            first = load_thread_config()
+            assert first is load_thread_config()
+
+            save_thread_columns(dict(THREAD_COLUMN_DEFAULTS), tmp_path / "c.toml")
+            # Cache was invalidated by save
+            from deepagents_cli.model_config import _thread_config_cache
+
+            assert _thread_config_cache is None
+        finally:
+            invalidate_thread_config_cache()
+
+    def test_save_relative_time_invalidates_cache(self, tmp_path: Path) -> None:
+        """Saving relative_time should invalidate the cached value."""
+        from deepagents_cli.model_config import (
+            _thread_config_cache,
+            invalidate_thread_config_cache,
+            load_thread_config,
+            save_thread_relative_time,
+        )
+
+        invalidate_thread_config_cache()
+        try:
+            load_thread_config()
+            save_thread_relative_time(False, tmp_path / "c.toml")
+            from deepagents_cli.model_config import _thread_config_cache
+
+            assert _thread_config_cache is None
+        finally:
+            invalidate_thread_config_cache()
+
+    def test_save_sort_order_invalidates_cache(self, tmp_path: Path) -> None:
+        """Saving sort_order should invalidate the cached value."""
+        from deepagents_cli.model_config import (
+            _thread_config_cache,
+            invalidate_thread_config_cache,
+            load_thread_config,
+            save_thread_sort_order,
+        )
+
+        invalidate_thread_config_cache()
+        try:
+            load_thread_config()
+            save_thread_sort_order("created_at", tmp_path / "c.toml")
+            from deepagents_cli.model_config import _thread_config_cache
+
+            assert _thread_config_cache is None
+        finally:
+            invalidate_thread_config_cache()
+
+
 class TestProviderApiKeyEnv:
     """Tests for PROVIDER_API_KEY_ENV constant."""
 

--- a/libs/cli/tests/unit_tests/test_sessions.py
+++ b/libs/cli/tests/unit_tests/test_sessions.py
@@ -533,20 +533,22 @@ class TestListThreadsWithMessageCount:
                 ),
                 patch.object(
                     sessions,
-                    "_load_latest_checkpoint_summary",
+                    "_load_latest_checkpoint_summaries_batch",
                     new_callable=AsyncMock,
-                    return_value=sessions._CheckpointSummary(
-                        message_count=3,
-                        initial_prompt=None,
-                    ),
-                ) as mock_summary,
+                    return_value={
+                        "thread1": sessions._CheckpointSummary(
+                            message_count=3,
+                            initial_prompt=None,
+                        ),
+                    },
+                ) as mock_batch,
             ):
                 first = asyncio.run(sessions.list_threads(include_message_count=True))
                 second = asyncio.run(sessions.list_threads(include_message_count=True))
 
                 assert first[0]["message_count"] == 3
                 assert second[0]["message_count"] == 3
-                assert mock_summary.await_count == 1
+                assert mock_batch.await_count == 1
         finally:
             sessions._message_count_cache.clear()
 
@@ -555,6 +557,7 @@ class TestListThreadsWithMessageCount:
     ) -> None:
         """A newer checkpoint should invalidate cached message count."""
         sessions._message_count_cache.clear()
+        call_count = 0
         try:
             with (
                 patch.object(
@@ -566,44 +569,52 @@ class TestListThreadsWithMessageCount:
                     new_callable=AsyncMock,
                     return_value=object(),
                 ),
-                patch.object(
-                    sessions,
-                    "_load_latest_checkpoint_summary",
-                    new_callable=AsyncMock,
-                    side_effect=[
-                        sessions._CheckpointSummary(
-                            message_count=3,
-                            initial_prompt=None,
-                        ),
-                        sessions._CheckpointSummary(
-                            message_count=4,
-                            initial_prompt=None,
-                        ),
-                    ],
-                ) as mock_summary,
             ):
-                first = asyncio.run(sessions.list_threads(include_message_count=True))
-                assert first[0]["message_count"] == 3
+                results = [
+                    {"thread1": sessions._CheckpointSummary(3, None)},
+                    {"thread1": sessions._CheckpointSummary(4, None)},
+                ]
 
-                conn = sqlite3.connect(str(temp_db_with_messages))
-                type_str, checkpoint_blob, metadata = conn.execute(
-                    "SELECT type, checkpoint, metadata FROM checkpoints "
-                    "WHERE thread_id = ? AND checkpoint_id = ?",
-                    ("thread1", "cp_1"),
-                ).fetchone()
-                conn.execute(
-                    "INSERT INTO checkpoints "
-                    "(thread_id, checkpoint_ns, checkpoint_id, type, checkpoint, "
-                    "metadata) "
-                    "VALUES (?, '', ?, ?, ?, ?)",
-                    ("thread1", "cp_2", type_str, checkpoint_blob, metadata),
-                )
-                conn.commit()
-                conn.close()
+                def _batch_side_effect(
+                    *_args: object, **_kwargs: object
+                ) -> dict[str, sessions._CheckpointSummary]:
+                    nonlocal call_count
+                    idx = min(call_count, len(results) - 1)
+                    call_count += 1
+                    return results[idx]
 
-                second = asyncio.run(sessions.list_threads(include_message_count=True))
-                assert second[0]["message_count"] == 4
-                assert mock_summary.await_count == 2
+                with patch.object(
+                    sessions,
+                    "_load_latest_checkpoint_summaries_batch",
+                    new_callable=AsyncMock,
+                    side_effect=_batch_side_effect,
+                ) as mock_batch:
+                    first = asyncio.run(
+                        sessions.list_threads(include_message_count=True)
+                    )
+                    assert first[0]["message_count"] == 3
+
+                    conn = sqlite3.connect(str(temp_db_with_messages))
+                    type_str, checkpoint_blob, metadata = conn.execute(
+                        "SELECT type, checkpoint, metadata FROM checkpoints "
+                        "WHERE thread_id = ? AND checkpoint_id = ?",
+                        ("thread1", "cp_1"),
+                    ).fetchone()
+                    conn.execute(
+                        "INSERT INTO checkpoints "
+                        "(thread_id, checkpoint_ns, checkpoint_id, type, checkpoint, "
+                        "metadata) "
+                        "VALUES (?, '', ?, ?, ?, ?)",
+                        ("thread1", "cp_2", type_str, checkpoint_blob, metadata),
+                    )
+                    conn.commit()
+                    conn.close()
+
+                    second = asyncio.run(
+                        sessions.list_threads(include_message_count=True)
+                    )
+                    assert second[0]["message_count"] == 4
+                    assert mock_batch.await_count == 2
         finally:
             sessions._message_count_cache.clear()
 
@@ -612,7 +623,7 @@ class TestPopulateThreadCheckpointDetails:
     """Tests for combined checkpoint-detail enrichment."""
 
     async def test_shared_summary_populates_count_and_prompt_once(self) -> None:
-        """One summary lookup should fill both fields for a thread row."""
+        """One batch lookup should fill both fields for a thread row."""
         threads: list[sessions.ThreadInfo] = [
             {
                 "thread_id": "thread-a",
@@ -631,13 +642,15 @@ class TestPopulateThreadCheckpointDetails:
             ),
             patch.object(
                 sessions,
-                "_load_latest_checkpoint_summary",
+                "_load_latest_checkpoint_summaries_batch",
                 new_callable=AsyncMock,
-                return_value=sessions._CheckpointSummary(
-                    message_count=4,
-                    initial_prompt="hello world",
-                ),
-            ) as mock_summary,
+                return_value={
+                    "thread-a": sessions._CheckpointSummary(
+                        message_count=4,
+                        initial_prompt="hello world",
+                    ),
+                },
+            ) as mock_batch,
         ):
             await sessions._populate_checkpoint_fields(  # pyright: ignore[reportPrivateUsage]
                 cast(
@@ -651,7 +664,7 @@ class TestPopulateThreadCheckpointDetails:
 
         assert threads[0]["message_count"] == 4
         assert threads[0]["initial_prompt"] == "hello world"
-        assert mock_summary.await_count == 1
+        assert mock_batch.await_count == 1
 
 
 class TestApplyCachedThreadMessageCounts:
@@ -861,6 +874,8 @@ class TestPrewarmThreadMessageCounts:
 
     async def test_prewarm_respects_visible_thread_columns(self) -> None:
         """Prewarm should only fetch checkpoint fields for visible columns."""
+        from deepagents_cli.model_config import ThreadConfig
+
         threads: list[sessions.ThreadInfo] = [
             {
                 "thread_id": "thread-a",
@@ -877,16 +892,20 @@ class TestPrewarmThreadMessageCounts:
                 return_value=threads,
             ),
             patch(
-                "deepagents_cli.model_config.load_thread_columns",
-                return_value={
-                    "thread_id": False,
-                    "messages": True,
-                    "created_at": True,
-                    "updated_at": True,
-                    "git_branch": False,
-                    "initial_prompt": False,
-                    "agent_name": False,
-                },
+                "deepagents_cli.model_config.load_thread_config",
+                return_value=ThreadConfig(
+                    columns={
+                        "thread_id": False,
+                        "messages": True,
+                        "created_at": True,
+                        "updated_at": True,
+                        "git_branch": False,
+                        "initial_prompt": False,
+                        "agent_name": False,
+                    },
+                    relative_time=True,
+                    sort_order="updated_at",
+                ),
             ),
             patch.object(
                 sessions,
@@ -1532,3 +1551,140 @@ class TestDeleteThreadCommandJson:
 
         result = json.loads(buf.getvalue())
         assert result["data"]["deleted"] is False
+
+
+class TestBatchCheckpointSummaries:
+    """Tests for _load_latest_checkpoint_summaries_batch."""
+
+    async def test_batch_returns_summaries_for_multiple_threads(self) -> None:
+        """Batch query should return summaries keyed by thread_id."""
+        serde = JsonPlusSerializer()
+        from langchain_core.messages import HumanMessage
+
+        checkpoint_data = {
+            "channel_values": {"messages": [HumanMessage(content="hello")]},
+        }
+        blob = serde.dumps_typed(checkpoint_data)
+
+        import aiosqlite
+
+        db_path = ":memory:"
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE checkpoints "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "type TEXT, checkpoint BLOB, metadata TEXT)"
+            )
+            for tid, cpid in [("t1", "cp_1"), ("t1", "cp_2"), ("t2", "cp_1")]:
+                await conn.execute(
+                    "INSERT INTO checkpoints VALUES (?, '', ?, ?, ?, '{}')",
+                    (tid, cpid, blob[0], blob[1]),
+                )
+            await conn.commit()
+
+            results = await sessions._load_latest_checkpoint_summaries_batch(
+                conn, ["t1", "t2"], serde
+            )
+
+        assert "t1" in results
+        assert "t2" in results
+        assert results["t1"].message_count == 1
+        assert results["t1"].initial_prompt == "hello"
+        assert results["t2"].message_count == 1
+
+    async def test_batch_chunking_returns_all_results(self) -> None:
+        """Chunking across multiple batches should merge all results."""
+        serde = JsonPlusSerializer()
+        from langchain_core.messages import HumanMessage
+
+        checkpoint_data = {
+            "channel_values": {"messages": [HumanMessage(content="hi")]},
+        }
+        blob = serde.dumps_typed(checkpoint_data)
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE checkpoints "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "type TEXT, checkpoint BLOB, metadata TEXT)"
+            )
+            thread_ids = [f"t{i}" for i in range(5)]
+            for tid in thread_ids:
+                await conn.execute(
+                    "INSERT INTO checkpoints VALUES (?, '', 'cp1', ?, ?, '{}')",
+                    (tid, blob[0], blob[1]),
+                )
+            await conn.commit()
+
+            with patch.object(sessions, "_SQLITE_MAX_VARIABLE_NUMBER", 2):
+                results = await sessions._load_latest_checkpoint_summaries_batch(
+                    conn, thread_ids, serde
+                )
+
+        assert set(results.keys()) == set(thread_ids)
+        for tid in thread_ids:
+            assert results[tid].message_count == 1
+
+    async def test_batch_empty_ids_returns_empty_dict(self) -> None:
+        """Empty thread_ids list should return empty dict without querying."""
+        serde = JsonPlusSerializer()
+        result = await sessions._load_latest_checkpoint_summaries_batch(
+            None,  # type: ignore[arg-type]  # connection not used
+            [],
+            serde,
+        )
+        assert result == {}
+
+    async def test_batch_populate_fills_multiple_threads(self) -> None:
+        """_populate_checkpoint_fields should batch-fill uncached threads."""
+        sessions._message_count_cache.clear()
+        sessions._initial_prompt_cache.clear()
+        try:
+            threads: list[sessions.ThreadInfo] = [
+                {
+                    "thread_id": "t1",
+                    "agent_name": "a",
+                    "updated_at": "2025-01-01",
+                    "latest_checkpoint_id": "cp_1",
+                },
+                {
+                    "thread_id": "t2",
+                    "agent_name": "b",
+                    "updated_at": "2025-01-02",
+                    "latest_checkpoint_id": "cp_2",
+                },
+            ]
+            with (
+                patch.object(
+                    sessions,
+                    "_get_jsonplus_serializer",
+                    new_callable=AsyncMock,
+                    return_value=object(),
+                ),
+                patch.object(
+                    sessions,
+                    "_load_latest_checkpoint_summaries_batch",
+                    new_callable=AsyncMock,
+                    return_value={
+                        "t1": sessions._CheckpointSummary(3, "prompt1"),
+                        "t2": sessions._CheckpointSummary(7, "prompt2"),
+                    },
+                ) as mock_batch,
+            ):
+                await sessions._populate_checkpoint_fields(
+                    cast("aiosqlite.Connection", object()),
+                    threads,
+                    include_message_count=True,
+                    include_initial_prompt=True,
+                )
+
+            assert threads[0]["message_count"] == 3
+            assert threads[0]["initial_prompt"] == "prompt1"
+            assert threads[1]["message_count"] == 7
+            assert threads[1]["initial_prompt"] == "prompt2"
+            mock_batch.assert_awaited_once()
+        finally:
+            sessions._message_count_cache.clear()
+            sessions._initial_prompt_cache.clear()

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -70,10 +70,10 @@ def _patch_list_threads(threads: list[ThreadInfo] | None = None) -> Any:  # noqa
 
 
 def _patch_columns(columns: dict[str, bool] | None = None) -> Any:  # noqa: ANN401
-    """Patch load_thread_columns and load_thread_sort_order for tests."""
+    """Patch thread config loaders for tests."""
     import contextlib
 
-    from deepagents_cli.model_config import THREAD_COLUMN_DEFAULTS
+    from deepagents_cli.model_config import THREAD_COLUMN_DEFAULTS, ThreadConfig
 
     cols = columns if columns is not None else THREAD_COLUMN_DEFAULTS
 
@@ -87,6 +87,14 @@ def _patch_columns(columns: dict[str, bool] | None = None) -> Any:  # noqa: ANN4
             patch(
                 "deepagents_cli.model_config.load_thread_sort_order",
                 return_value="updated_at",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_thread_config",
+                return_value=ThreadConfig(
+                    columns=dict(cols),
+                    relative_time=True,
+                    sort_order="updated_at",
+                ),
             ),
         ):
             yield
@@ -1529,7 +1537,7 @@ class TestThreadSelectorInitialSortOrder:
 
         import contextlib
 
-        from deepagents_cli.model_config import THREAD_COLUMN_DEFAULTS
+        from deepagents_cli.model_config import THREAD_COLUMN_DEFAULTS, ThreadConfig
 
         @contextlib.contextmanager
         def _patch_sort_created() -> Any:  # noqa: ANN401
@@ -1541,6 +1549,14 @@ class TestThreadSelectorInitialSortOrder:
                 patch(
                     "deepagents_cli.model_config.load_thread_sort_order",
                     return_value="created_at",
+                ),
+                patch(
+                    "deepagents_cli.model_config.load_thread_config",
+                    return_value=ThreadConfig(
+                        columns=dict(THREAD_COLUMN_DEFAULTS),
+                        relative_time=True,
+                        sort_order="created_at",
+                    ),
                 ),
             ):
                 yield
@@ -2739,3 +2755,105 @@ class TestColumnKeyConsistency:
             f"missing={order_keys - set(THREAD_COLUMN_DEFAULTS)}, "
             f"extra={set(THREAD_COLUMN_DEFAULTS) - order_keys}"
         )
+
+
+class TestThreadsMatch:
+    """Tests for _threads_match short-circuit comparison."""
+
+    @staticmethod
+    def _thread(tid: str, cp: str | None = None) -> ThreadInfo:
+        t: ThreadInfo = {
+            "thread_id": tid,
+            "agent_name": "a",
+            "updated_at": "x",
+        }
+        if cp is not None:
+            t["latest_checkpoint_id"] = cp
+        return t
+
+    def test_identical_lists_match(self) -> None:
+        """Identical thread lists should match."""
+        a = [self._thread("t1", "cp1"), self._thread("t2", "cp2")]
+        b = [self._thread("t1", "cp1"), self._thread("t2", "cp2")]
+        assert ThreadSelectorScreen._threads_match(a, b) is True
+
+    def test_different_lengths_do_not_match(self) -> None:
+        """Different-length lists should not match."""
+        a = [self._thread("t1")]
+        b = [self._thread("t1"), self._thread("t2")]
+        assert ThreadSelectorScreen._threads_match(a, b) is False
+
+    def test_different_thread_ids_do_not_match(self) -> None:
+        """Different thread IDs at same position should not match."""
+        a = [self._thread("t1", "cp1")]
+        b = [self._thread("t2", "cp1")]
+        assert ThreadSelectorScreen._threads_match(a, b) is False
+
+    def test_different_checkpoint_ids_do_not_match(self) -> None:
+        """Lists with different checkpoint IDs should not match."""
+        a = [self._thread("t1", "cp1")]
+        b = [self._thread("t1", "cp2")]
+        assert ThreadSelectorScreen._threads_match(a, b) is False
+
+    def test_reordered_threads_do_not_match(self) -> None:
+        """Positional comparison means reordered lists fail."""
+        a = [self._thread("t1", "cp1"), self._thread("t2", "cp2")]
+        b = [self._thread("t2", "cp2"), self._thread("t1", "cp1")]
+        assert ThreadSelectorScreen._threads_match(a, b) is False
+
+    def test_empty_lists_match(self) -> None:
+        """Two empty lists should match."""
+        assert ThreadSelectorScreen._threads_match([], []) is True
+
+
+class TestThreadSelectorDomSkip:
+    """Tests for skipping DOM rebuild when data matches prewarm cache."""
+
+    async def test_matching_refresh_skips_dom_rebuild(self) -> None:
+        """When refreshed threads match prefetched, DOM should not be rebuilt."""
+        prefetched: list[ThreadInfo] = [
+            {
+                "thread_id": "abc12345",
+                "agent_name": "my-agent",
+                "updated_at": "2025-01-15T10:30:00",
+                "latest_checkpoint_id": "cp_1",
+                "message_count": 5,
+            }
+        ]
+        # Same thread and checkpoint
+        refreshed: list[ThreadInfo] = [
+            {
+                "thread_id": "abc12345",
+                "agent_name": "my-agent",
+                "updated_at": "2025-01-15T10:30:00",
+                "latest_checkpoint_id": "cp_1",
+            }
+        ]
+        app = ThreadSelectorTestApp(current_thread="abc12345")
+
+        with patch(
+            "deepagents_cli.sessions.list_threads",
+            new_callable=AsyncMock,
+            return_value=refreshed,
+        ):
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    ThreadSelectorScreen(
+                        current_thread="abc12345",
+                        thread_limit=20,
+                        initial_threads=prefetched,
+                    )
+                )
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                initial_widgets = list(screen._option_widgets)
+                assert len(initial_widgets) == 1
+
+                # Wait for background refresh
+                for _ in range(10):
+                    await pilot.pause(0.05)
+
+                # Same widget objects should still be mounted (no rebuild)
+                assert screen._option_widgets == initial_widgets


### PR DESCRIPTION
`/threads` had three independent bottlenecks making it feel sluggish to open: three separate TOML config file reads, one sequential DB query per thread for checkpoint data, and a full DOM teardown/rebuild even when the prefetched data matched what was about to be fetched. All three are addressed, and repeated opens with unchanged data now skip disk I/O, DB queries, sorting, column width computation, and DOM reconstruction entirely.