### PR TITLE
perf(cli): speed up `/model` selector with cache pre-warming and async saves

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -699,6 +699,13 @@ class DeepAgentsApp(App):
                 group="startup-thread-prewarm",
             )
 
+            # Prewarm model caches so `/model` opens instantly.
+            self.run_worker(
+                self._prewarm_model_caches,
+                exclusive=True,
+                group="startup-model-prewarm",
+            )
+
         # Background update check (opt-out via DEEPAGENTS_NO_UPDATE_CHECK)
         if not os.environ.get("DEEPAGENTS_NO_UPDATE_CHECK"):
             self.run_worker(
@@ -757,6 +764,21 @@ class DeepAgentsApp(App):
         )
 
         await prewarm_thread_message_counts(limit=get_thread_limit())
+
+    async def _prewarm_model_caches(self) -> None:
+        """Prewarm model discovery and profile caches without blocking startup."""
+        try:
+            from deepagents_cli.model_config import (
+                get_available_models,
+                get_model_profiles,
+            )
+
+            await asyncio.to_thread(get_available_models)
+            await asyncio.to_thread(
+                get_model_profiles, cli_override=self._profile_override
+            )
+        except Exception:
+            logger.debug("Could not prewarm model caches", exc_info=True)
 
     async def _check_for_updates(self) -> None:
         """Check PyPI for a newer deepagents-cli version and notify the user."""
@@ -3215,7 +3237,7 @@ class DeepAgentsApp(App):
         if not self._checkpointer:
             # No checkpointer means we can't hot-swap
             # Save the preference and notify user
-            if save_recent_model(model_spec):
+            if await asyncio.to_thread(save_recent_model, model_spec):
                 await self._mount_message(
                     AppMessage(
                         f"Model preference set to {model_spec}. "
@@ -3289,7 +3311,7 @@ class DeepAgentsApp(App):
                 model=settings.model_name or "",
             )
 
-        config_saved = save_recent_model(display)
+        config_saved = await asyncio.to_thread(save_recent_model, display)
         if config_saved:
             await self._mount_message(AppMessage(f"Switched to {display}"))
         else:
@@ -3332,7 +3354,7 @@ class DeepAgentsApp(App):
             if provider:
                 model_spec = f"{provider}:{model_spec}"
 
-        if save_default_model(model_spec):
+        if await asyncio.to_thread(save_default_model, model_spec):
             await self._mount_message(AppMessage(f"Default model set to {model_spec}"))
         else:
             await self._mount_message(
@@ -3349,7 +3371,7 @@ class DeepAgentsApp(App):
         """
         from deepagents_cli.model_config import clear_default_model
 
-        if clear_default_model():
+        if await asyncio.to_thread(clear_default_model):
             await self._mount_message(
                 AppMessage(
                     "Default model cleared. "

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -209,6 +209,7 @@ _available_models_cache: dict[str, list[str]] | None = None
 _builtin_providers_cache: dict[str, Any] | None = None
 _default_config_cache: ModelConfig | None = None
 _profiles_cache: Mapping[str, ModelProfileEntry] | None = None
+_profiles_override_cache: tuple[int, Mapping[str, ModelProfileEntry]] | None = None
 
 
 def clear_caches() -> None:
@@ -216,11 +217,12 @@ def clear_caches() -> None:
 
     Intended for tests and for the `/reload` command.
     """
-    global _available_models_cache, _builtin_providers_cache, _default_config_cache, _profiles_cache  # noqa: PLW0603, E501  # Module-level caches require global statement
+    global _available_models_cache, _builtin_providers_cache, _default_config_cache, _profiles_cache, _profiles_override_cache  # noqa: PLW0603, E501  # Module-level caches require global statement
     _available_models_cache = None
     _builtin_providers_cache = None
     _default_config_cache = None
     _profiles_cache = None
+    _profiles_override_cache = None
     invalidate_thread_config_cache()
 
 
@@ -439,9 +441,12 @@ def get_model_profiles(
     Unlike `get_available_models()`, this includes all models from upstream
     profiles regardless of capability filters (tool calling, text I/O).
 
-    Results are cached when `cli_override` is None; use `clear_caches()`
-    to reset. When `cli_override` is provided the cache is bypassed
-    because CLI overrides are session-specific.
+    Results are cached; use `clear_caches()` to reset. When `cli_override` is
+    provided the result is stored in a single-slot cache keyed by
+    `id(cli_override)`. This relies on the caller retaining the same dict
+    object for the session (the CLI stores it once on the app instance);
+    passing a different dict with the same contents will bypass the cache
+    and overwrite the previous entry.
 
     Args:
         cli_override: Extra profile fields from `--profile-override`.
@@ -453,9 +458,13 @@ def get_model_profiles(
     Returns:
         Read-only mapping of spec strings to profile entries.
     """
-    global _profiles_cache  # noqa: PLW0603  # Module-level cache requires global statement
+    global _profiles_cache, _profiles_override_cache  # noqa: PLW0603  # Module-level caches require global statement
     if cli_override is None and _profiles_cache is not None:
         return _profiles_cache
+    if cli_override is not None and _profiles_override_cache is not None:
+        cached_id, cached_result = _profiles_override_cache
+        if cached_id == id(cli_override):
+            return cached_result
 
     result: dict[str, ModelProfileEntry] = {}
     config = ModelConfig.load()
@@ -500,9 +509,10 @@ def get_model_profiles(
                 result[spec] = _build_entry({}, overrides, cli_override)
 
     frozen = MappingProxyType(result)
-    # Only populate cache for the static (no CLI override) path.
     if cli_override is None:
         _profiles_cache = frozen
+    else:
+        _profiles_override_cache = (id(cli_override), frozen)
     return frozen
 
 

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -229,7 +229,6 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._options_container: Container | None = None
         self._option_widgets: list[ModelOption] = []
         self._filter_text = ""
-        self._rebuild_needed = True
         self._current_spec: str | None = None
         if current_model and current_provider:
             self._current_spec = f"{current_provider}:{current_model}"
@@ -316,7 +315,6 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         """
         self._filter_text = event.value
         self._update_filtered_list()
-        self._rebuild_needed = True
         self.call_after_refresh(self._update_display)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
@@ -385,7 +383,6 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
         await self._options_container.remove_children()
         self._option_widgets = []
-        self._rebuild_needed = False
 
         if not self._filtered_models:
             no_matches = Static("[dim]No matching models[/dim]")
@@ -425,13 +422,17 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         if self._current_model and self._current_provider:
             current_spec = f"{self._current_provider}:{self._current_model}"
 
+        # Resolve credentials upfront so the widget-building loop
+        # stays focused on layout
+        creds = {p: has_provider_credentials(p) for p in by_provider}
+
         # Collect all widgets first, then batch-mount once to avoid
         # individual DOM mutations per widget
         all_widgets: list[Static] = []
 
         for provider, model_entries in by_provider.items():
             # Provider header with credential indicator
-            has_creds = has_provider_credentials(provider)
+            has_creds = creds[provider]
             if has_creds is True:
                 cred_indicator = glyphs.checkmark
             elif has_creds is False:
@@ -763,12 +764,14 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         elif custom_input:
             self.dismiss((custom_input, ""))
 
-    def action_set_default(self) -> None:
+    async def action_set_default(self) -> None:
         """Toggle the highlighted model as the default.
 
         If the highlighted model is already the default, clears it.
         Otherwise sets it as the new default.
         """
+        import asyncio
+
         if not self._filtered_models or not self._option_widgets:
             return
 
@@ -777,18 +780,16 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
         if model_spec == self._default_spec:
             # Already default — clear it
-            if clear_default_model():
+            if await asyncio.to_thread(clear_default_model):
                 self._default_spec = None
-                self._rebuild_needed = True
                 self.call_after_refresh(self._update_display)
                 help_widget.update("[bold]Default cleared[/bold]")
                 self.set_timer(3.0, self._restore_help_text)
             else:
                 help_widget.update("[bold red]Failed to clear default[/bold red]")
                 self.set_timer(3.0, self._restore_help_text)
-        elif save_default_model(model_spec):
+        elif await asyncio.to_thread(save_default_model, model_spec):
             self._default_spec = model_spec
-            self._rebuild_needed = True
             self.call_after_refresh(self._update_display)
             help_widget.update(f"[bold]Default set to {model_spec}[/bold]")
             self.set_timer(3.0, self._restore_help_text)


### PR DESCRIPTION
Reduce latency on the `/model` selector by pre-warming model caches at startup and moving synchronous TOML config writes off the event loop. Previously, `get_available_models()` and `get_model_profiles()` cold-started on every `/model` open, and `--profile-override` sessions always bypassed the profile cache entirely. Config saves (`save_recent_model`, `save_default_model`, `clear_default_model`) blocked the main thread during file I/O.