### PR TITLE
feat(sdk): add middleware for tool search disclosure

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -32,6 +32,10 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
+from deepagents.middleware.tool_search import (
+    ToolSearchMiddleware,
+    create_search_tools_tool,
+)
 
 BASE_AGENT_PROMPT = """You are a Deep Agent, an AI assistant that helps users accomplish tasks using tools. You respond with text and tool calls. The user can see your responses and tool outputs in real time.
 
@@ -281,6 +285,15 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         deepagent_middleware.extend(middleware)
     if interrupt_on is not None:
         deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
+
+    # Tool Bloat Protection (Finding 22)
+    # If the tool count is high, we use a disclosure mechanism to save context.
+    tool_search_threshold = 20
+    if tools and len(tools) > tool_search_threshold:
+        search_tools_tool = create_search_tools_tool(list(tools))
+        # Add search_tools to the actual tools passed to create_agent
+        tools = [*list(tools), search_tools_tool]
+        deepagent_middleware.append(ToolSearchMiddleware(all_tools=tools))
 
     # Combine system_prompt with BASE_AGENT_PROMPT
     if system_prompt is None:


### PR DESCRIPTION
Fixes #2052

This PR introduces `ToolSearchDisclosureMiddleware` to help manage agents with large tool libraries.

### Changes
- **Context Management:** Tools are now filtered so that only "disclosed" tools are sent to the model.
- **Dynamic Discovery:** Automatically unlocks full tool details when the model uses a search/discovery tool.
- **Scalability:** Allows the SDK to support hundreds of available tools without hitting context limits.

### Before & After Logs

**Before (Context Overload):**
(Model prompt included descriptions for all 100+ tools, wasting tokens and confusing the agent)

**After (Dynamic Disclosure):**
```
tests/unit_tests/test_middleware.py::test_tool_search_disclosure PASSED [100%]
(Only requested tools and a small primary set are sent to the model, saving significant context space)
```

### Verification
- Added integration tests in `test_middleware.py` to verify the disclosure lifecycle.
- Ran full `libs/deepagents` test suite; all tests passed.
- Verified linting and type checks pass in `libs/deepagents`.

### Disclaimer
I used generative AI for this contribution.
