### PR TITLE
fix(sdk): resolve skills path for `virtual_mode` relative paths

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -401,6 +401,22 @@ def _format_skill_annotations(skill: SkillMetadata) -> str:
     return ", ".join(parts)
 
 
+def _resolve_effective_path(backend: BackendProtocol, source_path: str) -> str:
+    """Resolve effective path for listing skills.
+
+    Handles virtual_mode path resolution: when source_path is a relative path that
+    resolves to a direct child of backend.cwd, use "/" to list the backend's root.
+
+    This fixes an issue where backend=FilesystemBackend(root_dir="./skills/", virtual_mode=True)
+    and skills=["./skills/"] would fail because cwd=./skills and ls("./skills/")
+    resolves to cwd/skills which doesn't exist.
+    """
+    if source_path.startswith("/") or not hasattr(backend, "cwd"):
+        return source_path
+    resolved_source = (backend.cwd / source_path).resolve()  # type: ignore[operator]
+    return "/" if resolved_source.parent == backend.cwd else source_path  # type: ignore[union-attr]
+
+
 def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetadata]:
     """List all skills from a backend source.
 
@@ -424,7 +440,8 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
         List of skill metadata from successfully parsed `SKILL.md` files
     """
     skills: list[SkillMetadata] = []
-    ls_result = backend.ls(source_path)
+    effective_path = _resolve_effective_path(backend, source_path)
+    ls_result = backend.ls(effective_path)
     items = ls_result.entries if isinstance(ls_result, LsResult) else ls_result
 
     # Find all skill directories (directories containing SKILL.md)
@@ -502,7 +519,8 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
         List of skill metadata from successfully parsed `SKILL.md` files
     """
     skills: list[SkillMetadata] = []
-    ls_result = await backend.als(source_path)
+    effective_path = _resolve_effective_path(backend, source_path)
+    ls_result = await backend.als(effective_path)
     items = ls_result.entries if isinstance(ls_result, LsResult) else ls_result
 
     # Find all skill directories (directories containing SKILL.md)

--- a/libs/deepagents/tests/unit_tests/test_issue_2043_skills_virtual_mode.py
+++ b/libs/deepagents/tests/unit_tests/test_issue_2043_skills_virtual_mode.py
@@ -1,0 +1,87 @@
+"""Unit test for issue 2043: Skills not recognized with virtual_mode=True.
+
+https://github.com/langchain-ai/deepagents/issues/2043
+
+When using create_deep_agent with skills=["./skills/"] and FilesystemBackend
+with virtual_mode=True, the skills don't show up in the system prompt.
+
+Root cause: SkillsMiddleware calls backend.ls(source_path) where source_path is a
+relative path like "./skills/" that, when resolved relative to the backend's cwd,
+creates a nested path (cwd/./skills/ = cwd/skills) that doesn't exist.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from langchain_core.messages import AIMessage
+
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.graph import create_deep_agent
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+def _extract_text_from_content(content: list[dict]) -> str:
+    """Extract text from message content blocks.
+
+    Message content can be a list of content blocks with 'type' and 'text' fields.
+    """
+    parts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            parts.append(block.get("text", ""))
+        elif isinstance(block, str):
+            parts.append(block)
+    return "\n".join(parts)
+
+
+def test_issue_2043_skills_with_virtual_mode() -> None:
+    """Test that skills work correctly with virtual_mode=True.
+
+    This test reproduces issue 2043 where skills specified as a relative path
+    with trailing slash (e.g., "./skills/") don't get recognized when using
+    FilesystemBackend with virtual_mode=True.
+
+    The issue is that SkillsMiddleware calls backend.ls(source_path) where
+    source_path is "./skills/" and backend.cwd is the resolved "./skills/" path.
+    In virtual_mode, this resolves to cwd/skills which doesn't exist.
+    The fix detects when resolved_source.parent == cwd and uses "/" instead.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skills_dir = Path(tmpdir) / "skills"
+        skills_dir.mkdir()
+        my_skill = skills_dir / "my-skill"
+        my_skill.mkdir()
+        (my_skill / "SKILL.md").write_text("---\nname: my-skill\ndescription: A test skill\n---\n\n# My Skill\n\nThis is a test skill.\n")
+
+        original_cwd = Path.cwd()
+        os.chdir(tmpdir)
+        try:
+            backend = FilesystemBackend(root_dir="./skills/", virtual_mode=True)
+        finally:
+            os.chdir(str(original_cwd))
+
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="Done")]))
+
+        agent = create_deep_agent(
+            model=model,
+            tools=[],
+            backend=backend,
+            skills=["./skills/"],
+        )
+
+        agent.invoke({"messages": [{"role": "user", "content": "Hi"}]})
+
+        assert hasattr(model, "call_history"), "Model should have call_history"
+        assert len(model.call_history) > 0, "Model should have been called"
+
+        first_call = model.call_history[0]
+        messages = first_call.get("messages", [])
+        assert len(messages) > 0, "Should have messages"
+
+        system_message = messages[0]
+        content = system_message.content if hasattr(system_message, "content") else []
+        content_text = _extract_text_from_content(content) if isinstance(content, list) else str(content)
+
+        assert "my-skill" in content_text, f"Skills should be recognized. System prompt should contain 'my-skill' but got: {content_text[:500]}..."
+        assert "(No skills available" not in content_text, f"Skills section should not say 'No skills available'. Content: {content_text[:500]}..."


### PR DESCRIPTION
Fixes #2043

Fix skills path resolution when using FilesystemBackend with virtual_mode=True and relative path skills (e.g. `./skills/`). Before the fix, ls("./skills/") with cwd=/abs/skills resolved to cwd/skills which didn't exist, causing skills to show as "(No skills available yet)". The fix detects when source_path resolves to a direct child of backend.cwd and uses "/" to list the backend's root instead.

Before:
**Available Skills:**
(No skills available yet. You can create skills in ./skills/)

After:
**Available Skills:**
- **my-skill**: A test skill
  -> Read `/my-skill/SKILL.md` for full instructions

No breaking changes. No dependencies.

Verification:
- make lint ✅ (all packages linted)
- uv run pytest tests/unit_tests/test_issue_2043_skills_virtual_mode.py ✅ (1 passed)
- uv run pytest tests/unit_tests/ ✅ (874 passed, 73 skipped)