### PR TITLE
chore: promote `PLR6201` to safe-fix across all packages

### DIFF
--- a/libs/acp/pyproject.toml
+++ b/libs/acp/pyproject.toml
@@ -74,6 +74,7 @@ ignore = [
     "ISC001",  # Messes with the formatter
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed — too strict for generic wrappers
 ]
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -187,6 +187,7 @@ ignore = [
     "TD003",   # Missing issue link in TODO
 ]
 unfixable = ["B028"] # People should intentionally tune the stacklevel
+extend-safe-fixes = ["PLR6201"]
 
 flake8-annotations.allow-star-arg-any = true
 flake8-annotations.mypy-init-return = true

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -101,6 +101,7 @@ ignore = [
     "PLC0414", # Import alias does not rename original package — conflicts with type-checker re-export conventions
 ]
 unfixable = ["B028"]  # Rules that shouldn't be auto-fixed
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = true

--- a/libs/harbor/pyproject.toml
+++ b/libs/harbor/pyproject.toml
@@ -97,6 +97,7 @@ ignore = [
     "TD002",   # Missing author in TODO
     "TD003",   # Missing issue link in TODO
 ]
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/libs/partners/daytona/pyproject.toml
+++ b/libs/partners/daytona/pyproject.toml
@@ -71,6 +71,7 @@ ignore = [
     "ISC001",  # Messes with the formatter
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed — too strict for generic wrappers
 ]
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/libs/partners/modal/pyproject.toml
+++ b/libs/partners/modal/pyproject.toml
@@ -71,6 +71,7 @@ ignore = [
     "ISC001",  # Messes with the formatter
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed — too strict for generic wrappers
 ]
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -74,6 +74,7 @@ ignore = [
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed — too strict for generic wrappers
     "ASYNC109",  # StructuredTool async wrapper should mirror sync tool parameters
 ]
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/libs/partners/runloop/pyproject.toml
+++ b/libs/partners/runloop/pyproject.toml
@@ -72,6 +72,7 @@ ignore = [
     "ISC001",  # Messes with the formatter
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed — too strict for generic wrappers
 ]
+extend-safe-fixes = ["PLR6201"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Promote ruff's PLR6201 (literal membership test — `x in ("a", "b")` -> `x in {"a", "b"}`) from unsafe-fix to safe-fix across every package in the monorepo. This lets `ruff check --fix` auto-correct tuple-to-set membership tests without requiring the `--unsafe-fixes` flag.

The "unsafe" label is purely about the AST type change, not about any real behavioral difference.