### PR TITLE
refactor(sdk): extract model resolution helpers into `_models` module

### DIFF
--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -567,7 +567,7 @@ class TestCreateCliAgentInteractiveForwarding:
             patch("deepagents_cli.agent.MemoryMiddleware"),
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
             patch(
-                "deepagents.graph.init_chat_model",
+                "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
             patch("deepagents_cli.agent.get_system_prompt") as mock_get_prompt,
@@ -619,7 +619,7 @@ class TestCreateCliAgentInteractiveForwarding:
             patch("deepagents_cli.agent.MemoryMiddleware"),
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
             patch(
-                "deepagents.graph.init_chat_model",
+                "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
             patch("deepagents_cli.agent.get_system_prompt") as mock_get_prompt,
@@ -875,7 +875,7 @@ class TestCreateCliAgentSkillsSources:
             patch("deepagents_cli.agent.MemoryMiddleware"),
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
             patch(
-                "deepagents.graph.init_chat_model",
+                "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
         ):
@@ -952,7 +952,7 @@ class TestCreateCliAgentMemorySources:
                 return_value=mock_agent,
             ),
             patch(
-                "deepagents.graph.init_chat_model",
+                "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
         ):
@@ -1018,7 +1018,7 @@ class TestCreateCliAgentMemorySources:
                 return_value=mock_agent,
             ),
             patch(
-                "deepagents.graph.init_chat_model",
+                "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
         ):
@@ -1084,7 +1084,7 @@ class TestMiddlewareStackConformance:
                 side_effect=capture_create_agent,
             ),
             patch(
-                "deepagents.graph.init_chat_model",
+                "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
         ):

--- a/libs/deepagents/deepagents/_models.py
+++ b/libs/deepagents/deepagents/_models.py
@@ -1,0 +1,81 @@
+"""Shared helpers for resolving and inspecting chat models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.chat_models import init_chat_model
+from langchain_core.language_models import BaseChatModel
+
+
+def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
+    """Resolve a model string to a `BaseChatModel`.
+
+    If `model` is already a `BaseChatModel`, returns it unchanged.
+
+    String models are resolved via `init_chat_model`. OpenAI models
+    (prefixed with `openai:`) default to the Responses API.
+
+    Args:
+        model: Model string or pre-configured model instance.
+
+    Returns:
+        Resolved `BaseChatModel` instance.
+    """
+    if isinstance(model, BaseChatModel):
+        return model
+    if model.startswith("openai:"):
+        return init_chat_model(model, use_responses_api=True)
+    return init_chat_model(model)
+
+
+def get_model_identifier(model: BaseChatModel) -> str | None:
+    """Extract the provider-native model identifier from a chat model.
+
+    Providers do not agree on a single field name for the identifier. Some use
+    `model_name`, while others use `model`. Reading the serialized model config
+    lets us inspect both without relying on reflective attribute access.
+
+    Args:
+        model: Chat model instance to inspect.
+
+    Returns:
+        The configured model identifier, or `None` if it is unavailable.
+    """
+    config = model.model_dump()
+    return _string_value(config, "model_name") or _string_value(config, "model")
+
+
+def model_matches_spec(model: BaseChatModel, spec: str) -> bool:
+    """Check whether a model instance already matches a string model spec.
+
+    Matching is performed in two ways: first by exact string equality between
+    `spec` and the model identifier, then by comparing only the model-name
+    portion of a `provider:model` spec against the identifier. For example,
+    `"openai:gpt-5"` matches a model with identifier `"gpt-5"`.
+
+    Assumes the `provider:model` convention (single colon separator).
+
+    Args:
+        model: Chat model instance to inspect.
+        spec: Model spec in `provider:model` format (e.g., `openai:gpt-5`).
+
+    Returns:
+        `True` if the model already matches the spec, otherwise `False`.
+    """
+    current = get_model_identifier(model)
+    if current is None:
+        return False
+    if spec == current:
+        return True
+
+    _, separator, model_name = spec.partition(":")
+    return bool(separator) and model_name == current
+
+
+def _string_value(config: dict[str, Any], key: str) -> str | None:
+    """Return a non-empty string value from a serialized model config."""
+    value = config.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -7,7 +7,6 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import ResponseFormat
-from langchain.chat_models import init_chat_model
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from langchain_core.language_models import BaseChatModel
@@ -18,6 +17,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
+from deepagents._models import resolve_model
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -76,32 +76,6 @@ def get_default_model() -> ChatAnthropic:
     return ChatAnthropic(
         model_name="claude-sonnet-4-6",
     )
-
-
-def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
-    """Resolve a model string to a `BaseChatModel` instance.
-
-    If `model` is already a `BaseChatModel`, returns it unchanged.
-
-    String models are resolved via `init_chat_model`, with OpenAI models
-    defaulting to the Responses API. See the `create_deep_agent` docstring for
-    details on how to customize this behavior.
-
-    Args:
-        model: Model name string or pre-configured model instance.
-
-    Returns:
-        Resolved `BaseChatModel` instance.
-    """
-    if isinstance(model, BaseChatModel):
-        return model
-    if model.startswith("openai:"):
-        # Use Responses API by default. To use chat completions, use
-        # `model=init_chat_model("openai:...")`
-        # To disable data retention with the Responses API, use
-        # `model=init_chat_model("openai:...", use_responses_api=True, store=False, include=["reasoning.encrypted_content"])`
-        return init_chat_model(model, use_responses_api=True)
-    return init_chat_model(model)
 
 
 def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic with many conditional branches

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1165,7 +1165,7 @@ def create_summarization_tool_middleware(
         )
         ```
     """
-    from deepagents.graph import resolve_model  # noqa: PLC0415
+    from deepagents._models import resolve_model  # noqa: PLC0415
 
     if isinstance(model, str):
         model = resolve_model(model)

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -298,13 +298,12 @@ class TestDeepAgentEndToEnd:
         assert any("second call" in content for content in tool_contents)
 
     def test_deep_agent_with_string_model_name(self) -> None:
-        """Test that create_deep_agent handles string model names correctly.
+        """Test that create_deep_agent resolves string model names correctly.
 
         This test verifies that when a model name is passed as a string,
-        it is properly initialized using init_chat_model instead of
+        it is properly resolved to a chat model instead of
         causing an AttributeError when accessing the profile attribute.
         """
-        # Mock init_chat_model to return a fake model
         fake_model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -315,17 +314,11 @@ class TestDeepAgentEndToEnd:
             )
         )
 
-        with patch("deepagents.graph.init_chat_model", return_value=fake_model):
-            # This should not raise AttributeError: 'str' object has no attribute 'profile'
+        with patch("deepagents.graph.resolve_model", return_value=fake_model):
             agent = create_deep_agent(model="claude-sonnet-4-6", tools=[sample_tool])
-
-            # Verify agent was created successfully
             assert agent is not None
 
-            # Invoke the agent to ensure it works
             result = agent.invoke({"messages": [HumanMessage(content="Test message")]})
-
-            # Verify the agent executed correctly
             assert "messages" in result
             assert len(result["messages"]) > 0
 

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -1,0 +1,107 @@
+"""Tests for deepagents._models helpers."""
+
+from unittest.mock import MagicMock, patch
+
+from langchain_core.language_models import BaseChatModel
+
+from deepagents._models import (
+    _string_value,
+    get_model_identifier,
+    model_matches_spec,
+    resolve_model,
+)
+
+
+def _make_model(dump: dict) -> MagicMock:
+    """Create a mock BaseChatModel with a given model_dump return."""
+    model = MagicMock(spec=BaseChatModel)
+    model.model_dump.return_value = dump
+    return model
+
+
+class TestResolveModel:
+    """Tests for resolve_model."""
+
+    def test_passthrough_when_already_model(self) -> None:
+        model = MagicMock(spec=BaseChatModel)
+        assert resolve_model(model) is model
+
+    def test_openai_prefix_uses_responses_api(self) -> None:
+        with patch("deepagents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            result = resolve_model("openai:gpt-5")
+
+        mock.assert_called_once_with("openai:gpt-5", use_responses_api=True)
+        assert result is mock.return_value
+
+    def test_non_openai_string(self) -> None:
+        with patch("deepagents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            result = resolve_model("anthropic:claude-sonnet-4-6")
+
+        mock.assert_called_once_with("anthropic:claude-sonnet-4-6")
+        assert result is mock.return_value
+
+
+class TestGetModelIdentifier:
+    """Tests for get_model_identifier."""
+
+    def test_returns_model_name(self) -> None:
+        model = _make_model({"model_name": "gpt-5", "model": "something-else"})
+        assert get_model_identifier(model) == "gpt-5"
+
+    def test_falls_back_to_model(self) -> None:
+        model = _make_model({"model": "claude-sonnet-4-6"})
+        assert get_model_identifier(model) == "claude-sonnet-4-6"
+
+    def test_returns_none_when_missing(self) -> None:
+        model = _make_model({})
+        assert get_model_identifier(model) is None
+
+    def test_skips_empty_model_name(self) -> None:
+        model = _make_model({"model_name": "", "model": "fallback"})
+        assert get_model_identifier(model) == "fallback"
+
+    def test_skips_non_string_model_name(self) -> None:
+        model = _make_model({"model_name": 123, "model": "real-name"})
+        assert get_model_identifier(model) == "real-name"
+
+
+class TestModelMatchesSpec:
+    """Tests for model_matches_spec."""
+
+    def test_exact_match(self) -> None:
+        model = _make_model({"model_name": "claude-sonnet-4-6"})
+        assert model_matches_spec(model, "claude-sonnet-4-6") is True
+
+    def test_provider_prefixed_match(self) -> None:
+        model = _make_model({"model_name": "claude-sonnet-4-6"})
+        assert model_matches_spec(model, "anthropic:claude-sonnet-4-6") is True
+
+    def test_no_match(self) -> None:
+        model = _make_model({"model_name": "claude-sonnet-4-6"})
+        assert model_matches_spec(model, "openai:gpt-5") is False
+
+    def test_none_identifier_returns_false(self) -> None:
+        model = _make_model({})
+        assert model_matches_spec(model, "anything") is False
+
+    def test_bare_spec_without_colon_no_false_positive(self) -> None:
+        model = _make_model({"model_name": "gpt-5"})
+        assert model_matches_spec(model, "gpt-4o") is False
+
+
+class TestStringValue:
+    """Tests for _string_value."""
+
+    def test_present(self) -> None:
+        assert _string_value({"key": "val"}, "key") == "val"
+
+    def test_missing(self) -> None:
+        assert _string_value({}, "key") is None
+
+    def test_empty(self) -> None:
+        assert _string_value({"key": ""}, "key") is None
+
+    def test_non_string(self) -> None:
+        assert _string_value({"key": 42}, "key") is None


### PR DESCRIPTION
Extract `resolve_model`, `get_model_identifier`, and `model_matches_spec` from `graph.py` into a dedicated `_models.py` module. The graph module was becoming a grab-bag for model utilities that other modules (like `summarization.py`) needed, forcing circular-ish deferred imports. A standalone `_models` module gives the SDK a clean, importable surface for model resolution and introspection logic.

## Changes
- Introduce `deepagents/_models.py` with three public helpers: `resolve_model` (string-to-`BaseChatModel` resolution), `get_model_identifier` (extract provider-native model name from serialized config), and `model_matches_spec` (compare a live model against a `provider:model` spec string)
- Move `resolve_model` out of `graph.py` — `create_deep_agent` and `summarization.py` now import from `_models` instead of circular-importing from the graph module
- `summarization.py`'s deferred import switches from `deepagents.graph` to `deepagents._models`, keeping the lazy-load pattern but removing the dependency on the graph assembly module