### PR TITLE
fix(sdk): pass along check checkpoint for reconciliation

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -399,7 +399,11 @@ def _build_task_tool(  # noqa: C901
     else:
         description = task_description
 
-    def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
+    def _return_command_with_state_update(
+        result: dict,
+        tool_call_id: str,
+        subgraph_checkpoint_ns: str | None = None,
+    ) -> Command:
         # Validate that the result contains a 'messages' key
         if "messages" not in result:
             error_msg = (
@@ -412,10 +416,15 @@ def _build_task_tool(  # noqa: C901
         state_update = {k: v for k, v in result.items() if k not in _EXCLUDED_STATE_KEYS}
         # Strip trailing whitespace to prevent API errors with Anthropic
         message_text = result["messages"][-1].text.rstrip() if result["messages"][-1].text else ""
+        # Store the actual subgraph checkpoint_ns so the LangGraph SDK can
+        # retrieve the subagent's persisted message history after page reload.
+        # The namespace uses LangGraph's internal UUID-based task ID format
+        # (e.g. "tools:a1b2c3d4-..."), not the LLM provider tool call ID.
+        additional_kwargs = {"subgraph_checkpoint_ns": subgraph_checkpoint_ns} if subgraph_checkpoint_ns else {}
         return Command(
             update={
                 **state_update,
-                "messages": [ToolMessage(message_text, tool_call_id=tool_call_id)],
+                "messages": [ToolMessage(message_text, tool_call_id=tool_call_id, additional_kwargs=additional_kwargs)],
             }
         )
 
@@ -442,8 +451,13 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
+        # Capture the actual subgraph checkpoint_ns from the task's config.
+        # LangGraph's execution sets this to a UUID-based namespace (e.g. "tools:a1b2c3d4-...")
+        # which is where the subagent will persist its checkpoints. We store this in the
+        # resulting ToolMessage so the SDK can restore subagent history after page reload.
+        subgraph_checkpoint_ns = (runtime.config.get("configurable") or {}).get("checkpoint_ns")
         result = subagent.invoke(subagent_state)
-        return _return_command_with_state_update(result, runtime.tool_call_id)
+        return _return_command_with_state_update(result, runtime.tool_call_id, subgraph_checkpoint_ns)
 
     async def atask(
         description: Annotated[
@@ -460,8 +474,13 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
+        # Capture the actual subgraph checkpoint_ns from the task's config.
+        # LangGraph's execution sets this to a UUID-based namespace (e.g. "tools:a1b2c3d4-...")
+        # which is where the subagent will persist its checkpoints. We store this in the
+        # resulting ToolMessage so the SDK can restore subagent history after page reload.
+        subgraph_checkpoint_ns = (runtime.config.get("configurable") or {}).get("checkpoint_ns")
         result = await subagent.ainvoke(subagent_state)
-        return _return_command_with_state_update(result, runtime.tool_call_id)
+        return _return_command_with_state_update(result, runtime.tool_call_id, subgraph_checkpoint_ns)
 
     return StructuredTool.from_function(
         name="task",

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -19,6 +19,7 @@ from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from deepagents.backends.filesystem import FilesystemBackend
@@ -126,6 +127,54 @@ class TestSubAgents:
         # Verify the ToolMessage contains the subagent's final response
         subagent_tool_message = tool_messages[0]
         assert "The sum of 2 and 3 is 5." in subagent_tool_message.content, "ToolMessage should contain subagent's final message content"
+
+    def test_subagent_tool_message_contains_checkpoint_ns(self) -> None:
+        """Test that the ToolMessage carries the subgraph checkpoint_ns in additional_kwargs.
+
+        When LangGraph executes the task tool, it injects a UUID-based checkpoint_ns into
+        the config (e.g. "tools:a1b2c3d4-..."). This namespace identifies where the
+        subagent's checkpoints are persisted, and must be forwarded to the resulting
+        ToolMessage so the SDK can reconstruct subagent history after page reload.
+        """
+        from deepagents.middleware.subagents import _build_task_tool  # noqa: PLC0415
+
+        checkpoint_ns = "tools:a1b2c3d4-5678-90ab-cdef-000000000000"
+
+        subagent_chat_model = GenericFakeChatModel(
+            messages=iter([AIMessage(content="Done.")])
+        )
+        compiled_subagent = create_agent(model=subagent_chat_model)
+
+        task_tool = _build_task_tool(
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "A worker agent.",
+                    "runnable": compiled_subagent,
+                }
+            ]
+        )
+
+        mock_runtime = ToolRuntime(
+            state={"messages": []},
+            context=None,
+            tool_call_id="call_abc123",
+            store=None,
+            stream_writer=lambda _: None,
+            config=RunnableConfig(configurable={"checkpoint_ns": checkpoint_ns}),
+        )
+
+        result = task_tool.func(
+            description="Do something",
+            subagent_type="worker",
+            runtime=mock_runtime,
+        )
+
+        assert isinstance(result, Command)
+        messages = result.update["messages"]
+        assert len(messages) == 1
+        tool_msg = messages[0]
+        assert tool_msg.additional_kwargs.get("subgraph_checkpoint_ns") == checkpoint_ns
 
     def test_multiple_subagents_invoked_in_parallel(self) -> None:
         """Test that multiple different subagents can be launched in parallel.


### PR DESCRIPTION
Ports [langchain-ai/deepagentsjs#312](https://github.com/langchain-ai/deepagentsjs/pull/312) to Python.

## Why

When LangGraph executes the `task` tool, it injects a UUID-based `checkpoint_ns` (e.g. `"tools:a1b2c3d4-..."`) into the tool's `RunnableConfig`. This namespace identifies where the subagent's checkpoints are written. Without forwarding it to the resulting `ToolMessage`, the LangGraph SDK has no way to reconstruct a subagent's message history after a page reload — it only has the LLM provider's tool call ID, which doesn't map to a checkpoint namespace.

By storing `subgraph_checkpoint_ns` in `ToolMessage.additional_kwargs`, the SDK can query `getHistory` with the correct namespace.

## Review notes

- `runtime.config.get("configurable") or {}` is used (rather than `runtime.config.get("configurable", {})`) to safely handle a `None` value for `configurable` in addition to a missing key — this matches the defensive style of the JS `config?.configurable?.checkpoint_ns` optional chaining.
- The `additional_kwargs` key name (`subgraph_checkpoint_ns`) must stay in sync with the JS SDK, as the CLI reads this field to restore subagent history.
