### PR TITLE
fix(sdk): preserve `context_schema` type in `create_deep_agent`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -1,11 +1,11 @@
 """Deep Agents come with planning, filesystem, and subagents."""
 
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar, overload
+from typing import Any, overload
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, ContextT
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
@@ -32,9 +32,6 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
-
-# Type variable for context schema type inference
-ContextT = TypeVar("ContextT")
 
 BASE_AGENT_PROMPT = """You are a Deep Agent, an AI assistant that helps users accomplish tasks using tools. You respond with text and tool calls. The user can see your responses and tool outputs in real time.
 


### PR DESCRIPTION
Fixes #1778

**Problem:**
`create_deep_agent` returns `CompiledStateGraph` without generic type parameters, causing type checkers (Pylance, mypy) to fail when passing a `context` argument to `invoke()`.

**Solution:**
- Import `ContextT` from `langchain.agents.middleware.types` (must use the same TypeVar as langgraph)
- Added `@overload` decorators to handle both cases:
  - `context_schema=None` returns `CompiledStateGraph`
  - `context_schema=type[ContextT]` returns `CompiledStateGraph[Any, ContextT, Any, Any]`
- This matches the pattern used in `create_agent` from langchain.agents

**Before:**
```python
agent = create_deep_agent(context_schema=Context)
agent.invoke({"messages": [...]}, context=Context(user_name="John"))  # Type error!
```

**After:**
```python
agent = create_deep_agent(context_schema=Context)
agent.invoke({"messages": [...]}, context=Context(user_name="John"))  # Types correctly inferred
```