### PR TITLE
feat(cli): add sandbox type to trace metadata

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -598,7 +598,7 @@ class DeepAgentsApp(App):
         self._mcp_preload_kwargs = mcp_preload_kwargs
         self._connecting = server_kwargs is not None
         # Extract sandbox type from server kwargs for trace metadata.
-        # _server_config normalizes "none" → None, but server_kwargs carries
+        # ServerConfig.__post_init__ normalizes "none" → None, but server_kwargs carries
         # the raw argparse value, so guard against both.
         raw = (server_kwargs or {}).get("sandbox_type")
         self._sandbox_type: str | None = raw if raw and raw != "none" else None

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2107,6 +2107,7 @@ class DeepAgentsApp(App):
                 adapter=self._ui_adapter,
                 backend=self._backend,
                 image_tracker=self._image_tracker,
+                sandbox_type=self._sandbox_type,
                 context=CLIContext(
                     model=self._model_override,
                     model_params=self._model_params_override or {},

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -597,6 +597,11 @@ class DeepAgentsApp(App):
         self._server_kwargs = server_kwargs
         self._mcp_preload_kwargs = mcp_preload_kwargs
         self._connecting = server_kwargs is not None
+        # Extract sandbox type from server kwargs for trace metadata.
+        # _server_config normalizes "none" → None, but server_kwargs carries
+        # the raw argparse value, so guard against both.
+        raw = (server_kwargs or {}).get("sandbox_type")
+        self._sandbox_type: str | None = raw if raw and raw != "none" else None
         self._model_override: str | None = None
         self._model_params_override: dict[str, Any] | None = None
         self._mcp_tool_count = sum(len(s.tools) for s in (mcp_server_info or []))

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -766,6 +766,8 @@ async def run_non_interactive(
     }
     if cwd:
         metadata["cwd"] = cwd
+    if sandbox_type and sandbox_type != "none":
+        metadata["sandbox_type"] = sandbox_type
     from deepagents_cli.textual_adapter import _get_git_branch
 
     branch = _get_git_branch()

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -264,17 +264,21 @@ def _get_git_branch() -> str | None:
 def _build_stream_config(
     thread_id: str,
     assistant_id: str | None,
+    *,
+    sandbox_type: str | None = None,
 ) -> dict[str, Any]:
     """Build the LangGraph stream config dict.
 
     The `thread_id` in `configurable` is automatically propagated as run
     metadata by LangGraph, so it can be used for LangSmith filtering without
-    a separate metadata key. Includes the current working directory (`cwd`)
-    and git branch in metadata when available.
+    a separate metadata key. Includes the current working directory (`cwd`),
+    git branch, and sandbox type in metadata when available.
 
     Args:
         thread_id: The CLI session thread identifier.
         assistant_id: The agent/assistant identifier, if any.
+        sandbox_type: Sandbox provider name for trace metadata, or `None`
+            if no sandbox is active.
 
     Returns:
         Config dict with `configurable` and `metadata` keys.
@@ -296,6 +300,8 @@ def _build_stream_config(
     branch = _get_git_branch()
     if branch:
         metadata["git_branch"] = branch
+    if sandbox_type and sandbox_type != "none":
+        metadata["sandbox_type"] = sandbox_type
     return {
         "configurable": {"thread_id": thread_id},
         "metadata": metadata,
@@ -508,6 +514,8 @@ async def execute_task_textual(
     backend: Any = None,  # noqa: ANN401  # Dynamic backend type
     image_tracker: MediaTracker | None = None,
     context: CLIContext | None = None,
+    *,
+    sandbox_type: str | None = None,
 ) -> SessionStats:
     """Execute a task with output directed to Textual UI.
 
@@ -524,6 +532,8 @@ async def execute_task_textual(
         image_tracker: Optional tracker for images
         context: Optional `CLIContext` with model override and params, passed
             to the graph via `context=`.
+        sandbox_type: Sandbox provider name for trace metadata, or `None`
+            if no sandbox is active.
 
     Returns:
         Stats accumulated over this turn (request count, token counts,
@@ -571,7 +581,7 @@ async def execute_task_textual(
         message_content = final_input
 
     thread_id = session_state.thread_id
-    config = _build_stream_config(thread_id, assistant_id)
+    config = _build_stream_config(thread_id, assistant_id, sandbox_type=sandbox_type)
 
     await dispatch_hook("session.start", {"thread_id": thread_id})
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -300,7 +300,7 @@ def _build_stream_config(
     branch = _get_git_branch()
     if branch:
         metadata["git_branch"] = branch
-    if sandbox_type and sandbox_type != "none":
+    if sandbox_type:
         metadata["sandbox_type"] = sandbox_type
     return {
         "configurable": {"thread_id": thread_id},

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -300,7 +300,7 @@ def _build_stream_config(
     branch = _get_git_branch()
     if branch:
         metadata["git_branch"] = branch
-    if sandbox_type:
+    if sandbox_type and sandbox_type != "none":
         metadata["sandbox_type"] = sandbox_type
     return {
         "configurable": {"thread_id": thread_id},

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1235,6 +1235,7 @@ class TestRunAgentTaskMediaTracker:
             mock_execute.assert_awaited_once()
             assert mock_execute.await_args is not None
             assert mock_execute.await_args.kwargs["image_tracker"] is app._image_tracker
+            assert mock_execute.await_args.kwargs["sandbox_type"] is app._sandbox_type
 
     async def test_run_agent_task_finalizes_pending_tools_on_error(self) -> None:
         """Unexpected agent errors should stop/clear in-flight tool widgets."""

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -187,6 +187,21 @@ class TestBuildStreamConfig:
         config = _build_stream_config("t-abc", assistant_id=None)
         assert config["configurable"]["thread_id"] == "t-abc"
 
+    def test_sandbox_type_included_when_set(self) -> None:
+        """Sandbox type should appear in metadata when provided."""
+        config = _build_stream_config("t-sb", assistant_id=None, sandbox_type="daytona")
+        assert config["metadata"]["sandbox_type"] == "daytona"
+
+    def test_sandbox_type_absent_when_none(self) -> None:
+        """Sandbox type should be absent from metadata when not provided."""
+        config = _build_stream_config("t-nosb", assistant_id=None)
+        assert "sandbox_type" not in config["metadata"]
+
+    def test_sandbox_type_none_string_excluded(self) -> None:
+        """The argparse sentinel `"none"` should not leak into metadata."""
+        config = _build_stream_config("t-none", assistant_id=None, sandbox_type="none")
+        assert "sandbox_type" not in config["metadata"]
+
     def test_no_model_keys_in_configurable(self) -> None:
         """Model/model_params should not be in configurable."""
         config = _build_stream_config("t-no-model", assistant_id=None)


### PR DESCRIPTION
When running the CLI with `--sandbox`, there was no way to distinguish sandbox vs local runs in LangSmith traces. This threads `sandbox_type` (e.g. `"daytona"`, `"modal"`) into the LangGraph run metadata so traces are filterable by `metadata.sandbox_type` in the LangSmith UI.

## Changes
- Add `sandbox_type` kwarg to `_build_stream_config` and `execute_task_textual` in `textual_adapter.py`, writing it into the run metadata dict when a sandbox is active
- Thread `self._sandbox_type` from `DeepAgentsApp` through to `execute_task_textual` in the interactive path
- Add `sandbox_type` to metadata in `run_non_interactive` for the headless path, with a defensive guard against the `"none"` argparse sentinel
