### PR TITLE
fix(sdk): overwrite `write` on LangSmithSandbox

### DIFF
--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -9,6 +9,7 @@ from deepagents.backends.protocol import (
     ExecuteResponse,
     FileDownloadResponse,
     FileUploadResponse,
+    WriteResult,
 )
 from deepagents.backends.sandbox import BaseSandbox
 
@@ -65,6 +66,28 @@ class LangSmithSandbox(BaseSandbox):
             exit_code=result.exit_code,
             truncated=False,
         )
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Write content using the LangSmith SDK to avoid ARG_MAX.
+
+        `BaseSandbox.write()` sends the full content in a shell command, which
+        can exceed ARG_MAX for large content. This override uses the SDK's
+        native `write()`, which sends content in the HTTP body.
+
+        Args:
+            file_path: Destination path inside the sandbox.
+            content: Text content to write.
+
+        Returns:
+            `WriteResult` with the written path on success, or an error message.
+        """
+        from langsmith.sandbox import SandboxClientError  # noqa: PLC0415
+
+        try:
+            self._sandbox.write(file_path, content.encode("utf-8"))
+            return WriteResult(path=file_path, files_update=None)
+        except SandboxClientError as e:
+            return WriteResult(error=f"Failed to write file '{file_path}': {e}")
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
         """Download multiple files from the LangSmith sandbox.

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -71,6 +71,27 @@ def test_execute_with_zero_timeout() -> None:
     mock_sdk.run.assert_called_once_with("cmd", timeout=0)
 
 
+def test_write_success() -> None:
+    sb, mock_sdk = _make_sandbox()
+
+    result = sb.write("/app/test.txt", "hello world")
+
+    assert result.path == "/app/test.txt"
+    assert result.error is None
+    mock_sdk.write.assert_called_once_with("/app/test.txt", b"hello world")
+
+
+def test_write_error() -> None:
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.write.side_effect = SandboxClientError("permission denied")
+
+    result = sb.write("/readonly/test.txt", "content")
+
+    assert result.error is not None
+    assert "Failed to write file" in result.error
+    assert "/readonly/test.txt" in result.error
+
+
 def test_download_files_success() -> None:
     sb, mock_sdk = _make_sandbox()
     mock_sdk.read.return_value = b"file content"


### PR DESCRIPTION
BaseSandbox `write` uses a bash script. Here we delegate to sandbox native write to avoid running into ARG_MAX on shell command.