### PR TITLE
feat(sdk): Add LangSmith integration metadata to deepagents

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -18,7 +18,6 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
-from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -314,10 +313,11 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         debug=debug,
         name=name,
         cache=cache,
-    ).with_config({
-        "recursion_limit": 1000,
-        "metadata": {
-            "ls_integration": "deepagents",
-            "ls_integration_version": __version__,
-        },
-    })
+    ).with_config(
+        {
+            "recursion_limit": 1000,
+            "metadata": {
+                "ls_integration": "deepagents",
+            },
+        }
+    )


### PR DESCRIPTION
Adds `ls_integration` metadata to every agent created via create_deep_agent(), enabling identification of deepagent traces in LangSmith.

Before
<img width="1043" height="982" alt="image" src="https://github.com/user-attachments/assets/e4ea6979-eac3-4ca3-8a1f-33c5f56df2b3" />


After

<img width="1099" height="1064" alt="image" src="https://github.com/user-attachments/assets/95b37658-84a2-47e3-afd5-9acebe1add7c" />