### PR TITLE
hotfix(cli): guard `async_subagents` kwarg for sdk 0.4.x compat

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -899,15 +899,23 @@ def create_cli_agent(
     )
 
     # Create the agent
-    agent = create_deep_agent(
-        model=model,
-        system_prompt=system_prompt,
-        tools=tools,
-        backend=composite_backend,
-        middleware=agent_middleware,
-        interrupt_on=interrupt_on,
-        checkpointer=checkpointer,
-        subagents=custom_subagents or None,
-        async_subagents=async_subagents or None,
-    ).with_config(config)
+    #
+    # TODO: revert to direct keyword arguments once the CLI pins SDK >=0.5.0.
+    # We use **kwargs here because `async_subagents` was added in SDK 0.5.0 but
+    # the CLI still pins 0.4.x. Passing an unknown kwarg — even as None — raises
+    # TypeError, so we must omit it from the dict entirely when unused.
+    agent_kwargs: dict[str, Any] = {
+        "model": model,
+        "system_prompt": system_prompt,
+        "tools": tools,
+        "backend": composite_backend,
+        "middleware": agent_middleware,
+        "interrupt_on": interrupt_on,
+        "checkpointer": checkpointer,
+        "subagents": custom_subagents or None,
+    }
+    if async_subagents:
+        agent_kwargs["async_subagents"] = async_subagents
+
+    agent = create_deep_agent(**agent_kwargs).with_config(config)
     return agent, composite_backend

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -1447,3 +1447,32 @@ class TestLoadAsyncSubagents:
         config.write_text("this is not valid toml [[[")
         result = load_async_subagents(config)
         assert result == []
+
+
+class TestCreateDeepAgentKwargsWorkaround:
+    """Remind us to remove the **kwargs workaround once the SDK pin allows it.
+
+    `create_cli_agent` builds a dict and calls `create_deep_agent(**kwargs)`
+    instead of using direct keyword arguments because the pinned SDK (0.4.x)
+    doesn't accept `async_subagents`. Once the pin is bumped to >=0.5.0 the
+    workaround should be reverted to direct kwargs for readability and type
+    safety.
+    """
+
+    def test_revert_kwargs_workaround_when_sdk_pin_is_bumped(self) -> None:
+        import tomllib
+
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+
+        deps = data["project"]["dependencies"]
+        sdk_pin = next(d for d in deps if d.startswith("deepagents=="))
+        pinned_version = sdk_pin.split("==")[1]
+        major, minor = (int(x) for x in pinned_version.split(".")[:2])
+
+        assert (major, minor) < (0, 5), (
+            f"SDK pin is now {pinned_version} (>=0.5.0). "
+            "Revert the **kwargs workaround in create_cli_agent() back to "
+            "direct keyword arguments and delete this test."
+        )


### PR DESCRIPTION
PR #1758 landed CLI code that passes `async_subagents` to `create_deep_agent()`, but the CLI still pins SDK 0.4.x which doesn't accept that kwarg — meaning even `async_subagents=None` raises `TypeError` at runtime. This switches to a conditional `**kwargs` pattern so the kwarg is only passed when async subagents are actually configured, keeping the CLI compatible with the pinned SDK until 0.5.0 ships.