### PR TITLE
fix(cli): pre-flight health checks for MCP servers

### DIFF
--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,7 +30,10 @@ class MCPToolInfo:
     """Metadata for a single MCP tool."""
 
     name: str
+    """Tool name (may include server name prefix)."""
+
     description: str
+    """Human-readable description of what the tool does."""
 
 
 @dataclass
@@ -37,8 +41,13 @@ class MCPServerInfo:
     """Metadata for a connected MCP server and its tools."""
 
     name: str
+    """Server name from the MCP configuration."""
+
     transport: str
+    """Transport type (`stdio`, `sse`, or `http`)."""
+
     tools: list[MCPToolInfo] = field(default_factory=list)
+    """Tools exposed by this server."""
 
 
 _SUPPORTED_REMOTE_TYPES = {"sse", "http"}
@@ -361,6 +370,54 @@ class MCPSessionManager:
         await self.exit_stack.aclose()
 
 
+def _check_stdio_server(server_name: str, server_config: dict[str, Any]) -> None:
+    """Verify that a stdio server's command exists on PATH.
+
+    Args:
+        server_name: Name of the server (for error messages).
+        server_config: Server configuration dictionary with `command` key.
+
+    Raises:
+        RuntimeError: If the command is not found on PATH.
+    """
+    command = server_config["command"]
+    if shutil.which(command) is None:
+        msg = (
+            f"MCP server '{server_name}': command '{command}' not found on PATH. "
+            "Install it or check your MCP config."
+        )
+        raise RuntimeError(msg)
+
+
+async def _check_remote_server(server_name: str, server_config: dict[str, Any]) -> None:
+    """Check network connectivity to a remote MCP server URL.
+
+    Sends a lightweight HEAD request with a 2-second timeout to detect DNS
+    failures, refused connections, and network timeouts early, before the MCP
+    session handshake. HTTP error responses (4xx, 5xx) are not treated as
+    failures — only transport-level errors raise.
+
+    Args:
+        server_name: Name of the server (for error messages).
+        server_config: Server configuration dictionary with `url` key.
+
+    Raises:
+        RuntimeError: If the server URL is unreachable.
+    """
+    import httpx
+
+    url = server_config["url"]
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.head(url, timeout=2)
+    except (httpx.TransportError, httpx.InvalidURL, OSError) as exc:
+        msg = (
+            f"MCP server '{server_name}': URL '{url}' is unreachable: {exc}. "
+            "Check that the URL is correct and the server is running."
+        )
+        raise RuntimeError(msg) from exc
+
+
 async def _load_tools_from_config(
     config: dict[str, Any],
 ) -> tuple[list[BaseTool], MCPSessionManager, list[MCPServerInfo]]:
@@ -385,6 +442,14 @@ async def _load_tools_from_config(
         StreamableHttpConnection,
     )
     from langchain_mcp_adapters.tools import load_mcp_tools
+
+    # Pre-flight health checks (before allocating any resources)
+    for server_name, server_config in config["mcpServers"].items():
+        server_type = _resolve_server_type(server_config)
+        if server_type in _SUPPORTED_REMOTE_TYPES:
+            await _check_remote_server(server_name, server_config)
+        else:
+            _check_stdio_server(server_name, server_config)
 
     # Create connections dict for MultiServerMCPClient
     # Convert Claude Desktop format to langchain-mcp-adapters format

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -1,7 +1,7 @@
 """Tests for MCP tools configuration loading and validation."""
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,6 +11,8 @@ from deepagents_cli.mcp_tools import (
     MCPServerInfo,
     MCPSessionManager,
     MCPToolInfo,
+    _check_remote_server,
+    _check_stdio_server,
     _filter_project_stdio_servers,
     classify_discovered_configs,
     discover_mcp_configs,
@@ -447,6 +449,18 @@ class TestLoadMCPConfig:
 
 class TestGetMCPTools:
     """Test MCP tools loading from configuration."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_health_checks(self) -> Generator[None]:
+        """Bypass pre-flight health checks for all tests in this class."""
+        with (
+            patch("deepagents_cli.mcp_tools._check_stdio_server"),
+            patch(
+                "deepagents_cli.mcp_tools._check_remote_server",
+                new_callable=AsyncMock,
+            ),
+        ):
+            yield
 
     @patch("langchain_mcp_adapters.tools.load_mcp_tools")
     @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
@@ -1441,3 +1455,112 @@ class TestFilterProjectStdioServers:
         config = {"mcpServers": {"a": {"command": "x", "args": []}}}
         result = _filter_project_stdio_servers(config)
         assert result["mcpServers"] == {}
+
+
+class TestCheckStdioServer:
+    """Tests for _check_stdio_server pre-flight validation."""
+
+    def test_command_not_found(self) -> None:
+        """Raises RuntimeError with server name and command when missing."""
+        with (
+            patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
+            pytest.raises(
+                RuntimeError,
+                match="MCP server 'test-server': command 'nonexistent' not found",
+            ),
+        ):
+            _check_stdio_server("test-server", {"command": "nonexistent"})
+
+    def test_command_exists(self) -> None:
+        """No error when command exists on PATH."""
+        with patch(
+            "deepagents_cli.mcp_tools.shutil.which", return_value="/usr/bin/npx"
+        ):
+            _check_stdio_server("test-server", {"command": "npx"})
+
+
+class TestCheckRemoteServer:
+    """Tests for _check_remote_server pre-flight validation."""
+
+    async def test_unreachable(self) -> None:
+        """Raises RuntimeError when URL is unreachable."""
+        import httpx
+
+        mock_client = AsyncMock()
+        mock_client.head.side_effect = httpx.TransportError("connection refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(RuntimeError, match="unreachable"),
+        ):
+            await _check_remote_server("test-server", {"url": "http://localhost:9999"})
+
+    async def test_reachable(self) -> None:
+        """No error when URL responds."""
+        mock_client = AsyncMock()
+        mock_client.head = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await _check_remote_server("test-server", {"url": "http://localhost:8080"})
+
+        mock_client.head.assert_awaited_once_with("http://localhost:8080", timeout=2)
+
+    async def test_unreachable_os_error(self) -> None:
+        """Raises RuntimeError on OS-level socket errors."""
+        mock_client = AsyncMock()
+        mock_client.head.side_effect = OSError("Network is unreachable")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(RuntimeError, match="unreachable"),
+        ):
+            await _check_remote_server(
+                "test-server", {"url": "http://10.255.255.1:9999"}
+            )
+
+    async def test_invalid_url(self) -> None:
+        """Raises RuntimeError on malformed URLs."""
+        import httpx
+
+        mock_client = AsyncMock()
+        mock_client.head.side_effect = httpx.InvalidURL("Invalid URL")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(RuntimeError, match="unreachable"),
+        ):
+            await _check_remote_server("test-server", {"url": "http://"})
+
+
+class TestHealthCheckIntegration:
+    """Tests for health check integration in _load_tools_from_config."""
+
+    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
+    async def test_stdio_health_check_failure_skips_session(
+        self,
+        mock_client_class: MagicMock,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Health check failure cleans up and does not call client.session()."""
+        path = write_config(
+            {"mcpServers": {"fs": {"command": "missing-cmd", "args": []}}}
+        )
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        with (
+            patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
+            pytest.raises(RuntimeError, match="not found on PATH"),
+        ):
+            await get_mcp_tools(path)
+
+        # session() should never be called — health check fails first
+        mock_client.session.assert_not_called()


### PR DESCRIPTION
Fixes #1776

---

Pre-flight health checks in `_load_tools_from_config` catch missing binaries and unreachable URLs before the MCP session handshake, turning hangs into immediate `RuntimeError` with actionable diagnostics. Stdio servers are validated with `shutil.which`; remote servers get a HEAD probe with a 2-second timeout.

## Changes
- Add `_check_stdio_server` — verifies the configured `command` exists on PATH via `shutil.which`, raises `RuntimeError` naming the server and command if not found
- Add `_check_remote_server` — sends `httpx.AsyncClient.head()` with a 2-second timeout; catches `TransportError`, `InvalidURL`, and `OSError` to surface connectivity failures early (HTTP 4xx/5xx intentionally pass — this is a connectivity check, not an application health check)
- Run both checks in an upfront loop inside `_load_tools_from_config` *before* constructing `MultiServerMCPClient` or opening any sessions, so failures are clean and no resources leak
- `httpx` import is deferred inside `_check_remote_server` to preserve CLI startup performance
