### PR TITLE
fix(cli): use `max-height` for `tool-info-scroll` to shrink-wrap content

### DIFF
--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -146,7 +146,8 @@ Screen {
 
 /* Scrollable tool info area in approval menu */
 .approval-menu .tool-info-scroll {
-    height: 10;
+    height: auto;
+    max-height: 10;
     margin-top: 0;
 }
 


### PR DESCRIPTION
Change .tool-info-scroll from fixed height: 10 to height: auto with max-height: 10 so the HITL approval window shrinks to fit small content (e.g. web_search) while still capping at 10 lines for large outputs.

Fixes #1120

How did you verify your code works?

#### Before:
<img width="988" height="315" alt="Screenshot 2026-03-12 at 10 28 46 PM" src="https://github.com/user-attachments/assets/c454740e-bb5d-43b5-9864-91b83f40c8ee" />

#### After:
HITL menu with less content: no extra space
<img width="991" height="261" alt="Screenshot 2026-03-12 at 10 27 10 PM" src="https://github.com/user-attachments/assets/f27e2f0c-120a-453a-a914-fca9cfdd0a24" />

HITL menu with more content: shows scroll bar
<img width="999" height="298" alt="Screenshot 2026-03-12 at 10 31 32 PM" src="https://github.com/user-attachments/assets/80d23f09-eca6-4215-9225-5ae1406bac2b" />

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
LinkedIn: https://www.linkedin.com/in/gupta-gautam01/
