### PR TITLE
fix(cli): prevent reentrant model switching

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -617,6 +617,7 @@ class DeepAgentsApp(App):
         self._queued_widgets: deque[QueuedUserMessage] = deque()
         self._processing_pending = False
         self._thread_switching = False
+        self._model_switching = False
         # Message virtualization store
         self._message_store = MessageStore()
         # Lazily imported here to avoid pulling image dependencies into
@@ -3194,6 +3195,10 @@ class DeepAgentsApp(App):
         """
         logger.info("Switching model to %s", model_spec)
 
+        if self._model_switching:
+            await self._mount_message(AppMessage("Model switch already in progress."))
+            return
+
         from deepagents_cli.agent import create_cli_agent
         from deepagents_cli.model_config import (
             ModelConfigError,
@@ -3201,147 +3206,160 @@ class DeepAgentsApp(App):
             has_provider_credentials,
         )
 
-        # Strip leading colon — treat ":claude-opus-4-6" as "claude-opus-4-6"
-        model_spec = model_spec.removeprefix(":")
+        self._model_switching = True
+        try:
+            # Strip leading colon — treat ":claude-opus-4-6" as "claude-opus-4-6"
+            model_spec = model_spec.removeprefix(":")
 
-        parsed = ModelSpec.try_parse(model_spec)
-        if parsed:
-            provider: str | None = parsed.provider
-            model_name = parsed.model
-        else:
-            model_name = model_spec
-            provider = detect_provider(model_spec)
+            parsed = ModelSpec.try_parse(model_spec)
+            if parsed:
+                provider: str | None = parsed.provider
+                model_name = parsed.model
+            else:
+                model_name = model_spec
+                provider = detect_provider(model_spec)
 
-        # Check credentials
-        has_creds = has_provider_credentials(provider) if provider else None
-        if has_creds is False and provider is not None:
-            env_var = get_credential_env_var(provider)
-            detail = (
-                f"{env_var} is not set or is empty"
-                if env_var
-                else (
-                    f"provider '{provider}' is not recognized. "
-                    "Add it to ~/.deepagents/config.toml with an "
-                    "api_key_env field"
-                )
-            )
-            await self._mount_message(ErrorMessage(f"Missing credentials: {detail}"))
-            return
-        if has_creds is None and provider:
-            logger.debug(
-                "Credentials for provider '%s' cannot be verified; proceeding anyway",
-                provider,
-            )
-
-        # Check if already using this exact model
-        if model_name == settings.model_name and (
-            not provider or provider == settings.model_provider
-        ):
-            current = f"{settings.model_provider}:{settings.model_name}"
-            await self._mount_message(AppMessage(f"Already using {current}"))
-            return
-
-        # Check if we have what we need for hot-swap
-        if not self._checkpointer:
-            # No checkpointer means we can't hot-swap
-            # Save the preference and notify user
-            if await asyncio.to_thread(save_recent_model, model_spec):
-                await self._mount_message(
-                    AppMessage(
-                        f"Model preference set to {model_spec}. "
-                        "Restart the CLI for the change to take effect."
+            # Check credentials
+            has_creds = has_provider_credentials(provider) if provider else None
+            if has_creds is False and provider is not None:
+                env_var = get_credential_env_var(provider)
+                detail = (
+                    f"{env_var} is not set or is empty"
+                    if env_var
+                    else (
+                        f"provider '{provider}' is not recognized. "
+                        "Add it to ~/.deepagents/config.toml with an "
+                        "api_key_env field"
                     )
                 )
+                await self._mount_message(
+                    ErrorMessage(f"Missing credentials: {detail}")
+                )
+                return
+            if has_creds is None and provider:
+                logger.debug(
+                    "Credentials for provider '%s' cannot be verified;"
+                    " proceeding anyway",
+                    provider,
+                )
+
+            # Check if already using this exact model
+            if model_name == settings.model_name and (
+                not provider or provider == settings.model_provider
+            ):
+                current = f"{settings.model_provider}:{settings.model_name}"
+                await self._mount_message(AppMessage(f"Already using {current}"))
+                return
+
+            # Check if we have what we need for hot-swap
+            if not self._checkpointer:
+                # No checkpointer means we can't hot-swap
+                # Save the preference and notify user
+                if await asyncio.to_thread(save_recent_model, model_spec):
+                    await self._mount_message(
+                        AppMessage(
+                            f"Model preference set to {model_spec}. "
+                            "Restart the CLI for the change to take effect."
+                        )
+                    )
+                else:
+                    await self._mount_message(
+                        ErrorMessage(
+                            "Could not save model preference. "
+                            "Check permissions for ~/.deepagents/"
+                        )
+                    )
+                return
+
+            try:
+                result = create_model(
+                    model_spec,
+                    extra_kwargs=extra_kwargs,
+                    profile_overrides=self._profile_override,
+                )
+            except ModelConfigError as e:
+                logger.warning("Model config error for %s: %s", model_spec, e)
+                await self._mount_message(ErrorMessage(str(e)))
+                return
+            except Exception as e:
+                logger.exception("Failed to create model from spec %s", model_spec)
+                await self._mount_message(ErrorMessage(f"Failed to create model: {e}"))
+                return
+
+            # When switching models, settings must be updated before
+            # create_cli_agent because it builds the system prompt from global
+            # settings (model name, provider, context limit). Otherwise the
+            # prompt would describe the old model to the new one.
+            #
+            # Save previous values for rollback if agent creation fails.
+            prev_name = settings.model_name
+            prev_provider = settings.model_provider
+            prev_context_limit = settings.model_context_limit
+            result.apply_to_settings()
+
+            try:
+                new_agent, new_backend = create_cli_agent(
+                    model=result.model,
+                    assistant_id=self._assistant_id or "default",
+                    tools=self._tools,
+                    sandbox=self._sandbox,
+                    sandbox_type=self._sandbox_type,
+                    auto_approve=self._auto_approve,
+                    enable_ask_user=self._enable_ask_user,
+                    checkpointer=self._checkpointer,
+                    mcp_server_info=self._mcp_server_info,
+                )
+            except Exception as e:
+                # Roll back settings so the running agent isn't misrepresented.
+                settings.model_name = prev_name
+                settings.model_provider = prev_provider
+                settings.model_context_limit = prev_context_limit
+                logger.exception("Failed to create agent for model switch")
+                await self._mount_message(ErrorMessage(f"Model switch failed: {e}"))
+                return
+
+            # Swap agent
+            self._agent = new_agent
+            self._backend = new_backend
+
+            # Post-swap: update UI and save config
+            display = f"{settings.model_provider}:{settings.model_name}"
+            if self._status_bar:
+                self._status_bar.set_model(
+                    provider=settings.model_provider or "",
+                    model=settings.model_name or "",
+                )
+
+            config_saved = await asyncio.to_thread(save_recent_model, display)
+            if config_saved:
+                await self._mount_message(AppMessage(f"Switched to {display}"))
             else:
+                logger.warning(
+                    "Failed to save model preference after switching to %s"
+                    " — check ~/.deepagents/ permissions",
+                    display,
+                )
                 await self._mount_message(
                     ErrorMessage(
-                        "Could not save model preference. "
-                        "Check permissions for ~/.deepagents/"
+                        f"Switched to {display} (preference not saved — "
+                        "check ~/.deepagents/ permissions)"
                     )
                 )
-            return
 
-        try:
-            result = create_model(
-                model_spec,
-                extra_kwargs=extra_kwargs,
-                profile_overrides=self._profile_override,
-            )
-        except ModelConfigError as e:
-            await self._mount_message(ErrorMessage(str(e)))
-            return
-        except Exception as e:
-            logger.exception("Failed to create model from spec %s", model_spec)
-            await self._mount_message(ErrorMessage(f"Failed to create model: {e}"))
-            return
+            logger.info("Model switched to %s", display)
 
-        # When switching models, settings must be updated before
-        # create_cli_agent because it builds the system prompt from global
-        # settings (model name, provider, context limit). Otherwise the
-        # prompt would describe the old model to the new one.
-        #
-        # Save previous values for rollback if agent creation fails.
-        prev_name = settings.model_name
-        prev_provider = settings.model_provider
-        prev_context_limit = settings.model_context_limit
-        result.apply_to_settings()
+            # Scroll to bottom so the confirmation message is visible
+            def _scroll_after_switch() -> None:
+                try:
+                    chat = self.query_one("#chat", VerticalScroll)
+                    if chat.max_scroll_y > 0:
+                        chat.scroll_end(animate=False)
+                except NoMatches:
+                    pass
 
-        try:
-            new_agent, new_backend = create_cli_agent(
-                model=result.model,
-                assistant_id=self._assistant_id or "default",
-                tools=self._tools,
-                sandbox=self._sandbox,
-                sandbox_type=self._sandbox_type,
-                auto_approve=self._auto_approve,
-                enable_ask_user=self._enable_ask_user,
-                checkpointer=self._checkpointer,
-                mcp_server_info=self._mcp_server_info,
-            )
-        except Exception as e:
-            # Roll back settings so the running agent isn't misrepresented.
-            settings.model_name = prev_name
-            settings.model_provider = prev_provider
-            settings.model_context_limit = prev_context_limit
-            logger.exception("Failed to create agent for model switch")
-            await self._mount_message(ErrorMessage(f"Model switch failed: {e}"))
-            return
-
-        # Swap agent
-        self._agent = new_agent
-        self._backend = new_backend
-
-        # Post-swap: update UI and save config
-        display = f"{settings.model_provider}:{settings.model_name}"
-        if self._status_bar:
-            self._status_bar.set_model(
-                provider=settings.model_provider or "",
-                model=settings.model_name or "",
-            )
-
-        config_saved = await asyncio.to_thread(save_recent_model, display)
-        if config_saved:
-            await self._mount_message(AppMessage(f"Switched to {display}"))
-        else:
-            await self._mount_message(
-                AppMessage(
-                    f"Switched to {display} (preference not saved - "
-                    "check ~/.deepagents/ permissions)"
-                )
-            )
-
-        logger.info("Model switched to %s", display)
-
-        # Scroll to bottom so the confirmation message is visible
-        def _scroll_after_switch() -> None:
-            try:
-                chat = self.query_one("#chat", VerticalScroll)
-                if chat.max_scroll_y > 0:
-                    chat.scroll_end(animate=False)
-            except NoMatches:
-                pass
-
-        self.call_after_refresh(_scroll_after_switch)
+            self.call_after_refresh(_scroll_after_switch)
+        finally:
+            self._model_switching = False
 
     async def _set_default_model(self, model_spec: str) -> None:
         """Set the default model in config without switching the current session.

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -66,6 +66,7 @@ class TestModelSwitchNoOp:
         assert len(captured_messages) == 1
         assert "Already using" in captured_messages[0]
         assert "Switched to" not in captured_messages[0]
+        assert app._model_switching is False
 
 
 class TestModelSwitchErrorHandling:
@@ -105,6 +106,7 @@ class TestModelSwitchErrorHandling:
         assert len(captured_errors) == 1
         assert "Missing credentials" in captured_errors[0]
         assert "ANTHROPIC_API_KEY" in captured_errors[0]
+        assert app._model_switching is False
 
     async def test_create_model_config_error_shows_error(self) -> None:
         """_switch_model shows error when create_model raises ModelConfigError."""
@@ -220,6 +222,7 @@ class TestModelSwitchErrorHandling:
         assert settings.model_name == "gpt-4o"
         assert settings.model_provider == "openai"
         assert settings.model_context_limit == 128_000
+        assert app._model_switching is False
 
     async def test_context_limit_cleared_when_new_model_has_none(self) -> None:
         """Switching to a model without a context limit clears the old value."""
@@ -319,6 +322,7 @@ class TestModelSwitchErrorHandling:
         assert len(captured_messages) == 1
         assert "Model preference set" in captured_messages[0]
         assert "Restart" in captured_messages[0]
+        assert app._model_switching is False
 
     async def test_no_checkpointer_save_failure_shows_error(self) -> None:
         """_switch_model without checkpointer shows error when save fails."""
@@ -349,6 +353,7 @@ class TestModelSwitchErrorHandling:
         app._mount_message.assert_called_once()  # type: ignore[union-attr]
         assert len(captured_errors) == 1
         assert "Could not save model preference" in captured_errors[0]
+        assert app._model_switching is False
 
     async def test_hot_swap_save_failure_warns_in_message(self) -> None:
         """Successful hot-swap shows ErrorMessage when save_recent_model fails."""
@@ -394,6 +399,7 @@ class TestModelSwitchErrorHandling:
         assert len(captured_errors) == 1
         assert "Switched to" in captured_errors[0]
         assert "preference not saved" in captured_errors[0]
+        assert app._model_switching is False
 
 
 class TestModelSwitchConcurrencyGuard:

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -351,7 +351,7 @@ class TestModelSwitchErrorHandling:
         assert "Could not save model preference" in captured_errors[0]
 
     async def test_hot_swap_save_failure_warns_in_message(self) -> None:
-        """Successful hot-swap warns when save_recent_model fails."""
+        """Successful hot-swap shows ErrorMessage when save_recent_model fails."""
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # type: ignore[method-assign]
         app._checkpointer = MagicMock()
@@ -359,11 +359,11 @@ class TestModelSwitchErrorHandling:
         settings.model_name = "gpt-4o"
         settings.model_provider = "openai"
 
-        captured_messages: list[str] = []
-        original_init = AppMessage.__init__
+        captured_errors: list[str] = []
+        original_init = ErrorMessage.__init__
 
-        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
-            captured_messages.append(message)
+        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+            captured_errors.append(message)
             original_init(self, message, **kwargs)
 
         mock_model = MagicMock()
@@ -386,14 +386,152 @@ class TestModelSwitchErrorHandling:
                 return_value=(mock_agent, mock_backend),
             ),
             patch("deepagents_cli.app.save_recent_model", return_value=False),
-            patch.object(AppMessage, "__init__", capture_init),
+            patch.object(ErrorMessage, "__init__", capture_init),
         ):
             await app._switch_model("anthropic:claude-sonnet-4-5")
 
         app._mount_message.assert_called_once()  # type: ignore[union-attr]
+        assert len(captured_errors) == 1
+        assert "Switched to" in captured_errors[0]
+        assert "preference not saved" in captured_errors[0]
+
+
+class TestModelSwitchConcurrencyGuard:
+    """Tests for _model_switching concurrency guard."""
+
+    async def test_concurrent_model_switch_blocked(self) -> None:
+        """Second _switch_model call is rejected while first is in-flight."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._model_switching = True
+
+        captured_messages: list[str] = []
+        original_init = AppMessage.__init__
+
+        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
+            captured_messages.append(message)
+            original_init(self, message, **kwargs)
+
+        with patch.object(AppMessage, "__init__", capture_init):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        app._mount_message.assert_called_once()  # type: ignore[union-attr]
         assert len(captured_messages) == 1
-        assert "Switched to" in captured_messages[0]
-        assert "preference not saved" in captured_messages[0]
+        assert "already in progress" in captured_messages[0]
+
+    async def test_model_switching_flag_reset_on_success(self) -> None:
+        """_model_switching resets to False after a successful switch."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        mock_result = ModelResult(
+            model=MagicMock(),
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch("deepagents_cli.app.create_model", return_value=mock_result),
+            patch(
+                "deepagents_cli.agent.create_cli_agent",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch("deepagents_cli.app.save_recent_model", return_value=True),
+        ):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        assert app._model_switching is False
+
+    async def test_model_switching_flag_reset_on_error(self) -> None:
+        """_model_switching resets to False even when create_model raises."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.app.create_model",
+                side_effect=ModelConfigError("boom"),
+            ),
+        ):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        assert app._model_switching is False
+
+
+class TestModelSwitchLogging:
+    """Tests for logging in _switch_model error paths."""
+
+    async def test_model_config_error_logs_warning(self) -> None:
+        """ModelConfigError is logged at WARNING level."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        error = ModelConfigError("Missing package for provider 'anthropic'")
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch("deepagents_cli.app.create_model", side_effect=error),
+            patch("deepagents_cli.app.logger") as mock_logger,
+        ):
+            await app._switch_model("anthropic:invalid-model")
+
+        mock_logger.warning.assert_called_once()
+        assert "anthropic:invalid-model" in mock_logger.warning.call_args[0][1]
+
+    async def test_save_failure_after_swap_logs_warning(self) -> None:
+        """Failed save_recent_model after hot-swap is logged at WARNING level."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._checkpointer = MagicMock()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        mock_result = ModelResult(
+            model=MagicMock(),
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch("deepagents_cli.app.create_model", return_value=mock_result),
+            patch(
+                "deepagents_cli.agent.create_cli_agent",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch("deepagents_cli.app.save_recent_model", return_value=False),
+            patch("deepagents_cli.app.logger") as mock_logger,
+        ):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        mock_logger.warning.assert_called_once()
+        assert "anthropic:claude-sonnet-4-5" in mock_logger.warning.call_args[0][1]
 
 
 class TestModelSwitchConfigProvider:


### PR DESCRIPTION
Guard `_switch_model` against reentrant calls. The async method yields at multiple `await` points (credential checks, model creation, agent construction, config persistence), leaving a window where a second `/model` invocation could interleave and corrupt agent state. A `_model_switching` flag now short-circuits duplicate requests and is cleaned up in a `finally` block.

## Changes
- Add `_model_switching` instance flag on `DeepAgentsApp.__init__` and check it at the top of `_switch_model` — concurrent callers get an `AppMessage` and bail out immediately
- Wrap the entire body of `_switch_model` in `try/finally` to guarantee the flag is cleared on every exit path (success, early return, or exception)
- Promote the failed-save message from `AppMessage` to `ErrorMessage` with a logger warning, since a permission failure deserves error-level visibility