### PR TITLE
fix(cli): surface clear error for missing sandbox provider deps

### DIFF
--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import importlib.util
+import logging
 import os
 import shlex
 import string
@@ -20,6 +21,8 @@ from deepagents_cli.integrations.sandbox_provider import (
     SandboxNotFoundError,
     SandboxProvider,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -482,10 +485,19 @@ def verify_sandbox_deps(provider: str) -> None:
 
     entry = backend_modules.get(provider)
     if entry is None:
-        return  # Unknown provider — downstream code will handle it
+        logger.debug(
+            "No backend_modules entry for provider %r; skipping pre-flight check",
+            provider,
+        )
+        return
 
     module_name, extra = entry
-    if importlib.util.find_spec(module_name) is None:
+    try:
+        found = importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        found = False
+
+    if not found:
         msg = (
             f"Missing dependencies for '{provider}' sandbox. "
             f"Install with: pip install 'deepagents-cli[{extra}]'"

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import importlib.util
 import os
 import shlex
 import string
@@ -453,7 +454,47 @@ def _get_provider(provider_name: str) -> SandboxProvider:
     raise ValueError(msg)
 
 
+def verify_sandbox_deps(provider: str) -> None:
+    """Check that the required packages for a sandbox provider are installed.
+
+    Uses `importlib.util.find_spec` for a lightweight check with no actual
+    imports. Call this in the CLI process *before* spawning the server
+    subprocess so users get a clear, actionable error instead of an opaque
+    server crash.
+
+    Args:
+        provider: Sandbox provider name (e.g. `'daytona'`).
+
+    Raises:
+        ImportError: If the provider's backend package is not installed.
+    """
+    if not provider or provider in {"none", "langsmith"}:
+        return
+
+    # Map provider name → (backend module, pip extra).
+    # Only the backend module is checked because the underlying SDK is a
+    # transitive dependency of the backend package.
+    backend_modules: dict[str, tuple[str, str]] = {
+        "daytona": ("langchain_daytona", "daytona"),
+        "modal": ("langchain_modal", "modal"),
+        "runloop": ("langchain_runloop", "runloop"),
+    }
+
+    entry = backend_modules.get(provider)
+    if entry is None:
+        return  # Unknown provider — downstream code will handle it
+
+    module_name, extra = entry
+    if importlib.util.find_spec(module_name) is None:
+        msg = (
+            f"Missing dependencies for '{provider}' sandbox. "
+            f"Install with: pip install 'deepagents-cli[{extra}]'"
+        )
+        raise ImportError(msg)
+
+
 __all__ = [
     "create_sandbox",
     "get_default_working_dir",
+    "verify_sandbox_deps",
 ]

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1262,6 +1262,18 @@ def cli_main() -> None:
                         )
                 except Exception:
                     logger.debug("Failed to check for optional tools", exc_info=True)
+            # Validate sandbox provider deps before spawning server subprocess
+            if args.sandbox and args.sandbox not in {"none", "langsmith"}:
+                from deepagents_cli.integrations.sandbox_factory import (
+                    verify_sandbox_deps,
+                )
+
+                try:
+                    verify_sandbox_deps(args.sandbox)
+                except ImportError as exc:
+                    console.print(f"[bold red]Error:[/bold red] {exc}")
+                    sys.exit(1)
+
             # Non-interactive mode - execute single task and exit
             from deepagents_cli.non_interactive import run_non_interactive
 
@@ -1358,6 +1370,18 @@ def cli_main() -> None:
             # Generate new thread ID if not resuming
             if thread_id is None:
                 thread_id = generate_thread_id()
+
+            # Validate sandbox provider deps before spawning server subprocess
+            if args.sandbox and args.sandbox not in {"none", "langsmith"}:
+                from deepagents_cli.integrations.sandbox_factory import (
+                    verify_sandbox_deps,
+                )
+
+                try:
+                    verify_sandbox_deps(args.sandbox)
+                except ImportError as exc:
+                    console.print(f"[bold red]Error:[/bold red] {exc}")
+                    sys.exit(1)
 
             # Check project MCP trust before launching TUI
             mcp_trust_decision = _check_mcp_project_trust(

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
-from deepagents_cli.integrations.sandbox_factory import _get_provider
+from deepagents_cli.integrations.sandbox_factory import (
+    _get_provider,
+    verify_sandbox_deps,
+)
 
 
 @pytest.mark.parametrize(
@@ -34,3 +37,48 @@ def test_get_provider_raises_helpful_error_for_missing_optional_dependency(
         pytest.raises(ImportError, match=error),
     ):
         _get_provider(provider)
+
+
+class TestVerifySandboxDeps:
+    """Tests for the early sandbox dependency check."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["daytona", "modal", "runloop"],
+    )
+    def test_raises_import_error_when_backend_missing(self, provider: str) -> None:
+        """Should raise ImportError with install instructions."""
+        with (
+            patch(
+                "deepagents_cli.integrations.sandbox_factory.importlib.util.find_spec",
+                return_value=None,
+            ),
+            pytest.raises(
+                ImportError,
+                match=rf"Missing dependencies for '{provider}' sandbox.*"
+                rf"pip install 'deepagents-cli\[{provider}\]'",
+            ),
+        ):
+            verify_sandbox_deps(provider)
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["daytona", "modal", "runloop"],
+    )
+    def test_passes_when_backend_installed(self, provider: str) -> None:
+        """Should not raise when the backend module is found."""
+        spec_sentinel = object()
+        with patch(
+            "deepagents_cli.integrations.sandbox_factory.importlib.util.find_spec",
+            return_value=spec_sentinel,
+        ):
+            verify_sandbox_deps(provider)  # should not raise
+
+    @pytest.mark.parametrize("provider", ["none", "langsmith", "", None])
+    def test_skips_builtin_and_empty_providers(self, provider: str | None) -> None:
+        """Built-in and empty providers should be silently accepted."""
+        verify_sandbox_deps(provider)  # type: ignore[arg-type]
+
+    def test_skips_unknown_provider(self) -> None:
+        """Unknown providers are passed through for downstream handling."""
+        verify_sandbox_deps("unknown_provider")  # should not raise

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -43,16 +43,23 @@ class TestVerifySandboxDeps:
     """Tests for the early sandbox dependency check."""
 
     @pytest.mark.parametrize(
-        "provider",
-        ["daytona", "modal", "runloop"],
+        ("provider", "expected_module"),
+        [
+            ("daytona", "langchain_daytona"),
+            ("modal", "langchain_modal"),
+            ("runloop", "langchain_runloop"),
+        ],
     )
-    def test_raises_import_error_when_backend_missing(self, provider: str) -> None:
+    def test_raises_import_error_when_backend_missing(
+        self, provider: str, expected_module: str
+    ) -> None:
         """Should raise ImportError with install instructions."""
+        mock_find_spec = patch(
+            "deepagents_cli.integrations.sandbox_factory.importlib.util.find_spec",
+            return_value=None,
+        )
         with (
-            patch(
-                "deepagents_cli.integrations.sandbox_factory.importlib.util.find_spec",
-                return_value=None,
-            ),
+            mock_find_spec as find_spec,
             pytest.raises(
                 ImportError,
                 match=rf"Missing dependencies for '{provider}' sandbox.*"
@@ -60,6 +67,8 @@ class TestVerifySandboxDeps:
             ),
         ):
             verify_sandbox_deps(provider)
+
+        find_spec.assert_called_once_with(expected_module)
 
     @pytest.mark.parametrize(
         "provider",
@@ -73,6 +82,21 @@ class TestVerifySandboxDeps:
             return_value=spec_sentinel,
         ):
             verify_sandbox_deps(provider)  # should not raise
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [ImportError, ValueError],
+    )
+    def test_raises_when_find_spec_throws(self, exc_cls: type) -> None:
+        """find_spec can raise ImportError/ValueError in corrupted envs."""
+        with (
+            patch(
+                "deepagents_cli.integrations.sandbox_factory.importlib.util.find_spec",
+                side_effect=exc_cls("broken"),
+            ),
+            pytest.raises(ImportError, match="Missing dependencies"),
+        ):
+            verify_sandbox_deps("daytona")
 
     @pytest.mark.parametrize("provider", ["none", "langsmith", "", None])
     def test_skips_builtin_and_empty_providers(self, provider: str | None) -> None:


### PR DESCRIPTION
When a user runs `--sandbox daytona` (or modal/runloop) without the corresponding extra installed, the CLI spawns a `langgraph dev` subprocess that crashes with an opaque "Server process exited with code 3." The actual `ImportError` is buried in the subprocess's stderr and never surfaced. This adds an early dependency check in the CLI process itself — before the server subprocess is spawned — so users get a clear error with install instructions.

## Changes
- Add `verify_sandbox_deps()` in `sandbox_factory.py` that uses `importlib.util.find_spec` to check whether the provider's backend package (`langchain_daytona`, `langchain_modal`, `langchain_runloop`) is importable — no actual imports, sub-millisecond cost
- Call `verify_sandbox_deps()` in both the non-interactive and interactive branches of `cli_main()` before the server subprocess is launched, printing a clear `Error: Missing dependencies for '<provider>' sandbox. Install with: pip install 'deepagents-cli[<provider>]'` and exiting with code 1