### PR TITLE
feat(cli): add `sessions` as hidden keyword alias for `/threads`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,10 @@ The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents
 
 The `deepagents --help` screen is hand-maintained in `ui.show_help()`, separate from the argparse definitions in `main.parse_args()`. When adding a new CLI flag, update **both** files. A drift-detection test (`test_args.TestHelpScreenDrift`) fails if a flag is registered in argparse but missing from the help screen.
 
+**Slash commands:**
+
+Slash commands are defined in `SLASH_COMMANDS` in `libs/cli/deepagents_cli/widgets/autocomplete.py` as `(name, description, hidden_keywords)` tuples. Hidden keywords are space-separated terms that participate in fuzzy matching but are never displayed. To add an alias for an existing command, append it to the `hidden_keywords` string — do not create a duplicate command entry. For example, `/threads` has `sessions` as a hidden keyword so typing "sessions" surfaces it.
+
 **Adding a new model provider:**
 
 The CLI supports LangChain-based chat model providers as optional dependencies. To add a new provider, update these files (all entries alphabetically sorted):

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -107,7 +107,7 @@ SLASH_COMMANDS: list[tuple[str, str, str]] = [
     ("/reload", "Reload config from environment variables and .env", "refresh"),
     ("/remember", "Update memory and skills from conversation", ""),
     ("/tokens", "Token usage", "cost"),
-    ("/threads", "Browse and resume previous threads", "continue history"),
+    ("/threads", "Browse and resume previous threads", "continue history sessions"),
     ("/trace", "Open current thread in LangSmith", ""),
     ("/version", "Show version", ""),
 ]


### PR DESCRIPTION
Add `sessions` as a fuzzy-match alias for the `/threads` slash command. Users searching for "sessions" in the command palette now surface `/threads` without introducing a separate command or any dispatch changes.

## Changes
- Add `sessions` to the `hidden_keywords` for `/threads` in `SLASH_COMMANDS` so fuzzy matching picks it up
- Document the slash command tuple format and hidden-keyword alias pattern in `CLAUDE.md`