### PR TITLE
ci(infra): reject pr titles with empty scope parentheses

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -57,11 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "🚫 Reject empty scope"
-        if: contains(github.event.pull_request.title, '():')
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "::error::PR title has empty scope parentheses: '${{ github.event.pull_request.title }}'"
-          echo "Either remove the parentheses or provide a scope (e.g., 'fix(cli): ...')."
-          exit 1
+          if [[ "$PR_TITLE" =~ ^[a-z]+\(\)[!]?: ]]; then
+            echo "::error::PR title has empty scope parentheses: '$PR_TITLE'"
+            echo "Either remove the parentheses or provide a scope (e.g., 'fix(cli): ...')."
+            exit 1
+          fi
       - name: "✅ Validate Conventional Commits Format"
         uses: amannn/action-semantic-pull-request@v6
         env:


### PR DESCRIPTION
The `amannn/action-semantic-pull-request` action doesn't reject PR titles with empty scope parentheses like `fix(): something` — `requireScope: false` treats the empty capture as "no scope." Add an explicit guard step that catches this before the main validation runs.