### PR TITLE
test(sdk): gather `MemoryAgentBench` CI subset

### DIFF
--- a/libs/deepagents/tests/evals/memory_agent_bench/configs.py
+++ b/libs/deepagents/tests/evals/memory_agent_bench/configs.py
@@ -37,21 +37,25 @@ CR_SH_6K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_sh_6k",
     max_samples=1,
+    max_questions=25,
 )
 CR_SH_32K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_sh_32k",
     max_samples=1,
+    max_questions=25,
 )
 CR_SH_64K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_sh_64k",
     max_samples=1,
+    max_questions=25,
 )
 CR_SH_262K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_sh_262k",
     max_samples=1,
+    max_questions=25,
 )
 
 # -- Conflict Resolution (multi-hop) -----------------------------------------
@@ -60,21 +64,25 @@ CR_MH_6K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_mh_6k",
     max_samples=1,
+    max_questions=25,
 )
 CR_MH_32K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_mh_32k",
     max_samples=1,
+    max_questions=25,
 )
 CR_MH_64K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_mh_64k",
     max_samples=1,
+    max_questions=25,
 )
 CR_MH_262K = DatasetConfig(
     split="Conflict_Resolution",
     source="factconsolidation_mh_262k",
     max_samples=1,
+    max_questions=25,
 )
 
 # -- Test-Time Learning (ICL) ------------------------------------------------
@@ -83,31 +91,37 @@ TTL_BANKING77 = DatasetConfig(
     split="Test_Time_Learning",
     source="icl_banking77_5900shot_balance",
     max_samples=1,
+    max_questions=25,
 )
 TTL_CLINIC150 = DatasetConfig(
     split="Test_Time_Learning",
     source="icl_clinic150_7050shot_balance",
     max_samples=1,
+    max_questions=25,
 )
 TTL_NLU = DatasetConfig(
     split="Test_Time_Learning",
     source="icl_nlu_3000shot_balance",
     max_samples=1,
+    max_questions=25,
 )
 TTL_TREC_COARSE = DatasetConfig(
     split="Test_Time_Learning",
     source="icl_trec_coarse_2700shot_balance",
     max_samples=1,
+    max_questions=25,
 )
 TTL_TREC_FINE = DatasetConfig(
     split="Test_Time_Learning",
     source="icl_trec_fine_2700shot_balance",
     max_samples=1,
+    max_questions=25,
 )
 TTL_RECSYS = DatasetConfig(
     split="Test_Time_Learning",
     source="Recsys_redial_full",
     max_samples=1,
+    max_questions=25,
 )
 
 # -- Accurate Retrieval -------------------------------------------------------
@@ -116,36 +130,43 @@ AR_RULER_QA1 = DatasetConfig(
     split="Accurate_Retrieval",
     source="ruler_qa1_197K",
     max_samples=1,
+    max_questions=25,
 )
 AR_RULER_QA2 = DatasetConfig(
     split="Accurate_Retrieval",
     source="ruler_qa2_421k",
     max_samples=1,
+    max_questions=25,
 )
 AR_LONGMEMEVAL = DatasetConfig(
     split="Accurate_Retrieval",
     source="longmemeval_s_-1_500",
     max_samples=1,
+    max_questions=25,
 )
 AR_LONGMEMEVAL_STAR = DatasetConfig(
     split="Accurate_Retrieval",
     source="longmemeval_s_star_-1_500",
     max_samples=1,
+    max_questions=25,
 )
 AR_EVENTQA_FULL = DatasetConfig(
     split="Accurate_Retrieval",
     source="eventqa_full",
     max_samples=1,
+    max_questions=25,
 )
 AR_EVENTQA_64K = DatasetConfig(
     split="Accurate_Retrieval",
     source="eventqa_64k",
     max_samples=1,
+    max_questions=25,
 )
 AR_EVENTQA_128K = DatasetConfig(
     split="Accurate_Retrieval",
     source="eventqa_128k",
     max_samples=1,
+    max_questions=25,
 )
 
 # -- Long Range Understanding -------------------------------------------------
@@ -154,11 +175,13 @@ LRU_INFBENCH_SUM = DatasetConfig(
     split="Long_Range_Understanding",
     source="infbench_sum",
     max_samples=1,
+    max_questions=25,
 )
 LRU_DETECTIVE_QA = DatasetConfig(
     split="Long_Range_Understanding",
     source="detective_qa",
     max_samples=1,
+    max_questions=25,
 )
 
 
@@ -203,9 +226,24 @@ ALL_CONFIGS: list[DatasetConfig] = (
     CONFLICT_RESOLUTION_CONFIGS + TEST_TIME_LEARNING_CONFIGS + ACCURATE_RETRIEVAL_CONFIGS + LONG_RANGE_UNDERSTANDING_CONFIGS
 )
 
-# Small / cheap subset for regular CI runs
+# High-signal subset for CI: 2 per category, biased toward harder variants.
+#
+# Selection rationale (see MemoryAgentBench ICLR 2026 paper):
+#   CR  — SH@64K gives a good gradient at meaningful context length; MH@6K is
+#          a near-zero canary at the cheapest context length (MH is unsolved).
+#   TTL — CLINC150 is the hardest MCC (151 labels); Recsys is structurally
+#          different (recommendation, not classification).
+#   AR  — RULER QA2 is multi-hop retrieval (harder than QA1); EventQA-full
+#          is the only temporal-reasoning task.
+#   LRU — Both kept: infbench_sum (generation) and detective_qa (reasoning QA)
+#          test genuinely different skills.
 CI_CONFIGS: list[DatasetConfig] = [
-    DatasetConfig(split=CR_SH_6K.split, source=CR_SH_6K.source, max_questions=10),
-    DatasetConfig(split=CR_MH_6K.split, source=CR_MH_6K.source, max_questions=10),
-    DatasetConfig(split=TTL_BANKING77.split, source=TTL_BANKING77.source, max_questions=10),
+    CR_SH_64K,
+    CR_MH_6K,
+    TTL_CLINIC150,
+    TTL_RECSYS,
+    AR_RULER_QA2,
+    AR_EVENTQA_FULL,
+    LRU_INFBENCH_SUM,
+    LRU_DETECTIVE_QA,
 ]


### PR DESCRIPTION
## Summary

- Replaced the ad-hoc 3-config CI subset with a deliberate 8-config selection (2 per benchmark category), biased toward the hardest and most structurally distinct variants from the MemoryAgentBench benchmark (ICLR 2026).
- Capped all configs at 25 questions (up from unlimited for main configs, 10 for CI) as a cost/signal tradeoff -- each question replays the full conversation history, so cost grows super-linearly with question count.
- Added a guard unit test that locks the exact CI config list, category balance, and question cap so it can't drift silently.

## Dataset selection rationale

The benchmark has 23 configs across 4 memory competencies. Most configs within a category are variants of the same task at different context lengths or label counts, so running all of them yields diminishing signal. We picked 2 per category optimizing for:

1. **Maximum difficulty** — harder variants give better hill-climbing signal for regressions.
2. **Task diversity** — within each category, the two picks test structurally different skills rather than being scale variants of the same test.
3. **Cost awareness** — avoided the largest context lengths where the same task is already unsolved at shorter lengths.

| Category | Config | Why this one |
|---|---|---|
| Conflict Resolution | `CR_SH_64K` | Single-hop at 64K tokens. ~60% accuracy range in the paper gives a measurable gradient for improvements. |
| Conflict Resolution | `CR_MH_6K` | Multi-hop is near-zero accuracy even at 6K (the cheapest length). Serves as an aspirational canary without burning tokens at 262K. |
| Test-Time Learning | `TTL_CLINIC150` | Hardest multi-class classification (151 labels). Subsumes signal from BANKING77/NLU/TREC variants. |
| Test-Time Learning | `TTL_RECSYS` | Only non-classification TTL task (movie recommendation from dialogue). Structurally irreplaceable. |
| Accurate Retrieval | `AR_RULER_QA2` | Multi-hop document QA (harder than single-hop QA1). |
| Accurate Retrieval | `AR_EVENTQA_FULL` | Only temporal-reasoning retrieval task (novel event chains). Different skill from RULER/LongMemEval. |
| Long Range Understanding | `LRU_INFBENCH_SUM` | Novel summarization — tests global comprehension (generation). |
| Long Range Understanding | `LRU_DETECTIVE_QA` | Long-range reasoning QA over detective novels. Different from summarization. |

Dropped configs are either easier variants of a kept config (e.g., `CR_SH_6K` is strictly easier than `CR_SH_64K`), structurally redundant (e.g., all 5 MCC classification datasets test the same skill at different label counts), or more expensive versions of an already-unsolved task (e.g., `CR_MH_262K` when `CR_MH_6K` is already ~0%).