### PR TITLE
refactor(cli): unified slash-command registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,9 @@ When adding a user-facing CLI feature (new slash command, keybinding, workflow),
 
 **Slash commands:**
 
-Slash commands are defined in `SLASH_COMMANDS` in `libs/cli/deepagents_cli/widgets/autocomplete.py` as `(name, description, hidden_keywords)` tuples. Hidden keywords are space-separated terms that participate in fuzzy matching but are never displayed. To add an alias for an existing command, append it to the `hidden_keywords` string — do not create a duplicate command entry. For example, `/threads` has `sessions` as a hidden keyword so typing "sessions" surfaces it.
+Slash commands are defined as `SlashCommand` entries in the `COMMANDS` tuple in `libs/cli/deepagents_cli/command_registry.py`. Each entry declares the command name, description, `bypass_tier` (queue-bypass classification), optional `hidden_keywords` for fuzzy matching, and optional `aliases`. Bypass-tier frozensets and the `SLASH_COMMANDS` autocomplete list are derived automatically — no other file should hard-code command metadata.
+
+To add a new slash command: (1) add a `SlashCommand` entry to `COMMANDS` (keep alphabetical order), (2) set the appropriate `bypass_tier`, (3) add a handler branch in `_handle_command` in `app.py`, (4) run `make lint && make test` — the drift test will catch any mismatch.
 
 **Adding a new model provider:**
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -33,7 +33,6 @@ from deepagents_cli.command_registry import (
     ALWAYS_IMMEDIATE,
     BYPASS_WHEN_CONNECTING,
     IMMEDIATE_UI,
-    SIDE_EFFECT_FREE,
 )
 from deepagents_cli.config import (
     DOCS_URL,
@@ -1546,7 +1545,7 @@ class DeepAgentsApp(App):
             # Only bare form (no args) bypasses — /model opens selector,
             # /model <name> does a direct switch that shouldn't race with agent.
             return value == cmd
-        return cmd in SIDE_EFFECT_FREE
+        return False
 
     async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         """Handle submitted input from ChatInput widget."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1788,9 +1788,9 @@ class DeepAgentsApp(App):
     async def _open_url_command(self, command: str, cmd: str) -> None:
         """Open a URL in the browser and display a clickable link.
 
-        The browser opens immediately regardless of busy state. Chat output
-        (user echo + clickable link) is deferred until the current task
-        finishes so it doesn't inject mid-agent-output.
+        The browser opens immediately regardless of busy state. When the app is
+        busy, a queued indicator is shown and the real chat output (user echo
+        + clickable link) replaces it after the current task finishes.
 
         Args:
             command: The raw command text (displayed as user message).
@@ -1800,8 +1800,16 @@ class DeepAgentsApp(App):
         webbrowser.open(url)
 
         if self._agent_running or self._shell_running:
-            # Defer chat output until the current task finishes.
+            queued_widget = QueuedUserMessage(command)
+            self._queued_widgets.append(queued_widget)
+            await self._mount_message(queued_widget)
+
             async def _mount_output() -> None:
+                # Remove the ephemeral queued widget, then mount real output.
+                if queued_widget in self._queued_widgets:
+                    self._queued_widgets.remove(queued_widget)
+                with suppress(Exception):
+                    await queued_widget.remove()
                 await self._mount_message(UserMessage(command))
                 link = Content.styled(url, TStyle(dim=True, italic=True, link=url))
                 await self._mount_message(AppMessage(link))

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -275,32 +275,28 @@ typing before showing the approval widget regardless."""
 
 @dataclass(frozen=True, slots=True)
 class QueuedMessage:
-    """Represents a queued user message awaiting processing.
-
-    Attributes:
-        text: The message text content.
-        mode: The input mode that determines message routing.
-    """
+    """Represents a queued user message awaiting processing."""
 
     text: str
+    """The message text content."""
+
     mode: InputMode
+    """The input mode that determines message routing."""
 
 
 DeferredActionKind = Literal["model_switch", "thread_switch"]
 """Valid `DeferredAction.kind` values for type-checked deduplication."""
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class DeferredAction:
-    """An action deferred until the current busy state resolves.
-
-    Attributes:
-        kind: Identity key for deduplication — one of `DeferredActionKind`.
-        execute: Async callable that performs the actual work.
-    """
+    """An action deferred until the current busy state resolves."""
 
     kind: DeferredActionKind
+    """Identity key for deduplication — one of `DeferredActionKind`."""
+
     execute: Callable[[], Awaitable[None]]
+    """Async callable that performs the actual work."""
 
 
 class TextualTokenTracker:
@@ -1738,6 +1734,13 @@ class DeepAgentsApp(App):
             await self._maybe_drain_deferred()
         except Exception:
             logger.exception("Failed to drain deferred actions during shell cleanup")
+            with suppress(Exception):
+                await self._mount_message(
+                    ErrorMessage(
+                        "A deferred action failed after task completion. "
+                        "You may need to retry the operation."
+                    )
+                )
         await self._process_next_from_queue()
 
     async def _kill_shell_process(self) -> None:
@@ -2411,6 +2414,13 @@ class DeepAgentsApp(App):
             await self._maybe_drain_deferred()
         except Exception:
             logger.exception("Failed to drain deferred actions during agent cleanup")
+            with suppress(Exception):
+                await self._mount_message(
+                    ErrorMessage(
+                        "A deferred action failed after task completion. "
+                        "You may need to retry the operation."
+                    )
+                )
 
         # Process next message from queue if any
         await self._process_next_from_queue()
@@ -2935,7 +2945,7 @@ class DeepAgentsApp(App):
         self._deferred_actions.append(action)
 
     async def _maybe_drain_deferred(self) -> None:
-        """Drain deferred actions if not blocked by connection or active work."""
+        """Drain deferred actions unless a server connection is still in progress."""
         if not self._connecting:
             await self._drain_deferred_actions()
 
@@ -2946,14 +2956,19 @@ class DeepAgentsApp(App):
             try:
                 await action.execute()
             except Exception:
-                logger.exception("Failed to execute deferred action %r", action.kind)
-                label = action.kind.replace("_", " ")
-                await self._mount_message(
-                    ErrorMessage(
-                        f"Deferred {label} failed unexpectedly. "
-                        "You may need to retry the operation."
-                    )
+                logger.exception(
+                    "Failed to execute deferred action %r (callable=%r)",
+                    action.kind,
+                    action.execute,
                 )
+                label = action.kind.replace("_", " ")
+                with suppress(Exception):
+                    await self._mount_message(
+                        ErrorMessage(
+                            f"Deferred {label} failed unexpectedly. "
+                            "You may need to retry the operation."
+                        )
+                    )
 
     def _cancel_worker(self, worker: Worker[None] | None) -> None:
         """Discard the message queue and cancel an active worker.
@@ -3715,18 +3730,17 @@ class DeepAgentsApp(App):
 
 @dataclass(frozen=True)
 class AppResult:
-    """Result from running the Textual application.
-
-    Attributes:
-        return_code: Exit code (0 for success, non-zero for error).
-        thread_id: The final thread ID at shutdown. May differ from the
-            initial thread ID if the user switched threads via `/threads`.
-        session_stats: Cumulative usage stats across all turns in the session.
-    """
+    """Result from running the Textual application."""
 
     return_code: int
+    """Exit code (0 for success, non-zero for error)."""
+
     thread_id: str | None
+    """The final thread ID at shutdown. May differ from the initial thread ID if
+    the user switched threads via `/threads`."""
+
     session_stats: SessionStats = field(default_factory=SessionStats)
+    """Cumulative usage stats across all turns in the session."""
 
 
 async def run_textual_app(

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -33,6 +33,7 @@ from deepagents_cli.command_registry import (
     ALWAYS_IMMEDIATE,
     BYPASS_WHEN_CONNECTING,
     IMMEDIATE_UI,
+    SIDE_EFFECT_FREE,
 )
 from deepagents_cli.config import (
     DOCS_URL,
@@ -283,7 +284,7 @@ class QueuedMessage:
     """The input mode that determines message routing."""
 
 
-DeferredActionKind = Literal["model_switch", "thread_switch"]
+DeferredActionKind = Literal["model_switch", "thread_switch", "chat_output"]
 """Valid `DeferredAction.kind` values for type-checked deduplication."""
 
 
@@ -1545,7 +1546,7 @@ class DeepAgentsApp(App):
             # Only bare form (no args) bypasses — /model opens selector,
             # /model <name> does a direct switch that shouldn't race with agent.
             return value == cmd
-        return False
+        return cmd in SIDE_EFFECT_FREE
 
     async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         """Handle submitted input from ChatInput widget."""
@@ -1787,13 +1788,31 @@ class DeepAgentsApp(App):
     async def _open_url_command(self, command: str, cmd: str) -> None:
         """Open a URL in the browser and display a clickable link.
 
+        The browser opens immediately regardless of busy state. Chat output
+        (user echo + clickable link) is deferred until the current task
+        finishes so it doesn't inject mid-agent-output.
+
         Args:
             command: The raw command text (displayed as user message).
             cmd: The normalized slash command used to look up the URL.
         """
         url = _COMMAND_URLS[cmd]
-        await self._mount_message(UserMessage(command))
         webbrowser.open(url)
+
+        if self._agent_running or self._shell_running:
+            # Defer chat output until the current task finishes.
+            async def _mount_output() -> None:
+                await self._mount_message(UserMessage(command))
+                link = Content.styled(url, TStyle(dim=True, italic=True, link=url))
+                await self._mount_message(AppMessage(link))
+
+            # Append directly — no dedup; each URL command gets its own output.
+            self._deferred_actions.append(
+                DeferredAction(kind="chat_output", execute=_mount_output)
+            )
+            return
+
+        await self._mount_message(UserMessage(command))
         link = Content.styled(url, TStyle(dim=True, italic=True, link=url))
         await self._mount_message(AppMessage(link))
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -29,6 +29,12 @@ from textual.style import Style as TStyle
 from textual.widgets import Static
 
 from deepagents_cli.clipboard import copy_selection_to_clipboard
+from deepagents_cli.command_registry import (
+    ALWAYS_IMMEDIATE,
+    BYPASS_WHEN_CONNECTING,
+    IMMEDIATE_UI,
+    SIDE_EFFECT_FREE,
+)
 from deepagents_cli.config import (
     DOCS_URL,
     SHELL_TOOL_NAMES,
@@ -265,22 +271,6 @@ key presses.
 _DEFERRED_APPROVAL_TIMEOUT_SECONDS: float = 30.0
 """Maximum seconds the deferred-approval worker will wait for the user to stop
 typing before showing the approval widget regardless."""
-
-# ---------------------------------------------------------------------------
-# Slash-command bypass tiers
-# ---------------------------------------------------------------------------
-_ALWAYS_IMMEDIATE: frozenset[str] = frozenset({"/quit", "/q"})
-"""Execute regardless of any busy state (incl. thread switching)."""
-
-_BYPASS_WHEN_CONNECTING: frozenset[str] = frozenset({"/version"})
-"""Bypass only during initial connection, not during agent/shell."""
-
-_IMMEDIATE_UI: frozenset[str] = frozenset({"/model", "/threads"})
-"""Open modal UI immediately; actual side-effect deferred by callback.
-
-Any command added here MUST defer its real work to a selector callback
-(via `_defer_action`). The bypass is unconditional — no busy-state check.
-"""
 
 
 @dataclass(frozen=True, slots=True)
@@ -1554,13 +1544,13 @@ class DeepAgentsApp(App):
             `True` if the command should bypass the busy-state queue.
         """
         cmd = value.split(maxsplit=1)[0] if value else ""
-        if cmd in _BYPASS_WHEN_CONNECTING:
+        if cmd in BYPASS_WHEN_CONNECTING:
             return self._connecting and not (self._agent_running or self._shell_running)
-        if cmd in _IMMEDIATE_UI:
+        if cmd in IMMEDIATE_UI:
             # Only bare form (no args) bypasses — /model opens selector,
             # /model <name> does a direct switch that shouldn't race with agent.
             return value == cmd
-        return False
+        return cmd in SIDE_EFFECT_FREE
 
     async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         """Handle submitted input from ChatInput widget."""
@@ -1573,7 +1563,7 @@ class DeepAgentsApp(App):
         await dispatch_hook("user.prompt", {})
 
         # /quit and /q always execute immediately, even mid-thread-switch.
-        if mode == "command" and value.lower().strip() in _ALWAYS_IMMEDIATE:
+        if mode == "command" and value.lower().strip() in ALWAYS_IMMEDIATE:
             self.exit()
             return
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -266,6 +266,22 @@ _DEFERRED_APPROVAL_TIMEOUT_SECONDS: float = 30.0
 """Maximum seconds the deferred-approval worker will wait for the user to stop
 typing before showing the approval widget regardless."""
 
+# ---------------------------------------------------------------------------
+# Slash-command bypass tiers
+# ---------------------------------------------------------------------------
+_ALWAYS_IMMEDIATE: frozenset[str] = frozenset({"/quit", "/q"})
+"""Execute regardless of any busy state (incl. thread switching)."""
+
+_BYPASS_WHEN_CONNECTING: frozenset[str] = frozenset({"/version"})
+"""Bypass only during initial connection, not during agent/shell."""
+
+_IMMEDIATE_UI: frozenset[str] = frozenset({"/model", "/threads"})
+"""Open modal UI immediately; actual side-effect deferred by callback.
+
+Any command added here MUST defer its real work to a selector callback
+(via `_defer_action`). The bypass is unconditional — no busy-state check.
+"""
+
 
 @dataclass(frozen=True, slots=True)
 class QueuedMessage:
@@ -278,6 +294,23 @@ class QueuedMessage:
 
     text: str
     mode: InputMode
+
+
+DeferredActionKind = Literal["model_switch", "thread_switch"]
+"""Valid `DeferredAction.kind` values for type-checked deduplication."""
+
+
+@dataclass(frozen=True, slots=True)
+class DeferredAction:
+    """An action deferred until the current busy state resolves.
+
+    Attributes:
+        kind: Identity key for deduplication — one of `DeferredActionKind`.
+        execute: Async callable that performs the actual work.
+    """
+
+    kind: DeferredActionKind
+    execute: Callable[[], Awaitable[None]]
 
 
 class TextualTokenTracker:
@@ -647,10 +680,11 @@ class DeepAgentsApp(App):
         # User message queue for sequential processing
         self._pending_messages: deque[QueuedMessage] = deque()
         self._queued_widgets: deque[QueuedUserMessage] = deque()
-        self._deferred_actions: list[Callable[[], Awaitable[None]]] = []
         self._processing_pending = False
         self._thread_switching = False
         self._model_switching = False
+        # Deferred actions executed after the current busy state resolves
+        self._deferred_actions: list[DeferredAction] = []
         # Message virtualization store
         self._message_store = MessageStore()
         # Lazily imported here to avoid pulling image dependencies into
@@ -909,9 +943,16 @@ class DeepAgentsApp(App):
 
             async def _safe_drain() -> None:
                 try:
-                    await self._drain_deferred_actions()
+                    await self._maybe_drain_deferred()
                 except Exception:
                     logger.exception("Unhandled error while draining deferred actions")
+                    with suppress(Exception):
+                        await self._mount_message(
+                            ErrorMessage(
+                                "A deferred action failed during startup. "
+                                "You may need to retry the operation."
+                            )
+                        )
 
             self.call_after_refresh(lambda: asyncio.create_task(_safe_drain()))
 
@@ -1503,6 +1544,24 @@ class DeepAgentsApp(App):
             logger.warning("Unrecognized input mode %r, treating as normal", mode)
             await self._handle_user_message(value)
 
+    def _can_bypass_queue(self, value: str) -> bool:
+        """Check if a slash command can skip the message queue.
+
+        Args:
+            value: The lowered, stripped command string (e.g. `/model`).
+
+        Returns:
+            `True` if the command should bypass the busy-state queue.
+        """
+        cmd = value.split(maxsplit=1)[0] if value else ""
+        if cmd in _BYPASS_WHEN_CONNECTING:
+            return self._connecting and not (self._agent_running or self._shell_running)
+        if cmd in _IMMEDIATE_UI:
+            # Only bare form (no args) bypasses — /model opens selector,
+            # /model <name> does a direct switch that shouldn't race with agent.
+            return value == cmd
+        return False
+
     async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
         """Handle submitted input from ChatInput widget."""
         value = event.value
@@ -1513,8 +1572,8 @@ class DeepAgentsApp(App):
 
         await dispatch_hook("user.prompt", {})
 
-        # /quit should always work immediately, even during thread switching.
-        if mode == "command" and value.lower().strip() in {"/quit", "/q"}:
+        # /quit and /q always execute immediately, even mid-thread-switch.
+        if mode == "command" and value.lower().strip() in _ALWAYS_IMMEDIATE:
             self.exit()
             return
 
@@ -1531,24 +1590,9 @@ class DeepAgentsApp(App):
         # instead of processing. Messages queued during connection are drained
         # once the server is ready (see on_deep_agents_app_server_ready).
         if self._agent_running or self._shell_running or self._connecting:
-            # Allow certain commands to bypass the queue.
-            if mode == "command":
-                cmd = value.lower().strip()
-                # /version can run during connection (no server needed), but
-                # still queues when an agent or shell is actively running.
-                if (
-                    cmd == "/version"
-                    and self._connecting
-                    and not (self._agent_running or self._shell_running)
-                ):
-                    await self._process_message(value, mode)
-                    return
-                # /model (no args) and /threads open a selector UI immediately;
-                # the actual switch is deferred via the selector callbacks.
-                if cmd in {"/model", "/threads"}:
-                    await self._process_message(value, mode)
-                    return
-
+            if mode == "command" and self._can_bypass_queue(value.lower().strip()):
+                await self._process_message(value, mode)
+                return
             self._pending_messages.append(QueuedMessage(text=value, mode=mode))
             queued_widget = QueuedUserMessage(value)
             self._queued_widgets.append(queued_widget)
@@ -1700,9 +1744,10 @@ class DeepAgentsApp(App):
             await self._mount_message(AppMessage("Command interrupted"))
         if self._chat_input:
             self._chat_input.set_cursor_active(active=True)
-        # Execute deferred actions (e.g. model/thread switch) now that shell is idle
-        if not self._connecting:
-            await self._drain_deferred_actions()
+        try:
+            await self._maybe_drain_deferred()
+        except Exception:
+            logger.exception("Failed to drain deferred actions during shell cleanup")
         await self._process_next_from_queue()
 
     async def _kill_shell_process(self) -> None:
@@ -2372,9 +2417,10 @@ class DeepAgentsApp(App):
         if self._token_tracker:
             self._token_tracker.show()
 
-        # Execute deferred actions (e.g. model/thread switch) now that agent is idle
-        if not self._connecting:
-            await self._drain_deferred_actions()
+        try:
+            await self._maybe_drain_deferred()
+        except Exception:
+            logger.exception("Failed to drain deferred actions during agent cleanup")
 
         # Process next message from queue if any
         await self._process_next_from_queue()
@@ -2884,18 +2930,38 @@ class DeepAgentsApp(App):
         self._queued_widgets.clear()
         self._deferred_actions.clear()
 
+    def _defer_action(self, action: DeferredAction) -> None:
+        """Queue a deferred action, replacing any existing action of the same kind.
+
+        Last-write-wins: if the user selects a model twice while busy, only the
+        final selection runs.
+
+        Args:
+            action: The deferred action to queue.
+        """
+        self._deferred_actions = [
+            a for a in self._deferred_actions if a.kind != action.kind
+        ]
+        self._deferred_actions.append(action)
+
+    async def _maybe_drain_deferred(self) -> None:
+        """Drain deferred actions if not blocked by connection or active work."""
+        if not self._connecting:
+            await self._drain_deferred_actions()
+
     async def _drain_deferred_actions(self) -> None:
         """Execute deferred actions queued while busy (e.g. model/thread switch)."""
         while self._deferred_actions:
             action = self._deferred_actions.pop(0)
             try:
-                await action()
+                await action.execute()
             except Exception:
-                logger.exception("Failed to execute deferred action: %r", action)
+                logger.exception("Failed to execute deferred action %r", action.kind)
+                label = action.kind.replace("_", " ")
                 await self._mount_message(
                     ErrorMessage(
-                        "A deferred action failed unexpectedly. "
-                        "Check the log for details."
+                        f"Deferred {label} failed unexpectedly. "
+                        "You may need to retry the operation."
                     )
                 )
 
@@ -3260,9 +3326,14 @@ class DeepAgentsApp(App):
             if result is not None:
                 model_spec, _ = result
                 if self._agent_running or self._shell_running or self._connecting:
-                    self._deferred_actions.append(
-                        partial(
-                            self._switch_model, model_spec, extra_kwargs=extra_kwargs
+                    self._defer_action(
+                        DeferredAction(
+                            kind="model_switch",
+                            execute=partial(
+                                self._switch_model,
+                                model_spec,
+                                extra_kwargs=extra_kwargs,
+                            ),
                         )
                     )
                     self.notify(
@@ -3314,7 +3385,12 @@ class DeepAgentsApp(App):
             """Handle the thread selector result."""
             if result is not None:
                 if self._agent_running or self._shell_running or self._connecting:
-                    self._deferred_actions.append(partial(self._resume_thread, result))
+                    self._defer_action(
+                        DeferredAction(
+                            kind="thread_switch",
+                            execute=partial(self._resume_thread, result),
+                        )
+                    )
                     self.notify(
                         "Thread will switch after current task completes.", timeout=3
                     )

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -23,6 +23,9 @@ class BypassTier(StrEnum):
     IMMEDIATE_UI = "immediate_ui"
     """Open modal UI immediately; real work deferred via `_defer_action` callback."""
 
+    SIDE_EFFECT_FREE = "side_effect_free"
+    """Execute the side effect immediately; defer chat output until idle."""
+
     QUEUED = "queued"
     """Must wait in the queue when the app is busy."""
 
@@ -51,7 +54,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/changelog",
         description="Open changelog in browser",
-        bypass_tier=BypassTier.QUEUED,
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
     ),
     SlashCommand(
         name="/clear",
@@ -62,7 +65,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/docs",
         description="Open documentation in browser",
-        bypass_tier=BypassTier.QUEUED,
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
     ),
     SlashCommand(
         name="/editor",
@@ -72,7 +75,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/feedback",
         description="Submit a bug report or feature request",
-        bypass_tier=BypassTier.QUEUED,
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
     ),
     SlashCommand(
         name="/help",
@@ -82,7 +85,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/mcp",
         description="Show active MCP servers and tools",
-        bypass_tier=BypassTier.QUEUED,
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
         hidden_keywords="servers",
     ),
     SlashCommand(
@@ -172,13 +175,20 @@ BYPASS_WHEN_CONNECTING: frozenset[str] = _build_bypass_set(BypassTier.CONNECTING
 IMMEDIATE_UI: frozenset[str] = _build_bypass_set(BypassTier.IMMEDIATE_UI)
 """Commands that open modal UI immediately, deferring real work."""
 
+SIDE_EFFECT_FREE: frozenset[str] = _build_bypass_set(BypassTier.SIDE_EFFECT_FREE)
+"""Commands whose side effect fires immediately; chat output deferred until idle."""
+
 QUEUE_BOUND: frozenset[str] = _build_bypass_set(BypassTier.QUEUED)
 """Commands that must wait in the queue when the app is busy."""
 
 ALL_CLASSIFIED: frozenset[str] = (
-    ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | QUEUE_BOUND
+    ALWAYS_IMMEDIATE
+    | BYPASS_WHEN_CONNECTING
+    | IMMEDIATE_UI
+    | SIDE_EFFECT_FREE
+    | QUEUE_BOUND
 )
-"""Union of all four tiers — used by drift tests."""
+"""Union of all five tiers — used by drift tests."""
 
 
 # ---------------------------------------------------------------------------

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -23,9 +23,6 @@ class BypassTier(StrEnum):
     IMMEDIATE_UI = "immediate_ui"
     """Open modal UI immediately; real work deferred via `_defer_action` callback."""
 
-    SIDE_EFFECT_FREE = "side_effect_free"
-    """Fire-and-forget actions (e.g. open browser) that don't touch agent state."""
-
     QUEUED = "queued"
     """Must wait in the queue when the app is busy."""
 
@@ -54,7 +51,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/changelog",
         description="Open changelog in browser",
-        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
         name="/clear",
@@ -65,7 +62,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/docs",
         description="Open documentation in browser",
-        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
         name="/editor",
@@ -75,7 +72,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/feedback",
         description="Submit a bug report or feature request",
-        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
         name="/help",
@@ -85,7 +82,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/mcp",
         description="Show active MCP servers and tools",
-        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        bypass_tier=BypassTier.QUEUED,
         hidden_keywords="servers",
     ),
     SlashCommand(
@@ -175,20 +172,13 @@ BYPASS_WHEN_CONNECTING: frozenset[str] = _build_bypass_set(BypassTier.CONNECTING
 IMMEDIATE_UI: frozenset[str] = _build_bypass_set(BypassTier.IMMEDIATE_UI)
 """Commands that open modal UI immediately, deferring real work."""
 
-SIDE_EFFECT_FREE: frozenset[str] = _build_bypass_set(BypassTier.SIDE_EFFECT_FREE)
-"""Fire-and-forget commands that don't touch agent state."""
-
 QUEUE_BOUND: frozenset[str] = _build_bypass_set(BypassTier.QUEUED)
 """Commands that must wait in the queue when the app is busy."""
 
 ALL_CLASSIFIED: frozenset[str] = (
-    ALWAYS_IMMEDIATE
-    | BYPASS_WHEN_CONNECTING
-    | IMMEDIATE_UI
-    | SIDE_EFFECT_FREE
-    | QUEUE_BOUND
+    ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | QUEUE_BOUND
 )
-"""Union of all five tiers — used by drift tests."""
+"""Union of all four tiers — used by drift tests."""
 
 
 # ---------------------------------------------------------------------------

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -1,0 +1,201 @@
+"""Unified slash-command registry.
+
+Every slash command is declared once as a `SlashCommand` entry in `COMMANDS`.
+Bypass-tier frozensets and autocomplete tuples are derived automatically — no
+other file should hard-code command metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class BypassTier(StrEnum):
+    """Classification that controls whether a command can skip the message queue."""
+
+    ALWAYS = "always"
+    """Execute regardless of any busy state, including mid-thread-switch."""
+
+    CONNECTING = "connecting"
+    """Bypass only during initial server connection, not during agent/shell."""
+
+    IMMEDIATE_UI = "immediate_ui"
+    """Open modal UI immediately; real work deferred via `_defer_action` callback."""
+
+    SIDE_EFFECT_FREE = "side_effect_free"
+    """Fire-and-forget actions (e.g. open browser) that don't touch agent state."""
+
+    QUEUED = "queued"
+    """Must wait in the queue when the app is busy."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SlashCommand:
+    """A single slash-command definition."""
+
+    name: str
+    """Canonical command name (e.g. `/quit`)."""
+
+    description: str
+    """Short user-facing description."""
+
+    bypass_tier: BypassTier
+    """Queue-bypass classification."""
+
+    hidden_keywords: str = ""
+    """Space-separated terms for fuzzy matching (never displayed)."""
+
+    aliases: tuple[str, ...] = ()
+    """Alternative names (e.g. `("/q",)` for `/quit`)."""
+
+
+COMMANDS: tuple[SlashCommand, ...] = (
+    SlashCommand(
+        name="/changelog",
+        description="Open changelog in browser",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+    ),
+    SlashCommand(
+        name="/clear",
+        description="Clear chat and start new thread",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="reset",
+    ),
+    SlashCommand(
+        name="/docs",
+        description="Open documentation in browser",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+    ),
+    SlashCommand(
+        name="/editor",
+        description="Open prompt in external editor ($EDITOR)",
+        bypass_tier=BypassTier.QUEUED,
+    ),
+    SlashCommand(
+        name="/feedback",
+        description="Submit a bug report or feature request",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+    ),
+    SlashCommand(
+        name="/help",
+        description="Show help",
+        bypass_tier=BypassTier.QUEUED,
+    ),
+    SlashCommand(
+        name="/mcp",
+        description="Show active MCP servers and tools",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        hidden_keywords="servers",
+    ),
+    SlashCommand(
+        name="/model",
+        description="Switch or configure model (--model-params, --default)",
+        bypass_tier=BypassTier.IMMEDIATE_UI,
+    ),
+    SlashCommand(
+        name="/offload",
+        description="Free up context window space by offloading older messages",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="compact",
+        aliases=("/compact",),
+    ),
+    SlashCommand(
+        name="/quit",
+        description="Exit app",
+        bypass_tier=BypassTier.ALWAYS,
+        hidden_keywords="close leave",
+        aliases=("/q",),
+    ),
+    SlashCommand(
+        name="/reload",
+        description="Reload config from environment variables and .env",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="refresh",
+    ),
+    SlashCommand(
+        name="/remember",
+        description="Update memory and skills from conversation",
+        bypass_tier=BypassTier.QUEUED,
+    ),
+    SlashCommand(
+        name="/threads",
+        description="Browse and resume previous threads",
+        bypass_tier=BypassTier.IMMEDIATE_UI,
+        hidden_keywords="continue history sessions",
+    ),
+    SlashCommand(
+        name="/tokens",
+        description="Token usage",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="cost",
+    ),
+    SlashCommand(
+        name="/trace",
+        description="Open current thread in LangSmith",
+        bypass_tier=BypassTier.QUEUED,
+    ),
+    SlashCommand(
+        name="/version",
+        description="Show version",
+        bypass_tier=BypassTier.CONNECTING,
+    ),
+)
+"""All slash commands, alphabetically sorted by name."""
+
+
+# ---------------------------------------------------------------------------
+# Derived bypass-tier frozensets
+# ---------------------------------------------------------------------------
+
+
+def _build_bypass_set(tier: BypassTier) -> frozenset[str]:
+    """Build a frozenset of command names (including aliases) for a tier.
+
+    Args:
+        tier: The bypass tier to collect.
+
+    Returns:
+        Frozenset of all names and aliases that belong to `tier`.
+    """
+    names: set[str] = set()
+    for cmd in COMMANDS:
+        if cmd.bypass_tier == tier:
+            names.add(cmd.name)
+            names.update(cmd.aliases)
+    return frozenset(names)
+
+
+ALWAYS_IMMEDIATE: frozenset[str] = _build_bypass_set(BypassTier.ALWAYS)
+"""Commands that execute regardless of any busy state."""
+
+BYPASS_WHEN_CONNECTING: frozenset[str] = _build_bypass_set(BypassTier.CONNECTING)
+"""Commands that bypass only during initial server connection."""
+
+IMMEDIATE_UI: frozenset[str] = _build_bypass_set(BypassTier.IMMEDIATE_UI)
+"""Commands that open modal UI immediately, deferring real work."""
+
+SIDE_EFFECT_FREE: frozenset[str] = _build_bypass_set(BypassTier.SIDE_EFFECT_FREE)
+"""Fire-and-forget commands that don't touch agent state."""
+
+QUEUE_BOUND: frozenset[str] = _build_bypass_set(BypassTier.QUEUED)
+"""Commands that must wait in the queue when the app is busy."""
+
+ALL_CLASSIFIED: frozenset[str] = (
+    ALWAYS_IMMEDIATE
+    | BYPASS_WHEN_CONNECTING
+    | IMMEDIATE_UI
+    | SIDE_EFFECT_FREE
+    | QUEUE_BOUND
+)
+"""Union of all five tiers — used by drift tests."""
+
+
+# ---------------------------------------------------------------------------
+# Autocomplete tuples
+# ---------------------------------------------------------------------------
+
+SLASH_COMMANDS: list[tuple[str, str, str]] = [
+    (cmd.name, cmd.description, cmd.hidden_keywords) for cmd in COMMANDS
+]
+"""`(name, description, hidden_keywords)` tuples for `SlashCommandController`."""

--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -96,33 +96,6 @@ class CompletionController(Protocol):
 # Slash Command Completion
 # ============================================================================
 
-SLASH_COMMANDS: list[tuple[str, str, str]] = [
-    ("/help", "Show help", ""),
-    ("/changelog", "Open changelog in browser", ""),
-    ("/clear", "Clear chat and start new thread", "reset"),
-    ("/docs", "Open documentation in browser", ""),
-    ("/editor", "Open prompt in external editor ($EDITOR)", ""),
-    ("/feedback", "Submit a bug report or feature request", ""),
-    ("/mcp", "Show active MCP servers and tools", "servers"),
-    ("/model", "Switch or configure model (--model-params, --default)", ""),
-    (
-        "/offload",
-        "Free up context window space by offloading older messages",
-        "compact",
-    ),
-    ("/quit", "Exit app", "close leave"),
-    ("/reload", "Reload config from environment variables and .env", "refresh"),
-    ("/remember", "Update memory and skills from conversation", ""),
-    ("/tokens", "Token usage", "cost"),
-    ("/threads", "Browse and resume previous threads", "continue history sessions"),
-    ("/trace", "Open current thread in LangSmith", ""),
-    ("/version", "Show version", ""),
-]
-"""Built-in slash commands: (name, description, hidden_keywords).
-
-Hidden keywords are space-separated terms that participate in fuzzy matching
-but are never displayed to the user.
-"""
 
 MAX_SUGGESTIONS = 10
 """UI cap so the completion popup doesn't get unwieldy."""

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -17,6 +17,7 @@ from textual.reactive import reactive
 from textual.widgets import Static, TextArea
 from textual.widgets.text_area import Selection
 
+from deepagents_cli.command_registry import SLASH_COMMANDS
 from deepagents_cli.config import (
     COLORS,
     MODE_DISPLAY_GLYPHS,
@@ -27,7 +28,6 @@ from deepagents_cli.config import (
 )
 from deepagents_cli.input import IMAGE_PLACEHOLDER_PATTERN, VIDEO_PLACEHOLDER_PATTERN
 from deepagents_cli.widgets.autocomplete import (
-    SLASH_COMMANDS,
     CompletionResult,
     FuzzyFileController,
     MultiCompletionManager,

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2482,7 +2482,7 @@ class TestSlashCommandBypass:
 class TestBypassFrozensetDrift:
     """Ensure bypass frozensets stay in sync with _handle_command dispatch.
 
-    Every slash command must appear in exactly one of the five policy
+    Every slash command must appear in exactly one of the four policy
     frozensets (derived from `command_registry.COMMANDS`) AND in
     `_handle_command`. Adding a command to one without the other will fail
     these tests.
@@ -2512,13 +2512,10 @@ class TestBypassFrozensetDrift:
             ALWAYS_IMMEDIATE,
             BYPASS_WHEN_CONNECTING,
             IMMEDIATE_UI,
-            SIDE_EFFECT_FREE,
         )
 
         handled = self._handled_commands()
-        bypass = (
-            ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | SIDE_EFFECT_FREE
-        )
+        bypass = ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI
         missing = bypass - handled
         assert not missing, (
             f"Bypass commands {missing} are not handled in _handle_command. "
@@ -2744,23 +2741,13 @@ class TestDeferredActions:
             assert len(app._pending_messages) == 1
             assert app._pending_messages[0].text == "/model gpt-4"
 
-    async def test_can_bypass_queue_side_effect_free(self) -> None:
-        """SIDE_EFFECT_FREE commands bypass regardless of busy state."""
+    async def test_queued_commands_do_not_bypass(self) -> None:
+        """QUEUED commands (e.g. /changelog, /docs) must not bypass the queue."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-
-            for cmd in ("/changelog", "/docs", "/feedback", "/mcp"):
-                assert app._can_bypass_queue(cmd) is True
-
-                # Still bypass even when agent/shell running
-                app._agent_running = True
-                assert app._can_bypass_queue(cmd) is True
-                app._agent_running = False
-
-                app._shell_running = True
-                assert app._can_bypass_queue(cmd) is True
-                app._shell_running = False
+            for cmd in ("/changelog", "/docs", "/feedback", "/mcp", "/help"):
+                assert app._can_bypass_queue(cmd) is False
 
     async def test_can_bypass_queue_empty_string(self) -> None:
         """Empty string should not bypass the queue."""

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2482,7 +2482,7 @@ class TestSlashCommandBypass:
 class TestBypassFrozensetDrift:
     """Ensure bypass frozensets stay in sync with _handle_command dispatch.
 
-    Every slash command must appear in exactly one of the four policy
+    Every slash command must appear in exactly one of the five policy
     frozensets (derived from `command_registry.COMMANDS`) AND in
     `_handle_command`. Adding a command to one without the other will fail
     these tests.
@@ -2512,10 +2512,13 @@ class TestBypassFrozensetDrift:
             ALWAYS_IMMEDIATE,
             BYPASS_WHEN_CONNECTING,
             IMMEDIATE_UI,
+            SIDE_EFFECT_FREE,
         )
 
         handled = self._handled_commands()
-        bypass = ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI
+        bypass = (
+            ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | SIDE_EFFECT_FREE
+        )
         missing = bypass - handled
         assert not missing, (
             f"Bypass commands {missing} are not handled in _handle_command. "
@@ -2741,12 +2744,20 @@ class TestDeferredActions:
             assert len(app._pending_messages) == 1
             assert app._pending_messages[0].text == "/model gpt-4"
 
-    async def test_queued_commands_do_not_bypass(self) -> None:
-        """QUEUED commands (e.g. /changelog, /docs) must not bypass the queue."""
+    async def test_side_effect_free_bypasses_queue(self) -> None:
+        """SIDE_EFFECT_FREE commands bypass the queue."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            for cmd in ("/changelog", "/docs", "/feedback", "/mcp", "/help"):
+            for cmd in ("/changelog", "/docs", "/feedback", "/mcp"):
+                assert app._can_bypass_queue(cmd) is True
+
+    async def test_queued_commands_do_not_bypass(self) -> None:
+        """QUEUED commands must not bypass the queue."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            for cmd in ("/help", "/clear", "/tokens"):
                 assert app._can_bypass_queue(cmd) is False
 
     async def test_can_bypass_queue_empty_string(self) -> None:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2482,7 +2482,7 @@ class TestSlashCommandBypass:
 class TestBypassFrozensetDrift:
     """Ensure bypass frozensets stay in sync with _handle_command dispatch.
 
-    Every slash command must appear in exactly one of the four policy
+    Every slash command must appear in exactly one of the five policy
     frozensets (derived from `command_registry.COMMANDS`) AND in
     `_handle_command`. Adding a command to one without the other will fail
     these tests.
@@ -2743,3 +2743,56 @@ class TestDeferredActions:
 
             assert len(app._pending_messages) == 1
             assert app._pending_messages[0].text == "/model gpt-4"
+
+    async def test_can_bypass_queue_side_effect_free(self) -> None:
+        """SIDE_EFFECT_FREE commands bypass regardless of busy state."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            for cmd in ("/changelog", "/docs", "/feedback", "/mcp"):
+                assert app._can_bypass_queue(cmd) is True
+
+                # Still bypass even when agent/shell running
+                app._agent_running = True
+                assert app._can_bypass_queue(cmd) is True
+                app._agent_running = False
+
+                app._shell_running = True
+                assert app._can_bypass_queue(cmd) is True
+                app._shell_running = False
+
+    async def test_can_bypass_queue_empty_string(self) -> None:
+        """Empty string should not bypass the queue."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._can_bypass_queue("") is False
+
+    async def test_defer_action_mixed_kinds_preserves_ordering(self) -> None:
+        """Deferring mixed kinds keeps ordering; same-kind replaces in place."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            executed: list[str] = []
+
+            async def first_model() -> None:  # noqa: RUF029
+                executed.append("first_model")
+
+            async def thread_fn() -> None:  # noqa: RUF029
+                executed.append("thread")
+
+            async def second_model() -> None:  # noqa: RUF029
+                executed.append("second_model")
+
+            app._defer_action(DeferredAction(kind="model_switch", execute=first_model))
+            app._defer_action(DeferredAction(kind="thread_switch", execute=thread_fn))
+            app._defer_action(DeferredAction(kind="model_switch", execute=second_model))
+
+            assert len(app._deferred_actions) == 2
+            assert app._deferred_actions[0].kind == "thread_switch"
+            assert app._deferred_actions[1].kind == "model_switch"
+
+            await app._drain_deferred_actions()
+            assert executed == ["thread", "second_model"]

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2479,6 +2479,64 @@ class TestSlashCommandBypass:
             assert len(app._pending_messages) == 0
 
 
+class TestBypassFrozensetDrift:
+    """Ensure bypass frozensets stay in sync with _handle_command dispatch.
+
+    Every slash command must appear in exactly one of the four policy
+    frozensets (derived from `command_registry.COMMANDS`) AND in
+    `_handle_command`. Adding a command to one without the other will fail
+    these tests.
+    """
+
+    @staticmethod
+    def _handled_commands() -> set[str]:
+        """Extract slash-command literals from `_handle_command` source."""
+        import ast
+        import inspect
+        import textwrap
+
+        source = textwrap.dedent(inspect.getsource(DeepAgentsApp._handle_command))
+        tree = ast.parse(source)
+
+        handled: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                val = node.value.strip()
+                if val.startswith("/") and len(val) > 1:
+                    handled.add(val)
+        return handled
+
+    def test_all_bypass_commands_are_handled(self) -> None:
+        """Every command in a bypass frozenset must appear in _handle_command."""
+        from deepagents_cli.command_registry import (
+            ALWAYS_IMMEDIATE,
+            BYPASS_WHEN_CONNECTING,
+            IMMEDIATE_UI,
+            SIDE_EFFECT_FREE,
+        )
+
+        handled = self._handled_commands()
+        bypass = (
+            ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | SIDE_EFFECT_FREE
+        )
+        missing = bypass - handled
+        assert not missing, (
+            f"Bypass commands {missing} are not handled in _handle_command. "
+            "Add a handler or remove from the bypass frozenset."
+        )
+
+    def test_all_handled_commands_are_classified(self) -> None:
+        """Every command in _handle_command must be in a policy frozenset."""
+        from deepagents_cli.command_registry import ALL_CLASSIFIED
+
+        handled = self._handled_commands()
+        missing = handled - ALL_CLASSIFIED
+        assert not missing, (
+            f"Commands {missing} in _handle_command are not in any bypass "
+            "or QUEUE_BOUND frozenset. Classify them explicitly."
+        )
+
+
 class TestDeferredActions:
     """Test deferred action queueing and draining."""
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -29,6 +29,7 @@ from deepagents_cli.app import (
     _ITERM_CURSOR_GUIDE_ON,
     _TYPING_IDLE_THRESHOLD_SECONDS,
     DeepAgentsApp,
+    DeferredAction,
     QueuedMessage,
     TextualSessionState,
     _write_iterm_escape,
@@ -2487,12 +2488,14 @@ class TestDeferredActions:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            executed = []
+            executed: list[str] = []
 
             async def action() -> None:  # noqa: RUF029
                 executed.append("ran")
 
-            app._deferred_actions.append(action)
+            app._deferred_actions.append(
+                DeferredAction(kind="model_switch", execute=action)
+            )
             app._agent_running = True
 
             # Simulate agent finishing
@@ -2507,12 +2510,14 @@ class TestDeferredActions:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            executed = []
+            executed: list[str] = []
 
             async def action() -> None:  # noqa: RUF029
                 executed.append("ran")
 
-            app._deferred_actions.append(action)
+            app._deferred_actions.append(
+                DeferredAction(kind="model_switch", execute=action)
+            )
             app._shell_running = True
 
             await app._cleanup_shell_task()
@@ -2526,12 +2531,14 @@ class TestDeferredActions:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            executed = []
+            executed: list[str] = []
 
             async def action() -> None:  # noqa: RUF029
                 executed.append("ran")
 
-            app._deferred_actions.append(action)
+            app._deferred_actions.append(
+                DeferredAction(kind="model_switch", execute=action)
+            )
             app._agent_running = True
             app._connecting = True
 
@@ -2549,7 +2556,9 @@ class TestDeferredActions:
             async def action() -> None:
                 pass
 
-            app._deferred_actions.append(action)
+            app._deferred_actions.append(
+                DeferredAction(kind="model_switch", execute=action)
+            )
             app._discard_queue()
 
             assert len(app._deferred_actions) == 0
@@ -2563,7 +2572,9 @@ class TestDeferredActions:
             async def action() -> None:
                 pass
 
-            app._deferred_actions.append(action)
+            app._deferred_actions.append(
+                DeferredAction(kind="model_switch", execute=action)
+            )
             app._connecting = True
 
             app.on_deep_agents_app_server_start_failed(
@@ -2578,7 +2589,7 @@ class TestDeferredActions:
         async with app.run_test() as pilot:
             await pilot.pause()
 
-            executed = []
+            executed: list[str] = []
 
             async def bad_action() -> None:  # noqa: RUF029
                 msg = "boom"
@@ -2587,10 +2598,90 @@ class TestDeferredActions:
             async def good_action() -> None:  # noqa: RUF029
                 executed.append("ok")
 
-            app._deferred_actions.append(bad_action)
-            app._deferred_actions.append(good_action)
+            app._deferred_actions.append(
+                DeferredAction(kind="model_switch", execute=bad_action)
+            )
+            app._deferred_actions.append(
+                DeferredAction(kind="thread_switch", execute=good_action)
+            )
 
             await app._drain_deferred_actions()
 
             assert executed == ["ok"]
             assert len(app._deferred_actions) == 0
+
+    async def test_defer_action_deduplicates_by_kind(self) -> None:
+        """Deferring two actions of the same kind keeps only the last."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            executed: list[str] = []
+
+            async def first() -> None:  # noqa: RUF029
+                executed.append("first")
+
+            async def second() -> None:  # noqa: RUF029
+                executed.append("second")
+
+            app._defer_action(DeferredAction(kind="model_switch", execute=first))
+            app._defer_action(DeferredAction(kind="model_switch", execute=second))
+
+            assert len(app._deferred_actions) == 1
+            await app._drain_deferred_actions()
+            assert executed == ["second"]
+
+    async def test_can_bypass_queue_version_only_connecting(self) -> None:
+        """/version bypasses only during connection, not agent/shell."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Connecting only → bypass
+            app._connecting = True
+            app._agent_running = False
+            app._shell_running = False
+            assert app._can_bypass_queue("/version") is True
+
+            # Agent running (even if connecting) → no bypass
+            app._agent_running = True
+            assert app._can_bypass_queue("/version") is False
+
+            # Shell running (even if connecting) → no bypass
+            app._agent_running = False
+            app._shell_running = True
+            assert app._can_bypass_queue("/version") is False
+
+            # Not connecting → no bypass
+            app._connecting = False
+            app._shell_running = False
+            assert app._can_bypass_queue("/version") is False
+
+    async def test_can_bypass_queue_bare_model_bypasses(self) -> None:
+        """Bare /model should bypass the queue."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._can_bypass_queue("/model") is True
+            assert app._can_bypass_queue("/threads") is True
+
+    async def test_can_bypass_queue_model_with_args_no_bypass(self) -> None:
+        """/model with args should NOT bypass (direct switch must queue)."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._can_bypass_queue("/model gpt-4") is False
+            assert app._can_bypass_queue("/model --default foo") is False
+
+    async def test_model_with_args_still_queues(self) -> None:
+        """/model gpt-4 should be queued when busy, not bypass."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            app.post_message(ChatInput.Submitted("/model gpt-4", "command"))
+            await pilot.pause()
+
+            assert len(app._pending_messages) == 1
+            assert app._pending_messages[0].text == "/model gpt-4"

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from deepagents_cli.command_registry import SLASH_COMMANDS
 from deepagents_cli.widgets.autocomplete import (
     MAX_SUGGESTIONS,
-    SLASH_COMMANDS,
     CompletionController,
     FuzzyFileController,
     MultiCompletionManager,

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -11,9 +11,10 @@ from textual.app import App, ComposeResult
 from textual.containers import Container
 from textual.widgets import Static
 
+from deepagents_cli.command_registry import SLASH_COMMANDS
 from deepagents_cli.input import MediaTracker
 from deepagents_cli.widgets import chat_input as chat_input_module
-from deepagents_cli.widgets.autocomplete import MAX_SUGGESTIONS, SLASH_COMMANDS
+from deepagents_cli.widgets.autocomplete import MAX_SUGGESTIONS
 from deepagents_cli.widgets.chat_input import (
     ChatInput,
     ChatTextArea,

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -9,6 +9,7 @@ from deepagents_cli.command_registry import (
     COMMANDS,
     IMMEDIATE_UI,
     QUEUE_BOUND,
+    SIDE_EFFECT_FREE,
     SLASH_COMMANDS,
 )
 
@@ -53,6 +54,7 @@ class TestBypassTiers:
             ALWAYS_IMMEDIATE,
             BYPASS_WHEN_CONNECTING,
             IMMEDIATE_UI,
+            SIDE_EFFECT_FREE,
             QUEUE_BOUND,
         ]
         for i, a in enumerate(tiers):
@@ -61,7 +63,11 @@ class TestBypassTiers:
 
     def test_all_classified_is_union(self) -> None:
         assert ALL_CLASSIFIED == (
-            ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | QUEUE_BOUND
+            ALWAYS_IMMEDIATE
+            | BYPASS_WHEN_CONNECTING
+            | IMMEDIATE_UI
+            | SIDE_EFFECT_FREE
+            | QUEUE_BOUND
         )
 
     def test_aliases_in_correct_tier(self) -> None:

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -70,6 +70,10 @@ class TestBypassTiers:
             | QUEUE_BOUND
         )
 
+    def test_aliases_in_correct_tier(self) -> None:
+        assert "/q" in ALWAYS_IMMEDIATE
+        assert "/compact" in QUEUE_BOUND
+
     def test_every_command_classified(self) -> None:
         for cmd in COMMANDS:
             assert cmd.name in ALL_CLASSIFIED, f"{cmd.name} not in any tier"

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -9,7 +9,6 @@ from deepagents_cli.command_registry import (
     COMMANDS,
     IMMEDIATE_UI,
     QUEUE_BOUND,
-    SIDE_EFFECT_FREE,
     SLASH_COMMANDS,
 )
 
@@ -54,7 +53,6 @@ class TestBypassTiers:
             ALWAYS_IMMEDIATE,
             BYPASS_WHEN_CONNECTING,
             IMMEDIATE_UI,
-            SIDE_EFFECT_FREE,
             QUEUE_BOUND,
         ]
         for i, a in enumerate(tiers):
@@ -63,11 +61,7 @@ class TestBypassTiers:
 
     def test_all_classified_is_union(self) -> None:
         assert ALL_CLASSIFIED == (
-            ALWAYS_IMMEDIATE
-            | BYPASS_WHEN_CONNECTING
-            | IMMEDIATE_UI
-            | SIDE_EFFECT_FREE
-            | QUEUE_BOUND
+            ALWAYS_IMMEDIATE | BYPASS_WHEN_CONNECTING | IMMEDIATE_UI | QUEUE_BOUND
         )
 
     def test_aliases_in_correct_tier(self) -> None:

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -1,0 +1,104 @@
+"""Unit tests for the unified slash-command registry."""
+
+from __future__ import annotations
+
+from deepagents_cli.command_registry import (
+    ALL_CLASSIFIED,
+    ALWAYS_IMMEDIATE,
+    BYPASS_WHEN_CONNECTING,
+    COMMANDS,
+    IMMEDIATE_UI,
+    QUEUE_BOUND,
+    SIDE_EFFECT_FREE,
+    SLASH_COMMANDS,
+)
+
+
+class TestCommandIntegrity:
+    """Validate structural invariants of the COMMANDS registry."""
+
+    def test_names_start_with_slash(self) -> None:
+        for cmd in COMMANDS:
+            assert cmd.name.startswith("/"), f"{cmd.name} missing leading slash"
+
+    def test_aliases_start_with_slash(self) -> None:
+        for cmd in COMMANDS:
+            for alias in cmd.aliases:
+                assert alias.startswith("/"), (
+                    f"Alias {alias!r} of {cmd.name} missing leading slash"
+                )
+
+    def test_alphabetically_sorted(self) -> None:
+        names = [cmd.name for cmd in COMMANDS]
+        assert names == sorted(names), "COMMANDS must be sorted alphabetically by name"
+
+    def test_no_duplicate_names(self) -> None:
+        names = [cmd.name for cmd in COMMANDS]
+        assert len(names) == len(set(names)), "Duplicate command names found"
+
+    def test_no_duplicate_aliases(self) -> None:
+        all_names: list[str] = []
+        for cmd in COMMANDS:
+            all_names.append(cmd.name)
+            all_names.extend(cmd.aliases)
+        assert len(all_names) == len(set(all_names)), (
+            "Duplicate name or alias across entries"
+        )
+
+
+class TestBypassTiers:
+    """Validate derived bypass-tier frozensets."""
+
+    def test_tiers_mutually_exclusive(self) -> None:
+        tiers = [
+            ALWAYS_IMMEDIATE,
+            BYPASS_WHEN_CONNECTING,
+            IMMEDIATE_UI,
+            SIDE_EFFECT_FREE,
+            QUEUE_BOUND,
+        ]
+        for i, a in enumerate(tiers):
+            for b in tiers[i + 1 :]:
+                assert not (a & b), f"Overlap between tiers: {a & b}"
+
+    def test_all_classified_is_union(self) -> None:
+        assert ALL_CLASSIFIED == (
+            ALWAYS_IMMEDIATE
+            | BYPASS_WHEN_CONNECTING
+            | IMMEDIATE_UI
+            | SIDE_EFFECT_FREE
+            | QUEUE_BOUND
+        )
+
+    def test_every_command_classified(self) -> None:
+        for cmd in COMMANDS:
+            assert cmd.name in ALL_CLASSIFIED, f"{cmd.name} not in any tier"
+            for alias in cmd.aliases:
+                assert alias in ALL_CLASSIFIED, (
+                    f"Alias {alias!r} of {cmd.name} not in any tier"
+                )
+
+
+class TestSlashCommands:
+    """Validate the SLASH_COMMANDS autocomplete list."""
+
+    def test_length_matches_commands(self) -> None:
+        assert len(SLASH_COMMANDS) == len(COMMANDS)
+
+    def test_tuple_format(self) -> None:
+        for entry in SLASH_COMMANDS:
+            assert isinstance(entry, tuple)
+            assert len(entry) == 3
+            name, desc, keywords = entry
+            assert isinstance(name, str)
+            assert name.startswith("/")
+            assert isinstance(desc, str)
+            assert isinstance(keywords, str)
+
+    def test_excludes_aliases(self) -> None:
+        names = {entry[0] for entry in SLASH_COMMANDS}
+        for cmd in COMMANDS:
+            for alias in cmd.aliases:
+                assert alias not in names, (
+                    f"Alias {alias!r} should not appear in autocomplete"
+                )

--- a/libs/cli/tests/unit_tests/test_offload.py
+++ b/libs/cli/tests/unit_tests/test_offload.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from deepagents_cli.app import DeepAgentsApp
+from deepagents_cli.command_registry import SLASH_COMMANDS
 from deepagents_cli.config import settings
 from deepagents_cli.offload import (
     OffloadModelError,
@@ -17,7 +18,6 @@ from deepagents_cli.offload import (
     offload_messages_to_backend,
 )
 from deepagents_cli.textual_adapter import format_token_count
-from deepagents_cli.widgets.autocomplete import SLASH_COMMANDS
 from deepagents_cli.widgets.messages import AppMessage, ErrorMessage
 
 # Patch target for perform_offload (business logic)

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from deepagents_cli.command_registry import SLASH_COMMANDS
 from deepagents_cli.config import Settings
-from deepagents_cli.widgets.autocomplete import SLASH_COMMANDS
 
 _RELOAD_ENV_KEYS = (
     "OPENAI_API_KEY",


### PR DESCRIPTION
Related: #1974

---

Certain slash commands (`/quit`, `/version`, `/model`, `/threads`) can bypass the message queue when the app is busy. The original implementation used a hardcoded `if/elif` chain that would grow with each new bypassable command, stored deferred actions as raw callables with no identity or deduplication, and duplicated the drain guard in three places.

## Changes

- **Declarative command registry** — new `command_registry.py` with a `SlashCommand` dataclass and a single `COMMANDS` tuple as the source of truth. Bypass-tier frozensets, `SLASH_COMMANDS` autocomplete list, and `ALL_CLASSIFIED` test set are all derived automatically. Adding a new command is one entry in `COMMANDS` instead of edits across four files
- **`BypassTier` enum** — `StrEnum` with five members: `ALWAYS`, `CONNECTING`, `IMMEDIATE_UI`, `SIDE_EFFECT_FREE`, `QUEUED`. Each has a per-member docstring explaining when it applies
- **`SIDE_EFFECT_FREE` tier** — `/changelog`, `/docs`, `/feedback`, `/mcp` now fire their side effect immediately (browser open, modal push) even when the agent is running. Chat output (user echo + URL link) is deferred and shown as a queued message indicator until the current task finishes, preventing mid-output injection
- **`DeferredAction` dataclass** — replaces raw callables with `(kind, execute)` pairs. `_defer_action` deduplicates by kind (last-write-wins), so selecting a model twice while busy keeps only the final selection
- **Consolidated drain guard** — `_maybe_drain_deferred` centralizes the `if not self._connecting` check previously duplicated in three call sites
- **Error handling hardening** — drain failures in agent/shell cleanup now show an `ErrorMessage` to the user (previously only logged). `_mount_message` in the drain loop is wrapped in `with suppress(Exception)` so a mount failure can't abort remaining deferred actions