### PR TITLE
fix(cli): auto-discover models for `class_path` providers

### DIFF
--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -332,6 +332,25 @@ def _load_provider_profiles(module_path: str) -> dict[str, Any]:
     return getattr(module, "_PROFILES", {})
 
 
+def _profile_module_from_class_path(class_path: str) -> str | None:
+    """Derive the profile module path from a `class_path` config value.
+
+    Args:
+        class_path: Fully-qualified class in `module.path:ClassName` format.
+
+    Returns:
+        Dotted module path like `langchain_baseten.data._profiles`, or None
+            if `class_path` is malformed.
+    """
+    if ":" not in class_path:
+        return None
+    module_part, _ = class_path.split(":", 1)
+    package_root = module_part.split(".", maxsplit=1)[0]
+    if not package_root:
+        return None
+    return f"{package_root}.data._profiles"
+
+
 def get_available_models() -> dict[str, list[str]]:
     """Get available models dynamically from installed LangChain provider packages.
 
@@ -341,7 +360,9 @@ def get_available_models() -> dict[str, list[str]]:
 
     Returns:
         Dictionary mapping provider names to lists of model identifiers.
-            Only includes providers whose packages are installed.
+            Includes providers from the langchain registry, config-file
+            providers with explicit model lists, and `class_path` providers
+            whose packages expose a `_profiles` module.
     """
     global _available_models_cache  # noqa: PLW0603  # Module-level cache requires global statement
     if _available_models_cache is not None:
@@ -353,8 +374,10 @@ def get_available_models() -> dict[str, list[str]]:
     # Build the list dynamically from langchain's supported-provider registry
     # so new providers are picked up automatically when langchain adds them.
     provider_modules = _get_provider_profile_modules()
+    registry_providers: set[str] = set()
 
     for provider, module_path in provider_modules:
+        registry_providers.add(provider)
         try:
             profiles = _load_provider_profiles(module_path)
         except ImportError:
@@ -388,7 +411,43 @@ def get_available_models() -> dict[str, list[str]]:
     # Merge in models from config file (custom providers like ollama, fireworks)
     config = ModelConfig.load()
     for provider_name, provider_config in config.providers.items():
-        config_models = provider_config.get("models", [])
+        config_models = list(provider_config.get("models", []))
+
+        # For class_path providers not in the built-in registry, auto-discover
+        # models from the package's _profiles.py when no explicit models list.
+        if (
+            not config_models
+            and provider_name not in registry_providers
+            and provider_name not in available
+        ):
+            class_path = provider_config.get("class_path", "")
+            profile_module = _profile_module_from_class_path(class_path)
+            if profile_module:
+                try:
+                    profiles = _load_provider_profiles(profile_module)
+                except ImportError:
+                    logger.debug(
+                        "Could not import profiles from %s for class_path "
+                        "provider '%s' (package may not be installed)",
+                        profile_module,
+                        provider_name,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to load profiles from %s for class_path provider '%s'",
+                        profile_module,
+                        provider_name,
+                        exc_info=True,
+                    )
+                else:
+                    config_models = sorted(
+                        name
+                        for name, profile in profiles.items()
+                        if profile.get("tool_calling", False)
+                        and profile.get("text_inputs", True) is not False
+                        and profile.get("text_outputs", True) is not False
+                    )
+
         if provider_name not in available:
             if config_models:
                 available[provider_name] = config_models
@@ -472,7 +531,9 @@ def get_model_profiles(
     # Collect upstream profiles from provider packages.
     seen_specs: set[str] = set()
     provider_modules = _get_provider_profile_modules()
+    registry_providers: set[str] = set()
     for provider, module_path in provider_modules:
+        registry_providers.add(provider)
         try:
             profiles = _load_provider_profiles(module_path)
         except ImportError:
@@ -497,8 +558,41 @@ def get_model_profiles(
             overrides = config.get_profile_overrides(provider, model_name=model_name)
             result[spec] = _build_entry(upstream_profile, overrides, cli_override)
 
-    # Add config-only models that have no upstream profile.
+    # Add config-only models and class_path provider profiles.
     for provider_name, provider_config in config.providers.items():
+        # For class_path providers not in the built-in registry, load
+        # upstream profiles from the package's _profiles.py.
+        if provider_name not in registry_providers:
+            class_path = provider_config.get("class_path", "")
+            profile_module = _profile_module_from_class_path(class_path)
+            if profile_module:
+                try:
+                    pkg_profiles = _load_provider_profiles(profile_module)
+                except ImportError:
+                    logger.debug(
+                        "Could not import profiles from %s for class_path "
+                        "provider '%s' (package may not be installed)",
+                        profile_module,
+                        provider_name,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to load profiles from %s for class_path provider '%s'",
+                        profile_module,
+                        provider_name,
+                        exc_info=True,
+                    )
+                else:
+                    for model_name, upstream_profile in pkg_profiles.items():
+                        spec = f"{provider_name}:{model_name}"
+                        seen_specs.add(spec)
+                        overrides = config.get_profile_overrides(
+                            provider_name, model_name=model_name
+                        )
+                        result[spec] = _build_entry(
+                            upstream_profile, overrides, cli_override
+                        )
+
         config_models = provider_config.get("models", [])
         for model_name in config_models:
             spec = f"{provider_name}:{model_name}"

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +19,7 @@ from deepagents_cli.model_config import (
     _get_builtin_providers,
     _get_provider_profile_modules,
     _load_provider_profiles,
+    _profile_module_from_class_path,
     clear_caches,
     clear_default_model,
     get_available_models,
@@ -1013,8 +1014,8 @@ models = ["claude-sonnet-4-5"]
 
         assert models["anthropic"].count("claude-sonnet-4-5") == 1
 
-    def test_skips_config_provider_with_no_models(self, tmp_path):
-        """Config provider with empty models list is not added."""
+    def test_skips_config_provider_with_no_models_and_no_class_path(self, tmp_path):
+        """Config provider with no models and no class_path is not added."""
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
 [models.providers.empty]
@@ -1030,6 +1031,275 @@ api_key_env = "SOME_KEY"
             models = get_available_models()
 
         assert "empty" not in models
+
+
+class TestProfileModuleFromClassPath:
+    """Tests for _profile_module_from_class_path() helper."""
+
+    def test_derives_module_path(self):
+        """Derives profile module from a valid class_path."""
+        result = _profile_module_from_class_path(
+            "langchain_baseten.chat_models:ChatBaseten"
+        )
+        assert result == "langchain_baseten.data._profiles"
+
+    def test_returns_none_for_missing_colon(self):
+        """Returns None when class_path has no colon separator."""
+        assert _profile_module_from_class_path("my_package.MyChatModel") is None
+
+    def test_single_segment_package(self):
+        """Works with a single-segment package name."""
+        result = _profile_module_from_class_path("mypkg:MyClass")
+        assert result == "mypkg.data._profiles"
+
+    def test_returns_none_for_empty_module_part(self):
+        """Returns None when module part before colon is empty."""
+        assert _profile_module_from_class_path(":MyClass") is None
+
+
+class TestClassPathProviderAutoDiscovery:
+    """Tests for auto-discovering models from class_path provider packages."""
+
+    FAKE_BASETEN_PROFILES: ClassVar[dict[str, dict[str, Any]]] = {
+        "deepseek-ai/DeepSeek-V3.2": {
+            "tool_calling": True,
+            "text_inputs": True,
+            "text_outputs": True,
+        },
+        "Qwen/Qwen3-Coder": {
+            "tool_calling": True,
+            "text_inputs": True,
+            "text_outputs": True,
+        },
+        "some/no-tools-model": {
+            "tool_calling": False,
+            "text_inputs": True,
+            "text_outputs": True,
+        },
+    }
+
+    def test_get_available_models_discovers_class_path_profiles(self, tmp_path):
+        """class_path provider auto-discovers models from package profiles."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+""")
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_baseten.data._profiles":
+                return self.FAKE_BASETEN_PROFILES
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "baseten" in models
+        assert "deepseek-ai/DeepSeek-V3.2" in models["baseten"]
+        assert "Qwen/Qwen3-Coder" in models["baseten"]
+        # Filtered out: no tool_calling
+        assert "some/no-tools-model" not in models["baseten"]
+
+    def test_get_model_profiles_discovers_class_path_profiles(self, tmp_path):
+        """class_path provider profiles are included in get_model_profiles()."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+""")
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_baseten.data._profiles":
+                return self.FAKE_BASETEN_PROFILES
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        assert "baseten:deepseek-ai/DeepSeek-V3.2" in profiles
+        entry = profiles["baseten:deepseek-ai/DeepSeek-V3.2"]
+        assert entry["profile"]["tool_calling"] is True
+        # No config overrides, so overridden_keys should be empty
+        assert entry["overridden_keys"] == frozenset()
+        # Unlike get_available_models(), profiles include ALL models (no filter)
+        assert "baseten:some/no-tools-model" in profiles
+
+    def test_get_model_profiles_class_path_import_failure_graceful(self, tmp_path):
+        """get_model_profiles() degrades gracefully when class_path package fails."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+""")
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=ImportError("not installed"),
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        assert not any(key.startswith("baseten:") for key in profiles)
+
+    def test_class_path_profiles_merged_with_config_overrides(self, tmp_path):
+        """Config profile overrides are applied on top of class_path profiles."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+
+[models.providers.baseten.profile]
+max_input_tokens = 9999
+""")
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_baseten.data._profiles":
+                return {
+                    "my-model": {
+                        "tool_calling": True,
+                        "max_input_tokens": 4096,
+                    },
+                }
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        entry = profiles["baseten:my-model"]
+        assert entry["profile"]["max_input_tokens"] == 9999
+        assert "max_input_tokens" in entry["overridden_keys"]
+
+    def test_class_path_import_failure_graceful(self, tmp_path):
+        """Gracefully handles class_path package not being installed."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+""")
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=ImportError("not installed"),
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "baseten" not in models
+
+    def test_class_path_non_import_error_logs_warning(self, tmp_path, caplog):
+        """Non-ImportError from class_path package logs warning, not debug."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+""")
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_baseten.data._profiles":
+                msg = "broken profiles module"
+                raise RuntimeError(msg)
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            caplog.at_level(logging.WARNING, logger="deepagents_cli.model_config"),
+        ):
+            models = get_available_models()
+
+        assert "baseten" not in models
+        assert any(
+            "Failed to load profiles" in record.message and "baseten" in record.message
+            for record in caplog.records
+        )
+
+    def test_explicit_models_list_skips_auto_discovery(self, tmp_path):
+        """Explicit models list bypasses auto-discovery even when profiles exist."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.baseten]
+class_path = "langchain_baseten.chat_models:ChatBaseten"
+api_key_env = "BASETEN_API_KEY"
+models = ["my-explicit-model"]
+""")
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_baseten.data._profiles":
+                return self.FAKE_BASETEN_PROFILES
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "baseten" in models
+        assert models["baseten"] == ["my-explicit-model"]
+
+    def test_skips_builtin_registry_providers(self, tmp_path):
+        """Does not double-load profiles for providers in the built-in registry."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+class_path = "langchain_anthropic.chat_models:ChatAnthropic"
+""")
+        fake_profiles = {"claude-sonnet-4-5": {"tool_calling": True}}
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        # Should only appear once (from registry path, not double-loaded)
+        assert models["anthropic"].count("claude-sonnet-4-5") == 1
 
 
 class TestHasProviderCredentialsFallback:


### PR DESCRIPTION
Config-file providers that use `class_path` (e.g., baseten) but don't list explicit `models` were invisible in the `/models` selector. The model discovery pipeline only loaded profiles from langchain's built-in provider registry, so third-party packages outside that registry were silently skipped. Now `get_available_models()` and `get_model_profiles()` automatically probe the package's `_profiles.py` module when a `class_path` provider has no explicit models list.

## Changes
- Add `_profile_module_from_class_path()` helper that derives a `<package>.data._profiles` module path from a `class_path` config value like `"langchain_baseten.chat_models:ChatBaseten"`
- `get_available_models()` now auto-discovers models from `class_path` provider packages not in langchain's built-in registry, applying the same `tool_calling`/`text_inputs`/`text_outputs` filters as registry providers
- `get_model_profiles()` loads upstream profile data (context window sizes, capabilities) from `class_path` packages so the UI has accurate metadata — no capability filtering here, matching the existing convention for registry providers
- Auto-discovery is skipped when the config has an explicit `models` list, and `registry_providers` tracking prevents double-loading for providers that are already in langchain's registry
- Error handling splits `ImportError` (debug-level, expected when package isn't installed) from other exceptions (warning-level with `exc_info=True`), matching the existing pattern for registry provider profile loading
- Also includes the previously staged change: `has_provider_credentials()` now returns `None` (unknown) instead of `False` for providers not in the hardcoded map or langchain registry, letting third-party providers handle their own auth errors
