### PR TITLE
fix(cli): eliminate autocomplete popup flicker

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from pathlib import Path
@@ -162,6 +163,16 @@ class CompletionOption(Static):
             self._is_selected = selected
             self._update_display()
 
+    def set_content(
+        self, label: str, description: str, index: int, *, is_selected: bool
+    ) -> None:
+        """Replace label, description, index, and selection in-place."""
+        self._label = label
+        self._description = description
+        self._index = index
+        self._is_selected = is_selected
+        self._update_display()
+
     def on_click(self, event: Click) -> None:
         """Handle click on this option."""
         event.stop()
@@ -193,6 +204,9 @@ class CompletionPopup(VerticalScroll):
         self.can_focus = False
         self._options: list[CompletionOption] = []
         self._selected_index = 0
+        self._pending_suggestions: list[tuple[str, str]] = []
+        self._pending_selected: int = 0
+        self._rebuild_generation: int = 0
 
     def update_suggestions(
         self, suggestions: list[tuple[str, str]], selected_index: int
@@ -203,41 +217,82 @@ class CompletionPopup(VerticalScroll):
             return
 
         self._selected_index = selected_index
-        # Store pending update and schedule async rebuild
         self._pending_suggestions = suggestions
         self._pending_selected = selected_index
-        self.call_after_refresh(self._rebuild_options)
-        self.show()
+        # Increment generation so stale callbacks from prior calls are skipped.
+        self._rebuild_generation += 1
+        gen = self._rebuild_generation
+        # show() deferred to _rebuild_options to avoid a flash of stale content.
+        self.call_after_refresh(lambda: self._rebuild_options(gen))
 
-    async def _rebuild_options(self) -> None:
-        """Rebuild option widgets from pending suggestions."""
-        suggestions = getattr(self, "_pending_suggestions", [])
-        selected_index = getattr(self, "_pending_selected", 0)
+    async def _rebuild_options(self, generation: int) -> None:
+        """Rebuild option widgets from pending suggestions.
 
-        if not suggestions:
+        Reuses existing DOM nodes where possible to avoid flicker from
+        a full teardown/mount cycle while the popup is visible.
+
+        Args:
+            generation: Caller's generation counter; skipped if superseded.
+        """
+        if generation != self._rebuild_generation:
             return
 
-        # Remove existing options
-        await self.remove_children()
-        self._options.clear()
+        suggestions = self._pending_suggestions
+        selected_index = self._pending_selected
 
-        # Create new options
-        for idx, (label, description) in enumerate(suggestions):
-            option = CompletionOption(
-                label=label,
-                description=description,
-                index=idx,
-                is_selected=(idx == selected_index),
+        if not suggestions:
+            self.hide()
+            return
+
+        existing = len(self._options)
+        needed = len(suggestions)
+
+        # Update existing widgets in-place
+        for i in range(min(existing, needed)):
+            label, desc = suggestions[i]
+            self._options[i].set_content(
+                label, desc, i, is_selected=(i == selected_index)
             )
-            self._options.append(option)
-            await self.mount(option)
 
-        # Scroll selected option into view
+        # DOM mutations: trim extras / mount new widgets
+        try:
+            if existing > needed:
+                for option in self._options[needed:]:
+                    await option.remove()
+                del self._options[needed:]
+
+            if needed > existing:
+                new_widgets: list[CompletionOption] = []
+                for idx in range(existing, needed):
+                    label, desc = suggestions[idx]
+                    option = CompletionOption(
+                        label=label,
+                        description=desc,
+                        index=idx,
+                        is_selected=(idx == selected_index),
+                    )
+                    new_widgets.append(option)
+                self._options.extend(new_widgets)
+                await self.mount(*new_widgets)
+        except Exception:
+            logger.exception("Failed to rebuild completion popup; hiding to recover")
+            self._options = []
+            with contextlib.suppress(Exception):
+                await self.remove_children()
+            self.hide()
+            return
+
+        self.show()
+
         if 0 <= selected_index < len(self._options):
             self._options[selected_index].scroll_visible()
 
     def update_selection(self, selected_index: int) -> None:
         """Update which option is selected without rebuilding the list."""
+        # Keep pending state in sync so an in-flight _rebuild_options uses
+        # the latest selection.
+        self._pending_selected = selected_index
+
         if self._selected_index == selected_index:
             return
 
@@ -259,6 +314,7 @@ class CompletionPopup(VerticalScroll):
     def hide(self) -> None:
         """Hide the popup."""
         self._pending_suggestions = []
+        self._rebuild_generation += 1  # Cancel any in-flight rebuild
         self.styles.display = "none"  # type: ignore[assignment]  # Textual accepts string display values at runtime
 
     def show(self) -> None:
@@ -1689,12 +1745,16 @@ class ChatInput(Vertical):
         self, suggestions: list[tuple[str, str]], selected_index: int
     ) -> None:
         """Render completion suggestions in the popup."""
-        # Track suggestions locally for click handling
+        prev_suggestions = self._current_suggestions
         self._current_suggestions = suggestions
         self._current_selected_index = selected_index
 
         if self._popup:
-            self._popup.update_suggestions(suggestions, selected_index)
+            # If only the selection changed (same items), skip full rebuild
+            if suggestions == prev_suggestions:
+                self._popup.update_selection(selected_index)
+            else:
+                self._popup.update_suggestions(suggestions, selected_index)
         # Tell TextArea that completion is active so it yields navigation keys
         if self._text_area:
             self._text_area.set_completion_active(active=bool(suggestions))


### PR DESCRIPTION
The autocomplete popup in `CompletionPopup` flickered on first render and when switching between `@`/`/` modes. The old code called `show()` before option widgets were mounted (empty frame), tore down and rebuilt the entire DOM on every keystroke, and mounted widgets one at a time in a loop. Each of these caused a visible frame of stale or empty content.

## Changes

- Defer `CompletionPopup.show()` from `update_suggestions` into `_rebuild_options`, after widgets are mounted — eliminates the empty-frame flash when the popup first appears or reappears after a mode switch
- Reuse existing `CompletionOption` DOM nodes via new `set_content()` method instead of `remove_children()` + remount — only `option.remove()` or `mount()` when the list size changes, so the common case (typing more characters) is zero DOM mutations
- Add a generation counter (`_rebuild_generation`) to `update_suggestions` / `_rebuild_options` so stale `call_after_refresh` callbacks from rapid typing are skipped; `hide()` also bumps the counter to explicitly cancel in-flight rebuilds
- Skip full rebuild when only the selection index changed — `render_completion_suggestions` compares `suggestions == prev_suggestions` and routes to `update_selection` (CSS class swap) instead of `update_suggestions`
- Scope the `except Exception` handler to DOM mutations only (not the pure-Python `set_content` loop), and use `remove_children()` in recovery to prevent orphaned widgets
