### PR TITLE
feat(quickjs): add async support using a daemon thread

### DIFF
--- a/libs/partners/quickjs/README.md
+++ b/libs/partners/quickjs/README.md
@@ -32,9 +32,9 @@ With this middleware installed, the agent receives a `repl` tool that runs each 
 - The REPL is stateless. Each call starts from a fresh QuickJS context, so variables, functions, and other values defined in one `repl` call are not available in the next one.
 - Execution uses [QuickJS](https://bellard.org/quickjs/), so JavaScript support is limited to what QuickJS provides. It is good for small computations, control flow, JSON manipulation, and calling exposed foreign functions, but it is not a browser or Node.js runtime and does not provide their APIs.
 - Foreign functions support passing primitive values between JavaScript and Python, including `int`, `float`, `bool`, `str`, and `None`. Lists and dictionaries returned from Python are also supported and are bridged back into JavaScript arrays and objects.
+- Async foreign functions are supported. Because QuickJS callbacks are synchronous, awaitables are delegated to a dedicated daemon-thread event loop and their resolved results are returned back into the REPL call.
 
 ## Current limitations
 
 - Does not work with HIL in the REPL.
-- Does not support async foreign functions in the REPL yet.
 - Does not support `ToolRuntime` yet.

--- a/libs/partners/quickjs/langchain_quickjs/_foreign_function_bridge.py
+++ b/libs/partners/quickjs/langchain_quickjs/_foreign_function_bridge.py
@@ -9,15 +9,88 @@ functions behave more naturally from JavaScript.
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
+import threading
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Coroutine
+    from concurrent.futures import Future
 
     import quickjs
+
+
+class _AsyncLoopThread:
+    """Run coroutines on a dedicated daemon-thread event loop.
+
+    QuickJS only accepts synchronous Python callbacks via
+    `quickjs.Context.add_callable()`. This helper provides a long-lived event
+    loop on a background daemon thread so async foreign functions can still be
+    exposed through the synchronous QuickJS callback interface.
+    """
+
+    def __init__(self) -> None:
+        self._ready = threading.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        self._ready.wait()
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._ready.set()
+        loop.run_forever()
+
+    def submit(self, coroutine: Coroutine[Any, Any, Any]) -> Future[Any]:
+        loop = self._loop
+        if loop is None:
+            msg = "Async loop thread was not initialized."
+            raise RuntimeError(msg)
+        return asyncio.run_coroutine_threadsafe(coroutine, loop)
+
+
+_ASYNC_LOOP_THREAD = _AsyncLoopThread()
+
+
+def _await_if_needed(value: Any) -> Any:
+    """Resolve awaitable results on the background event loop when needed.
+
+    Args:
+        value: Either a plain return value or an awaitable produced by an async
+            foreign function or tool.
+
+    Returns:
+        The original value for synchronous call paths, or the completed result of
+        the awaitable after running it on the daemon-thread event loop.
+    """
+    if inspect.isawaitable(value):
+        return _ASYNC_LOOP_THREAD.submit(value).result()
+    return value
+
+
+def _invoke_tool(tool: BaseTool, payload: str | dict[str, Any]) -> Any:
+    """Invoke a tool through its sync or async entrypoint as appropriate.
+
+    Args:
+        tool: The tool to execute.
+        payload: Input payload already normalized for the tool schema.
+
+    Returns:
+        The tool result, awaiting `tool.ainvoke()` on the daemon-thread event
+        loop when the tool exposes only an async implementation.
+    """
+    if (
+        getattr(tool, "func", None) is None
+        and getattr(tool, "coroutine", None) is not None
+    ):
+        return _await_if_needed(tool.ainvoke(payload))
+    return _await_if_needed(tool.invoke(payload))
 
 
 def _wrap_tool_for_js(
@@ -31,15 +104,17 @@ def _wrap_tool_for_js(
     Args:
         tool: The LangChain tool to expose inside the QuickJS context.
         payload_builder: Helper that converts JavaScript positional and keyword
-            arguments into the payload shape expected by `tool.invoke()`.
+            arguments into the payload shape expected by the tool invocation.
 
     Returns:
         A Python callable that QuickJS can register via `Context.add_callable()`.
+        If the wrapped tool produces an awaitable, it is executed on the
+        daemon-thread event loop before the result is returned to QuickJS.
     """
 
     def tool_wrapper(*args: Any, **kwargs: Any) -> Any:
         payload = payload_builder(tool, args, kwargs)
-        return tool.invoke(payload)
+        return _invoke_tool(tool, payload)
 
     return tool_wrapper
 
@@ -69,12 +144,13 @@ def _wrap_function_for_js(implementation: Callable[..., Any]) -> Callable[..., A
         implementation: The Python callable to expose to QuickJS.
 
     Returns:
-        A callable that preserves invocation arguments and serializes any
+        A callable that preserves invocation arguments, resolves awaitables on
+        the daemon-thread event loop when necessary, and serializes any
         non-primitive return value through `_serialize_for_js()`.
     """
 
     def function_wrapper(*args: Any, **kwargs: Any) -> Any:
-        return _serialize_for_js(implementation(*args, **kwargs))
+        return _serialize_for_js(_await_if_needed(implementation(*args, **kwargs)))
 
     return function_wrapper
 

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import threading
+
 from deepagents.graph import create_deep_agent
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import tool
@@ -12,6 +15,31 @@ from tests.unit_tests.chat_model import GenericFakeChatModel
 def list_user_ids() -> list[str]:
     """Return example user identifiers for QuickJS bridging tests."""
     return ["user_1", "user_2", "user_3"]
+
+
+@tool("sync_label")
+def sync_label_tool(value: str) -> str:
+    """Return a labeled value from a synchronous LangChain tool."""
+    return f"sync:{value}"
+
+
+@tool("async_label")
+async def async_label_tool(value: str) -> str:
+    """Return a labeled value from an asynchronous LangChain tool."""
+    await asyncio.sleep(0)
+    return f"async:{value}"
+
+
+async def async_uppercase(value: str) -> str:
+    """Return an uppercased value after yielding to the event loop."""
+    await asyncio.sleep(0)
+    return value.upper()
+
+
+async def capture_thread_name() -> str:
+    """Return the name of the thread running the coroutine."""
+    await asyncio.sleep(0)
+    return threading.current_thread().name
 
 
 async def test_deepagent_with_quickjs_interpreter() -> None:
@@ -100,4 +128,139 @@ async def test_deepagent_with_quickjs_json_stringify_foreign_function() -> None:
     assert tool_messages[0].content_blocks == [
         {"type": "text", "text": '["user_1","user_2","user_3"]'}
     ]
+    assert result["messages"][-1].content_blocks == [{"type": "text", "text": "done"}]
+
+
+async def test_deepagent_with_quickjs_async_foreign_function() -> None:
+    """Verify the repl can call sync and async Python helpers in one evaluation."""
+    model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "repl",
+                            "args": {
+                                "code": (
+                                    "print(sync_label('hello'));\n"
+                                    "print(async_uppercase('world'));"
+                                )
+                            },
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+
+    agent = create_deep_agent(
+        model=model,
+        middleware=[QuickJSMiddleware(ptc=[sync_label_tool, async_uppercase])],
+    )
+
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="Use the repl to call the sync and async helpers")
+            ]
+        }
+    )
+
+    assert "messages" in result
+    tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content_blocks == [
+        {"type": "text", "text": "sync:hello\nWORLD"}
+    ]
+    assert result["messages"][-1].content_blocks == [{"type": "text", "text": "done"}]
+
+
+async def test_deepagent_with_quickjs_async_langchain_tool() -> None:
+    """Verify the repl supports async LangChain tools alongside sync ones."""
+    model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "repl",
+                            "args": {
+                                "code": (
+                                    "print(sync_label('left'));\n"
+                                    "print(async_label('right'));"
+                                )
+                            },
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+
+    agent = create_deep_agent(
+        model=model,
+        middleware=[QuickJSMiddleware(ptc=[sync_label_tool, async_label_tool])],
+    )
+
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="Use the repl to call the sync and async tools")
+            ]
+        }
+    )
+
+    assert "messages" in result
+    tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content_blocks == [
+        {"type": "text", "text": "sync:left\nasync:right"}
+    ]
+    assert result["messages"][-1].content_blocks == [{"type": "text", "text": "done"}]
+
+
+async def test_quickjs_async_foreign_function_runs_on_daemon_loop_thread() -> None:
+    """Verify async foreign functions execute on the background event-loop thread."""
+    model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "repl",
+                            "args": {"code": "print(capture_thread_name())"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+
+    agent = create_deep_agent(
+        model=model,
+        middleware=[QuickJSMiddleware(ptc=[capture_thread_name])],
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage(content="Use the repl to inspect the async thread")]}
+    )
+
+    assert "messages" in result
+    tool_messages = [msg for msg in result["messages"] if msg.type == "tool"]
+    assert len(tool_messages) == 1
+    thread_name = tool_messages[0].content
+    assert thread_name != threading.current_thread().name
+    assert thread_name.startswith("Thread-")
     assert result["messages"][-1].content_blocks == [{"type": "text", "text": "done"}]


### PR DESCRIPTION
Add async support using a daemon thread. This isn't as efficient for performance, but good enough for now, especially given that this programs are likely to be very little in reality