### PR TITLE
fix(cli): remove keybinding overrides that shadow textual built-ins

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -333,6 +333,19 @@ class ChatTextArea(TextArea):
             priority=True,
         ),
     ]
+    """Key bindings for the chat text area.
+
+    These are the single source of truth for shortcut keys. `_NEWLINE_KEYS`
+    is derived from this list so that `_on_key` stays in sync automatically.
+    """
+
+    _NEWLINE_KEYS: ClassVar[frozenset[str]] = frozenset(
+        key
+        for b in BINDINGS
+        if b.action == "insert_newline"
+        for key in b.key.split(",")
+    )
+    """Flattened set of keys that insert a newline, derived from `BINDINGS`."""
 
     _skip_history_change_events: int
     """Counter incremented before a history-driven text replacement so the
@@ -593,8 +606,8 @@ class ChatTextArea(TextArea):
         if event.key == "backslash" and event.character == "\\":
             self._backslash_pending_time = now
 
-        # Modifier+Enter inserts newline (Ctrl+J is most reliable across terminals)
-        if event.key in {"shift+enter", "ctrl+j", "alt+enter", "ctrl+enter"}:
+        # Modifier+Enter inserts newline — keys derived from BINDINGS
+        if event.key in self._NEWLINE_KEYS:
             event.prevent_default()
             event.stop()
             self.insert("\n")

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -16,7 +16,6 @@ from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static, TextArea
-from textual.widgets.text_area import Selection
 
 from deepagents_cli.command_registry import SLASH_COMMANDS
 from deepagents_cli.config import (
@@ -327,22 +326,12 @@ class ChatTextArea(TextArea):
 
     BINDINGS: ClassVar[list[Binding]] = [
         Binding(
-            "shift+enter,ctrl+j,alt+enter,ctrl+enter",
+            "shift+enter,alt+enter,ctrl+enter",
             "insert_newline",
             "New Line",
             show=False,
             priority=True,
         ),
-        Binding(
-            "ctrl+a",
-            "select_all_text",
-            "Select All",
-            show=False,
-            priority=True,
-        ),
-        # Mac Cmd+Z/Cmd+Shift+Z for undo/redo (in addition to Ctrl+Z/Y)
-        Binding("cmd+z,super+z", "undo", "Undo", show=False, priority=True),
-        Binding("cmd+shift+z,super+shift+z", "redo", "Redo", show=False, priority=True),
     ]
 
     _skip_history_change_events: int
@@ -434,16 +423,6 @@ class ChatTextArea(TextArea):
     def action_insert_newline(self) -> None:
         """Insert a newline character."""
         self.insert("\n")
-
-    def action_select_all_text(self) -> None:
-        """Select all text in the text area."""
-        if not self.text:
-            return
-        # Select from start to end
-        lines = self.text.split("\n")
-        end_row = len(lines) - 1
-        end_col = len(lines[end_row])
-        self.selection = Selection(start=(0, 0), end=(end_row, end_col))
 
     def _cancel_paste_burst_timer(self) -> None:
         """Cancel any scheduled paste-burst flush timer."""
@@ -621,12 +600,6 @@ class ChatTextArea(TextArea):
             self.insert("\n")
             return
 
-        if event.key == "ctrl+u":
-            event.prevent_default()
-            event.stop()
-            self._delete_current_line()
-            return
-
         if event.key == "backspace" and self._delete_image_placeholder(backwards=True):
             event.prevent_default()
             event.stop()
@@ -785,28 +758,6 @@ class ChatTextArea(TextArea):
         self._backslash_pending_time = None
         self.text = ""
         self.move_cursor((0, 0))
-
-    def _delete_current_line(self) -> None:
-        """Delete the current line under the cursor.
-
-        If the text has only one line, clears its content entirely. Otherwise
-        removes the line at the cursor row (along with its newline separator)
-        and moves the cursor to column 0 of the new current row.
-        """
-        lines = self.text.split("\n")
-        row, _ = self.cursor_location
-        if row >= len(lines):
-            return
-        if len(lines) == 1:
-            # Single line — clear content only
-            self.text = ""
-            self.move_cursor((0, 0))
-            return
-
-        lines.pop(row)
-        new_row = min(row, len(lines) - 1)
-        self.text = "\n".join(lines)
-        self.move_cursor((new_row, 0))
 
 
 class _CompletionViewAdapter:

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -33,7 +33,7 @@ _TIPS: list[str] = [
     "Use /remember to save learnings from this conversation",
     "Use /model to switch models mid-conversation",
     "Press ctrl+x to compose prompts in your external editor",
-    "Press ctrl+u to delete the current line in the chat input",
+    "Press ctrl+u to delete to the start of the line in the chat input",
 ]
 """Rotating tips shown in the welcome footer.
 

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -2090,11 +2090,31 @@ class TestVSCodeSpaceWorkaround:
             assert ta.text == "hello "
 
 
-class TestCtrlUDeleteLine:
-    """Test that ctrl+u deletes the current line rather than clearing all input."""
+class TestCtrlUDeleteToLineStart:
+    """Test that ctrl+u deletes from cursor to start of line (readline convention)."""
 
-    async def test_ctrl_u_clears_single_line(self) -> None:
-        """ctrl+u on a single line should clear that line's content."""
+    async def test_ctrl_u_deletes_to_line_start(self) -> None:
+        """ctrl+u with cursor mid-line should delete text before the cursor."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello world")
+            await pilot.pause()
+            # Cursor at end after insert — move to col 5
+            ta.move_cursor((0, 5))
+            await pilot.pause()
+
+            await pilot.press("ctrl+u")
+            await pilot.pause()
+
+            assert ta.text == " world"
+            assert ta.cursor_location == (0, 0)
+
+    async def test_ctrl_u_at_end_of_line_clears_line(self) -> None:
+        """ctrl+u at end of single line should clear it entirely."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -2124,8 +2144,27 @@ class TestCtrlUDeleteLine:
             assert ta.text == ""
             assert ta.cursor_location == (0, 0)
 
-    async def test_ctrl_u_removes_middle_line_in_multiline(self) -> None:
-        """ctrl+u should delete the line the cursor is on, leaving others."""
+    async def test_ctrl_u_at_start_of_line_is_noop(self) -> None:
+        """ctrl+u at column 0 should not delete anything."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.text = "hello world"
+            await pilot.pause()
+            ta.move_cursor((0, 0))
+            await pilot.pause()
+
+            await pilot.press("ctrl+u")
+            await pilot.pause()
+
+            assert ta.text == "hello world"
+            assert ta.cursor_location == (0, 0)
+
+    async def test_ctrl_u_multiline_only_affects_current_line(self) -> None:
+        """ctrl+u in a multiline buffer should only delete on the cursor's line."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -2134,75 +2173,15 @@ class TestCtrlUDeleteLine:
 
             ta.text = "line one\nline two\nline three"
             await pilot.pause()
-            # Place cursor on line 1 (second line)
+            # Place cursor at col 4 on line 1
             ta.move_cursor((1, 4))
             await pilot.pause()
 
             await pilot.press("ctrl+u")
             await pilot.pause()
 
-            assert ta.text == "line one\nline three"
-            # Cursor should be at row 1, col 0 (the line that shifted up)
+            assert ta.text == "line one\n two\nline three"
             assert ta.cursor_location == (1, 0)
-
-    async def test_ctrl_u_removes_last_line_in_multiline(self) -> None:
-        """ctrl+u on the last line should remove it and land on the new last line."""
-        app = _ChatInputTestApp()
-        async with app.run_test() as pilot:
-            chat = app.query_one(ChatInput)
-            ta = chat._text_area
-            assert ta is not None
-
-            ta.text = "first\nsecond\nthird"
-            await pilot.pause()
-            # Place cursor on last line
-            ta.move_cursor((2, 3))
-            await pilot.pause()
-
-            await pilot.press("ctrl+u")
-            await pilot.pause()
-
-            assert ta.text == "first\nsecond"
-            assert ta.cursor_location == (1, 0)
-
-    async def test_ctrl_u_removes_first_line_in_multiline(self) -> None:
-        """ctrl+u on the first line should remove it and cursor moves to row 0."""
-        app = _ChatInputTestApp()
-        async with app.run_test() as pilot:
-            chat = app.query_one(ChatInput)
-            ta = chat._text_area
-            assert ta is not None
-
-            ta.text = "alpha\nbeta\ngamma"
-            await pilot.pause()
-            ta.move_cursor((0, 2))
-            await pilot.pause()
-
-            await pilot.press("ctrl+u")
-            await pilot.pause()
-
-            assert ta.text == "beta\ngamma"
-            assert ta.cursor_location == (0, 0)
-
-    async def test_ctrl_u_does_not_clear_other_lines(self) -> None:
-        """ctrl+u should only affect the current line, not the whole buffer."""
-        app = _ChatInputTestApp()
-        async with app.run_test() as pilot:
-            chat = app.query_one(ChatInput)
-            ta = chat._text_area
-            assert ta is not None
-
-            ta.text = "keep this\ndelete me\nkeep this too"
-            await pilot.pause()
-            ta.move_cursor((1, 0))
-            await pilot.pause()
-
-            await pilot.press("ctrl+u")
-            await pilot.pause()
-
-            assert "keep this" in ta.text
-            assert "keep this too" in ta.text
-            assert "delete me" not in ta.text
 
 
 class _TextAreaTypingApp(App[None]):


### PR DESCRIPTION
Remove custom keybinding overrides from `ChatTextArea` that duplicate or conflict with Textual's built-in `TextArea` behavior. The custom `ctrl+a` (select all), `cmd+z`/`cmd+shift+z` (undo/redo), and `ctrl+u` (delete line) implementations shadowed native widget behavior — `ctrl+u` in particular deviated from the readline convention (delete to start of line) that Textual implements by default.

## Changes
- Remove `ctrl+j` from the `BINDINGS` list — it's already handled in `_on_key` as a newline-insertion alias and doesn't need a separate binding
- Remove custom `ctrl+a` select-all binding and `action_select_all_text` method — Textual's `TextArea` handles this natively
- Remove `cmd+z`/`cmd+shift+z` undo/redo bindings — already provided by `TextArea`
- Remove custom `ctrl+u` handler and `_delete_current_line` method — Textual's native `ctrl+u` follows the readline convention (delete from cursor to start of line), which is the expected behavior
- Remove unused `Selection` import

## Testing
- Rewrite `TestCtrlUDeleteLine` → `TestCtrlUDeleteToLineStart` to assert readline semantics: mid-line cursor deletes backwards to column 0, end-of-line clears the whole line, start-of-line is a no-op, multiline only affects the cursor's row