### PR TITLE
fix(cli): use UUID7 for thread IDs instead of 8-char hex

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -337,6 +337,17 @@ class TextualTokenTracker:
         self._update_callback(self.current_context)
 
 
+def _new_thread_id() -> str:
+    """Generate a new thread ID as a UUID7 string.
+
+    Returns:
+        UUID7 string.
+    """
+    from deepagents_cli.sessions import generate_thread_id
+
+    return generate_thread_id()
+
+
 class TextualSessionState:
     """Session state for the Textual app."""
 
@@ -350,10 +361,10 @@ class TextualSessionState:
 
         Args:
             auto_approve: Whether to auto-approve tool calls
-            thread_id: Optional thread ID (generates 8-char hex if not provided)
+            thread_id: Optional thread ID (generates UUID7 if not provided)
         """
         self.auto_approve = auto_approve
-        self.thread_id = thread_id or uuid.uuid4().hex[:8]
+        self.thread_id = thread_id or _new_thread_id()
 
     def reset_thread(self) -> str:
         """Reset to a new thread.
@@ -361,7 +372,7 @@ class TextualSessionState:
         Returns:
             The new thread_id.
         """
-        self.thread_id = uuid.uuid4().hex[:8]
+        self.thread_id = _new_thread_id()
         return self.thread_id
 
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -338,7 +338,7 @@ class TextualTokenTracker:
 
 
 def _new_thread_id() -> str:
-    """Generate a new thread ID as a UUID7 string.
+    """Deferred-import wrapper around `sessions.generate_thread_id`.
 
     Returns:
         UUID7 string.

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -10,7 +10,6 @@ import re
 import shlex
 import sys
 import threading
-import uuid
 from dataclasses import dataclass
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
@@ -915,7 +914,9 @@ class SessionState:
         self.no_splash = no_splash
         self.exit_hint_until: float | None = None
         self.exit_hint_handle = None
-        self.thread_id = str(uuid.uuid4())
+        from deepagents_cli.sessions import generate_thread_id
+
+        self.thread_id = generate_thread_id()
 
     def toggle_auto_approve(self) -> bool:
         """Toggle auto-approve and return the new state.

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -234,12 +233,14 @@ def get_db_path() -> Path:
 
 
 def generate_thread_id() -> str:
-    """Generate a new 8-char hex thread ID.
+    """Generate a new thread ID as a full UUID7 string.
 
     Returns:
-        8-character hexadecimal string.
+        UUID7 string (time-ordered, smithdb-compatible).
     """
-    return uuid.uuid4().hex[:8]
+    from uuid_utils import uuid7
+
+    return str(uuid7())
 
 
 async def _table_exists(conn: aiosqlite.Connection, table: str) -> bool:

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -236,7 +236,7 @@ def generate_thread_id() -> str:
     """Generate a new thread ID as a full UUID7 string.
 
     Returns:
-        UUID7 string (time-ordered, smithdb-compatible).
+        UUID7 string (time-ordered).
     """
     from uuid_utils import uuid7
 

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -236,7 +236,7 @@ def generate_thread_id() -> str:
     """Generate a new thread ID as a full UUID7 string.
 
     Returns:
-        UUID7 string (time-ordered).
+        UUID7 string (time-ordered for natural sort by creation time).
     """
     from uuid_utils import uuid7
 

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "pyperclip>=1.11.0,<2.0.0",
 
     # Utilities
+    "uuid-utils>=0.10.0,<1.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "requests>=2.0.0,<3.0.0",
     "pillow>=10.0.0,<13.0.0",

--- a/libs/cli/tests/unit_tests/test_sessions.py
+++ b/libs/cli/tests/unit_tests/test_sessions.py
@@ -33,10 +33,52 @@ class TestGenerateThreadId:
         tid = sessions.generate_thread_id()
         assert uuid.UUID(tid).version == 7
 
+    def test_monotonic_ordering(self) -> None:
+        """Thread IDs sort chronologically by creation time."""
+        ids = [sessions.generate_thread_id() for _ in range(10)]
+        assert ids == sorted(ids)
+
     def test_unique(self) -> None:
         """Thread IDs are unique."""
         ids = {sessions.generate_thread_id() for _ in range(100)}
         assert len(ids) == 100
+
+
+class TestMixedThreadIdFormats:
+    """Old 8-char hex IDs and new UUID7 IDs coexist in the database."""
+
+    def test_list_returns_both_formats(self, tmp_path: Path) -> None:
+        """list_threads returns threads regardless of ID format."""
+        db_path = tmp_path / "mixed.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE checkpoints (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                metadata BLOB,
+                PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+            )
+        """)
+        old_id = "a1b2c3d4"
+        new_id = sessions.generate_thread_id()
+        now = datetime.now(UTC).isoformat()
+        for tid in (old_id, new_id):
+            meta = json.dumps({"agent_name": "agent", "updated_at": now})
+            conn.execute(
+                "INSERT INTO checkpoints "
+                "(thread_id, checkpoint_ns, checkpoint_id, metadata) "
+                "VALUES (?, '', ?, ?)",
+                (tid, f"cp_{tid}", meta),
+            )
+        conn.commit()
+        conn.close()
+
+        with patch.object(sessions, "get_db_path", return_value=db_path):
+            threads = asyncio.run(sessions.list_threads())
+            returned_ids = {t["thread_id"] for t in threads}
+            assert old_id in returned_ids
+            assert new_id in returned_ids
 
 
 class TestThreadFunctions:

--- a/libs/cli/tests/unit_tests/test_sessions.py
+++ b/libs/cli/tests/unit_tests/test_sessions.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import sqlite3
+import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, cast
@@ -22,18 +23,17 @@ if TYPE_CHECKING:
 class TestGenerateThreadId:
     """Tests for generate_thread_id function."""
 
-    def test_length(self):
-        """Thread IDs are 8 characters."""
+    def test_length(self) -> None:
+        """Thread IDs use the canonical UUID string format."""
         tid = sessions.generate_thread_id()
-        assert len(tid) == 8
+        assert len(tid) == 36
 
-    def test_hex(self):
-        """Thread IDs are valid hex strings."""
+    def test_uuid7(self) -> None:
+        """Thread IDs are valid UUID7 strings."""
         tid = sessions.generate_thread_id()
-        # Should not raise
-        int(tid, 16)
+        assert uuid.UUID(tid).version == 7
 
-    def test_unique(self):
+    def test_unique(self) -> None:
         """Thread IDs are unique."""
         ids = {sessions.generate_thread_id() for _ in range(100)}
         assert len(ids) == 100
@@ -363,7 +363,7 @@ class TestTextualSessionState:
         """TextualSessionState generates ID if none provided."""
         state = TextualSessionState(thread_id=None)
         assert state.thread_id is not None
-        assert len(state.thread_id) == 8
+        assert uuid.UUID(state.thread_id).version == 7
 
     def test_reset_thread(self):
         """reset_thread generates a new thread ID."""
@@ -371,7 +371,7 @@ class TestTextualSessionState:
         old_id = state.thread_id
         new_id = state.reset_thread()
         assert new_id != old_id
-        assert len(new_id) == 8
+        assert uuid.UUID(new_id).version == 7
         assert state.thread_id == new_id
 
 

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -986,6 +986,7 @@ dependencies = [
     { name = "textual" },
     { name = "textual-autocomplete" },
     { name = "tomli-w" },
+    { name = "uuid-utils" },
 ]
 
 [package.optional-dependencies]
@@ -1130,6 +1131,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.0.0,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=3.0.0,<5.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
+    { name = "uuid-utils", specifier = ">=0.10.0,<1.0.0" },
 ]
 provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "all-providers"]
 

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -770,6 +770,7 @@ dependencies = [
     { name = "textual" },
     { name = "textual-autocomplete" },
     { name = "tomli-w" },
+    { name = "uuid-utils" },
 ]
 
 [package.metadata]
@@ -817,6 +818,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.0.0,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=3.0.0,<5.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
+    { name = "uuid-utils", specifier = ">=0.10.0,<1.0.0" },
 ]
 provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "all-providers"]
 


### PR DESCRIPTION
Switch thread IDs from truncated `uuid4` hex (8 chars) to full UUID7 strings via `uuid_utils`. UUID7 is time-ordered, which means thread IDs now sort chronologically by default and are valid UUIDs without conversion — needed for compatibility with the LangGraph API server's smithdb backend.

## Changes
- `generate_thread_id()` in `sessions.py` now returns `str(uuid7())` instead of `uuid.uuid4().hex[:8]`
- `TextualSessionState` in `app.py` delegates to a `_new_thread_id()` helper (deferred import of `sessions.generate_thread_id`) instead of inlining `uuid4` calls