### PR TITLE
chore(sdk): make `langsmith` explicit evals dep

### DIFF
--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -964,6 +964,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk", specifier = ">=3.9.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -55,6 +55,7 @@ test = [
 ]
 
 evals = [
+  "langsmith",
   "langchain-xai",
   "langchain-mistralai",
   "langchain-deepseek",

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -642,6 +642,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk" },
     { name = "tiktoken" },
 ]
@@ -679,6 +680,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk", specifier = ">=3.9.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]

--- a/libs/harbor/uv.lock
+++ b/libs/harbor/uv.lock
@@ -748,6 +748,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk", specifier = ">=3.9.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -660,6 +660,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk", specifier = ">=3.9.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -606,6 +606,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk", specifier = ">=3.9.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -414,6 +414,7 @@ evals = [
     { name = "langchain-mistralai" },
     { name = "langchain-ollama" },
     { name = "langchain-xai" },
+    { name = "langsmith" },
     { name = "nltk", specifier = ">=3.9.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]


### PR DESCRIPTION
Previously it came transitively