### PR TITLE
ci(infra): add `new-contributor` label for first-time external PRs

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -330,26 +330,49 @@ jobs:
 
             const TRUSTED_THRESHOLD = 5;
 
-            let mergedCount = 0;
+            async function ensureLabel(name, color = 'b76e79') {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                await github.rest.issues.createLabel({ owner, repo, name, color });
+              }
+            }
+
+            let mergedCount;
             try {
               const result = await github.rest.search.issuesAndPullRequests({
                 q: `repo:${owner}/${repo} is:pr is:merged author:"${author}"`,
                 per_page: 1,
               });
-              mergedCount = result?.data?.total_count ?? 0;
+              mergedCount = result?.data?.total_count;
             } catch (error) {
               if (error?.status !== 422) throw error;
               core.warning(`Search failed for ${author}; skipping tier label.`);
               return;
             }
 
+            if (mergedCount == null) {
+              core.warning(`Search response missing total_count for ${author}; skipping tier label.`);
+              return;
+            }
+
             if (mergedCount >= TRUSTED_THRESHOLD) {
+              await ensureLabel('trusted-contributor');
               await github.rest.issues.addLabels({
                 owner, repo,
                 issue_number: prNumber,
                 labels: ['trusted-contributor'],
               });
               console.log(`Applied 'trusted-contributor' to #${prNumber} (${mergedCount} merged PRs)`);
+            } else if (mergedCount === 0) {
+              await ensureLabel('new-contributor');
+              await github.rest.issues.addLabels({
+                owner, repo,
+                issue_number: prNumber,
+                labels: ['new-contributor'],
+              });
+              console.log(`Applied 'new-contributor' to #${prNumber} (0 merged PRs from ${author})`);
             } else {
               console.log(`No tier label for ${author} (${mergedCount} merged PRs)`);
             }
@@ -381,7 +404,7 @@ jobs:
             const LABEL_COLOR = 'b76e79';
 
             const sizeLabels = ['size: XS', 'size: S', 'size: M', 'size: L', 'size: XL'];
-            const tierLabels = ['trusted-contributor'];
+            const tierLabels = ['new-contributor', 'trusted-contributor'];
             const allTypeLabels = ['feature', 'fix', 'documentation', 'linting', 'refactor',
               'performance', 'tests', 'infra', 'revert', 'release', 'breaking'];
 
@@ -415,14 +438,14 @@ jobs:
               } catch (e) {
                 if (e.status !== 404) core.warning(`Membership check failed for ${author}: ${e.message}`);
               }
-              let mergedCount = 0;
+              let mergedCount = null;
               if (isExternal) {
                 try {
                   const result = await github.rest.search.issuesAndPullRequests({
                     q: `repo:${owner}/${repo} is:pr is:merged author:"${author}"`,
                     per_page: 1,
                   });
-                  mergedCount = result?.data?.total_count ?? 0;
+                  mergedCount = result?.data?.total_count ?? null;
                 } catch (e) {
                   if (e?.status !== 422) throw e;
                   core.warning(`Search failed for ${author}; skipping tier.`);
@@ -480,6 +503,8 @@ jobs:
               labels.add(info.isExternal ? 'external' : 'internal');
               if (info.isExternal && info.mergedCount >= TRUSTED_THRESHOLD) {
                 labels.add('trusted-contributor');
+              } else if (info.isExternal && info.mergedCount === 0) {
+                labels.add('new-contributor');
               }
 
               // Size + file labels


### PR DESCRIPTION
Label external PRs from first-time contributors with `new-contributor` so maintainers can prioritize welcome reviews and onboarding. Also fixes a pre-existing bug where the tier labeling step called `addLabels` without ensuring the label existed on the repo — a guaranteed 422 on any repo that hadn't run the backfill job first.

## Changes
- Add `new-contributor` label for external authors with zero previously merged PRs in both the per-PR `label` job and the `backfill` job
- Add `ensureLabel()` to the "Apply contributor tier label" step — previously, both `trusted-contributor` and the new `new-contributor` would 422 if the label didn't exist on the repo (the "Apply PR labels" step had this, but the tier step didn't)
- Change `mergedCount` default from `0` to `undefined`/`null` with an explicit null guard — prevents malformed search API responses from incorrectly triggering `new-contributor` (previously the `?? 0` fallback was harmless since it hit the no-op `else` branch; now `=== 0` triggers active labeling)
- Add `new-contributor` to `tierLabels` in the backfill job so it gets auto-created and cleaned up during `workflow_dispatch` runs