### PR TITLE
feat(cli): add `-y` and `-S` short flags for auto-approve and shell-allow-list

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -459,6 +459,7 @@ def parse_args() -> argparse.Namespace:
     add_json_output_arg(parser, default="text")
 
     parser.add_argument(
+        "-y",
         "--auto-approve",
         action="store_true",
         help=(
@@ -489,6 +490,7 @@ def parse_args() -> argparse.Namespace:
         help="Path to setup script to run in sandbox after creation",
     )
     parser.add_argument(
+        "-S",
         "--shell-allow-list",
         metavar="LIST",
         help="Comma-separated list of shell commands to auto-approve, "

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -108,7 +108,7 @@ def show_help() -> None:
     console.print("  --profile-override JSON    Override model profile fields as JSON")
     console.print("  -m, --message TEXT         Initial prompt to auto-submit on start")
     console.print(
-        "  --auto-approve             Auto-approve all tool calls (toggle: Shift+Tab)"
+        "  -y, --auto-approve         Auto-approve all tool calls (toggle: Shift+Tab)"
     )
     console.print("  --sandbox TYPE             Remote sandbox for execution")
     console.print(
@@ -134,7 +134,7 @@ def show_help() -> None:
         "  --json                     Emit machine-readable JSON for commands"
     )
     console.print(
-        "  --shell-allow-list CMDS    Comma-separated commands, 'recommended', or 'all'"
+        "  -S, --shell-allow-list CMDS  Comma-separated cmds, 'recommended', or 'all'"
     )
     console.print("  --default-model [MODEL]    Set, show, or manage the default model")
     console.print("  --clear-default-model      Clear the default model")
@@ -149,15 +149,15 @@ def show_help() -> None:
         style=COLORS["dim"],
     )
     console.print(
-        "  deepagents -n 'List files' --shell-allow-list recommended  # Use safe commands",  # noqa: E501
+        "  deepagents -n 'List files' -S recommended  # Use safe commands",
         style=COLORS["dim"],
     )
     console.print(
-        "  deepagents -n 'Search logs' --shell-allow-list ls,cat,grep # Specify list",
+        "  deepagents -n 'Search logs' -S ls,cat,grep # Specify list",
         style=COLORS["dim"],
     )
     console.print(
-        "  deepagents -n 'Fix tests' --shell-allow-list all           # Any command",
+        "  deepagents -n 'Fix tests' -S all           # Any command",
         style=COLORS["dim"],
     )
     console.print()

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -196,7 +196,7 @@ class TestSubcommandHelpFlags:
 
 
 class TestShortFlags:
-    """Test that short flag aliases (-a, -M, -v) parse correctly."""
+    """Test that short flag aliases (-a, -M, -S, -v, -y) parse correctly."""
 
     def test_short_agent_flag(self) -> None:
         """Verify -a sets agent."""
@@ -224,6 +224,18 @@ class TestShortFlags:
         ):
             parse_args()
         assert exc_info.value.code in (0, None)
+
+    def test_short_auto_approve_flag(self) -> None:
+        """Verify -y sets auto_approve."""
+        with patch.object(sys, "argv", ["deepagents", "-y"]):
+            args = parse_args()
+        assert args.auto_approve is True
+
+    def test_short_shell_allow_list_flag(self) -> None:
+        """Verify -S sets shell_allow_list."""
+        with patch.object(sys, "argv", ["deepagents", "-S", "ls,cat"]):
+            args = parse_args()
+        assert args.shell_allow_list == "ls,cat"
 
 
 class TestQuietArg:


### PR DESCRIPTION
Add short flags `-y` for `--auto-approve` and `-S` for `--shell-allow-list` to reduce typing in common CLI invocations. These are the two most-typed long flags in non-interactive workflows and had no short aliases.

## Changes
- Register `-y` as a short alias for `--auto-approve` and `-S` for `--shell-allow-list` in `parse_args()`
- Update the hand-maintained `show_help()` output and usage examples to reflect the new short forms