### PR TITLE
hotfix(cli): make summarization test compatible with sdk 0.4.11

### DIFF
--- a/libs/cli/tests/unit_tests/test_end_to_end.py
+++ b/libs/cli/tests/unit_tests/test_end_to_end.py
@@ -232,7 +232,7 @@ class TestDeepAgentsCLIEndToEnd:
             assert agent_response.generations[0].message.content == "response"
 
             # Verify conversation history was offloaded to backend
-            assert backend.ls_info("/conversation_history/").entries
+            assert backend.ls_info("/conversation_history/")
 
     def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
         """Test CLI agent with tools using a fake LLM model.


### PR DESCRIPTION
The CLI pins `deepagents==0.4.11` but #1870 updated this test
assertion to use `LsResult.entries`, which only exists in SDK 0.5.0.
The release pipeline installs the pinned version (not the editable
source), so `pre-release-checks` would fail with an `AttributeError`.

Revert to a plain truthiness check that works against both SDK
versions. The `.entries` accessor should be restored when the CLI
pin is bumped to 0.5.0.
