### PR TITLE
docs(infra): expand SDK pin mismatch comment with bypass and fix steps

### DIFF
--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -107,14 +107,18 @@ jobs:
               const body = [
                 marker,
                 '> [!WARNING]',
-                '> **SDK pin mismatch** — the next CLI release will fail until this is resolved.',
+                '> **SDK pin mismatch** — the CLI release workflow will fail at the "Verify CLI pins latest SDK version" step until this is resolved.',
                 '>',
                 '> | | Version |',
                 '> |---|---|',
                 `> | SDK (\`libs/deepagents/pyproject.toml\`) | \`${sdkVersion}\` |`,
                 `> | CLI pin (\`libs/cli/pyproject.toml\`) | \`${cliPin}\` |`,
                 '>',
-                `> Update \`libs/cli/pyproject.toml\` to pin \`deepagents==${sdkVersion}\`.`,
+                `> **To fix:** update \`libs/cli/pyproject.toml\` to pin \`deepagents==${sdkVersion}\`, then run \`cd libs/cli && uv lock\` and commit the lockfile update.`,
+                '>',
+                '> **To bypass:** if you intentionally need to pin an older SDK version, re-run the release workflow with `dangerous-skip-sdk-pin-check` enabled. Ensure the CLI does not contain any code that depends on functionality introduced in the newer SDK version — otherwise the published CLI will fail at runtime.',
+                '>',
+                '> See [`.github/RELEASING.md`](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#release-failed-cli-sdk-pin-mismatch) for the full recovery procedure.',
               ].join('\n');
 
               try {


### PR DESCRIPTION
Expand the SDK pin mismatch PR comment posted by `check_sdk_pin.yml` to be actionable instead of just diagnostic. The old comment said "the next CLI release will fail" with a one-line fix suggestion — contributors unfamiliar with the release pipeline had no way to know about the bypass option or the full recovery procedure.