### PR TITLE
feat: add novita provider to PROVIDER_API_KEY_ENV

### DIFF
--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -188,6 +188,7 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     "litellm": "LITELLM_API_KEY",
     "mistralai": "MISTRAL_API_KEY",
     "nvidia": "NVIDIA_API_KEY",
+    "novita": "NOVITA_API_KEY",
     "openai": "OPENAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
     "perplexity": "PPLX_API_KEY",

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -420,6 +420,7 @@ class TestProviderApiKeyEnv:
         assert PROVIDER_API_KEY_ENV["ibm"] == "WATSONX_APIKEY"
         assert PROVIDER_API_KEY_ENV["mistralai"] == "MISTRAL_API_KEY"
         assert PROVIDER_API_KEY_ENV["nvidia"] == "NVIDIA_API_KEY"
+        assert PROVIDER_API_KEY_ENV["novita"] == "NOVITA_API_KEY"
         assert PROVIDER_API_KEY_ENV["openai"] == "OPENAI_API_KEY"
         assert PROVIDER_API_KEY_ENV["openrouter"] == "OPENROUTER_API_KEY"
         assert PROVIDER_API_KEY_ENV["perplexity"] == "PPLX_API_KEY"


### PR DESCRIPTION
## Summary

- Adds NOVITA_API_KEY to PROVIDER_API_KEY_ENV mapping in model_config.py
- Adds unit test coverage for the novita provider configuration

## Related

opens a draft PR for the novita-integration branch

cc @langchain-ai/deepagents-maintainers