### PR TITLE
fix(cli): let unknown providers through credential check

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3213,17 +3213,25 @@ class DeepAgentsApp(App):
             provider = detect_provider(model_spec)
 
         # Check credentials
-        if provider and has_provider_credentials(provider) is False:
+        has_creds = has_provider_credentials(provider) if provider else None
+        if has_creds is False and provider is not None:
             env_var = get_credential_env_var(provider)
-            if env_var:
-                detail = f"{env_var} is not set or is empty"
-            else:
-                detail = (
+            detail = (
+                f"{env_var} is not set or is empty"
+                if env_var
+                else (
                     f"provider '{provider}' is not recognized. "
-                    "Add it to ~/.deepagents/config.toml with an api_key_env field"
+                    "Add it to ~/.deepagents/config.toml with an "
+                    "api_key_env field"
                 )
+            )
             await self._mount_message(ErrorMessage(f"Missing credentials: {detail}"))
             return
+        if has_creds is None and provider:
+            logger.debug(
+                "Credentials for provider '%s' cannot be verified; proceeding anyway",
+                provider,
+            )
 
         # Check if already using this exact model
         if model_name == settings.model_name and (

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -516,29 +516,17 @@ def get_model_profiles(
     return frozen
 
 
-def _is_langchain_supported_provider(provider: str) -> bool:
-    """Check if a provider is in langchain's built-in provider registry.
-
-    Args:
-        provider: Provider name to check.
-
-    Returns:
-        True if the provider is known to `init_chat_model`.
-    """
-    return provider in _get_builtin_providers()
-
-
 def has_provider_credentials(provider: str) -> bool | None:
     """Check if credentials are available for a provider.
 
-    Checks in order:
+    Resolution order:
 
     1. Config-file providers (`config.toml`) — takes priority so user
         overrides (e.g., custom `api_key_env` or `base_url`) are respected.
     2. Hardcoded `PROVIDER_API_KEY_ENV` mapping (anthropic, openai, etc.).
-    3. Langchain's `_SUPPORTED_PROVIDERS` registry — if the provider is known
-        to `init_chat_model`, credential status is unknown; the provider
-        itself will report auth failures at model-creation time.
+    3. For any other provider (e.g., third-party langchain provider
+        packages), credential status is unknown — the provider itself will
+        report auth failures at model-creation time.
 
     Args:
         provider: Provider name.
@@ -560,12 +548,14 @@ def has_provider_credentials(provider: str) -> bool | None:
     if env_var:
         return bool(os.environ.get(env_var))
 
-    # If langchain knows this provider, let it through — we can't verify
-    # credentials, but the provider will raise its own auth error if needed.
-    if _is_langchain_supported_provider(provider):
-        return None
-
-    return False
+    # Provider not found in config or hardcoded map — credential status is
+    # unknown. The provider itself will report auth failures at
+    # model-creation time.
+    logger.debug(
+        "No credential information for provider '%s'; deferring auth to provider",
+        provider,
+    )
+    return None
 
 
 def get_credential_env_var(provider: str) -> str | None:

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -108,9 +108,9 @@ class TestModelSpec:
 class TestHasProviderCredentials:
     """Tests for has_provider_credentials() function."""
 
-    def test_returns_false_for_unknown_provider(self):
-        """Returns False for unknown provider."""
-        assert has_provider_credentials("unknown") is False
+    def test_returns_none_for_unknown_provider(self):
+        """Returns None for unknown provider (let provider handle auth)."""
+        assert has_provider_credentials("unknown") is None
 
     def test_returns_true_when_env_var_set(self):
         """Returns True when provider env var is set."""
@@ -1073,20 +1073,13 @@ api_key_env = "FIREWORKS_API_KEY"
         ):
             assert has_provider_credentials("fireworks") is False
 
-    def test_returns_false_for_totally_unknown_provider(self):
-        """Returns False for provider not in hardcoded map, config, or langchain."""
-        assert has_provider_credentials("nonexistent_provider_xyz") is False
+    def test_returns_none_for_totally_unknown_provider(self):
+        """Returns None for provider not in hardcoded map or config.
 
-    def test_returns_none_for_langchain_known_provider(self):
-        """Returns None for a provider known to langchain but not in config."""
-        fake_registry = {
-            "ollama": ("langchain_ollama", "ChatOllama", None),
-        }
-        with patch(
-            "deepagents_cli.model_config._get_builtin_providers",
-            return_value=fake_registry,
-        ):
-            assert has_provider_credentials("ollama") is None
+        Unknown providers are let through so the provider itself can report
+        auth failures at model-creation time.
+        """
+        assert has_provider_credentials("nonexistent_provider_xyz") is None
 
 
 class TestModelConfigGetClassPath:


### PR DESCRIPTION
Remove the langchain `_SUPPORTED_PROVIDERS` registry lookup from `has_provider_credentials` so third-party provider packages (not in the hardcoded map or config file) are no longer silently rejected. Previously, unknown providers got `False` and were blocked with a "not recognized" error — now they get `None` and are let through, deferring auth validation to the provider itself. The credential guard in `_switch_model` is updated to handle the new semantics with debug logging for unverifiable providers.

### User impact

The credential check only happens when you interact with the model selector.

**Before:** Any provider not in the hardcoded map, `config.toml`, or langchain's built-in registry was blocked upfront with *"provider 'x' is not recognized."* This rejected third-party langchain provider packages (e.g., a community `langchain-myprovider` installed via pip) even when they had valid credentials.

**After:** The CLI only blocks when it *knows* credentials are missing (e.g., `ANTHROPIC_API_KEY` not set). Unrecognized providers are let through — the provider itself handles auth and reports failures.

**Tradeoff:** Typos in provider names (like `"antrhopic"`) previously got a helpful early error. Now they fall through to the provider layer, which will throw a less friendly error (e.g., `ValueError: Unsupported model provider`). A debug log is emitted for troubleshooting.