### PR TITLE
fix(cli): human-readable duration and consistent dim styling on teardown screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,10 @@ IMPORTANT: `Content` requires **Textual's** `Style` (`textual.style.Style`) for 
 
 **Decision rule:** if the value could ever come from outside the codebase (user input, tool output, API responses, file contents), use `from_markup` with `$var`. If it's a hardcoded string, glyph, or computed int, `styled` is fine.
 
+**Rich `console.print()` and number highlighting:**
+
+`console.print()` defaults to `highlight=True`, which runs `ReprHighlighter` and auto-applies bold + cyan to any detected numbers. This visually overrides subtle styles like `dim` (bold cancels dim in most terminals). Pass `highlight=False` on any `console.print()` call where the content contains numbers and consistent dim/subtle styling matters.
+
 **Textual patterns used in this codebase:**
 
 - **Workers** (`@work` decorator) for async operations - see [Workers guide](https://textual.textualize.io/guide/workers/)

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -165,9 +165,10 @@ def _format_duration(seconds: float) -> str:
     Returns:
         Formatted string like `"2.3s"`, `"5m 12s"`, or `"1h 23m 4s"`.
     """
-    if seconds < 60:  # noqa: PLR2004
-        return f"{seconds:.1f}s"
-    minutes, secs = divmod(int(seconds), 60)
+    rounded = round(seconds, 1)
+    if rounded < 60:  # noqa: PLR2004
+        return f"{rounded:.1f}s"
+    minutes, secs = divmod(int(rounded), 60)
     if minutes < 60:  # noqa: PLR2004
         return f"{minutes}m {secs}s"
     hours, minutes = divmod(minutes, 60)

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -156,6 +156,24 @@ def format_token_count(count: int) -> str:
     return str(count)
 
 
+def _format_duration(seconds: float) -> str:
+    """Format a duration in seconds into a human-readable string.
+
+    Args:
+        seconds: Duration in seconds.
+
+    Returns:
+        Formatted string like `"2.3s"`, `"5m 12s"`, or `"1h 23m 4s"`.
+    """
+    if seconds < 60:  # noqa: PLR2004
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(seconds), 60)
+    if minutes < 60:  # noqa: PLR2004
+        return f"{minutes}m {secs}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m {secs}s"
+
+
 def print_usage_table(
     stats: SessionStats,
     wall_time: float,
@@ -220,7 +238,11 @@ def print_usage_table(
         console.print(table)
     if has_time:
         console.print()
-        console.print(f"[dim]Agent active  {wall_time:.1f}s[/dim]")
+        console.print(
+            f"Agent active  {_format_duration(wall_time)}",
+            style="dim",
+            highlight=False,
+        )
 
 
 # Type alias matching HITLResponse["decisions"] element type

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -977,3 +977,9 @@ class TestFormatDuration:
 
     def test_fractional_under_minute(self) -> None:
         assert _format_duration(0.1) == "0.1s"
+
+    def test_rounding_near_minute_boundary(self) -> None:
+        assert _format_duration(59.95) == "1m 0s"
+
+    def test_just_under_minute_no_rounding(self) -> None:
+        assert _format_duration(59.94) == "59.9s"

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -23,6 +23,7 @@ from deepagents_cli.textual_adapter import (
     TextualUIAdapter,
     _build_interrupted_ai_message,
     _build_stream_config,
+    _format_duration,
     _is_summarization_chunk,
     execute_task_textual,
     format_token_count,
@@ -941,3 +942,38 @@ class TestPrintUsageTable:
         print_usage_table(stats, wall_time=0.01, console=console)
         output = buf.getvalue()
         assert output.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# _format_duration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDuration:
+    """Tests for `_format_duration` human-readable formatter."""
+
+    def test_sub_minute(self) -> None:
+        assert _format_duration(45.3) == "45.3s"
+
+    def test_exactly_one_minute(self) -> None:
+        assert _format_duration(60.0) == "1m 0s"
+
+    def test_minutes_and_seconds(self) -> None:
+        assert _format_duration(125.7) == "2m 5s"
+
+    def test_exactly_one_hour(self) -> None:
+        assert _format_duration(3600.0) == "1h 0m 0s"
+
+    def test_hours_minutes_seconds(self) -> None:
+        # 1383.5s -> 23m 3s
+        assert _format_duration(1383.5) == "23m 3s"
+
+    def test_large_duration(self) -> None:
+        # 2h 30m 45s = 9045s
+        assert _format_duration(9045.0) == "2h 30m 45s"
+
+    def test_zero(self) -> None:
+        assert _format_duration(0.0) == "0.0s"
+
+    def test_fractional_under_minute(self) -> None:
+        assert _format_duration(0.1) == "0.1s"


### PR DESCRIPTION
The "Agent active" duration line in the non-interactive teardown screen had two issues: Rich's default `ReprHighlighter` was applying bold + cyan to the number (visually overriding the `dim` style), and raw seconds like `1383.5s` weren't human-readable. Fix both by adding a `_format_duration` helper that produces `23m 3s`-style output and passing `highlight=False` to `console.print()`.

## Changes
- Add `_format_duration` in `textual_adapter.py` to convert seconds into `Xm Ys` / `Xh Ym Zs` format, used by `print_usage_table` for the "Agent active" line
- Pass `style="dim", highlight=False` to `console.print()` to prevent `ReprHighlighter` from overriding dim styling on the duration number
- Document the `highlight=True` footgun in `AGENTS.md` under the CLI's Rich usage guidance