### PR TITLE
fix(sdk): accept all langsmith tracing env vars in evals conftest

### DIFF
--- a/libs/deepagents/tests/evals/conftest.py
+++ b/libs/deepagents/tests/evals/conftest.py
@@ -24,11 +24,21 @@ def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001  # pytest h
     `LANGSMITH_TRACING=true`. Detect this early so the entire suite is skipped
     with a clear message instead of failing one-by-one.
     """
-    if os.environ.get("LANGSMITH_TRACING", "").lower() != "true":
+    tracing_enabled = any(
+        os.environ.get(var, "").lower() == "true"
+        for var in (
+            "LANGSMITH_TRACING_V2",
+            "LANGCHAIN_TRACING_V2",
+            "LANGSMITH_TRACING",
+            "LANGCHAIN_TRACING",
+        )
+    )
+    if not tracing_enabled:
         pytest.exit(
-            "Aborting: LANGSMITH_TRACING is not set to 'true'. "
+            "Aborting: LangSmith tracing is not enabled. "
             "All eval tests require LangSmith tracing. "
-            "Export LANGSMITH_TRACING=true and ensure a valid "
+            "Set one of LANGSMITH_TRACING / LANGSMITH_TRACING_V2 / "
+            "LANGCHAIN_TRACING_V2 to 'true' and ensure a valid "
             "LANGSMITH_API_KEY is set, then re-run.",
             returncode=1,
         )


### PR DESCRIPTION
The evals CI workflow sets `LANGSMITH_TRACING_V2=true`, which is a valid env var recognized by the LangSmith SDK. However, the evals conftest guard does a raw `os.environ.get("LANGSMITH_TRACING")` check, which misses the `_V2` variants entirely — causing every eval job to abort immediately with a misleading error.

## Changes
- Expand the tracing guard in `pytest_configure` (`tests/evals/conftest.py`) to accept all four env vars the LangSmith SDK recognizes: `LANGSMITH_TRACING_V2`, `LANGCHAIN_TRACING_V2`, `LANGSMITH_TRACING`, `LANGCHAIN_TRACING` — matching the precedence order in `langsmith.utils.tracing_is_enabled()`
- Update the abort message to list the accepted variables instead of only mentioning `LANGSMITH_TRACING`