### PR TITLE
ci: auto-create missing-issue-link label before applying

### DIFF
--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -12,7 +12,7 @@
 #   check passes (e.g. author edits the body to add a valid issue link).
 # - Respects maintainer reopens: if an org member manually reopens a
 #   previously auto-closed PR, enforcement is skipped so it stays open.
-# - Posts a comment explaining the requirement on failure.
+# - Posts (or updates) a comment explaining the requirement on failure.
 # - Cancels all other in-progress/queued CI runs for the PR on closure.
 # - Deduplicates comments via an HTML marker so re-runs don't spam.
 #
@@ -175,8 +175,24 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
+            const labelName = 'missing-issue-link';
+
+            // Ensure the label exists (no checkout/shared helper available)
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: labelName });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              try {
+                await github.rest.issues.createLabel({
+                  owner, repo, name: labelName, color: 'b76e79',
+                });
+              } catch (createErr) {
+                if (createErr.status !== 422) throw createErr;
+              }
+            }
+
             await github.rest.issues.addLabels({
-              owner, repo, issue_number: prNumber, labels: ['missing-issue-link'],
+              owner, repo, issue_number: prNumber, labels: [labelName],
             });
 
       - name: Remove missing-issue-link label and reopen PR
@@ -196,7 +212,9 @@ jobs:
               if (error.status !== 404) throw error;
             }
 
-            // Reopen PR only if it was previously closed by this workflow
+            // Reopen if this workflow previously closed the PR. We check the
+            // event payload labels (not live labels) because we already removed
+            // missing-issue-link above; the payload still reflects pre-step state.
             const labels = context.payload.pull_request.labels.map(l => l.name);
             if (context.payload.pull_request.state === 'closed' && labels.includes('missing-issue-link')) {
               await github.rest.pulls.update({


### PR DESCRIPTION
(Porting back from `langchain-ai/langchain`

The `missing-issue-link` label was assumed to pre-exist. If it doesn't (e.g., fresh fork or repo rename), `addLabels` throws a 404 and the step fails without closing or commenting — leaving the PR in a confusing half-enforced state. The "Add missing-issue-link label" step now creates the label on-demand before applying it, matching how `pr-labeler.js` handles `ensureLabel`.

## Changes
- Auto-create the `missing-issue-link` label (color `b76e79`) if it doesn't exist yet, with a 422 guard for concurrent creation races
- Fix header comment to say "Posts (or updates)" — the workflow already deduplicates via the HTML marker and updates existing comments
- Clarify the reopen-step comment: explains why it reads payload labels instead of live labels (the label was already removed in a prior step)