### PR TITLE
perf(cli): speed up unit tests in CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -13,6 +13,11 @@ on:
         required: true
         type: string
         description: "Python version to use"
+      coverage:
+        required: false
+        type: boolean
+        default: true
+        description: "Collect coverage (disable to speed up non-primary matrix legs)"
 
 permissions:
   contents: read
@@ -48,7 +53,12 @@ jobs:
         shell: bash
         env:
           RUN_SANDBOX_TESTS: "true"
-        run: make test
+        run: |
+          if [ "${{ inputs.coverage }}" = "false" ]; then
+            make test COV_ARGS=
+          else
+            make test
+          fi
 
       - name: "🧹 Verify Clean Working Directory"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
     with:
       working-directory: "libs/deepagents"
       python-version: ${{ matrix.python-version }}
+      coverage: ${{ matrix.python-version == '3.12' }}
 
   test-cli:
     name: "🧪 Test cli"
@@ -177,6 +178,7 @@ jobs:
     with:
       working-directory: "libs/cli"
       python-version: ${{ matrix.python-version }}
+      coverage: ${{ matrix.python-version == '3.12' }}
 
   test-harbor:
     name: "🧪 Test harbor"
@@ -190,6 +192,7 @@ jobs:
     with:
       working-directory: "libs/harbor"
       python-version: ${{ matrix.python-version }}
+      coverage: ${{ matrix.python-version == '3.12' }}
 
   test-daytona:
     name: "🧪 Test daytona"
@@ -203,6 +206,7 @@ jobs:
     with:
       working-directory: "libs/partners/daytona"
       python-version: ${{ matrix.python-version }}
+      coverage: ${{ matrix.python-version == '3.12' }}
 
   test-modal:
     name: "🧪 Test modal"
@@ -216,6 +220,7 @@ jobs:
     with:
       working-directory: "libs/partners/modal"
       python-version: ${{ matrix.python-version }}
+      coverage: ${{ matrix.python-version == '3.12' }}
 
   test-runloop:
     name: "🧪 Test runloop"
@@ -229,6 +234,7 @@ jobs:
     with:
       working-directory: "libs/partners/runloop"
       python-version: ${{ matrix.python-version }}
+      coverage: ${{ matrix.python-version == '3.12' }}
 
   # Final status check - ensures all jobs passed
   ci_success:

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -13,11 +13,12 @@ UV_FROZEN = true
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
+COV_ARGS ?= --cov=deepagents_cli --cov-report=term-missing
+
 test: ## Run unit tests
 test tests:
 	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE) \
-		--cov=deepagents_cli \
-		--cov-report=term-missing
+		$(COV_ARGS)
 
 coverage: ## Run unit tests with coverage
 	uv run --group test pytest --cov \

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -36,6 +36,9 @@ from deepagents_cli.widgets._links import open_style_link
 
 logger = logging.getLogger(__name__)
 
+_URL_FETCH_TIMEOUT = 2.0
+"""Seconds to wait for LangSmith thread-URL resolution before giving up."""
+
 _column_widths_cache: (
     tuple[
         tuple[tuple[str, str | None], ...],  # (thread_id, checkpoint_id) fingerprint
@@ -1380,7 +1383,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         try:
             thread_url = await asyncio.wait_for(
                 asyncio.to_thread(build_langsmith_thread_url, self._current_thread),
-                timeout=2.0,
+                timeout=_URL_FETCH_TIMEOUT,
             )
         except (TimeoutError, OSError):
             logger.debug(

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -1,6 +1,28 @@
 """Shared fixtures for CLI unit tests."""
 
+import contextlib
+
 import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _warm_model_caches() -> None:
+    """Pre-populate model-config caches once per xdist worker.
+
+    Tests like the model-selector UI tests call `get_available_models()` and
+    `get_model_profiles()` during widget init.  Without a warm cache the first
+    invocation in each worker process pays ~800-1200 ms of disk I/O to discover
+    provider profiles via `importlib.util`.  Paying that cost once per session
+    instead of once per test shaves significant time off the overall run.
+
+    Tests that explicitly need a clean cache (e.g. `test_model_config.py`) use
+    their own function-scoped `clear_caches()` fixture which overrides this.
+    """
+    with contextlib.suppress(Exception):
+        from deepagents_cli.model_config import get_available_models, get_model_profiles
+
+        get_available_models()
+        get_model_profiles()
 
 
 @pytest.fixture(autouse=True)

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -935,7 +935,7 @@ class TestFetchLangsmithProjectUrl:
             patch("langsmith.Client") as mock_client_cls,
         ):
             mock_client_cls.return_value.read_project.side_effect = lambda **_kwargs: (
-                time.sleep(0.1)
+                time.sleep(0.02)
             )
             result = fetch_langsmith_project_url("my-project")
 

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -861,11 +861,15 @@ class TestFetchThreadUrl:
         import time
 
         def _blocking(_tid: str) -> str:
-            time.sleep(3)
+            time.sleep(0.1)
             return "https://example.com"
 
         with (
             _patch_list_threads(),
+            patch(
+                "deepagents_cli.widgets.thread_selector._URL_FETCH_TIMEOUT",
+                0.01,
+            ),
             patch(
                 "deepagents_cli.widgets.thread_selector.build_langsmith_thread_url",
                 side_effect=_blocking,


### PR DESCRIPTION
Speed up CLI unit tests in CI by eliminating unnecessary overhead across three areas: cache cold-starts, wasted sleep time in timeout tests, and redundant coverage collection across the Python version matrix.

## Changes
- Add a session-scoped `_warm_model_caches` fixture in `conftest.py` that calls `get_available_models()` and `get_model_profiles()` once per xdist worker — avoids ~800-1200ms of `importlib.util` disk I/O on every model-selector UI test that creates a `ModelSelectorScreen`
- Extract `_URL_FETCH_TIMEOUT` constant in `thread_selector.py` and patch it to 0.01s in `test_timeout_leaves_title_unchanged`, reducing `time.sleep` from 3s to 0.1s — the previous 3s sleep caused a ~2.85s teardown penalty waiting for the orphaned thread
- Reduce `time.sleep(0.1)` to `time.sleep(0.02)` in `test_config.py::test_returns_none_when_lookup_times_out` — still 2x the patched 0.01s timeout, just less wasteful
- Add optional `coverage` boolean input to `_test.yml` (default `true`) and set `coverage: ${{ matrix.python-version == '3.12' }}` on all test jobs in `ci.yml` — non-primary matrix legs skip `--cov` overhead (~10-20% runtime savings each)
- Extract `COV_ARGS` variable in the CLI `Makefile` so CI can pass `COV_ARGS=` to disable coverage without a separate make target
