### PR TITLE
feat(cli): add `enabled` flag to hide providers from `/model` switcher

### DIFF
--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -131,6 +131,15 @@ class ProviderConfig(TypedDict, total=False):
         scripts — the user controls their own machine.
     """
 
+    enabled: bool
+    """Whether this provider appears in the model switcher.
+
+    Defaults to `True`. Set to `False` to hide a package-discovered provider
+    and all its models from the `/model` selector. Useful when a LangChain
+    provider package is installed as a transitive dependency but should not
+    be user-visible.
+    """
+
     models: list[str]
     """List of model identifiers available from this provider."""
 
@@ -371,6 +380,7 @@ def get_available_models() -> dict[str, list[str]]:
         return _available_models_cache
 
     available: dict[str, list[str]] = {}
+    config = ModelConfig.load()
 
     # Try to load from langchain provider profile data.
     # Build the list dynamically from langchain's supported-provider registry
@@ -380,6 +390,13 @@ def get_available_models() -> dict[str, list[str]]:
 
     for provider, module_path in provider_modules:
         registry_providers.add(provider)
+        # Skip providers explicitly disabled in config.
+        if not config.is_provider_enabled(provider):
+            logger.debug(
+                "Provider '%s' is disabled in config; skipping registry discovery",
+                provider,
+            )
+            continue
         try:
             profiles = _load_provider_profiles(module_path)
         except ImportError:
@@ -411,8 +428,15 @@ def get_available_models() -> dict[str, list[str]]:
             available[provider] = models
 
     # Merge in models from config file (custom providers like ollama, fireworks)
-    config = ModelConfig.load()
     for provider_name, provider_config in config.providers.items():
+        # Respect enabled = false (hide provider entirely).
+        if not config.is_provider_enabled(provider_name):
+            logger.debug(
+                "Provider '%s' is disabled in config; skipping",
+                provider_name,
+            )
+            continue
+
         config_models = list(provider_config.get("models", []))
 
         # For class_path providers not in the built-in registry, auto-discover
@@ -536,6 +560,13 @@ def get_model_profiles(
     registry_providers: set[str] = set()
     for provider, module_path in provider_modules:
         registry_providers.add(provider)
+        # Skip providers explicitly disabled in config.
+        if not config.is_provider_enabled(provider):
+            logger.debug(
+                "Provider '%s' is disabled in config; skipping profiles",
+                provider,
+            )
+            continue
         try:
             profiles = _load_provider_profiles(module_path)
         except ImportError:
@@ -562,6 +593,12 @@ def get_model_profiles(
 
     # Add config-only models and class_path provider profiles.
     for provider_name, provider_config in config.providers.items():
+        if not config.is_provider_enabled(provider_name):
+            logger.debug(
+                "Provider '%s' is disabled in config; skipping profiles",
+                provider_name,
+            )
+            continue
         # For class_path providers not in the built-in registry, load
         # upstream profiles from the package's _profiles.py.
         if provider_name not in registry_providers:
@@ -783,8 +820,17 @@ class ModelConfig:
                 self.recent_model,
             )
 
-        # Validate class_path format and params references
+        # Validate enabled field type and class_path format / params references
         for name, provider in self.providers.items():
+            enabled = provider.get("enabled")
+            if enabled is not None and not isinstance(enabled, bool):
+                logger.warning(
+                    "Provider '%s' has non-boolean 'enabled' value %r "
+                    "(expected true/false). Provider will remain visible.",
+                    name,
+                    enabled,
+                )
+
             class_path = provider.get("class_path")
             if class_path and ":" not in class_path:
                 logger.warning(
@@ -807,8 +853,30 @@ class ModelConfig:
                         key,
                     )
 
+    def is_provider_enabled(self, provider_name: str) -> bool:
+        """Check whether a provider should appear in the model switcher.
+
+        A provider is disabled when its config explicitly sets
+        `enabled = false`. Providers not present in the config file are
+        always considered enabled.
+
+        Args:
+            provider_name: The provider to check.
+
+        Returns:
+            `False` if the provider is explicitly disabled, `True` otherwise.
+        """
+        provider = self.providers.get(provider_name)
+        if not provider:
+            return True
+        return provider.get("enabled") is not False
+
     def get_all_models(self) -> list[tuple[str, str]]:
         """Get all models as `(model_name, provider_name)` tuples.
+
+        Returns raw config data — does not filter by `is_provider_enabled`.
+        For the filtered set shown in the model switcher, use
+        `get_available_models()`.
 
         Returns:
             List of tuples containing `(model_name, provider_name)`.
@@ -821,6 +889,8 @@ class ModelConfig:
 
     def get_provider_for_model(self, model_name: str) -> str | None:
         """Find the provider that contains this model.
+
+        Returns raw config data — does not filter by `is_provider_enabled`.
 
         Args:
             model_name: The model identifier to look up.

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1034,6 +1034,239 @@ api_key_env = "SOME_KEY"
         assert "empty" not in models
 
 
+class TestDisabledProviders:
+    """Tests for provider hiding via `enabled = false`."""
+
+    def test_enabled_false_hides_registry_provider(self, tmp_path: Path) -> None:
+        """Registry provider with `enabled = false` is hidden."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = false
+""")
+        fake_profiles = {
+            "claude-sonnet-4-5": {"tool_calling": True},
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "anthropic" not in models
+
+    def test_enabled_false_hides_config_only_provider(self, tmp_path: Path) -> None:
+        """A config-only provider with `enabled = false` is not shown."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.custom]
+enabled = false
+models = ["my-model"]
+api_key_env = "CUSTOM_KEY"
+""")
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=ImportError("not installed"),
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "custom" not in models
+
+    def test_enabled_true_preserves_provider(self, tmp_path: Path) -> None:
+        """A provider with `enabled = true` behaves normally."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = true
+""")
+        fake_profiles = {
+            "claude-sonnet-4-5": {"tool_calling": True},
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "anthropic" in models
+        assert "claude-sonnet-4-5" in models["anthropic"]
+
+    def test_enabled_false_excludes_from_profiles(self, tmp_path: Path) -> None:
+        """A disabled provider is excluded from get_model_profiles()."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = false
+""")
+        fake_profiles = {
+            "claude-sonnet-4-5": {
+                "tool_calling": True,
+                "max_input_tokens": 200000,
+            },
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        assert "anthropic:claude-sonnet-4-5" not in profiles
+
+    def test_enabled_false_excludes_config_only_from_profiles(
+        self, tmp_path: Path
+    ) -> None:
+        """A disabled config-only provider is excluded from profiles."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.custom]
+enabled = false
+models = ["my-model"]
+api_key_env = "CUSTOM_KEY"
+""")
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=ImportError("not installed"),
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            profiles = get_model_profiles()
+
+        assert "custom:my-model" not in profiles
+
+    def test_disabled_provider_does_not_affect_others(self, tmp_path: Path) -> None:
+        """Disabling one provider does not affect other providers."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = false
+
+[models.providers.custom]
+models = ["my-model"]
+api_key_env = "CUSTOM_KEY"
+""")
+        fake_profiles = {
+            "claude-sonnet-4-5": {"tool_calling": True},
+        }
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return fake_profiles
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.model_config._load_provider_profiles",
+                side_effect=mock_load,
+            ),
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+        ):
+            models = get_available_models()
+
+        assert "anthropic" not in models
+        assert "custom" in models
+        assert "my-model" in models["custom"]
+
+
+class TestIsProviderEnabled:
+    """Tests for ModelConfig.is_provider_enabled()."""
+
+    def test_returns_true_when_not_in_config(self) -> None:
+        """Providers not in config are enabled by default."""
+        config = ModelConfig()
+        assert config.is_provider_enabled("anthropic") is True
+
+    def test_returns_true_when_enabled_not_set(self, tmp_path: Path) -> None:
+        """Provider without `enabled` field is enabled."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+""")
+        config = ModelConfig.load(config_path)
+        assert config.is_provider_enabled("anthropic") is True
+
+    def test_returns_false_when_enabled_false(self, tmp_path: Path) -> None:
+        """`enabled = false` disables the provider."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = false
+""")
+        config = ModelConfig.load(config_path)
+        assert config.is_provider_enabled("anthropic") is False
+
+    def test_returns_true_for_nonempty_models_list(self, tmp_path: Path) -> None:
+        """Provider with models is enabled."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5"]
+""")
+        config = ModelConfig.load(config_path)
+        assert config.is_provider_enabled("anthropic") is True
+
+    def test_enabled_false_takes_precedence_over_models(self, tmp_path: Path) -> None:
+        """`enabled = false` hides provider even with models listed."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = false
+models = ["claude-sonnet-4-5"]
+""")
+        config = ModelConfig.load(config_path)
+        assert config.is_provider_enabled("anthropic") is False
+
+    def test_string_false_not_treated_as_disabled(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """String `"false"` is not bool `false`; provider stays enabled."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+enabled = "false"
+""")
+        with caplog.at_level(logging.WARNING, logger="deepagents_cli.model_config"):
+            config = ModelConfig.load(config_path)
+
+        assert config.is_provider_enabled("anthropic") is True
+        assert any("non-boolean" in r.message for r in caplog.records)
+
+
 class TestProfileModuleFromClassPath:
     """Tests for _profile_module_from_class_path() helper."""
 


### PR DESCRIPTION
Closes #1874

---

Add `enabled = false` support to `ProviderConfig` so users can hide package-discovered providers from the `/model` switcher. When a LangChain provider package is installed as a transitive dependency (e.g., `langchain-openai` pulled in by a custom gateway backend), its models previously appeared in the switcher with no way to suppress them.

## Changes

- Add optional `enabled` field to `ProviderConfig` — defaults to `True`; set `enabled = false` under `[models.providers.<name>]` to hide a provider and all its models from the switcher
- Add `ModelConfig.is_provider_enabled()` to centralize the check, used by both `get_available_models()` and `get_model_profiles()` across their registry and config-provider loops
- `_validate()` warns when `enabled` has a non-boolean value (e.g., TOML string `"false"` instead of bare `false`), since `is not False` would silently treat it as enabled
- All filter points emit `logger.debug` messages so `--verbose` reveals exactly why a provider was excluded
- `get_all_models()` and `get_provider_for_model()` intentionally remain unfiltered (raw config accessors) — docstrings clarify this
