### PR TITLE
fix(cli): use ascii-safe glyphs in tool status restore path

### DIFF
--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -556,14 +556,20 @@ class ToolCallMessage(Vertical):
                 self._output = output
                 if self._status_widget:
                     self._status_widget.add_class("error")
-                    self._status_widget.update(Content.styled("✗ Error", "red"))
+                    error_icon = get_glyphs().error
+                    self._status_widget.update(
+                        Content.styled(f"{error_icon} Error", "red")
+                    )
                     self._status_widget.display = True
                 self._update_output_display()
             case "rejected":
                 self._status = "rejected"
                 if self._status_widget:
                     self._status_widget.add_class("rejected")
-                    self._status_widget.update(Content.styled("✗ Rejected", "yellow"))
+                    error_icon = get_glyphs().error
+                    self._status_widget.update(
+                        Content.styled(f"{error_icon} Rejected", "yellow")
+                    )
                     self._status_widget.display = True
             case "skipped":
                 self._status = "skipped"
@@ -577,7 +583,10 @@ class ToolCallMessage(Vertical):
                 self._status = "running"
                 if self._status_widget:
                     self._status_widget.add_class("pending")
-                    self._status_widget.update(Content.styled("⠿ Running...", "yellow"))
+                    frame = get_glyphs().spinner_frames[0]
+                    self._status_widget.update(
+                        Content.styled(f"{frame} Running...", "yellow")
+                    )
                     self._status_widget.display = True
             case _:
                 # pending or unknown - leave as default


### PR DESCRIPTION
`ToolCallMessage._restore_status` hardcoded Unicode glyphs (`✗`, `⠿`) for the error, rejected, and running states, bypassing the `get_glyphs()` system. In ASCII charset mode these rendered as raw Unicode instead of their ASCII equivalents (`[X]`, ASCII spinner). The live code paths (`set_error`, `set_rejected`, `_update_running_animation`) already used `get_glyphs()` correctly — the restore path just never got the same treatment.

## Changes
- Replace hardcoded `✗` in the `"error"` and `"rejected"` branches of `ToolCallMessage._restore_status` with `get_glyphs().error`, matching `set_error` and `set_rejected`
- Replace hardcoded `⠿` in the `"running"` branch with `get_glyphs().spinner_frames[0]`, matching `_update_running_animation`