### PR TITLE
fix(cli): escape dynamic strings in rich markup to prevent markup injection

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -103,13 +103,15 @@ def list_agents(*, output_format: OutputFormat = "text") -> None:
         write_json("list", agents)
         return
 
+    from rich.markup import escape as escape_markup
+
     console.print("\n[bold]Available Agents:[/bold]\n", style=COLORS["primary"])
 
     for agent_path in sorted(agents_dir.iterdir()):
         if agent_path.is_dir():
-            agent_name = agent_path.name
+            agent_name = escape_markup(agent_path.name)
             agent_md = agent_path / "AGENTS.md"
-            is_default = agent_name == DEFAULT_AGENT_NAME
+            is_default = agent_path.name == DEFAULT_AGENT_NAME
             default_label = " [dim](default)[/dim]" if is_default else ""
 
             bullet = get_glyphs().bullet
@@ -118,14 +120,20 @@ def list_agents(*, output_format: OutputFormat = "text") -> None:
                     f"  {bullet} [bold]{agent_name}[/bold]{default_label}",
                     style=COLORS["primary"],
                 )
-                console.print(f"    {agent_path}", style=COLORS["dim"])
+                console.print(
+                    f"    {escape_markup(str(agent_path))}",
+                    style=COLORS["dim"],
+                )
             else:
                 console.print(
                     f"  {bullet} [bold]{agent_name}[/bold]{default_label}"
                     " [dim](incomplete)[/dim]",
                     style=COLORS["tool"],
                 )
-                console.print(f"    {agent_path}", style=COLORS["dim"])
+                console.print(
+                    f"    {escape_markup(str(agent_path))}",
+                    style=COLORS["dim"],
+                )
 
     console.print()
 

--- a/libs/cli/deepagents_cli/input.py
+++ b/libs/cli/deepagents_cli/input.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import unquote, urlparse
 
+from rich.markup import escape as escape_markup
+
 from deepagents_cli.config import console
 from deepagents_cli.media_utils import ImageData, VideoData
 
@@ -315,9 +317,16 @@ def parse_file_mentions(text: str) -> tuple[str, list[Path]]:
             if resolved.exists() and resolved.is_file():
                 files.append(resolved)
             else:
-                console.print(f"[yellow]Warning: File not found: {raw_path}[/yellow]")
+                console.print(
+                    f"[yellow]Warning: File not found: "
+                    f"{escape_markup(raw_path)}[/yellow]"
+                )
         except (OSError, RuntimeError) as e:
-            console.print(f"[yellow]Warning: Invalid path {raw_path}: {e}[/yellow]")
+            console.print(
+                f"[yellow]Warning: Invalid path "
+                f"{escape_markup(raw_path)}: "
+                f"{escape_markup(str(e))}[/yellow]"
+            )
 
     return text, files
 

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -9,6 +9,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from rich.markup import escape as escape_markup
+
 from deepagents_cli.config import console, get_glyphs
 
 if TYPE_CHECKING:
@@ -35,7 +37,9 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
         msg = f"Setup script not found: {setup_script_path}"
         raise FileNotFoundError(msg)
 
-    console.print(f"[dim]Running setup script: {setup_script_path}...[/dim]")
+    console.print(
+        f"[dim]Running setup script: {escape_markup(setup_script_path)}...[/dim]"
+    )
 
     # Read script content
     script_content = script_path.read_text(encoding="utf-8")
@@ -49,7 +53,7 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
 
     if result.exit_code != 0:
         console.print(f"[red]Setup script failed (exit {result.exit_code}):[/red]")
-        console.print(f"[dim]{result.output}[/dim]")
+        console.print(f"[dim]{escape_markup(result.output)}[/dim]")
         msg = "Setup failed - aborting"
         raise RuntimeError(msg)
 

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -33,6 +33,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.types import Command, Interrupt
 from pydantic import TypeAdapter, ValidationError
 from rich.console import Console
+from rich.markup import escape as escape_markup
 from rich.style import Style
 from rich.text import Text
 
@@ -291,7 +292,9 @@ def _process_ai_message(
                 state.tool_call_buffers[buffer_key]["name"] = chunk_name
                 if state.full_response and not state.quiet:
                     _write_newline()
-                console.print(f"[dim]🔧 Calling tool: {chunk_name}[/dim]")
+                console.print(
+                    f"[dim]🔧 Calling tool: {escape_markup(chunk_name)}[/dim]"
+                )
 
 
 def _process_message_chunk(
@@ -331,7 +334,7 @@ def _process_message_chunk(
     elif isinstance(message_obj, ToolMessage):
         record = file_op_tracker.complete_with_message(message_obj)
         if record and record.diff:
-            console.print(f"[dim]📝 {record.display_path}[/dim]")
+            console.print(f"[dim]📝 {escape_markup(record.display_path)}[/dim]")
 
 
 def _process_stream_chunk(
@@ -426,12 +429,14 @@ def _make_hitl_decision(
         command = action_request.get("args", {}).get("command", "")
 
         if is_shell_command_allowed(command, settings.shell_allow_list):
-            console.print(f"[dim]✓ Auto-approved: {command}[/dim]")
+            console.print(f"[dim]✓ Auto-approved: {escape_markup(command)}[/dim]")
             return {"type": "approve"}
 
         allowed_list_str = ", ".join(settings.shell_allow_list)
-        console.print(f"\n[red]Shell command rejected:[/red] {command}")
-        console.print(f"[yellow]Allowed commands:[/yellow] {allowed_list_str}")
+        console.print(f"\n[red]Shell command rejected:[/red] {escape_markup(command)}")
+        console.print(
+            f"[yellow]Allowed commands:[/yellow] {escape_markup(allowed_list_str)}"
+        )
         return {
             "type": "reject",
             "message": (
@@ -441,7 +446,7 @@ def _make_hitl_decision(
             ),
         }
 
-    console.print(f"[dim]✓ Auto-approved action: {action_name}[/dim]")
+    console.print(f"[dim]✓ Auto-approved action: {escape_markup(action_name)}[/dim]")
     return {"type": "approve"}
 
 
@@ -858,7 +863,7 @@ async def run_non_interactive(
         console.print("\n[yellow]Interrupted[/yellow]")
         return 130
     except HITLIterationLimitError as e:
-        console.print(f"\n[red]{e}[/red]")
+        console.print(f"\n[red]{escape_markup(str(e))}[/red]")
         console.print(
             "[yellow]Hint: The agent may be repeatedly attempting commands "
             "that are not in the allow-list. Consider expanding the "
@@ -867,11 +872,14 @@ async def run_non_interactive(
         return 1
     except (ValueError, OSError) as e:
         logger.exception("Error during non-interactive execution")
-        console.print(f"\n[red]Error: {e}[/red]")
+        console.print(f"\n[red]Error: {escape_markup(str(e))}[/red]")
         return 1
     except Exception as e:
         logger.exception("Unexpected error during non-interactive execution")
-        console.print(f"\n[red]Unexpected error ({type(e).__name__}): {e}[/red]")
+        console.print(
+            f"\n[red]Unexpected error ({type(e).__name__}): "
+            f"{escape_markup(str(e))}[/red]"
+        )
         return 1
     else:
         return 0

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -1116,6 +1116,7 @@ async def list_threads_command(
         write_json("threads list", list(threads))
         return
 
+    from rich.markup import escape as escape_markup
     from rich.table import Table
 
     from deepagents_cli.config import COLORS, console
@@ -1123,9 +1124,9 @@ async def list_threads_command(
     if not threads:
         filters = []
         if agent_name:
-            filters.append(f"agent '{agent_name}'")
+            filters.append(f"agent '{escape_markup(agent_name)}'")
         if branch:
-            filters.append(f"branch '{branch}'")
+            filters.append(f"branch '{escape_markup(branch)}'")
         if filters:
             console.print(
                 f"[yellow]No threads found for {' and '.join(filters)}.[/yellow]"
@@ -1137,9 +1138,10 @@ async def list_threads_command(
 
     title_parts = []
     if agent_name:
-        title_parts.append(f"agent '{agent_name}'")
+        title_parts.append(f"agent '{escape_markup(agent_name)}'")
     if branch:
-        title_parts.append(f"branch '{branch}'")
+        title_parts.append(f"branch '{escape_markup(branch)}'")
+
     title_filter = f" for {' and '.join(title_parts)}" if title_parts else ""
     sort_label = "created" if sort_by == "created" else "updated"
     title = f"Recent Threads{title_filter} (last {limit}, by {sort_label})"
@@ -1209,9 +1211,12 @@ async def delete_thread_command(
         write_json("threads delete", {"thread_id": thread_id, "deleted": deleted})
         return
 
+    from rich.markup import escape as escape_markup
+
     from deepagents_cli.config import console
 
+    escaped_id = escape_markup(thread_id)
     if deleted:
-        console.print(f"[green]Thread '{thread_id}' deleted.[/green]")
+        console.print(f"[green]Thread '{escaped_id}' deleted.[/green]")
     else:
-        console.print(f"[red]Thread '{thread_id}' not found.[/red]")
+        console.print(f"[red]Thread '{escaped_id}' not found.[/red]")

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
     from deepagents_cli.output import OutputFormat
 
+from rich.markup import escape as escape_markup
+
 from deepagents_cli.config import COLORS, Settings, console, get_glyphs
 from deepagents_cli.ui import (
     build_help_parent,
@@ -280,11 +282,17 @@ def _list(
         bullet = get_glyphs().bullet
         for skill in user_skills:
             skill_path = Path(skill["path"])
-            name = skill["name"]
+            name = escape_markup(skill["name"])
             console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
-            console.print(f"    {skill_path.parent}/", style=COLORS["dim"])
+            console.print(
+                f"    {escape_markup(str(skill_path.parent))}/",
+                style=COLORS["dim"],
+            )
             console.print()
-            console.print(f"    {skill['description']}", style=COLORS["dim"])
+            console.print(
+                f"    {escape_markup(skill['description'])}",
+                style=COLORS["dim"],
+            )
             console.print()
 
     # Show project skills
@@ -297,11 +305,17 @@ def _list(
         bullet = get_glyphs().bullet
         for skill in project_skills_list:
             skill_path = Path(skill["path"])
-            name = skill["name"]
+            name = escape_markup(skill["name"])
             console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
-            console.print(f"    {skill_path.parent}/", style=COLORS["dim"])
+            console.print(
+                f"    {escape_markup(str(skill_path.parent))}/",
+                style=COLORS["dim"],
+            )
             console.print()
-            console.print(f"    {skill['description']}", style=COLORS["dim"])
+            console.print(
+                f"    {escape_markup(skill['description'])}",
+                style=COLORS["dim"],
+            )
             console.print()
 
     # Show built-in skills
@@ -313,10 +327,13 @@ def _list(
         )
         bullet = get_glyphs().bullet
         for skill in built_in_skills_list:
-            name = skill["name"]
+            name = escape_markup(skill["name"])
             console.print(f"  {bullet} [bold]{name}[/bold]", style=COLORS["primary"])
             console.print()
-            console.print(f"    {skill['description']}", style=COLORS["dim"])
+            console.print(
+                f"    {escape_markup(skill['description'])}",
+                style=COLORS["dim"],
+            )
             console.print()
 
 
@@ -592,23 +609,30 @@ def _info(
             pass
 
     console.print(
-        f"\n[bold]Skill: {skill['name']}[/bold] "
+        f"\n[bold]Skill: {escape_markup(skill['name'])}[/bold] "
         f"[bold {source_color}]({source_label})[/bold {source_color}]\n",
         style=COLORS["primary"],
     )
     if shadowed_user_skill:
         console.print(
-            f"[yellow]Note: Overrides user skill '{skill_name}' "
+            f"[yellow]Note: Overrides user skill '{escape_markup(skill_name)}' "
             "of the same name[/yellow]\n"
         )
-    console.print(f"[bold]Location:[/bold] {skill_path.parent}/\n", style=COLORS["dim"])
     console.print(
-        f"[bold]Description:[/bold] {skill['description']}\n", style=COLORS["dim"]
+        f"[bold]Location:[/bold] {escape_markup(str(skill_path.parent))}/\n",
+        style=COLORS["dim"],
+    )
+    console.print(
+        f"[bold]Description:[/bold] {escape_markup(skill['description'])}\n",
+        style=COLORS["dim"],
     )
 
     # Show optional metadata fields
     for label, value in _format_info_fields(skill):
-        console.print(f"[bold]{label}:[/bold] {value}\n", style=COLORS["dim"])
+        console.print(
+            f"[bold]{label}:[/bold] {escape_markup(value)}\n",
+            style=COLORS["dim"],
+        )
 
     # List supporting files
     skill_dir = skill_path.parent
@@ -617,7 +641,7 @@ def _info(
     if supporting_files:
         console.print("[bold]Supporting Files:[/bold]", style=COLORS["dim"])
         for file in supporting_files:
-            console.print(f"  - {file.name}", style=COLORS["dim"])
+            console.print(f"  - {escape_markup(file.name)}", style=COLORS["dim"])
         console.print()
 
     # Show the full SKILL.md content
@@ -728,12 +752,12 @@ def _delete(
             file_count = -1
 
         console.print(
-            f"\n[bold]Skill:[/bold] {skill_name}"
+            f"\n[bold]Skill:[/bold] {escape_markup(skill_name)}"
             f" [bold {source_color}]({source_label})[/bold {source_color}]",
             style=COLORS["primary"],
         )
         console.print(
-            f"[bold]Location:[/bold] {skill_dir}/",
+            f"[bold]Location:[/bold] {escape_markup(str(skill_dir))}/",
             style=COLORS["dim"],
         )
         if file_count >= 0:

--- a/libs/cli/deepagents_cli/widgets/approval.py
+++ b/libs/cli/deepagents_cli/widgets/approval.py
@@ -205,7 +205,7 @@ class ApprovalMenu(Container):
         # Title - show count if multiple tools
         count = len(self._action_requests)
         if count == 1:
-            title = f">>> {self._tool_names[0]} Requires Approval <<<"
+            title = f">>> {escape_markup(self._tool_names[0])} Requires Approval <<<"
         else:
             title = f">>> {count} Tool Calls Require Approval <<<"
         yield Static(title, classes="approval-title")
@@ -285,14 +285,14 @@ class ApprovalMenu(Container):
 
             # Add tool header if multiple tools
             if len(self._action_requests) > 1:
-                header = Static(f"[bold]{i + 1}. {tool_name}[/bold]")
+                header = Static(f"[bold]{i + 1}. {escape_markup(tool_name)}[/bold]")
                 await self._tool_info_container.mount(header)
 
             # Show description if present
             description = action_request.get("description")
             if description:
                 desc_widget = Static(
-                    f"[dim]{description}[/dim]",
+                    f"[dim]{escape_markup(description)}[/dim]",
                     classes="approval-description",
                 )
                 await self._tool_info_container.mount(desc_widget)

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from rich.markup import escape as escape_markup
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
@@ -128,10 +129,12 @@ class CompletionOption(Static):
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if self._is_selected else "  "
 
+        escaped_label = escape_markup(self._label)
         if self._description:
-            text = f"{cursor}[bold]{self._label}[/bold]  [dim]{self._description}[/dim]"
+            escaped_desc = escape_markup(self._description)
+            text = f"{cursor}[bold]{escaped_label}[/bold]  [dim]{escaped_desc}[/dim]"
         else:
-            text = f"{cursor}[bold]{self._label}[/bold]"
+            text = f"{cursor}[bold]{escaped_label}[/bold]"
 
         self.update(text)
 

--- a/libs/cli/deepagents_cli/widgets/diff.py
+++ b/libs/cli/deepagents_cli/widgets/diff.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from rich.markup import escape as escape_markup
 from textual.containers import Vertical
 from textual.widgets import Static
 
@@ -12,19 +13,6 @@ from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
-
-
-def _escape_markup(text: str) -> str:
-    """Escape Rich markup characters in text.
-
-    Args:
-        text: Text that may contain Rich markup
-
-    Returns:
-        Escaped text safe for Rich rendering
-    """
-    # Escape brackets that could be interpreted as markup
-    return text.replace("[", r"\[").replace("]", r"\]")
 
 
 def format_diff_textual(diff: str, max_lines: int | None = 100) -> str:
@@ -88,7 +76,7 @@ def format_diff_textual(diff: str, max_lines: int | None = 100) -> str:
 
         # Handle diff lines - use gutter bar instead of +/- prefix
         content = line[1:] if line else ""
-        escaped_content = _escape_markup(content)
+        escaped_content = escape_markup(content)
 
         if line.startswith("-"):
             # Deletion - red gutter bar, subtle red background

--- a/libs/cli/deepagents_cli/widgets/mcp_viewer.py
+++ b/libs/cli/deepagents_cli/widgets/mcp_viewer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
+from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical, VerticalScroll
 from textual.events import (
@@ -39,9 +40,9 @@ class MCPToolItem(Static):
             index: Flat index of this tool in the list.
             classes: CSS classes.
         """
-        label = f"  {name}"
+        label = f"  {escape_markup(name)}"
         if description:
-            label += f" [dim]{description}[/dim]"
+            label += f" [dim]{escape_markup(description)}[/dim]"
         super().__init__(label, classes=classes)
         self.tool_name = name
         self.tool_description = description
@@ -62,7 +63,7 @@ class MCPToolItem(Static):
             Rich-markup label.
         """
         if not description:
-            return f"  {name}"
+            return f"  {escape_markup(name)}"
         prefix_len = 2 + len(name) + 1
         avail = self.size.width - prefix_len - 1 if self.size.width else 0
         ellipsis = " (...)"
@@ -71,7 +72,7 @@ class MCPToolItem(Static):
             desc_text = description[:cut] + ellipsis
         else:
             desc_text = description
-        return f"  {name} [dim]{desc_text}[/dim]"
+        return f"  {escape_markup(name)} [dim]{escape_markup(desc_text)}[/dim]"
 
     @staticmethod
     def _format_expanded(name: str, description: str) -> str:
@@ -84,9 +85,9 @@ class MCPToolItem(Static):
         Returns:
             Rich-markup label with full description on next line.
         """
-        lines = f"  [bold]{name}[/bold]"
+        lines = f"  [bold]{escape_markup(name)}[/bold]"
         if description:
-            lines += f"\n    [dim]{description}[/dim]"
+            lines += f"\n    [dim]{escape_markup(description)}[/dim]"
         return lines
 
     def toggle_expand(self) -> None:
@@ -259,8 +260,8 @@ class MCPViewerScreen(ModalScreen[None]):
                         tool_count = len(server.tools)
                         t_label = "tool" if tool_count == 1 else "tools"
                         yield Static(
-                            f"[bold]{server.name}[/bold]"
-                            f" [dim]{server.transport}"
+                            f"[bold]{escape_markup(server.name)}[/bold]"
+                            f" [dim]{escape_markup(server.transport)}"
                             f" {glyphs.bullet}"
                             f" {tool_count} {t_label}[/dim]",
                             classes="mcp-server-header",

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -877,17 +877,18 @@ class ToolCallMessage(Vertical):
                     path = Path(str(item))
                     name = path.name
                     # Color by file type
+                    escaped_name = escape_markup(name)
                     if path.suffix in {".py", ".pyx"}:
-                        lines.append(f"    [#3b82f6]{name}[/#3b82f6]")
+                        lines.append(f"    [#3b82f6]{escaped_name}[/#3b82f6]")
                     elif path.suffix in {".md", ".txt", ".rst"}:
-                        lines.append(f"    {name}")
+                        lines.append(f"    {escaped_name}")
                     elif path.suffix in {".json", ".yaml", ".yml", ".toml"}:
-                        lines.append(f"    [#f59e0b]{name}[/#f59e0b]")
+                        lines.append(f"    [#f59e0b]{escaped_name}[/#f59e0b]")
                     elif not path.suffix:
                         # Likely a directory or no extension
-                        lines.append(f"    [#10b981]{name}/[/#10b981]")
+                        lines.append(f"    [#10b981]{escaped_name}/[/#10b981]")
                     else:
-                        lines.append(f"    {name}")
+                        lines.append(f"    {escaped_name}")
 
                 truncation = None
                 if is_preview and len(items) > max_items:

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
 from textual.events import (
@@ -439,9 +440,10 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 cred_indicator = f"{glyphs.warning} missing credentials"
             else:
                 cred_indicator = f"{glyphs.question} credentials unknown"
+            escaped_prov = escape_markup(provider)
             all_widgets.append(
                 Static(
-                    f"[bold]{provider}[/bold] [dim]{cred_indicator}[/dim]",
+                    f"[bold]{escaped_prov}[/bold] [dim]{cred_indicator}[/dim]",
                     classes="model-provider-header",
                 )
             )
@@ -521,18 +523,19 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         """
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if selected else "  "
+        escaped_spec = escape_markup(model_spec)
         if not has_creds:
-            spec_text = f"[yellow]{model_spec}[/yellow]"
+            spec_text = f"[yellow]{escaped_spec}[/yellow]"
         elif is_default:
-            spec_text = f"[cyan]{model_spec}[/cyan]"
+            spec_text = f"[cyan]{escaped_spec}[/cyan]"
         else:
-            spec_text = model_spec
+            spec_text = escaped_spec
         suffix = " [dim](current)[/dim]" if current else ""
         default_suffix = " [cyan](default)[/cyan]" if is_default else ""
         if status == "deprecated":
             status_suffix = " [red](deprecated)[/red]"
         elif status:
-            status_suffix = f" [yellow]({status})[/yellow]"
+            status_suffix = f" [yellow]({escape_markup(status)})[/yellow]"
         else:
             status_suffix = ""
         return f"{cursor}{spec_text}{suffix}{default_suffix}{status_suffix}"
@@ -822,7 +825,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         elif await asyncio.to_thread(save_default_model, model_spec):
             self._default_spec = model_spec
             self.call_after_refresh(self._update_display)
-            help_widget.update(f"[bold]Default set to {model_spec}[/bold]")
+            help_widget.update(
+                f"[bold]Default set to {escape_markup(model_spec)}[/bold]"
+            )
             self.set_timer(3.0, self._restore_help_text)
         else:
             help_widget.update("[bold red]Failed to save default[/bold red]")

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -9,6 +9,7 @@ import sqlite3
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from rich.cells import cell_len
+from rich.markup import escape as escape_markup
 from rich.style import Style
 from rich.text import Text
 from textual.binding import Binding, BindingType
@@ -401,7 +402,7 @@ class DeleteThreadConfirmScreen(ModalScreen[bool]):
         """
         with Vertical(id="delete-confirm"):
             yield Static(
-                f"Delete thread [bold]{self._delete_thread_id}[/bold]?",
+                f"Delete thread [bold]{escape_markup(self._delete_thread_id)}[/bold]?",
                 classes="thread-confirm-text",
             )
             yield Static(

--- a/libs/cli/deepagents_cli/widgets/tool_widgets.py
+++ b/libs/cli/deepagents_cli/widgets/tool_widgets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from rich.markup import escape as escape_markup
 from textual.containers import Vertical
 from textual.widgets import Markdown, Static
 
@@ -15,15 +16,6 @@ _MAX_VALUE_LEN = 200
 _MAX_LINES = 30
 _MAX_DIFF_LINES = 50
 _MAX_PREVIEW_LINES = 20
-
-
-def _escape_markup(text: str) -> str:
-    """Escape Rich markup characters in text.
-
-    Returns:
-        Escaped text safe for Rich rendering.
-    """
-    return text.replace("[", r"\[").replace("]", r"\]")
 
 
 class ToolApprovalWidget(Vertical):
@@ -116,7 +108,9 @@ class EditFileApprovalWidget(ToolApprovalWidget):
 
         # File path header with stats
         stats_str = self._format_stats(additions, deletions)
-        yield Static(f"[bold cyan]File:[/bold cyan] {file_path}  {stats_str}")
+        yield Static(
+            f"[bold cyan]File:[/bold cyan] {escape_markup(file_path)}  {stats_str}"
+        )
         yield Static("")
 
         if not diff_lines and not old_string and not new_string:
@@ -211,7 +205,7 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         Returns:
             Static widget with styled diff line, or None for empty/skipped lines.
         """
-        content = _escape_markup(line[1:] if len(line) > 1 else "")
+        content = escape_markup(line[1:] if len(line) > 1 else "")
 
         if line.startswith("-"):
             return Static(f"[on #4a2020][#ff8787]- {content}[/#ff8787][/on #4a2020]")
@@ -237,7 +231,7 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         )
 
         for line in lines[:_MAX_PREVIEW_LINES]:
-            escaped = _escape_markup(line)
+            escaped = escape_markup(line)
             yield Static(f"{style} {escaped}{end_style}")
 
         if len(lines) > _MAX_PREVIEW_LINES:


### PR DESCRIPTION
Escape all dynamic strings interpolated into Rich markup f-strings across the CLI to prevent `MarkupError` crashes and garbled output when values contain square brackets (e.g., file paths like `project/[WIP]-feature`, exception messages with `[Errno 2]`, MCP tool descriptions with `[optional]`). Previously, any `[...]` in a user-controlled variable would be silently interpreted as a Rich formatting tag.