### PR TITLE
refactor(cli): replace markup escape with Content API across all widgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,9 +211,18 @@ def send_email(to: str, msg: str, *, priority: str = "normal") -> bool:
 
 **Styled text in widgets:**
 
-Prefer Textual's `Content` (`textual.content`) over Rich's `Text` for widget rendering. `Content` is immutable (like `str`) and integrates natively with Textual's rendering pipeline. Use `Content.assemble()` with `(text, style)` tuples to build styled text.
+Prefer Textual's `Content` (`textual.content`) over Rich's `Text` for widget rendering. `Content` is immutable (like `str`) and integrates natively with Textual's rendering pipeline. Rich `Text` is still correct for code that renders via Rich's `Console.print()` (e.g., `non_interactive.py`, `main.py`).
 
-IMPORTANT: `Content` requires **Textual's** `Style` (`textual.style.Style`) for rendering, not Rich's `Style` (`rich.style.Style`). Mixing Rich `Style` objects into `Content` spans will cause `TypeError` during widget rendering. String styles (`"bold cyan"`, `"dim"`) work for non-link styling. For links, use `TStyle(link=url)`. Rich `Text` is still correct for code that renders via Rich's `Console.print()` (e.g., `non_interactive.py`, `main.py`).
+IMPORTANT: `Content` requires **Textual's** `Style` (`textual.style.Style`) for rendering, not Rich's `Style` (`rich.style.Style`). Mixing Rich `Style` objects into `Content` spans will cause `TypeError` during widget rendering. String styles (`"bold cyan"`, `"dim"`) work for non-link styling. For links, use `TStyle(link=url)`.
+
+**Never use f-string interpolation in Rich markup** (e.g., `f"[bold]{var}[/bold]"`). If `var` contains square brackets, the markup breaks or throws. Use `Content` methods instead:
+
+- `Content.from_markup("[bold]$var[/bold]", var=value)` — for inline markup templates. `$var` substitution auto-escapes dynamic content. **Use when the variable is external/user-controlled** (tool args, file paths, user messages, diff content, error messages from exceptions).
+- `Content.styled(text, "bold")` — single style applied to plain text. No markup parsing. Use for static strings or when the variable is internal/trusted (glyphs, ints, enum-like status values). Avoid `Content.styled(f"..{var}..", style)` when `var` is user-controlled — while `styled` doesn't parse markup, the f-string pattern is fragile and inconsistent with the `from_markup` convention.
+- `Content.assemble("prefix: ", (text, "bold"), " ", other_content)` — for composing pre-built `Content` objects, `(text, style)` tuples, and plain strings. Plain strings are treated as plain text (no markup parsing). Use for structural composition, especially when parts use `TStyle(link=url)`.
+- `content.join(parts)` — like `str.join()` for `Content` objects.
+
+**Decision rule:** if the value could ever come from outside the codebase (user input, tool output, API responses, file contents), use `from_markup` with `$var`. If it's a hardcoded string, glyph, or computed int, `styled` is fine.
 
 **Textual patterns used in this codebase:**
 

--- a/libs/cli/deepagents_cli/widgets/approval.py
+++ b/libs/cli/deepagents_cli/widgets/approval.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
+from textual.content import Content
 from textual.message import Message
 from textual.widgets import Static
 
@@ -145,14 +145,14 @@ class ApprovalMenu(Container):
         command = str(req.get("args", {}).get("command", ""))
         return len(command) > _SHELL_COMMAND_TRUNCATE_LENGTH
 
-    def _get_command_display(self, *, expanded: bool) -> str:
-        """Get the command display string (truncated or full).
+    def _get_command_display(self, *, expanded: bool) -> Content:
+        """Get the command display content (truncated or full).
 
         Args:
             expanded: Whether to show the full command or truncated version.
 
         Returns:
-            Formatted command string with Rich markup.
+            Styled Content for the command display.
 
         Raises:
             RuntimeError: If called with empty action_requests.
@@ -172,25 +172,33 @@ class ApprovalMenu(Container):
                 command[:_SHELL_COMMAND_TRUNCATE_LENGTH] + get_glyphs().ellipsis
             )
 
-        escaped_truncated = escape_markup(command_display)
-        display = f"[bold #f59e0b]{escaped_truncated}[/bold #f59e0b]"
         if not expanded and len(command) > _SHELL_COMMAND_TRUNCATE_LENGTH:
-            display += " [dim](press 'e' to expand)[/dim]"
+            display = Content.from_markup(
+                "[bold #f59e0b]$cmd[/bold #f59e0b] [dim](press 'e' to expand)[/dim]",
+                cmd=command_display,
+            )
+        else:
+            display = Content.from_markup(
+                "[bold #f59e0b]$cmd[/bold #f59e0b]", cmd=command_display
+            )
 
         if not issues:
             return display
 
-        issue_summary = escape_markup(summarize_issues(issues))
-        raw_with_markers = escape_markup(render_with_unicode_markers(command_raw))
+        raw_with_markers = render_with_unicode_markers(command_raw)
         if not expanded and len(raw_with_markers) > _WARNING_TEXT_TRUNCATE_LENGTH:
             raw_with_markers = (
                 raw_with_markers[:_WARNING_TEXT_TRUNCATE_LENGTH] + get_glyphs().ellipsis
             )
 
-        return (
-            f"{display}\n"
-            f"[yellow]Warning:[/yellow] hidden chars detected ({issue_summary})\n"
-            f"[dim]raw: {raw_with_markers}[/dim]"
+        return Content.assemble(
+            display,
+            Content.from_markup(
+                "\n[yellow]Warning:[/yellow] hidden chars detected ($summary)\n"
+                "[dim]raw: $raw[/dim]",
+                summary=summarize_issues(issues),
+                raw=raw_with_markers,
+            ),
         )
 
     def compose(self) -> ComposeResult:
@@ -205,22 +213,28 @@ class ApprovalMenu(Container):
         # Title - show count if multiple tools
         count = len(self._action_requests)
         if count == 1:
-            title = f">>> {escape_markup(self._tool_names[0])} Requires Approval <<<"
+            title = Content.from_markup(
+                ">>> $name Requires Approval <<<", name=self._tool_names[0]
+            )
         else:
-            title = f">>> {count} Tool Calls Require Approval <<<"
+            title = Content(f">>> {count} Tool Calls Require Approval <<<")
         yield Static(title, classes="approval-title")
 
         if self._security_warnings:
-            warning_lines = ["[yellow]Warning:[/yellow] Potentially deceptive text"]
-            warning_lines.extend(
-                f"[dim]- {escape_markup(warning)}[/dim]"
+            parts: list[Content] = [
+                Content.from_markup(
+                    "[yellow]Warning:[/yellow] Potentially deceptive text"
+                ),
+            ]
+            parts.extend(
+                Content.from_markup("\n[dim]- $w[/dim]", w=warning)
                 for warning in self._security_warnings[:_WARNING_PREVIEW_LIMIT]
             )
             if len(self._security_warnings) > _WARNING_PREVIEW_LIMIT:
                 remaining = len(self._security_warnings) - _WARNING_PREVIEW_LIMIT
-                warning_lines.append(f"[dim]- +{remaining} more warning(s)[/dim]")
+                parts.append(Content.styled(f"\n- +{remaining} more warning(s)", "dim"))
             yield Static(
-                "\n".join(warning_lines),
+                Content.assemble(*parts),
                 classes="approval-security-warning",
             )
 
@@ -285,14 +299,20 @@ class ApprovalMenu(Container):
 
             # Add tool header if multiple tools
             if len(self._action_requests) > 1:
-                header = Static(f"[bold]{i + 1}. {escape_markup(tool_name)}[/bold]")
+                header = Static(
+                    Content.from_markup(
+                        "[bold]$num. $name[/bold]",
+                        num=i + 1,
+                        name=tool_name,
+                    )
+                )
                 await self._tool_info_container.mount(header)
 
             # Show description if present
             description = action_request.get("description")
             if description:
                 desc_widget = Static(
-                    f"[dim]{escape_markup(description)}[/dim]",
+                    Content.from_markup("[dim]$desc[/dim]", desc=description),
                     classes="approval-description",
                 )
                 await self._tool_info_container.mount(desc_widget)

--- a/libs/cli/deepagents_cli/widgets/ask_user.py
+++ b/libs/cli/deepagents_cli/widgets/ask_user.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical
+from textual.content import Content
 from textual.message import Message
 from textual.widgets import Input, Static
 
@@ -205,37 +205,38 @@ class AskUserMenu(Container):
 class _ChoiceOption(Static):
     """A single selectable choice option."""
 
-    def __init__(self, label: str, index: int, **kwargs: Any) -> None:
-        super().__init__(label, classes="ask-user-choice", **kwargs)
+    def __init__(
+        self, text: str, index: int, *, selected: bool = False, **kwargs: Any
+    ) -> None:
         self.choice_index: int = index
-        self.selected: bool = False
-        self._label: str = label
+        self.selected: bool = selected
+        self._text: str = text
+        super().__init__(self._render(), classes="ask-user-choice", **kwargs)
 
     def toggle(self) -> None:
         """Toggle the selected state."""
         self.selected = not self.selected
-        self._update_display()
+        self.update(self._render())
 
     def select(self) -> None:
         """Mark this choice as selected."""
         self.selected = True
-        self._update_display()
+        self.update(self._render())
 
     def deselect(self) -> None:
         """Mark this choice as deselected."""
         self.selected = False
-        self._update_display()
+        self.update(self._render())
 
-    def _update_display(self) -> None:
+    def _render(self) -> Content:
+        """Build display content with cursor prefix.
+
+        Returns:
+            Styled Content with selection cursor and label text.
+        """
         glyphs = get_glyphs()
-        raw = self._label.lstrip()
-        for prefix in (f"{glyphs.cursor} ", "  "):
-            if raw.startswith(prefix):
-                raw = raw[len(prefix) :]
-                break
-        self._label = raw
         prefix = f"{glyphs.cursor} " if self.selected else "  "
-        self.update(f"{prefix}{raw}")
+        return Content.from_markup("$prefix$text", prefix=prefix, text=self._text)
 
 
 class _QuestionWidget(Vertical):
@@ -270,23 +271,20 @@ class _QuestionWidget(Vertical):
 
     def compose(self) -> ComposeResult:
         q_text = self._question.get("question", "")
-        suffix = " [dim](required)[/dim]" if self._required else ""
-        yield Static(f"[bold]{self._index + 1}. {escape_markup(q_text)}[/bold]{suffix}")
+        if self._required:
+            markup = "[bold]$num. $text[/bold] [dim](required)[/dim]"
+        else:
+            markup = "[bold]$num. $text[/bold]"
+        yield Static(Content.from_markup(markup, num=self._index + 1, text=q_text))
 
         if self._q_type == "multiple_choice" and self._choices:
-            glyphs = get_glyphs()
             for i, choice in enumerate(self._choices):
-                label = escape_markup(choice.get("value", str(choice)))
-                prefix = f"{glyphs.cursor} " if i == 0 else "  "
-                cw = _ChoiceOption(f"{prefix}{label}", index=i)
-                if i == 0:
-                    cw.selected = True
+                label = choice.get("value", str(choice))
+                cw = _ChoiceOption(label, index=i, selected=(i == 0))
                 self._choice_widgets.append(cw)
                 yield cw
 
-            other_cw = _ChoiceOption(
-                f"  {OTHER_CHOICE_LABEL}", index=len(self._choices)
-            )
+            other_cw = _ChoiceOption(OTHER_CHOICE_LABEL, index=len(self._choices))
             self._choice_widgets.append(other_cw)
             yield other_cw
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -7,9 +7,9 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from rich.markup import escape as escape_markup
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.content import Content
 from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
@@ -129,14 +129,18 @@ class CompletionOption(Static):
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if self._is_selected else "  "
 
-        escaped_label = escape_markup(self._label)
         if self._description:
-            escaped_desc = escape_markup(self._description)
-            text = f"{cursor}[bold]{escaped_label}[/bold]  [dim]{escaped_desc}[/dim]"
+            content = Content.from_markup(
+                f"{cursor}[bold]$label[/bold]  [dim]$desc[/dim]",
+                label=self._label,
+                desc=self._description,
+            )
         else:
-            text = f"{cursor}[bold]{escaped_label}[/bold]"
+            content = Content.from_markup(
+                f"{cursor}[bold]$label[/bold]", label=self._label
+            )
 
-        self.update(text)
+        self.update(content)
 
         if self._is_selected:
             self.add_class("completion-option-selected")

--- a/libs/cli/deepagents_cli/widgets/diff.py
+++ b/libs/cli/deepagents_cli/widgets/diff.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-from rich.markup import escape as escape_markup
 from textual.containers import Vertical
+from textual.content import Content
 from textual.widgets import Static
 
 from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
 
 
-def format_diff_textual(diff: str, max_lines: int | None = 100) -> str:
+def format_diff_textual(diff: str, max_lines: int | None = 100) -> Content:
     """Format a unified diff with line numbers and colors.
 
     Args:
@@ -23,10 +23,10 @@ def format_diff_textual(diff: str, max_lines: int | None = 100) -> str:
         max_lines: Maximum number of diff lines to show (None for unlimited)
 
     Returns:
-        Rich-formatted diff string with line numbers
+        Styled `Content` with line numbers and color-coded diff lines.
     """
     if not diff:
-        return "[dim]No changes detected[/dim]"
+        return Content.styled("No changes detected", "dim")
 
     glyphs = get_glyphs()
     lines = diff.splitlines()
@@ -46,23 +46,27 @@ def format_diff_textual(diff: str, max_lines: int | None = 100) -> str:
             max_line = max(max_line, int(m.group(1)), int(m.group(2)))
     width = max(3, len(str(max_line + len(lines))))
 
-    formatted = []
+    formatted: list[str | Content] = []
 
     # Add stats header
-    stats_parts = []
+    stats_parts: list[str | tuple[str, str] | Content] = []
     if additions:
-        stats_parts.append(f"[green]+{additions}[/green]")
+        stats_parts.append((f"+{additions}", "green"))
     if deletions:
-        stats_parts.append(f"[red]-{deletions}[/red]")
+        if stats_parts:
+            stats_parts.append(" ")
+        stats_parts.append((f"-{deletions}", "red"))
     if stats_parts:
-        formatted.extend([" ".join(stats_parts), ""])  # Blank line after stats
+        formatted.extend([Content.assemble(*stats_parts), ""])  # Blank line after stats
 
     old_num = new_num = 0
     line_count = 0
 
     for line in lines:
         if max_lines and line_count >= max_lines:
-            formatted.append(f"\n[dim]... ({len(lines) - line_count} more lines)[/dim]")
+            formatted.append(
+                Content.styled(f"\n... ({len(lines) - line_count} more lines)", "dim")
+            )
             break
 
         # Skip file headers (--- and +++)
@@ -76,38 +80,52 @@ def format_diff_textual(diff: str, max_lines: int | None = 100) -> str:
 
         # Handle diff lines - use gutter bar instead of +/- prefix
         content = line[1:] if line else ""
-        escaped_content = escape_markup(content)
 
         if line.startswith("-"):
             # Deletion - red gutter bar, subtle red background
-            gutter = f"[red bold]{glyphs.gutter_bar}[/red bold]"
-            line_num = f"[dim]{old_num:>{width}}[/dim]"
-            content = f"[on #2d1515]{escaped_content}[/on #2d1515]"
-            formatted.append(f"{gutter}{line_num} {content}")
+            formatted.append(
+                Content.assemble(
+                    (f"{glyphs.gutter_bar}", "red bold"),
+                    (f"{old_num:>{width}}", "dim"),
+                    " ",
+                    Content.styled(content, "on #2d1515"),
+                )
+            )
             old_num += 1
             line_count += 1
         elif line.startswith("+"):
             # Addition - green gutter bar, subtle green background
-            gutter = f"[green bold]{glyphs.gutter_bar}[/green bold]"
-            line_num = f"[dim]{new_num:>{width}}[/dim]"
-            content = f"[on #152d15]{escaped_content}[/on #152d15]"
-            formatted.append(f"{gutter}{line_num} {content}")
+            formatted.append(
+                Content.assemble(
+                    (f"{glyphs.gutter_bar}", "green bold"),
+                    (f"{new_num:>{width}}", "dim"),
+                    " ",
+                    Content.styled(content, "on #152d15"),
+                )
+            )
             new_num += 1
             line_count += 1
         elif line.startswith(" "):
             # Context line - dim gutter
             formatted.append(
-                f"[dim]{glyphs.box_vertical}{old_num:>{width}}[/dim]  {escaped_content}"
+                Content.assemble(
+                    (f"{glyphs.box_vertical}{old_num:>{width}}", "dim"),
+                    f"  {content}",
+                )
             )
             old_num += 1
             new_num += 1
             line_count += 1
         elif line.strip() == "...":
             # Truncation marker
-            formatted.append("[dim]...[/dim]")
+            formatted.append(Content.styled("...", "dim"))
+            line_count += 1
+        else:
+            # Unrecognized diff line (e.g., "\ No newline at end of file")
+            formatted.append(Content.styled(line, "dim"))
             line_count += 1
 
-    return "\n".join(formatted)
+    return Content("\n").join(formatted)
 
 
 class EnhancedDiff(Vertical):
@@ -187,7 +205,7 @@ class EnhancedDiff(Vertical):
         glyphs = get_glyphs()
         h = glyphs.box_double_horizontal
         yield Static(
-            f"[bold cyan]{h}{h}{h} {self._title} {h}{h}{h}[/bold cyan]",
+            Content.styled(f"{h}{h}{h} {self._title} {h}{h}{h}", "bold cyan"),
             classes="diff-title",
         )
 
@@ -196,9 +214,11 @@ class EnhancedDiff(Vertical):
 
         additions, deletions = self._stats
         if additions or deletions:
-            stats_parts = []
+            content_parts: list[str | tuple[str, str]] = []
             if additions:
-                stats_parts.append(f"[green]+{additions}[/green]")
+                content_parts.append((f"+{additions}", "green"))
             if deletions:
-                stats_parts.append(f"[red]-{deletions}[/red]")
-            yield Static(" ".join(stats_parts), classes="diff-stats")
+                if content_parts:
+                    content_parts.append(" ")
+                content_parts.append((f"-{deletions}", "red"))
+            yield Static(Content.assemble(*content_parts), classes="diff-stats")

--- a/libs/cli/deepagents_cli/widgets/loading.py
+++ b/libs/cli/deepagents_cli/widgets/loading.py
@@ -6,6 +6,7 @@ from time import time
 from typing import TYPE_CHECKING
 
 from textual.containers import Horizontal
+from textual.content import Content
 from textual.widgets import Static
 
 from deepagents_cli.config import get_glyphs
@@ -129,7 +130,7 @@ class LoadingWidget(Static):
 
         if self._spinner_widget:
             frame = self._spinner.next_frame()
-            self._spinner_widget.update(f"[#FFD800]{frame}[/]")
+            self._spinner_widget.update(Content.styled(frame, "#FFD800"))
 
         if self._hint_widget and self._start_time is not None:
             elapsed = int(time() - self._start_time)
@@ -160,7 +161,7 @@ class LoadingWidget(Static):
         if self._hint_widget:
             self._hint_widget.update(f"(paused at {self._paused_elapsed}s)")
         if self._spinner_widget:
-            self._spinner_widget.update(f"[dim]{get_glyphs().pause}[/dim]")
+            self._spinner_widget.update(Content.styled(get_glyphs().pause, "dim"))
 
     def resume(self) -> None:
         """Resume the animation."""

--- a/libs/cli/deepagents_cli/widgets/mcp_viewer.py
+++ b/libs/cli/deepagents_cli/widgets/mcp_viewer.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical, VerticalScroll
+from textual.content import Content
 from textual.events import (
     Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
 )
@@ -40,16 +40,19 @@ class MCPToolItem(Static):
             index: Flat index of this tool in the list.
             classes: CSS classes.
         """
-        label = f"  {escape_markup(name)}"
         if description:
-            label += f" [dim]{escape_markup(description)}[/dim]"
+            label = Content.from_markup(
+                "  $name [dim]$desc[/dim]", name=name, desc=description
+            )
+        else:
+            label = Content.from_markup("  $name", name=name)
         super().__init__(label, classes=classes)
         self.tool_name = name
         self.tool_description = description
         self.index = index
         self._expanded = False
 
-    def _format_collapsed(self, name: str, description: str) -> str:
+    def _format_collapsed(self, name: str, description: str) -> Content:
         """Build the collapsed (single-line) label.
 
         Truncates the description with `(...)` if it would overflow
@@ -60,10 +63,10 @@ class MCPToolItem(Static):
             description: Tool description.
 
         Returns:
-            Rich-markup label.
+            Styled Content label.
         """
         if not description:
-            return f"  {escape_markup(name)}"
+            return Content.from_markup("  $name", name=name)
         prefix_len = 2 + len(name) + 1
         avail = self.size.width - prefix_len - 1 if self.size.width else 0
         ellipsis = " (...)"
@@ -72,10 +75,12 @@ class MCPToolItem(Static):
             desc_text = description[:cut] + ellipsis
         else:
             desc_text = description
-        return f"  {escape_markup(name)} [dim]{escape_markup(desc_text)}[/dim]"
+        return Content.from_markup(
+            "  $name [dim]$desc[/dim]", name=name, desc=desc_text
+        )
 
     @staticmethod
-    def _format_expanded(name: str, description: str) -> str:
+    def _format_expanded(name: str, description: str) -> Content:
         """Build the expanded (multi-line) label.
 
         Args:
@@ -83,12 +88,15 @@ class MCPToolItem(Static):
             description: Tool description.
 
         Returns:
-            Rich-markup label with full description on next line.
+            Styled Content label with full description on next line.
         """
-        lines = f"  [bold]{escape_markup(name)}[/bold]"
         if description:
-            lines += f"\n    [dim]{escape_markup(description)}[/dim]"
-        return lines
+            return Content.from_markup(
+                "  [bold]$name[/bold]\n    [dim]$desc[/dim]",
+                name=name,
+                desc=description,
+            )
+        return Content.from_markup("  [bold]$name[/bold]", name=name)
 
     def toggle_expand(self) -> None:
         """Toggle between collapsed and expanded view."""
@@ -260,10 +268,13 @@ class MCPViewerScreen(ModalScreen[None]):
                         tool_count = len(server.tools)
                         t_label = "tool" if tool_count == 1 else "tools"
                         yield Static(
-                            f"[bold]{escape_markup(server.name)}[/bold]"
-                            f" [dim]{escape_markup(server.transport)}"
-                            f" {glyphs.bullet}"
-                            f" {tool_count} {t_label}[/dim]",
+                            Content.from_markup(
+                                "[bold]$name[/bold]"
+                                f" [dim]$transport {glyphs.bullet}"
+                                f" {tool_count} {t_label}[/dim]",
+                                name=server.name,
+                                transport=server.transport,
+                            ),
                             classes="mcp-server-header",
                         )
                         for tool in server.tools:

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any
 
-from rich.markup import escape as escape_markup
 from textual.containers import Vertical
 from textual.content import Content
 from textual.widgets import Markdown, Static
@@ -100,16 +99,14 @@ def _mode_color(mode: str | None) -> str:
 
 @dataclass(frozen=True, slots=True)
 class FormattedOutput:
-    """Result of formatting tool output for display.
+    """Result of formatting tool output for display."""
 
-    Attributes:
-        content: The formatted output content with Rich markup.
-        truncation: Description of truncated content (e.g., "10 more lines"),
-            or None if no truncation occurred.
-    """
+    content: Content
+    """Styled `Content` for the formatted output."""
 
-    content: str
     truncation: str | None = None
+    """Description of truncated content (e.g., "10 more lines"), or None if no
+    truncation occurred."""
 
 
 # Maximum number of tool arguments to display inline
@@ -489,9 +486,11 @@ class ToolCallMessage(Vertical):
         Yields:
             Widgets for header, arguments, status, and output display.
         """
-        tool_label = escape_markup(format_tool_display(self._tool_name, self._args))
+        tool_label = format_tool_display(self._tool_name, self._args)
         yield Static(
-            f"[bold #f59e0b]{tool_label}[/bold #f59e0b]",
+            Content.from_markup(
+                "[bold #f59e0b]$label[/bold #f59e0b]", label=tool_label
+            ),
             classes="tool-header",
         )
         # Only show args for tools where header doesn't capture the key info
@@ -504,7 +503,7 @@ class ToolCallMessage(Vertical):
                 if len(args) > _MAX_INLINE_ARGS:
                     args_str += ", ..."
                 yield Static(
-                    f"[dim]({escape_markup(args_str)})[/dim]",
+                    Content.from_markup("[dim]($args)[/dim]", args=args_str),
                     classes="tool-args",
                 )
         # Status - shows running animation while pending, then final status
@@ -557,20 +556,20 @@ class ToolCallMessage(Vertical):
                 self._output = output
                 if self._status_widget:
                     self._status_widget.add_class("error")
-                    self._status_widget.update("[red]✗ Error[/red]")
+                    self._status_widget.update(Content.styled("✗ Error", "red"))
                     self._status_widget.display = True
                 self._update_output_display()
             case "rejected":
                 self._status = "rejected"
                 if self._status_widget:
                     self._status_widget.add_class("rejected")
-                    self._status_widget.update("[yellow]✗ Rejected[/yellow]")
+                    self._status_widget.update(Content.styled("✗ Rejected", "yellow"))
                     self._status_widget.display = True
             case "skipped":
                 self._status = "skipped"
                 if self._status_widget:
                     self._status_widget.add_class("rejected")
-                    self._status_widget.update("[dim]- Skipped[/dim]")
+                    self._status_widget.update(Content.styled("- Skipped", "dim"))
                     self._status_widget.display = True
             case "running":
                 # For running tools, show static "Running..." without animation
@@ -578,7 +577,7 @@ class ToolCallMessage(Vertical):
                 self._status = "running"
                 if self._status_widget:
                     self._status_widget.add_class("pending")
-                    self._status_widget.update("[yellow]⠿ Running...[/yellow]")
+                    self._status_widget.update(Content.styled("⠿ Running...", "yellow"))
                     self._status_widget.display = True
             case _:
                 # pending or unknown - leave as default
@@ -614,7 +613,8 @@ class ToolCallMessage(Vertical):
             elapsed_secs = int(time() - self._start_time)
             elapsed = f" ({elapsed_secs}s)"
 
-        self._status_widget.update(f"[yellow]{frame} Running...{elapsed}[/yellow]")
+        text = f"{frame} Running...{elapsed}"
+        self._status_widget.update(Content.styled(text, "yellow"))
 
     def _stop_animation(self) -> None:
         """Stop the running animation."""
@@ -659,7 +659,7 @@ class ToolCallMessage(Vertical):
             self._status_widget.remove_class("pending")
             self._status_widget.add_class("error")
             error_icon = get_glyphs().error
-            self._status_widget.update(f"[red]{error_icon} Error[/red]")
+            self._status_widget.update(Content.styled(f"{error_icon} Error", "red"))
             self._status_widget.display = True
         # Always show full error - errors should be visible
         self._expanded = True
@@ -673,7 +673,8 @@ class ToolCallMessage(Vertical):
             self._status_widget.remove_class("pending")
             self._status_widget.add_class("rejected")
             error_icon = get_glyphs().error
-            self._status_widget.update(f"[yellow]{error_icon} Rejected[/yellow]")
+            text = f"{error_icon} Rejected"
+            self._status_widget.update(Content.styled(text, "yellow"))
             self._status_widget.display = True
 
     def set_skipped(self) -> None:
@@ -683,7 +684,7 @@ class ToolCallMessage(Vertical):
         if self._status_widget:
             self._status_widget.remove_class("pending")
             self._status_widget.add_class("rejected")  # Use same styling as rejected
-            self._status_widget.update("[dim]- Skipped[/dim]")
+            self._status_widget.update(Content.styled("- Skipped", "dim"))
             self._status_widget.display = True
 
     def toggle_output(self) -> None:
@@ -715,7 +716,7 @@ class ToolCallMessage(Vertical):
         """
         output = output.strip()
         if not output:
-            return FormattedOutput(content="")
+            return FormattedOutput(content=Content(""))
 
         # Tool-specific formatting using dispatch table
         formatters = {
@@ -739,26 +740,26 @@ class ToolCallMessage(Vertical):
         if formatter:
             return formatter(output, is_preview=is_preview)
 
-        # Default: return as-is but escape markup
-        return FormattedOutput(content=escape_markup(output))
+        # Default: plain text (Content treats input as literal)
+        return FormattedOutput(content=Content(output))
 
-    def _prefix_output(self, content: str) -> str:  # noqa: PLR6301  # Grouped as method for widget cohesion
+    def _prefix_output(self, content: Content) -> Content:  # noqa: PLR6301  # Grouped as method for widget cohesion
         """Prefix output with output marker and indent continuation lines.
 
         Args:
-            content: The output content to prefix and indent.
+            content: The styled output content to prefix and indent.
 
         Returns:
-            Content with output prefix on first line and indented continuation.
+            `Content` with output prefix on first line and indented
+                continuation.
         """
-        lines = content.split("\n")
-        if not lines:
-            return ""
+        if not content.plain:
+            return Content("")
         output_prefix = get_glyphs().output_prefix
-        prefixed = f"{output_prefix} {lines[0]}"
-        if len(lines) > 1:
-            prefixed += "\n" + "\n".join(f"  {line}" for line in lines[1:])
-        return prefixed
+        lines = content.split("\n")
+        prefixed = [Content.assemble(f"{output_prefix} ", lines[0])]
+        prefixed.extend(Content.assemble("  ", line) for line in lines[1:])
+        return Content("\n").join(prefixed)
 
     def _format_todos_output(
         self, output: str, *, is_preview: bool = False
@@ -770,18 +771,18 @@ class ToolCallMessage(Vertical):
         """
         items = self._parse_todo_items(output)
         if items is None:
-            return FormattedOutput(content=escape_markup(output))
+            return FormattedOutput(content=Content(output))
 
         if not items:
-            return FormattedOutput(content="    [dim]No todos[/dim]")
+            return FormattedOutput(content=Content.styled("    No todos", "dim"))
 
-        lines: list[str] = []
+        lines: list[Content] = []
         max_items = 4 if is_preview else len(items)
 
         # Build stats header
-        stats_header = self._build_todo_stats(items)
-        if stats_header:
-            lines.extend([f"    [dim]{stats_header}[/dim]", ""])
+        stats = self._build_todo_stats(items)
+        if stats:
+            lines.extend([Content.assemble("    ", stats), Content("")])
 
         # Format each item
         lines.extend(self._format_single_todo(item) for item in items[:max_items])
@@ -790,7 +791,7 @@ class ToolCallMessage(Vertical):
         if is_preview and len(items) > max_items:
             truncation = f"{len(items) - max_items} more"
 
-        return FormattedOutput(content="\n".join(lines), truncation=truncation)
+        return FormattedOutput(content=Content("\n").join(lines), truncation=truncation)
 
     def _parse_todo_items(self, output: str) -> list | None:  # noqa: PLR6301  # Grouped as method for widget cohesion
         """Parse todo items from output.
@@ -810,11 +811,11 @@ class ToolCallMessage(Vertical):
         except (ValueError, SyntaxError):
             return None
 
-    def _build_todo_stats(self, items: list) -> str:  # noqa: PLR6301  # Grouped as method for widget cohesion
-        """Build stats string for todo list.
+    def _build_todo_stats(self, items: list) -> Content:  # noqa: PLR6301  # Grouped as method for widget cohesion
+        """Build stats content for todo list.
 
         Returns:
-            Formatted stats string showing active, pending, and completed counts.
+            Styled `Content` showing active, pending, and completed counts.
         """
         completed = sum(
             1 for i in items if isinstance(i, dict) and i.get("status") == "completed"
@@ -824,38 +825,46 @@ class ToolCallMessage(Vertical):
         )
         pending = len(items) - completed - active
 
-        parts = []
+        parts: list[Content] = []
         if active:
-            parts.append(f"[yellow]{active} active[/yellow]")
+            parts.append(Content.styled(f"{active} active", "yellow"))
         if pending:
-            parts.append(f"{pending} pending")
+            parts.append(Content.styled(f"{pending} pending", "dim"))
         if completed:
-            parts.append(f"[green]{completed} done[/green]")
-        return " | ".join(parts)
+            parts.append(Content.styled(f"{completed} done", "green"))
+        return Content.styled(" | ", "dim").join(parts) if parts else Content("")
 
-    def _format_single_todo(self, item: dict | str) -> str:  # noqa: PLR6301  # Grouped as method for widget cohesion
+    def _format_single_todo(self, item: dict | str) -> Content:  # noqa: PLR6301  # Grouped as method for widget cohesion
         """Format a single todo item.
 
         Returns:
-            Rich-formatted string with checkbox and status styling.
+            Styled `Content` with checkbox and status styling.
         """
         if isinstance(item, dict):
-            content = item.get("content", str(item))
+            text = item.get("content", str(item))
             status = item.get("status", "pending")
         else:
-            content = str(item)
+            text = str(item)
             status = "pending"
 
-        if len(content) > _MAX_TODO_CONTENT_LEN:
-            content = content[: _MAX_TODO_CONTENT_LEN - 3] + "..."
+        if len(text) > _MAX_TODO_CONTENT_LEN:
+            text = text[: _MAX_TODO_CONTENT_LEN - 3] + "..."
 
         glyphs = get_glyphs()
-        escaped = escape_markup(content)
         if status == "completed":
-            return f"    [green]{glyphs.checkmark} done[/green]   [dim]{escaped}[/dim]"
+            return Content.assemble(
+                Content.styled(f"    {glyphs.checkmark} done", "green"),
+                Content.styled(f"   {text}", "dim"),
+            )
         if status == "in_progress":
-            return f"    [yellow]{glyphs.circle_filled} active[/yellow] {escaped}"
-        return f"    [dim]{glyphs.circle_empty} todo[/dim]   {escaped}"
+            return Content.assemble(
+                Content.styled(f"    {glyphs.circle_filled} active", "yellow"),
+                f" {text}",
+            )
+        return Content.assemble(
+            Content.styled(f"    {glyphs.circle_empty} todo", "dim"),
+            f"   {text}",
+        )
 
     def _format_ls_output(  # noqa: PLR6301  # Grouped as method for widget cohesion
         self, output: str, *, is_preview: bool = False
@@ -869,35 +878,32 @@ class ToolCallMessage(Vertical):
         try:
             items = ast.literal_eval(output)
             if isinstance(items, list):
-                lines = []
-                max_items = 5 if is_preview else len(items)  # Show all when expanded
+                lines: list[Content] = []
+                max_items = 5 if is_preview else len(items)
                 for item in items[:max_items]:
                     path = Path(str(item))
                     name = path.name
-                    # Color by file type
-                    escaped_name = escape_markup(name)
                     if path.suffix in {".py", ".pyx"}:
-                        lines.append(f"    [#3b82f6]{escaped_name}[/#3b82f6]")
-                    elif path.suffix in {".md", ".txt", ".rst"}:
-                        lines.append(f"    {escaped_name}")
+                        lines.append(Content.styled(f"    {name}", "#3b82f6"))
                     elif path.suffix in {".json", ".yaml", ".yml", ".toml"}:
-                        lines.append(f"    [#f59e0b]{escaped_name}[/#f59e0b]")
+                        lines.append(Content.styled(f"    {name}", "#f59e0b"))
                     elif not path.suffix:
-                        # Likely a directory or no extension
-                        lines.append(f"    [#10b981]{escaped_name}/[/#10b981]")
+                        lines.append(Content.styled(f"    {name}/", "#10b981"))
                     else:
-                        lines.append(f"    {escaped_name}")
+                        lines.append(Content(f"    {name}"))
 
                 truncation = None
                 if is_preview and len(items) > max_items:
                     truncation = f"{len(items) - max_items} more"
 
-                return FormattedOutput(content="\n".join(lines), truncation=truncation)
+                return FormattedOutput(
+                    content=Content("\n").join(lines), truncation=truncation
+                )
         except (ValueError, SyntaxError):
             pass
 
-        # Fallback: just escape and return
-        return FormattedOutput(content=escape_markup(output))
+        # Fallback: plain text
+        return FormattedOutput(content=Content(output))
 
     def _format_file_output(  # noqa: PLR6301  # Grouped as method for widget cohesion
         self, output: str, *, is_preview: bool = False
@@ -910,8 +916,8 @@ class ToolCallMessage(Vertical):
         lines = output.split("\n")
         max_lines = 4 if is_preview else len(lines)
 
-        formatted_lines = [escape_markup(line) for line in lines[:max_lines]]
-        content = "\n".join(formatted_lines)
+        parts = [Content(line) for line in lines[:max_lines]]
+        content = Content("\n").join(parts)
 
         truncation = None
         if is_preview and len(lines) > max_lines:
@@ -931,23 +937,24 @@ class ToolCallMessage(Vertical):
         try:
             items = ast.literal_eval(output.strip())
             if isinstance(items, list):
-                lines = []
-                max_items = 5 if is_preview else len(items)  # Show all when expanded
+                parts: list[Content] = []
+                max_items = 5 if is_preview else len(items)
                 for item in items[:max_items]:
-                    # Show just filename or relative path
                     path = Path(str(item))
                     try:
                         rel = path.relative_to(Path.cwd())
                         display = str(rel)
                     except ValueError:
                         display = path.name
-                    lines.append(f"    {display}")
+                    parts.append(Content(f"    {display}"))
 
                 truncation = None
                 if is_preview and len(items) > max_items:
                     truncation = f"{len(items) - max_items} more files"
 
-                return FormattedOutput(content="\n".join(lines), truncation=truncation)
+                return FormattedOutput(
+                    content=Content("\n").join(parts), truncation=truncation
+                )
         except (ValueError, SyntaxError):
             pass
 
@@ -955,13 +962,13 @@ class ToolCallMessage(Vertical):
         lines = output.split("\n")
         max_lines = 5 if is_preview else len(lines)
 
-        formatted_lines = [
-            f"    {escape_markup(raw_line.strip())}"
+        parts = [
+            Content(f"    {raw_line.strip()}")
             for raw_line in lines[:max_lines]
             if raw_line.strip()
         ]
 
-        content = "\n".join(formatted_lines)
+        content = Content("\n").join(parts) if parts else Content("")
         truncation = None
         if is_preview and len(lines) > max_lines:
             truncation = f"{len(lines) - max_lines} more"
@@ -977,18 +984,16 @@ class ToolCallMessage(Vertical):
             FormattedOutput with shell output and optional truncation info.
         """
         lines = output.split("\n")
-        max_lines = 4 if is_preview else len(lines)  # Show all when expanded
+        max_lines = 4 if is_preview else len(lines)
 
-        formatted_lines = []
+        parts: list[Content] = []
         for i, line in enumerate(lines[:max_lines]):
-            escaped = escape_markup(line)
-            # Style only the first line (the command) in dim grey
-            if i == 0 and escaped.startswith("$ "):
-                formatted_lines.append(f"[dim]{escaped}[/dim]")
+            if i == 0 and line.startswith("$ "):
+                parts.append(Content.styled(line, "dim"))
             else:
-                formatted_lines.append(escaped)
+                parts.append(Content(line))
 
-        content = "\n".join(formatted_lines)
+        content = Content("\n").join(parts) if parts else Content("")
 
         truncation = None
         if is_preview and len(lines) > max_lines:
@@ -1043,26 +1048,29 @@ class ToolCallMessage(Vertical):
             return self._format_lines_output(lines, is_preview=is_preview)
 
         if "content" in data:
-            content = str(data["content"])
-            if is_preview and len(content) > _MAX_WEB_PREVIEW_LEN:
+            raw = str(data["content"])
+            if is_preview and len(raw) > _MAX_WEB_PREVIEW_LEN:
                 return FormattedOutput(
-                    content=escape_markup(content[:_MAX_WEB_PREVIEW_LEN]),
+                    content=Content(raw[:_MAX_WEB_PREVIEW_LEN]),
                     truncation="more",
                 )
-            return FormattedOutput(content=escape_markup(content))
+            return FormattedOutput(content=Content(raw))
 
         # Generic dict - show key fields
-        lines = []
+        parts: list[Content] = []
         max_keys = 3 if is_preview else len(data)
         for k, v in list(data.items())[:max_keys]:
             v_str = str(v)
             if is_preview and len(v_str) > _MAX_WEB_CONTENT_LEN:
                 v_str = v_str[:_MAX_WEB_CONTENT_LEN] + "..."
-            lines.append(f"  {k}: {escape_markup(v_str)}")
+            parts.append(Content(f"  {k}: {v_str}"))
         truncation = None
         if is_preview and len(data) > max_keys:
             truncation = f"{len(data) - max_keys} more"
-        return FormattedOutput(content="\n".join(lines), truncation=truncation)
+        return FormattedOutput(
+            content=Content("\n").join(parts) if parts else Content(""),
+            truncation=truncation,
+        )
 
     def _format_web_search_results(  # noqa: PLR6301  # Grouped as method for widget cohesion
         self, results: list, *, is_preview: bool
@@ -1073,22 +1081,22 @@ class ToolCallMessage(Vertical):
             FormattedOutput with search results and optional truncation info.
         """
         if not results:
-            return FormattedOutput(content="[dim]No results[/dim]")
-        lines = []
+            return FormattedOutput(content=Content.styled("No results", "dim"))
+        parts: list[Content] = []
         max_results = 3 if is_preview else len(results)
         for r in results[:max_results]:
             title = r.get("title", "")
             url = r.get("url", "")
-            lines.extend(
+            parts.extend(
                 [
-                    f"  [bold]{escape_markup(title)}[/bold]",
-                    f"  [dim]{escape_markup(url)}[/dim]",
+                    Content.styled(f"  {title}", "bold"),
+                    Content.styled(f"  {url}", "dim"),
                 ]
             )
         truncation = None
         if is_preview and len(results) > max_results:
             truncation = f"{len(results) - max_results} more results"
-        return FormattedOutput(content="\n".join(lines), truncation=truncation)
+        return FormattedOutput(content=Content("\n").join(parts), truncation=truncation)
 
     def _format_lines_output(  # noqa: PLR6301  # Grouped as method for widget cohesion
         self, lines: list[str], *, is_preview: bool
@@ -1099,7 +1107,8 @@ class ToolCallMessage(Vertical):
             FormattedOutput with lines content and optional truncation info.
         """
         max_lines = 4 if is_preview else len(lines)
-        content = "\n".join(escape_markup(line) for line in lines[:max_lines])
+        parts = [Content(line) for line in lines[:max_lines]]
+        content = Content("\n").join(parts) if parts else Content("")
         truncation = None
         if is_preview and len(lines) > max_lines:
             truncation = f"{len(lines) - max_lines} more lines"
@@ -1116,8 +1125,8 @@ class ToolCallMessage(Vertical):
         lines = output.split("\n")
         max_lines = 4 if is_preview else len(lines)
 
-        formatted_lines = [escape_markup(line) for line in lines[:max_lines]]
-        content = "\n".join(formatted_lines)
+        parts = [Content(line) for line in lines[:max_lines]]
+        content = Content("\n").join(parts) if parts else Content("")
 
         truncation = None
         if is_preview and len(lines) > max_lines:
@@ -1155,7 +1164,7 @@ class ToolCallMessage(Vertical):
             self._full_widget.display = True
             # Show collapse hint underneath
             self._hint_widget.update(
-                "[dim italic]click or Ctrl+E to collapse[/dim italic]"
+                Content.styled("click or Ctrl+E to collapse", "dim italic")
             )
             self._hint_widget.display = True
         else:
@@ -1170,12 +1179,12 @@ class ToolCallMessage(Vertical):
                 # Build hint with truncation info if available
                 if result.truncation:
                     ellipsis = get_glyphs().ellipsis
-                    hint = (
-                        f"[dim]{ellipsis} {result.truncation} "
-                        "— click or Ctrl+E to expand[/dim]"
+                    hint = Content.styled(
+                        f"{ellipsis} {result.truncation} — click or Ctrl+E to expand",
+                        "dim",
                     )
                 else:
-                    hint = "[dim italic]click or Ctrl+E to expand[/dim italic]"
+                    hint = Content.styled("click or Ctrl+E to expand", "dim italic")
                 self._hint_widget.update(hint)
                 self._hint_widget.display = True
             elif output_stripped:
@@ -1271,7 +1280,7 @@ class DiffMessage(_TimestampClickMixin, Static):
         """
         if self._file_path:
             yield Static(
-                f"[bold]File: {escape_markup(self._file_path)}[/bold]",
+                Content.from_markup("[bold]File: $path[/bold]", path=self._file_path),
                 classes="diff-header",
             )
 
@@ -1308,7 +1317,10 @@ class ErrorMessage(_TimestampClickMixin, Static):
         """
         # Store raw content for serialization
         self._content = error
-        super().__init__(Content.assemble(("Error: ", "bold red"), error), **kwargs)
+        super().__init__(
+            Content.from_markup("[bold red]Error: [/bold red]$err", err=error),
+            **kwargs,
+        )
 
     def on_mount(self) -> None:
         """Set border style based on charset mode."""

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
+from textual.content import Content
 from textual.events import (
     Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
 )
@@ -38,7 +38,7 @@ class ModelOption(Static):
 
     def __init__(
         self,
-        label: str,
+        label: str | Content,
         model_spec: str,
         provider: str,
         index: int,
@@ -49,7 +49,8 @@ class ModelOption(Static):
         """Initialize a model option.
 
         Args:
-            label: The display text for the option.
+            label: Display content — a `Content` object (preferred) or a
+                plain string that `Static` will parse as markup.
             model_spec: The model specification (provider:model format).
             provider: The provider name.
             index: The index of this option in the filtered list.
@@ -386,7 +387,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._option_widgets = []
 
         if not self._filtered_models:
-            no_matches = Static("[dim]No matching models[/dim]")
+            no_matches = Static(Content.styled("No matching models", "dim"))
             await self._options_container.mount(no_matches)
             self._update_footer()
             return
@@ -440,10 +441,13 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 cred_indicator = f"{glyphs.warning} missing credentials"
             else:
                 cred_indicator = f"{glyphs.question} credentials unknown"
-            escaped_prov = escape_markup(provider)
             all_widgets.append(
                 Static(
-                    f"[bold]{escaped_prov}[/bold] [dim]{cred_indicator}[/dim]",
+                    Content.from_markup(
+                        "[bold]$provider[/bold] [dim]$cred[/dim]",
+                        provider=provider,
+                        cred=cred_indicator,
+                    ),
                     classes="model-provider-header",
                 )
             )
@@ -505,7 +509,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         has_creds: bool | None,
         is_default: bool = False,
         status: str | None = None,
-    ) -> str:
+    ) -> Content:
         """Build the display label for a model option.
 
         Args:
@@ -519,32 +523,33 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 other non-None values render in yellow.
 
         Returns:
-            Rich-markup label string.
+            Styled Content label.
         """
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if selected else "  "
-        escaped_spec = escape_markup(model_spec)
         if not has_creds:
-            spec_text = f"[yellow]{escaped_spec}[/yellow]"
+            spec = Content.styled(model_spec, "yellow")
         elif is_default:
-            spec_text = f"[cyan]{escaped_spec}[/cyan]"
+            spec = Content.styled(model_spec, "cyan")
         else:
-            spec_text = escaped_spec
-        suffix = " [dim](current)[/dim]" if current else ""
-        default_suffix = " [cyan](default)[/cyan]" if is_default else ""
+            spec = Content(model_spec)
+        suffix = Content.styled(" (current)", "dim") if current else Content("")
+        default_suffix = (
+            Content.styled(" (default)", "cyan") if is_default else Content("")
+        )
         if status == "deprecated":
-            status_suffix = " [red](deprecated)[/red]"
+            status_suffix = Content.styled(" (deprecated)", "red")
         elif status:
-            status_suffix = f" [yellow]({escape_markup(status)})[/yellow]"
+            status_suffix = Content.styled(f" ({status})", "yellow")
         else:
-            status_suffix = ""
-        return f"{cursor}{spec_text}{suffix}{default_suffix}{status_suffix}"
+            status_suffix = Content("")
+        return Content.assemble(cursor, spec, suffix, default_suffix, status_suffix)
 
     @staticmethod
     def _format_footer(
         profile_entry: ModelProfileEntry | None,
         glyphs: Glyphs,
-    ) -> str:
+    ) -> Content:
         """Build the detail footer text for the highlighted model.
 
         Args:
@@ -552,24 +557,26 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             glyphs: Glyph set for display characters.
 
         Returns:
-            Rich-markup string for the 4-line footer.
+            Styled `Content` for the 4-line footer.
         """
         from deepagents_cli.textual_adapter import format_token_count
 
         if profile_entry is None or not profile_entry["profile"]:
-            return "[dim]Model profile not available :([/dim]\n\n\n"
+            return Content.styled("Model profile not available :(\n\n\n", "dim")
 
         profile = profile_entry["profile"]
         overridden = profile_entry["overridden_keys"]
 
-        def _mark(key: str, text: str) -> str:
-            return f"[yellow]*{text}[/yellow]" if key in overridden else text
+        def _mark(key: str, text: str) -> Content:
+            if key in overridden:
+                return Content.styled(f"*{text}", "yellow")
+            return Content(text)
 
-        def _format_token(key: str, suffix: str) -> str | None:
+        def _format_token(key: str, suffix: str) -> Content | None:
             """Format a token-count profile key, falling back to the raw value.
 
             Returns:
-                Formatted string with override marker, or None if key absent.
+                Styled `Content` with override marker, or None if key absent.
             """
             val = profile.get(key)
             if val is None:
@@ -580,28 +587,34 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 text = f"{val} {suffix}"
             return _mark(key, text)
 
-        def _format_flags(keys: list[tuple[str, str]]) -> list[str]:
+        def _format_flags(keys: list[tuple[str, str]]) -> list[Content]:
             """Render boolean profile keys as green (on) or dim (off) labels.
 
             Returns:
-                List of Rich-markup strings for present keys.
+                List of styled `Content` objects for present keys.
             """
-            parts: list[str] = []
+            parts: list[Content] = []
             for key, label in keys:
                 if key in profile:
-                    styled = (
-                        f"[green]{label}[/green]"
+                    base = (
+                        Content.styled(label, "green")
                         if profile[key]
-                        else f"[dim]{label}[/dim]"
+                        else Content.styled(label, "dim")
                     )
-                    parts.append(_mark(key, styled))
+                    if key in overridden:
+                        base = Content.assemble(Content.styled("*", "yellow"), base)
+                    parts.append(base)
             return parts
 
         # Line 1: Context window
         token_keys = [("max_input_tokens", "in"), ("max_output_tokens", "out")]
         ctx_parts = [p for k, s in token_keys if (p := _format_token(k, s)) is not None]
-        sep = f" {glyphs.bullet} "
-        line1 = f"Context: {sep.join(ctx_parts)}" if ctx_parts else ""
+        bullet_sep = Content(f" {glyphs.bullet} ")
+        line1 = (
+            Content.assemble("Context: ", bullet_sep.join(ctx_parts))
+            if ctx_parts
+            else Content("")
+        )
 
         # Line 2: Input modalities
         modality_keys = [
@@ -612,7 +625,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             ("video_inputs", "video"),
         ]
         modality_parts = _format_flags(modality_keys)
-        line2 = f"Input: {' '.join(modality_parts)}" if modality_parts else ""
+        space = Content(" ")
+        line2 = (
+            Content.assemble("Input: ", space.join(modality_parts))
+            if modality_parts
+            else Content("")
+        )
 
         # Line 3: Capabilities
         capability_keys = [
@@ -621,16 +639,22 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             ("structured_output", "structured output"),
         ]
         cap_parts = _format_flags(capability_keys)
-        line3 = f"Capabilities: {' '.join(cap_parts)}" if cap_parts else ""
+        line3 = (
+            Content.assemble("Capabilities: ", space.join(cap_parts))
+            if cap_parts
+            else Content("")
+        )
 
         # Line 4: Override notice
         displayed_keys = {k for k, _ in token_keys + modality_keys + capability_keys}
         has_visible_override = bool(overridden & displayed_keys)
         line4 = (
-            "[dim][yellow]*[/yellow] = override[/dim]" if has_visible_override else ""
+            Content.from_markup("[dim][yellow]*[/yellow] = override[/dim]")
+            if has_visible_override
+            else Content("")
         )
 
-        return f"{line1}\n{line2}\n{line3}\n{line4}"
+        return Content.assemble(line1, "\n", line2, "\n", line3, "\n", line4)
 
     def _get_model_status(self, model_spec: str) -> str | None:
         """Look up the status field for a model from its profile.
@@ -654,16 +678,16 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         """Update the detail footer for the currently highlighted model."""
         footer = self.query_one("#model-detail-footer", Static)
         if not self._filtered_models:
-            footer.update("[dim]No model selected[/dim]")
+            footer.update(Content.styled("No model selected", "dim"))
             return
         index = min(self._selected_index, len(self._filtered_models) - 1)
         spec, _ = self._filtered_models[index]
         entry = self._profiles.get(spec)
         try:
             text = self._format_footer(entry, get_glyphs())
-        except Exception:  # Resilient footer rendering
-            logger.debug("Failed to format footer for %s", spec, exc_info=True)
-            text = "[dim]Could not load profile details[/dim]\n\n\n"
+        except (KeyError, ValueError, TypeError):  # Resilient footer rendering
+            logger.warning("Failed to format footer for %s", spec, exc_info=True)
+            text = Content.styled("Could not load profile details\n\n\n", "dim")
         footer.update(text)
 
     def _move_selection(self, delta: int) -> None:
@@ -817,20 +841,24 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             if await asyncio.to_thread(clear_default_model):
                 self._default_spec = None
                 self.call_after_refresh(self._update_display)
-                help_widget.update("[bold]Default cleared[/bold]")
+                help_widget.update(Content.styled("Default cleared", "bold"))
                 self.set_timer(3.0, self._restore_help_text)
             else:
-                help_widget.update("[bold red]Failed to clear default[/bold red]")
+                help_widget.update(
+                    Content.styled("Failed to clear default", "bold red")
+                )
                 self.set_timer(3.0, self._restore_help_text)
         elif await asyncio.to_thread(save_default_model, model_spec):
             self._default_spec = model_spec
             self.call_after_refresh(self._update_display)
             help_widget.update(
-                f"[bold]Default set to {escape_markup(model_spec)}[/bold]"
+                Content.from_markup(
+                    "[bold]Default set to $spec[/bold]", spec=model_spec
+                )
             )
             self.set_timer(3.0, self._restore_help_text)
         else:
-            help_widget.update("[bold red]Failed to save default[/bold red]")
+            help_widget.update(Content.styled("Failed to save default", "bold red"))
             self.set_timer(3.0, self._restore_help_text)
 
     def _restore_help_text(self) -> None:

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -9,7 +9,6 @@ import sqlite3
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from rich.cells import cell_len
-from rich.markup import escape as escape_markup
 from textual.binding import Binding, BindingType
 from textual.color import Color as TColor
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -403,7 +402,10 @@ class DeleteThreadConfirmScreen(ModalScreen[bool]):
         """
         with Vertical(id="delete-confirm"):
             yield Static(
-                f"Delete thread [bold]{escape_markup(self._delete_thread_id)}[/bold]?",
+                Content.from_markup(
+                    "Delete thread [bold]$tid[/bold]?",
+                    tid=self._delete_thread_id,
+                ),
                 classes="thread-confirm-text",
             )
             yield Static(
@@ -818,12 +820,12 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                                 yield from self._option_widgets
                             else:
                                 yield Static(
-                                    "[dim]No threads found[/dim]",
+                                    Content.styled("No threads found", "dim"),
                                     classes="thread-empty",
                                 )
                         else:
                             yield Static(
-                                "[dim]Loading threads...[/dim]",
+                                Content.styled("Loading threads...", "dim"),
                                 classes="thread-empty",
                                 id="thread-loading",
                             )
@@ -1426,9 +1428,10 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 await scroll.remove_children()
                 await scroll.mount(
                     Static(
-                        (
-                            f"[red]Failed to load threads: {detail}. "
-                            "Press Esc to close.[/red]"
+                        Content.from_markup(
+                            "[red]Failed to load threads: $detail. "
+                            "Press Esc to close.[/red]",
+                            detail=detail,
                         ),
                         classes="thread-empty",
                     )
@@ -1462,7 +1465,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                     self._option_widgets = []
                     await scroll.mount(
                         Static(
-                            "[dim]No threads found[/dim]",
+                            Content.styled("No threads found", "dim"),
                             classes="thread-empty",
                         )
                     )

--- a/libs/cli/deepagents_cli/widgets/tool_widgets.py
+++ b/libs/cli/deepagents_cli/widgets/tool_widgets.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from rich.markup import escape as escape_markup
 from textual.containers import Vertical
+from textual.content import Content
 from textual.widgets import Markdown, Static
 
 if TYPE_CHECKING:
@@ -109,7 +109,12 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         # File path header with stats
         stats_str = self._format_stats(additions, deletions)
         yield Static(
-            f"[bold cyan]File:[/bold cyan] {escape_markup(file_path)}  {stats_str}"
+            Content.assemble(
+                Content.from_markup(
+                    "[bold cyan]File:[/bold cyan] $path  ", path=file_path
+                ),
+                stats_str,
+            )
         )
         yield Static("")
 
@@ -147,18 +152,22 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         return additions, deletions
 
     @staticmethod
-    def _format_stats(additions: int, deletions: int) -> str:
-        """Format stats as colored string.
+    def _format_stats(additions: int, deletions: int) -> Content:
+        """Format addition/deletion stats as styled Content.
 
         Returns:
-            Rich-formatted string showing additions and deletions.
+            Styled Content showing additions and deletions.
         """
-        parts = []
+        parts: list[str | tuple[str, str] | Content] = []
         if additions:
-            parts.append(f"[green]+{additions}[/green]")
+            if parts:
+                parts.append(" ")
+            parts.append((f"+{additions}", "green"))
         if deletions:
-            parts.append(f"[red]-{deletions}[/red]")
-        return " ".join(parts)
+            if parts:
+                parts.append(" ")
+            parts.append((f"-{deletions}", "red"))
+        return Content.assemble(*parts) if parts else Content("")
 
     def _render_diff_lines_only(self, diff_lines: list[str]) -> ComposeResult:
         """Render unified diff lines without returning stats.
@@ -171,7 +180,9 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         for line in diff_lines:
             if lines_shown >= _MAX_DIFF_LINES:
                 yield Static(
-                    f"[dim]... ({len(diff_lines) - lines_shown} more lines)[/dim]"
+                    Content.styled(
+                        f"... ({len(diff_lines) - lines_shown} more lines)", "dim"
+                    )
                 )
                 break
 
@@ -190,12 +201,12 @@ class EditFileApprovalWidget(ToolApprovalWidget):
             Static widgets showing removed and added content with styling.
         """
         if old_string:
-            yield Static("[bold red]Removing:[/bold red]")
+            yield Static(Content.styled("Removing:", "bold red"))
             yield from self._render_string_lines(old_string, is_addition=False)
             yield Static("")
 
         if new_string:
-            yield Static("[bold green]Adding:[/bold green]")
+            yield Static(Content.styled("Adding:", "bold green"))
             yield from self._render_string_lines(new_string, is_addition=True)
 
     @staticmethod
@@ -205,14 +216,22 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         Returns:
             Static widget with styled diff line, or None for empty/skipped lines.
         """
-        content = escape_markup(line[1:] if len(line) > 1 else "")
+        raw = line[1:] if len(line) > 1 else ""
 
         if line.startswith("-"):
-            return Static(f"[on #4a2020][#ff8787]- {content}[/#ff8787][/on #4a2020]")
+            return Static(
+                Content.from_markup(
+                    "[on #4a2020][#ff8787]- $text[/#ff8787][/on #4a2020]", text=raw
+                )
+            )
         if line.startswith("+"):
-            return Static(f"[on #1e4620][#8ce99a]+ {content}[/#8ce99a][/on #1e4620]")
+            return Static(
+                Content.from_markup(
+                    "[on #1e4620][#8ce99a]+ $text[/#8ce99a][/on #1e4620]", text=raw
+                )
+            )
         if line.startswith(" "):
-            return Static(f"[#aaaaaa]  {content}[/#aaaaaa]")
+            return Static(Content.from_markup("[#aaaaaa]  $text[/#aaaaaa]", text=raw))
         if line.strip():
             return Static(line, markup=False)
         return None
@@ -231,9 +250,8 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         )
 
         for line in lines[:_MAX_PREVIEW_LINES]:
-            escaped = escape_markup(line)
-            yield Static(f"{style} {escaped}{end_style}")
+            yield Static(Content.from_markup(f"{style} $text{end_style}", text=line))
 
         if len(lines) > _MAX_PREVIEW_LINES:
             remaining = len(lines) - _MAX_PREVIEW_LINES
-            yield Static(f"[dim]... ({remaining} more lines)[/dim]")
+            yield Static(Content.styled(f"... ({remaining} more lines)", "dim"))

--- a/libs/cli/tests/unit_tests/test_approval.py
+++ b/libs/cli/tests/unit_tests/test_approval.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from rich.markup import render
 
 from deepagents_cli.config import get_glyphs
 from deepagents_cli.widgets.approval import (
@@ -68,35 +67,35 @@ class TestGetCommandDisplay:
         """Test that short commands display in full regardless of expanded state."""
         menu = ApprovalMenu({"name": "shell", "args": {"command": "echo hello"}})
         display = menu._get_command_display(expanded=False)
-        assert "echo hello" in display
-        assert "press 'e' to expand" not in display
+        assert "echo hello" in display.plain
+        assert "press 'e' to expand" not in display.plain
 
     def test_long_command_truncated_when_not_expanded(self) -> None:
         """Test that long commands are truncated with expand hint."""
         long_command = "x" * (_SHELL_COMMAND_TRUNCATE_LENGTH + 50)
         menu = ApprovalMenu({"name": "shell", "args": {"command": long_command}})
         display = menu._get_command_display(expanded=False)
-        assert get_glyphs().ellipsis in display
-        assert "press 'e' to expand" in display
+        assert get_glyphs().ellipsis in display.plain
+        assert "press 'e' to expand" in display.plain
         # Check that the truncated portion is present
-        assert "x" * _SHELL_COMMAND_TRUNCATE_LENGTH in display
+        assert "x" * _SHELL_COMMAND_TRUNCATE_LENGTH in display.plain
 
     def test_long_command_shows_full_when_expanded(self) -> None:
         """Test that long commands display in full when expanded."""
         long_command = "x" * (_SHELL_COMMAND_TRUNCATE_LENGTH + 50)
         menu = ApprovalMenu({"name": "shell", "args": {"command": long_command}})
         display = menu._get_command_display(expanded=True)
-        assert long_command in display
-        assert "press 'e' to expand" not in display
-        assert get_glyphs().ellipsis not in display
+        assert long_command in display.plain
+        assert "press 'e' to expand" not in display.plain
+        assert get_glyphs().ellipsis not in display.plain
 
     def test_short_command_shows_full_even_when_expanded_true(self) -> None:
         """Test that short commands show in full even when expanded=True."""
         menu = ApprovalMenu({"name": "shell", "args": {"command": "echo hello"}})
         display = menu._get_command_display(expanded=True)
-        assert "echo hello" in display
-        assert "press 'e' to expand" not in display
-        assert get_glyphs().ellipsis not in display
+        assert "echo hello" in display.plain
+        assert "press 'e' to expand" not in display.plain
+        assert get_glyphs().ellipsis not in display.plain
 
     def test_command_at_boundary_plus_one_is_expandable(self) -> None:
         """Test off-by-one: command at exactly threshold + 1 is expandable."""
@@ -104,41 +103,39 @@ class TestGetCommandDisplay:
         menu = ApprovalMenu({"name": "shell", "args": {"command": boundary_command}})
         assert menu._has_expandable_command is True
         display = menu._get_command_display(expanded=False)
-        assert get_glyphs().ellipsis in display
-        assert "press 'e' to expand" in display
+        assert get_glyphs().ellipsis in display.plain
+        assert "press 'e' to expand" in display.plain
 
     def test_none_command_value_handled(self) -> None:
         """Test that None command value is handled gracefully."""
         menu = ApprovalMenu({"name": "shell", "args": {"command": None}})
         assert menu._has_expandable_command is False
         display = menu._get_command_display(expanded=False)
-        assert "None" in display
+        assert "None" in display.plain
 
     def test_integer_command_value_handled(self) -> None:
         """Test that integer command value is converted to string."""
         menu = ApprovalMenu({"name": "shell", "args": {"command": 12345}})
         assert menu._has_expandable_command is False
         display = menu._get_command_display(expanded=False)
-        assert "12345" in display
+        assert "12345" in display.plain
 
     def test_command_display_escapes_markup_tags(self) -> None:
-        """Shell command display should escape literal Rich tag sequences."""
+        """Shell command display should safely render literal bracket sequences."""
         command = "echo [/dim] [literal]"
         menu = ApprovalMenu({"name": "shell", "args": {"command": command}})
         display = menu._get_command_display(expanded=True)
-        rendered = render(display)
-        assert command in rendered.plain
+        assert command in display.plain
 
     def test_command_display_with_hidden_unicode_shows_warning(self) -> None:
         """Hidden Unicode should be surfaced with explicit warning details."""
         command = "echo a\u202eb"
         menu = ApprovalMenu({"name": "shell", "args": {"command": command}})
         display = menu._get_command_display(expanded=True)
-        rendered = render(display)
-        assert "echo ab" in rendered.plain
-        assert "hidden chars detected" in rendered.plain
-        assert "U+202E" in rendered.plain
-        assert "raw:" in rendered.plain
+        assert "echo ab" in display.plain
+        assert "hidden chars detected" in display.plain
+        assert "U+202E" in display.plain
+        assert "raw:" in display.plain
 
 
 class TestToggleExpand:
@@ -167,16 +164,16 @@ class TestToggleExpand:
         menu.action_toggle_expand()
         menu._command_widget.update.assert_called_once()
         expanded_call = menu._command_widget.update.call_args[0][0]
-        assert long_command in expanded_call
-        assert get_glyphs().ellipsis not in expanded_call
+        assert long_command in expanded_call.plain
+        assert get_glyphs().ellipsis not in expanded_call.plain
 
         # Second toggle: collapse
         menu._command_widget.reset_mock()
         menu.action_toggle_expand()
         menu._command_widget.update.assert_called_once()
         collapsed_call = menu._command_widget.update.call_args[0][0]
-        assert get_glyphs().ellipsis in collapsed_call
-        assert "press 'e' to expand" in collapsed_call
+        assert get_glyphs().ellipsis in collapsed_call.plain
+        assert "press 'e' to expand" in collapsed_call.plain
 
     def test_toggle_does_nothing_for_non_expandable(self) -> None:
         """Test that toggling does nothing for non-expandable commands."""

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from rich.markup import render
 from rich.style import Style
 from textual.content import Content
 
@@ -148,7 +147,7 @@ class TestToolCallMessageMarkupSafety:
         assert msg._args == args
 
     def test_tool_header_escapes_markup_in_label(self) -> None:
-        """Tool header should escape tool label content before Rich parsing."""
+        """Tool header should safely render label content with markup-like chars."""
         msg = ToolCallMessage(
             "task",
             {"description": "Search for closing tag [/dim] mismatches"},
@@ -157,9 +156,8 @@ class TestToolCallMessageMarkupSafety:
         # `task` has no inline args widget, so this validates the header markup.
         header = next(iter(msg.compose()))
         content = header._Static__content
-        assert isinstance(content, str)
-        rendered = render(content)
-        assert "[/dim]" in rendered.plain
+        assert isinstance(content, Content)
+        assert "[/dim]" in content.plain
 
     def test_tool_args_line_escapes_markup_values(self) -> None:
         """Inline args line should escape bracket content in argument values."""
@@ -171,10 +169,9 @@ class TestToolCallMessageMarkupSafety:
         widgets = list(msg.compose())
         args_widget = widgets[1]
         content = args_widget._Static__content  # type: ignore[attr-defined]
-        assert isinstance(content, str)
-        rendered = render(content)
-        assert "[foo]" in rendered.plain
-        assert "[/dim]" in rendered.plain
+        assert isinstance(content, Content)
+        assert "[foo]" in content.plain
+        assert "[/dim]" in content.plain
 
 
 class TestToolCallMessageShellCommand:
@@ -271,15 +268,17 @@ class TestToolCallMessageShellCommand:
     def test_format_shell_output_styles_only_first_line_dim(self) -> None:
         """Shell output formatting should only style the first command line in dim."""
         msg = ToolCallMessage("shell", {"command": "echo test"})
-        # Include a line that looks like a command prompt in the output
         output = "$ echo test\ntest output\n$ not a command"
         result = msg._format_shell_output(output, is_preview=False)
 
-        # First line (the command) should be wrapped in [dim] markup
-        assert "[dim]$ echo test[/dim]" in result.content
-        # Subsequent lines starting with $ should NOT be dimmed
-        assert "$ not a command" in result.content
-        assert "[dim]$ not a command" not in result.content
+        assert isinstance(result.content, Content)
+        lines = result.content.split("\n")
+        # First line (the command) should be styled dim
+        assert lines[0].plain == "$ echo test"
+        assert "dim" in lines[0].markup
+        # Subsequent lines should NOT be dim
+        assert lines[2].plain == "$ not a command"
+        assert "dim" not in lines[2].markup
 
 
 class TestUserMessageHighlighting:

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -691,8 +691,8 @@ class TestFormatOptionLabel:
             has_creds=True,
             status="deprecated",
         )
-        assert "(deprecated)" in label
-        assert "[red]" in label
+        assert "(deprecated)" in label.plain
+        assert "[red]" in label.markup
 
     def test_non_deprecated_model_no_tag(self) -> None:
         """Models without deprecated status should not show the tag."""
@@ -703,7 +703,7 @@ class TestFormatOptionLabel:
             has_creds=True,
             status=None,
         )
-        assert "(deprecated)" not in label
+        assert "(deprecated)" not in label.plain
 
     def test_other_status_renders_yellow(self) -> None:
         """Non-deprecated statuses (e.g., beta) render yellow, not red."""
@@ -714,9 +714,9 @@ class TestFormatOptionLabel:
             has_creds=True,
             status="beta",
         )
-        assert "(deprecated)" not in label
-        assert "(beta)" in label
-        assert "[yellow]" in label
+        assert "(deprecated)" not in label.plain
+        assert "(beta)" in label.plain
+        assert "[yellow]" in label.markup
 
     def test_all_suffixes_coexist(self) -> None:
         """Current + default + deprecated all render together."""
@@ -728,9 +728,9 @@ class TestFormatOptionLabel:
             is_default=True,
             status="deprecated",
         )
-        assert "(current)" in label
-        assert "(default)" in label
-        assert "(deprecated)" in label
+        assert "(current)" in label.plain
+        assert "(default)" in label.plain
+        assert "(deprecated)" in label.plain
 
 
 class TestGetModelStatus:
@@ -798,21 +798,22 @@ class TestModelDetailFooter:
             overridden_keys=frozenset(),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "200.0K" in result
-        assert "64.0K" in result
-        assert "text" in result
-        assert "image" in result
-        assert "tool calling" in result
-        assert "reasoning" in result
+        text = str(result)
+        assert "200.0K" in text
+        assert "64.0K" in text
+        assert "text" in text
+        assert "image" in text
+        assert "tool calling" in text
+        assert "reasoning" in text
         # No override marker
-        assert "* =" not in result
+        assert "* =" not in text
 
     def test_format_footer_no_profile(self) -> None:
         """None profile shows 'Model profile not available'."""
         from deepagents_cli.config import UNICODE_GLYPHS
 
         result = ModelSelectorScreen._format_footer(None, UNICODE_GLYPHS)
-        assert "Model profile not available :(" in result
+        assert "Model profile not available :(" in str(result)
 
     def test_format_footer_overridden_fields(self) -> None:
         """Overridden fields show yellow * marker and override legend."""
@@ -828,8 +829,10 @@ class TestModelDetailFooter:
             overridden_keys=frozenset({"max_input_tokens"}),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "[yellow]*" in result
-        assert "= override" in result
+        text = str(result)
+        assert "*" in text
+        assert "= override" in text
+        assert "[yellow]" in result.markup
 
     def test_format_footer_partial_profile(self) -> None:
         """Profile with only token counts still renders without crash."""
@@ -841,9 +844,10 @@ class TestModelDetailFooter:
             overridden_keys=frozenset(),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "4096" in result or "4.1K" in result or "4.0K" in result
+        text = str(result)
+        assert "4096" in text or "4.1K" in text or "4.0K" in text
         # Should not crash and should have content
-        assert "No profile data" not in result
+        assert "No profile data" not in text
 
     def test_format_footer_empty_profile(self) -> None:
         """Empty profile dict shows 'Model profile not available'."""
@@ -855,7 +859,7 @@ class TestModelDetailFooter:
             overridden_keys=frozenset(),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "Model profile not available :(" in result
+        assert "Model profile not available :(" in str(result)
 
     def test_format_footer_override_on_non_displayed_key(self) -> None:
         """Override on a non-displayed key should not show legend."""
@@ -867,7 +871,7 @@ class TestModelDetailFooter:
             overridden_keys=frozenset({"supports_thinking"}),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "= override" not in result
+        assert "= override" not in str(result)
 
     def test_format_footer_non_numeric_tokens(self) -> None:
         """Non-numeric token values render gracefully instead of crashing."""
@@ -879,8 +883,9 @@ class TestModelDetailFooter:
             overridden_keys=frozenset(),
         )
         result = ModelSelectorScreen._format_footer(entry, UNICODE_GLYPHS)
-        assert "unlimited" in result
-        assert "64.0K" in result
+        text = str(result)
+        assert "unlimited" in text
+        assert "64.0K" in text
 
     async def test_footer_updates_on_navigation(self) -> None:
         """Footer content changes when navigating to a different model."""

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -816,7 +816,9 @@ class TestThreadSelectorBuildTitle:
             s for s in title._spans if isinstance(s.style, TStyle) and s.style.link
         ]
         assert len(spans) > 0
-        assert spans[0].style.foreground == TColor.parse("cyan")
+        style = spans[0].style
+        assert isinstance(style, TStyle)
+        assert style.foreground == TColor.parse("cyan")
 
     async def test_title_widget_has_id(self) -> None:
         """Title widget should be queryable by ID for URL updates."""
@@ -2545,7 +2547,9 @@ class TestBuildThreadMessage:
             s for s in result._spans if isinstance(s.style, TStyle) and s.style.link
         ]
         assert len(spans) == 1
-        assert spans[0].style.link == url
+        style = spans[0].style
+        assert isinstance(style, TStyle)
+        assert style.link == url
 
     async def test_fallback_on_timeout(self) -> None:
         """Returns plain string when URL resolution times out."""


### PR DESCRIPTION
Eliminate all `rich.markup.escape` + f-string Rich markup patterns from CLI widgets, replacing them with Textual's `Content` API. The prior approach was fragile — any dynamic string containing square brackets could break or silently corrupt Rich markup. `Content.from_markup` with `$var` substitution auto-escapes external content at the API level, making markup injection structurally impossible.

## Changes

- Replace every `escape_markup` + f-string pattern across all 11 widget modules with `Content.from_markup("...$var...", var=value)` for user-controlled strings (tool args, file paths, commands, error messages) and `Content.styled(text, style)` for trusted/static text
- Change return types from `str` to `Content` on formatting methods: `_get_command_display`, `format_diff_textual`, `_format_option_label`, `_format_footer`, `_format_collapsed`/`_format_expanded`, `_format_stats`, `_build_todo_stats`, `_format_single_todo`, and all `FormattedOutput.content` fields
- Rewrite `_prefix_output` in `ToolCallMessage` to split and reassemble `Content` objects instead of raw string manipulation, preserving per-line styling through the prefix/indent step
- Simplify `_ChoiceOption` in `ask_user.py` — push cursor-prefix logic into a `_render()` method that returns `Content`, removing the fragile strip-and-re-prepend dance in `_update_display`
- Migrate diff stat rendering in `diff.py` and `tool_widgets.py` from markup strings to `Content.assemble` with `(text, style)` tuples, fixing an edge case where `Content("\n").join` wasn't handling the separator between addition/deletion stats
- Update `AGENTS.md` with the `Content` API decision rules: `from_markup` for external values, `styled` for trusted values, `assemble` for structural composition