### PR TITLE
fix(cli): resolve config-defined providers during runtime model swaps

### DIFF
--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from deepagents._models import model_matches_spec, resolve_model  # noqa: PLC2701
+from deepagents._models import model_matches_spec  # noqa: PLC2701
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     ModelRequest,
@@ -83,8 +83,10 @@ def _apply_overrides(request: ModelRequest) -> ModelRequest:
     new_model = None
     model = ctx.get("model")
     if model and not model_matches_spec(request.model, model):
+        from deepagents_cli.config import create_model
+
         logger.debug("Overriding model to %s", model)
-        new_model = resolve_model(model)
+        new_model = create_model(model).model
         overrides["model"] = new_model
 
     # Param merge

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -84,9 +84,18 @@ def _apply_overrides(request: ModelRequest) -> ModelRequest:
     model = ctx.get("model")
     if model and not model_matches_spec(request.model, model):
         from deepagents_cli.config import create_model
+        from deepagents_cli.model_config import ModelConfigError
 
         logger.debug("Overriding model to %s", model)
-        new_model = create_model(model).model
+        try:
+            new_model = create_model(model).model
+        except ModelConfigError:
+            logger.exception(
+                "Failed to resolve runtime model override '%s'; "
+                "continuing with current model",
+                model,
+            )
+            return request
         overrides["model"] = new_model
 
     # Param merge

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -1,10 +1,10 @@
 """Tests for ConfigurableModelMiddleware."""
 
-import sys
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
@@ -44,6 +44,13 @@ def _make_response() -> ModelResponse[Any]:
     """Create a minimal model response for handler mocks."""
     return ModelResponse(result=[AIMessage(content="response")])
 
+
+def _make_model_result(model: MagicMock) -> SimpleNamespace:
+    """Create a mock ModelResult with a .model attribute."""
+    return SimpleNamespace(model=model)
+
+
+_PATCH_CREATE = "deepagents_cli.config.create_model"
 
 _mw = ConfigurableModelMiddleware()
 
@@ -137,9 +144,7 @@ class TestModelSwap:
         request = _make_request(original, context=CLIContext(model="openai:gpt-4o"))
 
         captured: list[ModelRequest] = []
-        with patch(
-            "deepagents_cli.configurable_model.resolve_model", return_value=override
-        ):
+        with patch(_PATCH_CREATE, return_value=_make_model_result(override)):
             _mw.wrap_model_call(
                 request, lambda r: (captured.append(r), _make_response())[1]
             )
@@ -158,12 +163,41 @@ class TestModelSwap:
             captured.append(r)
             return _make_response()
 
-        with patch(
-            "deepagents_cli.configurable_model.resolve_model", return_value=override
-        ):
+        with patch(_PATCH_CREATE, return_value=_make_model_result(override)):
             await _mw.awrap_model_call(request, handler)
 
         assert captured[0].model is override
+
+    def test_class_path_provider_swapped(self) -> None:
+        """Config-defined class_path provider resolves through create_model."""
+        original = _make_model("claude-sonnet-4-6")
+        custom = _make_model("my-model")
+        request = _make_request(original, context=CLIContext(model="custom:my-model"))
+
+        captured: list[ModelRequest] = []
+        with patch(
+            _PATCH_CREATE, return_value=_make_model_result(custom)
+        ) as mock_create:
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        assert captured[0].model is custom
+        mock_create.assert_called_once_with("custom:my-model")
+
+    def test_create_model_error_propagates(self) -> None:
+        """ModelConfigError from create_model propagates to caller."""
+        from deepagents_cli.model_config import ModelConfigError
+
+        request = _make_request(
+            _make_model("claude-sonnet-4-6"),
+            context=CLIContext(model="unknown:bad-model"),
+        )
+        with (
+            patch(_PATCH_CREATE, side_effect=ModelConfigError("no such provider")),
+            pytest.raises(ModelConfigError, match="no such provider"),
+        ):
+            _mw.wrap_model_call(request, lambda _r: _make_response())
 
 
 class TestAnthropicSettingsStripped:
@@ -183,9 +217,7 @@ class TestAnthropicSettingsStripped:
         )
         captured: list[ModelRequest] = []
         with (
-            patch(
-                "deepagents_cli.configurable_model.resolve_model", return_value=override
-            ),
+            patch(_PATCH_CREATE, return_value=_make_model_result(override)),
             patch(
                 "deepagents_cli.configurable_model._is_anthropic_model",
                 return_value=False,
@@ -206,9 +238,7 @@ class TestAnthropicSettingsStripped:
         )
         captured: list[ModelRequest] = []
         with (
-            patch(
-                "deepagents_cli.configurable_model.resolve_model", return_value=override
-            ),
+            patch(_PATCH_CREATE, return_value=_make_model_result(override)),
             patch(
                 "deepagents_cli.configurable_model._is_anthropic_model",
                 return_value=True,
@@ -235,9 +265,7 @@ class TestAnthropicSettingsStripped:
         )
         captured: list[ModelRequest] = []
         with (
-            patch(
-                "deepagents_cli.configurable_model.resolve_model", return_value=override
-            ),
+            patch(_PATCH_CREATE, return_value=_make_model_result(override)),
             patch(
                 "deepagents_cli.configurable_model._is_anthropic_model",
                 return_value=False,
@@ -263,9 +291,7 @@ class TestAnthropicSettingsStripped:
             return _make_response()
 
         with (
-            patch(
-                "deepagents_cli.configurable_model.resolve_model", return_value=override
-            ),
+            patch(_PATCH_CREATE, return_value=_make_model_result(override)),
             patch(
                 "deepagents_cli.configurable_model._is_anthropic_model",
                 return_value=False,
@@ -291,9 +317,7 @@ class TestAnthropicSettingsStripped:
         )
         captured: list[ModelRequest] = []
         with (
-            patch(
-                "deepagents_cli.configurable_model.resolve_model", return_value=override
-            ),
+            patch(_PATCH_CREATE, return_value=_make_model_result(override)),
             patch(
                 "deepagents_cli.configurable_model._is_anthropic_model",
                 return_value=False,
@@ -317,9 +341,7 @@ class TestAnthropicSettingsStripped:
         )
         captured: list[ModelRequest] = []
         with (
-            patch(
-                "deepagents_cli.configurable_model.resolve_model", return_value=override
-            ),
+            patch(_PATCH_CREATE, return_value=_make_model_result(override)),
             patch(
                 "deepagents_cli.configurable_model._is_anthropic_model",
                 return_value=False,
@@ -387,9 +409,7 @@ class TestModelParams:
             ),
         )
         captured: list[ModelRequest] = []
-        with patch(
-            "deepagents_cli.configurable_model.resolve_model", return_value=override
-        ):
+        with patch(_PATCH_CREATE, return_value=_make_model_result(override)):
             _mw.wrap_model_call(
                 request, lambda r: (captured.append(r), _make_response())[1]
             )

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
-import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
@@ -185,19 +184,22 @@ class TestModelSwap:
         assert captured[0].model is custom
         mock_create.assert_called_once_with("custom:my-model")
 
-    def test_create_model_error_propagates(self) -> None:
-        """ModelConfigError from create_model propagates to caller."""
+    def test_create_model_error_falls_back_to_original(self) -> None:
+        """ModelConfigError falls back to original model instead of crashing."""
         from deepagents_cli.model_config import ModelConfigError
 
+        original = _make_model("claude-sonnet-4-6")
         request = _make_request(
-            _make_model("claude-sonnet-4-6"),
+            original,
             context=CLIContext(model="unknown:bad-model"),
         )
-        with (
-            patch(_PATCH_CREATE, side_effect=ModelConfigError("no such provider")),
-            pytest.raises(ModelConfigError, match="no such provider"),
-        ):
-            _mw.wrap_model_call(request, lambda _r: _make_response())
+        captured: list[ModelRequest] = []
+        with patch(_PATCH_CREATE, side_effect=ModelConfigError("no such provider")):
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        assert captured[0].model is original
 
 
 class TestAnthropicSettingsStripped:


### PR DESCRIPTION
Runtime model swaps via `ConfigurableModelMiddleware` used `resolve_model()` from the SDK layer, which delegates to `init_chat_model()` (LangChain's built-in provider registry). Config-defined providers (via `class_path` in `~/.deepagents/config.toml`) aren't in that registry, so custom specs raised `ValueError` on session resume, `/model` switching, and summarization. The fix routes swaps through the CLI's `create_model()`, which already handles both `class_path` and standard providers.

## Changes
- Replace `resolve_model(model)` with `create_model(model).model` in `_apply_overrides` — the CLI's `create_model` checks user config for `class_path` providers before falling back to `init_chat_model`, so custom providers now resolve correctly during runtime swaps
- Defer the `create_model` import to the swap branch in `_apply_overrides` to keep the module lightweight at import time
- Catch `ModelConfigError` from `create_model` and fall back to the original model with a logged traceback, keeping the session alive instead of crashing