### PR TITLE
ci: bound release contributor/notes collection to release commit (CLI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,11 +206,24 @@ jobs:
 
           echo "Previous tag: $PREV_TAG"
 
-          # Get commits between previous tag and HEAD for this package
+          # Resolve the actual release commit instead of using HEAD.
+          # release-please always updates CHANGELOG.md in the release commit,
+          # so on workflow_call this resolves to HEAD (effectively a no-op).
+          # On workflow_dispatch (manual/recovery), HEAD may be ahead of the
+          # release commit — this avoids attributing post-release commits to
+          # this release's contributor list.
+          RELEASE_COMMIT=$(git log -1 --format=%H -- "$WORKING_DIR/CHANGELOG.md")
+          if [ -z "$RELEASE_COMMIT" ]; then
+            echo "Warning: no CHANGELOG.md history found, falling back to HEAD"
+            RELEASE_COMMIT=$(git rev-parse HEAD)
+          fi
+          echo "Release commit (from CHANGELOG.md): $RELEASE_COMMIT"
+
+          # Get commits between previous tag and release commit for this package
           if [ -z "$PREV_TAG" ]; then
-            COMMITS=$(git rev-list HEAD -- "$WORKING_DIR" | head -100)
+            COMMITS=$(git rev-list "$RELEASE_COMMIT" -- "$WORKING_DIR" | head -100)
           else
-            COMMITS=$(git rev-list "$PREV_TAG"..HEAD -- "$WORKING_DIR" | head -100)
+            COMMITS=$(git rev-list "$PREV_TAG".."$RELEASE_COMMIT" -- "$WORKING_DIR" | head -100)
           fi
 
           # Find PRs and collect contributors (GitHub username + optional Twitter/LinkedIn)
@@ -405,14 +418,23 @@ jobs:
               PREV_TAG=""
             fi
 
+            # Use CHANGELOG.md's last edit as the release commit boundary.
+            # On manual dispatch, HEAD may be ahead of the actual release —
+            # this ensures the git log only covers commits up to the release.
+            RELEASE_COMMIT=$(git log -1 --format=%H -- "$WORKING_DIR/CHANGELOG.md")
+            if [ -z "$RELEASE_COMMIT" ]; then
+              echo "Warning: no CHANGELOG.md history found, falling back to HEAD"
+              RELEASE_COMMIT=$(git rev-parse HEAD)
+            fi
+
             if [ -z "$PREV_TAG" ]; then
               PREAMBLE="Initial release"
-              PREV_TAG=$(git rev-list --max-parents=0 HEAD)
+              PREV_TAG=$(git rev-list --max-parents=0 "$RELEASE_COMMIT")
             else
               PREAMBLE="Changes since $PREV_TAG"
             fi
 
-            GIT_LOG=$(git log --format="%s" "$PREV_TAG"..HEAD -- "$WORKING_DIR")
+            GIT_LOG=$(git log --format="%s" "$PREV_TAG".."$RELEASE_COMMIT" -- "$WORKING_DIR")
             RELEASE_BODY=$(printf "%s\n%s" "$PREAMBLE" "$GIT_LOG")
           fi
 


### PR DESCRIPTION
The `collect-contributors` and `release-notes` jobs in the release workflow use `HEAD` as the upper bound when walking git history for contributor attribution and release notes. On the normal `workflow_call` path this is fine — `HEAD` is the release merge commit. But on `workflow_dispatch` (manual/recovery releases), `HEAD` may be ahead of the actual release, causing post-release commits to leak into the contributor list and git-log-based release notes.

This resolves the boundary to the last commit that touched `$WORKING_DIR/CHANGELOG.md` instead, which release-please always modifies in the release commit. Falls back to `HEAD` if no CHANGELOG history exists (e.g., new packages).

## Changes
- Replace `HEAD` with a `RELEASE_COMMIT` variable in `collect-contributors` and the `release-notes` git-log fallback, resolved via `git log -1 --format=%%H -- "$WORKING_DIR/CHANGELOG.md"`
- Guard against missing CHANGELOG history — if `git log` returns empty, fall back to `HEAD` with a warning