### PR TITLE
ci(infra): standardize python setup via `uv_setup` composite action

### DIFF
--- a/.github/workflows/check_extras_sync.yml
+++ b/.github/workflows/check_extras_sync.yml
@@ -31,8 +31,8 @@ jobs:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
 
-      - name: "🐍 Set up Python 3.14"
-        uses: actions/setup-python@v6
+      - name: "🐍 Set up Python and uv"
+        uses: "./.github/actions/uv_setup"
         with:
           python-version: "3.14"
 

--- a/.github/workflows/check_lockfiles.yml
+++ b/.github/workflows/check_lockfiles.yml
@@ -26,11 +26,8 @@ jobs:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
 
-      - name: "🐍 Set up UV"
-        uses: astral-sh/setup-uv@v7
-
-      - name: "🐍 Set up Python 3.14"
-        uses: actions/setup-python@v6
+      - name: "🐍 Set up Python and uv"
+        uses: "./.github/actions/uv_setup"
         with:
           python-version: "3.14"
 

--- a/.github/workflows/check_versions.yml
+++ b/.github/workflows/check_versions.yml
@@ -27,8 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: "🐍 Set up Python 3.14"
-        uses: actions/setup-python@v6
+      - name: "🐍 Set up Python and uv"
+        uses: "./.github/actions/uv_setup"
         with:
           python-version: "3.14"
 


### PR DESCRIPTION
Standardize Python + uv setup across three CI workflows that were using `actions/setup-python` directly. The repo already has a `.github/actions/uv_setup` composite action that pins the uv version and configures dependency caching — these workflows were the last holdouts.