### PR TITLE
feat(cli): context-aware connecting banner for resume and local server

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -600,6 +600,8 @@ class DeepAgentsApp(App):
                 thread_id=self._lc_thread_id,
                 mcp_tool_count=self._mcp_tool_count,
                 connecting=self._connecting,
+                resuming=self._resume_thread_intent is not None,
+                local_server=self._server_kwargs is not None,
                 id="welcome-banner",
             )
             yield Container(id="messages")

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -64,6 +64,8 @@ class WelcomeBanner(Static):
         mcp_tool_count: int = 0,
         *,
         connecting: bool = False,
+        resuming: bool = False,
+        local_server: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the welcome banner.
@@ -73,12 +75,21 @@ class WelcomeBanner(Static):
             mcp_tool_count: Number of MCP tools loaded at startup.
             connecting: When `True`, show a "Connecting..." footer instead of
                 the normal ready prompt. Call `set_connected` to transition.
+            resuming: When `True`, the connecting footer says "Resuming..."
+                instead of any `'Connecting...'` variant.
+            local_server: When `True`, the connecting footer qualifies the
+                server as "local" (i.e. a server process managed by the
+                CLI).
+
+                Ignored when `resuming` is `True`.
             **kwargs: Additional arguments passed to parent.
         """
         # Avoid collision with Widget._thread_id (Textual internal int)
         self._cli_thread_id: str | None = thread_id
         self._mcp_tool_count = mcp_tool_count
         self._connecting = connecting
+        self._resuming = resuming
+        self._local_server = local_server
         self._failed = False
         self._failure_error: str = ""
         self._project_name: str | None = get_langsmith_project_name()
@@ -215,7 +226,12 @@ class WelcomeBanner(Static):
         if self._failed:
             parts.append(build_failure_footer(self._failure_error))
         elif self._connecting:
-            parts.append(build_connecting_footer())
+            parts.append(
+                build_connecting_footer(
+                    resuming=self._resuming,
+                    local_server=self._local_server,
+                )
+            )
         else:
             parts.append(build_welcome_footer())
         return Content.assemble(*parts)
@@ -237,13 +253,27 @@ def build_failure_footer(error: str) -> Content:
     )
 
 
-def build_connecting_footer() -> Content:
+def build_connecting_footer(
+    *, resuming: bool = False, local_server: bool = False
+) -> Content:
     """Build a footer shown while waiting for the server to connect.
+
+    Args:
+        resuming: Show `'Resuming...'` instead of any `'Connecting...'` variant.
+        local_server: Qualify the server as "local" in the connecting message.
+
+            Ignored when `resuming` is `True`.
 
     Returns:
         Content with a connecting status message.
     """
-    return Content.styled("\nConnecting to server...\n", "dim")
+    if resuming:
+        text = "\nResuming...\n"
+    elif local_server:
+        text = "\nConnecting to local server...\n"
+    else:
+        text = "\nConnecting to server...\n"
+    return Content.styled(text, "dim")
 
 
 def build_welcome_footer() -> Content:

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -400,3 +400,55 @@ class TestBuildConnectingFooter:
     def test_contains_connecting_message(self) -> None:
         """Footer should include the connecting status text."""
         assert "Connecting to server..." in build_connecting_footer().plain
+
+    def test_resuming_message(self) -> None:
+        """Footer should say 'Resuming...' when resuming."""
+        footer = build_connecting_footer(resuming=True)
+        assert "Resuming..." in footer.plain
+        assert "Connecting" not in footer.plain
+
+    def test_local_server_message(self) -> None:
+        """Footer should say 'local server' when local_server is True."""
+        footer = build_connecting_footer(local_server=True)
+        assert "Connecting to local server..." in footer.plain
+
+    def test_resuming_takes_precedence_over_local(self) -> None:
+        """Resuming text should win when both resuming and local_server are set."""
+        footer = build_connecting_footer(resuming=True, local_server=True)
+        assert "Resuming..." in footer.plain
+        assert "local server" not in footer.plain
+
+
+class TestBannerConnectingFooterVariants:
+    """Verify WelcomeBanner forwards resuming/local_server to _build_banner."""
+
+    def test_connecting_default(self) -> None:
+        """Baseline connecting banner shows generic server text."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True)
+        plain = widget._build_banner().plain
+        assert "Connecting to server..." in plain
+        assert "Ready to code" not in plain
+
+    def test_connecting_resuming(self) -> None:
+        """Banner forwards resuming flag to footer."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, resuming=True)
+        plain = widget._build_banner().plain
+        assert "Resuming..." in plain
+        assert "Connecting" not in plain
+
+    def test_connecting_local_server(self) -> None:
+        """Banner forwards local_server flag to footer."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, local_server=True)
+        plain = widget._build_banner().plain
+        assert "Connecting to local server..." in plain
+
+    def test_connecting_resuming_precedence(self) -> None:
+        """Resuming wins over local_server at the banner level."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, resuming=True, local_server=True)
+        plain = widget._build_banner().plain
+        assert "Resuming..." in plain
+        assert "local server" not in plain


### PR DESCRIPTION
Closes #2035

---

Make the welcome banner's connecting footer context-aware. When launching with `-r` (resume), show "Resuming..." instead of the generic server text. When the CLI is spawning a local `langgraph dev` process, say "Connecting to local server..." — leaving the generic "Connecting to server..." for a future remote deployment path. Closes #2035.

## Changes
- Add `resuming` and `local_server` keyword-only params to `WelcomeBanner` and `build_connecting_footer`, with `resuming` taking precedence when both are set
- `DeepAgentsApp.compose()` derives the flags from existing state: `resuming` from `_resume_thread_intent is not None`, `local_server` from `_server_kwargs is not None`
