### PR TITLE
refactor(cli): centralize charset check with helper

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -32,11 +32,10 @@ from deepagents_cli.clipboard import copy_selection_to_clipboard
 from deepagents_cli.config import (
     DOCS_URL,
     SHELL_TOOL_NAMES,
-    CharsetMode,
-    _detect_charset_mode,
     build_langsmith_thread_url,
     create_model,
     detect_provider,
+    is_ascii_mode,
     is_shell_command_allowed,
     newline_shortcut,
     settings,
@@ -709,7 +708,7 @@ class DeepAgentsApp(App):
         """Initialize components after mount."""
         chat = self.query_one("#chat", VerticalScroll)
         chat.anchor()
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             chat.styles.scrollbar_size_vertical = 0
 
         self._status_bar = self.query_one("#status-bar", StatusBar)

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -176,11 +176,6 @@ class Glyphs:
     # Diff-specific
     gutter_bar: str  # ▌ vs |
 
-    # Tree connectors (full prefixes for tree display)
-    tree_branch: str  # "├── " vs "+-- "
-    tree_last: str  # "└── " vs "`-- "
-    tree_vertical: str  # "│   " vs "|   "
-
     # Status bar
     git_branch: str  # "↗" vs "git:"
 
@@ -207,9 +202,6 @@ UNICODE_GLYPHS = Glyphs(
     box_horizontal="─",
     box_double_horizontal="═",
     gutter_bar="▌",
-    tree_branch="├── ",
-    tree_last="└── ",
-    tree_vertical="│   ",
     git_branch="↗",
 )
 
@@ -235,9 +227,6 @@ ASCII_GLYPHS = Glyphs(
     box_horizontal="-",
     box_double_horizontal="=",
     gutter_bar="|",
-    tree_branch="+-- ",
-    tree_last="`-- ",
-    tree_vertical="|   ",
     git_branch="git:",
 )
 
@@ -356,6 +345,18 @@ def reset_glyphs_cache() -> None:
     """Reset the glyphs cache (for testing)."""
     global _glyphs_cache  # noqa: PLW0603  # Module-level cache requires global statement
     _glyphs_cache = None
+
+
+def is_ascii_mode() -> bool:
+    """Check whether the terminal is in ASCII charset mode.
+
+    Convenience wrapper so widgets can branch on charset without importing
+    both `_detect_charset_mode` and `CharsetMode`.
+
+    Returns:
+        `True` when the detected charset mode is ASCII.
+    """
+    return _detect_charset_mode() == CharsetMode.ASCII
 
 
 def newline_shortcut() -> str:

--- a/libs/cli/deepagents_cli/widgets/approval.py
+++ b/libs/cli/deepagents_cli/widgets/approval.py
@@ -18,9 +18,8 @@ if TYPE_CHECKING:
 
 from deepagents_cli.config import (
     SHELL_TOOL_NAMES,
-    CharsetMode,
-    _detect_charset_mode,
     get_glyphs,
+    is_ascii_mode,
 )
 from deepagents_cli.unicode_security import (
     check_url_safety,
@@ -276,7 +275,7 @@ class ApprovalMenu(Container):
 
     async def on_mount(self) -> None:
         """Focus self on mount and update tool info."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border = ("ascii", "yellow")
 
         if not self._is_minimal:

--- a/libs/cli/deepagents_cli/widgets/ask_user.py
+++ b/libs/cli/deepagents_cli/widgets/ask_user.py
@@ -24,9 +24,8 @@ if TYPE_CHECKING:
     )
 
 from deepagents_cli.config import (
-    CharsetMode,
-    _detect_charset_mode,
     get_glyphs,
+    is_ascii_mode,
 )
 
 OTHER_CHOICE_LABEL = "Other (type your answer)"
@@ -110,7 +109,7 @@ class AskUserMenu(Container):
         )
 
     async def on_mount(self) -> None:  # noqa: D102
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border = ("ascii", "green")
         self._set_active_question(0)
 

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -22,9 +22,8 @@ from deepagents_cli.config import (
     MODE_DISPLAY_GLYPHS,
     MODE_PREFIXES,
     PREFIX_TO_MODE,
-    CharsetMode,
-    _detect_charset_mode,
     get_glyphs,
+    is_ascii_mode,
 )
 from deepagents_cli.input import IMAGE_PLACEHOLDER_PATTERN, VIDEO_PLACEHOLDER_PATTERN
 from deepagents_cli.widgets.autocomplete import (
@@ -904,7 +903,7 @@ class ChatInput(Vertical):
 
     def on_mount(self) -> None:
         """Initialize components after mount."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border = ("ascii", "cyan")
 
         self._text_area = self.query_one("#chat-input", ChatTextArea)

--- a/libs/cli/deepagents_cli/widgets/diff.py
+++ b/libs/cli/deepagents_cli/widgets/diff.py
@@ -9,7 +9,7 @@ from textual.containers import Vertical
 from textual.content import Content
 from textual.widgets import Static
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import get_glyphs, is_ascii_mode
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -193,7 +193,7 @@ class EnhancedDiff(Vertical):
 
     def on_mount(self) -> None:
         """Set border style based on charset mode."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border = ("ascii", "cyan")
 
     def compose(self) -> ComposeResult:

--- a/libs/cli/deepagents_cli/widgets/mcp_viewer.py
+++ b/libs/cli/deepagents_cli/widgets/mcp_viewer.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from deepagents_cli.mcp_tools import MCPServerInfo
 
-from deepagents_cli.config import CharsetMode, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import get_glyphs, is_ascii_mode
 
 
 class MCPToolItem(Static):
@@ -300,7 +300,7 @@ class MCPViewerScreen(ModalScreen[None]):
 
     async def on_mount(self) -> None:
         """Apply ASCII border fallback if needed."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             container = self.query_one(Vertical)
             container.styles.border = ("ascii", "green")
 

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -19,9 +19,8 @@ from deepagents_cli.config import (
     COLORS,
     MODE_DISPLAY_GLYPHS,
     PREFIX_TO_MODE,
-    CharsetMode,
-    _detect_charset_mode,
     get_glyphs,
+    is_ascii_mode,
 )
 from deepagents_cli.input import EMAIL_PREFIX_PATTERN, INPUT_HIGHLIGHT_PATTERN
 from deepagents_cli.tool_display import format_tool_display
@@ -166,7 +165,7 @@ class UserMessage(_TimestampClickMixin, Static):
         """Set border style based on charset mode and content prefix."""
         mode = PREFIX_TO_MODE.get(self._content[:1]) if self._content else None
         color = _mode_color(mode)
-        border_type = "ascii" if _detect_charset_mode() == CharsetMode.ASCII else "wide"
+        border_type = "ascii" if is_ascii_mode() else "wide"
         self.styles.border_left = (border_type, color)
 
     def compose(self) -> ComposeResult:
@@ -250,7 +249,7 @@ class QueuedUserMessage(Static):
 
     def on_mount(self) -> None:
         """Set border style based on charset mode."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border_left = ("ascii", "#6b7280")
 
     def compose(self) -> ComposeResult:
@@ -515,7 +514,7 @@ class ToolCallMessage(Vertical):
 
     def on_mount(self) -> None:
         """Cache widget references and hide all status/output areas initially."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border_left = ("ascii", "#3b3b3b")
 
         self._status_widget = self.query_one("#status", Static)
@@ -1299,7 +1298,7 @@ class DiffMessage(_TimestampClickMixin, Static):
 
     def on_mount(self) -> None:
         """Set border style based on charset mode."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border = ("ascii", "cyan")
 
 
@@ -1333,7 +1332,7 @@ class ErrorMessage(_TimestampClickMixin, Static):
 
     def on_mount(self) -> None:
         """Set border style based on charset mode."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             self.styles.border_left = ("ascii", "red")
 
 

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -19,7 +19,7 @@ from textual.widgets import Input, Static
 if TYPE_CHECKING:
     from textual.app import ComposeResult
 
-from deepagents_cli.config import CharsetMode, Glyphs, _detect_charset_mode, get_glyphs
+from deepagents_cli.config import Glyphs, get_glyphs, is_ascii_mode
 from deepagents_cli.model_config import (
     ModelConfig,
     ModelProfileEntry,
@@ -298,7 +298,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
     async def on_mount(self) -> None:
         """Set up the screen on mount."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             container = self.query_one(Vertical)
             container.styles.border = ("ascii", "green")
 

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -27,10 +27,9 @@ if TYPE_CHECKING:
     from textual.events import Click, Key
 
 from deepagents_cli.config import (
-    CharsetMode,
-    _detect_charset_mode,
     build_langsmith_thread_url,
     get_glyphs,
+    is_ascii_mode,
 )
 from deepagents_cli.sessions import ThreadInfo
 from deepagents_cli.widgets._links import open_style_link
@@ -871,7 +870,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
 
     async def on_mount(self) -> None:
         """Fetch threads, configure border for ASCII terminals, and build the list."""
-        if _detect_charset_mode() == CharsetMode.ASCII:
+        if is_ascii_mode():
             container = self.query_one("#thread-selector-shell", Vertical)
             container.styles.border = ("ascii", "green")
 

--- a/libs/cli/tests/unit_tests/test_charset.py
+++ b/libs/cli/tests/unit_tests/test_charset.py
@@ -16,6 +16,7 @@ from deepagents_cli.config import (
     _detect_charset_mode,
     get_banner,
     get_glyphs,
+    is_ascii_mode,
     reset_glyphs_cache,
 )
 
@@ -63,10 +64,6 @@ class TestGlyphs:
         assert ord(UNICODE_GLYPHS.box_horizontal) > 127
         assert ord(UNICODE_GLYPHS.box_double_horizontal) > 127
         assert ord(UNICODE_GLYPHS.gutter_bar) > 127
-        # Tree connectors (check first character of each)
-        assert ord(UNICODE_GLYPHS.tree_branch[0]) > 127
-        assert ord(UNICODE_GLYPHS.tree_last[0]) > 127
-        assert ord(UNICODE_GLYPHS.tree_vertical[0]) > 127
 
     def test_ascii_glyphs_are_ascii(self) -> None:
         """Test that ASCII_GLYPHS contains only ASCII characters."""
@@ -111,13 +108,6 @@ class TestGlyphs:
             assert ord(char) < 128
         for char in ASCII_GLYPHS.gutter_bar:
             assert ord(char) < 128
-        # Tree connectors
-        for char in ASCII_GLYPHS.tree_branch:
-            assert ord(char) < 128
-        for char in ASCII_GLYPHS.tree_last:
-            assert ord(char) < 128
-        for char in ASCII_GLYPHS.tree_vertical:
-            assert ord(char) < 128
 
     def test_glyphs_frozen(self) -> None:
         """Test that Glyphs instances are immutable."""
@@ -147,10 +137,6 @@ class TestGlyphs:
             "box_horizontal",
             "box_double_horizontal",
             "gutter_bar",
-            # Tree connectors
-            "tree_branch",
-            "tree_last",
-            "tree_vertical",
         ]
         for field in required_fields:
             assert hasattr(UNICODE_GLYPHS, field)
@@ -292,28 +278,6 @@ class TestGlyphUsability:
         assert ASCII_GLYPHS.box_double_horizontal == "="
         assert ASCII_GLYPHS.gutter_bar == "|"
 
-    def test_unicode_tree_connectors(self) -> None:
-        """Test Unicode tree connectors are the expected strings."""
-        assert UNICODE_GLYPHS.tree_branch == "├── "
-        assert UNICODE_GLYPHS.tree_last == "└── "
-        assert UNICODE_GLYPHS.tree_vertical == "│   "
-
-    def test_ascii_tree_connectors(self) -> None:
-        """Test ASCII tree connectors are simple ASCII."""
-        assert ASCII_GLYPHS.tree_branch == "+-- "
-        assert ASCII_GLYPHS.tree_last == "`-- "
-        assert ASCII_GLYPHS.tree_vertical == "|   "
-
-    def test_tree_connectors_consistent_width(self) -> None:
-        """Test that tree connectors have consistent width for alignment."""
-        # All tree connectors should be exactly 4 characters
-        assert len(UNICODE_GLYPHS.tree_branch) == 4
-        assert len(UNICODE_GLYPHS.tree_last) == 4
-        assert len(UNICODE_GLYPHS.tree_vertical) == 4
-        assert len(ASCII_GLYPHS.tree_branch) == 4
-        assert len(ASCII_GLYPHS.tree_last) == 4
-        assert len(ASCII_GLYPHS.tree_vertical) == 4
-
 
 class TestGetBanner:
     """Tests for get_banner function."""
@@ -362,3 +326,21 @@ class TestGetBanner:
         """Test that ASCII banner contains only ASCII characters."""
         for char in _ASCII_BANNER:
             assert ord(char) < 128, f"Non-ASCII character found: {char!r}"
+
+
+class TestIsAsciiMode:
+    """Tests for is_ascii_mode helper."""
+
+    def setup_method(self) -> None:
+        """Reset glyphs cache before each test."""
+        reset_glyphs_cache()
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "unicode"}, clear=False)
+    def test_false_in_unicode_mode(self) -> None:
+        """Test that is_ascii_mode returns False in Unicode mode."""
+        assert is_ascii_mode() is False
+
+    @patch.dict("os.environ", {"UI_CHARSET_MODE": "ascii"}, clear=False)
+    def test_true_in_ascii_mode(self) -> None:
+        """Test that is_ascii_mode returns True in ASCII mode."""
+        assert is_ascii_mode() is True


### PR DESCRIPTION
Centralize the repeated `_detect_charset_mode() == CharsetMode.ASCII` pattern behind a single `is_ascii_mode()` boolean predicate in `config.py`. Every widget that needed to branch on charset mode was importing two private/internal names (`_detect_charset_mode`, `CharsetMode`) just for this one check — now they import one public function. Also delete the unused `tree_branch`, `tree_last`, `tree_vertical` fields from `Glyphs`.

## Changes
- Add `is_ascii_mode() -> bool` to `config.py`, wrapping the `_detect_charset_mode() == CharsetMode.ASCII` check that was duplicated across 10 files
- Replace all 13 call sites in `app.py` and 9 widget modules (`messages.py`, `approval.py`, `ask_user.py`, `chat_input.py`, `diff.py`, `mcp_viewer.py`, `model_selector.py`, `thread_selector.py`) — each file drops its `CharsetMode` and `_detect_charset_mode` imports
- Remove `tree_branch`, `tree_last`, `tree_vertical` from `Glyphs` dataclass, `UNICODE_GLYPHS`, and `ASCII_GLYPHS` — these fields were defined but never referenced outside tests