### PR TITLE
feat(cli): enable `ask_user` tool by default

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -552,7 +552,6 @@ def create_cli_agent(
     enable_memory: bool = True,
     enable_skills: bool = True,
     enable_shell: bool = True,
-    enable_ask_user: bool = False,
     checkpointer: BaseCheckpointSaver | None = None,
     mcp_server_info: list[MCPServerInfo] | None = None,
 ) -> tuple[Pregel, CompositeBackend]:
@@ -589,7 +588,6 @@ def create_cli_agent(
         enable_skills: Enable `SkillsMiddleware` for custom agent skills
         enable_shell: Enable shell execution via `LocalShellBackend`
             (only in local mode). When enabled, the `execute` tool is available.
-        enable_ask_user: Enable the `ask_user` tool for interactive questioning.
         checkpointer: Optional checkpointer for session persistence.
 
             If `None`, uses `InMemorySaver` (no persistence across
@@ -647,10 +645,9 @@ def create_cli_agent(
     agent_middleware = []
 
     # Add ask_user middleware (must be early so its tool is available)
-    if enable_ask_user:
-        from deepagents_cli.ask_user import AskUserMiddleware
+    from deepagents_cli.ask_user import AskUserMiddleware
 
-        agent_middleware.append(AskUserMiddleware())
+    agent_middleware.append(AskUserMiddleware())
 
     # Add memory middleware
     if enable_memory:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -554,7 +554,6 @@ class DeepAgentsApp(App):
         assistant_id: str | None = None,
         backend: CompositeBackend | None = None,
         auto_approve: bool = False,
-        enable_ask_user: bool = False,
         cwd: str | Path | None = None,
         thread_id: str | None = None,
         initial_prompt: str | None = None,
@@ -573,8 +572,6 @@ class DeepAgentsApp(App):
             assistant_id: Agent identifier for memory storage
             backend: Backend for file operations
             auto_approve: Whether to start with auto-approve enabled
-            enable_ask_user: Whether `ask_user` should stay enabled when
-                recreating agents (for example during model hot-swap)
             cwd: Current working directory to display
             thread_id: Optional thread ID for session persistence
             initial_prompt: Optional prompt to auto-submit when session starts
@@ -592,7 +589,6 @@ class DeepAgentsApp(App):
         self._assistant_id = assistant_id
         self._backend = backend
         self._auto_approve = auto_approve
-        self._enable_ask_user = enable_ask_user
         self._cwd = str(cwd) if cwd else str(Path.cwd())
         # Avoid collision with App._thread_id
         self._lc_thread_id = thread_id
@@ -3316,7 +3312,6 @@ class DeepAgentsApp(App):
                     sandbox=self._sandbox,
                     sandbox_type=self._sandbox_type,
                     auto_approve=self._auto_approve,
-                    enable_ask_user=self._enable_ask_user,
                     checkpointer=self._checkpointer,
                     mcp_server_info=self._mcp_server_info,
                 )
@@ -3446,7 +3441,6 @@ async def run_textual_app(
     assistant_id: str | None = None,
     backend: CompositeBackend | None = None,
     auto_approve: bool = False,
-    enable_ask_user: bool = False,
     cwd: str | Path | None = None,
     thread_id: str | None = None,
     initial_prompt: str | None = None,
@@ -3464,8 +3458,6 @@ async def run_textual_app(
         assistant_id: Agent identifier for memory storage
         backend: Backend for file operations
         auto_approve: Whether to start with auto-approve enabled
-        enable_ask_user: Whether `ask_user` should stay enabled when
-            recreating agents (for example during model hot-swap)
         cwd: Current working directory to display
         thread_id: Optional thread ID for session persistence
         initial_prompt: Optional prompt to auto-submit when session starts
@@ -3485,7 +3477,6 @@ async def run_textual_app(
         assistant_id=assistant_id,
         backend=backend,
         auto_approve=auto_approve,
-        enable_ask_user=enable_ask_user,
         cwd=cwd,
         thread_id=thread_id,
         initial_prompt=initial_prompt,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -419,15 +419,6 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--ask-user",
-        action="store_true",
-        help=(
-            "Enable the ask_user tool, allowing the agent to ask "
-            "you questions during execution (opt-in)."
-        ),
-    )
-
-    parser.add_argument(
         "--sandbox",
         choices=["none", "modal", "daytona", "runloop", "langsmith"],
         default="none",
@@ -517,7 +508,6 @@ async def run_textual_cli_async(
     thread_id: str | None = None,
     is_resumed: bool = False,
     initial_prompt: str | None = None,
-    enable_ask_user: bool = False,
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
@@ -542,7 +532,6 @@ async def run_textual_cli_async(
         thread_id: Thread ID to use (new or resumed)
         is_resumed: Whether this is a resumed session
         initial_prompt: Optional prompt to auto-submit when session starts
-        enable_ask_user: Enable the ask_user tool
         mcp_config_path: Optional path to MCP servers JSON configuration file.
 
             Merged on top of auto-discovered configs (highest precedence).
@@ -658,7 +647,6 @@ async def run_textual_cli_async(
                 sandbox=sandbox_backend,
                 sandbox_type=sandbox_type if sandbox_type != "none" else None,
                 auto_approve=auto_approve,
-                enable_ask_user=enable_ask_user,
                 checkpointer=checkpointer,
                 mcp_server_info=mcp_server_info,
             )
@@ -681,7 +669,6 @@ async def run_textual_cli_async(
                 assistant_id=assistant_id,
                 backend=composite_backend,
                 auto_approve=auto_approve,
-                enable_ask_user=enable_ask_user,
                 cwd=Path.cwd(),
                 thread_id=thread_id,
                 initial_prompt=initial_prompt,
@@ -1409,7 +1396,6 @@ def cli_main() -> None:
                         thread_id=thread_id,
                         is_resumed=is_resumed,
                         initial_prompt=getattr(args, "initial_prompt", None),
-                        enable_ask_user=getattr(args, "ask_user", False),
                         mcp_config_path=getattr(args, "mcp_config", None),
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -106,7 +106,6 @@ def show_help() -> None:
     console.print(
         "  --auto-approve             Auto-approve all tool calls (toggle: Shift+Tab)"
     )
-    console.print("  --ask-user                 Enable ask_user interactive questions")
     console.print("  --sandbox TYPE             Remote sandbox for execution")
     console.print(
         "  --sandbox-id ID            Reuse existing sandbox (skips creation/cleanup)"

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -123,7 +123,6 @@ class TestTopLevelHelp:
         # Should contain global help content
         assert "deepagents" in output.lower()
         assert "--help" in output
-        assert "--ask-user" in output
 
     def test_help_subcommand_parses(self) -> None:
         """Running `deepagents help` should parse as command='help'.

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -790,40 +790,6 @@ class TestModelSwitchBareModelName:
         assert "Already using" in captured_messages[0]
 
 
-class TestModelSwitchAskUserPersistence:
-    """Tests for preserving ask_user enablement across model hot-swap."""
-
-    async def test_model_switch_preserves_enable_ask_user_flag(self) -> None:
-        """Rebuilt agent receives `enable_ask_user=True` when app is configured."""
-        app = DeepAgentsApp(enable_ask_user=True)
-        app._mount_message = AsyncMock()  # type: ignore[method-assign]
-        app._checkpointer = MagicMock()
-
-        settings.model_name = "gpt-4o"
-        settings.model_provider = "openai"
-
-        mock_result = ModelResult(
-            model=MagicMock(),
-            model_name="claude-sonnet-4-5",
-            provider="anthropic",
-        )
-
-        with (
-            patch(
-                "deepagents_cli.model_config.has_provider_credentials",
-                return_value=True,
-            ),
-            patch("deepagents_cli.app.create_model", return_value=mock_result),
-            patch("deepagents_cli.app.save_recent_model", return_value=True),
-            patch("deepagents_cli.agent.create_cli_agent") as mock_create_agent,
-        ):
-            mock_create_agent.return_value = (MagicMock(), MagicMock())
-            await app._switch_model("anthropic:claude-sonnet-4-5")
-
-        assert mock_create_agent.call_count == 1
-        assert mock_create_agent.call_args.kwargs["enable_ask_user"] is True
-
-
 class TestExtractModelParamsFlag:
     """Tests for _extract_model_params_flag helper."""
 


### PR DESCRIPTION
Enable the `ask_user` tool unconditionally. Previously it required an explicit `--ask-user` CLI flag. 

## Changes
- `AskUserMiddleware` is now always appended in `create_cli_agent` — the `enable_ask_user` guard and parameter are removed from `create_cli_agent`, `DeepAgentsApp.__init__`, `run_textual_app`, `run_textual_cli_async`, and `cli_main`
- Remove the `--ask-user` argparse flag from `parse_args()` and its corresponding line in `show_help()`