### PR TITLE
ci(cli): enable codspeed benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
+              - '.github/workflows/_benchmark.yml'
               - '.github/actions/**'
             evals:
               - 'libs/evals/**'
@@ -266,6 +267,16 @@ jobs:
       working-directory: "libs/deepagents"
     secrets: inherit
 
+  # Run CodSpeed benchmarks on CLI changes
+  benchmark-cli:
+    name: "⏱️ Benchmark cli"
+    needs: changes
+    if: needs.changes.outputs.cli == 'true' || github.event_name == 'push'
+    uses: ./.github/workflows/_benchmark.yml
+    with:
+      working-directory: "libs/cli"
+    secrets: inherit
+
   # Final status check - ensures all jobs passed
   ci_success:
     name: "✅ CI Success"
@@ -285,6 +296,7 @@ jobs:
       - test-modal
       - test-runloop
       - benchmark-deepagents
+      - benchmark-cli
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Enable CodSpeed wall-time benchmarks for `libs/cli/`. The SDK benchmarks remain disabled (`if: false`) pending separate integration work — this scopes CodSpeed to the CLI only, where import-time benchmarks are already written and ready.

## Changes
- Add `benchmark-cli` job in `ci.yml` calling the reusable `_benchmark.yml` workflow with `working-directory: "libs/cli"`, gated on CLI path changes or pushes to `main`
- Include `_benchmark.yml` in the CLI paths-filter so benchmark workflow edits trigger CLI CI
- Wire `benchmark-cli` into `ci_success.needs` for the final status gate