### PR TITLE
fix(evals): broken import in `test_hitl` from evals consolidation

### DIFF
--- a/libs/evals/tests/evals/test_hitl.py
+++ b/libs/evals/tests/evals/test_hitl.py
@@ -10,10 +10,26 @@ if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
 from deepagents import create_deep_agent
+from langchain_core.tools import tool
 from langgraph.types import Command
 
 from tests.evals.utils import run_agent
-from tests.utils import get_soccer_scores, get_weather, sample_tool
+
+
+@tool(description="Use this tool to get the weather")
+def get_weather(location: str) -> str:
+    return f"The weather in {location} is sunny."
+
+
+@tool(description="Use this tool to get the latest soccer scores")
+def get_soccer_scores(team: str) -> str:
+    return f"The latest soccer scores for {team} are 2-1."
+
+
+@tool(description="Sample tool")
+def sample_tool(sample_input: str) -> str:
+    return sample_input
+
 
 SAMPLE_TOOL_CONFIG = {
     "sample_tool": True,


### PR DESCRIPTION
The evals consolidation in #2032 moved `test_hitl.py` into `libs/evals/` but left a stale import pointing at the SDK's `tests.utils` module, which doesn't exist in the evals package. This broke test collection for the entire eval suite. Replace the cross-package import with inline `@tool` fixture definitions — the HITL tests only need callable tools to exercise the interrupt flow, not the SDK's specific implementations.

## Changes
- Replace `from tests.utils import get_soccer_scores, get_weather, sample_tool` with three inline `@tool`-decorated fixtures defined directly in `test_hitl.py`, removing the cross-package dependency on `libs/deepagents/tests/utils.py`