### PR TITLE
fix(cli): misleading "missing package" error when provider import fails

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1585,6 +1585,8 @@ def _create_model_via_init(
             return init_chat_model(model_name, model_provider=provider, **kwargs)
         return init_chat_model(model_name, **kwargs)
     except ImportError as e:
+        import importlib.util
+
         package_map = {
             "anthropic": "langchain-anthropic",
             "openai": "langchain-openai",
@@ -1593,9 +1595,20 @@ def _create_model_via_init(
             "nvidia": "langchain-nvidia-ai-endpoints",
         }
         package = package_map.get(provider, f"langchain-{provider}")
-        msg = (
-            f"Missing package for provider '{provider}'. Install: pip install {package}"
-        )
+        # Convert pip package name to Python module name for import check.
+        module_name = package.replace("-", "_")
+        if importlib.util.find_spec(module_name) is not None:
+            # Package is installed but an internal import failed — surface
+            # the real error instead of the misleading "missing package" hint.
+            msg = (
+                f"Provider package '{package}' is installed but failed to "
+                f"import for provider '{provider}': {e}"
+            )
+        else:
+            msg = (
+                f"Missing package for provider '{provider}'. "
+                f"Install: pip install {package}"
+            )
         raise ModelConfigError(msg) from e
     except (ValueError, TypeError) as e:
         spec = f"{provider}:{model_name}" if provider else model_name

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1597,7 +1597,11 @@ def _create_model_via_init(
         package = package_map.get(provider, f"langchain-{provider}")
         # Convert pip package name to Python module name for import check.
         module_name = package.replace("-", "_")
-        if importlib.util.find_spec(module_name) is not None:
+        try:
+            spec_found = importlib.util.find_spec(module_name) is not None
+        except (ImportError, ValueError):
+            spec_found = False
+        if spec_found:
             # Package is installed but an internal import failed — surface
             # the real error instead of the misleading "missing package" hint.
             msg = (

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1621,10 +1621,15 @@ class TestCreateModelViaInitImportError:
     @patch("langchain.chat_models.init_chat_model")
     def test_missing_package_error(self, mock_init: Mock) -> None:
         """Shows install hint when provider package is not installed."""
-        mock_init.side_effect = ImportError("No module named 'langchain_nvidia_ai_endpoints'")
+        mock_init.side_effect = ImportError(
+            "No module named 'langchain_nvidia_ai_endpoints'"
+        )
         with (
             patch("importlib.util.find_spec", return_value=None),
-            pytest.raises(ModelConfigError, match="Missing package for provider 'nvidia'"),
+            pytest.raises(
+                ModelConfigError,
+                match="Missing package for provider 'nvidia'",
+            ),
         ):
             _create_model_via_init("nemotron", "nvidia", {})
 
@@ -1643,7 +1648,9 @@ class TestCreateModelViaInitImportError:
             _create_model_via_init("nemotron", "nvidia", {})
 
     @patch("langchain.chat_models.init_chat_model")
-    def test_installed_but_broken_includes_original_error(self, mock_init: Mock) -> None:
+    def test_installed_but_broken_includes_original_error(
+        self, mock_init: Mock
+    ) -> None:
         """Original ImportError message is included when package is installed."""
         mock_init.side_effect = ImportError("some transitive dep missing")
         mock_spec = Mock()

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -14,6 +14,7 @@ from deepagents_cli.config import (
     ModelResult,
     Settings,
     _create_model_from_class,
+    _create_model_via_init,
     _get_provider_kwargs,
     build_langsmith_thread_url,
     create_model,
@@ -1612,6 +1613,58 @@ class TestCreateModelEdgeCaseParsing:
 
         create_model("")
         mock_default.assert_called_once()
+
+
+class TestCreateModelViaInitImportError:
+    """Tests for _create_model_via_init() ImportError handling."""
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_missing_package_error(self, mock_init: Mock) -> None:
+        """Shows install hint when provider package is not installed."""
+        mock_init.side_effect = ImportError("No module named 'langchain_nvidia_ai_endpoints'")
+        with (
+            patch("importlib.util.find_spec", return_value=None),
+            pytest.raises(ModelConfigError, match="Missing package for provider 'nvidia'"),
+        ):
+            _create_model_via_init("nemotron", "nvidia", {})
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_installed_but_broken_import(self, mock_init: Mock) -> None:
+        """Shows real error when package is installed but import fails internally."""
+        mock_init.side_effect = ImportError("cannot import name 'foo' from 'bar'")
+        mock_spec = Mock()
+        with (
+            patch("importlib.util.find_spec", return_value=mock_spec),
+            pytest.raises(
+                ModelConfigError,
+                match="installed but failed to import",
+            ),
+        ):
+            _create_model_via_init("nemotron", "nvidia", {})
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_installed_but_broken_includes_original_error(self, mock_init: Mock) -> None:
+        """Original ImportError message is included when package is installed."""
+        mock_init.side_effect = ImportError("some transitive dep missing")
+        mock_spec = Mock()
+        with (
+            patch("importlib.util.find_spec", return_value=mock_spec),
+            pytest.raises(ModelConfigError, match="some transitive dep missing"),
+        ):
+            _create_model_via_init("nemotron", "nvidia", {})
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_unknown_provider_fallback_package_name(self, mock_init: Mock) -> None:
+        """Unknown provider falls back to langchain-{provider} package name."""
+        mock_init.side_effect = ImportError("no module")
+        with (
+            patch("importlib.util.find_spec", return_value=None),
+            pytest.raises(
+                ModelConfigError,
+                match=r"pip install langchain-custom_provider",
+            ),
+        ):
+            _create_model_via_init("some-model", "custom_provider", {})
 
 
 class TestDetectProvider:

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1639,13 +1639,14 @@ class TestCreateModelViaInitImportError:
         mock_init.side_effect = ImportError("cannot import name 'foo' from 'bar'")
         mock_spec = Mock()
         with (
-            patch("importlib.util.find_spec", return_value=mock_spec),
+            patch("importlib.util.find_spec", return_value=mock_spec) as mock_find_spec,
             pytest.raises(
                 ModelConfigError,
                 match="installed but failed to import",
             ),
         ):
             _create_model_via_init("nemotron", "nvidia", {})
+        mock_find_spec.assert_called_once_with("langchain_nvidia_ai_endpoints")
 
     @patch("langchain.chat_models.init_chat_model")
     def test_installed_but_broken_includes_original_error(
@@ -1672,6 +1673,22 @@ class TestCreateModelViaInitImportError:
             ),
         ):
             _create_model_via_init("some-model", "custom_provider", {})
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_find_spec_raises_falls_back_to_missing(self, mock_init: Mock) -> None:
+        """find_spec failure falls back to 'missing package' message."""
+        mock_init.side_effect = ImportError("no module")
+        with (
+            patch(
+                "importlib.util.find_spec",
+                side_effect=ModuleNotFoundError("no parent"),
+            ),
+            pytest.raises(
+                ModelConfigError,
+                match="Missing package",
+            ),
+        ):
+            _create_model_via_init("model", "dotted.provider", {})
 
 
 class TestDetectProvider:


### PR DESCRIPTION
Relates to #1903, #1902

---

When `init_chat_model` raises an `ImportError`, the CLI always reported:

> Missing package for provider 'nvidia'. Install: pip install langchain-nvidia-ai-endpoints

...even when the package **is** installed but fails to import internally (e.g. transitive dependency issue, Python version incompatibility). This sends users on a wild goose chase reinstalling something they already have.

Now uses `importlib.util.find_spec()` to distinguish between the two cases:
- Package **not installed** → existing install hint (unchanged)
- Package **installed but broken** → surfaces the original `ImportError` so users can diagnose the real cause