### PR TITLE
fix(cli): use counter to close history-recall autocomplete race

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -586,7 +586,6 @@ class ChatTextArea(TextArea):
             if navigate:
                 event.prevent_default()
                 event.stop()
-                self._skip_history_change_events += 1
                 if event.key == "up":
                     self.post_message(self.HistoryPrevious(self.text))
                 else:
@@ -691,6 +690,7 @@ class ChatTextArea(TextArea):
     def clear_text(self) -> None:
         """Clear the text area."""
         self._in_history = False
+        self._skip_history_change_events = 0
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
@@ -917,6 +917,12 @@ class ChatInput(Vertical):
                 self._completion_manager.reset()
             self.scroll_visible()
             return
+        if self._text_area and self._text_area._skip_history_change_events < 0:
+            logger.warning(
+                "_skip_history_change_events is negative (%d); resetting to 0",
+                self._text_area._skip_history_change_events,
+            )
+            self._text_area._skip_history_change_events = 0
 
         if self._applying_inline_path_replacement:
             self._applying_inline_path_replacement = False

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -281,12 +281,10 @@ class ChatTextArea(TextArea):
         Binding("cmd+shift+z,super+shift+z", "redo", "Redo", show=False, priority=True),
     ]
 
-    _navigating_history: bool
-    """Transient guard set `True` only while `ChatInput` replaces text with a
-    history entry.
-
-    Prevents `watch_text` from treating the programmatic replacement as user
-    typing (which would trigger autocomplete, etc.).
+    _skip_history_change_events: int
+    """Counter incremented before a history-driven text replacement so the
+    resulting ``TextArea.Changed`` event (which fires asynchronously) can be
+    suppressed.  The handler decrements the counter.
     """
 
     _in_history: bool
@@ -332,7 +330,7 @@ class ChatTextArea(TextArea):
         # Remove placeholder if passed, TextArea doesn't support it the same way
         kwargs.pop("placeholder", None)
         super().__init__(**kwargs)
-        self._navigating_history = False
+        self._skip_history_change_events = 0
         self._in_history = False
         self._completion_active = False
         self._app_has_focus = True
@@ -588,7 +586,7 @@ class ChatTextArea(TextArea):
             if navigate:
                 event.prevent_default()
                 event.stop()
-                self._navigating_history = True
+                self._skip_history_change_events += 1
                 if event.key == "up":
                     self.post_message(self.HistoryPrevious(self.text))
                 else:
@@ -682,14 +680,13 @@ class ChatTextArea(TextArea):
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
         self._backslash_pending_time = None
-        self._navigating_history = True
+        self._skip_history_change_events += 1
         self.text = text
         # Move cursor to end
         lines = text.split("\n")
         last_row = len(lines) - 1
         last_col = len(lines[last_row])
         self.move_cursor((last_row, last_col))
-        self._navigating_history = False
 
     def clear_text(self) -> None:
         """Clear the text area."""
@@ -914,7 +911,8 @@ class ChatInput(Vertical):
 
         # History handlers explicitly decide mode and stripped display text.
         # Skip mode detection here so recalled entries don't inherit stale mode.
-        if self._text_area and self._text_area._navigating_history:
+        if self._text_area and self._text_area._skip_history_change_events > 0:
+            self._text_area._skip_history_change_events -= 1
             if self._completion_manager:
                 self._completion_manager.reset()
             self.scroll_visible()
@@ -1205,7 +1203,7 @@ class ChatInput(Vertical):
             self.mode = mode
             self._text_area.set_text_from_history(display_text)
         elif self._text_area:
-            self._text_area._navigating_history = False
+            self._text_area._skip_history_change_events = 0
         # Keep text area's _in_history in sync with the history manager.
         if self._text_area:
             self._text_area._in_history = self._history.in_history
@@ -1221,7 +1219,7 @@ class ChatInput(Vertical):
             self.mode = mode
             self._text_area.set_text_from_history(display_text)
         elif self._text_area:
-            self._text_area._navigating_history = False
+            self._text_area._skip_history_change_events = 0
         # Keep text area's _in_history in sync with the history manager.
         # When the user presses Down past the newest entry, get_next()
         # resets navigation internally, so in_history becomes False.

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -283,8 +283,9 @@ class ChatTextArea(TextArea):
 
     _skip_history_change_events: int
     """Counter incremented before a history-driven text replacement so the
-    resulting ``TextArea.Changed`` event (which fires asynchronously) can be
-    suppressed.  The handler decrements the counter.
+    resulting `TextArea.Changed` event (which fires on the next message-loop
+    iteration) can be suppressed.  `ChatInput.on_text_area_changed` decrements
+    the counter.
     """
 
     _in_history: bool
@@ -690,7 +691,10 @@ class ChatTextArea(TextArea):
     def clear_text(self) -> None:
         """Clear the text area."""
         self._in_history = False
-        self._skip_history_change_events = 0
+        # Increment (not reset) so any pending Changed event from a prior
+        # set_text_from_history is still suppressed, plus one for the
+        # self.text = "" assignment below.
+        self._skip_history_change_events += 1
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
@@ -1208,8 +1212,8 @@ class ChatInput(Vertical):
             mode, display_text = self._history_entry_mode_and_text(entry)
             self.mode = mode
             self._text_area.set_text_from_history(display_text)
-        elif self._text_area:
-            self._text_area._skip_history_change_events = 0
+        # No-match path: don't reset the counter — a pending Changed event
+        # from a prior set_text_from_history call may still be in flight.
         # Keep text area's _in_history in sync with the history manager.
         if self._text_area:
             self._text_area._in_history = self._history.in_history
@@ -1224,8 +1228,8 @@ class ChatInput(Vertical):
             mode, display_text = self._history_entry_mode_and_text(entry)
             self.mode = mode
             self._text_area.set_text_from_history(display_text)
-        elif self._text_area:
-            self._text_area._skip_history_change_events = 0
+        # No-match path: don't reset the counter — a pending Changed event
+        # from a prior set_text_from_history call may still be in flight.
         # Keep text area's _in_history in sync with the history manager.
         # When the user presses Down past the newest entry, get_next()
         # resets navigation internally, so in_history becomes False.

--- a/libs/cli/deepagents_cli/widgets/history.py
+++ b/libs/cli/deepagents_cli/widgets/history.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class HistoryManager:
@@ -50,6 +53,11 @@ class HistoryManager:
                     entries.append(entry if isinstance(entry, str) else str(entry))
                 self._entries = entries[-self.max_entries :]
         except (OSError, UnicodeDecodeError):
+            logger.warning(
+                "Failed to load history from %s; starting with empty history",
+                self.history_file,
+                exc_info=True,
+            )
             self._entries = []
 
     def _append_to_file(self, text: str) -> None:
@@ -59,7 +67,11 @@ class HistoryManager:
             with self.history_file.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(text) + "\n")
         except OSError:
-            pass
+            logger.warning(
+                "Failed to append history entry to %s",
+                self.history_file,
+                exc_info=True,
+            )
 
     def _compact_history(self) -> None:
         """Rewrite history file to remove old entries.
@@ -72,7 +84,11 @@ class HistoryManager:
                 for entry in self._entries:
                     f.write(json.dumps(entry) + "\n")
         except OSError:
-            pass
+            logger.warning(
+                "Failed to compact history file %s",
+                self.history_file,
+                exc_info=True,
+            )
 
     def add(self, text: str) -> None:
         """Add a command to history.

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -368,6 +368,49 @@ class TestHistoryNavigationFlag:
             controller = chat_input._completion_manager._active
             assert controller is not None
 
+    async def test_counter_resets_after_successful_recall(self) -> None:
+        """Counter should return to 0 after a history entry is recalled."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input._text_area
+            assert text_area is not None
+
+            # Seed history with an entry
+            chat_input._history._entries.append("previous entry")
+
+            # Recall via up arrow (cursor starts at (0,0) on empty input)
+            await pilot.press("up")
+            await pilot.pause()
+
+            assert text_area.text == "previous entry"
+            assert text_area._skip_history_change_events == 0
+
+    async def test_autocomplete_works_after_history_recall(self) -> None:
+        """Typing '/' after recalling history should trigger completions."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input._text_area
+            assert text_area is not None
+
+            # Seed and recall a history entry
+            chat_input._history._entries.append("previous entry")
+            await pilot.press("up")
+            await pilot.pause()
+            assert text_area.text == "previous entry"
+
+            # Clear and type '/' — autocomplete should activate
+            text_area.clear_text()
+            await pilot.pause()
+            text_area.insert("/")
+            await _pause_for_strip(pilot)
+
+            assert chat_input.mode == "command"
+            assert chat_input._completion_manager is not None
+            controller = chat_input._completion_manager._active
+            assert controller is not None
+
 
 class TestHistoryBoundaryNavigation:
     """Test that history navigation only triggers at input boundaries."""

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -329,22 +329,22 @@ class TestPromptIndicator:
 
 
 class TestHistoryNavigationFlag:
-    """Test that _navigating_history resets when history is exhausted."""
+    """Test that _skip_history_change_events resets when history is exhausted."""
 
     async def test_down_arrow_at_bottom_resets_navigating_flag(self) -> None:
-        """Pressing down with no history should not leave _navigating_history stuck."""
+        """Pressing down with no history should not leave _skip_history_change_events stuck."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat_input = app.query_one(ChatInput)
             text_area = chat_input._text_area
             assert text_area is not None
 
-            assert not text_area._navigating_history
+            assert text_area._skip_history_change_events == 0
 
             await pilot.press("down")
             await pilot.pause()
 
-            assert not text_area._navigating_history
+            assert text_area._skip_history_change_events == 0
 
     async def test_autocomplete_works_after_down_arrow(self) -> None:
         """Typing '/' after pressing down should still trigger completions."""

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -411,6 +411,60 @@ class TestHistoryNavigationFlag:
             controller = chat_input._completion_manager._active
             assert controller is not None
 
+    async def test_multiple_rapid_recalls_drain_counter(self) -> None:
+        """Multiple set_text_from_history calls should each reserve a skip."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input._text_area
+            assert text_area is not None
+
+            # Call set_text_from_history twice without letting events process
+            text_area.set_text_from_history("first")
+            text_area.set_text_from_history("second")
+            assert text_area._skip_history_change_events == 2
+
+            # Let both Changed events fire and drain the counter
+            await pilot.pause()
+            await pilot.pause()
+            assert text_area._skip_history_change_events == 0
+            assert text_area.text == "second"
+
+    async def test_clear_text_suppresses_own_changed_event(self) -> None:
+        """clear_text increments the counter so its Changed event is skipped."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input._text_area
+            assert text_area is not None
+
+            # Recall a history entry, then immediately clear
+            chat_input._history._entries.append("recalled")
+            await pilot.press("up")
+            await pilot.pause()
+            assert text_area.text == "recalled"
+
+            text_area.clear_text()
+            # Counter should be 1 (for the clear's own Changed event)
+            assert text_area._skip_history_change_events == 1
+            await pilot.pause()
+            assert text_area._skip_history_change_events == 0
+
+    async def test_negative_counter_resets_with_warning(self) -> None:
+        """Defensive check: negative counter is logged and reset to 0."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input._text_area
+            assert text_area is not None
+
+            # Force counter negative (simulates a bug elsewhere)
+            text_area._skip_history_change_events = -1
+            text_area.insert("x")
+            await pilot.pause()
+
+            assert text_area._skip_history_change_events == 0
+
 
 class TestHistoryBoundaryNavigation:
     """Test that history navigation only triggers at input boundaries."""

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -332,7 +332,7 @@ class TestHistoryNavigationFlag:
     """Test that _skip_history_change_events resets when history is exhausted."""
 
     async def test_down_arrow_at_bottom_resets_navigating_flag(self) -> None:
-        """Pressing down with no history should not leave _skip_history_change_events stuck."""
+        """Pressing down with no history should not leave the skip counter stuck."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat_input = app.query_one(ChatInput)


### PR DESCRIPTION
Fixes #1628

History recall (`Up` arrow) was supposed to suppress autocomplete suggestions, but a race condition allowed `@`-file completions to slip through. The boolean `_navigating_history` flag was reset synchronously in `set_text_from_history` *before* the async `TextArea.Changed` handler ran, so the guard was already `False` by the time `on_text_area_changed` checked it.

## Changes

- Replace the boolean `_navigating_history` flag with an integer counter `_skip_history_change_events` on `ChatTextArea`. The producer (`set_text_from_history`) increments before setting text; the consumer (`on_text_area_changed`) decrements when processing the resulting event. This eliminates the race because the guard isn't cleared until the handler actually fires — unlike the boolean, which was reset synchronously before the async handler ran.
- Remove the synchronous `_navigating_history = False` reset at the end of `set_text_from_history`; the handler now owns the decrement, and `clear_text` resets the counter to 0
- Add a defensive check for negative counter values with a warning log to catch any future bookkeeping bugs