### PR TITLE
perf(cli): use stream layout for messages container

### DIFF
--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -21,8 +21,10 @@ Screen {
     margin-bottom: 1;
 }
 
-/* Messages area */
+/* Messages area — uses undocumented "stream" layout (Textual ≥5.2.0) for
+   O(1) append performance via incremental placement caching. */
 #messages {
+    layout: stream;
     height: auto;
 }
 


### PR DESCRIPTION
Switch the `#messages` container from the default `vertical` layout to Textual's `stream` layout. The stream layout skips fractional/percentage resolution and caches widget placements incrementally — appending a new message widget to a long conversation is O(1) instead of re-laying-out every child. The trade-offs (no absolute positioning, no fractional heights, no layers) don't apply to this container since it's a simple append-only list of auto-height message widgets.