### PR TITLE
ci(cli): add concurrency control to deepagents workflow

### DIFF
--- a/.github/workflows/deepagents-example.yml
+++ b/.github/workflows/deepagents-example.yml
@@ -11,6 +11,11 @@ on:
         description: "Prompt for the agent"
         required: true
 
+# Cancel superseded runs when @deepagents is mentioned multiple times on the same PR/issue
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   deepagents:
     if: |


### PR DESCRIPTION
Add concurrency control to the `@deepagents` agent workflow. Without this, duplicate comment triggers pile up instead of cancelling the superseded run.