### PR TITLE
refactor(cli): migrate widget rendering from Rich `Text` to Textual `Content`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,12 @@ def send_email(to: str, msg: str, *, priority: str = "normal") -> bool:
 - **CSS reference:** https://textual.textualize.io/styles/
 - **API reference:** https://textual.textualize.io/api/
 
+**Styled text in widgets:**
+
+Prefer Textual's `Content` (`textual.content`) over Rich's `Text` for widget rendering. `Content` is immutable (like `str`) and integrates natively with Textual's rendering pipeline. Use `Content.assemble()` with `(text, style)` tuples to build styled text.
+
+IMPORTANT: `Content` requires **Textual's** `Style` (`textual.style.Style`) for rendering, not Rich's `Style` (`rich.style.Style`). Mixing Rich `Style` objects into `Content` spans will cause `TypeError` during widget rendering. String styles (`"bold cyan"`, `"dim"`) work for non-link styling. For links, use `TStyle(link=url)`. Rich `Text` is still correct for code that renders via Rich's `Console.print()` (e.g., `non_interactive.py`, `main.py`).
+
 **Textual patterns used in this codebase:**
 
 - **Workers** (`@work` decorator) for async operations - see [Workers guide](https://textual.textualize.io/guide/workers/)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -18,13 +18,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from rich.text import Text
 from textual.app import App
 from textual.binding import Binding, BindingType
 from textual.containers import Container, VerticalScroll
+from textual.content import Content
 from textual.css.query import NoMatches
 from textual.message import Message
 from textual.screen import ModalScreen
+from textual.style import Style as TStyle
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
 from deepagents_cli.config import (
@@ -1586,12 +1587,11 @@ class DeepAgentsApp(App):
         url = _COMMAND_URLS[cmd]
         await self._mount_message(UserMessage(command))
         webbrowser.open(url)
-        link = Text(url, style="dim italic")
-        link.stylize(f"link {url}", 0)
+        link = Content.styled(url, TStyle(dim=True, italic=True, link=url))
         await self._mount_message(AppMessage(link))
 
     @staticmethod
-    async def _build_thread_message(prefix: str, thread_id: str) -> str | Text:
+    async def _build_thread_message(prefix: str, thread_id: str) -> str | Content:
         """Build a thread status message, hyperlinking the ID when possible.
 
         Attempts to resolve the LangSmith thread URL with a short timeout.
@@ -1603,7 +1603,7 @@ class DeepAgentsApp(App):
             thread_id: The thread identifier.
 
         Returns:
-            A Rich `Text` with a clickable thread ID, or a plain string.
+            `Content` with a clickable thread ID, or a plain string.
         """
         try:
             url = await asyncio.wait_for(
@@ -1614,9 +1614,9 @@ class DeepAgentsApp(App):
             url = None
 
         if url:
-            return Text.assemble(
+            return Content.assemble(
                 f"{prefix}: ",
-                (thread_id, f"link {url}"),
+                (thread_id, TStyle(link=url)),
             )
         return f"{prefix}: {thread_id}"
 
@@ -1655,8 +1655,7 @@ class DeepAgentsApp(App):
             webbrowser.open(url)
         except Exception:
             logger.debug("Could not open browser for URL: %s", url, exc_info=True)
-        link = Text(url, style="dim italic")
-        link.stylize(f"link {url}", 0)
+        link = Content.styled(url, TStyle(dim=True, italic=True, link=url))
         await self._mount_message(AppMessage(link))
 
     async def _handle_command(self, command: str) -> None:
@@ -1671,7 +1670,7 @@ class DeepAgentsApp(App):
             self.exit()
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))
-            help_text = Text(
+            help_body = (
                 "Commands: /quit, /clear, /offload, /mcp, "
                 "/model [--model-params JSON] [--default], /reload, /remember, "
                 "/tokens, /threads, /trace, /changelog, /docs, /feedback, /help\n\n"
@@ -1682,10 +1681,12 @@ class DeepAgentsApp(App):
                 "  @filename       Auto-complete files and inject content\n"
                 "  /command        Slash commands (/help, /clear, /quit)\n"
                 "  !command        Run shell commands directly\n\n"
-                f"Docs: {DOCS_URL}",
-                style="dim italic",
+                "Docs: "
             )
-            help_text.stylize(f"link {DOCS_URL}", help_text.plain.index(DOCS_URL))
+            help_text = Content.assemble(
+                (help_body, "dim italic"),
+                (DOCS_URL, TStyle(dim=True, italic=True, link=DOCS_URL)),
+            )
             await self._mount_message(AppMessage(help_text))
 
         elif cmd in {"/changelog", "/docs", "/feedback"}:
@@ -2437,7 +2438,7 @@ class DeepAgentsApp(App):
         """
         try:
             thread_msg = await self._build_thread_message(prefix, thread_id)
-            if not isinstance(thread_msg, Text):
+            if not isinstance(thread_msg, Content):
                 logger.debug(
                     "Skipping thread link upgrade for %s: URL did not resolve",
                     thread_id,

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -12,8 +12,8 @@ from time import time
 from typing import TYPE_CHECKING, Any
 
 from rich.markup import escape as escape_markup
-from rich.text import Text
 from textual.containers import Vertical
+from textual.content import Content
 from textual.widgets import Markdown, Static
 
 from deepagents_cli.config import (
@@ -178,7 +178,7 @@ class UserMessage(_TimestampClickMixin, Static):
         Yields:
             Static widget containing the formatted user message.
         """
-        text = Text()
+        parts: list[str | tuple[str, str]] = []
         content = self._content
 
         # Use mode-specific prefix indicator when content starts with a
@@ -187,10 +187,10 @@ class UserMessage(_TimestampClickMixin, Static):
         mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
             glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
-            text.append(f"{glyph} ", style=f"bold {_mode_color(mode)}")
+            parts.append((f"{glyph} ", f"bold {_mode_color(mode)}"))
             content = content[1:]
         else:
-            text.append("> ", style=f"bold {COLORS['primary']}")
+            parts.append(("> ", f"bold {COLORS['primary']}"))
 
         # Highlight @mentions and /commands in the content
         last_end = 0
@@ -206,22 +206,22 @@ class UserMessage(_TimestampClickMixin, Static):
 
             # Add text before the match (unstyled)
             if start > last_end:
-                text.append(content[last_end:start])
+                parts.append(content[last_end:start])
 
             # The regex only matches tokens starting with / or @
             if token.startswith("/") and start == 0:
                 # /command at start - yellow/gold
-                text.append(token, style="bold #fbbf24")
+                parts.append((token, "bold #fbbf24"))
             elif token.startswith("@"):
                 # @file mention - green
-                text.append(token, style="bold #10b981")
+                parts.append((token, "bold #10b981"))
             last_end = end
 
         # Add remaining text after last match
         if last_end < len(content):
-            text.append(content[last_end:])
+            parts.append(content[last_end:])
 
-        yield Static(text)
+        yield Static(Content.assemble(*parts))
 
 
 class QueuedUserMessage(Static):
@@ -262,17 +262,15 @@ class QueuedUserMessage(Static):
         Yields:
             Static widget containing the formatted queued message (greyed out).
         """
-        text = Text()
         content = self._content
         mode = PREFIX_TO_MODE.get(content[:1]) if content else None
         if mode:
             glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
-            text.append(f"{glyph} ", style=f"bold {COLORS['dim']}")
+            prefix = (f"{glyph} ", f"bold {COLORS['dim']}")
             content = content[1:]
         else:
-            text.append("> ", style=f"bold {COLORS['dim']}")
-        text.append(content, style="#9ca3af")
-        yield Static(text)
+            prefix = ("> ", f"bold {COLORS['dim']}")
+        yield Static(Content.assemble(prefix, (content, "#9ca3af")))
 
 
 class AssistantMessage(_TimestampClickMixin, Vertical):
@@ -1310,10 +1308,7 @@ class ErrorMessage(_TimestampClickMixin, Static):
         """
         # Store raw content for serialization
         self._content = error
-        # Use Text object to combine styled prefix with unstyled error content
-        text = Text("Error: ", style="bold red")
-        text.append(error)
-        super().__init__(text, **kwargs)
+        super().__init__(Content.assemble(("Error: ", "bold red"), error), **kwargs)
 
     def on_mount(self) -> None:
         """Set border style based on charset mode."""
@@ -1340,23 +1335,24 @@ class AppMessage(Static):
     }
     """
 
-    def __init__(self, message: str | Text, **kwargs: Any) -> None:
+    def __init__(self, message: str | Content, **kwargs: Any) -> None:
         """Initialize a system message.
 
         Args:
-            message: The system message as a string or pre-styled Rich Text.
+            message: The system message as a string or pre-styled `Content`.
             **kwargs: Additional arguments passed to parent
         """
         # Store raw content for serialization
         self._content = message
-        # Use Text object to safely render message without markup parsing
-        content = (
-            message if isinstance(message, Text) else Text(message, style="dim italic")
+        rendered = (
+            message
+            if isinstance(message, Content)
+            else Content.styled(message, "dim italic")
         )
-        super().__init__(content, **kwargs)
+        super().__init__(rendered, **kwargs)
 
     def on_click(self, event: Click) -> None:
-        """Open Rich-style hyperlinks on single click and show timestamp."""
+        """Open style-embedded hyperlinks on single click and show timestamp."""
         open_style_link(event)
         _show_timestamp_toast(self)
 
@@ -1376,7 +1372,7 @@ class SummarizationMessage(AppMessage):
     }
     """
 
-    def __init__(self, message: str | Text | None = None, **kwargs: Any) -> None:
+    def __init__(self, message: str | Content | None = None, **kwargs: Any) -> None:
         """Initialize a summarization notification message.
 
         Args:
@@ -1386,11 +1382,11 @@ class SummarizationMessage(AppMessage):
                 Defaults to the standard summary notification.
             **kwargs: Additional arguments passed to parent.
         """
-        content: Text
+        rendered: Content
         if message is None:
-            content = Text("✓ Conversation offloaded", style="bold cyan")
-        elif isinstance(message, Text):
-            content = message
+            rendered = Content.styled("✓ Conversation offloaded", "bold cyan")
+        elif isinstance(message, Content):
+            rendered = message
         else:
-            content = Text(message, style="bold cyan")
-        super().__init__(content, **kwargs)
+            rendered = Content.styled(message, "bold cyan")
+        super().__init__(rendered, **kwargs)

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -7,8 +7,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from rich.text import Text
 from textual.containers import Horizontal
+from textual.content import Content
 from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
@@ -54,23 +54,19 @@ class ModelLabel(Widget):
         """Render the model label with width-aware truncation.
 
         Returns:
-            Right-aligned text, truncated from the left when necessary.
+            Text content, truncated from the left when necessary.
         """
         width = self.content_size.width
         if not self.model or width <= 0:
             return ""
         full = f"{self.provider}:{self.model}" if self.provider else self.model
         if len(full) <= width:
-            return Text(full, no_wrap=True, justify="right")
+            return Content(full)
         if len(self.model) <= width:
-            return Text(self.model, no_wrap=True, justify="right")
+            return Content(self.model)
         if width > 1:
-            return Text(
-                "\u2026" + self.model[-(width - 1) :],
-                no_wrap=True,
-                justify="right",
-            )
-        return Text("\u2026", no_wrap=True, justify="right")
+            return Content("\u2026" + self.model[-(width - 1) :])
+        return Content("\u2026")
 
 
 class StatusBar(Horizontal):

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -10,14 +10,15 @@ from typing import TYPE_CHECKING, ClassVar, cast
 
 from rich.cells import cell_len
 from rich.markup import escape as escape_markup
-from rich.style import Style
-from rich.text import Text
 from textual.binding import Binding, BindingType
+from textual.color import Color as TColor
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.content import Content
 from textual.css.query import NoMatches
 from textual.fuzzy import Matcher
 from textual.message import Message
 from textual.screen import ModalScreen
+from textual.style import Style as TStyle
 from textual.widgets import Checkbox, Input, Static
 
 if TYPE_CHECKING:
@@ -692,7 +693,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 self._selected_index = i
                 break
 
-    def _build_title(self, thread_url: str | None = None) -> str | Text:
+    def _build_title(self, thread_url: str | None = None) -> str | Content:
         """Build the title, optionally with a clickable thread ID link.
 
         Args:
@@ -700,14 +701,17 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 rendered as a clickable hyperlink.
 
         Returns:
-            Plain string or Rich `Text` with an embedded hyperlink.
+            Plain string or `Content` with an embedded hyperlink.
         """
         if not self._current_thread:
             return "Select Thread"
         if thread_url:
-            return Text.assemble(
+            return Content.assemble(
                 "Select Thread (current: ",
-                (self._current_thread, Style(color="cyan", link=thread_url)),
+                (
+                    self._current_thread,
+                    TStyle(foreground=TColor.parse("cyan"), link=thread_url),
+                ),
                 ")",
             )
         return f"Select Thread (current: {self._current_thread})"

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
-from rich.style import Style
-from rich.text import Text
+from textual.color import Color as TColor
+from textual.content import Content
+from textual.style import Style as TStyle
 from textual.widgets import Static
 
 if TYPE_CHECKING:
@@ -121,11 +122,11 @@ class WelcomeBanner(Static):
         self.update(self._build_banner(self._project_url))
 
     def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
-        """Open Rich-style hyperlinks on single click."""
+        """Open style-embedded hyperlinks on single click."""
         open_style_link(event)
 
-    def _build_banner(self, project_url: str | None = None) -> Text:
-        """Build the banner rich text.
+    def _build_banner(self, project_url: str | None = None) -> Content:
+        """Build the banner content.
 
         When a `project_url` is provided and a thread ID is set, the thread ID
         is rendered as a clickable hyperlink to the LangSmith thread view.
@@ -135,29 +136,40 @@ class WelcomeBanner(Static):
                 name and thread ID. When `None`, text is rendered without links.
 
         Returns:
-            Rich Text object containing the formatted banner.
+            Content object containing the formatted banner.
         """
-        banner = Text()
+        parts: list[str | tuple[str, str | TStyle] | Content] = []
         # Use orange for local, green for production
         banner_color = (
             COLORS["primary_dev"] if _is_editable_install() else COLORS["primary"]
         )
-        banner.append(get_banner() + "\n", style=Style(bold=True, color=banner_color))
+        parts.append(
+            (
+                get_banner() + "\n",
+                TStyle(foreground=TColor.parse(banner_color), bold=True),
+            )
+        )
 
         if self._project_name:
-            banner.append(f"{get_glyphs().checkmark} ", style="green")
-            banner.append("LangSmith tracing: ")
+            parts.extend(
+                [
+                    (f"{get_glyphs().checkmark} ", "green"),
+                    "LangSmith tracing: ",
+                ]
+            )
             if project_url:
-                banner.append(
-                    f"'{self._project_name}'",
-                    style=Style(
-                        color="cyan",
-                        link=f"{project_url}?utm_source=deepagents-cli",
-                    ),
+                parts.append(
+                    (
+                        f"'{self._project_name}'",
+                        TStyle(
+                            foreground=TColor.parse("cyan"),
+                            link=f"{project_url}?utm_source=deepagents-cli",
+                        ),
+                    )
                 )
             else:
-                banner.append(f"'{self._project_name}'", style="cyan")
-            banner.append("\n")
+                parts.append((f"'{self._project_name}'", "cyan"))
+            parts.append("\n")
 
         if self._cli_thread_id:
             if project_url:
@@ -165,72 +177,69 @@ class WelcomeBanner(Static):
                     f"{project_url.rstrip('/')}/t/{self._cli_thread_id}"
                     "?utm_source=deepagents-cli"
                 )
-                thread_line = Text.assemble(
-                    ("Thread: ", "dim"),
-                    (self._cli_thread_id, Style(dim=True, link=thread_url)),
-                    ("\n", "dim"),
+                parts.extend(
+                    [
+                        ("Thread: ", "dim"),
+                        (self._cli_thread_id, TStyle(dim=True, link=thread_url)),
+                        ("\n", "dim"),
+                    ]
                 )
-                banner.append_text(thread_line)
             else:
-                banner.append(f"Thread: {self._cli_thread_id}\n", style="dim")
+                parts.append((f"Thread: {self._cli_thread_id}\n", "dim"))
 
         if self._mcp_tool_count > 0:
-            banner.append(f"{get_glyphs().checkmark} ", style="green")
+            parts.append((f"{get_glyphs().checkmark} ", "green"))
             label = "MCP tool" if self._mcp_tool_count == 1 else "MCP tools"
-            banner.append(f"Loaded {self._mcp_tool_count} {label}\n")
+            parts.append(f"Loaded {self._mcp_tool_count} {label}\n")
 
         if self._failed:
-            banner.append_text(build_failure_footer(self._failure_error))
+            parts.append(build_failure_footer(self._failure_error))
         elif self._connecting:
-            banner.append_text(build_connecting_footer())
+            parts.append(build_connecting_footer())
         else:
-            banner.append_text(build_welcome_footer())
-        return banner
+            parts.append(build_welcome_footer())
+        return Content.assemble(*parts)
 
 
-def build_failure_footer(error: str) -> Text:
+def build_failure_footer(error: str) -> Content:
     """Build a footer shown when the server failed to start.
 
     Args:
         error: Error message describing the failure.
 
     Returns:
-        Rich Text with a persistent failure message.
+        Content with a persistent failure message.
     """
-    footer = Text()
-    footer.append("\nServer failed to start: ", style="bold red")
-    footer.append(error, style="red")
-    footer.append("\n", style="red")
-    return footer
+    return Content.assemble(
+        ("\nServer failed to start: ", "bold red"),
+        (error, "red"),
+        ("\n", "red"),
+    )
 
 
-def build_connecting_footer() -> Text:
+def build_connecting_footer() -> Content:
     """Build a footer shown while waiting for the server to connect.
 
     Returns:
-        Rich Text with a connecting status message.
+        Content with a connecting status message.
     """
-    footer = Text()
-    footer.append("\nConnecting to server...\n", style="dim")
-    return footer
+    return Content.styled("\nConnecting to server...\n", "dim")
 
 
-def build_welcome_footer() -> Text:
+def build_welcome_footer() -> Content:
     """Build the two-line footer shown at the bottom of the welcome banner.
 
     Returns:
-        Rich Text with the ready prompt and keyboard shortcut help line.
+        Content with the ready prompt and keyboard shortcut help line.
     """
-    footer = Text()
-    footer.append(
-        "\nReady to code! What would you like to build?\n", style=COLORS["primary"]
-    )
     bullet = get_glyphs().bullet
-    footer.append(
+    return Content.assemble(
+        ("\nReady to code! What would you like to build?\n", COLORS["primary"]),
         (
-            f"Enter send {bullet} {newline_shortcut()} newline "
-            f"{bullet} @ files {bullet} / commands"
+            (
+                f"Enter send {bullet} {newline_shortcut()} newline "
+                f"{bullet} @ files {bullet} / commands"
+            ),
+            "dim",
         ),
-        style="dim",
     )
-    return footer

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rich.markup import render
 from rich.style import Style
-from rich.text import Text
+from textual.content import Content
 
 from deepagents_cli.config import COLORS
 from deepagents_cli.input import INPUT_HIGHLIGHT_PATTERN
@@ -65,6 +65,13 @@ class TestErrorMessageMarkupSafety:
         msg = ErrorMessage(error)
         assert msg is not None
 
+    def test_error_message_has_prefix_and_body(self) -> None:
+        """ErrorMessage content should have `'Error: '` prefix followed by the body."""
+        msg = ErrorMessage("something broke")
+        rendered = msg._Static__content  # type: ignore[attr-defined]
+        assert isinstance(rendered, Content)
+        assert rendered.plain == "Error: something broke"
+
 
 class TestAppMessageMarkupSafety:
     """Test AppMessage handles content with brackets safely."""
@@ -81,6 +88,20 @@ class TestAppMessageMarkupSafety:
         msg = AppMessage(content)
         assert msg is not None
 
+    def test_app_message_str_gets_dim_italic(self) -> None:
+        """String input should be rendered as dim italic `Content`."""
+        msg = AppMessage("hello")
+        rendered = msg._Static__content  # type: ignore[attr-defined]
+        assert isinstance(rendered, Content)
+        assert rendered.plain == "hello"
+
+    def test_app_message_content_passthrough(self) -> None:
+        """Pre-styled `Content` should pass through unchanged."""
+        pre = Content.styled("styled", "bold cyan")
+        msg = AppMessage(pre)
+        rendered = msg._Static__content  # type: ignore[attr-defined]
+        assert rendered is pre
+
 
 class TestSummarizationMessage:
     """Tests for summarization notification widget."""
@@ -94,6 +115,20 @@ class TestSummarizationMessage:
         """SummarizationMessage should be treated like an AppMessage."""
         msg = SummarizationMessage()
         assert isinstance(msg, AppMessage)
+
+    def test_summarization_message_str_input(self) -> None:
+        """String input should be rendered as bold cyan `Content`."""
+        msg = SummarizationMessage("custom text")
+        rendered = msg._Static__content  # type: ignore[attr-defined]
+        assert isinstance(rendered, Content)
+        assert rendered.plain == "custom text"
+
+    def test_summarization_message_content_passthrough(self) -> None:
+        """Pre-styled `Content` should pass through unchanged."""
+        pre = Content.styled("pre-styled", "bold cyan")
+        msg = SummarizationMessage(pre)
+        rendered = msg._Static__content  # type: ignore[attr-defined]
+        assert rendered is pre
 
 
 class TestToolCallMessageMarkupSafety:
@@ -294,13 +329,13 @@ class TestUserMessageHighlighting:
         assert len(matches) == 0
 
 
-def _compose_text(widget: UserMessage | QueuedUserMessage) -> Text:
-    """Extract the Rich `Text` object from a message widget's first yielded Static."""
+def _compose_content(widget: UserMessage | QueuedUserMessage) -> Content:
+    """Extract the `Content` object from a message widget's first yielded Static."""
     statics = list(widget.compose())
     assert statics, "compose() yielded no widgets"
-    content = statics[0]._Static__content  # type: ignore[attr-defined]
-    assert isinstance(content, Text)
-    return content
+    result = statics[0]._Static__content  # type: ignore[attr-defined]
+    assert isinstance(result, Content)
+    return result
 
 
 class TestUserMessageModeRendering:
@@ -308,29 +343,29 @@ class TestUserMessageModeRendering:
 
     def test_shell_prefix_renders_dollar_indicator(self) -> None:
         """`UserMessage('!ls')` should render with `'$ '` prefix and shell body."""
-        text = _compose_text(UserMessage("!ls"))
-        assert text.plain == "$ ls"
-        first_span = text._spans[0]
+        content = _compose_content(UserMessage("!ls"))
+        assert content.plain == "$ ls"
+        first_span = content._spans[0]
         assert COLORS["mode_shell"] in str(first_span.style)
 
     def test_command_prefix_renders_slash_indicator(self) -> None:
         """`UserMessage('/help')` should render with `'/ '` prefix and body."""
-        text = _compose_text(UserMessage("/help"))
-        assert text.plain == "/ help"
-        first_span = text._spans[0]
+        content = _compose_content(UserMessage("/help"))
+        assert content.plain == "/ help"
+        first_span = content._spans[0]
         assert COLORS["mode_command"] in str(first_span.style)
 
     def test_normal_message_renders_angle_bracket(self) -> None:
         """`UserMessage('hello')` should render with `'> '` prefix."""
-        text = _compose_text(UserMessage("hello"))
-        assert text.plain == "> hello"
-        first_span = text._spans[0]
+        content = _compose_content(UserMessage("hello"))
+        assert content.plain == "> hello"
+        first_span = content._spans[0]
         assert COLORS["primary"] in str(first_span.style)
 
     def test_empty_content_renders_angle_bracket(self) -> None:
         """`UserMessage('')` should not crash and should render `'> '` prefix."""
-        text = _compose_text(UserMessage(""))
-        assert text.plain == "> "
+        content = _compose_content(UserMessage(""))
+        assert content.plain == "> "
 
 
 class TestQueuedUserMessageModeRendering:
@@ -338,23 +373,23 @@ class TestQueuedUserMessageModeRendering:
 
     def test_shell_prefix_renders_dimmed_dollar(self) -> None:
         """`QueuedUserMessage('!ls')` should render dimmed `'$ '` prefix."""
-        text = _compose_text(QueuedUserMessage("!ls"))
-        assert text.plain == "$ ls"
+        content = _compose_content(QueuedUserMessage("!ls"))
+        assert content.plain == "$ ls"
 
     def test_command_prefix_renders_dimmed_slash(self) -> None:
         """`QueuedUserMessage('/help')` should render dimmed `'/ '` prefix."""
-        text = _compose_text(QueuedUserMessage("/help"))
-        assert text.plain == "/ help"
+        content = _compose_content(QueuedUserMessage("/help"))
+        assert content.plain == "/ help"
 
     def test_normal_message_renders_dimmed_angle_bracket(self) -> None:
         """`QueuedUserMessage('hello')` should render dimmed `'> '` prefix."""
-        text = _compose_text(QueuedUserMessage("hello"))
-        assert text.plain == "> hello"
+        content = _compose_content(QueuedUserMessage("hello"))
+        assert content.plain == "> hello"
 
     def test_empty_content_renders_angle_bracket(self) -> None:
         """`QueuedUserMessage('')` should not crash and should render `'> '`."""
-        text = _compose_text(QueuedUserMessage(""))
-        assert text.plain == "> "
+        content = _compose_content(QueuedUserMessage(""))
+        assert content.plain == "> "
 
 
 class TestAppMessageAutoLinksDisabled:
@@ -369,10 +404,10 @@ _WEBBROWSER_OPEN = "deepagents_cli.widgets._links.webbrowser.open"
 
 
 class TestAppMessageOnClickOpensLink:
-    """Tests for `AppMessage.on_click` opening Rich-style hyperlinks."""
+    """Tests for `AppMessage.on_click` opening style-embedded hyperlinks."""
 
     def test_click_on_link_opens_browser(self) -> None:
-        """Clicking a Rich link should call `webbrowser.open`."""
+        """Clicking a styled link should call `webbrowser.open`."""
         msg = AppMessage("test")
         event = MagicMock()
         event.style = Style(link="https://example.com")

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -800,19 +800,23 @@ class TestThreadSelectorBuildTitle:
         assert "abc12345" in title
 
     def test_current_thread_with_url(self) -> None:
-        """Title with a LangSmith URL should produce a Rich Text with a link."""
-        from rich.text import Text
+        """Title with a LangSmith URL should produce Content with a link."""
+        from textual.color import Color as TColor
+        from textual.content import Content
+        from textual.style import Style as TStyle
 
         screen = ThreadSelectorScreen(current_thread="abc12345")
         title = screen._build_title(
             thread_url="https://smith.langchain.com/p/t/abc12345"
         )
-        assert isinstance(title, Text)
+        assert isinstance(title, Content)
         assert "abc12345" in title.plain
 
-        spans = [s for s in title._spans if s.style and "link" in str(s.style)]
+        spans = [
+            s for s in title._spans if isinstance(s.style, TStyle) and s.style.link
+        ]
         assert len(spans) > 0
-        assert "cyan" in str(spans[0].style)
+        assert spans[0].style.foreground == TColor.parse("cyan")
 
     async def test_title_widget_has_id(self) -> None:
         """Title widget should be queryable by ID for URL updates."""
@@ -833,7 +837,7 @@ class TestFetchThreadUrl:
 
     async def test_successful_url_updates_title(self) -> None:
         """Background worker should update the title with a clickable link."""
-        from rich.text import Text
+        from textual.content import Content
 
         with (
             _patch_list_threads(),
@@ -853,7 +857,7 @@ class TestFetchThreadUrl:
                 assert isinstance(screen, ThreadSelectorScreen)
                 title_widget = screen.query_one("#thread-title", Static)
                 content = title_widget._Static__content
-                assert isinstance(content, Text)
+                assert isinstance(content, Content)
                 assert "abc12345" in content.plain
 
     async def test_timeout_leaves_title_unchanged(self) -> None:
@@ -2473,11 +2477,11 @@ class TestUpgradeThreadMessageLink:
 
     async def test_noop_when_widget_unmounted(self) -> None:
         """Unmounted widget should not be updated even when link resolves."""
-        from rich.text import Text
+        from textual.content import Content
 
         app = DeepAgentsApp()
         app._build_thread_message = AsyncMock(  # type: ignore[assignment]
-            return_value=Text("Resumed thread: tid-1")
+            return_value=Content("Resumed thread: tid-1")
         )
         widget = MagicMock()
         widget.parent = None
@@ -2492,11 +2496,11 @@ class TestUpgradeThreadMessageLink:
         widget.update.assert_not_called()
 
     async def test_updates_widget_when_link_resolves(self) -> None:
-        """Resolved Rich text should replace widget content."""
-        from rich.text import Text
+        """Resolved Content should replace widget content."""
+        from textual.content import Content
 
         app = DeepAgentsApp()
-        linked = Text("Resumed thread: tid-1")
+        linked = Content("Resumed thread: tid-1")
         app._build_thread_message = AsyncMock(return_value=linked)  # type: ignore[assignment]
         widget = MagicMock()
         widget.parent = object()
@@ -2525,20 +2529,23 @@ class TestBuildThreadMessage:
         assert isinstance(result, str)
 
     async def test_hyperlinked_when_tracing_configured(self) -> None:
-        """Returns Rich Text with hyperlink when LangSmith URL is available."""
-        from rich.text import Text
+        """Returns Content with hyperlink when LangSmith URL is available."""
+        from textual.content import Content
+        from textual.style import Style as TStyle
 
         app = DeepAgentsApp()
         url = "https://smith.langchain.com/o/org/projects/p/proj/t/tid-123"
         with patch("deepagents_cli.app.build_langsmith_thread_url", return_value=url):
             result = await app._build_thread_message("Resumed thread", "tid-123")
 
-        assert isinstance(result, Text)
+        assert isinstance(result, Content)
         assert "Resumed thread: " in result.plain
         assert "tid-123" in result.plain
-        spans = [s for s in result._spans if s.style and "link" in str(s.style)]
+        spans = [
+            s for s in result._spans if isinstance(s.style, TStyle) and s.style.link
+        ]
         assert len(spans) == 1
-        assert url in str(spans[0].style)
+        assert spans[0].style.link == url
 
     async def test_fallback_on_timeout(self) -> None:
         """Returns plain string when URL resolution times out."""

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -3,19 +3,22 @@
 from unittest.mock import MagicMock, patch
 
 from rich.style import Style
-from rich.text import Text
+from textual.content import Content
+from textual.style import Style as TStyle
 
-from deepagents_cli.widgets.welcome import WelcomeBanner, build_welcome_footer
+from deepagents_cli.widgets.welcome import (
+    WelcomeBanner,
+    build_connecting_footer,
+    build_failure_footer,
+    build_welcome_footer,
+)
 
 
-def _extract_links(banner: Text, text_start: int, text_end: int) -> list[str]:
+def _extract_links(banner: Content, text_start: int, text_end: int) -> list[str]:
     """Extract link URLs from spans covering the given text range.
 
-    Note: This relies on `rich.text.Text._spans` internals and may need
-    updating if the Rich library changes its internal representation.
-
     Args:
-        banner: The Rich Text object to inspect.
+        banner: The Content object to inspect.
         text_start: Start index in the plain text.
         text_end: End index in the plain text.
 
@@ -23,10 +26,14 @@ def _extract_links(banner: Text, text_start: int, text_end: int) -> list[str]:
         List of link URL strings found on spans covering the range.
     """
     links: list[str] = []
-    for start, end, style in banner._spans:
-        if not isinstance(style, Style):
-            continue
-        if start <= text_start and end >= text_end and style.link:
+    for span in banner._spans:
+        style = span.style
+        if (
+            isinstance(style, TStyle)
+            and style.link
+            and span.start <= text_start
+            and span.end >= text_end
+        ):
             links.append(style.link)
     return links
 
@@ -168,11 +175,11 @@ class TestUpdateThreadId:
 class TestBuildBannerReturnType:
     """Tests for `_build_banner` return value."""
 
-    def test_returns_rich_text(self) -> None:
-        """`_build_banner` should return a `rich.text.Text` object."""
+    def test_returns_content(self) -> None:
+        """`_build_banner` should return a `Content` object."""
         widget = _make_banner(thread_id="abc")
         result = widget._build_banner()
-        assert isinstance(result, Text)
+        assert isinstance(result, Content)
 
 
 class TestAutoLinksDisabled:
@@ -228,9 +235,9 @@ class TestOnClickOpensLink:
 class TestBuildWelcomeFooter:
     """Tests for the `build_welcome_footer` standalone function."""
 
-    def test_returns_rich_text(self) -> None:
-        """Footer should return a `rich.text.Text` object."""
-        assert isinstance(build_welcome_footer(), Text)
+    def test_returns_content(self) -> None:
+        """Footer should return a `Content` object."""
+        assert isinstance(build_welcome_footer(), Content)
 
     def test_contains_ready_prompt(self) -> None:
         """Footer should include the ready-to-code prompt."""
@@ -327,3 +334,29 @@ class TestBannerFooterPosition:
         idx = plain.index("Ready to code")
         assert plain[idx - 1] == "\n"
         assert plain[idx - 2] == "\n"
+
+
+class TestBuildFailureFooter:
+    """Tests for the `build_failure_footer` standalone function."""
+
+    def test_returns_content(self) -> None:
+        """Footer should return a `Content` object."""
+        assert isinstance(build_failure_footer("oops"), Content)
+
+    def test_contains_error_message(self) -> None:
+        """Footer should include the failure prefix and error text."""
+        plain = build_failure_footer("connection refused").plain
+        assert "Server failed to start: " in plain
+        assert "connection refused" in plain
+
+
+class TestBuildConnectingFooter:
+    """Tests for the `build_connecting_footer` standalone function."""
+
+    def test_returns_content(self) -> None:
+        """Footer should return a `Content` object."""
+        assert isinstance(build_connecting_footer(), Content)
+
+    def test_contains_connecting_message(self) -> None:
+        """Footer should include the connecting status text."""
+        assert "Connecting to server..." in build_connecting_footer().plain


### PR DESCRIPTION
Migrate CLI widget rendering from Rich's `Text` to Textual's native `Content`. `Content` is immutable (like `str`) and renders through Textual's pipeline without the Rich-to-Textual translation layer. Rich `Text` remains in files that render via `Console.print()` (e.g., `non_interactive.py`, `main.py`).

## Changes
- Replace all `rich.text.Text` usage in widget code with `textual.content.Content` — mutable `Text().append()` chains become `Content.assemble(*parts)` with `(text, style)` tuples, and `Text(s, style=...)` becomes `Content.styled(s, style)`
- Use `textual.style.Style` (aliased `TStyle`) for link-bearing styles (`TStyle(link=url)`) and string shorthand (`"bold red"`, `"dim"`) for non-link styling — mixing Rich's `Style` into `Content` spans causes `TypeError` at render time
- `ModelLabel.render` returns bare `Content(text)` instead of `Text(text, no_wrap=True, justify="right")` — right-alignment is already handled by CSS `text-align: right` on the widget
- Update type signatures across `AppMessage`, `SummarizationMessage`, `_build_thread_message`, `_build_title`, and `_build_banner` from `Text` to `Content`
- Document the `Content` vs `Text` boundary in `AGENTS.md` under a new "Styled text in widgets" section