### PR TITLE
hotfix(cli): compat shim for `ls_info` return type in release tests

### DIFF
--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -1476,3 +1476,30 @@ class TestCreateDeepAgentKwargsWorkaround:
             "Revert the **kwargs workaround in create_cli_agent() back to "
             "direct keyword arguments and delete this test."
         )
+
+
+class TestLsEntriesShim:
+    """Remind us to remove the `_ls_entries` compat shim in test_end_to_end.py.
+
+    The PyPI SDK <0.5 returns a raw `list` from `ls_info`; >=0.5 returns
+    `LsResult` with `.entries`. Once the pin is bumped to >=0.5.0 the shim
+    should be deleted and callers inlined to `backend.ls_info(path).entries`.
+    """
+
+    def test_remove_ls_entries_shim_when_sdk_pin_is_bumped(self) -> None:
+        import tomllib
+
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+
+        deps = data["project"]["dependencies"]
+        sdk_pin = next(d for d in deps if d.startswith("deepagents=="))
+        pinned_version = sdk_pin.split("==")[1]
+        major, minor = (int(x) for x in pinned_version.split(".")[:2])
+
+        assert (major, minor) < (0, 5), (
+            f"SDK pin is now {pinned_version} (>=0.5.0). "
+            "Delete `_ls_entries()` from test_end_to_end.py and inline "
+            "`backend.ls_info(path).entries` at call sites."
+        )

--- a/libs/cli/tests/unit_tests/test_end_to_end.py
+++ b/libs/cli/tests/unit_tests/test_end_to_end.py
@@ -22,6 +22,16 @@ from pydantic import Field
 from deepagents_cli.agent import create_cli_agent
 
 
+def _ls_entries(backend: CompositeBackend, path: str) -> list | None:
+    """Compat shim: PyPI SDK <0.5 returns raw list; >=0.5 returns LsResult.
+
+    TODO(remove): delete this helper and inline `backend.ls_info(path).entries`
+    once the CLI pins `deepagents>=0.5`.
+    """
+    ls_result = backend.ls_info(path)
+    return ls_result.entries if hasattr(ls_result, "entries") else ls_result
+
+
 @tool(description="Sample tool")
 def sample_tool(sample_input: str) -> str:
     """A sample tool that returns the input string."""
@@ -232,7 +242,7 @@ class TestDeepAgentsCLIEndToEnd:
             assert agent_response.generations[0].message.content == "response"
 
             # Verify conversation history was offloaded to backend
-            assert backend.ls_info("/conversation_history/").entries
+            assert _ls_entries(backend, "/conversation_history/")
 
     def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
         """Test CLI agent with tools using a fake LLM model.


### PR DESCRIPTION
The CLI release workflow (`pre-release-checks`) installs the pinned PyPI SDK, not the local editable version. The published SDK's `CompositeBackend.ls_info` returns a raw `list`, while the local SDK now returns `LsResult` with an `.entries` attribute — causing `test_cli_agent_summarizes` to fail with `AttributeError: 'list' object has no attribute 'entries'`.

## Changes
- Add `_ls_entries()` compat shim in `test_end_to_end.py` that uses `hasattr` to handle both the legacy raw-list return (PyPI SDK <0.5) and the new `LsResult` return (SDK >=0.5)
- Add `TestLsEntriesShim` version-gate test in `test_agent.py` (same pattern as `TestCreateDeepAgentKwargsWorkaround`) — fails with a cleanup message once the SDK pin reaches >=0.5.0
