### PR TITLE
refactor(cli): drop `langchain_anthropic` import from provider detection

### DIFF
--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -41,19 +41,22 @@ class CLIContext(TypedDict, total=False):
 
 
 def _is_anthropic_model(model: object) -> bool:
-    """Check whether a resolved model is an Anthropic `ChatAnthropic` instance.
+    """Check whether a resolved model reports `'anthropic'` as its provider.
 
-    Returns `False` if `langchain-anthropic` is not installed.
+    Uses `_get_ls_params` from `BaseChatModel` to read the provider name.
 
     Returns:
-        `True` if the model is a `ChatAnthropic` instance.
+        `True` if the model's `ls_provider` is `'anthropic'`.
     """
     try:
-        from langchain_anthropic import ChatAnthropic
-    except ImportError:
-        logger.debug("langchain_anthropic not installed; assuming non-Anthropic model")
+        ls_params = model._get_ls_params()  # type: ignore[attr-defined]
+    except (AttributeError, TypeError, RuntimeError):
+        logger.debug(
+            "_get_ls_params raised for %s; assuming non-Anthropic",
+            type(model).__name__,
+        )
         return False
-    return isinstance(model, ChatAnthropic)
+    return isinstance(ls_params, dict) and ls_params.get("ls_provider") == "anthropic"
 
 
 _ANTHROPIC_ONLY_SETTINGS: set[str] = {"cache_control"}

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -20,6 +20,7 @@ def _make_model(name: str) -> MagicMock:
     model = MagicMock(spec=BaseChatModel)
     model.model_name = name
     model.model_dump.return_value = {"model_name": name}
+    model._get_ls_params.return_value = {"ls_provider": "openai"}
     return model
 
 
@@ -368,9 +369,18 @@ class TestIsAnthropicModel:
     def test_returns_false_for_non_anthropic(self) -> None:
         assert _is_anthropic_model(_make_model("gpt-4o")) is False
 
-    def test_returns_false_when_import_missing(self) -> None:
-        with patch.dict("sys.modules", {"langchain_anthropic": None}):
-            assert _is_anthropic_model(_make_model("anything")) is False
+    def test_returns_false_for_plain_object(self) -> None:
+        assert _is_anthropic_model(object()) is False
+
+    def test_returns_false_when_ls_params_returns_none(self) -> None:
+        model = MagicMock(spec=BaseChatModel)
+        model._get_ls_params.return_value = None
+        assert _is_anthropic_model(model) is False
+
+    def test_returns_false_when_ls_params_raises(self) -> None:
+        model = MagicMock(spec=BaseChatModel)
+        model._get_ls_params.side_effect = RuntimeError("not initialized")
+        assert _is_anthropic_model(model) is False
 
 
 class TestModelParams:


### PR DESCRIPTION
Replace `_is_anthropic_model`'s `isinstance(model, ChatAnthropic)` check with provider introspection via `BaseChatModel._get_ls_params()`. The old approach required importing `langchain_anthropic` at runtime — unnecessary since every LangChain chat model already reports its provider through `_get_ls_params`. This also removes a heavy import from the middleware hot path.
