### PR TITLE
fix(cli): load `.env.local` alongside `.env`

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -28,25 +28,29 @@ from deepagents_cli.project_utils import (
 logger = logging.getLogger(__name__)
 
 
-def _find_dotenv_from_start_path(start_path: Path) -> Path | None:
-    """Find the nearest `.env` file from an explicit start path upward.
+def _find_dotenv_files_from_start_path(start_path: Path) -> list[Path]:
+    """Find the nearest `.env` / `.env.local` files from a start path upward.
 
     Args:
         start_path: Directory to start searching from.
 
     Returns:
-        Path to the nearest `.env` file, or `None` if not found.
+        Ordered dotenv files from the nearest matching directory.
     """
     current = start_path.expanduser().resolve()
     for parent in [current, *list(current.parents)]:
-        candidate = parent / ".env"
-        try:
-            if candidate.is_file():
-                return candidate
-        except OSError:
-            logger.warning("Could not inspect .env candidate %s", candidate)
-            return None
-    return None
+        candidates = [parent / ".env", parent / ".env.local"]
+        existing: list[Path] = []
+        for candidate in candidates:
+            try:
+                if candidate.is_file():
+                    existing.append(candidate)
+            except OSError:
+                logger.warning("Could not inspect .env candidate %s", candidate)
+                return []
+        if existing:
+            return existing
+    return []
 
 
 def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> bool:
@@ -60,12 +64,27 @@ def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> b
         `True` when a dotenv file was loaded, `False` otherwise.
     """
     if start_path is None:
-        return dotenv.load_dotenv(override=override)
+        loaded = False
+        for candidate in (Path(".env"), Path(".env.local")):
+            try:
+                if candidate.is_file():
+                    loaded = (
+                        dotenv.load_dotenv(dotenv_path=candidate, override=override)
+                        or loaded
+                    )
+            except OSError:
+                logger.warning("Could not inspect .env candidate %s", candidate)
+                return loaded
+        return loaded or dotenv.load_dotenv(override=override)
 
-    dotenv_path = _find_dotenv_from_start_path(start_path)
-    if dotenv_path is None:
+    dotenv_paths = _find_dotenv_files_from_start_path(start_path)
+    if not dotenv_paths:
         return False
-    return dotenv.load_dotenv(dotenv_path=dotenv_path, override=override)
+
+    loaded = False
+    for dotenv_path in dotenv_paths:
+        loaded = dotenv.load_dotenv(dotenv_path=dotenv_path, override=override) or loaded
+    return loaded
 
 
 _bootstrap_project_context = _get_server_project_context()

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -1,7 +1,7 @@
 """Tests for runtime config reload behavior."""
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -137,16 +137,35 @@ class TestReloadFromEnvironment:
     def test_calls_dotenv_load(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Reload should anchor dotenv loading to the explicit start path."""
+        """Reload should anchor dotenv loading to explicit `.env` files."""
         settings = Settings.from_environment(start_path=tmp_path)
         mock_load = MagicMock(return_value=False)
         env_file = tmp_path / ".env"
+        env_local_file = tmp_path / ".env.local"
         env_file.write_text("OPENAI_API_KEY=sk-test\n")
+        env_local_file.write_text("LANGSMITH_TRACING=true\n")
         monkeypatch.setattr("deepagents_cli.config.dotenv.load_dotenv", mock_load)
 
         settings.reload_from_environment(start_path=tmp_path)
 
-        mock_load.assert_called_once_with(dotenv_path=env_file, override=True)
+        assert mock_load.call_args_list == [
+            call(dotenv_path=env_file, override=True),
+            call(dotenv_path=env_local_file, override=True),
+        ]
+
+    def test_calls_dotenv_load_for_env_local_only(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Reload should load `.env.local` even when `.env` is absent."""
+        settings = Settings.from_environment(start_path=tmp_path)
+        mock_load = MagicMock(return_value=False)
+        env_local_file = tmp_path / ".env.local"
+        env_local_file.write_text("LANGSMITH_TRACING=true\n")
+        monkeypatch.setattr("deepagents_cli.config.dotenv.load_dotenv", mock_load)
+
+        settings.reload_from_environment(start_path=tmp_path)
+
+        mock_load.assert_called_once_with(dotenv_path=env_local_file, override=True)
 
     def test_multiple_simultaneous_changes(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary
- load the nearest project `.env.local` alongside `.env` during CLI bootstrap and reload
- preserve the nearest-directory search behavior instead of walking past a directory that already defines dotenv files
- add unit coverage for both `.env` + `.env.local` and `.env.local`-only reload cases

## Why
A lot of projects keep local developer settings in `.env.local` rather than `.env`. The CLI currently only loads `.env`, which means provider credentials or LangSmith tracing flags placed in `.env.local` are silently missed even though they are available to adjacent tooling.

## Testing
- `uv run --group test pytest tests/unit_tests/test_reload.py -q`
- `uv run --group test pytest tests/unit_tests/test_config.py -q`