### PR TITLE
fix(cli): isolate test history writes from real history file

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -38,6 +38,15 @@ from deepagents_cli.widgets.history import HistoryManager
 logger = logging.getLogger(__name__)
 
 
+def _default_history_path() -> Path:
+    """Return the default history file path.
+
+    Extracted as a function so tests can monkeypatch it to a temp path,
+    preventing test runs from polluting `~/.deepagents/history.jsonl`.
+    """
+    return Path.home() / ".deepagents" / "history.jsonl"
+
+
 _PASTE_BURST_CHAR_GAP_SECONDS = 0.03
 """Maximum time between chars to treat input as a paste-like burst."""
 
@@ -914,7 +923,7 @@ class ChatInput(Vertical):
 
         # Set up history manager
         if history_file is None:
-            history_file = Path.home() / ".deepagents" / "history.jsonl"
+            history_file = _default_history_path()
         self._history = HistoryManager(history_file)
 
     def compose(self) -> ComposeResult:  # noqa: PLR6301  # Textual widget method convention

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -1,8 +1,14 @@
 """Shared fixtures for CLI unit tests."""
 
+from __future__ import annotations
+
 import contextlib
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -46,3 +52,17 @@ def _clear_langsmith_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "DEEPAGENTS_LANGSMITH_PROJECT",
     ):
         monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect ChatInput history to a temp file.
+
+    Without this, every test that mounts a ``ChatInput`` widget writes to the
+    real ``~/.deepagents/history.jsonl``, causing duplicate/stale entries that
+    persist across test runs and branch switches.
+    """
+    monkeypatch.setattr(
+        "deepagents_cli.widgets.chat_input._default_history_path",
+        lambda: tmp_path / "history.jsonl",
+    )


### PR DESCRIPTION
Test apps in `test_chat_input.py` created `ChatInput` without passing a `history_file`, so every `make test` run appended test entries (`[image 1]`, `!ls`, `!already-prefixed`) to the real `~/.deepagents/history.jsonl`. Deleting the file didn't help — the next test run recreated it with the same duplicated content.

## Changes
- Extract `_default_history_path()` in `chat_input.py` so the default `~/.deepagents/history.jsonl` path is monkeypatchable — `ChatInput.__init__` now calls this instead of inlining `Path.home() / ...`
- Add autouse `_isolate_history` fixture in `conftest.py` that redirects all `ChatInput` history writes to `tmp_path`, preventing any test from touching the real history file