### PR TITLE
fix(infra): resolve module crash blocking external PR enforcement

### DIFF
--- a/.github/scripts/pr-labeler.js
+++ b/.github/scripts/pr-labeler.js
@@ -1,9 +1,7 @@
 // Shared helpers for pr_labeler.yml and tag-external-issues.yml.
 //
 // Usage from actions/github-script (requires actions/checkout first):
-//   const helpers = require('./.github/scripts/pr-labeler.js');
-//   const config = helpers.loadConfig();
-//   const h = helpers.init(github, owner, repo, config);
+//   const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
 const fs = require('fs');
 const path = require('path');
@@ -34,7 +32,10 @@ function loadConfig() {
   return config;
 }
 
-function init(github, owner, repo, config) {
+function init(github, owner, repo, config, core) {
+  if (!core) {
+    throw new Error('init() requires a `core` parameter (e.g., from actions/github-script)');
+  }
   const {
     trustedThreshold,
     labelColor,
@@ -62,7 +63,6 @@ function init(github, owner, repo, config) {
       } catch (createErr) {
         // 422 = label created by a concurrent run between our get and create
         if (createErr.status !== 422) throw createErr;
-        const core = require('@actions/core');
         core.info(`Label "${name}" creation returned 422 (likely already exists)`);
       }
     }
@@ -198,7 +198,6 @@ function init(github, owner, repo, config) {
         mergedCount = result?.data?.total_count ?? null;
       } catch (e) {
         if (e?.status !== 422) throw e;
-        const core = require('@actions/core');
         core.warning(`Search failed for ${author}; skipping tier.`);
       }
     }
@@ -211,7 +210,6 @@ function init(github, owner, repo, config) {
   // ── Tier label resolution ───────────────────────────────────────────
 
   async function applyTierLabel(issueNumber, author, { skipNewContributor = false } = {}) {
-    const core = require('@actions/core');
     let mergedCount;
     try {
       const result = await github.rest.search.issuesAndPullRequests({
@@ -265,9 +263,9 @@ function init(github, owner, repo, config) {
   };
 }
 
-function loadAndInit(github, owner, repo) {
+function loadAndInit(github, owner, repo, core) {
   const config = loadConfig();
-  return { config, h: init(github, owner, repo, config) };
+  return { config, h: init(github, owner, repo, config, core) };
 }
 
 module.exports = { loadConfig, init, loadAndInit };

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -76,7 +76,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const author = context.payload.sender.login;
             const { isExternal } = await h.checkMembership(
@@ -155,7 +155,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const pr = context.payload.pull_request;
             if (!pr) return;
@@ -248,7 +248,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const pr = context.payload.pull_request;
             await h.applyTierLabel(pr.number, pr.user.login);
@@ -263,7 +263,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const prNumber = context.payload.pull_request.number;
             await h.ensureLabel('external');

--- a/.github/workflows/pr_labeler_backfill.yml
+++ b/.github/workflows/pr_labeler_backfill.yml
@@ -48,7 +48,7 @@ jobs:
               return;
             }
 
-            const { config, h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { config, h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             for (const name of [...h.sizeLabels, ...h.tierLabels]) {
               await h.ensureLabel(name);

--- a/.github/workflows/tag-external-issues.yml
+++ b/.github/workflows/tag-external-issues.yml
@@ -66,7 +66,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const author = context.payload.sender.login;
             const { isExternal } = await h.checkMembership(
@@ -84,7 +84,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const issue = context.payload.issue;
             // new-contributor is only meaningful on PRs, not issues
@@ -99,7 +99,7 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.issue.number;
 
-            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const label = '${{ steps.check-membership.outputs.is-external }}' === 'true'
               ? 'external' : 'internal';
@@ -139,7 +139,7 @@ jobs:
               return;
             }
 
-            const { config, h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo);
+            const { config, h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
 
             const tierLabels = ['trusted-contributor'];
             for (const name of tierLabels) {


### PR DESCRIPTION
`pr-labeler.js` used `require('@actions/core')` to access GitHub Actions logging helpers, but that module is bundled inside `actions/github-script`'s dist — not resolvable via Node's `require()` from a checked-out file on disk. The `applyTierLabel` call site hit this unconditionally, crashing the tier-label step on every external PR. Because that step runs before the "add external label" step, the crash prevented the `external` label from ever being applied — which meant `require_issue_link.yml` never triggered and unapproved external PRs stayed open.

Ported from langchain-ai/langchain#36059.

## Changes
- Thread the `core` object (provided by `actions/github-script` at eval time) through `loadAndInit()` → `init()` instead of calling `require('@actions/core')` from the checked-out script — fixes the `MODULE_NOT_FOUND` crash on all three call sites (`ensureLabel`, `getContributorInfo`, `applyTierLabel`)
- Add a fail-fast guard in `init()` for missing `core` to surface a clear error instead of an opaque `TypeError`
- Update all 10 `loadAndInit(github, owner, repo)` call sites across `pr_labeler.yml`, `pr_labeler_backfill.yml`, and `tag-external-issues.yml` to pass `core`