### PR TITLE
fix(sdk): use Sequence instead of list for subagents parameter

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -84,7 +84,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     *,
     system_prompt: str | SystemMessage | None = None,
     middleware: Sequence[AgentMiddleware] = (),
-    subagents: list[SubAgent | CompiledSubAgent] | None = None,
+    subagents: Sequence[SubAgent | CompiledSubAgent] | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
     response_format: ResponseFormat | None = None,

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -289,7 +289,7 @@ def _get_subagents_legacy(
     default_tools: Sequence[BaseTool | Callable | dict[str, Any]],
     default_middleware: list[AgentMiddleware] | None,
     default_interrupt_on: dict[str, bool | InterruptOnConfig] | None,
-    subagents: list[SubAgent | CompiledSubAgent],
+    subagents: Sequence[SubAgent | CompiledSubAgent],
     general_purpose_agent: bool,
 ) -> list[_SubagentSpec]:
     """Create subagent instances from specifications.
@@ -546,7 +546,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         self,
         *,
         backend: BackendProtocol | BackendFactory | None = None,
-        subagents: list[SubAgent | CompiledSubAgent] | None = None,
+        subagents: Sequence[SubAgent | CompiledSubAgent] | None = None,
         system_prompt: str | None = TASK_SYSTEM_PROMPT,
         task_description: str | None = None,
         **deprecated_kwargs: Unpack[_DeprecatedKwargs],


### PR DESCRIPTION
Fixes #1904

The `subagents` parameter in `create_deep_agent()` and `SubAgentMiddleware.__init__()` is typed as `list[SubAgent | CompiledSubAgent]`, which causes type checker errors when passing a `list[SubAgent]` due to `list` invariance. Changed to `Sequence` (covariant), consistent with how `tools` and `middleware` parameters are already typed.

**How I verified:** `make lint` passes (ruff check, ruff format, ty type checker). Type-annotation-only change — no runtime behavior changes.

AI was used to assist with this contribution.