### PR TITLE
feat(cli): add baseten as a model provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,21 @@ The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents
 
 The `deepagents --help` screen is hand-maintained in `ui.show_help()`, separate from the argparse definitions in `main.parse_args()`. When adding a new CLI flag, update **both** files. A drift-detection test (`test_args.TestHelpScreenDrift`) fails if a flag is registered in argparse but missing from the help screen.
 
+**Adding a new model provider:**
+
+The CLI supports LangChain-based chat model providers as optional dependencies. To add a new provider, update these files (all entries alphabetically sorted):
+
+1. `libs/cli/deepagents_cli/model_config.py` — add `"provider_name": "ENV_VAR_NAME"` to `PROVIDER_API_KEY_ENV`
+2. `libs/cli/pyproject.toml` — add `provider = ["langchain-provider>=X.Y.Z,<N.0.0"]` to `[project.optional-dependencies]` and include it in the `all-providers` composite extra
+3. `libs/cli/tests/unit_tests/test_model_config.py` — add `assert PROVIDER_API_KEY_ENV["provider_name"] == "ENV_VAR_NAME"` to `TestProviderApiKeyEnv.test_contains_major_providers`
+
+**Not required** unless the provider's models have a distinctive name prefix (like `gpt-*`, `claude*`, `gemini*`):
+
+- `detect_provider()` in `config.py` — only needed for auto-detection from bare model names
+- `Settings.has_*` property in `config.py` — only needed if referenced by `detect_provider()` fallback logic
+
+Model discovery, credential checking, and UI integration are automatic once `PROVIDER_API_KEY_ENV` is populated and the `langchain-*` package is installed.
+
 **Building chat/streaming interfaces:**
 
 - Blog post: [Anatomy of a Textual User Interface](https://textual.textualize.io/blog/2024/09/15/anatomy-of-a-textual-user-interface/) - demonstrates building an AI chat interface with streaming responses

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -176,6 +176,7 @@ DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.toml"
 PROVIDER_API_KEY_ENV: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "azure_openai": "AZURE_OPENAI_API_KEY",
+    "baseten": "BASETEN_API_KEY",
     "cohere": "COHERE_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
     "fireworks": "FIREWORKS_API_KEY",

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
 [project.optional-dependencies]
 # Model providers
 anthropic = ["langchain-anthropic>=1.0.0,<2.0.0"]
+baseten = ["langchain-baseten>=0.1.9,<1.0.0"]
 bedrock = ["langchain-aws>=1.0.0,<2.0.0"]
 cohere = ["langchain-cohere>=0.5.0,<1.0.0"]
 deepseek = ["langchain-deepseek>=1.0.0,<2.0.0"]
@@ -88,7 +89,7 @@ perplexity = ["langchain-perplexity>=1.0.0,<2.0.0"]
 vertexai = ["langchain-google-vertexai>=3.0.0,<4.0.0"]
 xai = ["langchain-xai>=1.0.0,<2.0.0"]
 all-providers = [
-    "deepagents-cli[anthropic,bedrock,cohere,deepseek,fireworks,google-genai,groq,huggingface,ibm,litellm,mistralai,nvidia,ollama,openai,openrouter,perplexity,vertexai,xai]",
+    "deepagents-cli[anthropic,baseten,bedrock,cohere,deepseek,fireworks,google-genai,groq,huggingface,ibm,litellm,mistralai,nvidia,ollama,openai,openrouter,perplexity,vertexai,xai]",
 ]
 
 [project.scripts]

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -409,6 +409,7 @@ class TestProviderApiKeyEnv:
         """Contains environment variables for major providers."""
         assert PROVIDER_API_KEY_ENV["anthropic"] == "ANTHROPIC_API_KEY"
         assert PROVIDER_API_KEY_ENV["azure_openai"] == "AZURE_OPENAI_API_KEY"
+        assert PROVIDER_API_KEY_ENV["baseten"] == "BASETEN_API_KEY"
         assert PROVIDER_API_KEY_ENV["cohere"] == "COHERE_API_KEY"
         assert PROVIDER_API_KEY_ENV["deepseek"] == "DEEPSEEK_API_KEY"
         assert PROVIDER_API_KEY_ENV["fireworks"] == "FIREWORKS_API_KEY"

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -243,6 +243,40 @@ wheels = [
 ]
 
 [[package]]
+name = "baseten-performance-client"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/eb/dc8a0dd381cdac0132ea0f7833e707413a137f0590a849504e03d40776eb/baseten_performance_client-0.1.5.tar.gz", hash = "sha256:8e6999295fa2a5ce54aeb83f1c04417628282b66117c22101d023c746522816a", size = 92286, upload-time = "2026-01-30T06:37:30.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/fa/98a00aba838856b7ec4acd4b397dfb7a8a29575787e5849503402f4030cd/baseten_performance_client-0.1.5-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:482955696ae2520c6dff144f20b49d1f520c905d9030c8055c5afac62c220b2c", size = 3147816, upload-time = "2026-01-30T06:37:14.854Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/b8db03a7ad89f2f13e778f3051487a4f12b4bd0acbd701ae6dd3da1d2533/baseten_performance_client-0.1.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b8eade7428cfca9d19a0e7a8b476bd70d7e48bcefc339a29e457d16edc0dc2da", size = 3060717, upload-time = "2026-01-30T06:37:10.434Z" },
+    { url = "https://files.pythonhosted.org/packages/86/97/5d1cad74be84a38e6046c3de88b761e0400fc5dea533a4d11aebea78a8cb/baseten_performance_client-0.1.5-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4651b2416a1a90fc3afb4c43c14a5aa51896f9ffc31d2f366515c405dd03c94", size = 5530068, upload-time = "2026-01-30T06:36:59.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/caf41d87bc1a0bf61deb398593d7a64f8b8757f6208c41168d62808c1aab/baseten_performance_client-0.1.5-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a89576b0c3872aa5d0fe29b2d3a44fd0d61b930e8b1293ce4d985b960584fa2e", size = 5732313, upload-time = "2026-01-30T06:36:51.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7a/0968e269ccc2a50a5f2092df8b4b43a3bdc02c96ffeed4d70e18469a2234/baseten_performance_client-0.1.5-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f89b3c38693bfc3b973b6cf02ec679ef914b2d9ef77f9ab182fd9d5b5f2e61b", size = 5432538, upload-time = "2026-01-30T06:37:04.574Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/37/858a1ce843b69168a92009550315b87266c39c5d8b4c7fa72185017a07f8/baseten_performance_client-0.1.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1d23d805446520e61234d5c97e02eaf9eed3a49ad73f4ba7e9c120000b8fbbfa", size = 6028052, upload-time = "2026-01-30T06:37:17.661Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a8/1254e1f6b623e352faf687012a26911faf85e99f078b5c2b4b1cb416f2fd/baseten_performance_client-0.1.5-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:e9f1227c0a7cc9297629da8a41bc03fe4c91298776d11207a865c30e3463ab39", size = 5102401, upload-time = "2026-01-30T06:37:20.63Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d7/750149a0a3b2a598fcf953373d8bb5033cf254a5dbc11adfdabb716d9e37/baseten_performance_client-0.1.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:a1d7acbc55a716ad7664e4170179f45fa262b9da64c10452fadeec7d3b2fbbf8", size = 5534519, upload-time = "2026-01-30T06:37:24.336Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c7/783c8bad9c2603b6f68d103b8a9e9a125751b9c482604d4be60fc59688b4/baseten_performance_client-0.1.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:df0a073a1a9fb55992e2a96bff9e1d06d75c58ce2c5a4a5c84b950e9d1550834", size = 5721807, upload-time = "2026-01-30T06:37:27.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/95/b9df7ae97cbb8d8b748ef1237e638bdc3ea5d1fea9ded8b6e03a63b8644d/baseten_performance_client-0.1.5-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:13c3b0cadcacb83499050fa14d0eaa5fd161c05bc7ff8cc88c3150e663d21993", size = 3160489, upload-time = "2026-01-30T06:37:16.266Z" },
+    { url = "https://files.pythonhosted.org/packages/79/38/2e92a0ce0a6b2c00b4ebc4654759c57b445df4c734f5e7526e9892f97947/baseten_performance_client-0.1.5-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:549774519199a9dd29d447c121d16d0539e521724cc84b86d265a85d37b2efcd", size = 3075288, upload-time = "2026-01-30T06:37:12.932Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/da/36237d3cf7d9d4d703d1b49c6a2404c82bd52b2825c2cca51e9571292122/baseten_performance_client-0.1.5-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4289efa45a0b58030b8afd39de49cfb13ae3df2a6d6fcff914c05050201a53d4", size = 5537399, upload-time = "2026-01-30T06:37:00.922Z" },
+    { url = "https://files.pythonhosted.org/packages/31/40/826100d99ba83fa087702fa2b8482de03efb955c8ef7467adf2088554eb6/baseten_performance_client-0.1.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05ebb680e6ae7471be67edaa570a9e37bbed4c8f127cd357ecebddad149f58c7", size = 5737746, upload-time = "2026-01-30T06:36:53.767Z" },
+    { url = "https://files.pythonhosted.org/packages/60/56/5bb14d8caf8d86e8c29679276c9a7de9ac6c5b6e6e807cd7607b82ec1ca7/baseten_performance_client-0.1.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a646d9cd6f4ecd2732bfd4fcb279934e982bbdd589770d9262a57de8f64d7d92", size = 5436024, upload-time = "2026-01-30T06:37:07.329Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/74/e9314f9fbb3ed482a076ae1365ff25434df2aa02b279942227b5232b63fd/baseten_performance_client-0.1.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e63398c779fd9f02c194810b83aa6d133a8ef2b10840335d62369ba1c8f1fb0a", size = 5714843, upload-time = "2026-01-30T06:36:35.695Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9e/e3fe5724f328ab55b3e0a58d1d24432ab0131a9bb83b9181a129a3ec9e80/baseten_performance_client-0.1.5-cp38-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:1e6436ccd2e16b347e7c56cbaced4c6d79c908a8315fa49087a46ab9424c65c6", size = 4850782, upload-time = "2026-01-30T06:36:41.461Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4ca4ad5d22415f9c334318aeba20e6324b5c06501d07caca32aa3d2333b5/baseten_performance_client-0.1.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:61e26074ea8401441638f034f793cc44e860c42ef32d7387f217383cc2529a99", size = 6036443, upload-time = "2026-01-30T06:37:19.055Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7a/8ed76be21f70b269b0c31f79b8c25eac0caa2c86180094f1c40f5f14072a/baseten_performance_client-0.1.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9d17185b3ccf6967517a2bf9605b5f6835f25beab547876781e91f92c0874b38", size = 5103375, upload-time = "2026-01-30T06:37:22.916Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d6/4f386ed0825b8799031cc89e123e34fb78bf16858db6a8f959e21f5906fb/baseten_performance_client-0.1.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5a1d60f380dda875aeb35ed31aa1d859b9e04f0eba4e46ca1a62e0ba35feb5f2", size = 5539203, upload-time = "2026-01-30T06:37:25.817Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/38/c9bb285592afc400fda1b7fd54b4b9758b468062d8db68048aebe35e88ff/baseten_performance_client-0.1.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c4c4bef13dfb0e1b1436749b4d21d21179cb066b38d94789ddd6ba3e3566eea9", size = 5724862, upload-time = "2026-01-30T06:37:28.884Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f4/ad409cc286dc61d6bdab92ac3f4f00545f5988c2dbda481c446cabb3c8b3/baseten_performance_client-0.1.5-cp38-abi3-win_amd64.whl", hash = "sha256:f00aa89592ff53418dde223a50b82b6a01f3c5315bf188a36687e0ce7cd0b6e1", size = 2809316, upload-time = "2026-01-30T06:37:32.414Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3a/1def52754477403bb58e7c0ba9aca4e3322847be59c5951e5a544b2f807b/baseten_performance_client-0.1.5-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b349015ef7998aadb238dbc9178c99ca8be908805784cc7415ad9bf31d7552c3", size = 5531762, upload-time = "2026-01-30T06:37:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/cc/0d1439d043f15e0b65bac6d49dec1002c8b94959d141d546927d5c568d32/baseten_performance_client-0.1.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:592744c6ee0c5fa366d26a62fbe24dee0bce5b7f0eab50563ddce3a4d2eb9193", size = 5431874, upload-time = "2026-01-30T06:37:08.857Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -958,6 +992,7 @@ dependencies = [
 all-providers = [
     { name = "langchain-anthropic" },
     { name = "langchain-aws" },
+    { name = "langchain-baseten" },
     { name = "langchain-cohere" },
     { name = "langchain-deepseek" },
     { name = "langchain-fireworks" },
@@ -977,6 +1012,9 @@ all-providers = [
 ]
 anthropic = [
     { name = "langchain-anthropic" },
+]
+baseten = [
+    { name = "langchain-baseten" },
 ]
 bedrock = [
     { name = "langchain-aws" },
@@ -1053,10 +1091,11 @@ requires-dist = [
     { name = "daytona", specifier = ">=0.113.0,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-acp", specifier = ">=0.0.4" },
-    { name = "deepagents-cli", extras = ["anthropic", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
+    { name = "deepagents-cli", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
     { name = "langchain", specifier = ">=1.2.10,<2.0.0" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.1.9,<1.0.0" },
     { name = "langchain-cohere", marker = "extra == 'cohere'", specifier = ">=0.5.0,<1.0.0" },
     { name = "langchain-deepseek", marker = "extra == 'deepseek'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-fireworks", marker = "extra == 'fireworks'", specifier = ">=1.0.0,<2.0.0" },
@@ -1092,7 +1131,7 @@ requires-dist = [
     { name = "textual-autocomplete", specifier = ">=3.0.0,<5.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
 ]
-provides-extras = ["anthropic", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "all-providers"]
+provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "all-providers"]
 
 [package.metadata.requires-dev]
 test = [
@@ -2271,6 +2310,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/ff/bcb2df2c3646178892eea5c1bdebb505648e4cd0c4e81b473945e6b74ad5/langchain_aws-1.2.4.tar.gz", hash = "sha256:82214150ef251eec21e627c46febed38c16c8e866044a21b7ed9b815a84ca1c9", size = 402314, upload-time = "2026-02-10T21:59:25.761Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/53/d4e3c37050518ecee2004f35f737d10978338300147a4c8a3d21f792560a/langchain_aws-1.2.4-py3-none-any.whl", hash = "sha256:13052f5a36cf687613817e56de0d3602d2823229fb090387be09f6794402614e", size = 165457, upload-time = "2026-02-10T21:59:24.183Z" },
+]
+
+[[package]]
+name = "langchain-baseten"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "baseten-performance-client" },
+    { name = "langchain-core" },
+    { name = "openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/34/20d3166f827f19ae24701319e2c5693f830561d37f587db958f39e295a73/langchain_baseten-0.1.9.tar.gz", hash = "sha256:1c55aa7abfe28403df5c275036ddada4b948345b9bf28b718fb91cc24db0ff4f", size = 17368, upload-time = "2025-11-03T22:58:22.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/a4/0179849fc3fe09e5e62f9f9a19c50e3765ea6185ec6d837555bbd2dc62d6/langchain_baseten-0.1.9-py3-none-any.whl", hash = "sha256:924a3494f92c16c10e9195ca8824fb1e7a7867f1fa0746698b91f5bb479fe752", size = 15216, upload-time = "2025-11-03T22:58:21.713Z" },
 ]
 
 [[package]]

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -778,10 +778,11 @@ requires-dist = [
     { name = "daytona", specifier = ">=0.113.0,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-acp", specifier = ">=0.0.4" },
-    { name = "deepagents-cli", extras = ["anthropic", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
+    { name = "deepagents-cli", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
     { name = "langchain", specifier = ">=1.2.10,<2.0.0" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.1.9,<1.0.0" },
     { name = "langchain-cohere", marker = "extra == 'cohere'", specifier = ">=0.5.0,<1.0.0" },
     { name = "langchain-deepseek", marker = "extra == 'deepseek'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-fireworks", marker = "extra == 'fireworks'", specifier = ">=1.0.0,<2.0.0" },
@@ -817,7 +818,7 @@ requires-dist = [
     { name = "textual-autocomplete", specifier = ">=3.0.0,<5.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
 ]
-provides-extras = ["anthropic", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "all-providers"]
+provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "all-providers"]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
Add Baseten as a supported model provider in the CLI. Users can install via `pip install deepagents-cli[baseten]` and authenticate with `BASETEN_API_KEY`, then select models with `baseten:<model-name>`.