### PR TITLE
chore(sdk): add docs link to `LocalShellBackend` `virtual_mode` deprecation warning

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -173,7 +173,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 "it does not provide sandboxing or process isolation. "
                 "Security note: leaving virtual_mode=False allows absolute paths and '..' to bypass root_dir, "
                 "and LocalShellBackend provides no sandboxing (execute runs commands on the host; virtual_mode does not restrict shell execution). "
-                "Please consult the API reference for usage guidelines.",
+                "See https://reference.langchain.com/python/deepagents/ for usage guidelines.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
- Replace vague "Please consult the API reference for usage guidelines" with an actual link to `https://reference.langchain.com/python/deepagents/` in the `LocalShellBackend` `virtual_mode` deprecation warning.