### PR TITLE
fix(cli): middle truncation instead of basename for long paths in tool display

### DIFF
--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -119,6 +119,9 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
     def abbreviate_path(path_str: str, max_length: int = 60) -> str:
         """Abbreviate a file path intelligently - show basename or relative path.
 
+        For long paths, uses middle truncation to preserve both leading directory
+        context and the filename, avoiding ambiguity in monorepos/worktrees.
+
         Returns:
             Shortened path string suitable for display.
         """
@@ -146,8 +149,15 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
         except Exception:  # noqa: BLE001  # Fallback to original string on any path resolution error
             return truncate_value(path_str, max_length)
         else:
-            # Otherwise, just show basename (filename only)
-            return path.name
+            # Middle-truncate to keep leading context and filename visible
+            name = path.name
+            if len(name) >= max_length - 4:
+                return name
+            budget = max_length - len(name) - 4  # 4 chars for "/…/"
+            parent_str = str(path.parent)
+            if budget > 0 and len(parent_str) > budget:
+                return parent_str[:budget] + "/\u2026/" + name
+            return parent_str + "/" + name
 
     # Tool-specific formatting - show the most important argument(s)
     if tool_name in {"read_file", "write_file", "edit_file"}:


### PR DESCRIPTION
## Summary

`abbreviate_path()` drops all directory context for long paths by falling back to `path.name` (basename only), making tool display ambiguous in monorepos and worktrees where multiple packages contain identically named files.

## Problem

When a file path exceeds 60 characters, the current implementation falls through to:
```python
return path.name  # e.g., "config.py"
```

In a monorepo like:
```
packages/frontend/src/config.py
packages/backend/src/config.py
```

Both display as just `config.py`, making it impossible to tell which file is being edited.

## Fix

Replace the basename-only fallback with middle truncation that preserves both leading directory context and the filename:

```
/home/user/project/packages/frontend/src/config.py  →  /home/user/proj/…/config.py
```

The truncation allocates available space to the parent directory prefix (truncated with `…`) and always shows the full filename. Short paths and paths within `max_length` are unaffected.

## Testing

- Short paths: unchanged behavior
- Relative paths: unchanged (still preferred when shorter)
- Long absolute paths: now show `parent_prefix/…/filename` instead of just `filename`
- Edge case (filename alone exceeds limit): falls back to basename

Closes #1142