### PR TITLE
ci: log evals dispatch inputs to job summary

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -102,6 +102,25 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: "📝 Log dispatch inputs"
+        continue-on-error: true
+        env:
+          MODELS: ${{ inputs.models }}
+          MODELS_OVERRIDE: ${{ inputs.models_override || '(empty)' }}
+          RESOLVED: ${{ inputs.models_override || inputs.models || 'all' }}
+          BRANCH: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          echo "### 📊 Eval dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Input | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`models_override\` | \`${MODELS_OVERRIDE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Resolved** | \`${RESOLVED}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch | \`${BRANCH}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Triggered by | \`${ACTOR}\` |" >> "$GITHUB_STEP_SUMMARY"
+
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
 


### PR DESCRIPTION
Add a dispatch-input logging step to the evals workflow so the GitHub Actions job summary shows which models were selected, the resolved model set, branch, and triggering actor. Makes it easier to audit and debug eval runs without digging through workflow logs. All `${{ }}` expressions are passed through `env:` (not interpolated directly in `run:`) to avoid script injection from the free-text `models_override` input. The step uses `continue-on-error: true` so a transient summary-file failure can't block the eval pipeline.

## Changes
- Add a "Log dispatch inputs" step to the `prep` job in `evals.yml` that writes a markdown table to `$GITHUB_STEP_SUMMARY` with `models`, `models_override`, resolved model set, branch, and actor
- Route all workflow expression values through the step's `env:` block to prevent GitHub Actions script injection via the free-text `models_override` input
- Mark the step `continue-on-error: true` so logging failures don't block downstream eval jobs