### PR TITLE
perf(cli): offload blocking path ops from textual event loop

### DIFF
--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -476,6 +476,29 @@ def _build_interrupted_ai_message(
     )
 
 
+def _read_mentioned_file(file_path: Path, max_embed_bytes: int) -> str:
+    """Read a mentioned file for inline embedding (sync, for use with to_thread).
+
+    Args:
+        file_path: Resolved path to the file.
+        max_embed_bytes: Size threshold; larger files get a reference only.
+
+    Returns:
+        Markdown snippet with the file content or a size-exceeded reference.
+    """
+    file_size = file_path.stat().st_size
+    if file_size > max_embed_bytes:
+        size_kb = file_size // 1024
+        return (
+            f"\n### {file_path.name}\n"
+            f"Path: `{file_path}`\n"
+            f"Size: {size_kb}KB (too large to embed, "
+            "use read_file tool to view)"
+        )
+    content = file_path.read_text(encoding="utf-8")
+    return f"\n### {file_path.name}\nPath: `{file_path}`\n```\n{content}\n```"
+
+
 async def execute_task_textual(
     user_input: str,
     agent: Any,  # noqa: ANN401  # Dynamic agent graph type
@@ -509,8 +532,10 @@ async def execute_task_textual(
     Raises:
         ValidationError: If HITL request validation fails (re-raised).
     """
-    # Parse file mentions and inject content if any
-    prompt_text, mentioned_files = parse_file_mentions(user_input)
+    # Parse file mentions and inject content if any — offload blocking I/O
+    prompt_text, mentioned_files = await asyncio.to_thread(
+        parse_file_mentions, user_input
+    )
 
     # Max file size to embed inline (256KB, matching mistral-vibe)
     # Larger files get a reference instead - use read_file tool to view them
@@ -520,22 +545,10 @@ async def execute_task_textual(
         context_parts = [prompt_text, "\n\n## Referenced Files\n"]
         for file_path in mentioned_files:
             try:
-                file_size = file_path.stat().st_size
-                if file_size > max_embed_bytes:
-                    # File too large - include reference instead of content
-                    size_kb = file_size // 1024
-                    context_parts.append(
-                        f"\n### {file_path.name}\n"
-                        f"Path: `{file_path}`\n"
-                        f"Size: {size_kb}KB (too large to embed, "
-                        "use read_file tool to view)"
-                    )
-                else:
-                    content = file_path.read_text()
-                    context_parts.append(
-                        f"\n### {file_path.name}\n"
-                        f"Path: `{file_path}`\n```\n{content}\n```"
-                    )
+                part = await asyncio.to_thread(
+                    _read_mentioned_file, file_path, max_embed_bytes
+                )
+                context_parts.append(part)
             except Exception as e:  # noqa: BLE001  # Resilient adapter error handling
                 context_parts.append(
                     f"\n### {file_path.name}\n[Error reading file: {e}]"

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -6,6 +6,8 @@ for slash commands (/) and file mentions (@).
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import shutil
 
 # S404: subprocess is required for git ls-files to get project file list
@@ -495,6 +497,16 @@ class FuzzyFileController:
     def refresh_cache(self) -> None:
         """Force refresh of file cache."""
         self._file_cache = None
+
+    async def warm_cache(self) -> None:
+        """Pre-populate the file cache off the event loop."""
+        if self._file_cache is not None:
+            return
+        # Best-effort; _get_files() falls back to sync on failure.
+        with contextlib.suppress(Exception):
+            self._file_cache = await asyncio.to_thread(
+                _get_project_files, self._project_root
+            )
 
     @staticmethod
     def can_handle(text: str, cursor_index: int) -> bool:

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from pathlib import Path
@@ -416,7 +417,7 @@ class ChatTextArea(TextArea):
         row, col = self.cursor_location
         return row == 0 and col == 0
 
-    def _flush_paste_burst(self) -> None:
+    async def _flush_paste_burst(self) -> None:
         """Flush buffered burst text through dropped-path parsing.
 
         When parsing fails, the buffered text is inserted unchanged so regular
@@ -431,7 +432,10 @@ class ChatTextArea(TextArea):
 
         from deepagents_cli.input import parse_pasted_path_payload
 
-        parsed = parse_pasted_path_payload(payload)
+        try:
+            parsed = await asyncio.to_thread(parse_pasted_path_payload, payload)
+        except Exception:  # noqa: BLE001  # Treat thread failure as non-path text
+            parsed = None
         if parsed is not None:
             self.post_message(self.PastedPaths(payload, parsed.paths))
             return
@@ -501,7 +505,7 @@ class ChatTextArea(TextArea):
                     event.stop()
                     return
 
-            self._flush_paste_burst()
+            await self._flush_paste_burst()
 
         if (
             event.is_printable
@@ -654,11 +658,14 @@ class ChatTextArea(TextArea):
         """Handle paste events and detect dragged file paths."""
         self._backslash_pending_time = None
         if self._paste_burst_buffer:
-            self._flush_paste_burst()
+            await self._flush_paste_burst()
 
         from deepagents_cli.input import parse_pasted_path_payload
 
-        parsed = parse_pasted_path_payload(event.text)
+        try:
+            parsed = await asyncio.to_thread(parse_pasted_path_payload, event.text)
+        except Exception:  # noqa: BLE001  # Treat thread failure as non-path text
+            parsed = None
         if parsed is None:
             # Don't call super() here — Textual's MRO dispatch already calls
             # TextArea._on_paste after this handler returns. Calling super()
@@ -883,13 +890,21 @@ class ChatInput(Vertical):
         # Both controllers implement the CompletionController protocol but have
         # different concrete types; the list-item warning is a false positive.
         self._completion_view = _CompletionViewAdapter(self)
+        self._file_controller = FuzzyFileController(
+            self._completion_view, cwd=self._cwd
+        )
         self._completion_manager = MultiCompletionManager(
             [
                 SlashCommandController(SLASH_COMMANDS, self._completion_view),
-                FuzzyFileController(self._completion_view, cwd=self._cwd),
+                self._file_controller,
             ]  # type: ignore[list-item]  # Controller types are compatible at runtime
         )
 
+        self.run_worker(
+            self._file_controller.warm_cache(),
+            exclusive=False,
+            exit_on_error=False,
+        )
         self._text_area.focus()
 
     def on_text_area_changed(self, event: TextArea.Changed) -> None:


### PR DESCRIPTION
Synchronous filesystem calls (`stat()`, `read_text()`, `subprocess.run()`, `iterdir()`) in the Textual event loop block the UI thread. On large repos or network-mounted drives, `@`-mention file completion, file-mention submission, and path pasting can freeze the terminal for multiple seconds. These changes offload every hot-path blocking I/O call to `asyncio.to_thread()`, keeping the event loop responsive.

## Changes

- **Pre-warm `@`-mention file cache at mount time** — `ChatInput.on_mount()` now launches a Textual worker calling `FuzzyFileController.warm_cache()`, which runs `_get_project_files()` (git ls-files + glob fallback) in a thread. First `@` keystroke hits a warm cache instead of blocking; if the user beats the worker, the existing sync fallback in `_get_files()` fires as before.
- **Offload file-mention I/O in `execute_task_textual`** — `parse_file_mentions()` and per-file `stat()`/`read_text()` are wrapped in `asyncio.to_thread()`. Extract `_read_mentioned_file()` as a sync helper to keep the offload clean.
- **Make `_flush_paste_burst()` async** — `parse_pasted_path_payload()` (which calls `iterdir()` for unicode-space path resolution) is offloaded to a thread in both `_flush_paste_burst()` and `_on_paste()`. All three call sites (`_on_key`, `_on_paste`, `set_timer` callback) updated to `await`.
