### PR TITLE
fix(sdk): preserve context schema typing in `create_deep_agent`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -1,11 +1,11 @@
 """Deep Agents come with planning, filesystem, and subagents."""
 
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from typing import Any
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware, ResponseT
+from langchain.agents.middleware.types import AgentMiddleware, ContextT, ResponseT
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
@@ -32,8 +32,6 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
-
-ContextT = TypeVar("ContextT")
 
 BASE_AGENT_PROMPT = """You are a Deep Agent, an AI assistant that helps users accomplish tasks using tools. You respond with text and tool calls. The user can see your responses and tool outputs in real time.
 


### PR DESCRIPTION
## Summary
- preserve the runtime context type in `create_deep_agent`'s `context_schema` signature
- return a parameterized `CompiledStateGraph` so type checkers infer `invoke(..., context=...)` correctly
- keep runtime behavior unchanged

## Testing
- python3 -m py_compile libs/deepagents/deepagents/graph.py

Closes #1778