### PR TITLE
ci: grant id-token permission for codspeed benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,9 @@ jobs:
   benchmark-deepagents:
     name: "⏱️ Benchmark deepagents"
     needs: changes
-    if: needs.changes.outputs.deepagents == 'true' || github.event_name == 'push'
+    # TODO: re-enable once CodSpeed integration is ready
+    #if: needs.changes.outputs.deepagents == 'true' || github.event_name == 'push'
+    if: false
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/deepagents"


### PR DESCRIPTION
(also disable codspeed for now)

Grant `id-token: write` to the CI workflow so the `_benchmark.yml` reusable workflow can authenticate with CodSpeed via OIDC. Without this, GitHub Actions rejects the workflow at compile time — reusable workflows can't escalate permissions beyond what the caller grants — causing every CI run to `startup_failure` since `benchmark-deepagents` was added in #1944.

## Changes
- Add `id-token: write` to the top-level `permissions` block in `ci.yml`, required by `_benchmark.yml`'s `CodSpeedHQ/action@v4` OIDC authentication