### PR TITLE
fix(cli): show checkmark for `class_path` providers in model selector

### DIFF
--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -654,10 +654,12 @@ def has_provider_credentials(provider: str) -> bool | None:
 
     Resolution order:
 
-    1. Config-file providers (`config.toml`) — takes priority so user
-        overrides (e.g., custom `api_key_env` or `base_url`) are respected.
-    2. Hardcoded `PROVIDER_API_KEY_ENV` mapping (anthropic, openai, etc.).
-    3. For any other provider (e.g., third-party langchain provider
+    1. Config-file providers (`config.toml`) with `api_key_env` — takes
+        priority so user overrides are respected.
+    2. Config-file providers with `class_path` but no `api_key_env` —
+        assumed to manage their own auth (e.g., custom headers, JWT, mTLS).
+    3. Hardcoded `PROVIDER_API_KEY_ENV` mapping (anthropic, openai, etc.).
+    4. For any other provider (e.g., third-party langchain provider
         packages), credential status is unknown — the provider itself will
         report auth failures at model-creation time.
 
@@ -665,15 +667,22 @@ def has_provider_credentials(provider: str) -> bool | None:
         provider: Provider name.
 
     Returns:
-        True if credentials are confirmed available, False if confirmed
-            missing, or None if credential status cannot be determined.
+        True if credentials are confirmed available or the provider is
+            expected to manage its own auth (e.g., `class_path` providers),
+            False if confirmed missing, or None if credential status cannot
+            be determined.
     """
     # Config-file providers take priority when api_key_env is specified.
     config = ModelConfig.load()
-    if config.providers.get(provider):
+    provider_config = config.providers.get(provider)
+    if provider_config:
         result = config.has_credentials(provider)
         if result is not None:
             return result
+        # class_path providers that omit api_key_env manage their own auth
+        # (e.g., custom headers, JWT, mTLS) — treat as available.
+        if provider_config.get("class_path"):
+            return True
         # No api_key_env in config — fall through to hardcoded map.
 
     # Fall back to hardcoded well-known providers.

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -1577,6 +1577,36 @@ api_key_env = "FIREWORKS_API_KEY"
         ):
             assert has_provider_credentials("fireworks") is False
 
+    def test_class_path_provider_without_api_key_env_returns_true(self, tmp_path):
+        """Returns True for class_path provider with no api_key_env.
+
+        class_path providers manage their own auth (e.g., custom headers, JWT)
+        so they should be treated as having credentials available.
+        """
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.cis]
+class_path = "agent_forge.integrations:CISChat"
+models = ["aviato-turbo"]
+""")
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            assert has_provider_credentials("cis") is True
+
+    def test_class_path_with_api_key_env_respects_env_var(self, tmp_path):
+        """api_key_env takes precedence over class_path for credential check."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.cis]
+class_path = "agent_forge.integrations:CISChat"
+models = ["aviato-turbo"]
+api_key_env = "CIS_API_KEY"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            assert has_provider_credentials("cis") is False
+
     def test_returns_none_for_totally_unknown_provider(self):
         """Returns None for provider not in hardcoded map or config.
 


### PR DESCRIPTION
`class_path` providers that configure a custom `BaseChatModel` subclass in `config.toml` handle their own authentication (JWT, custom headers, mTLS, etc.) — they don't use an `api_key_env` variable. Previously, `has_provider_credentials` returned `None` for these providers, causing the `/model` selector to show a misleading "? credentials unknown" indicator next to them.

## Changes
- `has_provider_credentials` now returns `True` for config-file providers that have a `class_path` but no `api_key_env`, short-circuiting before the hardcoded `PROVIDER_API_KEY_ENV` fallback. When both `class_path` and `api_key_env` are present, the env var check still takes precedence.
- Docstring updated to reflect the new four-step resolution order and the broadened semantics of the `True` return value.