### PR TITLE
feat(sdk): add timestamp tracking to `AsyncSubAgentJob`

### DIFF
--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Annotated, Any, NotRequired, TypedDict
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ModelResponse, ResponseT
@@ -86,6 +87,24 @@ class AsyncSubAgentJob(TypedDict):
     Typed as `str` rather than a `Literal` because the LangGraph SDK's
     `Run.status` is `str` — using a `Literal` here would require `cast` at every
     SDK boundary.
+    """
+
+    created_at: str
+    """ISO-8601 timestamp (UTC) when the job was created, with second precision.
+
+    Format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2024-01-15T10:30:00Z`).
+    """
+
+    last_checked_at: str
+    """ISO-8601 timestamp (UTC) when the job status was last checked via SDK.
+
+    Format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2024-01-15T10:30:00Z`).
+    """
+
+    last_updated_at: str
+    """ISO-8601 timestamp (UTC) when the job was last updated with a new message.
+
+    Format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2024-01-15T10:30:00Z`).
     """
 
 
@@ -237,12 +256,16 @@ def _build_launch_tool(
             logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
             return f"Failed to launch async subagent '{subagent_type}': {e}"
         job_id = thread["thread_id"]
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         job: AsyncSubAgentJob = {
             "job_id": job_id,
             "agent_name": subagent_type,
             "thread_id": job_id,
             "run_id": run["run_id"],
             "status": "running",
+            "created_at": now,
+            "last_checked_at": now,
+            "last_updated_at": now,
         }
         msg = f"Launched async subagent. job_id: {job_id}"
         return Command(
@@ -273,12 +296,16 @@ def _build_launch_tool(
             logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
             return f"Failed to launch async subagent '{subagent_type}': {e}"
         job_id = thread["thread_id"]
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         job: AsyncSubAgentJob = {
             "job_id": job_id,
             "agent_name": subagent_type,
             "thread_id": job_id,
             "run_id": run["run_id"],
             "status": "running",
+            "created_at": now,
+            "last_checked_at": now,
+            "last_updated_at": now,
         }
         msg = f"Launched async subagent. job_id: {job_id}"
         return Command(
@@ -325,12 +352,16 @@ def _build_check_command(
     tool_call_id: str | None,
 ) -> Command:
     """Build the `Command` update for a check result."""
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     updated_job = AsyncSubAgentJob(
         job_id=job["job_id"],
         agent_name=job["agent_name"],
         thread_id=job["thread_id"],
         run_id=job["run_id"],
         status=result["status"],
+        created_at=job["created_at"],
+        last_checked_at=now,
+        last_updated_at=job["last_updated_at"],
     )
     return Command(
         update={
@@ -451,12 +482,16 @@ def _build_update_tool(
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             logger.warning("Failed to update async subagent '%s': %s", tracked["agent_name"], e)
             return f"Failed to update async subagent: {e}"
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         job: AsyncSubAgentJob = {
             "job_id": tracked["job_id"],
             "agent_name": tracked["agent_name"],
             "thread_id": tracked["thread_id"],
             "run_id": run["run_id"],
             "status": "running",
+            "created_at": tracked["created_at"],
+            "last_checked_at": tracked["last_checked_at"],
+            "last_updated_at": now,
         }
         msg = f"Updated async subagent. job_id: {tracked['job_id']}"
         return Command(
@@ -486,12 +521,16 @@ def _build_update_tool(
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             logger.warning("Failed to update async subagent '%s': %s", tracked["agent_name"], e)
             return f"Failed to update async subagent: {e}"
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         job: AsyncSubAgentJob = {
             "job_id": tracked["job_id"],
             "agent_name": tracked["agent_name"],
             "thread_id": tracked["thread_id"],
             "run_id": run["run_id"],
             "status": "running",
+            "created_at": tracked["created_at"],
+            "last_checked_at": tracked["last_checked_at"],
+            "last_updated_at": now,
         }
         msg = f"Updated async subagent. job_id: {tracked['job_id']}"
         return Command(
@@ -531,12 +570,16 @@ def _build_cancel_tool(
             client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         updated = AsyncSubAgentJob(
             job_id=tracked["job_id"],
             agent_name=tracked["agent_name"],
             thread_id=tracked["thread_id"],
             run_id=tracked["run_id"],
             status="cancelled",
+            created_at=tracked["created_at"],
+            last_checked_at=now,
+            last_updated_at=tracked["last_updated_at"],
         )
         msg = f"Cancelled async subagent job: {tracked['job_id']}"
         return Command(
@@ -559,12 +602,16 @@ def _build_cancel_tool(
             await client.runs.cancel(thread_id=tracked["thread_id"], run_id=tracked["run_id"])
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             return f"Failed to cancel run: {e}"
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         updated = AsyncSubAgentJob(
             job_id=tracked["job_id"],
             agent_name=tracked["agent_name"],
             thread_id=tracked["thread_id"],
             run_id=tracked["run_id"],
             status="cancelled",
+            created_at=tracked["created_at"],
+            last_checked_at=now,
+            last_updated_at=tracked["last_updated_at"],
         )
         msg = f"Cancelled async subagent job: {tracked['job_id']}"
         return Command(
@@ -668,6 +715,7 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
             return "No async subagent jobs tracked."
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
         entries: list[str] = []
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         for job in filtered:
             status = _fetch_live_status(clients, job)
             entries.append(_format_job_entry(job, status))
@@ -677,6 +725,9 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
                 thread_id=job["thread_id"],
                 run_id=job["run_id"],
                 status=status,
+                created_at=job["created_at"],
+                last_checked_at=now,
+                last_updated_at=job["last_updated_at"],
             )
         msg = f"{len(entries)} tracked job(s):\n" + "\n".join(entries)
         return Command(
@@ -700,6 +751,7 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
         statuses = await asyncio.gather(*(_afetch_live_status(clients, job) for job in filtered))
         updated_jobs: dict[str, AsyncSubAgentJob] = {}
         entries: list[str] = []
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         for job, status in zip(filtered, statuses, strict=True):
             entries.append(_format_job_entry(job, status))
             updated_jobs[job["job_id"]] = AsyncSubAgentJob(
@@ -708,6 +760,9 @@ def _build_list_jobs_tool(clients: _ClientCache) -> StructuredTool:
                 thread_id=job["thread_id"],
                 run_id=job["run_id"],
                 status=status,
+                created_at=job["created_at"],
+                last_checked_at=now,
+                last_updated_at=job["last_updated_at"],
             )
         msg = f"{len(entries)} tracked job(s):\n" + "\n".join(entries)
         return Command(

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -47,6 +47,9 @@ def _make_runtime_with_job(
     run_id: str = "run_xyz",
     status: str = "running",
     tool_call_id: str = "tc_test",
+    created_at: str = "2024-01-15T10:30:00Z",
+    last_checked_at: str = "2024-01-15T10:30:00Z",
+    last_updated_at: str = "2024-01-15T10:30:00Z",
 ) -> ToolRuntime:
     """Create a runtime with a single tracked job in state."""
     jobs: dict[str, AsyncSubAgentJob] = {
@@ -56,6 +59,9 @@ def _make_runtime_with_job(
             "thread_id": job_id,
             "run_id": run_id,
             "status": status,
+            "created_at": created_at,
+            "last_checked_at": last_checked_at,
+            "last_updated_at": last_updated_at,
         },
     }
     return ToolRuntime(
@@ -267,6 +273,9 @@ class TestCheckTool:
                 "thread_id": "thread_abc",
                 "run_id": "run_xyz",
                 "status": "running",
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
         }
         return ToolRuntime(
@@ -366,6 +375,9 @@ class TestUpdateTool:
                 "thread_id": "thread_abc",
                 "run_id": "run_old",
                 "status": "running",
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
         }
         rt = ToolRuntime(
@@ -429,6 +441,9 @@ class TestListJobsTool:
                 "thread_id": "t1",
                 "run_id": "r1",
                 "status": "running",  # stale — SDK will return "success"
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
             "t2": {
                 "job_id": "t2",
@@ -436,6 +451,9 @@ class TestListJobsTool:
                 "thread_id": "t2",
                 "run_id": "r2",
                 "status": "running",
+                "created_at": "2024-01-15T10:31:00Z",
+                "last_checked_at": "2024-01-15T10:31:00Z",
+                "last_updated_at": "2024-01-15T10:31:00Z",
             },
         }
         rt = ToolRuntime(
@@ -473,6 +491,9 @@ class TestListJobsTool:
                 "thread_id": "t1",
                 "run_id": "r1",
                 "status": "cancelled",
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
             "t2": {
                 "job_id": "t2",
@@ -480,6 +501,9 @@ class TestListJobsTool:
                 "thread_id": "t2",
                 "run_id": "r2",
                 "status": "success",
+                "created_at": "2024-01-15T10:31:00Z",
+                "last_checked_at": "2024-01-15T10:31:00Z",
+                "last_updated_at": "2024-01-15T10:31:00Z",
             },
             "t3": {
                 "job_id": "t3",
@@ -487,6 +511,9 @@ class TestListJobsTool:
                 "thread_id": "t3",
                 "run_id": "r3",
                 "status": "error",
+                "created_at": "2024-01-15T10:32:00Z",
+                "last_checked_at": "2024-01-15T10:32:00Z",
+                "last_updated_at": "2024-01-15T10:32:00Z",
             },
         }
         rt = ToolRuntime(
@@ -521,6 +548,9 @@ class TestListJobsTool:
                 "thread_id": "t1",
                 "run_id": "r1",
                 "status": "running",
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
             "t2": {
                 "job_id": "t2",
@@ -528,6 +558,9 @@ class TestListJobsTool:
                 "thread_id": "t2",
                 "run_id": "r2",
                 "status": "success",
+                "created_at": "2024-01-15T10:31:00Z",
+                "last_checked_at": "2024-01-15T10:31:00Z",
+                "last_updated_at": "2024-01-15T10:31:00Z",
             },
         }
         rt = ToolRuntime(
@@ -603,6 +636,9 @@ class TestAsyncTools:
                 "thread_id": "thread_abc",
                 "run_id": "run_xyz",
                 "status": "running",
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
         }
         rt = ToolRuntime(
@@ -639,6 +675,9 @@ class TestAsyncTools:
                 "thread_id": "thread_abc",
                 "run_id": "run_old",
                 "status": "running",
+                "created_at": "2024-01-15T10:30:00Z",
+                "last_checked_at": "2024-01-15T10:30:00Z",
+                "last_updated_at": "2024-01-15T10:30:00Z",
             },
         }
         rt = ToolRuntime(


### PR DESCRIPTION
Adds `created_at`, `last_checked_at`, and `last_updated_at` timestamp fields to the `AsyncSubAgentJob` TypedDict for better observability of async subagent job lifecycles.

The timestamps are ISO-8601 formatted (UTC) with second precision and are updated at appropriate points:
- `created_at`: set when a job is launched
- `last_checked_at`: updated when job status is checked via SDK
- `last_updated_at`: updated when a job is updated with a new message

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).