### PR TITLE
feat(cli): show editable install source path in help and banner

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -15,6 +15,7 @@ from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote, urlparse
 
 import dotenv
 from rich.console import Console
@@ -243,8 +244,8 @@ ASCII_GLYPHS = Glyphs(
 _glyphs_cache: Glyphs | None = None
 """Module-level cache for detected glyphs."""
 
-_editable_cache: bool | None = None
-"""Module-level cache for editable install detection."""
+_editable_cache: tuple[bool, str | None] | None = None
+"""Module-level cache for editable install info: (is_editable, source_path)."""
 
 _langsmith_url_cache: tuple[str, str] | None = None
 """Module-level cache for successful LangSmith project URL lookups."""
@@ -256,30 +257,62 @@ Kept short so tracing metadata can never stall CLI flows.
 """
 
 
-def _is_editable_install() -> bool:
-    """Check if deepagents-cli is installed in editable mode.
-
-    Uses PEP 610 direct_url.json metadata to detect editable installs.
+def _resolve_editable_info() -> tuple[bool, str | None]:
+    """Parse PEP 610 `direct_url.json` once and cache both results.
 
     Returns:
-        True if installed in editable mode, False otherwise.
+        Tuple of (is_editable, contracted_source_path). The path is
+        `~`-contracted when it falls under the user's home directory, or
+        `None` when the install is non-editable or the path is unavailable.
     """
     global _editable_cache  # noqa: PLW0603  # Module-level cache requires global statement
     if _editable_cache is not None:
         return _editable_cache
 
+    editable = False
+    path: str | None = None
+
     try:
         dist = distribution("deepagents-cli")
-        direct_url = dist.read_text("direct_url.json")
-        if direct_url:
-            data = json.loads(direct_url)
-            _editable_cache = data.get("dir_info", {}).get("editable", False)
-        else:
-            _editable_cache = False
+        raw = dist.read_text("direct_url.json")
+        if raw:
+            data = json.loads(raw)
+            editable = data.get("dir_info", {}).get("editable", False)
+            if editable:
+                url = data.get("url", "")
+                if url.startswith("file://"):
+                    path = unquote(urlparse(url).path)
+                    home = str(Path.home())
+                    if path.startswith(home):
+                        path = "~" + path[len(home) :]
     except (PackageNotFoundError, FileNotFoundError, json.JSONDecodeError, TypeError):
-        _editable_cache = False
+        logger.debug(
+            "Failed to read editable install info from PEP 610 metadata",
+            exc_info=True,
+        )
 
+    _editable_cache = (editable, path)
     return _editable_cache
+
+
+def _is_editable_install() -> bool:
+    """Check if deepagents-cli is installed in editable mode.
+
+    Uses PEP 610 `direct_url.json` metadata to detect editable installs.
+
+    Returns:
+        `True` if installed in editable mode, `False` otherwise.
+    """
+    return _resolve_editable_info()[0]
+
+
+def _get_editable_install_path() -> str | None:
+    """Return the `~`-contracted source directory for an editable install.
+
+    Returns `None` for non-editable installs or when the path cannot be
+    determined.
+    """
+    return _resolve_editable_info()[1]
 
 
 def _detect_charset_mode() -> CharsetMode:

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -7,10 +7,13 @@ argparse tree.  It must stay lightweight — no SDK or langchain imports.
 import argparse
 from collections.abc import Callable
 
+from rich.markup import escape
+
 from deepagents_cli._version import __version__
 from deepagents_cli.config import (
     COLORS,
     DOCS_URL,
+    _get_editable_install_path,
     _is_editable_install,
     console,
 )
@@ -59,7 +62,8 @@ def _print_option_section(*lines: str, title: str = "Options") -> None:
 
 def show_help() -> None:
     """Show top-level help information for the deepagents CLI."""
-    install_type = " (local)" if _is_editable_install() else ""
+    editable_path = _get_editable_install_path()
+    install_type = f" (local: {escape(editable_path)})" if editable_path else ""
     banner_color = (
         COLORS["primary_dev"] if _is_editable_install() else COLORS["primary"]
     )

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 from deepagents_cli.config import (
     COLORS,
+    _get_editable_install_path,
     _is_editable_install,
     fetch_langsmith_project_url,
     get_banner,
@@ -163,6 +164,10 @@ class WelcomeBanner(Static):
                 TStyle(foreground=TColor.parse(banner_color), bold=True),
             )
         )
+
+        editable_path = _get_editable_install_path()
+        if editable_path:
+            parts.extend([("Installed from: ", "dim"), (editable_path, "dim"), "\n"])
 
         if self._project_name:
             parts.extend(

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -173,6 +173,44 @@ class TestUpdateThreadId:
         assert links[0] == f"{project_url}/t/new_id?utm_source=deepagents-cli"
 
 
+class TestBuildBannerEditableInstall:
+    """Tests for the editable-install path in `_build_banner`."""
+
+    def test_build_banner_with_editable_install(self) -> None:
+        """Banner should include install path when running from editable install."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "deepagents_cli.widgets.welcome._is_editable_install",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.widgets.welcome._get_editable_install_path",
+                return_value="~/dev/deepagents",
+            ),
+        ):
+            widget = WelcomeBanner()
+            banner = widget._build_banner()
+        assert "Installed from: ~/dev/deepagents" in banner.plain
+
+    def test_build_banner_without_editable_install(self) -> None:
+        """Banner should not include install path for non-editable installs."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "deepagents_cli.widgets.welcome._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.widgets.welcome._get_editable_install_path",
+                return_value=None,
+            ),
+        ):
+            widget = WelcomeBanner()
+            banner = widget._build_banner()
+        assert "Installed from:" not in banner.plain
+
+
 class TestBuildBannerReturnType:
     """Tests for `_build_banner` return value."""
 


### PR DESCRIPTION
For dev/debugging, show the source directory of editable CLI installs in both the `--help` screen and the interactive welcome banner. Useful when switching between worktree installs — the path makes it immediately obvious which checkout is running.