### PR TITLE
ci: suppress pytest streaming output in CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -56,9 +56,9 @@ jobs:
           RUN_SANDBOX_TESTS: "true"
         run: |
           if [ "${{ inputs.coverage }}" = "false" ]; then
-            make test COV_ARGS=
+            make test COV_ARGS= PYTEST_EXTRA=-q
           else
-            make test
+            make test PYTEST_EXTRA=-q
           fi
 
       - name: "🧹 Verify Clean Working Directory"

--- a/libs/acp/Makefile
+++ b/libs/acp/Makefile
@@ -8,9 +8,10 @@
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/
+PYTEST_EXTRA ?=
 
 test: ## Run unit tests with coverage
-	uv run pytest --disable-socket --allow-unix-socket $(TEST_FILE) --timeout 10 --cov=deepagents_acp --cov-report=term-missing --cov-report=xml
+	uv run pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE) --timeout 10 --cov=deepagents_acp --cov-report=term-missing --cov-report=xml
 
 test_watch: ## Run tests in watch mode
 	uv run ptw . -- $(TEST_FILE)

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -14,10 +14,11 @@ TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 COV_ARGS ?= --cov=deepagents_cli --cov-report=term-missing
+PYTEST_EXTRA ?=
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE) \
+	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(PYTEST_EXTRA) $(TEST_FILE) \
 		$(COV_ARGS)
 
 coverage: ## Run unit tests with coverage

--- a/libs/deepagents/Makefile
+++ b/libs/deepagents/Makefile
@@ -12,11 +12,12 @@ UV_FROZEN = true
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 SMOKE_TESTS ?= tests/unit_tests/smoke_tests/
+PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -n auto -vvv --disable-socket --allow-unix-socket $(TEST_FILE) \
+	uv run --group test pytest -n auto -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE) \
 		--cov=deepagents \
 		--cov-report=term-missing
 

--- a/libs/harbor/Makefile
+++ b/libs/harbor/Makefile
@@ -9,9 +9,10 @@
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests
 INTEGRATION_FILES ?= tests/integration_tests
+PYTEST_EXTRA ?=
 
 test: ## Run unit tests
-	uv run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_integration: ## Run integration tests
 	uv run pytest $(INTEGRATION_FILES)

--- a/libs/partners/daytona/Makefile
+++ b/libs/partners/daytona/Makefile
@@ -10,12 +10,13 @@ UV_FROZEN = true
 ######################
 
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test: ## Run integration tests
 integration_test integration_tests:

--- a/libs/partners/modal/Makefile
+++ b/libs/partners/modal/Makefile
@@ -10,12 +10,13 @@ UV_FROZEN = true
 ######################
 
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test: ## Run integration tests
 integration_test integration_tests:

--- a/libs/partners/quickjs/Makefile
+++ b/libs/partners/quickjs/Makefile
@@ -10,12 +10,13 @@ UV_FROZEN = true
 ######################
 
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE) \
+	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE) \
 		--cov=langchain_quickjs \
 		--cov-report=term-missing
 

--- a/libs/partners/runloop/Makefile
+++ b/libs/partners/runloop/Makefile
@@ -10,12 +10,13 @@ UV_FROZEN = true
 ######################
 
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test: ## Run integration tests
 integration_test integration_tests:


### PR DESCRIPTION
Does not affect evals

Reduce CI log noise by suppressing pytest's per-test dot/verbose streaming output. The `_test.yml` workflow now passes `PYTEST_EXTRA=-q` to `make test`, which overrides the default verbosity with quiet mode — failures still print in full, but the thousands of `.......` progress lines are gone. Local `make test` is unaffected since `PYTEST_EXTRA` defaults empty.

## Changes
- Add `PYTEST_EXTRA ?=` variable to all 8 package Makefiles (`cli`, `deepagents`, `acp`, `harbor`, `daytona`, `modal`, `runloop`, `quickjs`) and inject it into each `test` target's pytest invocation
- Pass `PYTEST_EXTRA=-q` in `_test.yml` for both coverage and no-coverage branches
