### PR TITLE
perf(cli): sub 250ms first paint

### DIFF
--- a/libs/cli/deepagents_cli/__init__.py
+++ b/libs/cli/deepagents_cli/__init__.py
@@ -1,9 +1,35 @@
 """Deep Agents CLI - Interactive AI coding assistant."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from deepagents_cli._version import __version__
-from deepagents_cli.main import cli_main
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = [
     "__version__",
-    "cli_main",
+    "cli_main",  # noqa: F822  # resolved lazily by __getattr__
 ]
+
+
+def __getattr__(name: str) -> Callable[[], None]:
+    """Lazy import for `cli_main` to avoid loading `main.py` at package import.
+
+    `main.py` pulls in `asyncio` and stdlib modules that aren't needed
+    when submodules like `config` or `widgets` are imported directly.
+
+    Returns:
+        The requested callable.
+
+    Raises:
+        AttributeError: If *name* is not a lazily-provided attribute.
+    """
+    if name == "cli_main":
+        from deepagents_cli.main import cli_main
+
+        return cli_main
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/libs/cli/deepagents_cli/__init__.py
+++ b/libs/cli/deepagents_cli/__init__.py
@@ -18,8 +18,9 @@ __all__ = [
 def __getattr__(name: str) -> Callable[[], None]:
     """Lazy import for `cli_main` to avoid loading `main.py` at package import.
 
-    `main.py` pulls in `asyncio` and stdlib modules that aren't needed
-    when submodules like `config` or `widgets` are imported directly.
+    `main.py` pulls in `argparse`, signal handling, and other startup machinery
+    that isn't needed when submodules like `config` or `widgets` are
+    imported directly.
 
     Returns:
         The requested callable.

--- a/libs/cli/deepagents_cli/_version.py
+++ b/libs/cli/deepagents_cli/_version.py
@@ -1,3 +1,6 @@
-"""Version information for `deepagents-cli`."""
+"""Version information and lightweight constants for `deepagents-cli`."""
 
 __version__ = "0.0.34"  # x-release-please-version
+
+DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
+"""URL for `deepagents-cli` documentation."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -457,6 +457,7 @@ class DeepAgentsApp(App):
         server_proc: ServerProcess | None = None,
         server_kwargs: dict[str, Any] | None = None,
         mcp_preload_kwargs: dict[str, Any] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the Deep Agents application.
@@ -484,6 +485,10 @@ class DeepAgentsApp(App):
                 for `start_server_and_get_agent`.
             mcp_preload_kwargs: Kwargs for `_preload_session_mcp_server_info`,
                 run concurrently with server startup when `server_kwargs` is set.
+            model_kwargs: Kwargs for deferred `create_model()`.
+
+                When provided, model creation runs in a background worker after
+                first paint instead of blocking startup.
             **kwargs: Additional arguments passed to parent
         """
         super().__init__(**kwargs)
@@ -500,6 +505,7 @@ class DeepAgentsApp(App):
         self._server_proc = server_proc
         self._server_kwargs = server_kwargs
         self._mcp_preload_kwargs = mcp_preload_kwargs
+        self._model_kwargs = model_kwargs
         self._connecting = server_kwargs is not None
         # Extract sandbox type from server kwargs for trace metadata.
         # ServerConfig.__post_init__ normalizes "none" → None, but server_kwargs carries
@@ -725,7 +731,30 @@ class DeepAgentsApp(App):
         )
 
     async def _start_server_background(self) -> None:
-        """Background worker: start server + MCP preload concurrently."""
+        """Background worker: start server + MCP preload concurrently.
+
+        Also runs deferred model creation if `model_kwargs` was provided,
+        so the langchain import + init doesn't block first paint.
+        """
+        # Run deferred model creation before starting the server so
+        # settings.model_name / model_provider are populated for the
+        # status bar and server process.
+        if self._model_kwargs is not None:
+            from deepagents_cli.config import create_model
+            from deepagents_cli.model_config import ModelConfigError, save_recent_model
+
+            try:
+                result = create_model(**self._model_kwargs)
+            except ModelConfigError as exc:
+                self.post_message(self.ServerStartFailed(error=exc))
+                return
+            result.apply_to_settings()
+
+            # Persist the resolved model so [models].recent is always populated,
+            # not only after an explicit /model switch.
+            save_recent_model(f"{result.provider}:{result.model_name}")
+            self._model_kwargs = None  # consumed
+
         from deepagents_cli.server_manager import start_server_and_get_agent
 
         coros: list[Any] = [start_server_and_get_agent(**self._server_kwargs)]  # type: ignore[arg-type]
@@ -3763,6 +3792,7 @@ async def run_textual_app(
     server_proc: ServerProcess | None = None,
     server_kwargs: dict[str, Any] | None = None,
     mcp_preload_kwargs: dict[str, Any] | None = None,
+    model_kwargs: dict[str, Any] | None = None,
 ) -> AppResult:
     """Run the Textual application.
 
@@ -3787,6 +3817,10 @@ async def run_textual_app(
         server_proc: LangGraph server process for the interactive session.
         server_kwargs: Kwargs for deferred `start_server_and_get_agent` call.
         mcp_preload_kwargs: Kwargs for concurrent MCP metadata preload.
+        model_kwargs: Kwargs for deferred `create_model()` call.
+
+            When provided, model creation runs in a background worker after
+            first paint so the splash screen appears immediately.
 
     Returns:
         An `AppResult` with the return code and final thread ID.
@@ -3804,6 +3838,7 @@ async def run_textual_app(
         server_proc=server_proc,
         server_kwargs=server_kwargs,
         mcp_preload_kwargs=mcp_preload_kwargs,
+        model_kwargs=model_kwargs,
     )
     try:
         await app.run_async()

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -599,7 +599,12 @@ class DeepAgentsApp(App):
         yield StatusBar(cwd=self._cwd, id="status-bar")
 
     async def on_mount(self) -> None:
-        """Initialize components after mount."""
+        """Initialize components after mount.
+
+        Only widget queries and lightweight config go here — anything that
+        would delay the first rendered frame (subprocess calls, heavy
+        imports) is deferred to `_post_paint_init` via `call_after_refresh`.
+        """
         # Move all objects allocated during import/compose into the permanent
         # generation so the cyclic GC skips them during first-paint rendering.
         import gc
@@ -618,12 +623,27 @@ class DeepAgentsApp(App):
         if self._auto_approve:
             self._status_bar.set_auto_approve(enabled=True)
 
-        # Set git branch in status bar
+        # Focus the input immediately so the cursor is visible on first paint
+        self._chat_input.focus_input()
+
+        # Defer everything else until after the first frame renders so the
+        # user sees the splash screen instantly.
+        self.call_after_refresh(self._post_paint_init)
+
+    async def _post_paint_init(self) -> None:
+        """Run after the first frame renders.
+
+        Houses git-branch detection, session state creation, background
+        workers, and optional-tool checks.
+        """
+        # Git branch — runs in a thread to avoid blocking the event loop,
+        # renders on the next frame (~11ms subprocess).
         from deepagents_cli.textual_adapter import _get_git_branch
 
-        self._status_bar.branch = _get_git_branch() or ""
+        if self._status_bar:
+            self._status_bar.branch = await asyncio.to_thread(_get_git_branch) or ""
 
-        # Create session state
+        # Create session state (imports deepagents_cli.sessions)
         self._session_state = TextualSessionState(
             auto_approve=self._auto_approve,
             thread_id=self._lc_thread_id,
@@ -660,9 +680,6 @@ class DeepAgentsApp(App):
             exclusive=True,
             group="startup-import-prewarm",
         )
-
-        # Focus the input (autocomplete is now built into ChatInput)
-        self._chat_input.focus_input()
 
         # Warn about missing optional tools (advisory only — never block startup)
         try:
@@ -736,9 +753,10 @@ class DeepAgentsApp(App):
         Also runs deferred model creation if `model_kwargs` was provided,
         so the langchain import + init doesn't block first paint.
         """
-        # Run deferred model creation before starting the server so
-        # settings.model_name / model_provider are populated for the
-        # status bar and server process.
+        # Run deferred model creation. settings.model_name / model_provider
+        # are already set eagerly for the status bar display; this call
+        # does the heavy langchain import + SDK init and may refine them
+        # (e.g., context_limit from the model profile).
         if self._model_kwargs is not None:
             from deepagents_cli.config import create_model
             from deepagents_cli.model_config import ModelConfigError, save_recent_model
@@ -749,9 +767,6 @@ class DeepAgentsApp(App):
                 self.post_message(self.ServerStartFailed(error=exc))
                 return
             result.apply_to_settings()
-
-            # Persist the resolved model so [models].recent is always populated,
-            # not only after an explicit /model switch.
             save_recent_model(f"{result.provider}:{result.model_name}")
             self._model_kwargs = None  # consumed
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -626,25 +626,44 @@ class DeepAgentsApp(App):
         # Focus the input immediately so the cursor is visible on first paint
         self._chat_input.focus_input()
 
-        # Resolve git branch right after first paint — highest priority
-        # deferred item since it's visible in the status bar.
-        self.call_after_refresh(self._resolve_git_branch_and_continue)
+        # Start branch resolution immediately — the thread launches now
+        # (during on_mount) so by the time the first frame finishes painting
+        # the subprocess is already done. _post_paint_init fires the heavier
+        # workers (server, model creation) afterward.
+        self._startup_task = asyncio.create_task(
+            self._resolve_git_branch_and_continue()
+        )
 
     async def _resolve_git_branch_and_continue(self) -> None:
         """Resolve git branch immediately, then fire remaining init workers.
 
         Called via `call_after_refresh` so it runs right after first paint.
-        The branch subprocess gets a thread before the heavy workers
-        (model creation, server start) saturate I/O.
+        Inlines the subprocess call to avoid importing `textual_adapter` which
+        would block the event loop and delay the branch render.
         """
-        from deepagents_cli.textual_adapter import _get_git_branch
+        import subprocess  # noqa: S404  # stdlib, already loaded
 
-        branch = await asyncio.to_thread(_get_git_branch) or ""
+        def _get_branch() -> str:
+            try:
+                result = subprocess.run(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                    check=False,
+                )
+                if result.returncode == 0:
+                    return result.stdout.strip()
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                pass
+            return ""
+
+        branch = await asyncio.to_thread(_get_branch)
         if self._status_bar:
             self._status_bar.branch = branch
 
-        # Now kick off everything else
-        await self._post_paint_init()
+        # Yield to Textual so the branch renders before heavy workers start
+        self.call_after_refresh(self._post_paint_init)
 
     async def _post_paint_init(self) -> None:
         """Fire background workers for remaining startup work.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -451,6 +451,7 @@ class DeepAgentsApp(App):
         auto_approve: bool = False,
         cwd: str | Path | None = None,
         thread_id: str | None = None,
+        resume_thread: str | None = None,
         initial_prompt: str | None = None,
         mcp_server_info: list[MCPServerInfo] | None = None,
         profile_override: dict[str, Any] | None = None,
@@ -470,6 +471,12 @@ class DeepAgentsApp(App):
             auto_approve: Whether to start with auto-approve enabled
             cwd: Current working directory to display
             thread_id: Optional thread ID for session persistence
+            resume_thread: Raw resume intent from `-r` flag.
+
+                `'__MOST_RECENT__'` for bare `-r`, a thread ID string for
+                `-r <id>`, or `None` for new sessions.
+
+                Resolved asynchronously in `_start_server_background`.
             initial_prompt: Optional prompt to auto-submit when session starts
             mcp_server_info: MCP server metadata for the `/mcp` viewer.
             profile_override: Extra profile fields from `--profile-override`,
@@ -499,6 +506,7 @@ class DeepAgentsApp(App):
         self._cwd = str(cwd) if cwd else str(Path.cwd())
         # Avoid collision with App._thread_id
         self._lc_thread_id = thread_id
+        self._resume_thread_intent = resume_thread
         self._initial_prompt = initial_prompt
         self._mcp_server_info = mcp_server_info
         self._profile_override = profile_override
@@ -817,12 +825,82 @@ class DeepAgentsApp(App):
             group="startup-model-prewarm",
         )
 
+    async def _resolve_resume_thread(self) -> None:
+        """Resolve a `-r` resume intent into a concrete thread ID.
+
+        Called as the first phase of `_start_server_background` when
+        `self._resume_thread_intent` is set. Mutates `self._lc_thread_id` and
+        optionally `self._assistant_id` / `self._server_kwargs`.
+        """
+        from deepagents_cli.sessions import (
+            find_similar_threads,
+            generate_thread_id,
+            get_most_recent,
+            get_thread_agent,
+            thread_exists,
+        )
+
+        resume = self._resume_thread_intent
+        self._resume_thread_intent = None  # consumed
+
+        if not resume:
+            return
+
+        # "agent" is the default from argparse (_DEFAULT_AGENT_NAME in main.py)
+        default_agent = "agent"
+
+        if resume == "__MOST_RECENT__":
+            agent_filter = (
+                self._assistant_id if self._assistant_id != default_agent else None
+            )
+            thread_id = await get_most_recent(agent_filter)
+            if thread_id:
+                agent_name = await get_thread_agent(thread_id)
+                if agent_name:
+                    self._assistant_id = agent_name
+                    if self._server_kwargs:
+                        self._server_kwargs["assistant_id"] = agent_name
+                self._lc_thread_id = thread_id
+            else:
+                # No previous thread — fall through to new thread
+                self._lc_thread_id = generate_thread_id()
+                self.call_from_thread(
+                    self.notify,
+                    "No previous threads, starting new.",
+                    severity="warning",
+                )
+        # Specific thread ID
+        elif await thread_exists(resume):
+            self._lc_thread_id = resume
+            if self._assistant_id == default_agent:
+                agent_name = await get_thread_agent(resume)
+                if agent_name:
+                    self._assistant_id = agent_name
+                    if self._server_kwargs:
+                        self._server_kwargs["assistant_id"] = agent_name
+        else:
+            # Thread not found — notify + fall back to new thread
+            self._lc_thread_id = generate_thread_id()
+            similar = await find_similar_threads(resume)
+            hint = f"Thread '{resume}' not found."
+            if similar:
+                hint += f" Did you mean: {', '.join(str(t) for t in similar)}?"
+            self.call_from_thread(self.notify, hint, severity="warning")
+
+        # Update session state (created in on_mount before worker starts)
+        if self._session_state:
+            self._session_state.thread_id = self._lc_thread_id
+
     async def _start_server_background(self) -> None:
         """Background worker: start server + MCP preload concurrently.
 
         Also runs deferred model creation if `model_kwargs` was provided,
         so the langchain import + init doesn't block first paint.
         """
+        # Phase 1: Resolve resume thread (if any) before server startup
+        if self._resume_thread_intent:
+            await self._resolve_resume_thread()
+
         # Run deferred model creation. settings.model_name / model_provider
         # are already set eagerly for the status bar display; this call
         # does the heavy langchain import + SDK init and may refine them
@@ -3873,6 +3951,7 @@ async def run_textual_app(
     auto_approve: bool = False,
     cwd: str | Path | None = None,
     thread_id: str | None = None,
+    resume_thread: str | None = None,
     initial_prompt: str | None = None,
     mcp_server_info: list[MCPServerInfo] | None = None,
     profile_override: dict[str, Any] | None = None,
@@ -3894,6 +3973,11 @@ async def run_textual_app(
         auto_approve: Whether to start with auto-approve enabled.
         cwd: Current working directory to display.
         thread_id: Optional thread ID for session persistence.
+        resume_thread: Raw resume intent from `-r` flag. `'__MOST_RECENT__'` for
+            bare `-r`, a thread ID string for `-r <id>`, or `None` for new
+            sessions.
+
+            Resolved asynchronously during TUI startup.
         initial_prompt: Optional prompt to auto-submit when session starts.
         mcp_server_info: MCP server metadata for the `/mcp` viewer.
         profile_override: Extra profile fields from `--profile-override`,
@@ -3919,6 +4003,7 @@ async def run_textual_app(
         auto_approve=auto_approve,
         cwd=cwd,
         thread_id=thread_id,
+        resume_thread=resume_thread,
         initial_prompt=initial_prompt,
         mcp_server_info=mcp_server_info,
         profile_override=profile_override,

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -470,13 +470,18 @@ class DeepAgentsApp(App):
             backend: Backend for file operations
             auto_approve: Whether to start with auto-approve enabled
             cwd: Current working directory to display
-            thread_id: Optional thread ID for session persistence
+            thread_id: Thread ID for the session.
+
+                `None` when `resume_thread` is provided (resolved asynchronously).
             resume_thread: Raw resume intent from `-r` flag.
 
                 `'__MOST_RECENT__'` for bare `-r`, a thread ID string for
                 `-r <id>`, or `None` for new sessions.
 
-                Resolved asynchronously in `_start_server_background`.
+                Resolved via `_resolve_resume_thread`
+                during `_start_server_background`.
+
+                Requires `server_kwargs` to be set; ignored otherwise.
             initial_prompt: Optional prompt to auto-submit when session starts
             mcp_server_info: MCP server metadata for the `/mcp` viewer.
             profile_override: Extra profile fields from `--profile-override`,
@@ -828,9 +833,10 @@ class DeepAgentsApp(App):
     async def _resolve_resume_thread(self) -> None:
         """Resolve a `-r` resume intent into a concrete thread ID.
 
-        Called as the first phase of `_start_server_background` when
-        `self._resume_thread_intent` is set. Mutates `self._lc_thread_id` and
-        optionally `self._assistant_id` / `self._server_kwargs`.
+        Consumes `self._resume_thread_intent` and resolves it into a concrete
+        thread ID. Mutates `self._lc_thread_id` and optionally
+        `self._assistant_id` / `self._server_kwargs`. Falls back to a fresh
+        thread on any DB error.
         """
         from deepagents_cli.sessions import (
             find_similar_threads,
@@ -846,53 +852,63 @@ class DeepAgentsApp(App):
         if not resume:
             return
 
-        # "agent" is the default from argparse (_DEFAULT_AGENT_NAME in main.py)
+        # Matches _DEFAULT_AGENT_NAME in main.py. Do NOT import it — main.py is
+        # the CLI entry point and pulls in argparse, rich, etc. at module level.
+        # Even a deferred import drags in the full dep tree for a single
+        # string constant.
         default_agent = "agent"
 
-        if resume == "__MOST_RECENT__":
-            agent_filter = (
-                self._assistant_id if self._assistant_id != default_agent else None
-            )
-            thread_id = await get_most_recent(agent_filter)
-            if thread_id:
-                agent_name = await get_thread_agent(thread_id)
-                if agent_name:
-                    self._assistant_id = agent_name
-                    if self._server_kwargs:
-                        self._server_kwargs["assistant_id"] = agent_name
-                self._lc_thread_id = thread_id
-            else:
-                # No previous thread — fall through to new thread
-                self._lc_thread_id = generate_thread_id()
-                self.call_from_thread(
-                    self.notify,
-                    "No previous threads, starting new.",
-                    severity="warning",
+        try:
+            if resume == "__MOST_RECENT__":
+                agent_filter = (
+                    self._assistant_id if self._assistant_id != default_agent else None
                 )
-        # Specific thread ID
-        elif await thread_exists(resume):
-            self._lc_thread_id = resume
-            if self._assistant_id == default_agent:
-                agent_name = await get_thread_agent(resume)
-                if agent_name:
-                    self._assistant_id = agent_name
-                    if self._server_kwargs:
-                        self._server_kwargs["assistant_id"] = agent_name
-        else:
-            # Thread not found — notify + fall back to new thread
+                thread_id = await get_most_recent(agent_filter)
+                if thread_id:
+                    agent_name = await get_thread_agent(thread_id)
+                    if agent_name:
+                        self._assistant_id = agent_name
+                        if self._server_kwargs:
+                            self._server_kwargs["assistant_id"] = agent_name
+                    self._lc_thread_id = thread_id
+                else:
+                    self._lc_thread_id = generate_thread_id()
+                    if agent_filter:
+                        msg = f"No previous threads for '{agent_filter}', starting new."
+                    else:
+                        msg = "No previous threads, starting new."
+                    self.notify(msg, severity="warning")
+            elif await thread_exists(resume):
+                self._lc_thread_id = resume
+                if self._assistant_id == default_agent:
+                    agent_name = await get_thread_agent(resume)
+                    if agent_name:
+                        self._assistant_id = agent_name
+                        if self._server_kwargs:
+                            self._server_kwargs["assistant_id"] = agent_name
+            else:
+                # Thread not found — notify + fall back to new thread
+                self._lc_thread_id = generate_thread_id()
+                similar = await find_similar_threads(resume)
+                hint = f"Thread '{resume}' not found."
+                if similar:
+                    hint += f" Did you mean: {', '.join(str(t) for t in similar)}?"
+                self.notify(hint, severity="warning")
+        except Exception:
+            logger.exception("Failed to resolve resume thread %r", resume)
             self._lc_thread_id = generate_thread_id()
-            similar = await find_similar_threads(resume)
-            hint = f"Thread '{resume}' not found."
-            if similar:
-                hint += f" Did you mean: {', '.join(str(t) for t in similar)}?"
-            self.call_from_thread(self.notify, hint, severity="warning")
+            self.notify(
+                "Could not look up thread history. Starting new session.",
+                severity="warning",
+            )
 
-        # Update session state (created in on_mount before worker starts)
+        # Update session state if ready (may still be initializing in a
+        # concurrent worker)
         if self._session_state:
             self._session_state.thread_id = self._lc_thread_id
 
     async def _start_server_background(self) -> None:
-        """Background worker: start server + MCP preload concurrently.
+        """Background worker: resolve resume-thread intent, start server + MCP preload.
 
         Also runs deferred model creation if `model_kwargs` was provided,
         so the langchain import + init doesn't block first paint.
@@ -3972,7 +3988,10 @@ async def run_textual_app(
         backend: Backend for file operations.
         auto_approve: Whether to start with auto-approve enabled.
         cwd: Current working directory to display.
-        thread_id: Optional thread ID for session persistence.
+        thread_id: Thread ID for the session.
+
+            `None` when `resume_thread` is provided (the TUI resolves the final
+            ID asynchronously).
         resume_thread: Raw resume intent from `-r` flag. `'__MOST_RECENT__'` for
             bare `-r`, a thread ID string for `-r <id>`, or `None` for new
             sessions.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -546,6 +546,8 @@ class DeepAgentsApp(App):
         self._deferred_actions: list[DeferredAction] = []
         # Message virtualization store
         self._message_store = MessageStore()
+        # Startup task reference (set in on_mount)
+        self._startup_task: asyncio.Task[None] | None = None
         # Lazily imported here to avoid pulling image dependencies into
         # argument parsing paths.
         from deepagents_cli.input import MediaTracker
@@ -635,35 +637,44 @@ class DeepAgentsApp(App):
         )
 
     async def _resolve_git_branch_and_continue(self) -> None:
-        """Resolve git branch immediately, then fire remaining init workers.
+        """Resolve git branch, then schedule remaining init workers.
 
-        Called via `call_after_refresh` so it runs right after first paint.
-        Inlines the subprocess call to avoid importing `textual_adapter` which
-        would block the event loop and delay the branch render.
+        Launched via `asyncio.create_task()` during `on_mount` so the subprocess
+        runs concurrently with first-paint rendering. `_post_paint_init` is
+        scheduled via `call_after_refresh` regardless of whether branch
+        resolution succeeds.
         """
-        import subprocess  # noqa: S404  # stdlib, already loaded
+        try:
+            import subprocess  # noqa: S404  # stdlib, already loaded
 
-        def _get_branch() -> str:
-            try:
-                result = subprocess.run(
-                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
-                    capture_output=True,
-                    text=True,
-                    timeout=2,
-                    check=False,
-                )
-                if result.returncode == 0:
-                    return result.stdout.strip()
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-                pass
-            return ""
+            def _get_branch() -> str:
+                try:
+                    result = subprocess.run(
+                        ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+                        capture_output=True,
+                        text=True,
+                        timeout=2,
+                        check=False,
+                    )
+                    if result.returncode == 0:
+                        return result.stdout.strip()
+                except FileNotFoundError:
+                    pass  # git not installed
+                except subprocess.TimeoutExpired:
+                    logger.debug("Git branch detection timed out")
+                except OSError:
+                    logger.debug("Git branch detection failed", exc_info=True)
+                return ""
 
-        branch = await asyncio.to_thread(_get_branch)
-        if self._status_bar:
-            self._status_bar.branch = branch
-
-        # Yield to Textual so the branch renders before heavy workers start
-        self.call_after_refresh(self._post_paint_init)
+            branch = await asyncio.to_thread(_get_branch)
+            if self._status_bar:
+                self._status_bar.branch = branch
+        except Exception:
+            logger.warning("Git branch resolution failed", exc_info=True)
+        finally:
+            # Always schedule post-paint init — even if branch resolution
+            # fails, the app must still start the server, session, etc.
+            self.call_after_refresh(self._post_paint_init)
 
     async def _post_paint_init(self) -> None:
         """Fire background workers for remaining startup work.
@@ -738,7 +749,15 @@ class DeepAgentsApp(App):
                 thread_id=self._lc_thread_id,
             )
 
-        self._session_state = await asyncio.to_thread(_create)
+        try:
+            self._session_state = await asyncio.to_thread(_create)
+        except Exception:
+            logger.exception("Failed to create session state")
+            self.notify(
+                "Session initialization failed. Some features may be unavailable.",
+                severity="error",
+                timeout=10,
+            )
 
     async def _check_optional_tools_background(self) -> None:
         """Check for optional tools in a thread and notify if missing."""
@@ -756,8 +775,11 @@ class DeepAgentsApp(App):
 
         try:
             missing = await asyncio.to_thread(check_optional_tools)
-        except Exception:
+        except (OSError, FileNotFoundError):
             logger.debug("Failed to check for optional tools", exc_info=True)
+            return
+        except Exception:
+            logger.warning("Unexpected error checking optional tools", exc_info=True)
             return
 
         for tool in missing:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -981,19 +981,21 @@ class DeepAgentsApp(App):
             )
             from langchain_core.messages import AIMessage  # noqa: F401
             from langgraph.types import Command  # noqa: F401
-
-            # Widgets deferred from app.py module level
-            from deepagents_cli.widgets.approval import ApprovalMenu  # noqa: F401
-            from deepagents_cli.widgets.ask_user import AskUserMenu  # noqa: F401
-            from deepagents_cli.widgets.model_selector import (
-                ModelSelectorScreen,  # noqa: F401
-            )
-            from deepagents_cli.widgets.thread_selector import (  # noqa: F401
-                DeleteThreadConfirmScreen,
-                ThreadSelectorScreen,
-            )
         except Exception:
-            logger.debug("Could not prewarm deferred imports", exc_info=True)
+            logger.warning("Could not prewarm third-party imports", exc_info=True)
+
+        # Widgets deferred from app.py module level — a failure here indicates
+        # a packaging or code bug (same as the block above), so we let
+        # exceptions propagate.
+        from deepagents_cli.widgets.approval import ApprovalMenu  # noqa: F401
+        from deepagents_cli.widgets.ask_user import AskUserMenu  # noqa: F401
+        from deepagents_cli.widgets.model_selector import (
+            ModelSelectorScreen,  # noqa: F401
+        )
+        from deepagents_cli.widgets.thread_selector import (  # noqa: F401
+            DeleteThreadConfirmScreen,
+            ThreadSelectorScreen,
+        )
 
     async def _prewarm_threads_cache(self) -> None:  # noqa: PLR6301  # Worker hook kept as instance method
         """Prewarm thread selector cache without blocking app startup."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -626,30 +626,33 @@ class DeepAgentsApp(App):
         # Focus the input immediately so the cursor is visible on first paint
         self._chat_input.focus_input()
 
-        # Defer everything else until after the first frame renders so the
-        # user sees the splash screen instantly.
-        self.call_after_refresh(self._post_paint_init)
+        # Resolve git branch right after first paint — highest priority
+        # deferred item since it's visible in the status bar.
+        self.call_after_refresh(self._resolve_git_branch_and_continue)
 
-    async def _post_paint_init(self) -> None:
-        """Run after the first frame renders.
+    async def _resolve_git_branch_and_continue(self) -> None:
+        """Resolve git branch immediately, then fire remaining init workers.
 
-        Houses git-branch detection, session state creation, background
-        workers, and optional-tool checks.
+        Called via `call_after_refresh` so it runs right after first paint.
+        The branch subprocess gets a thread before the heavy workers
+        (model creation, server start) saturate I/O.
         """
-        # Git branch — runs in a thread to avoid blocking the event loop,
-        # renders on the next frame (~11ms subprocess).
         from deepagents_cli.textual_adapter import _get_git_branch
 
+        branch = await asyncio.to_thread(_get_git_branch) or ""
         if self._status_bar:
-            self._status_bar.branch = await asyncio.to_thread(_get_git_branch) or ""
+            self._status_bar.branch = branch
 
-        # Create session state (imports deepagents_cli.sessions)
-        self._session_state = TextualSessionState(
-            auto_approve=self._auto_approve,
-            thread_id=self._lc_thread_id,
-        )
+        # Now kick off everything else
+        await self._post_paint_init()
 
-        # Create token tracker that updates status bar
+    async def _post_paint_init(self) -> None:
+        """Fire background workers for remaining startup work.
+
+        Everything here is non-blocking: workers and thread-offloaded calls
+        so the UI stays responsive.
+        """
+        # Create token tracker (lightweight, no imports)
         self._token_tracker = TextualTokenTracker(
             self._update_tokens, self._hide_tokens
         )
@@ -658,7 +661,10 @@ class DeepAgentsApp(App):
         if self._agent:
             self._init_agent_adapter()
 
-        # Deferred server startup: run in background while TUI is visible
+        # Fire-and-forget workers — none of these block the event loop.
+        self.run_worker(self._init_session_state, exclusive=True, group="session-init")
+
+        # Server startup (model creation + server process)
         if self._server_kwargs is not None:
             self.run_worker(
                 self._start_server_background,
@@ -674,34 +680,19 @@ class DeepAgentsApp(App):
                 group="startup-update-check",
             )
 
-        # Prewarm deferred widget imports in a thread so first use is instant
+        # Prewarm deferred widget imports in a thread
         self.run_worker(
             asyncio.to_thread(self._prewarm_deferred_imports),
             exclusive=True,
             group="startup-import-prewarm",
         )
 
-        # Warn about missing optional tools (advisory only — never block startup)
-        try:
-            from deepagents_cli.main import (
-                check_optional_tools,
-                format_tool_warning_tui,
-            )
-        except ImportError:
-            logger.warning(
-                "Could not import optional tools checker; skipping tool warnings",
-                exc_info=True,
-            )
-        else:
-            try:
-                for tool in check_optional_tools():
-                    self.notify(
-                        format_tool_warning_tui(tool),
-                        severity="warning",
-                        timeout=15,
-                    )
-            except Exception:
-                logger.debug("Failed to check for optional tools", exc_info=True)
+        # Optional tool warnings in a thread (shutil.which is sync I/O)
+        self.run_worker(
+            self._check_optional_tools_background,
+            exclusive=True,
+            group="startup-tool-check",
+        )
 
         # Auto-submit initial prompt if provided via -m flag.
         # This check must come first because _lc_thread_id and _agent are
@@ -718,6 +709,44 @@ class DeepAgentsApp(App):
                 self.call_after_refresh(
                     lambda: asyncio.create_task(self._load_thread_history())
                 )
+
+    async def _init_session_state(self) -> None:
+        """Create session state in a thread (imports deepagents_cli.sessions)."""
+
+        def _create() -> TextualSessionState:
+            return TextualSessionState(
+                auto_approve=self._auto_approve,
+                thread_id=self._lc_thread_id,
+            )
+
+        self._session_state = await asyncio.to_thread(_create)
+
+    async def _check_optional_tools_background(self) -> None:
+        """Check for optional tools in a thread and notify if missing."""
+        try:
+            from deepagents_cli.main import (
+                check_optional_tools,
+                format_tool_warning_tui,
+            )
+        except ImportError:
+            logger.warning(
+                "Could not import optional tools checker",
+                exc_info=True,
+            )
+            return
+
+        try:
+            missing = await asyncio.to_thread(check_optional_tools)
+        except Exception:
+            logger.debug("Failed to check for optional tools", exc_info=True)
+            return
+
+        for tool in missing:
+            self.notify(
+                format_tool_warning_tui(tool),
+                severity="warning",
+                timeout=15,
+            )
 
     def _init_agent_adapter(self) -> None:
         """Create the UI adapter and kick off background cache prewarming."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -34,26 +34,14 @@ from deepagents_cli._session_stats import (
     SpinnerStatus,
     format_token_count,
 )
-from deepagents_cli.clipboard import copy_selection_to_clipboard
-from deepagents_cli.command_registry import (
-    ALWAYS_IMMEDIATE,
-    BYPASS_WHEN_CONNECTING,
-    IMMEDIATE_UI,
-    SIDE_EFFECT_FREE,
-)
-from deepagents_cli.config import (
-    DOCS_URL,
-    SHELL_TOOL_NAMES,
-    build_langsmith_thread_url,
-    create_model,
-    detect_provider,
-    is_ascii_mode,
-    is_shell_command_allowed,
-    newline_shortcut,
-    settings,
-)
-from deepagents_cli.hooks import dispatch_hook
-from deepagents_cli.model_config import ModelSpec, save_recent_model
+
+# Only is_ascii_mode is needed before first paint (on_mount scrollbar config).
+# All other config imports — settings, create_model, detect_provider, etc. — are
+# deferred to local imports at their call sites since they are only accessed
+# after user interaction begins.
+from deepagents_cli._version import DOCS_URL
+from deepagents_cli.config import is_ascii_mode
+from deepagents_cli.prompts import REMEMBER_PROMPT
 from deepagents_cli.widgets.chat_input import ChatInput
 from deepagents_cli.widgets.loading import LoadingWidget
 from deepagents_cli.widgets.message_store import (
@@ -374,121 +362,7 @@ _COMMAND_URLS: dict[str, str] = {
     "/docs": DOCS_URL,
     "/feedback": "https://github.com/langchain-ai/deepagents/issues/new/choose",
 }
-
-# Prompt for /remember command - triggers agent to review conversation and update
-# memory/skills
-REMEMBER_PROMPT = """Review our conversation and capture valuable knowledge. Focus especially on **best practices** we discussed or discovered—these are the most important things to preserve.
-
-## Step 1: Identify Best Practices and Key Learnings
-
-Scan the conversation for:
-
-### Best Practices (highest priority)
-- **Patterns that worked well** - approaches, techniques, or solutions we found effective
-- **Anti-patterns to avoid** - mistakes, gotchas, or approaches that caused problems
-- **Quality standards** - criteria we established for good code, documentation, or processes
-- **Decision rationale** - why we chose one approach over another
-
-### Other Valuable Knowledge
-- Coding conventions and style preferences
-- Project architecture decisions
-- Workflows and processes we developed
-- Tools, libraries, or techniques worth remembering
-- Feedback I gave about your behavior or outputs
-
-## Step 2: Decide Where to Store Each Learning
-
-For each best practice or learning, choose the right destination:
-
-### -> Memory (AGENTS.md) for preferences and guidelines
-Use memory when the knowledge is:
-- A preference or guideline (not a multi-step process)
-- Something to always keep in mind
-- A simple rule or pattern
-
-**Global** (`~/.deepagents/agent/AGENTS.md`): Universal preferences across all projects
-**Project** (`.deepagents/AGENTS.md`): Project-specific conventions and decisions
-
-### -> Skill for reusable workflows and methodologies
-**Create a skill when** we developed:
-- A multi-step process worth reusing
-- A methodology for a specific type of task
-- A workflow with best practices baked in
-- A procedure that should be followed consistently
-
-Skills are more powerful than memory entries because they can encode **how** to do something well, not just **what** to remember.
-
-## Step 3: Create Skills for Significant Best Practices
-
-If we established best practices around a workflow or process, capture them in a skill.
-
-**Example:** If we discussed best practices for code review, create a `code-review` skill that encodes those practices into a reusable workflow.
-
-### Skill Location
-`~/.deepagents/agent/skills/<skill-name>/SKILL.md`
-
-### Skill Structure
-```
-skill-name/
-├── SKILL.md          (required - main instructions with best practices)
-├── scripts/          (optional - executable code)
-├── references/       (optional - detailed documentation)
-└── assets/           (optional - templates, examples)
-```
-
-### SKILL.md Format
-```markdown
----
-name: skill-name
-description: "What this skill does AND when to use it. Include triggers like 'when the user asks to X' or 'when working with Y'. This description determines when the skill activates."
----
-
-# Skill Name
-
-## Overview
-Brief explanation of what this skill accomplishes.
-
-## Best Practices
-Capture the key best practices upfront:
-- Best practice 1: explanation
-- Best practice 2: explanation
-
-## Process
-Step-by-step instructions (imperative form):
-1. First, do X
-2. Then, do Y
-3. Finally, do Z
-
-## Common Pitfalls
-- Pitfall to avoid and why
-- Another anti-pattern we discovered
-```
-
-### Key Principles
-1. **Encode best practices prominently** - Put them near the top so they guide the entire workflow
-2. **Concise is key** - Only include non-obvious knowledge. Every paragraph should justify its token cost.
-3. **Clear triggers** - The description determines when the skill activates. Be specific.
-4. **Imperative form** - Write as commands: "Create a file" not "You should create a file"
-5. **Include anti-patterns** - What NOT to do is often as valuable as what to do
-
-## Step 4: Update Memory for Simpler Learnings
-
-For preferences, guidelines, and simple rules that don't warrant a full skill:
-
-```markdown
-## Best Practices
-- When doing X, always Y because Z
-- Avoid A because it leads to B
-```
-
-Use `edit_file` to update existing files or `write_file` to create new ones.
-
-## Step 5: Summarize Changes
-
-List what you captured and where you stored it:
-- Skills created (with key best practices encoded)
-- Memory entries added (with location)
-"""  # noqa: E501
+"""Slash-command to URL mapping for commands that just open a browser."""
 
 
 class DeepAgentsApp(App):
@@ -720,6 +594,12 @@ class DeepAgentsApp(App):
 
     async def on_mount(self) -> None:
         """Initialize components after mount."""
+        # Move all objects allocated during import/compose into the permanent
+        # generation so the cyclic GC skips them during first-paint rendering.
+        import gc
+
+        gc.freeze()
+
         chat = self.query_one("#chat", VerticalScroll)
         chat.anchor()
         if is_ascii_mode():
@@ -986,9 +866,23 @@ class DeepAgentsApp(App):
         Populates `sys.modules` so the first user-triggered inline import
         is a cheap dict lookup instead of a cold module load.
         """
+        # Internal modules moved from top-level to local imports — a failure
+        # here indicates a packaging or code bug, not a missing optional dep, so
+        # we let the exception propagate (the worker catches it and logs
+        # at WARNING).
+        from deepagents_cli.clipboard import (
+            copy_selection_to_clipboard,  # noqa: F401
+        )
+        from deepagents_cli.command_registry import ALWAYS_IMMEDIATE  # noqa: F401
+        from deepagents_cli.config import settings  # noqa: F401
+        from deepagents_cli.hooks import dispatch_hook  # noqa: F401
+        from deepagents_cli.model_config import ModelSpec  # noqa: F401
+
         try:
-            # Heavy deps deferred from textual_adapter / tool_display —
-            # hit on first message send and first tool approval
+            # Heavy third-party deps deferred from textual_adapter /
+            # tool_display — hit on first message send and first tool
+            # approval. Best-effort: missing optional deps should not block the
+            # TUI from rendering.
             from deepagents.backends import DEFAULT_EXECUTE_TIMEOUT  # noqa: F401
             from langchain.agents.middleware.human_in_the_loop import (  # noqa: F401
                 ApproveDecision,
@@ -1269,6 +1163,12 @@ class DeepAgentsApp(App):
         Returns:
             A Future that resolves to the user's decision.
         """
+        from deepagents_cli.config import (
+            SHELL_TOOL_NAMES,
+            is_shell_command_allowed,
+            settings,
+        )
+
         loop = asyncio.get_running_loop()
         result_future: asyncio.Future = loop.create_future()
 
@@ -1577,6 +1477,12 @@ class DeepAgentsApp(App):
         Returns:
             `True` if the command should bypass the busy-state queue.
         """
+        from deepagents_cli.command_registry import (
+            BYPASS_WHEN_CONNECTING,
+            IMMEDIATE_UI,
+            SIDE_EFFECT_FREE,
+        )
+
         cmd = value.split(maxsplit=1)[0] if value else ""
         if cmd in BYPASS_WHEN_CONNECTING:
             return self._connecting and not (self._agent_running or self._shell_running)
@@ -1594,9 +1500,13 @@ class DeepAgentsApp(App):
         # Reset quit pending state on any input
         self._quit_pending = False
 
+        from deepagents_cli.hooks import dispatch_hook
+
         await dispatch_hook("user.prompt", {})
 
         # /quit and /q always execute immediately, even mid-thread-switch.
+        from deepagents_cli.command_registry import ALWAYS_IMMEDIATE
+
         if mode == "command" and value.lower().strip() in ALWAYS_IMMEDIATE:
             self.exit()
             return
@@ -1877,6 +1787,8 @@ class DeepAgentsApp(App):
         Returns:
             `Content` with a clickable thread ID, or a plain string.
         """
+        from deepagents_cli.config import build_langsmith_thread_url
+
         try:
             url = await asyncio.wait_for(
                 asyncio.to_thread(build_langsmith_thread_url, thread_id),
@@ -1902,6 +1814,8 @@ class DeepAgentsApp(App):
         Args:
             command: The raw command text (displayed as user message).
         """
+        from deepagents_cli.config import build_langsmith_thread_url
+
         await self._mount_message(UserMessage(command))
         if not self._session_state:
             await self._mount_message(AppMessage("No active session."))
@@ -1936,6 +1850,8 @@ class DeepAgentsApp(App):
         Args:
             command: The slash command (including /)
         """
+        from deepagents_cli.config import newline_shortcut, settings
+
         cmd = command.lower().strip()
 
         if cmd in {"/quit", "/q"}:
@@ -2203,6 +2119,8 @@ class DeepAgentsApp(App):
             A string like `"20.0K (10% of 200.0K)"` or
             `"last 6 messages"`, or `None` if the budget cannot be determined.
         """
+        from deepagents_cli.config import create_model, settings
+
         try:
             from deepagents.middleware.summarization import (
                 compute_summarization_defaults,
@@ -2226,6 +2144,7 @@ class DeepAgentsApp(App):
 
     async def _handle_offload(self) -> None:
         """Offload older messages to free context window space."""
+        from deepagents_cli.config import settings
         from deepagents_cli.offload import (
             OffloadModelError,
             OffloadThresholdNotMet,
@@ -2261,6 +2180,8 @@ class DeepAgentsApp(App):
         # Prevent concurrent user input while offload modifies state
         self._agent_running = True
         try:
+            from deepagents_cli.hooks import dispatch_hook
+
             await dispatch_hook("context.offload", {})
             # Keep old hook name for backward compatibility
             await dispatch_hook("context.compact", {})
@@ -3383,6 +3304,8 @@ class DeepAgentsApp(App):
 
     def on_mouse_up(self, event: MouseUp) -> None:  # noqa: ARG002  # Textual event handler signature
         """Copy selection to clipboard on mouse release."""
+        from deepagents_cli.clipboard import copy_selection_to_clipboard
+
         copy_selection_to_clipboard(self)
 
     # =========================================================================
@@ -3401,6 +3324,7 @@ class DeepAgentsApp(App):
         """
         from functools import partial
 
+        from deepagents_cli.config import settings
         from deepagents_cli.widgets.model_selector import ModelSelectorScreen
 
         def handle_result(result: tuple[str, str] | None) -> None:
@@ -3644,16 +3568,19 @@ class DeepAgentsApp(App):
                 for auto-detection.
             extra_kwargs: Extra constructor kwargs from `--model-params`.
         """
+        from deepagents_cli.config import create_model, detect_provider, settings
+        from deepagents_cli.model_config import (
+            ModelSpec,
+            get_credential_env_var,
+            has_provider_credentials,
+            save_recent_model,
+        )
+
         logger.info("Switching model to %s", model_spec)
 
         if self._model_switching:
             await self._mount_message(AppMessage("Model switch already in progress."))
             return
-
-        from deepagents_cli.model_config import (
-            get_credential_env_var,
-            has_provider_credentials,
-        )
 
         self._model_switching = True
         try:
@@ -3763,7 +3690,8 @@ class DeepAgentsApp(App):
         Args:
             model_spec: The model specification (e.g., `'anthropic:claude-opus-4-6'`).
         """
-        from deepagents_cli.model_config import save_default_model
+        from deepagents_cli.config import detect_provider
+        from deepagents_cli.model_config import ModelSpec, save_default_model
 
         model_spec = model_spec.removeprefix(":")
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
-from deepagents_cli._version import DOCS_URL as DOCS_URL, __version__
+from deepagents_cli._version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 
 _bootstrap_done = False
 """Whether `_ensure_bootstrap()` has executed."""
+
+_bootstrap_lock = threading.Lock()
+"""Guards `_ensure_bootstrap()` against concurrent access from the main
+thread and the prewarm worker thread."""
+
+_singleton_lock = threading.Lock()
+"""Guards lazy singleton construction in `_get_console` / `_get_settings`."""
 
 _bootstrap_start_path: Path | None = None
 """Working directory captured at bootstrap time for dotenv and project discovery."""
@@ -87,46 +94,50 @@ def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> b
 def _ensure_bootstrap() -> None:
     """Run one-time bootstrap: dotenv loading and `LANGSMITH_PROJECT` override.
 
-    Idempotent — subsequent calls are no-ops. Called automatically by
-    `_get_settings()` when `settings` is first accessed.
+    Idempotent and thread-safe — subsequent calls are no-ops. Called
+    automatically by `_get_settings()` when `settings` is first accessed.
 
     The flag is set in `finally` so that partial failures (e.g. a
     malformed `.env`) still mark bootstrap as done — preventing infinite retry
-    loops — while allowing the exception to propagate.
+    loops. Exceptions are caught and logged at ERROR level; the CLI proceeds
+    with the environment as-is.
     """
     global _bootstrap_done, _bootstrap_start_path, _original_langsmith_project  # noqa: PLW0603
 
     if _bootstrap_done:
         return
 
-    try:
-        from deepagents_cli.project_utils import (
-            get_server_project_context as _get_server_project_context,
-        )
+    with _bootstrap_lock:
+        if _bootstrap_done:  # double-check after acquiring lock
+            return
 
-        ctx = _get_server_project_context()
-        _bootstrap_start_path = ctx.user_cwd if ctx else None
-        _load_dotenv(start_path=_bootstrap_start_path)
+        try:
+            from deepagents_cli.project_utils import (
+                get_server_project_context as _get_server_project_context,
+            )
 
-        # Capture AFTER dotenv loading so .env-only values are visible,
-        # but BEFORE the override below replaces it.
-        _original_langsmith_project = os.environ.get("LANGSMITH_PROJECT")
+            ctx = _get_server_project_context()
+            _bootstrap_start_path = ctx.user_cwd if ctx else None
+            _load_dotenv(start_path=_bootstrap_start_path)
 
-        # CRITICAL: Override LANGSMITH_PROJECT to route agent traces to a
-        # separate project. LangSmith reads LANGSMITH_PROJECT at invocation
-        # time, so we override it here and preserve the user's original value
-        # for shell commands.
-        deepagents_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
-        if deepagents_project:
-            os.environ["LANGSMITH_PROJECT"] = deepagents_project
-    except Exception:
-        logger.warning(
-            "Bootstrap failed; .env values and LANGSMITH_PROJECT override "
-            "may be missing. The CLI will proceed with environment as-is.",
-            exc_info=True,
-        )
-    finally:
-        _bootstrap_done = True
+            # Capture AFTER dotenv loading so .env-only values are visible,
+            # but BEFORE the override below replaces it.
+            _original_langsmith_project = os.environ.get("LANGSMITH_PROJECT")
+
+            # CRITICAL: Override LANGSMITH_PROJECT to route agent traces to a
+            # separate project. LangSmith reads LANGSMITH_PROJECT at invocation
+            # time, so we override it here and preserve the user's original
+            # value for shell commands.
+            deepagents_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
+            if deepagents_project:
+                os.environ["LANGSMITH_PROJECT"] = deepagents_project
+        except Exception:
+            logger.exception(
+                "Bootstrap failed; .env values and LANGSMITH_PROJECT override "
+                "may be missing. The CLI will proceed with environment as-is.",
+            )
+        finally:
+            _bootstrap_done = True
 
 
 if TYPE_CHECKING:
@@ -1944,11 +1955,15 @@ def _get_console() -> Console:
     cached = globals().get("console")
     if cached is not None:
         return cached
-    from rich.console import Console
+    with _singleton_lock:
+        cached = globals().get("console")
+        if cached is not None:
+            return cached
+        from rich.console import Console
 
-    inst = Console(highlight=False)
-    globals()["console"] = inst
-    return inst
+        inst = Console(highlight=False)
+        globals()["console"] = inst
+        return inst
 
 
 def _get_settings() -> Settings:
@@ -1964,17 +1979,21 @@ def _get_settings() -> Settings:
     cached = globals().get("settings")
     if cached is not None:
         return cached
-    _ensure_bootstrap()
-    try:
-        inst = Settings.from_environment(start_path=_bootstrap_start_path)
-    except Exception:
-        logger.exception(
-            "Failed to initialize settings from environment (start_path=%s)",
-            _bootstrap_start_path,
-        )
-        raise
-    globals()["settings"] = inst
-    return inst
+    with _singleton_lock:
+        cached = globals().get("settings")
+        if cached is not None:
+            return cached
+        _ensure_bootstrap()
+        try:
+            inst = Settings.from_environment(start_path=_bootstrap_start_path)
+        except Exception:
+            logger.exception(
+                "Failed to initialize settings from environment (start_path=%s)",
+                _bootstrap_start_path,
+            )
+            raise
+        globals()["settings"] = inst
+        return inst
 
 
 def __getattr__(name: str) -> Settings | Console:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -59,7 +59,7 @@ def _find_dotenv_from_start_path(start_path: Path) -> Path | None:
                 return candidate
         except OSError:
             logger.warning("Could not inspect .env candidate %s", candidate)
-            return None
+            continue
     return None
 
 
@@ -119,6 +119,12 @@ def _ensure_bootstrap() -> None:
         deepagents_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
         if deepagents_project:
             os.environ["LANGSMITH_PROJECT"] = deepagents_project
+    except Exception:
+        logger.warning(
+            "Bootstrap failed; .env values and LANGSMITH_PROJECT override "
+            "may be missing. The CLI will proceed with environment as-is.",
+            exc_info=True,
+        )
     finally:
         _bootstrap_done = True
 
@@ -1235,8 +1241,8 @@ def get_langsmith_project_name() -> str | None:
     When both are present, resolves the project name with priority:
     `settings.deepagents_langchain_project` (from
     `DEEPAGENTS_LANGSMITH_PROJECT`), then `LANGSMITH_PROJECT` from the
-    environment (note: this may already have been overridden at import
-    time to match `DEEPAGENTS_LANGSMITH_PROJECT`), then `'default'`.
+    environment (note: this may already have been overridden at bootstrap time
+    to match `DEEPAGENTS_LANGSMITH_PROJECT`), then `'default'`.
 
     Returns:
         Project name string when LangSmith tracing is active, None otherwise.
@@ -1959,7 +1965,14 @@ def _get_settings() -> Settings:
     if cached is not None:
         return cached
     _ensure_bootstrap()
-    inst = Settings.from_environment(start_path=_bootstrap_start_path)
+    try:
+        inst = Settings.from_environment(start_path=_bootstrap_start_path)
+    except Exception:
+        logger.exception(
+            "Failed to initialize settings from environment (start_path=%s)",
+            _bootstrap_start_path,
+        )
+        raise
     globals()["settings"] = inst
     return inst
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -17,15 +17,29 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
-import dotenv
-from rich.console import Console
-
-from deepagents_cli._version import __version__
-from deepagents_cli.project_utils import (
-    get_server_project_context as _get_server_project_context,
-)
+from deepagents_cli._version import DOCS_URL as DOCS_URL, __version__
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy bootstrap: dotenv loading, LANGSMITH_PROJECT override, and start-path
+# detection are deferred until first access of `settings` (via module
+# `__getattr__`).  This avoids disk I/O and path traversal during import for
+# callers that never touch `settings` (e.g. `deepagents --help`).
+# ---------------------------------------------------------------------------
+
+_bootstrap_done = False
+"""Whether `_ensure_bootstrap()` has executed."""
+
+_bootstrap_start_path: Path | None = None
+"""Working directory captured at bootstrap time for dotenv and project discovery."""
+
+_original_langsmith_project: str | None = None
+"""Caller's `LANGSMITH_PROJECT` value before the CLI overrides it for agent traces.
+
+Captured inside `_ensure_bootstrap()` after dotenv loading but before the
+`LANGSMITH_PROJECT` override, so `.env`-only values are visible.
+"""
 
 
 def _find_dotenv_from_start_path(start_path: Path) -> Path | None:
@@ -59,6 +73,8 @@ def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> b
     Returns:
         `True` when a dotenv file was loaded, `False` otherwise.
     """
+    import dotenv
+
     if start_path is None:
         return dotenv.load_dotenv(override=override)
 
@@ -68,38 +84,55 @@ def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> b
     return dotenv.load_dotenv(dotenv_path=dotenv_path, override=override)
 
 
-_bootstrap_project_context = _get_server_project_context()
-_bootstrap_start_path = (
-    _bootstrap_project_context.user_cwd if _bootstrap_project_context else None
-)
+def _ensure_bootstrap() -> None:
+    """Run one-time bootstrap: dotenv loading and `LANGSMITH_PROJECT` override.
 
-_load_dotenv(start_path=_bootstrap_start_path)
+    Idempotent — subsequent calls are no-ops. Called automatically by
+    `_get_settings()` when `settings` is first accessed.
 
-# CRITICAL: Override LANGSMITH_PROJECT to route agent traces to separate project
-# LangSmith reads LANGSMITH_PROJECT at invocation time, so we override it here
-# and preserve the user's original value for shell commands
-_deepagents_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
-_original_langsmith_project = os.environ.get("LANGSMITH_PROJECT")
-if _deepagents_project:
-    # Override LANGSMITH_PROJECT for agent traces
-    os.environ["LANGSMITH_PROJECT"] = _deepagents_project
+    The flag is set in `finally` so that partial failures (e.g. a
+    malformed `.env`) still mark bootstrap as done — preventing infinite retry
+    loops — while allowing the exception to propagate.
+    """
+    global _bootstrap_done, _bootstrap_start_path, _original_langsmith_project  # noqa: PLW0603
 
-from deepagents_cli.model_config import (  # noqa: E402  # Import after os.environ setup above
-    ModelConfig,
-    ModelConfigError,
-    ModelSpec,
-)
-from deepagents_cli.project_utils import (  # noqa: E402
-    find_project_agent_md as _find_project_agent_md,
-    find_project_root as _find_project_root,
-)
+    if _bootstrap_done:
+        return
+
+    try:
+        from deepagents_cli.project_utils import (
+            get_server_project_context as _get_server_project_context,
+        )
+
+        ctx = _get_server_project_context()
+        _bootstrap_start_path = ctx.user_cwd if ctx else None
+        _load_dotenv(start_path=_bootstrap_start_path)
+
+        # Capture AFTER dotenv loading so .env-only values are visible,
+        # but BEFORE the override below replaces it.
+        _original_langsmith_project = os.environ.get("LANGSMITH_PROJECT")
+
+        # CRITICAL: Override LANGSMITH_PROJECT to route agent traces to a
+        # separate project. LangSmith reads LANGSMITH_PROJECT at invocation
+        # time, so we override it here and preserve the user's original value
+        # for shell commands.
+        deepagents_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
+        if deepagents_project:
+            os.environ["LANGSMITH_PROJECT"] = deepagents_project
+    finally:
+        _bootstrap_done = True
+
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
     from langchain_core.runnables import RunnableConfig
+    from rich.console import Console
 
-DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
-"""URL for deepagents-cli documentation."""
+    # Static type stubs for lazy module attributes resolved by __getattr__.
+    # At runtime these are created on first access by _get_settings() /
+    # _get_console() and cached in globals().
+    settings: Settings
+    console: Console
 
 COLORS = {
     "primary": "#10b981",
@@ -442,9 +475,6 @@ MAX_ARG_LENGTH = 150
 # Agent configuration
 config: RunnableConfig = {"recursion_limit": 1000}
 
-# Rich console instance
-console = Console(highlight=False)
-
 
 class _ShellAllowAll(list):  # noqa: FURB189  # sentinel type, not a general-purpose list subclass
     """Sentinel subclass for unrestricted shell access.
@@ -594,13 +624,18 @@ class Settings:
         # Detect LangSmith configuration
         # DEEPAGENTS_LANGSMITH_PROJECT: Project for deepagents agent tracing
         # user_langchain_project: User's ORIGINAL LANGSMITH_PROJECT (before override)
-        # Note: LANGSMITH_PROJECT was already overridden at module import time (above)
-        # so we use the saved original value, not the current os.environ value
+        # When accessed via the module-level `settings` singleton,
+        # _ensure_bootstrap() has already run and may have overridden
+        # LANGSMITH_PROJECT. We use the saved original value, not the
+        # current os.environ value. Direct callers should ensure
+        # bootstrap has run if they depend on the override.
         deepagents_langchain_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
         user_langchain_project = _original_langsmith_project  # Use saved original!
 
         # Detect project
-        project_root = _find_project_root(start_path)
+        from deepagents_cli.project_utils import find_project_root
+
+        project_root = find_project_root(start_path)
 
         # Parse shell command allow-list from environment
         # Format: comma-separated list of commands (e.g., "ls,cat,grep,pwd")
@@ -674,7 +709,9 @@ class Settings:
             shell_allow_list = previous["shell_allow_list"]
 
         try:
-            project_root = _find_project_root(start_path)
+            from deepagents_cli.project_utils import find_project_root
+
+            project_root = find_project_root(start_path)
         except OSError:
             logger.warning(
                 "Could not detect project root during reload; keeping previous value"
@@ -801,7 +838,9 @@ class Settings:
         """
         if not self.project_root:
             return []
-        return _find_project_agent_md(self.project_root)
+        from deepagents_cli.project_utils import find_project_agent_md
+
+        return find_project_agent_md(self.project_root)
 
     @staticmethod
     def _is_valid_agent_name(agent_name: str) -> bool:
@@ -965,10 +1004,6 @@ class Settings:
             Path to the `built_in_skills/` directory within the package.
         """
         return Path(__file__).parent / "built_in_skills"
-
-
-# Global settings instance (initialized once)
-settings = Settings.from_environment(start_path=_bootstrap_start_path)
 
 
 class SessionState:
@@ -1216,7 +1251,7 @@ def get_langsmith_project_name() -> str | None:
         return None
 
     return (
-        settings.deepagents_langchain_project
+        _get_settings().deepagents_langchain_project
         or os.environ.get("LANGSMITH_PROJECT")
         or "default"
     )
@@ -1370,12 +1405,14 @@ def detect_provider(model_name: str) -> str | None:
         return "openai"
 
     if model_lower.startswith("claude"):
-        if not settings.has_anthropic and settings.has_vertex_ai:
+        s = _get_settings()
+        if not s.has_anthropic and s.has_vertex_ai:
             return "google_vertexai"
         return "anthropic"
 
     if model_lower.startswith("gemini"):
-        if settings.has_vertex_ai and not settings.has_google:
+        s = _get_settings()
+        if s.has_vertex_ai and not s.has_google:
             return "google_vertexai"
         return "google_genai"
 
@@ -1400,6 +1437,8 @@ def _get_default_model_spec() -> str:
     Raises:
         ModelConfigError: If no credentials are configured.
     """
+    from deepagents_cli.model_config import ModelConfig, ModelConfigError
+
     config = ModelConfig.load()
     if config.default_model:
         return config.default_model
@@ -1407,15 +1446,16 @@ def _get_default_model_spec() -> str:
     if config.recent_model:
         return config.recent_model
 
-    if settings.has_openai:
+    s = _get_settings()
+    if s.has_openai:
         return "openai:gpt-5.2"
-    if settings.has_anthropic:
+    if s.has_anthropic:
         return "anthropic:claude-sonnet-4-6"
-    if settings.has_google:
+    if s.has_google:
         return "google_genai:gemini-3.1-pro-preview"
-    if settings.has_vertex_ai:
+    if s.has_vertex_ai:
         return "google_vertexai:gemini-3.1-pro-preview"
-    if settings.has_nvidia:
+    if s.has_nvidia:
         return "nvidia:nvidia/nemotron-3-super-120b-a12b"
 
     msg = (
@@ -1483,6 +1523,8 @@ def _get_provider_kwargs(
     Returns:
         Dictionary of provider-specific kwargs.
     """
+    from deepagents_cli.model_config import ModelConfig
+
     config = ModelConfig.load()
     result: dict[str, Any] = config.get_kwargs(provider, model_name=model_name)
     base_url = config.get_base_url(provider)
@@ -1524,6 +1566,8 @@ def _create_model_from_class(
     from langchain_core.language_models import (
         BaseChatModel as _BaseChatModel,  # Runtime import; module level is typing only
     )
+
+    from deepagents_cli.model_config import ModelConfigError
 
     if ":" not in class_path:
         msg = (
@@ -1580,6 +1624,8 @@ def _create_model_via_init(
         ModelConfigError: On import, value, or runtime errors.
     """
     from langchain.chat_models import init_chat_model
+
+    from deepagents_cli.model_config import ModelConfigError
 
     try:
         if provider:
@@ -1646,9 +1692,10 @@ class ModelResult:
 
     def apply_to_settings(self) -> None:
         """Commit this result's metadata to global `settings`."""
-        settings.model_name = self.model_name
-        settings.model_provider = self.provider
-        settings.model_context_limit = self.context_limit
+        s = _get_settings()
+        s.model_name = self.model_name
+        s.model_provider = self.provider
+        s.model_context_limit = self.context_limit
 
 
 def _apply_profile_overrides(
@@ -1677,6 +1724,8 @@ def _apply_profile_overrides(
         ModelConfigError: If `raise_on_failure` is `True` and the model
             rejects profile assignment.
     """
+    from deepagents_cli.model_config import ModelConfigError
+
     logger.debug("Applying %s profile overrides: %s", label, overrides)
     profile = getattr(model, "profile", None)
     merged = {**profile, **overrides} if isinstance(profile, dict) else overrides
@@ -1739,6 +1788,8 @@ def create_model(
         >>> model = create_model("gpt-4o")  # Auto-detects openai
         >>> model = create_model()  # Uses environment defaults
     """
+    from deepagents_cli.model_config import ModelConfig, ModelConfigError, ModelSpec
+
     if not model_spec:
         model_spec = _get_default_model_spec()
 
@@ -1838,6 +1889,7 @@ def validate_model_capabilities(model: BaseChatModel, model_name: str) -> None:
         a warning. Exits via sys.exit(1) if model profile explicitly indicates
         tool_calling=False.
     """
+    console = _get_console()
     profile = getattr(model, "profile", None)
 
     if profile is None:
@@ -1872,3 +1924,61 @@ def validate_model_capabilities(model: BaseChatModel, model_name: str) -> None:
             f"[dim][yellow]Warning:[/yellow] Model '{model_name}' has limited context "
             f"({max_input_tokens:,} tokens). Agent performance may be affected.[/dim]"
         )
+
+
+def _get_console() -> Console:
+    """Return the lazily-initialized global `Console` instance.
+
+    Defers the `rich.console` import until console output is actually
+    needed. The result is cached in `globals()["console"]`.
+
+    Returns:
+        The global Rich `Console` singleton.
+    """
+    cached = globals().get("console")
+    if cached is not None:
+        return cached
+    from rich.console import Console
+
+    inst = Console(highlight=False)
+    globals()["console"] = inst
+    return inst
+
+
+def _get_settings() -> Settings:
+    """Return the lazily-initialized global `Settings` instance.
+
+    Ensures bootstrap has run before constructing settings. The result is cached
+    in `globals()["settings"]` so subsequent access — including
+    `from config import settings` in other modules — resolves instantly.
+
+    Returns:
+        The global `Settings` singleton.
+    """
+    cached = globals().get("settings")
+    if cached is not None:
+        return cached
+    _ensure_bootstrap()
+    inst = Settings.from_environment(start_path=_bootstrap_start_path)
+    globals()["settings"] = inst
+    return inst
+
+
+def __getattr__(name: str) -> Settings | Console:
+    """Lazy module attributes for `settings` and `console`.
+
+    Defers heavy initialization until first access. Subsequent accesses hit
+    the module-level attribute directly (no `__getattr__` overhead).
+
+    Returns:
+        The requested lazy singleton.
+
+    Raises:
+        AttributeError: If *name* is not a lazily-provided attribute.
+    """
+    if name == "settings":
+        return _get_settings()
+    if name == "console":
+        return _get_console()
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/libs/cli/deepagents_cli/file_ops.py
+++ b/libs/cli/deepagents_cli/file_ops.py
@@ -136,9 +136,9 @@ def resolve_physical_path(
         return None
     try:
         if assistant_id and path_str.startswith("/memories/"):
-            from deepagents_cli.config import settings as _settings
+            from deepagents_cli.config import settings
 
-            agent_dir = _settings.get_agent_dir(assistant_id)
+            agent_dir = settings.get_agent_dir(assistant_id)
             suffix = path_str.removeprefix("/memories/").lstrip("/")
             return (agent_dir / suffix).resolve()
         path = Path(path_str)

--- a/libs/cli/deepagents_cli/file_ops.py
+++ b/libs/cli/deepagents_cli/file_ops.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from deepagents_cli.config import settings
-
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -138,7 +136,9 @@ def resolve_physical_path(
         return None
     try:
         if assistant_id and path_str.startswith("/memories/"):
-            agent_dir = settings.get_agent_dir(assistant_id)
+            from deepagents_cli.config import settings as _settings
+
+            agent_dir = _settings.get_agent_dir(assistant_id)
             suffix = path_str.removeprefix("/memories/").lstrip("/")
             return (agent_dir / suffix).resolve()
         path = Path(path_str)

--- a/libs/cli/deepagents_cli/hooks.py
+++ b/libs/cli/deepagents_cli/hooks.py
@@ -23,11 +23,7 @@ import subprocess  # noqa: S404
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from deepagents_cli.model_config import DEFAULT_CONFIG_DIR
-
 logger = logging.getLogger(__name__)
-
-_HOOKS_PATH = DEFAULT_CONFIG_DIR / "hooks.json"
 
 _hooks_config: list[dict[str, Any]] | None = None
 """Cached config — loaded lazily on first dispatch."""
@@ -47,16 +43,20 @@ def _load_hooks() -> list[dict[str, Any]]:
     if _hooks_config is not None:
         return _hooks_config
 
-    if not _HOOKS_PATH.is_file():
+    from deepagents_cli.model_config import DEFAULT_CONFIG_DIR
+
+    hooks_path = DEFAULT_CONFIG_DIR / "hooks.json"
+
+    if not hooks_path.is_file():
         _hooks_config = []
         return _hooks_config
 
     try:
-        data = json.loads(_HOOKS_PATH.read_text())
+        data = json.loads(hooks_path.read_text())
         if not isinstance(data, dict):
             logger.warning(
                 "Hooks config at %s must be a JSON object, got %s",
-                _HOOKS_PATH,
+                hooks_path,
                 type(data).__name__,
             )
             _hooks_config = []
@@ -65,14 +65,14 @@ def _load_hooks() -> list[dict[str, Any]]:
         if not isinstance(hooks, list):
             logger.warning(
                 "Hooks config 'hooks' key at %s must be a list, got %s",
-                _HOOKS_PATH,
+                hooks_path,
                 type(hooks).__name__,
             )
             _hooks_config = []
             return _hooks_config
         _hooks_config = hooks
     except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Failed to load hooks config from %s: %s", _HOOKS_PATH, exc)
+        logger.warning("Failed to load hooks config from %s: %s", hooks_path, exc)
         _hooks_config = []
 
     return _hooks_config

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -648,29 +648,17 @@ async def run_textual_cli_async(
     """
     from rich.text import Text
 
-    from deepagents_cli.app import run_textual_app
-    from deepagents_cli.config import console, create_model
-    from deepagents_cli.model_config import ModelConfigError, save_recent_model
+    from deepagents_cli.app import AppResult, run_textual_app
 
-    try:
-        result = create_model(
-            model_name,
-            extra_kwargs=model_params,
-            profile_overrides=profile_override,
-        )
-    except ModelConfigError as e:
-        from deepagents_cli.app import AppResult
-
-        console.print(f"[bold red]Error:[/bold red] {e}")
-        return AppResult(return_code=1, thread_id=None)
-
-    result.apply_to_settings()
-
-    # Persist the resolved model so [models].recent is always populated,
-    # not only after an explicit /model switch.
-    save_recent_model(f"{result.provider}:{result.model_name}")
-
-    from deepagents_cli.app import AppResult
+    # Model creation is deferred to a background worker inside the TUI so
+    # first paint is not blocked by the langchain import + init.
+    # The model_kwargs are passed through to DeepAgentsApp which runs
+    # create_model() after the splash screen is visible.
+    model_kwargs: dict[str, Any] = {
+        "model_spec": model_name,
+        "extra_kwargs": model_params,
+        "profile_overrides": profile_override,
+    }
 
     # Build kwargs for deferred server startup (runs inside the TUI)
     server_kwargs: dict[str, Any] = {
@@ -706,9 +694,12 @@ async def run_textual_cli_async(
             profile_override=profile_override,
             server_kwargs=server_kwargs,
             mcp_preload_kwargs=mcp_preload_kwargs,
+            model_kwargs=model_kwargs,
         )
     except Exception as e:
         logger.debug("App error", exc_info=True)
+        from deepagents_cli.config import console
+
         error_text = Text("Application error: ", style="red")
         error_text.append(str(e))
         console.print(error_text)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1093,8 +1093,8 @@ def cli_main() -> None:
     try:
         args = parse_args()
 
-        # Import console/settings AFTER arg parsing so headless fast-paths
-        # (--help, --version) never pay the config bootstrap cost.
+        # Import console/settings AFTER arg parsing so --help (which exits
+        # inside parse_args) never pays the settings bootstrap cost.
         from deepagents_cli.config import console, settings
 
         model_params: dict[str, Any] | None = None

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1058,10 +1058,10 @@ def cli_main() -> None:
     if sys.platform == "darwin":
         os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "0"
 
-    # Note: LANGSMITH_PROJECT is already overridden in config.py
-    # (before LangChain imports). This ensures agent traces use
-    # DEEPAGENTS_LANGSMITH_PROJECT while shell commands use the
-    # user's original LANGSMITH_PROJECT (via LocalShellBackend env).
+    # Note: LANGSMITH_PROJECT override is handled lazily by config.py's
+    # _ensure_bootstrap() (triggered on first access of `settings`).
+    # This ensures agent traces use DEEPAGENTS_LANGSMITH_PROJECT while
+    # shell commands use the user's original LANGSMITH_PROJECT.
 
     # Fast path: print version without loading heavy dependencies
     if len(sys.argv) == 2 and sys.argv[1] in {"-v", "--version"}:  # noqa: PLR2004  # argv length check for fast-path
@@ -1085,10 +1085,12 @@ def cli_main() -> None:
     if "--acp" not in sys.argv[1:]:
         check_cli_dependencies()
 
-    from deepagents_cli.config import console, settings
-
     try:
         args = parse_args()
+
+        # Import console/settings AFTER arg parsing so headless fast-paths
+        # (--help, --version) never pay the config bootstrap cost.
+        from deepagents_cli.config import console, settings
 
         model_params: dict[str, Any] | None = None
         raw_kwargs = getattr(args, "model_params", None)
@@ -1491,8 +1493,12 @@ def cli_main() -> None:
                 hint.append(str(thread_id), style="cyan")
                 console.print(hint)
     except KeyboardInterrupt:
-        # Clean exit on Ctrl+C - suppress ugly traceback
-        console.print("\n\n[yellow]Interrupted[/yellow]")
+        # Clean exit on Ctrl+C — suppress ugly traceback.
+        # `console` may not be bound if Ctrl+C arrives during config import.
+        try:
+            console.print("\n\n[yellow]Interrupted[/yellow]")
+        except NameError:
+            sys.stderr.write("\n\nInterrupted\n")
         sys.exit(0)
 
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -608,6 +608,7 @@ async def run_textual_cli_async(
     model_params: dict[str, Any] | None = None,
     profile_override: dict[str, Any] | None = None,
     thread_id: str | None = None,
+    resume_thread: str | None = None,
     initial_prompt: str | None = None,
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
@@ -634,6 +635,12 @@ async def run_textual_cli_async(
 
             Merged on top of config file profile overrides.
         thread_id: Thread ID to use (new or resumed)
+        resume_thread: Raw resume intent from `-r` flag.
+
+            `'__MOST_RECENT__'` for bare `-r`, a thread ID string for `-r <id>`,
+            or `None` for new sessions.
+
+            Resolved asynchronously inside the TUI.
         initial_prompt: Optional prompt to auto-submit when session starts
         mcp_config_path: Optional path to MCP servers JSON configuration file.
 
@@ -712,6 +719,7 @@ async def run_textual_cli_async(
             auto_approve=auto_approve,
             cwd=Path.cwd(),
             thread_id=thread_id,
+            resume_thread=resume_thread,
             initial_prompt=initial_prompt,
             profile_override=profile_override,
             server_kwargs=server_kwargs,
@@ -1364,72 +1372,15 @@ def cli_main() -> None:
                 build_langsmith_thread_url,
             )
             from deepagents_cli.sessions import (
-                find_similar_threads,
                 generate_thread_id,
-                get_most_recent,
-                get_thread_agent,
                 thread_exists,
             )
 
-            thread_id = None
-
-            if args.resume_thread == "__MOST_RECENT__":
-                # -r (no ID): Get most recent thread
-                # If --agent specified, filter by that agent; otherwise get
-                # most recent overall
-                agent_filter = args.agent if args.agent != _DEFAULT_AGENT_NAME else None
-                thread_id = asyncio.run(get_most_recent(agent_filter))
-                if thread_id:
-                    agent_name = asyncio.run(get_thread_agent(thread_id))
-                    if agent_name:
-                        args.agent = agent_name
-                else:
-                    if agent_filter:
-                        msg = Text("No previous thread for '", style="yellow")
-                        msg.append(args.agent)
-                        msg.append("', starting new.", style="yellow")
-                    else:
-                        msg = Text("No previous threads, starting new.", style="yellow")
-                    console.print(msg)
-
-            elif args.resume_thread:
-                # -r <ID>: Resume specific thread
-                if asyncio.run(thread_exists(args.resume_thread)):
-                    thread_id = args.resume_thread
-                    if args.agent == _DEFAULT_AGENT_NAME:
-                        agent_name = asyncio.run(get_thread_agent(thread_id))
-                        if agent_name:
-                            args.agent = agent_name
-                else:
-                    error_msg = Text("Thread '", style="red")
-                    error_msg.append(args.resume_thread)
-                    error_msg.append("' not found.", style="red")
-                    console.print(error_msg)
-
-                    # Check for similar thread IDs
-                    similar = asyncio.run(find_similar_threads(args.resume_thread))
-                    if similar:
-                        console.print()
-                        console.print("[yellow]Did you mean?[/yellow]")
-                        for tid in similar:
-                            hint = Text("  deepagents -r ", style="cyan")
-                            hint.append(str(tid), style="cyan")
-                            console.print(hint)
-                        console.print()
-
-                    console.print(
-                        "[dim]Use 'deepagents threads list' to see "
-                        "available threads.[/dim]"
-                    )
-                    console.print(
-                        "[dim]Use 'deepagents -r' to resume the most "
-                        "recent thread.[/dim]"
-                    )
-                    sys.exit(1)
-
-            # Generate new thread ID if not resuming
-            if thread_id is None:
-                thread_id = generate_thread_id()
+            # Instead of resolving thread_id here with synchronous asyncio.run()
+            # DB calls, pass the raw resume request to the TUI and let it
+            # resolve asynchronously during startup.
+            resume_thread = args.resume_thread  # "__MOST_RECENT__", "<id>", or None
+            thread_id = None if resume_thread else generate_thread_id()
 
             # Validate sandbox provider deps before spawning server subprocess
             if args.sandbox and args.sandbox not in {"none", "langsmith"}:
@@ -1462,6 +1413,7 @@ def cli_main() -> None:
                         model_params=model_params,
                         profile_override=profile_override,
                         thread_id=thread_id,
+                        resume_thread=resume_thread,
                         initial_prompt=getattr(args, "initial_prompt", None),
                         mcp_config_path=getattr(args, "mcp_config", None),
                         no_mcp=getattr(args, "no_mcp", False),
@@ -1482,21 +1434,22 @@ def cli_main() -> None:
 
             # Show LangSmith thread link for threads with checkpointed
             # content (same table that backs the `/threads` listing).
-            try:
-                thread_url = build_langsmith_thread_url(thread_id)
-                if thread_url and asyncio.run(thread_exists(thread_id)):
-                    console.print()
-                    ls_hint = Text("View this thread in LangSmith: ", style="dim")
-                    ls_hint.append(
-                        thread_url,
-                        style=Style(dim=True, link=thread_url),
+            if thread_id:
+                try:
+                    thread_url = build_langsmith_thread_url(thread_id)
+                    if thread_url and asyncio.run(thread_exists(thread_id)):
+                        console.print()
+                        ls_hint = Text("View this thread in LangSmith: ", style="dim")
+                        ls_hint.append(
+                            thread_url,
+                            style=Style(dim=True, link=thread_url),
+                        )
+                        console.print(ls_hint)
+                except Exception:
+                    logger.debug(
+                        "Could not display LangSmith thread URL on teardown",
+                        exc_info=True,
                     )
-                    console.print(ls_hint)
-            except Exception:
-                logger.debug(
-                    "Could not display LangSmith thread URL on teardown",
-                    exc_info=True,
-                )
 
             # Show resume hint on exit for threads with checkpointed content.
             if thread_id and return_code == 0 and asyncio.run(thread_exists(thread_id)):

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -649,11 +649,25 @@ async def run_textual_cli_async(
     from rich.text import Text
 
     from deepagents_cli.app import AppResult, run_textual_app
+    from deepagents_cli.config import (
+        _get_default_model_spec,
+        detect_provider,
+        settings,
+    )
+    from deepagents_cli.model_config import ModelSpec
 
-    # Model creation is deferred to a background worker inside the TUI so
-    # first paint is not blocked by the langchain import + init.
-    # The model_kwargs are passed through to DeepAgentsApp which runs
-    # create_model() after the splash screen is visible.
+    # Resolve display-name cheaply (<1ms, no langchain) so the status
+    # bar can show the model on first paint. The expensive create_model()
+    # (~560ms) is deferred to a background worker.
+    resolved_spec = model_name or _get_default_model_spec()
+    parsed = ModelSpec.try_parse(resolved_spec)
+    if parsed:
+        settings.model_provider = parsed.provider
+        settings.model_name = parsed.model
+    else:
+        settings.model_name = resolved_spec
+        settings.model_provider = detect_provider(resolved_spec) or ""
+
     model_kwargs: dict[str, Any] = {
         "model_spec": model_name,
         "extra_kwargs": model_params,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -634,7 +634,10 @@ async def run_textual_cli_async(
         profile_override: Extra profile fields from `--profile-override`.
 
             Merged on top of config file profile overrides.
-        thread_id: Thread ID to use (new or resumed)
+        thread_id: Thread ID for the session.
+
+            `None` when `resume_thread` is provided (the TUI resolves the final
+            ID asynchronously).
         resume_thread: Raw resume intent from `-r` flag.
 
             `'__MOST_RECENT__'` for bare `-r`, a thread ID string for `-r <id>`,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -654,12 +654,20 @@ async def run_textual_cli_async(
         detect_provider,
         settings,
     )
-    from deepagents_cli.model_config import ModelSpec
+    from deepagents_cli.model_config import ModelConfigError, ModelSpec
 
     # Resolve display-name cheaply (<1ms, no langchain) so the status
     # bar can show the model on first paint. The expensive create_model()
     # (~560ms) is deferred to a background worker.
-    resolved_spec = model_name or _get_default_model_spec()
+
+    try:
+        resolved_spec = model_name or _get_default_model_spec()
+    except ModelConfigError as e:
+        from deepagents_cli.config import console
+
+        console.print(f"[bold red]Error:[/bold red] {e}", highlight=False)
+        return AppResult(return_code=1, thread_id=None)
+
     parsed = ModelSpec.try_parse(resolved_spec)
     if parsed:
         settings.model_provider = parsed.provider

--- a/libs/cli/deepagents_cli/prompts.py
+++ b/libs/cli/deepagents_cli/prompts.py
@@ -1,0 +1,115 @@
+# ruff: noqa: E501  # Long prompt strings
+"""Prompt constants used by slash commands."""
+
+REMEMBER_PROMPT = """Review our conversation and capture valuable knowledge. Focus especially on **best practices** we discussed or discovered—these are the most important things to preserve.
+
+## Step 1: Identify Best Practices and Key Learnings
+
+Scan the conversation for:
+
+### Best Practices (highest priority)
+- **Patterns that worked well** - approaches, techniques, or solutions we found effective
+- **Anti-patterns to avoid** - mistakes, gotchas, or approaches that caused problems
+- **Quality standards** - criteria we established for good code, documentation, or processes
+- **Decision rationale** - why we chose one approach over another
+
+### Other Valuable Knowledge
+- Coding conventions and style preferences
+- Project architecture decisions
+- Workflows and processes we developed
+- Tools, libraries, or techniques worth remembering
+- Feedback I gave about your behavior or outputs
+
+## Step 2: Decide Where to Store Each Learning
+
+For each best practice or learning, choose the right destination:
+
+### -> Memory (AGENTS.md) for preferences and guidelines
+Use memory when the knowledge is:
+- A preference or guideline (not a multi-step process)
+- Something to always keep in mind
+- A simple rule or pattern
+
+**Global** (`~/.deepagents/agent/AGENTS.md`): Universal preferences across all projects
+**Project** (`.deepagents/AGENTS.md`): Project-specific conventions and decisions
+
+### -> Skill for reusable workflows and methodologies
+**Create a skill when** we developed:
+- A multi-step process worth reusing
+- A methodology for a specific type of task
+- A workflow with best practices baked in
+- A procedure that should be followed consistently
+
+Skills are more powerful than memory entries because they can encode **how** to do something well, not just **what** to remember.
+
+## Step 3: Create Skills for Significant Best Practices
+
+If we established best practices around a workflow or process, capture them in a skill.
+
+**Example:** If we discussed best practices for code review, create a `code-review` skill that encodes those practices into a reusable workflow.
+
+### Skill Location
+`~/.deepagents/agent/skills/<skill-name>/SKILL.md`
+
+### Skill Structure
+```
+skill-name/
+├── SKILL.md          (required - main instructions with best practices)
+├── scripts/          (optional - executable code)
+├── references/       (optional - detailed documentation)
+└── assets/           (optional - templates, examples)
+```
+
+### SKILL.md Format
+```markdown
+---
+name: skill-name
+description: "What this skill does AND when to use it. Include triggers like 'when the user asks to X' or 'when working with Y'. This description determines when the skill activates."
+---
+
+# Skill Name
+
+## Overview
+Brief explanation of what this skill accomplishes.
+
+## Best Practices
+Capture the key best practices upfront:
+- Best practice 1: explanation
+- Best practice 2: explanation
+
+## Process
+Step-by-step instructions (imperative form):
+1. First, do X
+2. Then, do Y
+3. Finally, do Z
+
+## Common Pitfalls
+- Pitfall to avoid and why
+- Another anti-pattern we discovered
+```
+
+### Key Principles
+1. **Encode best practices prominently** - Put them near the top so they guide the entire workflow
+2. **Concise is key** - Only include non-obvious knowledge. Every paragraph should justify its token cost.
+3. **Clear triggers** - The description determines when the skill activates. Be specific.
+4. **Imperative form** - Write as commands: "Create a file" not "You should create a file"
+5. **Include anti-patterns** - What NOT to do is often as valuable as what to do
+
+## Step 4: Update Memory for Simpler Learnings
+
+For preferences, guidelines, and simple rules that don't warrant a full skill:
+
+```markdown
+## Best Practices
+- When doing X, always Y because Z
+- Avoid A because it leads to B
+```
+
+Use `edit_file` to update existing files or `write_file` to create new ones.
+
+## Step 5: Summarize Changes
+
+List what you captured and where you stored it:
+- Skills created (with key best practices encoded)
+- Memory entries added (with location)
+"""

--- a/libs/cli/deepagents_cli/prompts.py
+++ b/libs/cli/deepagents_cli/prompts.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E501  # Long prompt strings
-"""Prompt constants used by slash commands."""
+"""Prompt constants for slash commands."""
 
 REMEMBER_PROMPT = """Review our conversation and capture valuable knowledge. Focus especially on **best practices** we discussed or discovered—these are the most important things to preserve.
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -38,7 +38,6 @@ from deepagents_cli._session_stats import (
     SpinnerStatus as SpinnerStatus,
     format_token_count as format_token_count,
 )
-from deepagents_cli.config import settings
 from deepagents_cli.file_ops import FileOpTracker
 from deepagents_cli.hooks import dispatch_hook
 from deepagents_cli.input import MediaTracker, parse_file_mentions
@@ -781,7 +780,9 @@ async def execute_task_textual(
                             input_toks = usage.get("input_tokens", 0)
                             output_toks = usage.get("output_tokens", 0)
                             total_toks = usage.get("total_tokens", 0)
-                            active_model = settings.model_name or ""
+                            from deepagents_cli.config import settings as _settings
+
+                            active_model = _settings.model_name or ""
                             if input_toks or output_toks:
                                 # Model gives split counts — preferred path
                                 turn_stats.record_request(

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -780,9 +780,9 @@ async def execute_task_textual(
                             input_toks = usage.get("input_tokens", 0)
                             output_toks = usage.get("output_tokens", 0)
                             total_toks = usage.get("total_tokens", 0)
-                            from deepagents_cli.config import settings as _settings
+                            from deepagents_cli.config import settings
 
-                            active_model = _settings.model_name or ""
+                            active_model = settings.model_name or ""
                             if input_toks or output_toks:
                                 # Model gives split counts — preferred path
                                 turn_stats.record_request(

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -6,10 +6,9 @@ argparse tree.  It must stay lightweight — no SDK or langchain imports.
 
 from rich.markup import escape
 
-from deepagents_cli._version import __version__
+from deepagents_cli._version import DOCS_URL, __version__
 from deepagents_cli.config import (
     COLORS,
-    DOCS_URL,
     _get_editable_install_path,
     _is_editable_install,
     console,

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from textual.containers import Vertical
 from textual.content import Content
-from textual.widgets import Markdown, Static
+from textual.widgets import Static
 
 from deepagents_cli.config import (
     COLORS,
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
     from textual.events import Click
     from textual.timer import Timer
+    from textual.widgets import Markdown
     from textual.widgets._markdown import MarkdownStream
 
 logger = logging.getLogger(__name__)
@@ -307,10 +308,14 @@ class AssistantMessage(_TimestampClickMixin, Vertical):
         Yields:
             Markdown widget for rendering assistant content.
         """
+        from textual.widgets import Markdown
+
         yield Markdown("", id="assistant-content")
 
     def on_mount(self) -> None:
         """Store reference to markdown widget."""
+        from textual.widgets import Markdown
+
         self._markdown = self.query_one("#assistant-content", Markdown)
 
     def _get_markdown(self) -> Markdown:
@@ -320,6 +325,8 @@ class AssistantMessage(_TimestampClickMixin, Vertical):
             The Markdown widget for this message.
         """
         if self._markdown is None:
+            from textual.widgets import Markdown
+
             self._markdown = self.query_one("#assistant-content", Markdown)
         return self._markdown
 
@@ -330,6 +337,8 @@ class AssistantMessage(_TimestampClickMixin, Vertical):
             The MarkdownStream instance for streaming content.
         """
         if self._stream is None:
+            from textual.widgets import Markdown
+
             self._stream = Markdown.get_stream(self._get_markdown())
         return self._stream
 

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -14,7 +14,7 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
-from deepagents_cli.config import COLORS, get_glyphs, settings
+from deepagents_cli.config import COLORS, get_glyphs
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +220,8 @@ class StatusBar(Horizontal):
 
     def on_mount(self) -> None:
         """Set reactive values after mount to trigger watchers safely."""
+        from deepagents_cli.config import settings
+
         self.cwd = self._initial_cwd
         # Set initial model display
         label = self.query_one("#model-display", ModelLabel)

--- a/libs/cli/tests/integration_tests/benchmarks/test_startup_benchmarks.py
+++ b/libs/cli/tests/integration_tests/benchmarks/test_startup_benchmarks.py
@@ -63,6 +63,11 @@ HEAVY_MODULES = frozenset(
         "deepagents_cli.sessions",
         "deepagents_cli.integrations.sandbox_factory",
         "deepagents_cli.tools",
+        # Deferred from config.py module level to lazy local imports
+        "dotenv",
+        "dotenv.main",
+        "deepagents_cli.model_config",
+        "deepagents_cli.project_utils",
     }
 )
 
@@ -136,6 +141,7 @@ class TestImportIsolation:
         [
             "from deepagents_cli.main import parse_args",
             "from deepagents_cli.main import check_cli_dependencies",
+            "from deepagents_cli.config import is_ascii_mode",
             "import deepagents_cli.ui",
             "import deepagents_cli.skills.commands",
             "from deepagents_cli._cli_context import CLIContext",
@@ -147,6 +153,7 @@ class TestImportIsolation:
         ids=[
             "main.parse_args",
             "main.check_cli_dependencies",
+            "config.is_ascii_mode",
             "ui",
             "skills.commands",
             "_cli_context.CLIContext",

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1118,7 +1118,7 @@ class TestTraceCommand:
 
             with (
                 patch(
-                    "deepagents_cli.app.build_langsmith_thread_url",
+                    "deepagents_cli.config.build_langsmith_thread_url",
                     return_value="https://smith.langchain.com/o/org/projects/p/proj/t/test-thread-123",
                 ),
                 patch("deepagents_cli.app.webbrowser.open") as mock_open,
@@ -1144,7 +1144,7 @@ class TestTraceCommand:
             app._session_state = TextualSessionState()
 
             with patch(
-                "deepagents_cli.app.build_langsmith_thread_url",
+                "deepagents_cli.config.build_langsmith_thread_url",
                 return_value=None,
             ):
                 await app._handle_trace_command("/trace")
@@ -1175,7 +1175,7 @@ class TestTraceCommand:
 
             with (
                 patch(
-                    "deepagents_cli.app.build_langsmith_thread_url",
+                    "deepagents_cli.config.build_langsmith_thread_url",
                     return_value="https://smith.langchain.com/t/test-thread-123",
                 ),
                 patch(
@@ -1200,7 +1200,7 @@ class TestTraceCommand:
             app._session_state = TextualSessionState(thread_id="test-thread-123")
 
             with patch(
-                "deepagents_cli.app.build_langsmith_thread_url",
+                "deepagents_cli.config.build_langsmith_thread_url",
                 side_effect=RuntimeError("SDK error"),
             ):
                 await app._handle_trace_command("/trace")

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1827,3 +1827,127 @@ class TestLazyModuleAttributes:
         a = _get_settings()
         b = _get_settings()
         assert a is b
+
+    def test_ensure_bootstrap_langsmith_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_ensure_bootstrap copies DEEPAGENTS_LANGSMITH_PROJECT."""
+        import deepagents_cli.config as config_mod
+        from deepagents_cli.config import _ensure_bootstrap
+
+        original_done = config_mod._bootstrap_done
+        original_ls = config_mod._original_langsmith_project
+        config_mod._bootstrap_done = False
+
+        try:
+            monkeypatch.setenv("DEEPAGENTS_LANGSMITH_PROJECT", "my-agent-project")
+            monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
+
+            with (
+                patch("deepagents_cli.config._load_dotenv"),
+                patch(
+                    "deepagents_cli.project_utils.get_server_project_context",
+                    return_value=None,
+                ),
+            ):
+                _ensure_bootstrap()
+
+            assert config_mod._original_langsmith_project is None
+            import os
+
+            assert os.environ["LANGSMITH_PROJECT"] == "my-agent-project"
+        finally:
+            config_mod._bootstrap_done = original_done
+            config_mod._original_langsmith_project = original_ls
+
+    def test_ensure_bootstrap_preserves_original_langsmith(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_ensure_bootstrap captures original LANGSMITH_PROJECT."""
+        import deepagents_cli.config as config_mod
+        from deepagents_cli.config import _ensure_bootstrap
+
+        original_done = config_mod._bootstrap_done
+        original_ls = config_mod._original_langsmith_project
+        config_mod._bootstrap_done = False
+
+        try:
+            monkeypatch.setenv("LANGSMITH_PROJECT", "user-project")
+            monkeypatch.setenv("DEEPAGENTS_LANGSMITH_PROJECT", "agent-project")
+
+            with (
+                patch("deepagents_cli.config._load_dotenv"),
+                patch(
+                    "deepagents_cli.project_utils.get_server_project_context",
+                    return_value=None,
+                ),
+            ):
+                _ensure_bootstrap()
+
+            assert config_mod._original_langsmith_project == "user-project"
+            import os
+
+            assert os.environ["LANGSMITH_PROJECT"] == "agent-project"
+        finally:
+            config_mod._bootstrap_done = original_done
+            config_mod._original_langsmith_project = original_ls
+
+
+class TestFindDotenvFromStartPath:
+    """Tests for _find_dotenv_from_start_path."""
+
+    def test_finds_env_in_start_dir(self, tmp_path: Path) -> None:
+        """Finds .env in the start directory itself."""
+        from deepagents_cli.config import _find_dotenv_from_start_path
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=val")
+        assert _find_dotenv_from_start_path(tmp_path) == env_file
+
+    def test_finds_env_in_parent(self, tmp_path: Path) -> None:
+        """Finds .env in a parent directory."""
+        from deepagents_cli.config import _find_dotenv_from_start_path
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=val")
+        child = tmp_path / "a" / "b"
+        child.mkdir(parents=True)
+        assert _find_dotenv_from_start_path(child) == env_file
+
+    def test_returns_none_when_no_env(self, tmp_path: Path) -> None:
+        """Returns None when no .env exists anywhere."""
+        from deepagents_cli.config import _find_dotenv_from_start_path
+
+        child = tmp_path / "a"
+        child.mkdir()
+        # No .env anywhere under tmp_path — the search will keep going
+        # to real parent dirs, but tmp_path itself has none
+        result = _find_dotenv_from_start_path(child)
+        # May find a real .env in parent dirs; just check it doesn't crash
+        assert result is None or result.name == ".env"
+
+    def test_continues_past_oserror_on_intermediate_dir(self, tmp_path: Path) -> None:
+        """OSError on an intermediate .env candidate doesn't abort search."""
+        from deepagents_cli.config import _find_dotenv_from_start_path
+
+        # Create .env in the grandparent
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=val")
+
+        child = tmp_path / "sub"
+        child.mkdir()
+
+        # Patch is_file to raise OSError for the child's .env candidate
+        original_is_file = Path.is_file
+
+        def patched_is_file(self: Path) -> bool:
+            if self == child / ".env":
+                msg = "Permission denied"
+                raise OSError(msg)
+            return original_is_file(self)
+
+        with patch.object(Path, "is_file", patched_is_file):
+            result = _find_dotenv_from_start_path(child)
+
+        # Should continue past the OSError and find .env in parent
+        assert result == env_file

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1763,3 +1763,39 @@ class TestDetectProvider:
             assert detect_provider("GPT-4o") == "openai"
         finally:
             settings.anthropic_api_key = None
+
+
+class TestLazyModuleAttributes:
+    """Tests for lazy `__getattr__` resolution of `settings` and `console`."""
+
+    def test_getattr_returns_settings(self) -> None:
+        """Module __getattr__ resolves 'settings' to a Settings instance."""
+        from deepagents_cli.config import _get_settings
+
+        result = _get_settings()
+        assert isinstance(result, Settings)
+
+    def test_getattr_returns_console(self) -> None:
+        """Module __getattr__ resolves 'console' to a Console instance."""
+        from rich.console import Console
+
+        from deepagents_cli.config import _get_console
+
+        result = _get_console()
+        assert isinstance(result, Console)
+
+    def test_getattr_raises_for_unknown(self) -> None:
+        """Module __getattr__ raises AttributeError for unknown names."""
+        import deepagents_cli.config as config_mod
+
+        with pytest.raises(AttributeError, match="no attribute"):
+            getattr(config_mod, "nonexistent_attr_xyz")  # noqa: B009  # intentional __getattr__ test
+
+    def test_ensure_bootstrap_is_idempotent(self) -> None:
+        """_ensure_bootstrap is a no-op on second call."""
+        from deepagents_cli.config import _ensure_bootstrap
+
+        # First call already ran (settings was imported above).
+        # Calling again should be a harmless no-op.
+        _ensure_bootstrap()
+        assert isinstance(settings, Settings)

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1799,3 +1799,31 @@ class TestLazyModuleAttributes:
         # Calling again should be a harmless no-op.
         _ensure_bootstrap()
         assert isinstance(settings, Settings)
+
+    def test_ensure_bootstrap_marks_done_on_failure(self) -> None:
+        """_ensure_bootstrap sets flag even when the try body raises."""
+        import deepagents_cli.config as config_mod
+        from deepagents_cli.config import _ensure_bootstrap
+
+        # Reset flag so bootstrap will re-enter
+        original = config_mod._bootstrap_done
+        config_mod._bootstrap_done = False
+
+        try:
+            with patch(
+                "deepagents_cli.config._load_dotenv", side_effect=RuntimeError("boom")
+            ):
+                _ensure_bootstrap()  # should warn, not raise
+
+            # Flag must be set even after failure
+            assert config_mod._bootstrap_done is True
+        finally:
+            config_mod._bootstrap_done = original
+
+    def test_get_settings_returns_same_instance(self) -> None:
+        """_get_settings caches in globals — two calls return the same object."""
+        from deepagents_cli.config import _get_settings
+
+        a = _get_settings()
+        b = _get_settings()
+        assert a is b

--- a/libs/cli/tests/unit_tests/test_hooks.py
+++ b/libs/cli/tests/unit_tests/test_hooks.py
@@ -35,7 +35,8 @@ class TestLoadHooks:
 
     def test_missing_config_file(self, tmp_path):
         """Returns empty list when config file does not exist."""
-        with patch.object(hooks_mod, "_HOOKS_PATH", tmp_path / "nonexistent.json"):
+        # tmp_path exists but has no hooks.json
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == []
@@ -43,30 +44,27 @@ class TestLoadHooks:
     def test_valid_config(self, tmp_path):
         """Parses hooks array from well-formed config."""
         config = {"hooks": [{"command": ["echo", "hi"], "events": ["session.start"]}]}
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text(json.dumps(config))
+        (tmp_path / "hooks.json").write_text(json.dumps(config))
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == config["hooks"]
 
     def test_malformed_json(self, tmp_path):
         """Returns empty list and logs warning on invalid JSON."""
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text("{not json!!")
+        (tmp_path / "hooks.json").write_text("{not json!!")
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == []
 
     def test_missing_hooks_key(self, tmp_path):
         """Returns empty list when 'hooks' key is absent."""
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text(json.dumps({"other": "data"}))
+        (tmp_path / "hooks.json").write_text(json.dumps({"other": "data"}))
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == []
@@ -77,7 +75,7 @@ class TestLoadHooks:
         cfg_path = tmp_path / "hooks.json"
         cfg_path.write_text(json.dumps(config))
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             first = hooks_mod._load_hooks()
             # Overwrite file — cached result should still be returned.
             cfg_path.write_text(json.dumps({"hooks": []}))
@@ -88,11 +86,10 @@ class TestLoadHooks:
 
     def test_os_error(self, tmp_path):
         """Returns empty list on OS-level read failure."""
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text("{}")
+        (tmp_path / "hooks.json").write_text("{}")
 
         with (
-            patch.object(hooks_mod, "_HOOKS_PATH", cfg_path),
+            patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path),
             patch("pathlib.Path.read_text", side_effect=OSError("permission denied")),
         ):
             result = hooks_mod._load_hooks()
@@ -101,30 +98,27 @@ class TestLoadHooks:
 
     def test_non_dict_json(self, tmp_path):
         """Returns empty list when config root is not a JSON object."""
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text(json.dumps([1, 2, 3]))
+        (tmp_path / "hooks.json").write_text(json.dumps([1, 2, 3]))
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == []
 
     def test_non_list_hooks_value(self, tmp_path):
         """Returns empty list when 'hooks' value is not a list."""
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text(json.dumps({"hooks": "not-a-list"}))
+        (tmp_path / "hooks.json").write_text(json.dumps({"hooks": "not-a-list"}))
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == []
 
     def test_null_json(self, tmp_path):
         """Returns empty list when config is JSON null."""
-        cfg_path = tmp_path / "hooks.json"
-        cfg_path.write_text("null")
+        (tmp_path / "hooks.json").write_text("null")
 
-        with patch.object(hooks_mod, "_HOOKS_PATH", cfg_path):
+        with patch("deepagents_cli.model_config.DEFAULT_CONFIG_DIR", tmp_path):
             result = hooks_mod._load_hooks()
 
         assert result == []

--- a/libs/cli/tests/unit_tests/test_imports.py
+++ b/libs/cli/tests/unit_tests/test_imports.py
@@ -1,5 +1,7 @@
 """Test importing files."""
 
+import pytest
+
 
 def test_imports() -> None:
     """Test importing deepagents modules."""
@@ -8,3 +10,20 @@ def test_imports() -> None:
         integrations,
     )
     from deepagents_cli.main import cli_main
+
+
+class TestLazyPackageGetattr:
+    """Tests for __init__.py lazy __getattr__ resolution."""
+
+    def test_cli_main_via_package(self) -> None:
+        """Package-level __getattr__ resolves cli_main lazily."""
+        from deepagents_cli import cli_main
+
+        assert callable(cli_main)
+
+    def test_unknown_attr_raises(self) -> None:
+        """Accessing an unknown attribute raises AttributeError."""
+        import deepagents_cli
+
+        with pytest.raises(AttributeError, match="has no attribute"):
+            getattr(deepagents_cli, "nonexistent_xyz")  # noqa: B009

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -173,13 +173,7 @@ class TestRunTextualCliAsyncMcp:
     """
 
     async def test_passes_server_and_mcp_kwargs_to_textual_app(self) -> None:
-        """Interactive TUI should receive server_kwargs and mcp_preload_kwargs."""
-        model_result = SimpleNamespace(
-            model=object(),
-            provider="openai",
-            model_name="gpt-5",
-            apply_to_settings=MagicMock(),
-        )
+        """TUI should receive server, mcp_preload, and model kwargs."""
         app_result = AppResult(return_code=0, thread_id="thread-123")
         captured_kwargs: dict[str, Any] = {}
 
@@ -188,19 +182,13 @@ class TestRunTextualCliAsyncMcp:
             await asyncio.sleep(0)
             return app_result
 
-        with (
-            patch("deepagents_cli.config.console"),
-            patch("deepagents_cli.config.create_model", return_value=model_result),
-            patch("deepagents_cli.model_config.save_recent_model"),
-            patch("deepagents_cli.app.run_textual_app", new=_run_textual_app_stub),
-        ):
+        with patch("deepagents_cli.app.run_textual_app", new=_run_textual_app_stub):
             result = await run_textual_cli_async(
                 "agent",
                 thread_id="thread-123",
             )
 
         assert result == app_result
-        model_result.apply_to_settings.assert_called_once_with()
 
         # Server kwargs forwarded for deferred startup inside the TUI
         assert captured_kwargs["server_kwargs"] is not None
@@ -211,14 +199,13 @@ class TestRunTextualCliAsyncMcp:
         assert captured_kwargs["mcp_preload_kwargs"] is not None
         assert captured_kwargs["mcp_preload_kwargs"]["no_mcp"] is False
 
+        # Model kwargs forwarded for deferred create_model() inside the TUI
+        assert captured_kwargs["model_kwargs"] is not None
+        assert captured_kwargs["model_kwargs"]["model_spec"] is None
+        assert captured_kwargs["model_kwargs"]["extra_kwargs"] is None
+
     async def test_no_mcp_kwargs_when_disabled(self) -> None:
         """mcp_preload_kwargs should be None when no_mcp=True."""
-        model_result = SimpleNamespace(
-            model=object(),
-            provider="openai",
-            model_name="gpt-5",
-            apply_to_settings=MagicMock(),
-        )
         app_result = AppResult(return_code=0, thread_id="thread-123")
         captured_kwargs: dict[str, Any] = {}
 
@@ -227,12 +214,7 @@ class TestRunTextualCliAsyncMcp:
             await asyncio.sleep(0)
             return app_result
 
-        with (
-            patch("deepagents_cli.config.console"),
-            patch("deepagents_cli.config.create_model", return_value=model_result),
-            patch("deepagents_cli.model_config.save_recent_model"),
-            patch("deepagents_cli.app.run_textual_app", new=_run_textual_app_stub),
-        ):
+        with patch("deepagents_cli.app.run_textual_app", new=_run_textual_app_stub):
             await run_textual_cli_async(
                 "agent",
                 thread_id="thread-123",

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -596,3 +596,38 @@ class TestFormatToolWarnings:
         """Unknown tools get a generic message."""
         assert format_tool_warning_tui("foo") == "foo is not installed."
         assert format_tool_warning_cli("foo") == "foo is not installed."
+
+
+class TestRunTextualCliAsyncModelConfigError:
+    """Verify ModelConfigError is caught cleanly before launching the TUI."""
+
+    async def test_returns_error_code_on_no_credentials(self) -> None:
+        """ModelConfigError from _get_default_model_spec gives return code 1."""
+        from deepagents_cli.model_config import ModelConfigError
+
+        with (
+            patch(
+                "deepagents_cli.config._get_default_model_spec",
+                side_effect=ModelConfigError("No credentials configured"),
+            ),
+            patch("deepagents_cli.config._get_console") as mock_console_fn,
+        ):
+            mock_console = MagicMock()
+            mock_console_fn.return_value = mock_console
+
+            result = await run_textual_cli_async("agent")
+
+        assert result.return_code == 1
+        assert result.thread_id is None
+
+    async def test_no_error_when_model_name_provided(self) -> None:
+        """Explicit model_name bypasses _get_default_model_spec."""
+        app_result = AppResult(return_code=0, thread_id="t-1")
+
+        async def _stub(**_kwargs: Any) -> AppResult:  # noqa: RUF029  # must be async for run_textual_app signature
+            return app_result
+
+        with patch("deepagents_cli.app.run_textual_app", new=_stub):
+            result = await run_textual_cli_async("agent", model_name="openai:gpt-4o")
+
+        assert result.return_code == 0

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -186,6 +186,7 @@ class TestRunTextualCliAsyncMcp:
             result = await run_textual_cli_async(
                 "agent",
                 thread_id="thread-123",
+                model_name="openai:gpt-4o",
             )
 
         assert result == app_result
@@ -201,7 +202,7 @@ class TestRunTextualCliAsyncMcp:
 
         # Model kwargs forwarded for deferred create_model() inside the TUI
         assert captured_kwargs["model_kwargs"] is not None
-        assert captured_kwargs["model_kwargs"]["model_spec"] is None
+        assert captured_kwargs["model_kwargs"]["model_spec"] == "openai:gpt-4o"
         assert captured_kwargs["model_kwargs"]["extra_kwargs"] is None
 
     async def test_no_mcp_kwargs_when_disabled(self) -> None:
@@ -218,6 +219,7 @@ class TestRunTextualCliAsyncMcp:
             await run_textual_cli_async(
                 "agent",
                 thread_id="thread-123",
+                model_name="openai:gpt-4o",
                 no_mcp=True,
             )
 

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -79,7 +79,7 @@ def mock_create_model() -> Iterator[Mock]:
         )
 
     with patch(
-        "deepagents_cli.app.create_model",
+        "deepagents_cli.config.create_model",
         side_effect=fake_create_model,
     ) as mock:
         yield mock
@@ -197,7 +197,7 @@ class TestModelSwitchErrorHandling:
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=True,
             ),
-            patch("deepagents_cli.app.save_recent_model", return_value=False),
+            patch("deepagents_cli.model_config.save_recent_model", return_value=False),
             patch.object(ErrorMessage, "__init__", capture_err),
             patch.object(AppMessage, "__init__", capture_app),
         ):
@@ -234,7 +234,7 @@ class TestModelSwitchErrorHandling:
                 return_value=True,
             ),
             patch(
-                "deepagents_cli.app.save_recent_model", return_value=True
+                "deepagents_cli.model_config.save_recent_model", return_value=True
             ) as mock_save,
             patch.object(AppMessage, "__init__", capture_init),
         ):
@@ -265,7 +265,7 @@ class TestModelSwitchErrorHandling:
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=True,
             ),
-            patch("deepagents_cli.app.save_recent_model", return_value=True),
+            patch("deepagents_cli.model_config.save_recent_model", return_value=True),
         ):
             await app._switch_model(
                 "anthropic:claude-sonnet-4-5",
@@ -295,7 +295,7 @@ class TestModelSwitchErrorHandling:
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=True,
             ),
-            patch("deepagents_cli.app.save_recent_model", return_value=True),
+            patch("deepagents_cli.model_config.save_recent_model", return_value=True),
         ):
             await app._switch_model(
                 "anthropic:claude-sonnet-4-5",
@@ -346,7 +346,7 @@ class TestModelSwitchConcurrencyGuard:
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=True,
             ),
-            patch("deepagents_cli.app.save_recent_model", return_value=True),
+            patch("deepagents_cli.model_config.save_recent_model", return_value=True),
         ):
             await app._switch_model("anthropic:claude-sonnet-4-5")
 
@@ -390,7 +390,7 @@ api_key_env = "FIREWORKS_API_KEY"
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch.dict("os.environ", {"FIREWORKS_API_KEY": "test-key"}),
             patch(
-                "deepagents_cli.app.save_recent_model", return_value=True
+                "deepagents_cli.model_config.save_recent_model", return_value=True
             ) as mock_save,
             patch.object(AppMessage, "__init__", capture_app),
         ):
@@ -464,7 +464,7 @@ models = ["llama3"]
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch(
-                "deepagents_cli.app.save_recent_model", return_value=True
+                "deepagents_cli.model_config.save_recent_model", return_value=True
             ) as mock_save,
             patch.object(AppMessage, "__init__", capture_app),
         ):
@@ -497,13 +497,13 @@ class TestModelSwitchBareModelName:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.detect_provider", return_value="openai"),
+            patch("deepagents_cli.config.detect_provider", return_value="openai"),
             patch(
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=True,
             ),
             patch(
-                "deepagents_cli.app.save_recent_model", return_value=True
+                "deepagents_cli.model_config.save_recent_model", return_value=True
             ) as mock_save,
             patch.object(AppMessage, "__init__", capture_init),
         ):
@@ -532,7 +532,7 @@ class TestModelSwitchBareModelName:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.detect_provider", return_value="openai"),
+            patch("deepagents_cli.config.detect_provider", return_value="openai"),
             patch(
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=False,
@@ -567,7 +567,7 @@ class TestModelSwitchBareModelName:
             original_init(self, message, **kwargs)
 
         with (
-            patch("deepagents_cli.app.detect_provider", return_value="openai"),
+            patch("deepagents_cli.config.detect_provider", return_value="openai"),
             patch(
                 "deepagents_cli.model_config.has_provider_credentials",
                 return_value=True,

--- a/libs/cli/tests/unit_tests/test_prompts.py
+++ b/libs/cli/tests/unit_tests/test_prompts.py
@@ -1,0 +1,9 @@
+"""Tests for prompts module."""
+
+from deepagents_cli.prompts import REMEMBER_PROMPT
+
+
+def test_remember_prompt_is_nonempty_string() -> None:
+    """`REMEMBER_PROMPT` should be a non-empty string."""
+    assert isinstance(REMEMBER_PROMPT, str)
+    assert len(REMEMBER_PROMPT) > 0

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -37,7 +37,7 @@ class TestReloadFromEnvironment:
             return False
 
         monkeypatch.setattr(
-            "deepagents_cli.config.dotenv.load_dotenv",
+            "dotenv.load_dotenv",
             _fake_load_dotenv,
         )
 
@@ -142,7 +142,7 @@ class TestReloadFromEnvironment:
         mock_load = MagicMock(return_value=False)
         env_file = tmp_path / ".env"
         env_file.write_text("OPENAI_API_KEY=sk-test\n")
-        monkeypatch.setattr("deepagents_cli.config.dotenv.load_dotenv", mock_load)
+        monkeypatch.setattr("dotenv.load_dotenv", mock_load)
 
         settings.reload_from_environment(start_path=tmp_path)
 
@@ -181,7 +181,7 @@ class TestReloadErrorPaths:
             return False
 
         monkeypatch.setattr(
-            "deepagents_cli.config.dotenv.load_dotenv",
+            "dotenv.load_dotenv",
             _fake_load_dotenv,
         )
 
@@ -210,7 +210,9 @@ class TestReloadErrorPaths:
             msg = "No such file or directory"
             raise FileNotFoundError(msg)
 
-        monkeypatch.setattr("deepagents_cli.config._find_project_root", _raise_oserror)
+        monkeypatch.setattr(
+            "deepagents_cli.project_utils.find_project_root", _raise_oserror
+        )
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert settings.project_root == original_root

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -2524,7 +2524,8 @@ class TestBuildThreadMessage:
     async def test_plain_text_when_tracing_not_configured(self) -> None:
         """Returns plain string when LangSmith URL is not available."""
         app = DeepAgentsApp()
-        with patch("deepagents_cli.app.build_langsmith_thread_url", return_value=None):
+        target = "deepagents_cli.config.build_langsmith_thread_url"
+        with patch(target, return_value=None):
             result = await app._build_thread_message("Resumed thread", "tid-123")
 
         assert result == "Resumed thread: tid-123"
@@ -2537,7 +2538,8 @@ class TestBuildThreadMessage:
 
         app = DeepAgentsApp()
         url = "https://smith.langchain.com/o/org/projects/p/proj/t/tid-123"
-        with patch("deepagents_cli.app.build_langsmith_thread_url", return_value=url):
+        target = "deepagents_cli.config.build_langsmith_thread_url"
+        with patch(target, return_value=url):
             result = await app._build_thread_message("Resumed thread", "tid-123")
 
         assert isinstance(result, Content)
@@ -2567,7 +2569,7 @@ class TestBuildThreadMessage:
         """Returns plain string when URL resolution raises an exception."""
         app = DeepAgentsApp()
         with patch(
-            "deepagents_cli.app.build_langsmith_thread_url",
+            "deepagents_cli.config.build_langsmith_thread_url",
             side_effect=OSError("network error"),
         ):
             result = await app._build_thread_message("Resumed thread", "t-1")


### PR DESCRIPTION
***real title:** defer heavy imports and initialization until after first paint*

Aggressive first-paint optimization for the CLI: defer all heavy imports and initialization until after the TUI renders its first frame. `config.py` no longer runs dotenv loading, settings construction, or `rich.console` creation at import time — these are lazy singletons resolved on first access via module `__getattr__`. Model creation moves from the pre-TUI codepath into a background worker, with only a cheap display-name parse populating the status bar before paint. Thread resumption (`-r` flag) is no longer resolved synchronously with blocking `asyncio.run()` calls in `cli_main` — the raw intent is passed to the TUI and resolved asynchronously in `_start_server_background`. `on_mount` is split into a minimal widget-setup phase and a post-paint `_post_paint_init` that fires all remaining workers.

## Changes
- Make `settings` and `console` in `config.py` lazy module attributes via `__getattr__` + `_get_settings()` / `_get_console()`, with a new `_ensure_bootstrap()` that defers dotenv loading and `LANGSMITH_PROJECT` override until first `settings` access
- Defer `create_model()` from `run_textual_cli_async` into `_start_server_background` — the caller now only resolves a display name via `ModelSpec.try_parse` and sets `settings.model_name`/`model_provider` for the status bar
- Split `on_mount` into a lightweight phase (widget queries, `gc.freeze()`, input focus, git branch task) and `_post_paint_init` (session state, server startup, import prewarming, optional tool checks) — all post-paint work runs as Textual workers or `asyncio.to_thread` calls
- Move thread resumption (`-r` flag) from synchronous `asyncio.run()` calls in `cli_main` to async `_resolve_resume_thread` in `DeepAgentsApp`, eliminating ~60 lines of blocking startup code and multiple DB round-trips before first paint
- Inline git branch resolution in `_resolve_git_branch_and_continue` via `subprocess.run` in a thread, avoiding the `textual_adapter` import that previously blocked mount
- Move `REMEMBER_PROMPT` from `app.py` to new `prompts.py` and `DOCS_URL` from `config.py` to `_version.py` to keep both importable without pulling in heavy dependency trees
- Convert all remaining top-level imports in `app.py` (`clipboard`, `command_registry`, `hooks`, `model_config`, most of `config`) to local imports at their call sites
- Defer `Markdown` widget import in `messages.py` to `compose`/`on_mount`/accessor methods, and defer `settings` in `status.py`, `file_ops.py`, `textual_adapter.py` to local scope
- Make `__init__.py` `cli_main` export lazy via package-level `__getattr__`, and defer `DEFAULT_CONFIG_DIR` import in `hooks.py` to `_load_hooks()`

## Testing
- New `TestLazyModuleAttributes` in `test_config.py` covering `_get_settings`, `_get_console`, unknown-attr error, bootstrap idempotency, and bootstrap-marks-done-on-failure
- New `TestLazyPackageGetattr` in `test_imports.py` for `__init__.py` lazy resolution
- Benchmark `HEAVY_MODULES` expanded to include `dotenv`, `model_config`, `project_utils`; `config.is_ascii_mode` added to import-isolation parametrize