### PR TITLE
fix(sdk): filesystem prompt

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -982,7 +982,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_description = self._custom_tool_descriptions.get("execute") or EXECUTE_TOOL_DESCRIPTION
 
         def sync_execute(  # noqa: PLR0911 - early returns for distinct error conditions
-            command: Annotated[str, "Shell command to execute in the sandbox environment."],
+            command: Annotated[
+                str,
+                "Shell command to execute in the sandbox environment. If the command includes a path parameter, please prefer using use relative path, such as 'xx/xxx'.",
+            ],
             runtime: ToolRuntime[None, FilesystemState],
             timeout: Annotated[
                 int | None,
@@ -1036,7 +1039,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             return "".join(parts)
 
         async def async_execute(  # noqa: PLR0911 - early returns for distinct error conditions
-            command: Annotated[str, "Shell command to execute in the sandbox environment."],
+            command: Annotated[
+                str,
+                "Shell command to execute in the sandbox environment. If the command includes a path parameter, please prefer using use relative path, such as 'xx/xxx'.",
+            ],
             runtime: ToolRuntime[None, FilesystemState],
             # ASYNC109 - timeout is a semantic parameter forwarded to the
             # backend's implementation, not an asyncio.timeout() contract.


### PR DESCRIPTION
Hello author,

Today, while using the `LocalShellBackend` module within the backend component, I encountered an issue involving recursive loops triggered by the tool the model uses to execute commands.

Root Cause: Simply put, the issue arises because the model does not know whether the path passed during command execution should be a relative path or an absolute path.

Here is a demo:
```python
from pathlib import Path
from deepagents import create_deep_agent
from deepagents.backends import LocalShellBackend
from langgraph.graph.state import CompiledStateGraph

from model.Ark import ArkModel

class DeepBackend:
    agent: CompiledStateGraph
    workspace_path: str = Path(Path.cwd(), 'deep_agent_workspace')
    
    def created_agents(self, **kwargs):
        self.agent = create_deep_agent(
        model=ArkModel().model,
        **kwargs
        )
        return self.agent
    
    @property
    def local_shell(self):
        return LocalShellBackend(
            root_dir=str(self.workspace_path),
            inherit_env=True,
            virtual_mode=True
        )
        
    def start(self):
        agent = self.created_agents(
        backend = self.local_shell
    )
        result = agent.invoke({ 'messages': [{ 'role': 'user', 'content': 'Execute scripts/index.js' }] })
        print(result['messages'][-1].content)

DeepBackend().start()

```

Code Run result:

Because the filesystem prompt is not strictly defined, when executing the local_shell module, the execute function will directly retrieve the root_dir from FilesystemBackend in the self.cwd field.

<img width="825" height="135" alt="image" src="https://github.com/user-attachments/assets/aa7d1ab3-a566-41b3-adf4-7e3fe97029c0" />

Execution Results:

Due to a lack of rigor in the `filesystem` prompt design, when execution reached the `local_shell` module, the `self.cwd` variable within the `execute` function directly retrieved the `root_dir` value from the `FilesystemBackend`.

Consequently, the command passed by the Large Language Model (LLM) became: `node /scripts/index.js`.
As a result, the `subprocess.run` call consistently failed. Subsequently, the LLM entered a continuous retry loop,
executing the following command:

```sh
## Since /scripts is not the root directory, this command continued to fail.
cd /scripts/index.js && node index.js
...
```
There was an additional issue here: the `self.cwd` variable consistently retrieved the value of the `root_dir` parameter.
And so, this process looped *n* times, leading to a continuous depletion of my tokens.



Therefore, this Pull Request (PR) aims to resolve this specific issue.