### PR TITLE
feat(cli): auto-update lifecycle, `/update` command, install script ux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,10 @@ The CLI must stay fast to launch. Never import heavy packages (e.g., `deepagents
 - Keep top-level imports in `main.py` and other entry-point modules minimal.
 - Defer heavy imports to the point where they are actually needed (inside functions/methods).
 - To read another package's version without importing it, use `importlib.metadata.version("package-name")`.
+- Feature-gate checks on the startup hot path (before background workers fire) must be lightweight — env var lookups, small file reads. Never pull in expensive modules just to decide whether to skip a feature.
+- When adding logic that already exists elsewhere (e.g., editable-install detection), import the existing cached implementation rather than duplicating it.
+- Features that run shell commands silently must be opt-in, never default-enabled. Gate behind an explicit env var or config key.
+- Background workers that spawn subprocesses must set a timeout to avoid blocking indefinitely.
 
 **CLI help screen:**
 

--- a/libs/cli/deepagents_cli/_version.py
+++ b/libs/cli/deepagents_cli/_version.py
@@ -4,3 +4,14 @@ __version__ = "0.0.34"  # x-release-please-version
 
 DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
 """URL for `deepagents-cli` documentation."""
+
+PYPI_URL = "https://pypi.org/pypi/deepagents-cli/json"
+"""PyPI JSON API endpoint for version checks."""
+
+CHANGELOG_URL = (
+    "https://github.com/langchain-ai/deepagents/blob/main/libs/cli/CHANGELOG.md"
+)
+"""URL for the full changelog."""
+
+USER_AGENT = f"deepagents-cli/{__version__} update-check"
+"""User-Agent header sent with PyPI requests."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -719,7 +719,8 @@ class DeepAgentsApp(App):
                 group="server-startup",
             )
 
-        # Background update check (opt-out via env var or config.toml [update].check)
+        # Background update check and what's-new banner
+        # (opt-out via env var or config.toml [update].check)
         from deepagents_cli.update_check import is_update_check_enabled
 
         if is_update_check_enabled():
@@ -1203,6 +1204,11 @@ class DeepAgentsApp(App):
                 )
         except Exception:
             logger.warning("Auto-update failed unexpectedly", exc_info=True)
+            self.notify(
+                "Update failed unexpectedly.",
+                severity="warning",
+                timeout=10,
+            )
 
     async def _show_whats_new(self) -> None:
         """Show a 'what's new' banner on the first launch after an upgrade."""
@@ -1225,6 +1231,7 @@ class DeepAgentsApp(App):
             )
         except Exception:
             logger.debug("What's new banner display failed", exc_info=True)
+            return
 
         try:
             from deepagents_cli._version import __version__ as cli_version
@@ -1260,7 +1267,7 @@ class DeepAgentsApp(App):
                     "Upgrading..."
                 )
             )
-            success, _output = await perform_upgrade()
+            success, output = await perform_upgrade()
             if success:
                 self._update_available = (False, None)
                 await self._mount_message(
@@ -1268,11 +1275,12 @@ class DeepAgentsApp(App):
                 )
             else:
                 cmd = upgrade_command()
+                detail = f": {output[:200]}" if output else ""
                 await self._mount_message(
-                    AppMessage(f"Auto-update failed. Run manually: {cmd}")
+                    AppMessage(f"Auto-update failed{detail}\nRun manually: {cmd}")
                 )
         except Exception as exc:
-            logger.debug("/update command failed", exc_info=True)
+            logger.warning("/update command failed", exc_info=True)
             await self._mount_message(
                 ErrorMessage(f"Update failed: {type(exc).__name__}: {exc}")
             )

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -39,7 +39,7 @@ from deepagents_cli._session_stats import (
 # All other config imports — settings, create_model, detect_provider, etc. — are
 # deferred to local imports at their call sites since they are only accessed
 # after user interaction begins.
-from deepagents_cli._version import DOCS_URL
+from deepagents_cli._version import CHANGELOG_URL, DOCS_URL
 from deepagents_cli.config import is_ascii_mode
 from deepagents_cli.prompts import REMEMBER_PROMPT
 from deepagents_cli.widgets.chat_input import ChatInput
@@ -358,7 +358,7 @@ class TextualSessionState:
 
 
 _COMMAND_URLS: dict[str, str] = {
-    "/changelog": "https://github.com/langchain-ai/deepagents/blob/main/libs/cli/CHANGELOG.md",
+    "/changelog": CHANGELOG_URL,
     "/docs": DOCS_URL,
     "/feedback": "https://github.com/langchain-ai/deepagents/issues/new/choose",
 }
@@ -547,6 +547,8 @@ class DeepAgentsApp(App):
         # Typing-aware approval deferral state
         self._last_typed_at: float | None = None
         self._approval_placeholder: Static | None = None
+        # Update availability state — set by _check_for_updates, read on exit
+        self._update_available: tuple[bool, str | None] = (False, None)
         # Cumulative usage stats across all turns in this session
         self._session_stats: SessionStats = SessionStats()
         # User message queue for sequential processing
@@ -717,12 +719,19 @@ class DeepAgentsApp(App):
                 group="server-startup",
             )
 
-        # Background update check (opt-out via DEEPAGENTS_NO_UPDATE_CHECK)
-        if not os.environ.get("DEEPAGENTS_NO_UPDATE_CHECK"):
+        # Background update check (opt-out via env var or config.toml [update].check)
+        from deepagents_cli.update_check import is_update_check_enabled
+
+        if is_update_check_enabled():
             self.run_worker(
                 self._check_for_updates,
                 exclusive=True,
                 group="startup-update-check",
+            )
+            self.run_worker(
+                self._show_whats_new,
+                exclusive=True,
+                group="startup-whats-new",
             )
 
         # Prewarm deferred widget imports in a thread
@@ -1140,22 +1149,133 @@ class DeepAgentsApp(App):
             logger.debug("Could not prewarm model caches", exc_info=True)
 
     async def _check_for_updates(self) -> None:
-        """Check PyPI for a newer deepagents-cli version and notify the user."""
+        """Check PyPI for a newer version and optionally auto-update."""
+        # Phase 1: version check (benign failure)
         try:
-            from deepagents_cli.update_check import is_update_available
+            from deepagents_cli.update_check import (
+                is_auto_update_enabled,
+                is_update_available,
+                upgrade_command,
+            )
 
             available, latest = await asyncio.to_thread(is_update_available)
-            if available:
-                from deepagents_cli._version import __version__ as cli_version
+            if not available:
+                return
+
+            self._update_available = (True, latest)
+        except Exception:
+            logger.debug("Background update check failed", exc_info=True)
+            return
+
+        # Phase 2: auto-update or notify (failures surfaced to user)
+        try:
+            from deepagents_cli._version import __version__ as cli_version
+
+            if is_auto_update_enabled():
+                from deepagents_cli.update_check import perform_upgrade
 
                 self.notify(
+                    f"Updating to v{latest}...",
+                    severity="information",
+                    timeout=5,
+                )
+                success, _output = await perform_upgrade()
+                if success:
+                    self.notify(
+                        f"Updated to v{latest}. Restart to use the new version.",
+                        severity="information",
+                        timeout=10,
+                    )
+                else:
+                    cmd = upgrade_command()
+                    self.notify(
+                        f"Auto-update failed. Run manually: {cmd}",
+                        severity="warning",
+                        timeout=15,
+                    )
+            else:
+                cmd = upgrade_command()
+                self.notify(
                     f"Update available: v{latest} (current: v{cli_version}). "
-                    "Run: uv tool upgrade deepagents-cli",
+                    f"Run: {cmd}",
                     severity="information",
                     timeout=15,
                 )
         except Exception:
-            logger.debug("Background update check failed", exc_info=True)
+            logger.warning("Auto-update failed unexpectedly", exc_info=True)
+
+    async def _show_whats_new(self) -> None:
+        """Show a 'what's new' banner on the first launch after an upgrade."""
+        try:
+            from deepagents_cli.update_check import should_show_whats_new
+
+            if not await asyncio.to_thread(should_show_whats_new):
+                return
+        except Exception:
+            logger.debug("What's new check failed", exc_info=True)
+            return
+
+        try:
+            from deepagents_cli._version import __version__ as cli_version
+
+            await self._mount_message(
+                AppMessage(
+                    f"Updated to v{cli_version}\nSee what's new: {CHANGELOG_URL}"
+                )
+            )
+        except Exception:
+            logger.debug("What's new banner display failed", exc_info=True)
+
+        try:
+            from deepagents_cli._version import __version__ as cli_version
+            from deepagents_cli.update_check import mark_version_seen
+
+            await asyncio.to_thread(mark_version_seen, cli_version)
+        except Exception:
+            logger.warning("Failed to persist seen-version marker", exc_info=True)
+
+    async def _handle_update_command(self) -> None:
+        """Handle the `/update` slash command — check for and install updates."""
+        await self._mount_message(UserMessage("/update"))
+        try:
+            from deepagents_cli.update_check import (
+                is_update_available,
+                perform_upgrade,
+                upgrade_command,
+            )
+
+            await self._mount_message(AppMessage("Checking for updates..."))
+            available, latest = await asyncio.to_thread(
+                is_update_available, bypass_cache=True
+            )
+            if not available:
+                await self._mount_message(AppMessage("Already on the latest version."))
+                return
+
+            from deepagents_cli._version import __version__ as cli_version
+
+            await self._mount_message(
+                AppMessage(
+                    f"Update available: v{latest} (current: v{cli_version}). "
+                    "Upgrading..."
+                )
+            )
+            success, _output = await perform_upgrade()
+            if success:
+                self._update_available = (False, None)
+                await self._mount_message(
+                    AppMessage(f"Updated to v{latest}. Restart to use the new version.")
+                )
+            else:
+                cmd = upgrade_command()
+                await self._mount_message(
+                    AppMessage(f"Auto-update failed. Run manually: {cmd}")
+                )
+        except Exception as exc:
+            logger.debug("/update command failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(f"Update failed: {type(exc).__name__}: {exc}")
+            )
 
     def on_scroll_up(self, _event: ScrollUp) -> None:
         """Handle scroll up to check if we need to hydrate older messages."""
@@ -2072,8 +2192,9 @@ class DeepAgentsApp(App):
             await self._mount_message(UserMessage(command))
             help_body = (
                 "Commands: /quit, /clear, /offload, /editor, /mcp, "
-                "/model [--model-params JSON] [--default], /reload, /remember, "
-                "/tokens, /threads, /trace, /changelog, /docs, /feedback, /help\n\n"
+                "/model [--model-params JSON] [--default], /reload, "
+                "/remember, /tokens, /threads, /trace, /update, "
+                "/changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
                 f"  {newline_shortcut():<15} Insert newline\n"
@@ -2150,6 +2271,8 @@ class DeepAgentsApp(App):
             await self._show_thread_selector()
         elif cmd == "/trace":
             await self._handle_trace_command(command)
+        elif cmd == "/update":
+            await self._handle_update_command()
         elif cmd == "/tokens":
             await self._mount_message(UserMessage(command))
             if self._token_tracker and self._token_tracker.current_context > 0:
@@ -4006,6 +4129,9 @@ class AppResult:
     session_stats: SessionStats = field(default_factory=SessionStats)
     """Cumulative usage stats across all turns in the session."""
 
+    update_available: tuple[bool, str | None] = (False, None)
+    """`(is_available, latest_version)` for post-exit update warning."""
+
 
 async def run_textual_app(
     *,
@@ -4092,4 +4218,5 @@ async def run_textual_app(
         return_code=app.return_code or 0,
         thread_id=app._lc_thread_id,
         session_stats=app._session_stats,
+        update_available=app._update_available,
     )

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -136,6 +136,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
+        name="/update",
+        description="Check for and install updates",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="upgrade",
+    ),
+    SlashCommand(
         name="/version",
         description="Show version",
         bypass_tier=BypassTier.CONNECTING,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -577,6 +577,11 @@ def parse_args() -> argparse.Namespace:
         logger.warning("Unexpected error looking up SDK version", exc_info=True)
         sdk_version = "unknown"
     parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Check for and install updates, then exit",
+    )
+    parser.add_argument(
         "--acp",
         action="store_true",
         help="Run as an ACP server over stdio instead of launching the Textual UI",
@@ -1218,6 +1223,55 @@ def cli_main() -> None:
                 "--non-interactive (-n) or piped stdin"
             )
             sys.exit(2)
+
+        # Handle --update (headless, no session)
+        if args.update:
+            try:
+                from rich.markup import escape
+
+                from deepagents_cli._version import __version__ as cli_version
+                from deepagents_cli.update_check import (
+                    is_update_available,
+                    perform_upgrade,
+                    upgrade_command,
+                )
+
+                console.print("Checking for updates...", style="dim")
+                available, latest = is_update_available(bypass_cache=True)
+                if latest is None:
+                    console.print(
+                        "[bold yellow]Warning:[/bold yellow] Could not "
+                        "reach PyPI. Check your network and try again."
+                    )
+                    sys.exit(1)
+                if not available:
+                    console.print(f"Already on the latest version (v{cli_version}).")
+                    sys.exit(0)
+
+                console.print(
+                    f"Update available: v{latest} "
+                    f"(current: v{cli_version}). Upgrading..."
+                )
+                success, output = asyncio.run(perform_upgrade())
+                if success:
+                    console.print(f"[green]Updated to v{latest}.[/green]")
+                else:
+                    cmd = upgrade_command()
+                    detail = f": {escape(output[:200])}" if output else ""
+                    console.print(
+                        f"[bold red]Auto-update failed{detail}[/bold red]\n"
+                        f"Run manually: [cyan]{cmd}[/cyan]"
+                    )
+                    sys.exit(1)
+                sys.exit(0)
+            except Exception:
+                logger.warning("--update failed", exc_info=True)
+                console.print(
+                    "[bold red]Error:[/bold red] Update failed.\n"
+                    "Run manually: [cyan]uv tool upgrade "
+                    "deepagents-cli[/cyan]"
+                )
+                sys.exit(1)
 
         # Handle --default-model / --clear-default-model (headless, no session)
         if args.clear_default_model:

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1461,6 +1461,22 @@ def cli_main() -> None:
                 hint = Text("deepagents -r ", style="cyan")
                 hint.append(str(thread_id), style="cyan")
                 console.print(hint)
+
+            # Warn about available update on exit
+            try:
+                if result.update_available[0]:
+                    from deepagents_cli.update_check import upgrade_command
+
+                    latest = result.update_available[1]
+                    console.print()
+                    update_msg = Text("Update available: ", style="yellow bold")
+                    update_msg.append(f"v{latest}", style="yellow")
+                    console.print(update_msg)
+                    cmd_hint = Text("Run: ", style="dim")
+                    cmd_hint.append(upgrade_command(), style="cyan")
+                    console.print(cmd_hint)
+            except Exception:
+                logger.debug("Failed to display exit update banner", exc_info=True)
     except KeyboardInterrupt:
         # Clean exit on Ctrl+C — suppress ugly traceback.
         # `console` may not be bound if Ctrl+C arrives during config import.

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -114,6 +114,9 @@ def show_help() -> None:
     )
     console.print("  --default-model [MODEL]    Set, show, or manage the default model")
     console.print("  --clear-default-model      Clear the default model")
+    console.print(
+        "  --update                   Check for and install updates, then exit"
+    )
     console.print("  --acp                      Run as an ACP server over stdio")
     console.print("  -v, --version              Show deepagents CLI and SDK versions")
     console.print("  -h, --help                 Show this help message and exit")

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -1,29 +1,50 @@
-"""Background update check for deepagents-cli.
+"""Update lifecycle for `deepagents-cli`.
 
-Compares the installed version against PyPI and caches the result
-(see `CACHE_TTL`). All errors are silently swallowed to avoid disrupting
-user experience.
+Handles version checking against PyPI (with caching), install-method detection,
+auto-upgrade execution, config-driven opt-in/out, and "what's new" tracking.
+
+All errors are silently swallowed to avoid disrupting user experience.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
+import shutil
+import sys
 import time
-from typing import TYPE_CHECKING
+import tomllib
+from typing import TYPE_CHECKING, Literal
 
-from deepagents_cli._version import __version__
+from deepagents_cli._version import PYPI_URL, USER_AGENT, __version__
 
 if TYPE_CHECKING:
     from pathlib import Path
-from deepagents_cli.model_config import DEFAULT_CONFIG_DIR
+
+from deepagents_cli.model_config import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_PATH
 
 logger = logging.getLogger(__name__)
 
-PYPI_URL = "https://pypi.org/pypi/deepagents-cli/json"
 CACHE_FILE: Path = DEFAULT_CONFIG_DIR / "latest_version.json"
+SEEN_VERSION_FILE: Path = DEFAULT_CONFIG_DIR / "seen_version.json"
 CACHE_TTL = 86_400  # 24 hours
-USER_AGENT = f"deepagents-cli/{__version__} update-check"
+
+InstallMethod = Literal["uv", "pip", "brew", "unknown"]
+
+_UPGRADE_COMMANDS: dict[InstallMethod, str] = {
+    "uv": "uv tool upgrade deepagents-cli",
+    "brew": "brew upgrade deepagents-cli",
+    "pip": "pip install --upgrade deepagents-cli",
+}
+"""Upgrade commands keyed by install method.
+
+Execution order is determined by `perform_upgrade`, which tries the detected
+method only.
+"""
+
+_UPGRADE_TIMEOUT = 120  # seconds
 
 
 def _parse_version(v: str) -> tuple[int, ...]:
@@ -34,30 +55,39 @@ def _parse_version(v: str) -> tuple[int, ...]:
 
     Returns:
         Tuple of integers, e.g. `(1, 2, 3)`.
-
     """
     return tuple(int(x) for x in v.strip().split("."))
 
 
-def get_latest_version() -> str | None:
+def get_latest_version(*, bypass_cache: bool = False) -> str | None:
     """Fetch the latest deepagents-cli version from PyPI, with caching.
 
     Results are cached to `CACHE_FILE` to avoid repeated network calls.
+
+    Args:
+        bypass_cache: Skip the cache and always hit PyPI.
 
     Returns:
         The latest version string, or `None` on any failure.
     """
     try:
-        if CACHE_FILE.exists():
+        if not bypass_cache and CACHE_FILE.exists():
             data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
             if time.time() - data.get("checked_at", 0) < CACHE_TTL:
                 return data["version"]
-    except Exception:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
         logger.debug("Failed to read update-check cache", exc_info=True)
 
     try:
         import requests
+    except ImportError:
+        logger.warning(
+            "requests package not installed — update checks disabled. "
+            "Install with: pip install requests"
+        )
+        return None
 
+    try:
         resp = requests.get(
             PYPI_URL,
             headers={"User-Agent": USER_AGENT},
@@ -65,7 +95,7 @@ def get_latest_version() -> str | None:
         )
         resp.raise_for_status()
         latest: str = resp.json()["info"]["version"]
-    except Exception:
+    except (requests.RequestException, KeyError, json.JSONDecodeError):
         logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
         return None
 
@@ -75,21 +105,26 @@ def get_latest_version() -> str | None:
             json.dumps({"version": latest, "checked_at": time.time()}),
             encoding="utf-8",
         )
-    except Exception:
+    except OSError:
         logger.debug("Failed to write update-check cache", exc_info=True)
 
     return latest
 
 
-def is_update_available() -> tuple[bool, str | None]:
+def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None]:
     """Check whether a newer version of deepagents-cli is available.
 
+    Args:
+        bypass_cache: Skip the cache and always hit PyPI.
+
     Returns:
-        A `(available, latest)` tuple. `available` is `True` when
-        the PyPI version is strictly newer than the installed version;
-        `latest` is the version string (or `None` when the check fails).
+        A `(available, latest)` tuple.
+
+            `available` is `True` when the PyPI version is strictly newer than
+            the installed version; `latest` is the version string (or `None`
+            when the check fails).
     """
-    latest = get_latest_version()
+    latest = get_latest_version(bypass_cache=bypass_cache)
     if latest is None:
         return False, None
 
@@ -100,3 +135,196 @@ def is_update_available() -> tuple[bool, str | None]:
         logger.debug("Failed to compare versions", exc_info=True)
 
     return False, None
+
+
+# ---------------------------------------------------------------------------
+# Install method detection
+# ---------------------------------------------------------------------------
+
+
+def detect_install_method() -> InstallMethod:
+    """Detect how `deepagents-cli` was installed.
+
+    Checks `sys.prefix` against known paths for uv and Homebrew.
+
+    Returns:
+        `'unknown'` for editable/dev installs, otherwise falls back to `'pip'`.
+    """
+    from deepagents_cli.config import _is_editable_install
+
+    prefix = sys.prefix
+    # uv tool installs live under ~/.local/share/uv/tools/
+    if "/uv/tools/" in prefix or "\\uv\\tools\\" in prefix:
+        return "uv"
+    # Homebrew prefixes
+    if any(
+        prefix.startswith(p)
+        for p in ("/opt/homebrew", "/usr/local/Cellar", "/home/linuxbrew")
+    ):
+        return "brew"
+    # Editable / dev installs — don't auto-upgrade
+    if _is_editable_install():
+        return "unknown"
+    return "pip"
+
+
+def upgrade_command(method: InstallMethod | None = None) -> str:
+    """Return the shell command to upgrade `deepagents-cli`.
+
+    Falls back to the pip command for unrecognised install methods.
+
+    Args:
+        method: Install method override.
+
+            Auto-detected if `None`.
+    """
+    if method is None:
+        method = detect_install_method()
+    return _UPGRADE_COMMANDS.get(method, _UPGRADE_COMMANDS["pip"])
+
+
+async def perform_upgrade() -> tuple[bool, str]:
+    """Attempt to upgrade `deepagents-cli` using the detected install method.
+
+    Only tries the detected method — does not fall back to other package
+    managers to avoid cross-environment contamination.
+
+    Returns:
+        `(success, output)` — *output* is the combined stdout/stderr.
+    """
+    method = detect_install_method()
+    if method == "unknown":
+        return False, "Editable install detected — skipping auto-update."
+
+    cmd = _UPGRADE_COMMANDS.get(method)
+    if cmd is None:
+        return False, f"No upgrade command for install method: {method}"
+
+    # Skip brew if binary not on PATH
+    if method == "brew" and not shutil.which("brew"):
+        return False, "brew not found on PATH."
+
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_UPGRADE_TIMEOUT
+        )
+        output = (stdout or b"").decode() + (stderr or b"").decode()
+        if proc.returncode == 0:
+            return True, output.strip()
+        logger.warning(
+            "Upgrade via %s exited with code %d: %s",
+            method,
+            proc.returncode,
+            output.strip(),
+        )
+        return False, output.strip()
+    except TimeoutError:
+        msg = f"Upgrade command timed out after {_UPGRADE_TIMEOUT}s: {cmd}"
+        logger.warning(msg)
+        return False, msg
+    except OSError:
+        logger.warning("Failed to execute upgrade command: %s", cmd, exc_info=True)
+        return False, f"Failed to execute: {cmd}"
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def is_update_check_enabled() -> bool:
+    """Return whether update checks are enabled.
+
+    Checks `DEEPAGENTS_NO_UPDATE_CHECK` env var and the `[update].check` key
+    in `config.toml`.
+
+    Defaults to enabled.
+    """
+    if os.environ.get("DEEPAGENTS_NO_UPDATE_CHECK"):
+        return False
+    return _read_update_config().get("check", True)
+
+
+def is_auto_update_enabled() -> bool:
+    """Return whether auto-update is enabled.
+
+    Opt-in via `DEEPAGENTS_AUTO_UPDATE=1` env var or
+    `[update].auto_update = true` in `config.toml`.
+
+    Defaults to `False`.
+
+    Always disabled for editable installs.
+    """
+    from deepagents_cli.config import _is_editable_install
+
+    if _is_editable_install():
+        return False
+    if os.environ.get("DEEPAGENTS_AUTO_UPDATE"):
+        return True
+    return _read_update_config().get("auto_update", False)
+
+
+def _read_update_config() -> dict[str, bool]:
+    """Read `[update]` section from `config.toml`.
+
+    Returns:
+        A dict of boolean config values, empty on missing/unreadable file.
+    """
+    try:
+        if not DEFAULT_CONFIG_PATH.exists():
+            return {}
+        with DEFAULT_CONFIG_PATH.open("rb") as f:
+            data = tomllib.load(f)
+        section = data.get("update", {})
+        return {k: v for k, v in section.items() if isinstance(v, bool)}
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.debug("Could not read [update] config", exc_info=True)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# "What's new" tracking
+# ---------------------------------------------------------------------------
+
+
+def get_seen_version() -> str | None:
+    """Return the last version the user saw the "what's new" banner for."""
+    try:
+        if SEEN_VERSION_FILE.exists():
+            data = json.loads(SEEN_VERSION_FILE.read_text(encoding="utf-8"))
+            return data.get("version")
+    except Exception:
+        logger.debug("Failed to read seen-version file", exc_info=True)
+    return None
+
+
+def mark_version_seen(version: str) -> None:
+    """Record that the user has seen the "what's new" banner for *version*."""
+    try:
+        SEEN_VERSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+        SEEN_VERSION_FILE.write_text(
+            json.dumps({"version": version, "seen_at": time.time()}),
+            encoding="utf-8",
+        )
+    except Exception:
+        logger.debug("Failed to write seen-version file", exc_info=True)
+
+
+def should_show_whats_new() -> bool:
+    """Return `True` if this is the first launch on a newer version."""
+    seen = get_seen_version()
+    if seen is None:
+        # First run ever — mark current as seen, don't show banner.
+        mark_version_seen(__version__)
+        return False
+    try:
+        return _parse_version(__version__) > _parse_version(seen)
+    except (ValueError, TypeError):
+        logger.debug("Failed to compare versions for what's-new check", exc_info=True)
+        return False

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -3,7 +3,8 @@
 Handles version checking against PyPI (with caching), install-method detection,
 auto-upgrade execution, config-driven opt-in/out, and "what's new" tracking.
 
-All errors are silently swallowed to avoid disrupting user experience.
+Public entry points never raise; errors are caught and logged to avoid
+disrupting user experience.
 """
 
 from __future__ import annotations
@@ -40,8 +41,8 @@ _UPGRADE_COMMANDS: dict[InstallMethod, str] = {
 }
 """Upgrade commands keyed by install method.
 
-Execution order is determined by `perform_upgrade`, which tries the detected
-method only.
+`perform_upgrade` runs only the command matching the detected install method;
+no fallback chain.
 """
 
 _UPGRADE_TIMEOUT = 120  # seconds
@@ -95,7 +96,7 @@ def get_latest_version(*, bypass_cache: bool = False) -> str | None:
         )
         resp.raise_for_status()
         latest: str = resp.json()["info"]["version"]
-    except (requests.RequestException, KeyError, json.JSONDecodeError):
+    except (requests.RequestException, OSError, KeyError, json.JSONDecodeError):
         logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
         return None
 
@@ -148,7 +149,8 @@ def detect_install_method() -> InstallMethod:
     Checks `sys.prefix` against known paths for uv and Homebrew.
 
     Returns:
-        `'unknown'` for editable/dev installs, otherwise falls back to `'pip'`.
+        The detected install method: `'uv'`, `'brew'`, `'pip'`, or `'unknown'`
+            (editable/dev installs).
     """
     from deepagents_cli.config import _is_editable_install
 
@@ -171,7 +173,7 @@ def detect_install_method() -> InstallMethod:
 def upgrade_command(method: InstallMethod | None = None) -> str:
     """Return the shell command to upgrade `deepagents-cli`.
 
-    Falls back to the pip command for unrecognised install methods.
+    Falls back to the pip command for unrecognized install methods.
 
     Args:
         method: Install method override.
@@ -225,6 +227,8 @@ async def perform_upgrade() -> tuple[bool, str]:
         )
         return False, output.strip()
     except TimeoutError:
+        proc.kill()
+        await proc.wait()
         msg = f"Upgrade command timed out after {_UPGRADE_TIMEOUT}s: {cmd}"
         logger.warning(msg)
         return False, msg
@@ -265,7 +269,7 @@ def is_auto_update_enabled() -> bool:
 
     if _is_editable_install():
         return False
-    if os.environ.get("DEEPAGENTS_AUTO_UPDATE"):
+    if os.environ.get("DEEPAGENTS_AUTO_UPDATE", "").lower() in {"1", "true", "yes"}:
         return True
     return _read_update_config().get("auto_update", False)
 
@@ -284,7 +288,7 @@ def _read_update_config() -> dict[str, bool]:
         section = data.get("update", {})
         return {k: v for k, v in section.items() if isinstance(v, bool)}
     except (OSError, tomllib.TOMLDecodeError):
-        logger.debug("Could not read [update] config", exc_info=True)
+        logger.warning("Could not read [update] config — using defaults", exc_info=True)
         return {}
 
 
@@ -299,7 +303,7 @@ def get_seen_version() -> str | None:
         if SEEN_VERSION_FILE.exists():
             data = json.loads(SEEN_VERSION_FILE.read_text(encoding="utf-8"))
             return data.get("version")
-    except Exception:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
         logger.debug("Failed to read seen-version file", exc_info=True)
     return None
 
@@ -312,7 +316,7 @@ def mark_version_seen(version: str) -> None:
             json.dumps({"version": version, "seen_at": time.time()}),
             encoding="utf-8",
         )
-    except Exception:
+    except OSError:
         logger.debug("Failed to write seen-version file", exc_info=True)
 
 

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -34,6 +34,7 @@ _TIPS: list[str] = [
     "Use /model to switch models mid-conversation",
     "Press ctrl+x to compose prompts in your external editor",
     "Press ctrl+u to delete to the start of the line in the chat input",
+    "Type /update to check for and install updates",
 ]
 """Rotating tips shown in the welcome footer.
 

--- a/libs/cli/scripts/install.sh
+++ b/libs/cli/scripts/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Install deepagents-cli via uv.
 #
+# Interactive mode detection, color logging, and optional tool install
+# patterns adapted from hermes-agent (NousResearch/hermes-agent).
+#
 # Usage:
 #   curl -LsSf https://raw.githubusercontent.com/langchain-ai/deepagents/main/libs/cli/scripts/install.sh | bash
 #
@@ -9,11 +12,106 @@
 #                        "anthropic,groq", or "daytona"
 #                        (see pyproject.toml for available extras)
 #   DEEPAGENTS_PYTHON  — Python version to use (default: 3.13)
+#   DEEPAGENTS_SKIP_OPTIONAL — set to 1 to skip optional tool checks
 #   UV_BIN             — path to uv binary (auto-detected if unset)
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Colors & logging
+# ---------------------------------------------------------------------------
+if [ -t 1 ] || [ "${FORCE_COLOR:-}" = "1" ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  CYAN='\033[0;36m'
+  BOLD='\033[1m'
+  NC='\033[0m'
+else
+  RED='' GREEN='' YELLOW='' CYAN='' BOLD='' NC=''
+fi
+
+log_info()    { printf "${CYAN}▸${NC} %s\n" "$*"; }
+log_success() { printf "${GREEN}✔${NC} %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}⚠${NC} %s\n" "$*" >&2; }
+log_error()   { printf "${RED}✖${NC} %s\n" "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Exit trap — ensures the user always sees an actionable message on failure
+# ---------------------------------------------------------------------------
+cleanup() {
+  local exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    echo "" >&2
+    log_error "Installation failed (exit code ${exit_code}). See errors above."
+    log_error "For help, visit: https://docs.langchain.com/oss/python/deepagents/cli/overview"
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Interactive mode detection
+# ---------------------------------------------------------------------------
+# When piped (curl | bash), stdin is not a terminal, but /dev/tty may still be
+# available for prompts. IS_INTERACTIVE controls whether we ask the user
+# questions; we never block a piped install on missing input.
+IS_INTERACTIVE=false
+if [ -t 0 ]; then
+  IS_INTERACTIVE=true
+elif [ -r /dev/tty ]; then
+  # piped install but terminal is readable — can prompt via /dev/tty
+  IS_INTERACTIVE=true
+fi
+
+# ---------------------------------------------------------------------------
+# OS / platform detection
+# ---------------------------------------------------------------------------
+detect_os() {
+  case "$(uname -s)" in
+    Darwin)  OS="macos" ;;
+    Linux)
+             # shellcheck disable=SC2034
+             # shellcheck disable=SC1091
+             DISTRO=$(. /etc/os-release 2>/dev/null && echo "${ID:-unknown}" || echo "unknown")
+             OS="linux"
+             ;;
+    MINGW*|MSYS*|CYGWIN*)
+             OS="windows" ;;
+    *)       OS="unknown" ;;
+  esac
+}
+detect_os
+
+# ---------------------------------------------------------------------------
+# Prompt helper — reads from /dev/tty when stdin is piped
+# ---------------------------------------------------------------------------
+prompt_yn() {
+  local question="$1"
+  if [ "$IS_INTERACTIVE" = false ]; then
+    return 1
+  fi
+  local reply
+  if [ -t 0 ]; then
+    printf "%s [y/N] " "$question"
+    read -r reply
+  else
+    printf "%s [y/N] " "$question" > /dev/tty
+    if ! read -r reply < /dev/tty 2>/dev/null; then
+      log_warn "Could not read from /dev/tty — skipping prompt."
+      return 1
+    fi
+  fi
+  if [[ "$reply" =~ ^[Yy]$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 EXTRAS="${DEEPAGENTS_EXTRAS:-}"
 PYTHON_VERSION="${DEEPAGENTS_PYTHON:-3.13}"
+SKIP_OPTIONAL="${DEEPAGENTS_SKIP_OPTIONAL:-0}"
 
 # Validate and normalize extras: accept bare CSV, wrap in brackets for pip
 if [[ -n "$EXTRAS" ]]; then
@@ -21,25 +119,36 @@ if [[ -n "$EXTRAS" ]]; then
   EXTRAS="${EXTRAS#[}"
   EXTRAS="${EXTRAS%]}"
   if [[ ! "$EXTRAS" =~ ^[-a-zA-Z0-9,]+$ ]]; then
-    echo "Error: DEEPAGENTS_EXTRAS must be comma-separated extra names, e.g. 'anthropic,groq' or 'daytona'" >&2
+    log_error "DEEPAGENTS_EXTRAS must be comma-separated extra names, e.g. 'anthropic,groq' or 'daytona'"
     exit 1
   fi
   EXTRAS="[${EXTRAS}]"
 fi
 
+# ---------------------------------------------------------------------------
+# uv installation
+# ---------------------------------------------------------------------------
 install_uv() {
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL https://astral.sh/uv/install.sh | sh
+    log_info "Downloading uv installer..."
+    if ! curl -fsSL https://astral.sh/uv/install.sh | sh; then
+      log_error "uv installation failed. See errors above."
+      exit 1
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- https://astral.sh/uv/install.sh | sh
+    log_info "Downloading uv installer..."
+    if ! wget -qO- https://astral.sh/uv/install.sh | sh; then
+      log_error "uv installation failed. See errors above."
+      exit 1
+    fi
   else
-    echo "Error: curl or wget is required to install uv." >&2
+    log_error "curl or wget is required to install uv."
     exit 1
   fi
 }
 
 if ! command -v uv >/dev/null 2>&1; then
-  echo "uv not found — installing..." >&2
+  log_info "uv not found — installing..."
   install_uv
 fi
 
@@ -57,22 +166,177 @@ if [ -z "${UV_BIN:-}" ]; then
   if ! command -v uv >/dev/null 2>&1; then
     UV_BIN="${HOME}/.local/bin/uv"
     if [ ! -x "$UV_BIN" ]; then
-      echo "Error: uv not found after installation. Restart your shell or add ~/.local/bin to PATH." >&2
+      log_error "uv not found after installation. Restart your shell or add ~/.local/bin to PATH."
       exit 1
     fi
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# Install deepagents-cli
+# ---------------------------------------------------------------------------
 PACKAGE="deepagents-cli${EXTRAS}"
-echo "Installing ${PACKAGE}..." >&2
-"$UV_BIN" tool install -U --python "$PYTHON_VERSION" "$PACKAGE"
+log_info "Installing ${PACKAGE}..."
+if ! "$UV_BIN" tool install -U --python "$PYTHON_VERSION" "$PACKAGE"; then
+  log_error "Failed to install ${PACKAGE}. See errors above."
+  log_error "Common fixes: check your network, try a different Python version (DEEPAGENTS_PYTHON=3.12), or install manually."
+  exit 1
+fi
+log_success "deepagents-cli installed."
 
+# ---------------------------------------------------------------------------
+# Post-install verification
+# ---------------------------------------------------------------------------
+DEEPAGENTS_BIN=""
+if command -v deepagents >/dev/null 2>&1; then
+  DEEPAGENTS_BIN="deepagents"
+elif [ -x "${HOME}/.local/bin/deepagents" ]; then
+  DEEPAGENTS_BIN="${HOME}/.local/bin/deepagents"
+fi
+
+if [ -n "$DEEPAGENTS_BIN" ]; then
+  if VERSION=$("$DEEPAGENTS_BIN" -v 2>&1); then
+    log_success "Verified: deepagents ${VERSION}"
+  else
+    log_warn "deepagents binary found but 'deepagents -v' failed:"
+    log_warn "  ${VERSION}"
+    log_warn "The installation may be broken. Try running: deepagents -v"
+  fi
+else
+  log_warn "deepagents command not found in PATH. Restart your shell or run:"
+  log_warn "  source ~/.zshrc   # (or ~/.bashrc)"
+fi
+
+# ---------------------------------------------------------------------------
+# Optional tools — ripgrep
+# ---------------------------------------------------------------------------
+
+# Pre-check: verify sudo is usable before running sudo commands.
+# Returns 0 if sudo is available (cached or passwordless), 1 otherwise.
+check_sudo() {
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 1
+  fi
+  # -v -n: validate cached credentials, non-interactive (no password prompt)
+  if sudo -v -n 2>/dev/null; then
+    return 0
+  fi
+  # Interactive: warn and let sudo prompt normally
+  if [ "$IS_INTERACTIVE" = true ]; then
+    log_warn "sudo may prompt for your password."
+    return 0
+  fi
+  return 1
+}
+
+install_ripgrep_via_pkg() {
+  case "$OS" in
+    macos)
+      if command -v brew >/dev/null 2>&1; then
+        log_info "Installing ripgrep via Homebrew (this may take a moment)..."
+        if HOMEBREW_NO_AUTO_UPDATE=1 brew install ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      fi
+      if command -v port >/dev/null 2>&1 && check_sudo; then
+        log_info "Installing ripgrep via MacPorts..."
+        if sudo port install ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      fi
+      ;;
+    linux)
+      if command -v apt-get >/dev/null 2>&1 && check_sudo; then
+        log_info "Installing ripgrep via apt-get..."
+        if sudo apt-get install -y ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      elif command -v dnf >/dev/null 2>&1 && check_sudo; then
+        log_info "Installing ripgrep via dnf..."
+        if sudo dnf install -y ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      elif command -v pacman >/dev/null 2>&1 && check_sudo; then
+        log_info "Installing ripgrep via pacman..."
+        if sudo pacman -S --noconfirm ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      elif command -v zypper >/dev/null 2>&1 && check_sudo; then
+        log_info "Installing ripgrep via zypper..."
+        if sudo zypper install -y ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      elif command -v apk >/dev/null 2>&1 && check_sudo; then
+        log_info "Installing ripgrep via apk..."
+        if sudo apk add ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      elif command -v nix-env >/dev/null 2>&1; then
+        log_info "Installing ripgrep via nix..."
+        if nix-env -iA nixpkgs.ripgrep; then
+          command -v rg >/dev/null 2>&1 && return 0
+        fi
+      fi
+      ;;
+  esac
+  return 1
+}
+
+install_ripgrep_via_cargo() {
+  if command -v cargo >/dev/null 2>&1; then
+    log_info "Installing ripgrep via cargo (no sudo needed)..."
+    if cargo install ripgrep; then
+      command -v rg >/dev/null 2>&1 && return 0
+      log_warn "cargo install succeeded but rg not found in PATH."
+    fi
+  fi
+  return 1
+}
+
+ripgrep_manual_hint() {
+  log_warn "ripgrep is not installed; the grep tool will use a slower fallback."
+  case "$OS" in
+    macos)  log_warn "  Install: brew install ripgrep" ;;
+    *)      log_warn "  Install: https://github.com/BurntSushi/ripgrep#installation" ;;
+  esac
+}
+
+if [ "$SKIP_OPTIONAL" != "1" ]; then
+  echo ""
+  log_info "Checking optional tools..."
+
+  if command -v rg >/dev/null 2>&1; then
+    rg_version=$(rg --version 2>/dev/null | head -1 | awk '{print $2}') || rg_version="(version unknown)"
+    log_success "ripgrep ${rg_version} found"
+  else
+    log_warn "ripgrep not found — recommended for faster file search."
+
+    installed=false
+    if prompt_yn "  Install ripgrep?"; then
+      if install_ripgrep_via_pkg; then
+        installed=true
+      elif install_ripgrep_via_cargo; then
+        installed=true
+      fi
+
+      if [ "$installed" = true ]; then
+        log_success "ripgrep installed."
+      else
+        log_error "Automatic install failed."
+        ripgrep_manual_hint
+      fi
+    else
+      ripgrep_manual_hint
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
 echo ""
-echo "deepagents-cli installed successfully."
-echo "Run:  deepagents"
-echo ""
-echo "If the command is not found, restart your shell or run:"
-echo "  source ~/.zshrc   # (or ~/.bashrc)"
+# shellcheck disable=SC2059
+printf "${GREEN}✔${NC} Setup complete. Run: ${BOLD}deepagents${NC}\n"
 echo ""
 echo "For help and support, see the Deep Agents CLI docs:"
 echo "  https://docs.langchain.com/oss/python/deepagents/cli/overview"

--- a/libs/cli/scripts/install.sh
+++ b/libs/cli/scripts/install.sh
@@ -176,7 +176,21 @@ fi
 # Install deepagents-cli
 # ---------------------------------------------------------------------------
 PACKAGE="deepagents-cli${EXTRAS}"
-log_info "Installing ${PACKAGE}..."
+
+# Capture pre-install version (if any) for messaging
+PRE_VERSION=""
+if command -v deepagents >/dev/null 2>&1; then
+  PRE_VERSION=$(deepagents -v 2>/dev/null | head -1 | awk '{print $NF}') || PRE_VERSION=""
+elif [ -x "${HOME}/.local/bin/deepagents" ]; then
+  PRE_VERSION=$("${HOME}/.local/bin/deepagents" -v 2>/dev/null | head -1 | awk '{print $NF}') || PRE_VERSION=""
+fi
+
+if [ -n "$PRE_VERSION" ]; then
+  log_info "deepagents-cli ${PRE_VERSION} found — checking for updates..."
+else
+  log_info "Installing ${PACKAGE}..."
+fi
+
 if ! "$UV_BIN" tool install -U --python "$PYTHON_VERSION" "$PACKAGE"; then
   log_error "Failed to install ${PACKAGE}. See errors above."
   log_error "Common fixes: check your network, try a different Python version (DEEPAGENTS_PYTHON=3.12), or install manually."

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -114,8 +114,8 @@ class TestSlashCommands:
 class TestHelpBodyDrift:
     """Ensure the /help body in app.py stays in sync with COMMANDS.
 
-    The "Commands: ..." line in the ``/help`` handler is hand-maintained
-    separately from the ``COMMANDS`` tuple in ``command_registry.py``.  This
+    The "Commands: ..." line in the `/help` handler is hand-maintained
+    separately from the `COMMANDS` tuple in `command_registry.py`.  This
     test catches drift — e.g. a new command added to the registry but
     forgotten in the help output.
     """

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from deepagents_cli.command_registry import (
     ALL_CLASSIFIED,
     ALWAYS_IMMEDIATE,
@@ -106,3 +109,46 @@ class TestSlashCommands:
                 assert alias not in names, (
                     f"Alias {alias!r} should not appear in autocomplete"
                 )
+
+
+class TestHelpBodyDrift:
+    """Ensure the /help body in app.py stays in sync with COMMANDS.
+
+    The "Commands: ..." line in the ``/help`` handler is hand-maintained
+    separately from the ``COMMANDS`` tuple in ``command_registry.py``.  This
+    test catches drift — e.g. a new command added to the registry but
+    forgotten in the help output.
+    """
+
+    def test_help_body_lists_all_commands(self) -> None:
+        """Every command in COMMANDS must appear in the /help body."""
+        app_src = (
+            Path(__file__).resolve().parents[2] / "deepagents_cli" / "app.py"
+        ).read_text()
+
+        # Isolate the "Commands: ..." section (before "Interactive Features")
+        match = re.search(
+            r'"Commands:\s*(.*?)(?=Interactive Features)',
+            app_src,
+            re.DOTALL,
+        )
+        assert match, "Could not locate Commands section in help_body"
+        commands_section = match.group(1)
+
+        help_cmds = set(re.findall(r"/[a-z]+", commands_section))
+        registry_cmds = {cmd.name for cmd in COMMANDS}
+
+        # Commands intentionally omitted from the help body
+        excluded = {"/version"}
+
+        missing = registry_cmds - help_cmds - excluded
+        extra = help_cmds - registry_cmds
+
+        assert not missing, (
+            f"Commands in COMMANDS but missing from /help body: {missing}\n"
+            "Add them to help_body in app.py _handle_command()."
+        )
+        assert not extra, (
+            f"Commands in /help body but missing from COMMANDS: {extra}\n"
+            "Remove them from help_body or add to COMMANDS in command_registry.py."
+        )


### PR DESCRIPTION
Overhaul the CLI's update lifecycle — version checks, auto-upgrade, install-method detection, and a new `/update` slash command — so users can stay current without leaving the TUI. The install script also gets a major quality-of-life pass with colored logging, interactive prompts, error trapping, and optional ripgrep installation.

## Changes

- Add `detect_install_method()` in `update_check.py` that inspects `sys.prefix` to distinguish uv, Homebrew, pip, and editable installs — `upgrade_command()` and `perform_upgrade()` use this to select the right upgrade path
- Add opt-in auto-update behind `DEEPAGENTS_AUTO_UPDATE` env var or `[update].auto_update` in `config.toml`; `_check_for_updates` now auto-upgrades when enabled, otherwise shows an install-method-aware hint
- Add "what's new" banner on first launch after an upgrade via `should_show_whats_new()` / `mark_version_seen()`, tracked in `~/.deepagents/seen_version.json`
- Add `/update` slash command (`_handle_update_command`) that checks PyPI with `bypass_cache=True`, runs the upgrade in-process, and reports success/failure inline
- Surface `update_available` through `AppResult` so `cli_main` prints an exit-time update banner when a newer version was detected during the session
- Rewrite `scripts/install.sh` with colored log helpers, an `EXIT` trap for actionable failure messages, interactive mode detection (`/dev/tty` for piped installs), post-install verification (`deepagents -v`), and optional ripgrep installation via platform package managers with cargo fallback
- Move `PYPI_URL` and `USER_AGENT` from `update_check.py` to `_version.py` as canonical constants; narrow bare `except` clauses to specific exception types throughout `update_check.py`

## Testing

- Add `TestHelpBodyDrift` in `test_command_registry.py` — parses the `/help` output in `app.py` and asserts every command in the `COMMANDS` registry appears there, catching future drift between the two
