### PR TITLE
chore(infra): add quickjs to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ on:
           - deepagents-harbor
           - langchain-daytona
           - langchain-modal
+          - langchain-quickjs
           - langchain-runloop
         default: deepagents
       dangerous-nonmain-release:
@@ -82,12 +83,15 @@ jobs:
             langchain-modal)
               echo "working-dir=libs/partners/modal" >> $GITHUB_OUTPUT
               ;;
+            langchain-quickjs)
+              echo "working-dir=libs/partners/quickjs" >> $GITHUB_OUTPUT
+              ;;
             langchain-runloop)
               echo "working-dir=libs/partners/runloop" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "Error: Unknown package '$PACKAGE'"
-              echo "Valid packages are: deepagents, deepagents-cli, deepagents-acp, deepagents-harbor, langchain-daytona, langchain-modal, langchain-runloop"
+              echo "Valid packages are: deepagents, deepagents-cli, deepagents-acp, deepagents-harbor, langchain-daytona, langchain-modal, langchain-quickjs, langchain-runloop"
               exit 1
               ;;
           esac


### PR DESCRIPTION
Adds  to the manual package release workflow so the partner package can be selected and mapped to  during release runs.

This keeps the release workflow in sync with the existing CI coverage for quickjs and avoids manual workflow edits when publishing that package.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).