### PR TITLE
ci(infra): auto-swap release PR label on manual dispatch

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -254,7 +254,7 @@ This means the CLI's pinned `deepagents` dependency in `libs/cli/pyproject.toml`
    - Click **Run workflow**
    - Select `main` branch and `deepagents-cli` package
 
-3. **Fix the `autorelease: pending` label** if the original automated release left it on the merged release PR. The failed workflow skipped the `mark-release` job, so the label was never swapped. See [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label) for the fix. **If you skip this step, release-please will not create new release PRs.**
+3. **Verify the `autorelease: pending` label was swapped.** The `mark-release` job will attempt to find the release PR by label and update it automatically, even on manual dispatch. If the label wasn't swapped (e.g., the job failed), fix it manually — see [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label). **If you skip this step, release-please will not create new release PRs.**
 
 ### Re-releasing a Version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -694,6 +694,7 @@ jobs:
       - name: Update release PR label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_NAME: ${{ needs.build.outputs.pkg-name }}
         run: |
           # Find the release PR that was merged (look for PR associated with this commit)
           PR_NUMBER=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
@@ -708,5 +709,27 @@ jobs:
               echo "PR #$PR_NUMBER does not have 'autorelease: pending' label, skipping (not a release PR)"
             fi
           else
-            echo "No PR found for commit ${{ github.sha }}, skipping label update"
+            echo "No PR found via commit ${{ github.sha }}, searching by label..."
+            # Fallback: find the most recently merged release PR with autorelease: pending.
+            # This handles manual dispatch where github.sha may not be the merge commit
+            # (e.g., other commits landed on main between the merge and the manual trigger).
+            PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
+              --state merged \
+              --label "autorelease: pending" \
+              --label "release" \
+              --search "\"release($PKG_NAME)\" in:title" \
+              --json number --jq '.[0].number // empty') || {
+              echo "::warning::gh pr list failed. Label swap could not be performed automatically."
+              echo "Manual fix: gh pr edit <PR_NUMBER> --remove-label 'autorelease: pending' --add-label 'autorelease: tagged'"
+              exit 0
+            }
+            if [ -n "$PR_NUMBER" ]; then
+              echo "Found release PR #$PR_NUMBER via label search, updating labels..."
+              if ! gh pr edit "$PR_NUMBER" --remove-label "autorelease: pending" --add-label "autorelease: tagged"; then
+                echo "::warning::Failed to update labels on PR #$PR_NUMBER. Manual fix required."
+                echo "Run: gh pr edit $PR_NUMBER --remove-label 'autorelease: pending' --add-label 'autorelease: tagged'"
+              fi
+            else
+              echo "::warning::No release PR with 'autorelease: pending' found for $PKG_NAME. Manual label update may be required."
+            fi
           fi


### PR DESCRIPTION
When manually triggering `release.yml` (e.g., to skip the SDK pin check), `github.sha` points to the tip of `main` — which may have moved past the release PR's merge commit. The `mark-release` job's commit-based PR lookup fails silently, leaving `autorelease: pending` on the PR and blocking future release-please runs. This adds a label-based fallback search so the label swap works on manual dispatch without manual intervention.

## Changes
- Add a fallback in `mark-release`'s "Update release PR label" step that searches by `autorelease: pending` + `release` labels and title pattern when the commit-based `gh api` lookup returns empty
- Use `::warning::` annotations instead of silent `exit 0` / `|| true` so API failures and missing PRs surface in the Actions summary rather than hiding in logs
- Update the "SDK Pin Mismatch" recovery steps in `RELEASING.md` to reflect the automated fallback (verify instead of manual-fix-required)