### PR TITLE
fix(cli): pass `is_preview` to `_format_single_todo` to allow full content on expand

### DIFF
--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -858,7 +858,10 @@ class ToolCallMessage(Vertical):
         return Content.styled(" | ", "dim").join(parts) if parts else Content("")
 
     def _format_single_todo(  # noqa: PLR6301
-        self, item: dict | str, *, is_preview: bool = True,
+        self,
+        item: dict | str,
+        *,
+        is_preview: bool = True,
     ) -> Content:
         """Format a single todo item.
 

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -805,7 +805,7 @@ class ToolCallMessage(Vertical):
             lines.extend([Content.assemble("    ", stats), Content("")])
 
         # Format each item
-        lines.extend(self._format_single_todo(item) for item in items[:max_items])
+        lines.extend(self._format_single_todo(item, is_preview=is_preview) for item in items[:max_items])
 
         truncation = None
         if is_preview and len(items) > max_items:
@@ -854,8 +854,12 @@ class ToolCallMessage(Vertical):
             parts.append(Content.styled(f"{completed} done", "green"))
         return Content.styled(" | ", "dim").join(parts) if parts else Content("")
 
-    def _format_single_todo(self, item: dict | str) -> Content:  # noqa: PLR6301  # Grouped as method for widget cohesion
+    def _format_single_todo(self, item: dict | str, *, is_preview: bool = True) -> Content:  # noqa: PLR6301  # Grouped as method for widget cohesion
         """Format a single todo item.
+
+        Args:
+            item: Todo item dict or string.
+            is_preview: Truncate content at ``_MAX_TODO_CONTENT_LEN`` when True.
 
         Returns:
             Styled `Content` with checkbox and status styling.
@@ -867,7 +871,7 @@ class ToolCallMessage(Vertical):
             text = str(item)
             status = "pending"
 
-        if len(text) > _MAX_TODO_CONTENT_LEN:
+        if is_preview and len(text) > _MAX_TODO_CONTENT_LEN:
             text = text[: _MAX_TODO_CONTENT_LEN - 3] + "..."
 
         glyphs = get_glyphs()

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -805,7 +805,10 @@ class ToolCallMessage(Vertical):
             lines.extend([Content.assemble("    ", stats), Content("")])
 
         # Format each item
-        lines.extend(self._format_single_todo(item, is_preview=is_preview) for item in items[:max_items])
+        lines.extend(
+            self._format_single_todo(item, is_preview=is_preview)
+            for item in items[:max_items]
+        )
 
         truncation = None
         if is_preview and len(items) > max_items:
@@ -854,7 +857,9 @@ class ToolCallMessage(Vertical):
             parts.append(Content.styled(f"{completed} done", "green"))
         return Content.styled(" | ", "dim").join(parts) if parts else Content("")
 
-    def _format_single_todo(self, item: dict | str, *, is_preview: bool = True) -> Content:  # noqa: PLR6301  # Grouped as method for widget cohesion
+    def _format_single_todo(  # noqa: PLR6301
+        self, item: dict | str, *, is_preview: bool = True,
+    ) -> Content:
         """Format a single todo item.
 
         Args:


### PR DESCRIPTION
## Summary

`_format_single_todo()` unconditionally truncates todo content at 70 characters (`_MAX_TODO_CONTENT_LEN`) regardless of whether the widget is in collapsed (preview) or expanded state. Clicking "expand" on the todo output shows the same truncated text, making long todo items unreadable.

## Problem

The issue reports that todo items are unreadable when expanded. Other formatters in the same file (`_format_ls_output`, `_format_shell_output`, `_format_file_output`, `_format_search_output`) all correctly use `is_preview` to vary content length — `_format_single_todo` was the only one that did not.

**Root cause**: `_format_single_todo()` has no `is_preview` parameter and always truncates.

## Fix

1. Add `is_preview` keyword parameter (default `True` for backward compatibility)
2. Only truncate at 70 chars when `is_preview=True`
3. Pass `is_preview` from `_format_todos_output()` to each `_format_single_todo()` call

## Before / After

**Before (collapsed and expanded show the same truncated text):**
```
☐ Implement the user authentication flow including JWT token validat...
```
Expanding shows the exact same truncated line — the full content is lost.

**After (collapsed truncates, expanded shows full text):**

Collapsed:
```
☐ Implement the user authentication flow including JWT token validat...
```
Expanded:
```
☐ Implement the user authentication flow including JWT token validation, refresh token rotation, and session management with Redis backing store
```

## Testing

- Existing `_format_todos_output` behavior preserved for preview mode
- Expanded mode now shows complete todo text
- CI lint (E501) resolved in follow-up commit

Closes #1403