### PR TITLE
ci: skip excluded files when applying package labels in `pr-labeler`

### DIFF
--- a/.github/scripts/pr-labeler-config.json
+++ b/.github/scripts/pr-labeler-config.json
@@ -62,19 +62,23 @@
   "fileRules": [
     {
       "label": "deepagents",
-      "prefix": "libs/deepagents/"
+      "prefix": "libs/deepagents/",
+      "skipExcludedFiles": true
     },
     {
       "label": "cli",
-      "prefix": "libs/cli/"
+      "prefix": "libs/cli/",
+      "skipExcludedFiles": true
     },
     {
       "label": "acp",
-      "prefix": "libs/acp/"
+      "prefix": "libs/acp/",
+      "skipExcludedFiles": true
     },
     {
       "label": "evals",
-      "prefix": "libs/evals/"
+      "prefix": "libs/evals/",
+      "skipExcludedFiles": true
     },
     {
       "label": "github_actions",

--- a/.github/scripts/pr-labeler.js
+++ b/.github/scripts/pr-labeler.js
@@ -109,15 +109,22 @@ function init(github, owner, repo, config, core) {
           `(expected one of: prefix, suffix, exact, pattern)`
         );
       }
-      return { label: rule.label, test };
+      return { label: rule.label, test, skipExcluded: !!rule.skipExcludedFiles };
     });
   }
 
   function matchFileLabels(files, fileRules) {
     const rules = fileRules || buildFileRules();
+    const excluded = new Set(excludedFiles);
     const labels = new Set();
     for (const rule of rules) {
-      if (files.some(f => rule.test(f.filename ?? ''))) {
+      // skipExcluded: ignore files whose basename is in the top-level
+      // "excludedFiles" list (e.g. uv.lock) so lockfile-only changes
+      // don't trigger package labels.
+      const candidates = rule.skipExcluded
+        ? files.filter(f => !excluded.has((f.filename ?? '').split('/').pop()))
+        : files;
+      if (candidates.some(f => rule.test(f.filename ?? ''))) {
         labels.add(rule.label);
       }
     }


### PR DESCRIPTION
A PR that only touches `libs/cli/uv.lock` currently gets the `cli` label because the file rule matches on the `libs/cli/` prefix. This is misleading — lockfile-only changes aren't meaningful CLI changes. The `excludedFiles` list already existed in config (for size calculations), but file rules didn't consult it.

## Changes
- Add `skipExcludedFiles` option to file rules in `pr-labeler-config.json`, enabled for the four package rules (`deepagents`, `cli`, `acp`, `evals`) so lockfile-only PRs don't trigger package labels
- `matchFileLabels` in `pr-labeler.js` now filters out files whose basename appears in the top-level `excludedFiles` list (currently just `uv.lock`) before testing rules that opt in via `skipExcluded`
- Non-package rules (`github_actions`, `dependencies`) are unaffected — they don't set the flag