### PR TITLE
fix(cli): rebind toggle tool output to `ctrl+o` to unblock `cmd+right`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -394,7 +394,7 @@ class DeepAgentsApp(App):
             priority=True,
         ),
         Binding(
-            "ctrl+e",
+            "ctrl+o",
             "toggle_tool_output",
             "Toggle Tool Output",
             show=False,

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -387,7 +387,7 @@ class ToolCallMessage(Vertical):
     """Widget displaying a tool call with collapsible output.
 
     Tool outputs are shown as a 3-line preview by default.
-    Press Ctrl+E to expand/collapse the full output.
+    Press Ctrl+O to expand/collapse the full output.
     Shows an animated "Running..." indicator while the tool is executing.
     """
 
@@ -1193,7 +1193,7 @@ class ToolCallMessage(Vertical):
             self._full_widget.display = True
             # Show collapse hint underneath
             self._hint_widget.update(
-                Content.styled("click or Ctrl+E to collapse", "dim italic")
+                Content.styled("click or Ctrl+O to collapse", "dim italic")
             )
             self._hint_widget.display = True
         else:
@@ -1209,11 +1209,11 @@ class ToolCallMessage(Vertical):
                 if result.truncation:
                     ellipsis = get_glyphs().ellipsis
                     hint = Content.styled(
-                        f"{ellipsis} {result.truncation} — click or Ctrl+E to expand",
+                        f"{ellipsis} {result.truncation} — click or Ctrl+O to expand",
                         "dim",
                     )
                 else:
-                    hint = Content.styled("click or Ctrl+E to expand", "dim italic")
+                    hint = Content.styled("click or Ctrl+O to expand", "dim italic")
                 self._hint_widget.update(hint)
                 self._hint_widget.display = True
             elif output_stripped:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -156,21 +156,21 @@ class TestAppBindings:
         assert ctrl_c.action == "quit_or_interrupt"
         assert ctrl_c.priority is True
 
-    def test_toggle_tool_output_has_ctrl_e_binding(self) -> None:
-        """Ctrl+E should be bound to toggle_tool_output with priority."""
+    def test_toggle_tool_output_has_ctrl_o_binding(self) -> None:
+        """Ctrl+O should be bound to toggle_tool_output with priority."""
         bindings = [b for b in DeepAgentsApp.BINDINGS if isinstance(b, Binding)]
         bindings_by_key = {b.key: b for b in bindings}
-        ctrl_e = bindings_by_key.get("ctrl+e")
+        ctrl_o = bindings_by_key.get("ctrl+o")
 
-        assert ctrl_e is not None
-        assert ctrl_e.action == "toggle_tool_output"
-        assert ctrl_e.priority is True
+        assert ctrl_o is not None
+        assert ctrl_o.action == "toggle_tool_output"
+        assert ctrl_o.priority is True
 
-    def test_ctrl_o_not_bound_to_toggle_tool_output(self) -> None:
-        """Ctrl+O should not exist (replaced by Ctrl+E)."""
+    def test_ctrl_e_not_bound(self) -> None:
+        """Ctrl+E must not be bound — it shadows TextArea cursor_line_end."""
         bindings = [b for b in DeepAgentsApp.BINDINGS if isinstance(b, Binding)]
         bindings_by_key = {b.key: b for b in bindings}
-        assert "ctrl+o" not in bindings_by_key
+        assert "ctrl+e" not in bindings_by_key
 
 
 class TestITerm2CursorGuide:


### PR DESCRIPTION
The app-level `ctrl+e` binding for `toggle_tool_output` (`priority=True`) shadows Textual's built-in `TextArea` binding of `ctrl+e` → `cursor_line_end`. On macOS terminals, Cmd+Right sends `ctrl+e`, so pressing Cmd+Right toggled tool output instead of moving the cursor to end of line. Cmd+Left (which sends `ctrl+a`) was unaffected because nothing at the app level binds that key.

## Changes
- Rebind `toggle_tool_output` from `ctrl+e` to `ctrl+o` in `DeepAgentsApp.BINDINGS`, freeing `ctrl+e` for Textual's `cursor_line_end` action
- Update all `ToolCallMessage` hint strings in `messages.py` to reference `Ctrl+O` instead of `Ctrl+E`
- Invert the binding guard tests: assert `ctrl+o` is bound to `toggle_tool_output` and `ctrl+e` is absent from app-level bindings
