### PR TITLE
fix(infra): fall through to label search when commit lookup finds non-release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,23 +696,30 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
         run: |
-          # Find the release PR that was merged (look for PR associated with this commit)
-          PR_NUMBER=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
+          UPDATED=false
+
+          # Try 1: find PR associated with this commit
+          PR_NUMBER=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty' 2>/dev/null) || PR_NUMBER=""
           if [ -n "$PR_NUMBER" ]; then
-            # Only update label if this is actually a release PR (has autorelease: pending label)
-            # This prevents accidentally labeling feature PRs when workflow is manually triggered
             HAS_PENDING=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -q "autorelease: pending" && echo "true" || echo "false")
             if [ "$HAS_PENDING" = "true" ]; then
               echo "Found release PR #$PR_NUMBER with 'autorelease: pending', updating labels..."
-              gh pr edit "$PR_NUMBER" --remove-label "autorelease: pending" --add-label "autorelease: tagged" || true
+              if gh pr edit "$PR_NUMBER" --remove-label "autorelease: pending" --add-label "autorelease: tagged"; then
+                UPDATED=true
+              else
+                echo "::warning::Failed to update labels on PR #$PR_NUMBER via commit lookup. Falling through to label search..."
+              fi
             else
-              echo "PR #$PR_NUMBER does not have 'autorelease: pending' label, skipping (not a release PR)"
+              echo "PR #$PR_NUMBER (from commit lookup) is not the release PR, falling through to label search..."
             fi
           else
-            echo "No PR found via commit ${{ github.sha }}, searching by label..."
-            # Fallback: find the most recently merged release PR with autorelease: pending.
-            # This handles manual dispatch where github.sha may not be the merge commit
-            # (e.g., other commits landed on main between the merge and the manual trigger).
+            echo "No PR found via commit ${{ github.sha }}, falling through to label search..."
+          fi
+
+          # Try 2: fallback label search when commit-based lookup didn't find the release PR.
+          # This handles manual dispatch where github.sha may not be the merge commit
+          # (e.g., other commits landed on main between the merge and the manual trigger).
+          if [ "$UPDATED" = "false" ]; then
             PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
               --state merged \
               --label "autorelease: pending" \


### PR DESCRIPTION
The `mark-release` job's label-swap step looked up the PR associated with `github.sha`, but on manual dispatch (or when commits land after the release PR merge), that SHA points to a non-release commit. The commit→PR API returned the wrong PR, found no `autorelease: pending` label, and exited — never reaching the fallback label search. This left release PRs permanently stuck with `autorelease: pending`, which can confuse release-please on subsequent runs.

## Changes
- Restructure the label-swap logic into two sequential phases gated by an `UPDATED` flag: commit-based lookup (Try 1) and label-based search (Try 2). Previously the fallback only ran when the commit returned **no** PR — now it also runs when the commit returns a non-release PR or when the `gh pr edit` call fails.
- Replace `|| true` on `gh pr edit` with an `if/else` that only sets `UPDATED=true` on success. The old pattern silently swallowed edit failures, which in the new two-phase structure would have incorrectly skipped the fallback.
- Guard the `gh api` commit-lookup call with `2>/dev/null) || PR_NUMBER=""` so a transient API failure gracefully falls through to Try 2 instead of aborting the step under `set -e`.