### PR TITLE
fix(cli): forward `DAYTONA_API_URL` to avoid deprecated `server_url` access

### DIFF
--- a/libs/cli/deepagents_cli/integrations/daytona.py
+++ b/libs/cli/deepagents_cli/integrations/daytona.py
@@ -158,7 +158,12 @@ class DaytonaProvider(SandboxProvider):
         if not self._api_key:
             msg = "DAYTONA_API_KEY environment variable not set"
             raise ValueError(msg)
-        self._client = Daytona(DaytonaConfig(api_key=self._api_key))
+        self._client = Daytona(
+            DaytonaConfig(
+                api_key=self._api_key,
+                api_url=os.environ.get("DAYTONA_API_URL"),
+            )
+        )
 
     def get_or_create(
         self,


### PR DESCRIPTION
Forward `DAYTONA_API_URL` from the environment into `DaytonaConfig` so the SDK's `Daytona.__init__` short-circuits past the deprecated `config.server_url` field access. The Daytona SDK internally does `config.api_url or config.server_url` — when `api_url` is `None`, Pydantic emits a `DeprecationWarning` on the `server_url` access since the field is marked `Field(deprecated=...)`.

## Changes
- Pass `api_url=os.environ.get("DAYTONA_API_URL")` to `DaytonaConfig` in `DaytonaProvider.__init__`, preventing the SDK from falling through to the deprecated `server_url` property when the env var is set