### PR TITLE
fix(sdk): support bare store keys in root listing

### DIFF
--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -352,12 +352,16 @@ class StoreBackend(BackendProtocol):
         normalized_path = path if path.endswith("/") else path + "/"
 
         for item in items:
+            normalized_key = str(item.key)
+            if not normalized_key.startswith("/"):
+                normalized_key = "/" + normalized_key
+
             # Check if file is in the specified directory or a subdirectory
-            if not str(item.key).startswith(normalized_path):
+            if not normalized_key.startswith(normalized_path):
                 continue
 
             # Get the relative path after the directory
-            relative = str(item.key)[len(normalized_path) :]
+            relative = normalized_key[len(normalized_path) :]
 
             # If relative path contains '/', it's in a subdirectory
             if "/" in relative:
@@ -376,7 +380,7 @@ class StoreBackend(BackendProtocol):
             size = len("\n".join(raw)) if isinstance(raw, list) else len(raw)
             infos.append(
                 {
-                    "path": item.key,
+                    "path": normalized_key,
                     "is_dir": False,
                     "size": int(size),
                     "modified_at": fd.get("modified_at", ""),

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -128,6 +128,36 @@ def test_store_backend_ls_trailing_slash():
     assert [fi["path"] for fi in listing1] == [fi["path"] for fi in listing2]
 
 
+def test_store_backend_ls_root_handles_bare_store_keys() -> None:
+    rt = make_runtime()
+    be = StoreBackend(rt, namespace=lambda _ctx: ("filesystem",))
+
+    bare_items = {
+        "test.md": "root file",
+        "notes/todo.md": "nested file",
+    }
+
+    for key, content in bare_items.items():
+        rt.store.put(
+            ("filesystem",),
+            key,
+            {
+                "content": content,
+                "encoding": "utf-8",
+                "created_at": "2026-03-18T00:00:00Z",
+                "modified_at": "2026-03-18T00:00:00Z",
+            },
+        )
+
+    listing = be.ls("/").entries
+    assert listing is not None
+
+    paths = [entry["path"] for entry in listing]
+    assert "/test.md" in paths
+    assert "/notes/" in paths
+    assert "/notes/todo.md" not in paths
+
+
 @pytest.mark.parametrize("file_format", ["v1", "v2"])
 def test_store_backend_intercept_large_tool_result(file_format):
     """Test that StoreBackend properly handles large tool result interception."""


### PR DESCRIPTION
Fixes #1655

Normalize bare store keys inside `StoreBackend.ls()` so root listings include direct files even when the underlying store omits a leading slash. Added a focused regression test covering bare root keys and preserving nested directory behavior.

How I verified this works:
- `PATH="$PWD/.condaenv/bin:$PATH" PYTHONPATH="$PWD/libs/deepagents:$PYTHONPATH" ./.condaenv/bin/python -m pytest libs/deepagents/tests/unit_tests/backends/test_store_backend.py -q`

AI assistance disclaimer: I used AI assistance to help draft and implement this small patch, then reviewed the resulting changes and test coverage before opening the PR.