### PR TITLE
fix(cli): replace per-chunk `scroll_end` with anchor to fix scrollbar flicker

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -680,8 +680,9 @@ class DeepAgentsApp(App):
 
     async def on_mount(self) -> None:
         """Initialize components after mount."""
+        chat = self.query_one("#chat", VerticalScroll)
+        chat.anchor()
         if _detect_charset_mode() == CharsetMode.ASCII:
-            chat = self.query_one("#chat", VerticalScroll)
             chat.styles.scrollbar_size_vertical = 0
 
         self._status_bar = self.query_one("#status-bar", StatusBar)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from textual.app import App
+from textual.app import App, ScreenStackError
 from textual.binding import Binding, BindingType
 from textual.containers import Container, VerticalScroll
 from textual.content import Content
@@ -773,7 +773,6 @@ class DeepAgentsApp(App):
             update_status=self._update_status,
             request_approval=self._request_approval,
             on_auto_approve_enabled=self._on_auto_approve_enabled,
-            scroll_to_bottom=self._scroll_chat_to_bottom,
             set_spinner=self._set_spinner,
             set_active_message=self._set_active_message,
             sync_message_content=self._sync_message_content,
@@ -968,24 +967,6 @@ class DeepAgentsApp(App):
         if self._status_bar:
             self._status_bar.hide_tokens()
 
-    def _scroll_chat_to_bottom(self) -> None:
-        """Scroll chat to bottom using sticky scroll pattern.
-
-        Only scrolls if user is already at/near the bottom.
-        This prevents dragging the user back if they've scrolled up to read.
-        """
-        chat = self.query_one("#chat", VerticalScroll)
-
-        # Nothing to scroll if content fits in viewport
-        if chat.max_scroll_y <= 0:
-            return
-
-        # Sticky scroll: only scroll to bottom if user is near the bottom
-        # "Near" means within 100 pixels of the bottom (about 6-7 lines)
-        distance_from_bottom = chat.max_scroll_y - chat.scroll_y
-        if distance_from_bottom < 100:  # noqa: PLR2004  # Pixel distance threshold for sticky scroll
-            chat.scroll_end(animate=False)
-
     def _check_hydration_needed(self) -> None:
         """Check if we need to hydrate messages from the store.
 
@@ -1159,8 +1140,8 @@ class DeepAgentsApp(App):
             if not self._is_spinner_at_correct_position(messages):
                 await self._loading_widget.remove()
                 await self._mount_before_queued(messages, self._loading_widget)
-        # NOTE: Don't call _scroll_chat_to_bottom() here - it would re-anchor
-        # and drag user back to bottom if they've scrolled away during streaming
+        # NOTE: Don't call anchor() here - it would re-anchor and drag user back
+        # to bottom if they've scrolled away during streaming
 
     async def _request_approval(
         self,
@@ -1216,7 +1197,8 @@ class DeepAgentsApp(App):
                             f"✓ Auto-approved shell command (allow-list): {command}"
                         )
                         await self._mount_before_queued(messages, auto_msg)
-                    self._scroll_chat_to_bottom()
+                    with suppress(NoMatches, ScreenStackError):
+                        self.query_one("#chat", VerticalScroll).anchor()
                 except Exception:  # noqa: S110, BLE001  # Resilient auto-message display
                     pass  # Don't fail if we can't show the message
 
@@ -1510,9 +1492,9 @@ class DeepAgentsApp(App):
             if proc.returncode and proc.returncode != 0:
                 await self._mount_message(ErrorMessage(f"Exit code: {proc.returncode}"))
 
-            # Scroll to show the output (user-initiated command, so scroll is expected)
-            chat = self.query_one("#chat", VerticalScroll)
-            chat.scroll_end(animate=False)
+            # Anchor to bottom so shell output stays visible
+            with suppress(NoMatches, ScreenStackError):
+                self.query_one("#chat", VerticalScroll).anchor()
 
         except OSError as e:
             logger.exception("Failed to execute shell command: %s", command)
@@ -1887,18 +1869,9 @@ class DeepAgentsApp(App):
             await self._mount_message(UserMessage(command))
             await self._mount_message(AppMessage(f"Unknown command: {cmd}"))
 
-        # Scroll to bottom after command output is rendered.
-        # Use call_after_refresh so the layout pass completes first;
-        # otherwise max_scroll_y is still stale.
-        def _scroll_after_command() -> None:
-            try:
-                chat = self.query_one("#chat", VerticalScroll)
-                if chat.max_scroll_y > 0:
-                    chat.scroll_end(animate=False)
-            except NoMatches:
-                pass
-
-        self.call_after_refresh(_scroll_after_command)
+        # Anchor to bottom so command output stays visible
+        with suppress(NoMatches, ScreenStackError):
+            self.query_one("#chat", VerticalScroll).anchor()
 
     async def _get_conversation_token_count(self) -> int | None:
         """Return the approximate conversation-only token count.
@@ -2093,13 +2066,9 @@ class DeepAgentsApp(App):
         # Mount the user message
         await self._mount_message(UserMessage(message))
 
-        # Scroll to bottom when user sends a new message
-        try:
-            chat = self.query_one("#chat", VerticalScroll)
-            if chat.max_scroll_y > 0:
-                chat.scroll_end(animate=False)
-        except NoMatches:
-            pass
+        # Anchor to bottom so streaming response stays visible
+        with suppress(NoMatches, ScreenStackError):
+            self.query_one("#chat", VerticalScroll).anchor()
 
         # Check if agent is available
         if self._agent and self._ui_adapter and self._session_state:
@@ -2567,7 +2536,7 @@ class DeepAgentsApp(App):
                 thread_id=history_thread_id,
             )
 
-            # 10. Scroll once
+            # 10. Scroll once to bottom after history loads
             def scroll_to_end() -> None:
                 with suppress(NoMatches):
                     chat = self.query_one("#chat", VerticalScroll)
@@ -3349,16 +3318,9 @@ class DeepAgentsApp(App):
                 await self._mount_message(AppMessage(f"Switched to {display}"))
             logger.info("Model switched to %s (via configurable middleware)", display)
 
-            # Scroll to bottom so the confirmation message is visible
-            def _scroll_after_switch() -> None:
-                try:
-                    chat = self.query_one("#chat", VerticalScroll)
-                    if chat.max_scroll_y > 0:
-                        chat.scroll_end(animate=False)
-                except NoMatches:
-                    pass
-
-            self.call_after_refresh(_scroll_after_switch)
+            # Anchor to bottom so the confirmation message is visible
+            with suppress(NoMatches, ScreenStackError):
+                self.query_one("#chat", VerticalScroll).anchor()
         finally:
             self._model_switching = False
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -356,9 +356,6 @@ class TextualUIAdapter:
     When awaited, returns a `Future` that resolves to user answers.
     """
 
-    _scroll_to_bottom: Callable[[], None] | None
-    """Callback to scroll chat to bottom."""
-
     _set_spinner: Callable[[SpinnerStatus], Awaitable[None]] | None
     """Callback to show/hide loading spinner."""
 
@@ -380,7 +377,6 @@ class TextualUIAdapter:
         update_status: Callable[[str], None],
         request_approval: Callable[..., Awaitable[Any]],
         on_auto_approve_enabled: Callable[[], None] | None = None,
-        scroll_to_bottom: Callable[[], None] | None = None,
         set_spinner: Callable[[SpinnerStatus], Awaitable[None]] | None = None,
         set_active_message: Callable[[str | None], None] | None = None,
         sync_message_content: Callable[[str, str], None] | None = None,
@@ -402,7 +398,6 @@ class TextualUIAdapter:
                 "Auto-approve all" from an approval dialog.
 
                 Used by the app to sync the status bar indicator and session state.
-            scroll_to_bottom: Callback to scroll chat to bottom.
             set_spinner: Callback to show/hide loading spinner (pass `None` to hide).
             set_active_message: Callback to set the active streaming message ID.
             sync_message_content: Callback to sync final content back to the
@@ -414,7 +409,6 @@ class TextualUIAdapter:
         self._update_status = update_status
         self._request_approval = request_approval
         self._on_auto_approve_enabled = on_auto_approve_enabled
-        self._scroll_to_bottom = scroll_to_bottom
         self._set_spinner = set_spinner
         self._set_active_message = set_active_message
         self._sync_message_content = sync_message_content
@@ -861,12 +855,6 @@ async def execute_task_textual(
                                 # better performance)
                                 await current_msg.append_content(text)
 
-                                # Sticky scroll: scroll to bottom only if user is
-                                # near bottom. This lets users scroll away and
-                                # stay where they are
-                                if adapter._scroll_to_bottom:
-                                    adapter._scroll_to_bottom()
-
                         elif block_type in {"tool_call_chunk", "tool_call"}:
                             chunk_name = block.get("name")
                             chunk_args = block.get("args")
@@ -969,10 +957,6 @@ async def execute_task_textual(
                                 tool_msg = ToolCallMessage(buffer_name, parsed_args)
                                 await adapter._mount_message(tool_msg)
                                 adapter._current_tool_messages[buffer_id] = tool_msg
-
-                                # Sticky scroll after tool call is shown
-                                if adapter._scroll_to_bottom:
-                                    adapter._scroll_to_bottom()
 
                             tool_call_buffers.pop(buffer_key, None)
 


### PR DESCRIPTION
Replace per-chunk `scroll_end()` calls during streaming with Textual's `anchor()` API, which pins the chat container to the bottom and auto-follows new content without repeated scroll operations. The old approach fired `_scroll_chat_to_bottom()` on every text chunk and tool-call mount in the streaming loop, causing visible scrollbar flicker as `scroll_end` recalculated positions each frame.

## Changes
- Replace the custom sticky-scroll implementation in `_scroll_chat_to_bottom()` (distance-from-bottom threshold + `scroll_end`) with a single `chat.anchor()` call, then inline and delete the method — all 5 call sites now use `anchor()` directly
- Remove the `scroll_to_bottom` callback from `TextualUIAdapter` (parameter, attribute, docstring, and both per-chunk invocations in `execute_task_textual`) — the adapter no longer drives scroll behavior
- Collapse deferred `call_after_refresh` scroll callbacks (slash commands, model switch) into immediate `anchor()` calls guarded by `suppress(NoMatches, ScreenStackError)`
- Retain the one-shot `scroll_end(immediate=True)` in `_load_thread_history` since that's a single position jump after all content is mounted, not streaming follow
