### PR TITLE
chore(cli): move to runtime context

### DIFF
--- a/libs/cli/deepagents_cli/_server_config.py
+++ b/libs/cli/deepagents_cli/_server_config.py
@@ -162,11 +162,7 @@ class ServerConfig:
             "ENABLE_ASK_USER": str(self.enable_ask_user).lower(),
             "ENABLE_MEMORY": str(self.enable_memory).lower(),
             "ENABLE_SKILLS": str(self.enable_skills).lower(),
-            "SANDBOX_TYPE": (
-                self.sandbox_type
-                if self.sandbox_type and self.sandbox_type != "none"
-                else None
-            ),
+            "SANDBOX_TYPE": self.sandbox_type,
             "SANDBOX_ID": self.sandbox_id,
             "SANDBOX_SETUP": self.sandbox_setup,
             "CWD": self.cwd,
@@ -269,9 +265,7 @@ class ServerConfig:
             interactive=interactive,
             enable_shell=enable_shell,
             enable_ask_user=enable_ask_user,
-            sandbox_type=sandbox_type
-            if sandbox_type and sandbox_type != "none"
-            else None,
+            sandbox_type=sandbox_type,
             sandbox_id=sandbox_id,
             sandbox_setup=_normalize_path(
                 sandbox_setup, project_context, "sandbox setup"

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -805,10 +805,6 @@ def create_cli_agent(
             routes={},
         )
 
-    from deepagents.graph import resolve_model
-
-    model = resolve_model(model)
-
     from deepagents.middleware.summarization import create_summarization_tool_middleware
 
     agent_middleware.append(

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -27,7 +27,6 @@ from textual.message import Message
 from textual.screen import ModalScreen
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
-from deepagents_cli.configurable_model import CLIContext
 from deepagents_cli.config import (
     DOCS_URL,
     SHELL_TOOL_NAMES,
@@ -40,6 +39,7 @@ from deepagents_cli.config import (
     newline_shortcut,
     settings,
 )
+from deepagents_cli.configurable_model import CLIContext
 from deepagents_cli.hooks import dispatch_hook
 from deepagents_cli.model_config import ModelSpec, save_recent_model
 from deepagents_cli.textual_adapter import (

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -590,7 +590,8 @@ class DeepAgentsApp(App):
         """Initialize the Deep Agents application.
 
         Args:
-            agent: Pre-configured LangGraph agent for the session.
+            agent: Pre-configured LangGraph agent, or `None` when server
+                startup is deferred via `server_kwargs`.
             assistant_id: Agent identifier for memory storage
             backend: Backend for file operations
             auto_approve: Whether to start with auto-approve enabled
@@ -890,7 +891,7 @@ class DeepAgentsApp(App):
             banner = self.query_one("#welcome-banner", WelcomeBanner)
             banner.set_connected(self._mcp_tool_count)
         except NoMatches:
-            pass
+            logger.warning("Welcome banner not found during server ready transition")
 
         # Now that the agent is available, set up the adapter
         self._init_agent_adapter()
@@ -924,12 +925,12 @@ class DeepAgentsApp(App):
             severity="error",
             timeout=30,
         )
-        # Update banner to show the failure
+        # Update banner to show persistent failure state
         try:
             banner = self.query_one("#welcome-banner", WelcomeBanner)
-            banner.set_connected(0)
+            banner.set_failed(str(event.error))
         except NoMatches:
-            pass
+            logger.warning("Welcome banner not found during server failure transition")
 
         # Discard any messages queued while the server was starting
         if self._pending_messages:
@@ -1014,7 +1015,7 @@ class DeepAgentsApp(App):
         # Sticky scroll: only scroll to bottom if user is near the bottom
         # "Near" means within 100 pixels of the bottom (about 6-7 lines)
         distance_from_bottom = chat.max_scroll_y - chat.scroll_y
-        if distance_from_bottom < 100:  # noqa: PLR2004  # Token count threshold
+        if distance_from_bottom < 100:  # noqa: PLR2004  # Pixel distance threshold for sticky scroll
             chat.scroll_end(animate=False)
 
     def _check_hydration_needed(self) -> None:
@@ -2370,7 +2371,7 @@ class DeepAgentsApp(App):
     async def _run_agent_task(self, message: str) -> None:
         """Run the agent task in a background worker.
 
-        This runs in a worker thread so the main event loop stays responsive.
+        This runs in a Textual worker so the main event loop stays responsive.
         """
         # Caller ensures _ui_adapter is set (checked in _handle_user_message)
         if self._ui_adapter is None:
@@ -2587,6 +2588,10 @@ class DeepAgentsApp(App):
         if not self._remote_agent():
             return values
 
+        logger.debug(
+            "Remote state empty for thread %s; falling back to local checkpointer",
+            thread_id,
+        )
         fallback_values = await self._read_channel_values_from_checkpointer(thread_id)
         fallback_messages = fallback_values.get("messages")
         if isinstance(fallback_messages, list) and fallback_messages:
@@ -2652,31 +2657,19 @@ class DeepAgentsApp(App):
                     channel_values = tup.checkpoint.get("channel_values", {})
                     if isinstance(channel_values, dict):
                         return dict(channel_values)
+        except (ImportError, OSError) as exc:
+            logger.warning(
+                "Failed to read checkpointer directly for %s: %s",
+                thread_id,
+                exc,
+            )
         except Exception:
             logger.warning(
-                "Failed to read checkpointer directly for %s",
+                "Unexpected error reading checkpointer for %s",
                 thread_id,
                 exc_info=True,
             )
         return {}
-
-    @staticmethod
-    async def _read_messages_from_checkpointer(thread_id: str) -> list[Any]:
-        """Read messages directly from the SQLite checkpointer.
-
-        Args:
-            thread_id: Thread ID to look up.
-
-        Returns:
-            List of LangChain message objects, or empty list on failure.
-        """
-        channel_values = await DeepAgentsApp._read_channel_values_from_checkpointer(
-            thread_id
-        )
-        messages = channel_values.get("messages")
-        if isinstance(messages, list):
-            return messages
-        return []
 
     async def _upgrade_thread_message_link(
         self,
@@ -3601,7 +3594,8 @@ class DeepAgentsApp(App):
                         "preference. Check permissions for ~/.deepagents/"
                     )
                 )
-            await self._mount_message(AppMessage(f"Switched to {display}"))
+            else:
+                await self._mount_message(AppMessage(f"Switched to {display}"))
             logger.info("Model switched to %s (via configurable middleware)", display)
 
             # Scroll to bottom so the confirmation message is visible

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -27,6 +27,7 @@ from textual.message import Message
 from textual.screen import ModalScreen
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
+from deepagents_cli.configurable_model import CLIContext
 from deepagents_cli.config import (
     DOCS_URL,
     SHELL_TOOL_NAMES,
@@ -2384,8 +2385,10 @@ class DeepAgentsApp(App):
                 adapter=self._ui_adapter,
                 backend=self._backend,
                 image_tracker=self._image_tracker,
-                model_override=self._model_override,
-                model_params=self._model_params_override,
+                context=CLIContext(
+                    model=self._model_override,
+                    model_params=self._model_params_override or {},
+                ),
             )
         except Exception as e:  # Resilient tool rendering
             logger.exception("Agent execution failed")
@@ -3583,8 +3586,8 @@ class DeepAgentsApp(App):
                 return
 
             # Set the model override for ConfigurableModelMiddleware.
-            # The next stream call will pass this in config["configurable"]["model"],
-            # and the middleware swaps the model per-invocation — no server restart.
+            # The next stream call passes CLIContext via context= and the
+            # middleware swaps the model per-invocation — no graph recreation.
             self._model_override = display
             self._model_params_override = extra_kwargs
 

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -44,8 +44,9 @@ class CLIContext:
 def _apply_overrides(request: ModelRequest) -> ModelRequest:
     """Apply model/param overrides from ``CLIContext`` on the runtime.
 
-    Returns the original request unchanged when no ``CLIContext`` is present
-    or it contains no overrides.
+    Returns:
+        The original request unchanged when no ``CLIContext`` is present
+        or it contains no overrides, otherwise a new request with overrides.
     """
     runtime = request.runtime
     if runtime is None:
@@ -73,16 +74,18 @@ class ConfigurableModelMiddleware(AgentMiddleware):
 
     _deepagents_prepend = True
 
-    def wrap_model_call(
+    def wrap_model_call(  # noqa: PLR6301
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
+        """Apply runtime overrides and delegate to the next handler."""  # noqa: DOC201
         return handler(_apply_overrides(request))
 
-    async def awrap_model_call(
+    async def awrap_model_call(  # noqa: PLR6301
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
+        """Apply runtime overrides and delegate to the next async handler."""  # noqa: DOC201
         return await handler(_apply_overrides(request))

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -3,9 +3,6 @@
 Allows switching the model per invocation by passing a ``CLIContext``
 via ``context=`` on ``agent.astream()`` / ``agent.invoke()`` without
 recompiling the graph.
-
-Per-invocation model settings can be merged from
-``CLIContext.model_params``.
 """
 
 from __future__ import annotations
@@ -23,8 +20,6 @@ from langchain.agents.middleware.types import (
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
-
-    from langchain_core.language_models import BaseChatModel
 
 
 logger = logging.getLogger(__name__)
@@ -46,117 +41,48 @@ class CLIContext:
     into ``model_settings``."""
 
 
+def _apply_overrides(request: ModelRequest) -> ModelRequest:
+    """Apply model/param overrides from ``CLIContext`` on the runtime.
+
+    Returns the original request unchanged when no ``CLIContext`` is present
+    or it contains no overrides.
+    """
+    runtime = request.runtime
+    if runtime is None:
+        return request
+    ctx = runtime.context
+    if not isinstance(ctx, CLIContext):
+        return request
+
+    overrides: dict[str, Any] = {}
+
+    # Model swap
+    if ctx.model is not None and not model_matches_spec(request.model, ctx.model):
+        logger.debug("Overriding model to %s", ctx.model)
+        overrides["model"] = resolve_model(ctx.model)
+
+    # Param merge
+    if ctx.model_params:
+        overrides["model_settings"] = {**request.model_settings, **ctx.model_params}
+
+    return request.override(**overrides) if overrides else request
+
+
 class ConfigurableModelMiddleware(AgentMiddleware):
     """Swap the model or per-call settings from ``runtime.context``."""
 
     _deepagents_prepend = True
-
-    @staticmethod
-    def _get_context(request: ModelRequest) -> CLIContext | None:
-        """Extract ``CLIContext`` from the runtime, if present.
-
-        Args:
-            request: The current model request.
-
-        Returns:
-            The ``CLIContext`` instance, or ``None`` when unavailable.
-        """
-        runtime = request.runtime
-        if runtime is None:
-            return None
-        ctx = runtime.context
-        if isinstance(ctx, CLIContext):
-            return ctx
-        return None
-
-    def _get_override_model(self, request: ModelRequest) -> BaseChatModel | None:
-        """Read the model override from runtime context, if present.
-
-        Args:
-            request: The current model request.
-
-        Returns:
-            A resolved ``BaseChatModel`` if an override is specified, else ``None``.
-        """
-        ctx = self._get_context(request)
-        if ctx is None or ctx.model is None:
-            return None
-
-        if model_matches_spec(request.model, ctx.model):
-            return None
-
-        logger.debug("Overriding model to %s", ctx.model)
-        return resolve_model(ctx.model)
-
-    def _get_model_params(self, request: ModelRequest) -> dict[str, Any] | None:
-        """Read invocation param overrides from runtime context.
-
-        Args:
-            request: The current model request.
-
-        Returns:
-            A non-empty dict of params to merge into ``model_settings``,
-            or ``None`` if no overrides are configured.
-        """
-        ctx = self._get_context(request)
-        if ctx is None or not ctx.model_params:
-            return None
-        return ctx.model_params
-
-    def _apply_overrides(self, request: ModelRequest) -> ModelRequest:
-        """Apply model and param overrides from runtime context.
-
-        Args:
-            request: The original model request.
-
-        Returns:
-            A (possibly new) request with model and/or ``model_settings``
-            overrides applied.  Returns the original request unchanged if
-            no overrides are configured.
-        """
-        overrides: dict[str, Any] = {}
-
-        override_model = self._get_override_model(request)
-        if override_model is not None:
-            overrides["model"] = override_model
-
-        params = self._get_model_params(request)
-        if params is not None:
-            merged = {**request.model_settings, **params}
-            overrides["model_settings"] = merged
-
-        if overrides:
-            return request.override(**overrides)
-        return request
 
     def wrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
-        """Swap the model / merge invocation params before the handler executes.
-
-        Args:
-            request: The model request.
-            handler: The next handler in the middleware chain.
-
-        Returns:
-            The model response from the handler.
-        """
-        return handler(self._apply_overrides(request))
+        return handler(_apply_overrides(request))
 
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        """Async version of ``wrap_model_call``.
-
-        Args:
-            request: The model request.
-            handler: The next async handler in the middleware chain.
-
-        Returns:
-            The model response from the handler.
-        """
-        return await handler(self._apply_overrides(request))
+        return await handler(_apply_overrides(request))

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -1,16 +1,18 @@
-"""CLI middleware for runtime model selection via LangGraph config.
+"""CLI middleware for runtime model selection via LangGraph runtime context.
 
-Allows switching the model per invocation by passing the model spec
-in `config["configurable"]["model"]` without recompiling the graph.
+Allows switching the model per invocation by passing a ``CLIContext``
+via ``context=`` on ``agent.astream()`` / ``agent.invoke()`` without
+recompiling the graph.
 
 Per-invocation model settings can be merged from
-`config["configurable"]["model_params"]`.
+``CLIContext.model_params``.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 from deepagents._models import model_matches_spec, resolve_model  # noqa: PLC2701
 from langchain.agents.middleware.types import (
@@ -18,153 +20,99 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
 )
-from langgraph.config import get_config
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from langchain_core.language_models import BaseChatModel
-    from langchain_core.runnables import RunnableConfig
 
 
 logger = logging.getLogger(__name__)
 
 
-class _RuntimeWithConfig(Protocol):
-    """Protocol for runtimes that expose a `config` attribute."""
+@dataclass
+class CLIContext:
+    """Runtime context passed via ``context=`` to the LangGraph graph.
 
-    config: RunnableConfig | None
+    Carries per-invocation overrides that ``ConfigurableModelMiddleware``
+    reads from ``request.runtime.context``.
+    """
 
+    model: str | None = None
+    """Model spec to swap at runtime (e.g. ``"openai:gpt-4o"``)."""
 
-class _ConfigurableModelConfig(TypedDict, total=False):
-    """Supported `config["configurable"]` keys for model overrides."""
-
-    model: str
-    model_params: dict[str, Any]
+    model_params: dict[str, Any] = field(default_factory=dict)
+    """Invocation params (e.g. ``temperature``, ``max_tokens``) to merge
+    into ``model_settings``."""
 
 
 class ConfigurableModelMiddleware(AgentMiddleware):
-    """Swap the model or per-call settings from `config["configurable"]`."""
+    """Swap the model or per-call settings from ``runtime.context``."""
 
     _deepagents_prepend = True
 
     @staticmethod
-    def _get_runnable_config(request: ModelRequest) -> RunnableConfig:
-        """Extract runnable config for the current model request.
-
-        LangGraph recommends `get_config()` for middleware access. We still
-        accept `request.runtime.config` as a fallback because tests and some
-        call sites inject it directly.
+    def _get_context(request: ModelRequest) -> CLIContext | None:
+        """Extract ``CLIContext`` from the runtime, if present.
 
         Args:
             request: The current model request.
 
         Returns:
-            Runnable config for this request, or an empty dict when unavailable.
+            The ``CLIContext`` instance, or ``None`` when unavailable.
         """
-        empty_config: RunnableConfig = {}
-
-        try:
-            return get_config()
-        except RuntimeError:
-            runtime = request.runtime
-            if runtime is None:
-                return empty_config
-
-            try:
-                runtime_config = cast("_RuntimeWithConfig", runtime).config
-            except AttributeError:
-                return empty_config
-
-            if runtime_config is None:
-                return empty_config
-            return runtime_config
-
-    @classmethod
-    def _get_configurable(cls, request: ModelRequest) -> _ConfigurableModelConfig:
-        """Extract validated `configurable` settings from runnable config.
-
-        Args:
-            request: The current model request.
-
-        Returns:
-            The validated `configurable` settings.
-
-        Raises:
-            TypeError: If the runnable config is not a dict.
-            TypeError: If `config["configurable"]` is not a dict.
-        """
-        config = cls._get_runnable_config(request)
-        if not isinstance(config, dict):
-            msg = "`config` must be a dictionary."
-            raise TypeError(msg)
-        configurable = config.get("configurable", {})
-        if not isinstance(configurable, dict):
-            msg = "`config['configurable']` must be a dictionary."
-            raise TypeError(msg)
-        return cast("_ConfigurableModelConfig", configurable)
+        runtime = request.runtime
+        if runtime is None:
+            return None
+        ctx = runtime.context
+        if isinstance(ctx, CLIContext):
+            return ctx
+        return None
 
     def _get_override_model(self, request: ModelRequest) -> BaseChatModel | None:
-        """Read the model override from runtime config, if present.
+        """Read the model override from runtime context, if present.
 
         Args:
             request: The current model request.
 
         Returns:
-            A resolved `BaseChatModel` if an override is specified, else `None`.
-
-        Raises:
-            TypeError: If `config["configurable"]["model"]` is not a string.
+            A resolved ``BaseChatModel`` if an override is specified, else ``None``.
         """
-        configurable = self._get_configurable(request)
-        raw_model_spec = configurable.get("model")
-        if raw_model_spec is None:
-            return None
-        if not isinstance(raw_model_spec, str):
-            msg = "`config['configurable']['model']` must be a string."
-            raise TypeError(msg)
-
-        if model_matches_spec(request.model, raw_model_spec):
+        ctx = self._get_context(request)
+        if ctx is None or ctx.model is None:
             return None
 
-        logger.debug("Overriding model to %s", raw_model_spec)
-        return resolve_model(raw_model_spec)
+        if model_matches_spec(request.model, ctx.model):
+            return None
 
-    @staticmethod
-    def _get_model_params(request: ModelRequest) -> dict[str, Any] | None:
-        """Read invocation param overrides from runtime config.
+        logger.debug("Overriding model to %s", ctx.model)
+        return resolve_model(ctx.model)
+
+    def _get_model_params(self, request: ModelRequest) -> dict[str, Any] | None:
+        """Read invocation param overrides from runtime context.
 
         Args:
             request: The current model request.
 
         Returns:
-            A non-empty dict of params to merge into `model_settings`,
-                or `None` if no overrides are configured.
-
-        Raises:
-            TypeError: If `model_params` is not a dict.
+            A non-empty dict of params to merge into ``model_settings``,
+            or ``None`` if no overrides are configured.
         """
-        configurable = ConfigurableModelMiddleware._get_configurable(request)
-        raw_params = configurable.get("model_params")
-        if raw_params is None:
+        ctx = self._get_context(request)
+        if ctx is None or not ctx.model_params:
             return None
-        if not isinstance(raw_params, dict):
-            msg = "`config['configurable']['model_params']` must be a dictionary."
-            raise TypeError(msg)
-        return raw_params or None
+        return ctx.model_params
 
     def _apply_overrides(self, request: ModelRequest) -> ModelRequest:
-        """Apply model and param overrides from runtime config.
+        """Apply model and param overrides from runtime context.
 
         Args:
             request: The original model request.
 
         Returns:
-            A (possibly new) request with model and/or `model_settings`
-                overrides applied.
-
-                Returns the original request unchanged if no overrides are
-                configured.
+            A (possibly new) request with model and/or ``model_settings``
+            overrides applied.  Returns the original request unchanged if
+            no overrides are configured.
         """
         overrides: dict[str, Any] = {}
 
@@ -202,7 +150,7 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        """Async version of `wrap_model_call`.
+        """Async version of ``wrap_model_call``.
 
         Args:
             request: The model request.

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -1,14 +1,13 @@
 """CLI middleware for runtime model selection via LangGraph runtime context.
 
-Allows switching the model per invocation by passing a ``CLIContext``
-via ``context=`` on ``agent.astream()`` / ``agent.invoke()`` without
-recompiling the graph.
+Allows switching the model per invocation by passing a `CLIContext` via
+`context=` on `agent.astream()` / `agent.invoke()` without recompiling
+the graph.
 """
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from deepagents._models import model_matches_spec, resolve_model  # noqa: PLC2701
@@ -17,6 +16,7 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
 )
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -25,52 +25,54 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class CLIContext:
-    """Runtime context passed via ``context=`` to the LangGraph graph.
+class CLIContext(TypedDict, total=False):
+    """Runtime context passed via `context=` to the LangGraph graph.
 
-    Carries per-invocation overrides that ``ConfigurableModelMiddleware``
-    reads from ``request.runtime.context``.
+    Carries per-invocation overrides that `ConfigurableModelMiddleware`
+    reads from `request.runtime.context`.
     """
 
-    model: str | None = None
-    """Model spec to swap at runtime (e.g. ``"openai:gpt-4o"``)."""
+    model: str | None
+    """Model spec to swap at runtime (e.g. `'openai:gpt-4o'`)."""
 
-    model_params: dict[str, Any] = field(default_factory=dict)
-    """Invocation params (e.g. ``temperature``, ``max_tokens``) to merge
-    into ``model_settings``."""
+    model_params: dict[str, Any]
+    """Invocation params (e.g. `temperature`, `max_tokens`) to merge
+    into `model_settings`."""
 
 
 def _apply_overrides(request: ModelRequest) -> ModelRequest:
-    """Apply model/param overrides from ``CLIContext`` on the runtime.
+    """Apply model/param overrides from `CLIContext` on the runtime.
 
     Returns:
-        The original request unchanged when no ``CLIContext`` is present
-        or it contains no overrides, otherwise a new request with overrides.
+        The original request unchanged when no `CLIContext` is present or it
+            contains no overrides, otherwise a new request with overrides.
     """
     runtime = request.runtime
     if runtime is None:
         return request
+
     ctx = runtime.context
-    if not isinstance(ctx, CLIContext):
+    if not isinstance(ctx, dict):
         return request
 
     overrides: dict[str, Any] = {}
 
     # Model swap
-    if ctx.model is not None and not model_matches_spec(request.model, ctx.model):
-        logger.debug("Overriding model to %s", ctx.model)
-        overrides["model"] = resolve_model(ctx.model)
+    model = ctx.get("model")
+    if model and not model_matches_spec(request.model, model):
+        logger.debug("Overriding model to %s", model)
+        overrides["model"] = resolve_model(model)
 
     # Param merge
-    if ctx.model_params:
-        overrides["model_settings"] = {**request.model_settings, **ctx.model_params}
+    model_params = ctx.get("model_params", {})
+    if model_params:
+        overrides["model_settings"] = {**request.model_settings, **model_params}
 
     return request.override(**overrides) if overrides else request
 
 
 class ConfigurableModelMiddleware(AgentMiddleware):
-    """Swap the model or per-call settings from ``runtime.context``."""
+    """Swap the model or per-call settings from `runtime.context`."""
 
     _deepagents_prepend = True
 

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -3,6 +3,9 @@
 Provides `run_non_interactive` which runs a single user task against the
 agent graph, streams results to stdout, and exits with an appropriate code.
 
+The agent runs inside a `langgraph dev` server subprocess, connected via
+the `RemoteAgent` client (see `server_manager.server_session`).
+
 Shell commands are gated by an optional allow-list (`--shell-allow-list`):
 
 - Not set → shell disabled, all other tool calls auto-approved.

--- a/libs/cli/deepagents_cli/remote_client.py
+++ b/libs/cli/deepagents_cli/remote_client.py
@@ -99,6 +99,7 @@ class RemoteAgent:
         stream_mode: list[str] | None = None,
         subgraphs: bool = False,
         config: dict[str, Any] | None = None,
+        context: Any | None = None,  # noqa: ANN401
         durability: str | None = None,  # noqa: ARG002
     ) -> AsyncIterator[tuple[tuple[str, ...], str, Any]]:
         """Stream agent execution, yielding tuples matching Pregel's format.
@@ -112,6 +113,8 @@ class RemoteAgent:
             stream_mode: Stream modes to request.
             subgraphs: Whether to stream subgraph events.
             config: LangGraph config with `configurable.thread_id`, etc.
+            context: Runtime context (e.g. `CLIContext`) forwarded to the
+                server via the SDK's `context=` parameter.
             durability: Ignored (server manages durability).
 
         Yields:
@@ -128,11 +131,16 @@ class RemoteAgent:
         config = _prepare_config(config)
         dropped_count = 0
 
+        kwargs: dict[str, Any] = {}
+        if context is not None:
+            kwargs["context"] = context
+
         async for ns, mode, data in graph.astream(
             input,
             stream_mode=stream_mode or ["messages", "updates"],
             subgraphs=subgraphs,
             config=config,
+            **kwargs,
         ):
             logger.debug("RemoteGraph event mode=%s ns=%s", mode, ns)
 

--- a/libs/cli/deepagents_cli/server.py
+++ b/libs/cli/deepagents_cli/server.py
@@ -126,7 +126,7 @@ def generate_langgraph_json(
 def _scoped_env_overrides(
     overrides: dict[str, str],
 ) -> Iterator[None]:
-    """Context manager that applies env-var overrides and rolls them back.
+    """Apply env-var overrides, rolling back only on exception.
 
     Separates the concern of temporary `os.environ` mutations from subprocess
     management, making both independently testable.

--- a/libs/cli/deepagents_cli/server_graph.py
+++ b/libs/cli/deepagents_cli/server_graph.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import atexit
 import logging
 import sys
+import traceback
 from typing import Any
 
 from deepagents_cli._server_config import ServerConfig
@@ -184,6 +185,7 @@ try:
 except Exception as exc:
     logger.critical("Failed to initialize server graph", exc_info=True)
     print(  # noqa: T201  # stderr fallback — logger may not reach parent process
-        f"Failed to initialize server graph: {exc}", file=sys.stderr
+        f"Failed to initialize server graph: {exc}\n{traceback.format_exc()}",
+        file=sys.stderr,
     )
     sys.exit(1)

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -33,6 +33,7 @@ from pydantic import TypeAdapter, ValidationError
 from deepagents_cli._debug import configure_debug_logging
 from deepagents_cli.ask_user import AskUserRequest
 from deepagents_cli.config import settings
+from deepagents_cli.configurable_model import CLIContext
 from deepagents_cli.file_ops import FileOpTracker
 from deepagents_cli.hooks import dispatch_hook
 from deepagents_cli.input import MediaTracker, parse_file_mentions
@@ -260,9 +261,6 @@ def _get_git_branch() -> str | None:
 def _build_stream_config(
     thread_id: str,
     assistant_id: str | None,
-    *,
-    model_override: str | None = None,
-    model_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the LangGraph stream config dict.
 
@@ -274,11 +272,6 @@ def _build_stream_config(
     Args:
         thread_id: The CLI session thread identifier.
         assistant_id: The agent/assistant identifier, if any.
-        model_override: Model spec to pass via `configurable` for
-            `ConfigurableModelMiddleware` to swap at runtime.
-        model_params: Invocation params (e.g., `temperature`, `max_tokens`)
-            to pass via `configurable["model_params"]` for
-            `ConfigurableModelMiddleware` to merge into `model_settings`.
 
     Returns:
         Config dict with `configurable` and `metadata` keys.
@@ -300,13 +293,8 @@ def _build_stream_config(
     branch = _get_git_branch()
     if branch:
         metadata["git_branch"] = branch
-    configurable: dict[str, Any] = {"thread_id": thread_id}
-    if model_override:
-        configurable["model"] = model_override
-    if model_params:
-        configurable["model_params"] = model_params
     return {
-        "configurable": configurable,
+        "configurable": {"thread_id": thread_id},
         "metadata": metadata,
     }
 
@@ -502,8 +490,7 @@ async def execute_task_textual(
     adapter: TextualUIAdapter,
     backend: Any = None,  # noqa: ANN401  # Dynamic backend type
     image_tracker: MediaTracker | None = None,
-    model_override: str | None = None,
-    model_params: dict[str, Any] | None = None,
+    context: CLIContext | None = None,
 ) -> SessionStats:
     """Execute a task with output directed to Textual UI.
 
@@ -518,10 +505,8 @@ async def execute_task_textual(
         adapter: The TextualUIAdapter for UI operations
         backend: Optional backend for file operations
         image_tracker: Optional tracker for images
-        model_override: Model spec to pass via `configurable` for runtime
-            model switching (e.g., `"openai:gpt-4o"`).
-        model_params: Invocation params (e.g., `temperature`, `max_tokens`)
-            forwarded to `ConfigurableModelMiddleware` via the stream config.
+        context: Optional ``CLIContext`` with model override and params,
+            passed to the graph via ``context=``.
 
     Returns:
         Stats accumulated over this turn (request count, token counts,
@@ -579,12 +564,7 @@ async def execute_task_textual(
         message_content = final_input
 
     thread_id = session_state.thread_id
-    config = _build_stream_config(
-        thread_id,
-        assistant_id,
-        model_override=model_override,
-        model_params=model_params,
-    )
+    config = _build_stream_config(thread_id, assistant_id)
 
     await dispatch_hook("session.start", {"thread_id": thread_id})
 
@@ -633,6 +613,7 @@ async def execute_task_textual(
                 stream_mode=["messages", "updates"],
                 subgraphs=True,
                 config=config,
+                context=context,
                 durability="exit",
             ):
                 if not isinstance(chunk, tuple) or len(chunk) != 3:  # noqa: PLR2004  # stream chunk is a 3-tuple (namespace, mode, data)

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -33,7 +33,7 @@ from pydantic import TypeAdapter, ValidationError
 from deepagents_cli._debug import configure_debug_logging
 from deepagents_cli.ask_user import AskUserRequest
 from deepagents_cli.config import settings
-from deepagents_cli.configurable_model import CLIContext
+from deepagents_cli.configurable_model import CLIContext  # noqa: TC001
 from deepagents_cli.file_ops import FileOpTracker
 from deepagents_cli.hooks import dispatch_hook
 from deepagents_cli.input import MediaTracker, parse_file_mentions

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -505,8 +505,8 @@ async def execute_task_textual(
         adapter: The TextualUIAdapter for UI operations
         backend: Optional backend for file operations
         image_tracker: Optional tracker for images
-        context: Optional ``CLIContext`` with model override and params,
-            passed to the graph via ``context=``.
+        context: Optional `CLIContext` with model override and params, passed
+            to the graph via `context=`.
 
     Returns:
         Stats accumulated over this turn (request count, token counts,

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -62,6 +62,8 @@ class WelcomeBanner(Static):
         self._cli_thread_id: str | None = thread_id
         self._mcp_tool_count = mcp_tool_count
         self._connecting = connecting
+        self._failed = False
+        self._failure_error: str = ""
         self._project_name: str | None = get_langsmith_project_name()
         self._project_url: str | None = None
 
@@ -103,7 +105,19 @@ class WelcomeBanner(Static):
             mcp_tool_count: Number of MCP tools loaded during connection.
         """
         self._connecting = False
+        self._failed = False
         self._mcp_tool_count = mcp_tool_count
+        self.update(self._build_banner(self._project_url))
+
+    def set_failed(self, error: str) -> None:
+        """Transition from "connecting" to a persistent failure state.
+
+        Args:
+            error: Error message describing the server startup failure.
+        """
+        self._connecting = False
+        self._failed = True
+        self._failure_error = error
         self.update(self._build_banner(self._project_url))
 
     def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
@@ -165,11 +179,29 @@ class WelcomeBanner(Static):
             label = "MCP tool" if self._mcp_tool_count == 1 else "MCP tools"
             banner.append(f"Loaded {self._mcp_tool_count} {label}\n")
 
-        if self._connecting:
+        if self._failed:
+            banner.append_text(build_failure_footer(self._failure_error))
+        elif self._connecting:
             banner.append_text(build_connecting_footer())
         else:
             banner.append_text(build_welcome_footer())
         return banner
+
+
+def build_failure_footer(error: str) -> Text:
+    """Build a footer shown when the server failed to start.
+
+    Args:
+        error: Error message describing the failure.
+
+    Returns:
+        Rich Text with a persistent failure message.
+    """
+    footer = Text()
+    footer.append("\nServer failed to start: ", style="bold red")
+    footer.append(error, style="red")
+    footer.append("\n", style="red")
+    return footer
 
 
 def build_connecting_footer() -> Text:

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -1102,7 +1102,7 @@ class TestCreateCliAgentProjectContext:
             patch("deepagents_cli.agent.MemoryMiddleware"),
             patch("deepagents_cli.agent.list_subagents", return_value=[]) as mock_list,
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
-            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents._models.init_chat_model", return_value=fake_model),
         ):
             create_cli_agent(
                 model="fake-model",
@@ -1179,7 +1179,7 @@ class TestCreateCliAgentProjectContext:
             patch("deepagents_cli.agent.MemoryMiddleware", FakeMemoryMiddleware),
             patch("deepagents_cli.agent.FilesystemBackend"),
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
-            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents._models.init_chat_model", return_value=fake_model),
         ):
             create_cli_agent(
                 model="fake-model",
@@ -1239,7 +1239,7 @@ class TestCreateCliAgentProjectContext:
                 "deepagents_cli.agent.LocalShellBackend", return_value=mock_backend
             ) as mock_shell,
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
-            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents._models.init_chat_model", return_value=fake_model),
         ):
             create_cli_agent(
                 model="fake-model",
@@ -1290,7 +1290,7 @@ class TestCreateCliAgentProjectContext:
             patch("deepagents_cli.agent.SkillsMiddleware"),
             patch("deepagents_cli.agent.FilesystemBackend") as mock_filesystem,
             patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
-            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents._models.init_chat_model", return_value=fake_model),
         ):
             create_cli_agent(
                 model="fake-model",

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
-import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
@@ -24,6 +23,7 @@ def _make_model(name: str) -> MagicMock:
 def _make_request(
     model: BaseChatModel,
     context: CLIContext | None = None,
+    model_settings: dict[str, Any] | None = None,
 ) -> ModelRequest:
     """Create a ModelRequest with a runtime that carries CLIContext."""
     runtime = SimpleNamespace(context=context)
@@ -32,6 +32,7 @@ def _make_request(
         messages=[HumanMessage(content="hi")],
         tools=[],
         runtime=cast("Any", runtime),
+        model_settings=model_settings,
     )
 
 
@@ -40,292 +41,185 @@ def _make_response() -> ModelResponse[Any]:
     return ModelResponse(result=[AIMessage(content="response")])
 
 
-class TestGetOverrideModel:
-    """Tests for `_get_override_model` logic."""
+_mw = ConfigurableModelMiddleware()
 
-    def test_no_context_returns_none(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(model, context=None)
-        assert mw._get_override_model(request) is None
 
-    def test_empty_context_returns_none(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(model, context=CLIContext())
-        assert mw._get_override_model(request) is None
+class TestNoOverride:
+    """Cases where the middleware should pass the request through unchanged."""
 
-    def test_same_model_spec_returns_none(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
+    def test_no_context(self) -> None:
+        request = _make_request(_make_model("claude-sonnet-4-6"), context=None)
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
+        assert captured[0].model is request.model
+
+    def test_empty_context(self) -> None:
+        request = _make_request(_make_model("claude-sonnet-4-6"), context=CLIContext())
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
+        assert captured[0] is request
+
+    def test_same_model_spec(self) -> None:
         request = _make_request(
-            model,
+            _make_model("claude-sonnet-4-6"),
             context=CLIContext(model="claude-sonnet-4-6"),
         )
-        assert mw._get_override_model(request) is None
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
+        assert captured[0] is request
 
-    def test_provider_prefixed_spec_matches_model_name(self) -> None:
-        """`anthropic:claude-sonnet-4-6` should match the resolved model name."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
+    def test_provider_prefixed_spec_matches(self) -> None:
         request = _make_request(
-            model,
+            _make_model("claude-sonnet-4-6"),
             context=CLIContext(model="anthropic:claude-sonnet-4-6"),
         )
-        assert mw._get_override_model(request) is None
-
-    def test_different_model_resolves_override(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(
-            model,
-            context=CLIContext(model="openai:gpt-4o"),
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
         )
-        with patch("deepagents_cli.configurable_model.resolve_model") as mock_resolve:
-            mock_resolve.return_value = _make_model("gpt-4o")
-            result = mw._get_override_model(request)
+        assert captured[0] is request
 
-        assert result is not None
-        assert result is mock_resolve.return_value
-        mock_resolve.assert_called_once_with("openai:gpt-4o")
-
-    def test_none_runtime_returns_none(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
+    def test_none_runtime(self) -> None:
         request = ModelRequest(
-            model=model,
+            model=_make_model("claude-sonnet-4-6"),
             messages=[HumanMessage(content="hi")],
             tools=[],
             runtime=None,
         )
-        assert mw._get_override_model(request) is None
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
+        assert captured[0].model is request.model
 
-    def test_non_cli_context_returns_none(self) -> None:
-        """Runtime with a non-CLIContext context should be ignored."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
+    def test_non_cli_context_ignored(self) -> None:
         runtime = SimpleNamespace(context={"model": "openai:gpt-4o"})
         request = ModelRequest(
-            model=model,
+            model=_make_model("claude-sonnet-4-6"),
             messages=[HumanMessage(content="hi")],
             tools=[],
             runtime=cast("Any", runtime),
         )
-        assert mw._get_override_model(request) is None
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
+        assert captured[0].model is request.model
+
+    def test_empty_model_params(self) -> None:
+        request = _make_request(
+            _make_model("claude-sonnet-4-6"),
+            context=CLIContext(model_params={}),
+        )
+        captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
+        assert captured[0] is request
 
 
-class TestWrapModelCall:
-    """Tests for sync `wrap_model_call`."""
+class TestModelSwap:
+    """Cases where the middleware should swap the model."""
 
-    def test_override_swaps_model_on_request(self) -> None:
-        mw = ConfigurableModelMiddleware()
+    def test_different_model_swapped(self) -> None:
         original = _make_model("claude-sonnet-4-6")
         override = _make_model("gpt-4o")
-        request = _make_request(
-            original,
-            context=CLIContext(model="openai:gpt-4o"),
-        )
+        request = _make_request(original, context=CLIContext(model="openai:gpt-4o"))
 
         captured: list[ModelRequest] = []
-        response = _make_response()
-
-        def handler(req: ModelRequest) -> ModelResponse[Any]:
-            captured.append(req)
-            return response
-
         with patch(
-            "deepagents_cli.configurable_model.resolve_model",
-            return_value=override,
+            "deepagents_cli.configurable_model.resolve_model", return_value=override
         ):
-            result = mw.wrap_model_call(request, handler)
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
 
-        assert request.model is original
-        assert len(captured) == 1
         assert captured[0].model is override
-        assert result is response
+        assert request.model is original  # original unchanged
 
-    def test_no_override_preserves_model(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        original = _make_model("claude-sonnet-4-6")
-        request = _make_request(original, context=CLIContext())
-
-        captured: list[ModelRequest] = []
-        response = _make_response()
-
-        def handler(req: ModelRequest) -> ModelResponse[Any]:
-            captured.append(req)
-            return response
-
-        result = mw.wrap_model_call(request, handler)
-
-        assert captured[0].model is original
-        assert result is response
-
-
-class TestAsyncWrapModelCall:
-    """Tests for async `awrap_model_call`."""
-
-    async def test_override_swaps_model_on_request(self) -> None:
-        mw = ConfigurableModelMiddleware()
+    async def test_async_model_swapped(self) -> None:
         original = _make_model("claude-sonnet-4-6")
         override = _make_model("gpt-4o")
-        request = _make_request(
-            original,
-            context=CLIContext(model="openai:gpt-4o"),
-        )
+        request = _make_request(original, context=CLIContext(model="openai:gpt-4o"))
 
         captured: list[ModelRequest] = []
-        response = _make_response()
 
-        async def handler(req: ModelRequest) -> ModelResponse[Any]:
-            await asyncio.sleep(0)
-            captured.append(req)
-            return response
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:
+            captured.append(r)
+            return _make_response()
 
         with patch(
-            "deepagents_cli.configurable_model.resolve_model",
-            return_value=override,
+            "deepagents_cli.configurable_model.resolve_model", return_value=override
         ):
-            result = await mw.awrap_model_call(request, handler)
+            await _mw.awrap_model_call(request, handler)
 
-        assert request.model is original
         assert captured[0].model is override
-        assert result is response
-
-    async def test_no_override_preserves_model(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        original = _make_model("claude-sonnet-4-6")
-        request = _make_request(original, context=CLIContext())
-
-        response = _make_response()
-
-        async def handler(_req: ModelRequest) -> ModelResponse[Any]:
-            await asyncio.sleep(0)
-            return response
-
-        result = await mw.awrap_model_call(request, handler)
-
-        assert request.model is original
-        assert result is response
 
 
 class TestModelParams:
-    """Tests for `model_params` override via CLIContext."""
+    """Cases where model_params are merged into model_settings."""
 
-    def test_params_only_merges_model_settings(self) -> None:
-        """`model_params` without a model swap merges into `model_settings`."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
+    def test_params_merged(self) -> None:
         request = _make_request(
-            model,
+            _make_model("claude-sonnet-4-6"),
             context=CLIContext(model_params={"temperature": 0.7}),
         )
-
         captured: list[ModelRequest] = []
-
-        def handler(req: ModelRequest) -> ModelResponse[Any]:
-            captured.append(req)
-            return _make_response()
-
-        mw.wrap_model_call(request, handler)
-
-        assert len(captured) == 1
-        assert captured[0].model is model
-        assert captured[0].model_settings == {"temperature": 0.7}
-
-    def test_params_with_model_swap(self) -> None:
-        """`model_params` and a model swap should both apply."""
-        mw = ConfigurableModelMiddleware()
-        original = _make_model("claude-sonnet-4-6")
-        override = _make_model("gpt-4o")
-        request = _make_request(
-            original,
-            context=CLIContext(
-                model="openai:gpt-4o",
-                model_params={"max_tokens": 1024},
-            ),
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
         )
 
+        assert captured[0].model is request.model
+        assert captured[0].model_settings == {"temperature": 0.7}
+
+    def test_params_merge_preserves_existing(self) -> None:
+        request = _make_request(
+            _make_model("claude-sonnet-4-6"),
+            context=CLIContext(model_params={"temperature": 0.5}),
+            model_settings={"max_tokens": 2048},
+        )
         captured: list[ModelRequest] = []
+        _mw.wrap_model_call(
+            request, lambda r: (captured.append(r), _make_response())[1]
+        )
 
-        def handler(req: ModelRequest) -> ModelResponse[Any]:
-            captured.append(req)
-            return _make_response()
+        assert captured[0].model_settings == {"max_tokens": 2048, "temperature": 0.5}
 
+    def test_params_with_model_swap(self) -> None:
+        override = _make_model("gpt-4o")
+        request = _make_request(
+            _make_model("claude-sonnet-4-6"),
+            context=CLIContext(
+                model="openai:gpt-4o", model_params={"max_tokens": 1024}
+            ),
+        )
+        captured: list[ModelRequest] = []
         with patch(
-            "deepagents_cli.configurable_model.resolve_model",
-            return_value=override,
+            "deepagents_cli.configurable_model.resolve_model", return_value=override
         ):
-            mw.wrap_model_call(request, handler)
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
 
         assert captured[0].model is override
         assert captured[0].model_settings == {"max_tokens": 1024}
 
-    def test_empty_params_no_op(self) -> None:
-        """An empty `model_params` dict should not trigger an override."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
+    async def test_async_params(self) -> None:
         request = _make_request(
-            model,
-            context=CLIContext(model_params={}),
-        )
-
-        captured: list[ModelRequest] = []
-
-        def handler(req: ModelRequest) -> ModelResponse[Any]:
-            captured.append(req)
-            return _make_response()
-
-        mw.wrap_model_call(request, handler)
-
-        assert captured[0] is request
-
-    def test_params_merge_preserves_existing_settings(self) -> None:
-        """`model_params` should merge on top of existing model settings."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        runtime = SimpleNamespace(
-            context=CLIContext(model_params={"temperature": 0.5})
-        )
-        request = ModelRequest(
-            model=model,
-            messages=[HumanMessage(content="hi")],
-            tools=[],
-            runtime=cast("Any", runtime),
-            model_settings={"max_tokens": 2048},
-        )
-
-        captured: list[ModelRequest] = []
-
-        def handler(req: ModelRequest) -> ModelResponse[Any]:
-            captured.append(req)
-            return _make_response()
-
-        mw.wrap_model_call(request, handler)
-
-        assert captured[0].model_settings == {
-            "max_tokens": 2048,
-            "temperature": 0.5,
-        }
-
-    async def test_async_params_override(self) -> None:
-        """`model_params` should work in the async path."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(
-            model,
+            _make_model("claude-sonnet-4-6"),
             context=CLIContext(model_params={"temperature": 0.3}),
         )
-
         captured: list[ModelRequest] = []
-        response = _make_response()
 
-        async def handler(req: ModelRequest) -> ModelResponse[Any]:
-            await asyncio.sleep(0)
-            captured.append(req)
-            return response
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:
+            captured.append(r)
+            return _make_response()
 
-        result = await mw.awrap_model_call(request, handler)
-
+        await _mw.awrap_model_call(request, handler)
         assert captured[0].model_settings == {"temperature": 0.3}
-        assert result is response

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -98,8 +98,8 @@ class TestNoOverride:
         )
         assert captured[0].model is request.model
 
-    def test_non_cli_context_ignored(self) -> None:
-        runtime = SimpleNamespace(context={"model": "openai:gpt-4o"})
+    def test_non_dict_context_ignored(self) -> None:
+        runtime = SimpleNamespace(context="not-a-dict")
         request = ModelRequest(
             model=_make_model("claude-sonnet-4-6"),
             messages=[HumanMessage(content="hi")],

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -150,7 +150,7 @@ class TestModelSwap:
 
         captured: list[ModelRequest] = []
 
-        async def handler(r: ModelRequest) -> ModelResponse[Any]:
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:  # noqa: RUF029
             captured.append(r)
             return _make_response()
 
@@ -217,7 +217,7 @@ class TestModelParams:
         )
         captured: list[ModelRequest] = []
 
-        async def handler(r: ModelRequest) -> ModelResponse[Any]:
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:  # noqa: RUF029
             captured.append(r)
             return _make_response()
 

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -10,7 +10,7 @@ from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
 
-from deepagents_cli.configurable_model import ConfigurableModelMiddleware
+from deepagents_cli.configurable_model import CLIContext, ConfigurableModelMiddleware
 
 
 def _make_model(name: str) -> MagicMock:
@@ -23,10 +23,10 @@ def _make_model(name: str) -> MagicMock:
 
 def _make_request(
     model: BaseChatModel,
-    config: dict | None = None,
+    context: CLIContext | None = None,
 ) -> ModelRequest:
-    """Create a ModelRequest with a runtime that carries config."""
-    runtime = SimpleNamespace(config=config or {})
+    """Create a ModelRequest with a runtime that carries CLIContext."""
+    runtime = SimpleNamespace(context=context)
     return ModelRequest(
         model=model,
         messages=[HumanMessage(content="hi")],
@@ -43,10 +43,16 @@ def _make_response() -> ModelResponse[Any]:
 class TestGetOverrideModel:
     """Tests for `_get_override_model` logic."""
 
-    def test_no_configurable_key_returns_none(self) -> None:
+    def test_no_context_returns_none(self) -> None:
         mw = ConfigurableModelMiddleware()
         model = _make_model("claude-sonnet-4-6")
-        request = _make_request(model, config={})
+        request = _make_request(model, context=None)
+        assert mw._get_override_model(request) is None
+
+    def test_empty_context_returns_none(self) -> None:
+        mw = ConfigurableModelMiddleware()
+        model = _make_model("claude-sonnet-4-6")
+        request = _make_request(model, context=CLIContext())
         assert mw._get_override_model(request) is None
 
     def test_same_model_spec_returns_none(self) -> None:
@@ -54,7 +60,7 @@ class TestGetOverrideModel:
         model = _make_model("claude-sonnet-4-6")
         request = _make_request(
             model,
-            config={"configurable": {"model": "claude-sonnet-4-6"}},
+            context=CLIContext(model="claude-sonnet-4-6"),
         )
         assert mw._get_override_model(request) is None
 
@@ -64,7 +70,7 @@ class TestGetOverrideModel:
         model = _make_model("claude-sonnet-4-6")
         request = _make_request(
             model,
-            config={"configurable": {"model": "anthropic:claude-sonnet-4-6"}},
+            context=CLIContext(model="anthropic:claude-sonnet-4-6"),
         )
         assert mw._get_override_model(request) is None
 
@@ -73,7 +79,7 @@ class TestGetOverrideModel:
         model = _make_model("claude-sonnet-4-6")
         request = _make_request(
             model,
-            config={"configurable": {"model": "openai:gpt-4o"}},
+            context=CLIContext(model="openai:gpt-4o"),
         )
         with patch("deepagents_cli.configurable_model.resolve_model") as mock_resolve:
             mock_resolve.return_value = _make_model("gpt-4o")
@@ -83,75 +89,22 @@ class TestGetOverrideModel:
         assert result is mock_resolve.return_value
         mock_resolve.assert_called_once_with("openai:gpt-4o")
 
-    def test_uses_langgraph_config_when_available(self) -> None:
+    def test_none_runtime_returns_none(self) -> None:
         mw = ConfigurableModelMiddleware()
         model = _make_model("claude-sonnet-4-6")
         request = ModelRequest(
             model=model,
             messages=[HumanMessage(content="hi")],
             tools=[],
-            runtime=cast("Any", SimpleNamespace()),
-        )
-
-        with (
-            patch(
-                "deepagents_cli.configurable_model.get_config",
-                return_value={"configurable": {"model": "openai:gpt-4o"}},
-            ),
-            patch("deepagents_cli.configurable_model.resolve_model") as mock_resolve,
-        ):
-            mock_resolve.return_value = _make_model("gpt-4o")
-            result = mw._get_override_model(request)
-
-        assert result is not None
-        mock_resolve.assert_called_once_with("openai:gpt-4o")
-
-    def test_none_runtime_config_returns_none(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        runtime = SimpleNamespace(config=None)
-        request = ModelRequest(
-            model=model,
-            messages=[HumanMessage(content="hi")],
-            tools=[],
-            runtime=cast("Any", runtime),
+            runtime=None,
         )
         assert mw._get_override_model(request) is None
 
-    def test_invalid_runtime_config_type_raises_type_error(self) -> None:
+    def test_non_cli_context_returns_none(self) -> None:
+        """Runtime with a non-CLIContext context should be ignored."""
         mw = ConfigurableModelMiddleware()
         model = _make_model("claude-sonnet-4-6")
-        request = ModelRequest(
-            model=model,
-            messages=[HumanMessage(content="hi")],
-            tools=[],
-            runtime=cast("Any", SimpleNamespace(config="not-a-dict")),
-        )
-
-        with pytest.raises(TypeError, match="`config` must be a dictionary"):
-            mw._get_override_model(request)
-
-    def test_invalid_configurable_type_raises_type_error(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(model, config={"configurable": "openai:gpt-4o"})
-
-        with pytest.raises(TypeError, match="config\\['configurable'\\]"):
-            mw._get_override_model(request)
-
-    def test_invalid_model_spec_type_raises_type_error(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(model, config={"configurable": {"model": 123}})
-
-        with pytest.raises(TypeError, match="config\\['configurable'\\]\\['model'\\]"):
-            mw._get_override_model(request)
-
-    def test_missing_runtime_attr_returns_none(self) -> None:
-        """Runtime without `config` should not crash."""
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        runtime = SimpleNamespace()
+        runtime = SimpleNamespace(context={"model": "openai:gpt-4o"})
         request = ModelRequest(
             model=model,
             messages=[HumanMessage(content="hi")],
@@ -170,7 +123,7 @@ class TestWrapModelCall:
         override = _make_model("gpt-4o")
         request = _make_request(
             original,
-            config={"configurable": {"model": "openai:gpt-4o"}},
+            context=CLIContext(model="openai:gpt-4o"),
         )
 
         captured: list[ModelRequest] = []
@@ -194,7 +147,7 @@ class TestWrapModelCall:
     def test_no_override_preserves_model(self) -> None:
         mw = ConfigurableModelMiddleware()
         original = _make_model("claude-sonnet-4-6")
-        request = _make_request(original, config={})
+        request = _make_request(original, context=CLIContext())
 
         captured: list[ModelRequest] = []
         response = _make_response()
@@ -218,7 +171,7 @@ class TestAsyncWrapModelCall:
         override = _make_model("gpt-4o")
         request = _make_request(
             original,
-            config={"configurable": {"model": "openai:gpt-4o"}},
+            context=CLIContext(model="openai:gpt-4o"),
         )
 
         captured: list[ModelRequest] = []
@@ -242,7 +195,7 @@ class TestAsyncWrapModelCall:
     async def test_no_override_preserves_model(self) -> None:
         mw = ConfigurableModelMiddleware()
         original = _make_model("claude-sonnet-4-6")
-        request = _make_request(original, config={})
+        request = _make_request(original, context=CLIContext())
 
         response = _make_response()
 
@@ -257,7 +210,7 @@ class TestAsyncWrapModelCall:
 
 
 class TestModelParams:
-    """Tests for `model_params` override via configurable."""
+    """Tests for `model_params` override via CLIContext."""
 
     def test_params_only_merges_model_settings(self) -> None:
         """`model_params` without a model swap merges into `model_settings`."""
@@ -265,7 +218,7 @@ class TestModelParams:
         model = _make_model("claude-sonnet-4-6")
         request = _make_request(
             model,
-            config={"configurable": {"model_params": {"temperature": 0.7}}},
+            context=CLIContext(model_params={"temperature": 0.7}),
         )
 
         captured: list[ModelRequest] = []
@@ -287,12 +240,10 @@ class TestModelParams:
         override = _make_model("gpt-4o")
         request = _make_request(
             original,
-            config={
-                "configurable": {
-                    "model": "openai:gpt-4o",
-                    "model_params": {"max_tokens": 1024},
-                }
-            },
+            context=CLIContext(
+                model="openai:gpt-4o",
+                model_params={"max_tokens": 1024},
+            ),
         )
 
         captured: list[ModelRequest] = []
@@ -316,7 +267,7 @@ class TestModelParams:
         model = _make_model("claude-sonnet-4-6")
         request = _make_request(
             model,
-            config={"configurable": {"model_params": {}}},
+            context=CLIContext(model_params={}),
         )
 
         captured: list[ModelRequest] = []
@@ -334,7 +285,7 @@ class TestModelParams:
         mw = ConfigurableModelMiddleware()
         model = _make_model("claude-sonnet-4-6")
         runtime = SimpleNamespace(
-            config={"configurable": {"model_params": {"temperature": 0.5}}}
+            context=CLIContext(model_params={"temperature": 0.5})
         )
         request = ModelRequest(
             model=model,
@@ -363,7 +314,7 @@ class TestModelParams:
         model = _make_model("claude-sonnet-4-6")
         request = _make_request(
             model,
-            config={"configurable": {"model_params": {"temperature": 0.3}}},
+            context=CLIContext(model_params={"temperature": 0.3}),
         )
 
         captured: list[ModelRequest] = []
@@ -378,16 +329,3 @@ class TestModelParams:
 
         assert captured[0].model_settings == {"temperature": 0.3}
         assert result is response
-
-    def test_invalid_model_params_type_raises_type_error(self) -> None:
-        mw = ConfigurableModelMiddleware()
-        model = _make_model("claude-sonnet-4-6")
-        request = _make_request(
-            model,
-            config={"configurable": {"model_params": "temperature=0.3"}},
-        )
-
-        with pytest.raises(
-            TypeError, match="config\\['configurable'\\]\\['model_params'\\]"
-        ):
-            mw.wrap_model_call(request, lambda _req: _make_response())

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -170,7 +170,7 @@ class TestModelSwitchErrorHandling:
         assert app._model_switching is False
 
     async def test_save_recent_model_failure_shows_warning(self) -> None:
-        """Permission error saving recent model shows warning but still switches."""
+        """Permission error saving recent model shows error, no success message."""
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # type: ignore[method-assign]
         app._agent = _make_remote_agent()
@@ -208,8 +208,8 @@ class TestModelSwitchErrorHandling:
         assert "could not save" in captured_errors[0].lower()
         assert "~/.deepagents/" in captured_errors[0]
 
-        # Should still confirm the switch happened
-        assert any("Switched to" in m for m in captured_messages)
+        # Should NOT show success message when save fails
+        assert not any("Switched to" in m for m in captured_messages)
         assert app._model_override == "anthropic:claude-sonnet-4-5"
 
     async def test_remote_agent_sets_model_override(self) -> None:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -187,41 +187,11 @@ class TestBuildStreamConfig:
         config = _build_stream_config("t-abc", assistant_id=None)
         assert config["configurable"]["thread_id"] == "t-abc"
 
-    def test_model_override_in_configurable(self) -> None:
-        """Model override should appear in `configurable["model"]`."""
-        config = _build_stream_config(
-            "t-model", assistant_id=None, model_override="openai:gpt-4o"
-        )
-        assert config["configurable"]["model"] == "openai:gpt-4o"
-
-    def test_no_model_override_omits_key(self) -> None:
-        """Absent model override should not add a `model` key."""
+    def test_no_model_keys_in_configurable(self) -> None:
+        """Model/model_params should not be in configurable (moved to runtime context)."""
         config = _build_stream_config("t-no-model", assistant_id=None)
         assert "model" not in config["configurable"]
-
-    def test_model_params_in_configurable(self) -> None:
-        """Model params should appear in `configurable["model_params"]`."""
-        params = {"temperature": 0.7, "max_tokens": 1024}
-        config = _build_stream_config(
-            "t-params", assistant_id=None, model_params=params
-        )
-        assert config["configurable"]["model_params"] == params
-
-    def test_no_model_params_omits_key(self) -> None:
-        """Absent model params should not add a `model_params` key."""
-        config = _build_stream_config("t-no-params", assistant_id=None)
         assert "model_params" not in config["configurable"]
-
-    def test_model_override_and_params_together(self) -> None:
-        """Both model override and params can coexist in configurable."""
-        config = _build_stream_config(
-            "t-both",
-            assistant_id=None,
-            model_override="anthropic:claude-sonnet-4-5",
-            model_params={"temperature": 0.3},
-        )
-        assert config["configurable"]["model"] == "anthropic:claude-sonnet-4-5"
-        assert config["configurable"]["model_params"] == {"temperature": 0.3}
 
 
 class TestGetGitBranch:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -188,7 +188,7 @@ class TestBuildStreamConfig:
         assert config["configurable"]["thread_id"] == "t-abc"
 
     def test_no_model_keys_in_configurable(self) -> None:
-        """Model/model_params should not be in configurable (moved to runtime context)."""
+        """Model/model_params should not be in configurable."""
         config = _build_stream_config("t-no-model", assistant_id=None)
         assert "model" not in config["configurable"]
         assert "model_params" not in config["configurable"]

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -7,7 +7,6 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import ResponseFormat
-from langchain.chat_models import init_chat_model
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from langchain_core.language_models import BaseChatModel
@@ -18,6 +17,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
+from deepagents._models import resolve_model
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -76,32 +76,6 @@ def get_default_model() -> ChatAnthropic:
     return ChatAnthropic(
         model_name="claude-sonnet-4-6",
     )
-
-
-def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
-    """Resolve a model string to a `BaseChatModel` instance.
-
-    If `model` is already a `BaseChatModel`, returns it unchanged.
-
-    String models are resolved via `init_chat_model`, with OpenAI models
-    defaulting to the Responses API. See the `create_deep_agent` docstring for
-    details on how to customize this behavior.
-
-    Args:
-        model: Model name string or pre-configured model instance.
-
-    Returns:
-        Resolved `BaseChatModel` instance.
-    """
-    if isinstance(model, BaseChatModel):
-        return model
-    if model.startswith("openai:"):
-        # Use Responses API by default. To use chat completions, use
-        # `model=init_chat_model("openai:...")`
-        # To disable data retention with the Responses API, use
-        # `model=init_chat_model("openai:...", use_responses_api=True, store=False, include=["reasoning.encrypted_content"])`
-        return init_chat_model(model, use_responses_api=True)
-    return init_chat_model(model)
 
 
 def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic with many conditional branches

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -7,6 +7,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import ResponseFormat
+from langchain.chat_models import init_chat_model
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from langchain_core.language_models import BaseChatModel
@@ -17,7 +18,6 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
-from deepagents._models import resolve_model
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -78,28 +78,30 @@ def get_default_model() -> ChatAnthropic:
     )
 
 
-def _split_middleware(
-    middleware: Sequence[AgentMiddleware],
-) -> tuple[list[AgentMiddleware], list[AgentMiddleware]]:
-    """Partition middleware into prepended and trailing groups.
+def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
+    """Resolve a model string to a `BaseChatModel` instance.
 
-    Callers can mark middleware with the private `_deepagents_prepend` flag
-    when it must run before the built-in deep-agent middleware stack.
+    If `model` is already a `BaseChatModel`, returns it unchanged.
+
+    String models are resolved via `init_chat_model`, with OpenAI models
+    defaulting to the Responses API. See the `create_deep_agent` docstring for
+    details on how to customize this behavior.
 
     Args:
-        middleware: Middleware passed to `create_deep_agent()`.
+        model: Model name string or pre-configured model instance.
 
     Returns:
-        Two lists: `(prepended, trailing)`.
+        Resolved `BaseChatModel` instance.
     """
-    prepended: list[AgentMiddleware] = []
-    trailing: list[AgentMiddleware] = []
-    for item in middleware:
-        if getattr(item, "_deepagents_prepend", False):
-            prepended.append(item)
-        else:
-            trailing.append(item)
-    return prepended, trailing
+    if isinstance(model, BaseChatModel):
+        return model
+    if model.startswith("openai:"):
+        # Use Responses API by default. To use chat completions, use
+        # `model=init_chat_model("openai:...")`
+        # To disable data retention with the Responses API, use
+        # `model=init_chat_model("openai:...", use_responses_api=True, store=False, include=["reasoning.encrypted_content"])`
+        return init_chat_model(model, use_responses_api=True)
+    return init_chat_model(model)
 
 
 def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic with many conditional branches
@@ -208,11 +210,9 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     model = get_default_model() if model is None else resolve_model(model)
 
     backend = backend if backend is not None else (StateBackend)
-    prepended_middleware, trailing_middleware = _split_middleware(middleware)
 
     # Build general-purpose subagent with default middleware stack
     gp_middleware: list[AgentMiddleware[Any, Any, Any]] = [
-        *prepended_middleware,
         TodoListMiddleware(),
         FilesystemMiddleware(backend=backend),
         create_summarization_middleware(model, backend),
@@ -244,7 +244,6 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
 
             # Build middleware: base stack + skills (if specified) + user's middleware
             subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
-                *prepended_middleware,
                 TodoListMiddleware(),
                 FilesystemMiddleware(backend=backend),
                 create_summarization_middleware(subagent_model, backend),
@@ -269,7 +268,6 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
 
     # Build main agent middleware stack
     deepagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
-        *prepended_middleware,
         TodoListMiddleware(),
     ]
     if memory is not None:
@@ -289,8 +287,8 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         ]
     )
 
-    if trailing_middleware:
-        deepagent_middleware.extend(trailing_middleware)
+    if middleware:
+        deepagent_middleware.extend(middleware)
     if interrupt_on is not None:
         deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
 


### PR DESCRIPTION
# Changes Made

## `libs/cli/deepagents_cli/configurable_model.py`

Rewrote to use `runtime.context` instead of `config["configurable"]`:

- Added `CLIContext` dataclass with `model: str | None` and `model_params: dict[str, Any]`
- `ConfigurableModelMiddleware` now reads from `request.runtime.context` (checks for `CLIContext` instance) instead of `get_config()["configurable"]`
- Removed all `get_config()`, `_get_runnable_config()`, `_get_configurable()` indirection, `_RuntimeWithConfig` protocol, `_ConfigurableModelConfig` TypedDict

## `libs/cli/deepagents_cli/textual_adapter.py`

- `_build_stream_config()` no longer accepts or sets `model_override`/`model_params` in configurable — it only handles `thread_id` and metadata
- `execute_task_textual()` takes `context: CLIContext | None` instead of `model_override`/`model_params`
- `agent.astream()` now passes `context=context`

## `libs/cli/deepagents_cli/app.py`

- `_run_agent_task()` constructs `CLIContext(model=..., model_params=...)` and passes it to `execute_task_textual()`
- Updated com in `_switch_model()`

## `libs/deepagents/deepagents/graph.py`

Reverted to main (removes the `_split_middleware`/`_deepagents_prepend` changes).