### PR TITLE
fix(cli): harden MCP pre-flight health checks

### DIFF
--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -378,9 +378,12 @@ def _check_stdio_server(server_name: str, server_config: dict[str, Any]) -> None
         server_config: Server configuration dictionary with `command` key.
 
     Raises:
-        RuntimeError: If the command is not found on PATH.
+        RuntimeError: If the command is missing from config or not found on PATH.
     """
-    command = server_config["command"]
+    command = server_config.get("command")
+    if command is None:
+        msg = f"MCP server '{server_name}': missing 'command' in config."
+        raise RuntimeError(msg)
     if shutil.which(command) is None:
         msg = (
             f"MCP server '{server_name}': command '{command}' not found on PATH. "
@@ -395,18 +398,22 @@ async def _check_remote_server(server_name: str, server_config: dict[str, Any]) 
     Sends a lightweight HEAD request with a 2-second timeout to detect DNS
     failures, refused connections, and network timeouts early, before the MCP
     session handshake. HTTP error responses (4xx, 5xx) are not treated as
-    failures — only transport-level errors raise.
+    failures — only transport errors, invalid URLs, and OS-level socket
+    errors raise.
 
     Args:
         server_name: Name of the server (for error messages).
         server_config: Server configuration dictionary with `url` key.
 
     Raises:
-        RuntimeError: If the server URL is unreachable.
+        RuntimeError: If the server URL is unreachable or invalid.
     """
     import httpx
 
-    url = server_config["url"]
+    url = server_config.get("url")
+    if url is None:
+        msg = f"MCP server '{server_name}': missing 'url' in config."
+        raise RuntimeError(msg)
     try:
         async with httpx.AsyncClient() as client:
             await client.head(url, timeout=2)
@@ -443,13 +450,23 @@ async def _load_tools_from_config(
     )
     from langchain_mcp_adapters.tools import load_mcp_tools
 
-    # Pre-flight health checks (before allocating any resources)
+    # Pre-flight health checks (best-effort early detection; the session setup
+    # below has its own error handling for TOCTOU races).
+    errors: list[str] = []
     for server_name, server_config in config["mcpServers"].items():
         server_type = _resolve_server_type(server_config)
-        if server_type in _SUPPORTED_REMOTE_TYPES:
-            await _check_remote_server(server_name, server_config)
-        else:
-            _check_stdio_server(server_name, server_config)
+        try:
+            if server_type in _SUPPORTED_REMOTE_TYPES:
+                await _check_remote_server(server_name, server_config)
+            elif server_type == "stdio":
+                _check_stdio_server(server_name, server_config)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+    if errors:
+        msg = "Pre-flight health check(s) failed:\n" + "\n".join(
+            f"  - {e}" for e in errors
+        )
+        raise RuntimeError(msg)
 
     # Create connections dict for MultiServerMCPClient
     # Convert Claude Desktop format to langchain-mcp-adapters format

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -1478,6 +1478,11 @@ class TestCheckStdioServer:
         ):
             _check_stdio_server("test-server", {"command": "npx"})
 
+    def test_missing_command_key(self) -> None:
+        """Raises RuntimeError when config lacks `command` key."""
+        with pytest.raises(RuntimeError, match="missing 'command' in config"):
+            _check_stdio_server("test-server", {})
+
 
 class TestCheckRemoteServer:
     """Tests for _check_remote_server pre-flight validation."""
@@ -1539,6 +1544,26 @@ class TestCheckRemoteServer:
         ):
             await _check_remote_server("test-server", {"url": "http://"})
 
+    async def test_missing_url_key(self) -> None:
+        """Raises RuntimeError when config lacks `url` key."""
+        with pytest.raises(RuntimeError, match="missing 'url' in config"):
+            await _check_remote_server("test-server", {})
+
+    async def test_timeout(self) -> None:
+        """Raises RuntimeError on connection timeout."""
+        import httpx
+
+        mock_client = AsyncMock()
+        mock_client.head.side_effect = httpx.TimeoutException("timed out")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(RuntimeError, match="unreachable"),
+        ):
+            await _check_remote_server("test-server", {"url": "http://slow:8080"})
+
 
 class TestHealthCheckIntegration:
     """Tests for health check integration in _load_tools_from_config."""
@@ -1558,9 +1583,103 @@ class TestHealthCheckIntegration:
 
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
-            pytest.raises(RuntimeError, match="not found on PATH"),
+            pytest.raises(RuntimeError, match="Pre-flight health check"),
         ):
             await get_mcp_tools(path)
 
         # session() should never be called — health check fails first
         mock_client.session.assert_not_called()
+
+    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
+    async def test_remote_health_check_failure_skips_session(
+        self,
+        mock_client_class: MagicMock,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Remote health check failure prevents session creation."""
+        import httpx
+
+        path = write_config(
+            {"mcpServers": {"api": {"type": "sse", "url": "http://down:9999"}}}
+        )
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_http = AsyncMock()
+        mock_http.head.side_effect = httpx.TransportError("refused")
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_http),
+            pytest.raises(RuntimeError, match="Pre-flight health check"),
+        ):
+            await get_mcp_tools(path)
+
+        mock_client.session.assert_not_called()
+
+    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
+    async def test_multi_server_collects_all_failures(
+        self,
+        mock_client_class: MagicMock,
+        write_config: Callable[..., str],
+    ) -> None:
+        """All server failures are reported in a single error."""
+        path = write_config(
+            {
+                "mcpServers": {
+                    "a": {"command": "missing-a", "args": []},
+                    "b": {"command": "missing-b", "args": []},
+                }
+            }
+        )
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        with (
+            patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            await get_mcp_tools(path)
+
+        error_msg = str(exc_info.value)
+        assert "missing-a" in error_msg
+        assert "missing-b" in error_msg
+        mock_client.session.assert_not_called()
+
+    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
+    async def test_mixed_stdio_and_remote_checks(
+        self,
+        mock_client_class: MagicMock,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Both stdio and remote health checks run for mixed configs."""
+        import httpx
+
+        path = write_config(
+            {
+                "mcpServers": {
+                    "local": {"command": "missing-cmd", "args": []},
+                    "remote": {"type": "sse", "url": "http://down:9999"},
+                }
+            }
+        )
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_http = AsyncMock()
+        mock_http.head.side_effect = httpx.TransportError("refused")
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
+            patch("httpx.AsyncClient", return_value=mock_http),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            await get_mcp_tools(path)
+
+        # Both failures appear in the error message
+        error_msg = str(exc_info.value)
+        assert "missing-cmd" in error_msg
+        assert "down:9999" in error_msg


### PR DESCRIPTION
Follow-up to #2008. The pre-flight health checks introduced there failed fast on the first broken server and would throw a bare `KeyError` if a config was missing `command` or `url` keys. This hardens the checks: collect all failures into a single error message, guard against missing config keys, and fix an inaccurate docstring.

## Changes
- `_load_tools_from_config` now collects all health check failures and raises a single `RuntimeError` listing every broken server, instead of aborting on the first one
- `_check_stdio_server` and `_check_remote_server` use `.get()` with an explicit guard for missing `command`/`url` keys — raises a clear `RuntimeError` instead of a bare `KeyError`
- Health check dispatch uses explicit `elif server_type == "stdio"` instead of a catch-all `else`, so unknown transport types are silently skipped rather than misrouted to the stdio check
- Fix `_check_remote_server` docstring: the except clause catches `httpx.TransportError`, `httpx.InvalidURL`, and `OSError` — not just "transport-level errors"