### PR TITLE
fix(harbor): align backend return types with protocol

### DIFF
--- a/libs/harbor/deepagents_harbor/backend.py
+++ b/libs/harbor/deepagents_harbor/backend.py
@@ -3,13 +3,17 @@
 import asyncio
 import base64
 import json
+import logging
 import shlex
 
 from deepagents.backends.protocol import (
     EditResult,
     ExecuteResponse,
     FileInfo,
+    GlobResult,
     GrepMatch,
+    GrepResult,
+    LsResult,
     ReadResult,
     SandboxBackendProtocol,
     WriteResult,
@@ -24,6 +28,8 @@ _EXIT_NOT_FOUND = 1
 _EXIT_MULTIPLE_MATCHES = 2
 _EXIT_FILE_MISSING = 3
 _EXIT_DECODE_FAILED = 4
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_COMMAND_TIMEOUT_SEC = 300
 """Default per-command timeout (5 minutes) to prevent stuck command hangs."""
@@ -339,7 +345,7 @@ __DEEPAGENTS_EOF__
         """Edit a file by replacing string occurrences using shell commands."""
         raise NotImplementedError(_SYNC_NOT_SUPPORTED)
 
-    async def als_info(self, path: str) -> list[FileInfo]:
+    async def als_info(self, path: str) -> LsResult:
         """List directory contents with metadata using shell commands."""
         safe_path = shlex.quote(path)
 
@@ -361,7 +367,11 @@ done
         result = await self.aexecute(cmd)
 
         if result.exit_code != 0:
-            return []
+            detail = result.output.strip() if result.output else ""
+            return LsResult(
+                error=f"Directory not found or not accessible: {path}"
+                + (f" ({detail})" if detail else "")
+            )
 
         file_infos: list[FileInfo] = []
         for line in result.output.strip().split("\n"):
@@ -370,10 +380,12 @@ done
             parts = line.split("|")
             if len(parts) == _PIPE_FIELD_COUNT:
                 file_infos.append({"path": parts[0], "is_dir": parts[1] == "true"})
+            else:
+                logger.debug("Skipping malformed ls output line: %r", line)
 
-        return file_infos
+        return LsResult(entries=file_infos)
 
-    def ls_info(self, path: str) -> list[FileInfo]:
+    def ls_info(self, path: str) -> LsResult:
         """List directory contents with metadata using shell commands."""
         raise NotImplementedError(_SYNC_NOT_SUPPORTED)
 
@@ -382,7 +394,7 @@ done
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
-    ) -> list[GrepMatch] | str:
+    ) -> GrepResult:
         """Search for pattern in files using grep."""
         search_path = shlex.quote(path or ".")
 
@@ -397,12 +409,19 @@ done
         # Escape pattern for grep
         safe_pattern = shlex.quote(pattern)
 
-        cmd = f"grep {grep_opts} {glob_pattern} -e {safe_pattern} {search_path} 2>/dev/null || true"
+        cmd = f"grep {grep_opts} {glob_pattern} -e {safe_pattern} {search_path} 2>/dev/null"
         result = await self.aexecute(cmd)
+
+        # grep exit codes: 0=matches found, 1=no matches, 2+=error
+        if result.exit_code is not None and result.exit_code > 1:
+            detail = result.output.strip() if result.output else ""
+            return GrepResult(
+                error=f"Grep failed (exit {result.exit_code})" + (f": {detail}" if detail else "")
+            )
 
         output = result.output.rstrip()
         if not output:
-            return []
+            return GrepResult(matches=[])
 
         # Parse grep output into GrepMatch objects
         matches: list[GrepMatch] = []
@@ -419,20 +438,21 @@ done
                         }
                     )
                 except ValueError:
+                    logger.debug("Skipping malformed grep output line: %r", line)
                     continue
 
-        return matches
+        return GrepResult(matches=matches)
 
     def grep_raw(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
-    ) -> list[GrepMatch] | str:
+    ) -> GrepResult:
         """Search for pattern in files using grep."""
         raise NotImplementedError(_SYNC_NOT_SUPPORTED)
 
-    async def aglob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+    async def aglob_info(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching glob pattern using shell commands.
 
         Please note that this implementation does not currently support all glob
@@ -457,11 +477,15 @@ done
         result = await self.aexecute(cmd)
 
         if result.exit_code != 0:
-            return []
+            detail = result.output.strip() if result.output else ""
+            return GlobResult(
+                error=f"Path not found or not accessible: {path}"
+                + (f" ({detail})" if detail else "")
+            )
 
         output = result.output.strip()
         if not output:
-            return []
+            return GlobResult(matches=[])
 
         # Parse output into FileInfo dicts
         file_infos: list[FileInfo] = []
@@ -476,9 +500,11 @@ done
                         "is_dir": parts[1] == "true",
                     }
                 )
+            else:
+                logger.debug("Skipping malformed glob output line: %r", line)
 
-        return file_infos
+        return GlobResult(matches=file_infos)
 
-    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+    def glob_info(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching glob pattern using shell commands."""
         raise NotImplementedError(_SYNC_NOT_SUPPORTED)

--- a/libs/harbor/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/harbor/deepagents_harbor/deepagents_wrapper.py
@@ -155,11 +155,15 @@ class DeepAgentsWrapper(BaseAgent):
             Formatted system prompt with directory context
         """
         # Get directory information from backend
-        ls_info = await backend.als_info(".")
+        ls_result = await backend.als_info(".")
         current_dir = (await backend.aexecute("pwd")).output
 
-        total_files = len(ls_info) if ls_info else 0
-        first_files = ls_info[:_MAX_FILE_LISTING] if ls_info else []
+        if ls_result.error:
+            logger.warning("Failed to list working directory: %s", ls_result.error)
+
+        entries = ls_result.entries or []
+        total_files = len(entries)
+        first_files = entries[:_MAX_FILE_LISTING]
 
         # Build file listing header based on actual count
         if total_files == 0:


### PR DESCRIPTION
The `HarborSandbox` backend returned raw lists (`list[FileInfo]`, `list[GrepMatch] | str`) from `ls_info`, `grep_raw`, and `glob_info` instead of the `LsResult`, `GrepResult`, and `GlobResult` dataclasses declared in `BackendProtocol`.

While fixing the return types, also addressed error handling gaps: grep swallowed all errors via `|| true`, error messages discarded shell output, and the one caller in `deepagents_wrapper.py` silently treated `ls_info` failures as empty directories.

## Changes
- Wrap `als_info`/`ls_info` returns in `LsResult`, `agrep_raw`/`grep_raw` in `GrepResult`, and `aglob_info`/`glob_info` in `GlobResult` to match `BackendProtocol` signatures
- Remove `|| true` from the grep shell command and add exit-code-based error detection — `GrepResult.error` was previously unreachable for this backend
- Include `result.output` in error messages for `als_info` and `aglob_info` failures (matching the pattern `aedit` already uses)
- Log a warning in `DeepAgentsWrapper._get_formatted_system_prompt` when `als_info` returns an error instead of silently falling through to "Current directory is empty"
- Add `logger.debug` for malformed output lines during ls/grep/glob parsing
