### PR TITLE
ci(infra): add pre-commit hooks for lockfile, extras sync, and version checks

### DIFF
--- a/.github/scripts/check_version_equality.py
+++ b/.github/scripts/check_version_equality.py
@@ -1,0 +1,101 @@
+"""Check that pyproject.toml and _version.py versions stay in sync.
+
+Prevents releases with mismatched version numbers across the SDK and CLI
+packages. Used by the CI workflow in .github/workflows/check_versions.yml
+and as a pre-commit hook.
+"""
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+PACKAGES = [
+    ("libs/deepagents/pyproject.toml", "libs/deepagents/deepagents/_version.py"),
+    ("libs/cli/pyproject.toml", "libs/cli/deepagents_cli/_version.py"),
+]
+
+_VERSION_RE = re.compile(r'^__version__\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def _get_pyproject_version(path: Path) -> str:
+    """Extract version from pyproject.toml.
+
+    Args:
+        path: Path to pyproject.toml.
+
+    Returns:
+        Version string.
+    """
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    try:
+        return data["project"]["version"]
+    except KeyError:
+        msg = f"Could not find project.version in {path}"
+        raise ValueError(msg) from None
+
+
+def _get_version_py(path: Path) -> str:
+    """Extract __version__ from _version.py.
+
+    Args:
+        path: Path to _version.py.
+
+    Returns:
+        Version string.
+
+    Raises:
+        ValueError: If __version__ is not found.
+    """
+    text = path.read_text()
+    match = _VERSION_RE.search(text)
+    if not match:
+        msg = f"Could not find __version__ in {path}"
+        raise ValueError(msg)
+    return match.group(1)
+
+
+def main() -> int:
+    """Check version equality across packages.
+
+    Returns:
+        0 if all versions match, 1 if there are mismatches.
+    """
+    root = Path(__file__).resolve().parents[2]
+    errors: list[str] = []
+
+    for pyproject_rel, version_py_rel in PACKAGES:
+        pyproject_path = root / pyproject_rel
+        version_py_path = root / version_py_rel
+
+        missing = [p for p in (pyproject_path, version_py_path) if not p.exists()]
+        if missing:
+            errors.append(
+                f"  {pyproject_rel.split('/')[1]}: file(s) not found: "
+                + ", ".join(str(m) for m in missing)
+            )
+            continue
+
+        pyproject_ver = _get_pyproject_version(pyproject_path)
+        version_py_ver = _get_version_py(version_py_path)
+
+        if pyproject_ver != version_py_ver:
+            pkg = pyproject_path.parent.name
+            errors.append(
+                f"  {pkg}: pyproject.toml={pyproject_ver}, "
+                f"_version.py={version_py_ver}"
+            )
+        else:
+            print(f"{pyproject_path.parent.name} versions match: {pyproject_ver}")
+
+    if errors:
+        print("Version mismatch detected:")
+        print("\n".join(errors))
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check_versions.yml
+++ b/.github/workflows/check_versions.yml
@@ -1,4 +1,4 @@
-# Ensures version numbers in pyproject.toml and version.py stay in sync.
+# Ensures version numbers in pyproject.toml and _version.py stay in sync.
 #
 # (Prevents releases with mismatched version numbers)
 
@@ -12,40 +12,25 @@ on:
       - "libs/cli/pyproject.toml"
       - "libs/cli/deepagents_cli/_version.py"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   check_version_equality:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
       - uses: actions/checkout@v6
 
+      - name: "🐍 Set up Python 3.14"
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
       - name: "✅ Verify pyproject.toml & _version.py Match"
-        run: |
-          # Check deepagents versions
-          DEEPAGENTS_PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' libs/deepagents/pyproject.toml)
-          DEEPAGENTS_VERSION_PY_VERSION=$(grep -Po '(?<=^__version__ = ")[^"]*' libs/deepagents/deepagents/_version.py)
-
-          if [ "$DEEPAGENTS_PYPROJECT_VERSION" != "$DEEPAGENTS_VERSION_PY_VERSION" ]; then
-            echo "deepagents versions in pyproject.toml and _version.py do not match!"
-            echo "pyproject.toml version: $DEEPAGENTS_PYPROJECT_VERSION"
-            echo "_version.py version: $DEEPAGENTS_VERSION_PY_VERSION"
-            exit 1
-          else
-            echo "deepagents versions match: $DEEPAGENTS_PYPROJECT_VERSION"
-          fi
-
-          # Check deepagents-cli versions
-          CLI_PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' libs/cli/pyproject.toml)
-          CLI_VERSION_PY_VERSION=$(grep -Po '(?<=^__version__ = ")[^"]*' libs/cli/deepagents_cli/_version.py)
-
-          if [ "$CLI_PYPROJECT_VERSION" != "$CLI_VERSION_PY_VERSION" ]; then
-            echo "deepagents-cli versions in pyproject.toml and _version.py do not match!"
-            echo "pyproject.toml version: $CLI_PYPROJECT_VERSION"
-            echo "_version.py version: $CLI_VERSION_PY_VERSION"
-            exit 1
-          else
-            echo "deepagents-cli versions match: $CLI_PYPROJECT_VERSION"
-          fi
+        run: python .github/scripts/check_version_equality.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,21 @@ repos:
         entry: make -C libs/acp format lint
         files: ^libs/acp/
         pass_filenames: false
+      - id: lock-check
+        name: check lockfiles are up-to-date
+        language: system
+        entry: make lock-check
+        files: (^libs/.*/pyproject\.toml|^libs/.*/uv\.lock)$
+        pass_filenames: false
+      - id: extras-sync
+        name: check extras sync with required deps
+        language: system
+        entry: python3 .github/scripts/check_extras_sync.py libs/cli/pyproject.toml
+        files: ^libs/cli/pyproject\.toml$
+        pass_filenames: false
+      - id: version-equality
+        name: check pyproject.toml and _version.py match
+        language: system
+        entry: python3 .github/scripts/check_version_equality.py
+        files: (^libs/deepagents/pyproject\.toml|^libs/deepagents/deepagents/_version\.py|^libs/cli/pyproject\.toml|^libs/cli/deepagents_cli/_version\.py)$
+        pass_filenames: false


### PR DESCRIPTION
Add three pre-commit hooks that catch lockfile drift, extras/dependency mismatches, and `pyproject.toml` vs `_version.py` version mismatches locally before they hit CI. The version equality check is extracted into a shared Python script (`check_version_equality.py`) that replaces the inline `grep -Po` shell in the CI workflow, giving both contexts a single source of truth and fixing a portability issue (GNU grep isn't available on macOS).

## Changes
- Add `lock-check`, `extras-sync`, and `version-equality` local hooks in `.pre-commit-config.yaml`, each scoped to trigger only on relevant file patterns via `files` regexes
- Extract the version equality logic from inline shell in `check_versions.yml` into `check_version_equality.py` — the CI workflow and the pre-commit hook both call the same script
- Fail loudly on missing files in `check_version_equality.py` instead of silently skipping — the old `grep` approach would also fail on missing files, so the silent `continue` would have been a regression
- Add `concurrency`, `timeout-minutes`, and `setup-python@v6` to `check_versions.yml` to match the sibling `check_extras_sync.yml` workflow