### PR TITLE
feat(sdk): add skill pack support to skills middleware (experimental)

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -401,57 +401,37 @@ def _format_skill_annotations(skill: SkillMetadata) -> str:
     return ", ".join(parts)
 
 
-def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetadata]:
-    """List all skills from a backend source.
-
-    Scans backend for subdirectories containing `SKILL.md` files, downloads
-    their content, parses YAML frontmatter, and returns skill metadata.
-
-    Expected structure:
-
-    ```txt
-    source_path/
-    └── skill-name/
-        ├── SKILL.md   # Required
-        └── helper.py  # Optional
-    ```
+def _download_and_parse_skills(
+    backend: BackendProtocol,
+    dir_paths: list[str],
+) -> tuple[list[SkillMetadata], list[str]]:
+    """Download `SKILL.md` from each directory and parse metadata.
 
     Args:
-        backend: Backend instance to use for file operations
-        source_path: Path to the skills directory in the backend
+        backend: Backend instance to use for file operations.
+        dir_paths: List of directory paths to check for `SKILL.md`.
 
     Returns:
-        List of skill metadata from successfully parsed `SKILL.md` files
+        Tuple of (parsed skill metadata, directories that had no `SKILL.md`).
     """
-    skills: list[SkillMetadata] = []
-    ls_result = backend.ls(source_path)
-    items = ls_result.entries if isinstance(ls_result, LsResult) else ls_result
-
-    # Find all skill directories (directories containing SKILL.md)
-    skill_dirs = []
-    for item in items or []:
-        if not item.get("is_dir"):
-            continue
-        skill_dirs.append(item["path"])
-
-    if not skill_dirs:
-        return []
-
-    # For each skill directory, check if SKILL.md exists and download it
-    skill_md_paths = []
-    for skill_dir_path in skill_dirs:
-        # Construct SKILL.md path using PurePosixPath for safe, standardized path operations
-        skill_dir = PurePosixPath(skill_dir_path)
+    skill_md_paths: list[tuple[str, str]] = []
+    for dir_path in dir_paths:
+        skill_dir = PurePosixPath(dir_path)
         skill_md_path = str(skill_dir / "SKILL.md")
-        skill_md_paths.append((skill_dir_path, skill_md_path))
+        skill_md_paths.append((dir_path, skill_md_path))
 
     paths_to_download = [skill_md_path for _, skill_md_path in skill_md_paths]
     responses = backend.download_files(paths_to_download)
 
-    # Parse each downloaded SKILL.md
-    for (skill_dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
+    skills: list[SkillMetadata] = []
+    no_skill_md: list[str] = []
+    for (dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
         if response.error:
-            # Skill doesn't have a SKILL.md, skip it
+            # Only treat "file_not_found" as a potential skill pack.
+            # Other errors (permission_denied, is_directory, invalid_path)
+            # indicate the directory itself is inaccessible.
+            if response.error == "file_not_found":
+                no_skill_md.append(dir_path)
             continue
 
         if response.content is None:
@@ -464,10 +444,7 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
             logger.warning("Error decoding %s: %s", skill_md_path, e)
             continue
 
-        # Extract directory name from path using PurePosixPath
-        directory_name = PurePosixPath(skill_dir_path).name
-
-        # Parse metadata
+        directory_name = PurePosixPath(dir_path).name
         skill_metadata = _parse_skill_metadata(
             content=content,
             skill_path=skill_md_path,
@@ -476,7 +453,115 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
         if skill_metadata:
             skills.append(skill_metadata)
 
+    return skills, no_skill_md
+
+
+def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetadata]:
+    """List all skills from a backend source.
+
+    Scans backend for subdirectories containing `SKILL.md` files, downloads
+    their content, parses YAML frontmatter, and returns skill metadata.
+
+    Also supports **skill packs** (one level of nesting): if a subdirectory
+    does not contain a `SKILL.md` file, its own subdirectories are scanned
+    for skills. This allows a single symlink to a skill collection
+    (e.g., `~/.agents/skills/superpowers → pack/skills/`) to expose all
+    skills within it.
+
+    Expected structures:
+
+    ```txt
+    source_path/
+    ├── skill-name/            # direct skill
+    │   ├── SKILL.md
+    │   └── helper.py
+    └── skill-pack/            # skill pack (no SKILL.md)
+        ├── nested-skill-a/
+        │   └── SKILL.md
+        └── nested-skill-b/
+            └── SKILL.md
+    ```
+
+    Args:
+        backend: Backend instance to use for file operations
+        source_path: Path to the skills directory in the backend
+
+    Returns:
+        List of skill metadata from successfully parsed `SKILL.md` files
+    """
+    ls_result = backend.ls(source_path)
+    items = ls_result.entries if isinstance(ls_result, LsResult) else ls_result
+
+    dir_paths = [item["path"] for item in (items or []) if item.get("is_dir")]
+    if not dir_paths:
+        return []
+
+    skills, pack_dirs = _download_and_parse_skills(backend, dir_paths)
+
+    # Scan one level deeper for skill packs (directories without a loadable SKILL.md)
+    for pack_dir in pack_dirs:
+        try:
+            nested_result = backend.ls(pack_dir)
+        except (OSError, NotImplementedError):
+            logger.warning("Failed to list pack directory %s", pack_dir, exc_info=True)
+            continue
+        nested_items = nested_result.entries if isinstance(nested_result, LsResult) else nested_result
+        nested_dirs = [item["path"] for item in (nested_items or []) if item.get("is_dir")]
+        nested_skills, _ = _download_and_parse_skills(backend, nested_dirs)
+        skills.extend(nested_skills)
+
     return skills
+
+
+async def _adownload_and_parse_skills(
+    backend: BackendProtocol,
+    dir_paths: list[str],
+) -> tuple[list[SkillMetadata], list[str]]:
+    """Async version of `_download_and_parse_skills`.
+
+    Args:
+        backend: Backend instance to use for file operations.
+        dir_paths: List of directory paths to check for `SKILL.md`.
+
+    Returns:
+        Tuple of (parsed skill metadata, directories that had no `SKILL.md`).
+    """
+    skill_md_paths: list[tuple[str, str]] = []
+    for dir_path in dir_paths:
+        skill_dir = PurePosixPath(dir_path)
+        skill_md_path = str(skill_dir / "SKILL.md")
+        skill_md_paths.append((dir_path, skill_md_path))
+
+    paths_to_download = [skill_md_path for _, skill_md_path in skill_md_paths]
+    responses = await backend.adownload_files(paths_to_download)
+
+    skills: list[SkillMetadata] = []
+    no_skill_md: list[str] = []
+    for (dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
+        if response.error:
+            no_skill_md.append(dir_path)
+            continue
+
+        if response.content is None:
+            logger.warning("Downloaded skill file %s has no content", skill_md_path)
+            continue
+
+        try:
+            content = response.content.decode("utf-8")
+        except UnicodeDecodeError as e:
+            logger.warning("Error decoding %s: %s", skill_md_path, e)
+            continue
+
+        directory_name = PurePosixPath(dir_path).name
+        skill_metadata = _parse_skill_metadata(
+            content=content,
+            skill_path=skill_md_path,
+            directory_name=directory_name,
+        )
+        if skill_metadata:
+            skills.append(skill_metadata)
+
+    return skills, no_skill_md
 
 
 async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetadata]:
@@ -485,13 +570,24 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
     Scans backend for subdirectories containing `SKILL.md` files, downloads
     their content, parses YAML frontmatter, and returns skill metadata.
 
-    Expected structure:
+    Also supports **skill packs** (one level of nesting): if a subdirectory
+    does not contain a `SKILL.md` file, its own subdirectories are scanned
+    for skills. This allows a single symlink to a skill collection
+    (e.g., `~/.agents/skills/superpowers → pack/skills/`) to expose all
+    skills within it.
+
+    Expected structures:
 
     ```txt
     source_path/
-    └── skill-name/
-        ├── SKILL.md   # Required
-        └── helper.py  # Optional
+    ├── skill-name/            # direct skill
+    │   ├── SKILL.md
+    │   └── helper.py
+    └── skill-pack/            # skill pack (no SKILL.md)
+        ├── nested-skill-a/
+        │   └── SKILL.md
+        └── nested-skill-b/
+            └── SKILL.md
     ```
 
     Args:
@@ -501,58 +597,26 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
     Returns:
         List of skill metadata from successfully parsed `SKILL.md` files
     """
-    skills: list[SkillMetadata] = []
     ls_result = await backend.als(source_path)
     items = ls_result.entries if isinstance(ls_result, LsResult) else ls_result
 
-    # Find all skill directories (directories containing SKILL.md)
-    skill_dirs = []
-    for item in items or []:
-        if not item.get("is_dir"):
-            continue
-        skill_dirs.append(item["path"])
-
-    if not skill_dirs:
+    dir_paths = [item["path"] for item in (items or []) if item.get("is_dir")]
+    if not dir_paths:
         return []
 
-    # For each skill directory, check if SKILL.md exists and download it
-    skill_md_paths = []
-    for skill_dir_path in skill_dirs:
-        # Construct SKILL.md path using PurePosixPath for safe, standardized path operations
-        skill_dir = PurePosixPath(skill_dir_path)
-        skill_md_path = str(skill_dir / "SKILL.md")
-        skill_md_paths.append((skill_dir_path, skill_md_path))
+    skills, pack_dirs = await _adownload_and_parse_skills(backend, dir_paths)
 
-    paths_to_download = [skill_md_path for _, skill_md_path in skill_md_paths]
-    responses = await backend.adownload_files(paths_to_download)
-
-    # Parse each downloaded SKILL.md
-    for (skill_dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
-        if response.error:
-            # Skill doesn't have a SKILL.md, skip it
-            continue
-
-        if response.content is None:
-            logger.warning("Downloaded skill file %s has no content", skill_md_path)
-            continue
-
+    # Scan one level deeper for skill packs (directories without a loadable SKILL.md)
+    for pack_dir in pack_dirs:
         try:
-            content = response.content.decode("utf-8")
-        except UnicodeDecodeError as e:
-            logger.warning("Error decoding %s: %s", skill_md_path, e)
+            nested_result = await backend.als(pack_dir)
+        except (OSError, NotImplementedError):
+            logger.warning("Failed to list pack directory %s", pack_dir, exc_info=True)
             continue
-
-        # Extract directory name from path using PurePosixPath
-        directory_name = PurePosixPath(skill_dir_path).name
-
-        # Parse metadata
-        skill_metadata = _parse_skill_metadata(
-            content=content,
-            skill_path=skill_md_path,
-            directory_name=directory_name,
-        )
-        if skill_metadata:
-            skills.append(skill_metadata)
+        nested_items = nested_result.entries if isinstance(nested_result, LsResult) else nested_result
+        nested_dirs = [item["path"] for item in (nested_items or []) if item.get("is_dir")]
+        nested_skills, _ = await _adownload_and_parse_skills(backend, nested_dirs)
+        skills.extend(nested_skills)
 
     return skills
 

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -468,6 +468,10 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
     (e.g., `~/.agents/skills/superpowers → pack/skills/`) to expose all
     skills within it.
 
+    Warning:
+        Skill pack support is experimental. The nesting heuristic and discovery
+        semantics may change in future versions.
+
     Expected structures:
 
     ```txt
@@ -498,7 +502,7 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
 
     skills, pack_dirs = _download_and_parse_skills(backend, dir_paths)
 
-    # Scan one level deeper for skill packs (directories without a loadable SKILL.md)
+    # Experimental: scan one level deeper for skill packs (directories without a loadable SKILL.md)
     for pack_dir in pack_dirs:
         try:
             nested_result = backend.ls(pack_dir)
@@ -508,6 +512,13 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
         nested_items = nested_result.entries if isinstance(nested_result, LsResult) else nested_result
         nested_dirs = [item["path"] for item in (nested_items or []) if item.get("is_dir")]
         nested_skills, _ = _download_and_parse_skills(backend, nested_dirs)
+        if nested_skills:
+            pack_name = PurePosixPath(pack_dir).name
+            logger.info(
+                "Discovered %d skill(s) from skill pack '%s' (experimental)",
+                len(nested_skills),
+                pack_name,
+            )
         skills.extend(nested_skills)
 
     return skills
@@ -576,6 +587,10 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
     (e.g., `~/.agents/skills/superpowers → pack/skills/`) to expose all
     skills within it.
 
+    Warning:
+        Skill pack support is experimental. The nesting heuristic and discovery
+        semantics may change in future versions.
+
     Expected structures:
 
     ```txt
@@ -606,7 +621,7 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
 
     skills, pack_dirs = await _adownload_and_parse_skills(backend, dir_paths)
 
-    # Scan one level deeper for skill packs (directories without a loadable SKILL.md)
+    # Experimental: scan one level deeper for skill packs (directories without a loadable SKILL.md)
     for pack_dir in pack_dirs:
         try:
             nested_result = await backend.als(pack_dir)
@@ -616,6 +631,13 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
         nested_items = nested_result.entries if isinstance(nested_result, LsResult) else nested_result
         nested_dirs = [item["path"] for item in (nested_items or []) if item.get("is_dir")]
         nested_skills, _ = await _adownload_and_parse_skills(backend, nested_dirs)
+        if nested_skills:
+            pack_name = PurePosixPath(pack_dir).name
+            logger.info(
+                "Discovered %d skill(s) from skill pack '%s' (experimental)",
+                len(nested_skills),
+                pack_name,
+            )
         skills.extend(nested_skills)
 
     return skills

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -550,7 +550,11 @@ async def _adownload_and_parse_skills(
     no_skill_md: list[str] = []
     for (dir_path, skill_md_path), response in zip(skill_md_paths, responses, strict=True):
         if response.error:
-            no_skill_md.append(dir_path)
+            # Only treat "file_not_found" as a potential skill pack.
+            # Other errors (permission_denied, is_directory, invalid_path)
+            # indicate the directory itself is inaccessible.
+            if response.error == "file_not_found":
+                no_skill_md.append(dir_path)
             continue
 
         if response.content is None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -601,7 +601,7 @@ def test_list_skills_from_backend_nonexistent_path(tmp_path: Path) -> None:
 
 
 def test_list_skills_from_backend_missing_skill_md(tmp_path: Path) -> None:
-    """Test that directories without SKILL.md are skipped."""
+    """Test that directories without SKILL.md and no nested skills are skipped."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create a valid skill and an invalid one (missing SKILL.md)
@@ -1601,3 +1601,90 @@ async def test_skills_middleware_with_store_backend_assistant_id_async() -> None
     assert len(result_4["skills_metadata"]) == 1
     assert result_4["skills_metadata"][0]["name"] == "async-skill-one"
     assert result_4["skills_metadata"][0]["description"] == "Async skill for assistant 1"
+
+
+# -- Skill pack (nested directory) tests --
+
+
+def test_list_skills_from_backend_skill_pack(tmp_path: Path) -> None:
+    """Test that skills nested inside a skill pack directory are discovered."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    # Skill pack: a directory without SKILL.md containing skill subdirectories
+    pack_skill_a = str(skills_dir / "my-pack" / "skill-a" / "SKILL.md")
+    pack_skill_b = str(skills_dir / "my-pack" / "skill-b" / "SKILL.md")
+
+    backend.upload_files(
+        [
+            (pack_skill_a, make_skill_content("skill-a", "Skill A").encode("utf-8")),
+            (pack_skill_b, make_skill_content("skill-b", "Skill B").encode("utf-8")),
+        ]
+    )
+
+    skills = _list_skills(backend, str(skills_dir))
+
+    assert len(skills) == 2
+    skill_names = {s["name"] for s in skills}
+    assert skill_names == {"skill-a", "skill-b"}
+
+
+def test_list_skills_from_backend_mixed_direct_and_pack(tmp_path: Path) -> None:
+    """Test that direct skills and skill pack skills are both discovered."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    # Direct skill
+    direct_path = str(skills_dir / "direct-skill" / "SKILL.md")
+    # Skill pack
+    pack_path = str(skills_dir / "my-pack" / "pack-skill" / "SKILL.md")
+
+    backend.upload_files(
+        [
+            (direct_path, make_skill_content("direct-skill", "Direct").encode("utf-8")),
+            (pack_path, make_skill_content("pack-skill", "From pack").encode("utf-8")),
+        ]
+    )
+
+    skills = _list_skills(backend, str(skills_dir))
+
+    assert len(skills) == 2
+    skill_names = {s["name"] for s in skills}
+    assert skill_names == {"direct-skill", "pack-skill"}
+
+
+def test_list_skills_from_backend_pack_does_not_recurse_beyond_one_level(tmp_path: Path) -> None:
+    """Test that nesting beyond one extra level is not discovered."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    # Two levels deep — should NOT be found
+    deep_path = str(skills_dir / "outer" / "inner" / "deep-skill" / "SKILL.md")
+
+    backend.upload_files([(deep_path, make_skill_content("deep-skill", "Too deep").encode("utf-8"))])
+
+    skills = _list_skills(backend, str(skills_dir))
+    assert skills == []
+
+
+def test_list_skills_from_backend_dir_with_skill_md_not_treated_as_pack(tmp_path: Path) -> None:
+    """Test that a directory with SKILL.md is treated as a skill, not a pack."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    # Directory has both SKILL.md and a subdirectory with SKILL.md
+    parent_path = str(skills_dir / "parent-skill" / "SKILL.md")
+    child_path = str(skills_dir / "parent-skill" / "child-skill" / "SKILL.md")
+
+    backend.upload_files(
+        [
+            (parent_path, make_skill_content("parent-skill", "Parent").encode("utf-8")),
+            (child_path, make_skill_content("child-skill", "Child").encode("utf-8")),
+        ]
+    )
+
+    skills = _list_skills(backend, str(skills_dir))
+
+    # Only the parent should be found — it has SKILL.md so it's a skill, not a pack
+    assert len(skills) == 1
+    assert skills[0]["name"] == "parent-skill"

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
@@ -404,3 +404,84 @@ async def test_agent_with_skills_middleware_empty_sources_async(tmp_path: Path) 
 
     assert "Skills System" in content
     assert "No skills available" in content
+
+
+# -- Skill pack (nested directory) async tests --
+
+
+async def test_alist_skills_from_backend_skill_pack(tmp_path: Path) -> None:
+    """Test that skills nested inside a skill pack directory are discovered (async)."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    pack_skill_a = str(skills_dir / "my-pack" / "skill-a" / "SKILL.md")
+    pack_skill_b = str(skills_dir / "my-pack" / "skill-b" / "SKILL.md")
+
+    backend.upload_files(
+        [
+            (pack_skill_a, make_skill_content("skill-a", "Skill A").encode("utf-8")),
+            (pack_skill_b, make_skill_content("skill-b", "Skill B").encode("utf-8")),
+        ]
+    )
+
+    skills = await _alist_skills(backend, str(skills_dir))
+
+    assert len(skills) == 2
+    skill_names = {s["name"] for s in skills}
+    assert skill_names == {"skill-a", "skill-b"}
+
+
+async def test_alist_skills_from_backend_mixed_direct_and_pack(tmp_path: Path) -> None:
+    """Test that direct skills and skill pack skills are both discovered (async)."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    direct_path = str(skills_dir / "direct-skill" / "SKILL.md")
+    pack_path = str(skills_dir / "my-pack" / "pack-skill" / "SKILL.md")
+
+    backend.upload_files(
+        [
+            (direct_path, make_skill_content("direct-skill", "Direct").encode("utf-8")),
+            (pack_path, make_skill_content("pack-skill", "From pack").encode("utf-8")),
+        ]
+    )
+
+    skills = await _alist_skills(backend, str(skills_dir))
+
+    assert len(skills) == 2
+    skill_names = {s["name"] for s in skills}
+    assert skill_names == {"direct-skill", "pack-skill"}
+
+
+async def test_alist_skills_from_backend_pack_does_not_recurse_beyond_one_level(tmp_path: Path) -> None:
+    """Test that nesting beyond one extra level is not discovered (async)."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    deep_path = str(skills_dir / "outer" / "inner" / "deep-skill" / "SKILL.md")
+
+    backend.upload_files([(deep_path, make_skill_content("deep-skill", "Too deep").encode("utf-8"))])
+
+    skills = await _alist_skills(backend, str(skills_dir))
+    assert skills == []
+
+
+async def test_alist_skills_from_backend_dir_with_skill_md_not_treated_as_pack(tmp_path: Path) -> None:
+    """Test that a directory with SKILL.md is treated as a skill, not a pack (async)."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    skills_dir = tmp_path / "skills"
+    parent_path = str(skills_dir / "parent-skill" / "SKILL.md")
+    child_path = str(skills_dir / "parent-skill" / "child-skill" / "SKILL.md")
+
+    backend.upload_files(
+        [
+            (parent_path, make_skill_content("parent-skill", "Parent").encode("utf-8")),
+            (child_path, make_skill_content("child-skill", "Child").encode("utf-8")),
+        ]
+    )
+
+    skills = await _alist_skills(backend, str(skills_dir))
+
+    assert len(skills) == 1
+    assert skills[0]["name"] == "parent-skill"


### PR DESCRIPTION
> [!WARNING]
> **Experimental -- subject to change**

Add skill pack support to the skills middleware. The [Agent Skills spec](https://agentskills.io) defines only the single-skill format (`SKILL.md` in a directory) — it has no concept of bundling or distributing groups of skills. Yet every major tool in the ecosystem (Codex plugins, Gemini CLI extensions, Superpowers, OpenCode) is independently inventing ad-hoc solutions for this. This PR adds the foundational nesting primitive: directories without a `SKILL.md` are scanned one level deeper for nested skills, enabling a single symlink to a skill collection (e.g., `~/.agents/skills/superpowers → collection/skills/`) to expose all skills within it. This matches the Codex/Superpowers symlink convention and unblocks future pack features (manifests, distribution, namespacing) without any breaking changes (existing flat skill layouts are unaffected).

## Changes
- Extract `_download_and_parse_skills` / `_adownload_and_parse_skills` helpers from the inline download+parse logic in `_list_skills` / `_alist_skills`, returning both parsed skills and directories that had no `SKILL.md`
- Add skill pack scanning to `_list_skills` and `_alist_skills`: after the initial pass, directories where `SKILL.md` was not found (`file_not_found` only — `permission_denied` and other errors are not misclassified) are listed one level deeper for nested skills. Nesting beyond one level is intentionally not supported.
- Wrap `backend.ls(pack_dir)` calls in `try/except (OSError, NotImplementedError)` so a single inaccessible pack directory doesn't abort discovery of all remaining packs

> [!WARNING]
> **Experimental -- subject to change**