### PR TITLE
fix(cli): patch model identity in system prompt on `/model` swap

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -272,6 +272,39 @@ def reset_agent(
     console.print(f"Location: {agent_dir}\n", style=COLORS["dim"])
 
 
+MODEL_IDENTITY_RE = re.compile(r"### Model Identity\n\n.*?(?=###|\Z)", re.DOTALL)
+"""Matches the `### Model Identity` section in the system prompt, up to the
+next heading or end of string."""
+
+
+def build_model_identity_section(
+    name: str | None,
+    provider: str | None = None,
+    context_limit: int | None = None,
+) -> str:
+    """Build the `### Model Identity` section for the system prompt.
+
+    Args:
+        name: Model identifier (e.g. `claude-opus-4-6`).
+        provider: Provider identifier (e.g. `anthropic`).
+        context_limit: Max input tokens from the model profile.
+
+    Returns:
+        The section text including the heading and trailing newline,
+        or an empty string if `name` is falsy.
+    """
+    if not name:
+        return ""
+    section = f"### Model Identity\n\nYou are running as model `{name}`"
+    if provider:
+        section += f" (provider: {provider})"
+    section += ".\n"
+    if context_limit:
+        section += f"Your context window is {context_limit:,} tokens.\n"
+    section += "\n"
+    return section
+
+
 def get_system_prompt(
     assistant_id: str,
     sandbox_type: str | None = None,
@@ -346,20 +379,11 @@ def get_system_prompt(
             "available. Never run commands that block waiting for stdin."
         )
 
-    # Build model identity section
-    model_identity_section = ""
-    if settings.model_name:
-        model_identity_section = (
-            f"### Model Identity\n\nYou are running as model `{settings.model_name}`"
-        )
-        if settings.model_provider:
-            model_identity_section += f" (provider: {settings.model_provider})"
-        model_identity_section += ".\n"
-        if settings.model_context_limit:
-            model_identity_section += (
-                f"Your context window is {settings.model_context_limit:,} tokens.\n"
-            )
-        model_identity_section += "\n"
+    model_identity_section = build_model_identity_section(
+        settings.model_name,
+        provider=settings.model_provider,
+        context_limit=settings.model_context_limit,
+    )
 
     # Build working directory section (local vs sandbox)
     if sandbox_type:

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -75,7 +75,8 @@ def _apply_overrides(request: ModelRequest) -> ModelRequest:
 
         logger.debug("Overriding model to %s", model)
         try:
-            new_model = create_model(model).model
+            model_result = create_model(model)
+            new_model = model_result.model
         except ModelConfigError:
             logger.exception(
                 "Failed to resolve runtime model override '%s'; "
@@ -107,6 +108,35 @@ def _apply_overrides(request: ModelRequest) -> ModelRequest:
             overrides["model_settings"] = {
                 k: v for k, v in settings.items() if k not in dropped
             }
+
+    # Patch the Model Identity section in the system prompt so the new model
+    # sees its own name/provider/context-limit, not the original's.
+    # We read metadata from model_result (not the CLI settings singleton)
+    # because the middleware runs in the server subprocess where settings
+    # are never updated by /model.
+    if new_model is not None and request.system_prompt:
+        from deepagents_cli.agent import (
+            MODEL_IDENTITY_RE,
+            build_model_identity_section,
+        )
+
+        prompt = request.system_prompt
+        new_identity = build_model_identity_section(
+            model_result.model_name,
+            provider=model_result.provider,
+            context_limit=model_result.context_limit,
+        )
+        patched = MODEL_IDENTITY_RE.sub(new_identity, prompt, count=1)
+        if patched != prompt:
+            overrides["system_prompt"] = patched
+        elif "### Model Identity" in prompt:
+            logger.warning(
+                "System prompt contains '### Model Identity' but regex "
+                "did not match; identity section was NOT updated for "
+                "model '%s'. The regex may be out of sync with the "
+                "prompt template.",
+                model_result.model_name,
+            )
 
     return request.override(**overrides)
 

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -9,6 +9,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
 
 from deepagents_cli._cli_context import CLIContext
+from deepagents_cli.agent import build_model_identity_section
 from deepagents_cli.configurable_model import (
     ConfigurableModelMiddleware,
     _is_anthropic_model,
@@ -28,16 +29,20 @@ def _make_request(
     model: BaseChatModel,
     context: CLIContext | None = None,
     model_settings: dict[str, Any] | None = None,
+    system_prompt: str | None = None,
 ) -> ModelRequest:
     """Create a ModelRequest with a runtime that carries CLIContext."""
     runtime = SimpleNamespace(context=context)
-    return ModelRequest(
-        model=model,
-        messages=[HumanMessage(content="hi")],
-        tools=[],
-        runtime=cast("Any", runtime),
-        model_settings=model_settings,
-    )
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": [HumanMessage(content="hi")],
+        "tools": [],
+        "runtime": cast("Any", runtime),
+        "model_settings": model_settings,
+    }
+    if system_prompt is not None:
+        kwargs["system_prompt"] = system_prompt
+    return ModelRequest(**kwargs)
 
 
 def _make_response() -> ModelResponse[Any]:
@@ -45,9 +50,20 @@ def _make_response() -> ModelResponse[Any]:
     return ModelResponse(result=[AIMessage(content="response")])
 
 
-def _make_model_result(model: MagicMock) -> SimpleNamespace:
-    """Create a mock ModelResult with a .model attribute."""
-    return SimpleNamespace(model=model)
+def _make_model_result(
+    model: MagicMock,
+    *,
+    model_name: str = "",
+    provider: str = "",
+    context_limit: int | None = None,
+) -> SimpleNamespace:
+    """Create a mock ModelResult with model metadata."""
+    return SimpleNamespace(
+        model=model,
+        model_name=model_name or model.model_name,
+        provider=provider,
+        context_limit=context_limit,
+    )
 
 
 _PATCH_CREATE = "deepagents_cli.config.create_model"
@@ -442,3 +458,114 @@ class TestModelParams:
 
         await _mw.awrap_model_call(request, handler)
         assert captured[0].model_settings == {"temperature": 0.3}
+
+
+class TestModelIdentityPatch:
+    """System prompt Model Identity section is updated on model swap."""
+
+    _OLD_PROMPT = (
+        "Some preamble.\n\n---\n\n"
+        "### Model Identity\n\n"
+        "You are running as model `claude-opus-4-6` (provider: anthropic).\n"
+        "Your context window is 200,000 tokens.\n\n"
+        "### Skills Directory\n\nYour skills are stored at: `/tmp/skills`\n"
+    )
+
+    def test_identity_replaced_on_swap(self) -> None:
+        override = _make_model("gpt-4o")
+        result = _make_model_result(
+            override, model_name="gpt-4o", provider="openai", context_limit=128_000
+        )
+        request = _make_request(
+            _make_model("claude-opus-4-6"),
+            context=CLIContext(model="openai:gpt-4o"),
+            system_prompt=self._OLD_PROMPT,
+        )
+        captured: list[ModelRequest] = []
+        with patch(_PATCH_CREATE, return_value=result):
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        prompt = captured[0].system_prompt
+        assert prompt is not None
+        assert "`gpt-4o`" in prompt
+        assert "(provider: openai)" in prompt
+        assert "128,000 tokens" in prompt
+        assert "`claude-opus-4-6`" not in prompt
+        # Surrounding content must survive the replacement
+        assert "Some preamble." in prompt
+        assert "### Skills Directory" in prompt
+        assert "`/tmp/skills`" in prompt
+
+    def test_no_identity_section_left_unchanged(self) -> None:
+        """Prompt without identity section is not modified."""
+        bare_prompt = "You are a helpful assistant.\n\n### Skills Directory\n"
+        override = _make_model("gpt-4o")
+        result = _make_model_result(override, model_name="gpt-4o", provider="openai")
+        request = _make_request(
+            _make_model("claude-opus-4-6"),
+            context=CLIContext(model="openai:gpt-4o"),
+            system_prompt=bare_prompt,
+        )
+        captured: list[ModelRequest] = []
+        with patch(_PATCH_CREATE, return_value=result):
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        assert captured[0].system_prompt == bare_prompt
+
+    def test_no_system_prompt_skips_patch(self) -> None:
+        """When system_prompt is None, no patching is attempted."""
+        override = _make_model("gpt-4o")
+        request = _make_request(
+            _make_model("claude-opus-4-6"),
+            context=CLIContext(model="openai:gpt-4o"),
+        )
+        captured: list[ModelRequest] = []
+        with patch(_PATCH_CREATE, return_value=_make_model_result(override)):
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        assert captured[0].model is override
+
+    def test_identity_at_end_of_prompt(self) -> None:
+        """Identity section at the very end (no trailing ###) is still replaced."""
+        prompt = (
+            "Preamble.\n\n### Model Identity\n\nYou are running as model `old`.\n\n"
+        )
+        override = _make_model("gpt-4o")
+        result = _make_model_result(override, model_name="gpt-4o", provider="openai")
+        request = _make_request(
+            _make_model("old"),
+            context=CLIContext(model="openai:gpt-4o"),
+            system_prompt=prompt,
+        )
+        captured: list[ModelRequest] = []
+        with patch(_PATCH_CREATE, return_value=result):
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        patched = captured[0].system_prompt
+        assert patched is not None
+        assert "`gpt-4o`" in patched
+        assert "`old`" not in patched
+        assert "Preamble." in patched
+
+    def test_identity_without_context_limit(self) -> None:
+        result = build_model_identity_section("gpt-4o", provider="openai")
+        assert "`gpt-4o`" in result
+        assert "(provider: openai)" in result
+        assert "context window" not in result
+
+    def test_identity_without_provider(self) -> None:
+        result = build_model_identity_section("local-llama", context_limit=4096)
+        assert "`local-llama`" in result
+        assert "provider" not in result
+        assert "4,096 tokens" in result
+
+    def test_identity_no_model_name(self) -> None:
+        assert build_model_identity_section(None) == ""


### PR DESCRIPTION
When a user swaps models mid-conversation via `/model`, the system prompt's Model Identity section still references the original model's name, provider, and context window. The agent then "thinks" it's a different model than it actually is, which can affect behavior. This fixes it by patching the identity section in the `ConfigurableModelMiddleware` whenever a runtime model override is applied.

## Changes
- Extract `build_model_identity_section()` and `MODEL_IDENTITY_RE` in `agent.py` — reusable builder + regex that `get_system_prompt` and the middleware both share
- `_apply_overrides` in `configurable_model.py` now regex-replaces the `### Model Identity` section with one reflecting the new model's metadata from `model_result` (not the CLI settings singleton, which isn't updated in the server subprocess)
- Log a warning if the prompt contains the heading text but the regex fails to match — signals the regex has drifted from the template

## Testing
- `TestModelIdentityPatch` covers: full replacement with provider + context limit, prompts without an identity section, `None` system prompts, identity at end-of-prompt (no trailing `###`), and `build_model_identity_section` edge cases (no provider, no context limit, no model name)