### PR TITLE
fix(sdk): handle list type in `_file_data_reducer` to prevent TypeError

### DIFF
--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -83,6 +83,8 @@ class StateBackend(BackendProtocol):
             Directories have a trailing / in their path and is_dir=True.
         """
         files = self.runtime.state.get("files", {})
+        if not isinstance(files, dict):
+            files = {}
         infos: list[FileInfo] = []
         subdirs: set[str] = set()
 

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -497,6 +497,9 @@ def _filter_files_by_path(files: dict[str, Any], normalized_path: str) -> dict[s
         _filter_files_by_path(files, "/dir/file")  # Returns {"/dir/file": {...}}
         _filter_files_by_path(files, "/dir")       # Returns both files
     """
+    if not isinstance(files, dict):
+        return {}
+
     # Check if path matches an exact file
     if normalized_path in files:
         return {normalized_path: files[normalized_path]}

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -95,6 +95,22 @@ def _file_data_reducer(left: dict[str, FileData] | None, right: dict[str, FileDa
         # Result: {"/file1.txt": FileData(...), "/file3.txt": FileData(...)}
         ```
     """
+    # Defensive: handle list types that can occur with certain checkpointer
+    # or channel update configurations (see issue #731).
+    if isinstance(left, list):
+        merged_left: dict[str, FileData] = {}
+        for item in left:
+            if isinstance(item, dict):
+                merged_left.update({k: v for k, v in item.items() if v is not None})
+        left = merged_left or None
+
+    if isinstance(right, list):
+        merged_right: dict[str, FileData | None] = {}
+        for item in right:
+            if isinstance(item, dict):
+                merged_right.update(item)
+        right = merged_right
+
     if left is None:
         return {k: v for k, v in right.items() if v is not None}
 

--- a/libs/deepagents/tests/unit_tests/test_file_system_tools.py
+++ b/libs/deepagents/tests/unit_tests/test_file_system_tools.py
@@ -11,8 +11,67 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.memory import InMemorySaver
 
 from deepagents.backends.state import StateBackend
+from deepagents.backends.utils import _filter_files_by_path
 from deepagents.graph import create_deep_agent
+from deepagents.middleware.filesystem import _file_data_reducer
 from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+class TestFileDataReducerListHandling:
+    """Tests for _file_data_reducer handling list inputs (issue #731)."""
+
+    def test_left_empty_list(self) -> None:
+        right = {"/a.txt": {"content": "hello", "modified_at": 1.0}}
+        result = _file_data_reducer([], right)  # type: ignore[arg-type]
+        assert result == {"/a.txt": {"content": "hello", "modified_at": 1.0}}
+
+    def test_left_list_of_dicts(self) -> None:
+        left = [
+            {"/a.txt": {"content": "a", "modified_at": 1.0}},
+            {"/b.txt": {"content": "b", "modified_at": 2.0}},
+        ]
+        right = {"/c.txt": {"content": "c", "modified_at": 3.0}}
+        result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+        assert "/a.txt" in result
+        assert "/b.txt" in result
+        assert "/c.txt" in result
+
+    def test_right_empty_list(self) -> None:
+        left = {"/a.txt": {"content": "hello", "modified_at": 1.0}}
+        result = _file_data_reducer(left, [])  # type: ignore[arg-type]
+        assert result == {"/a.txt": {"content": "hello", "modified_at": 1.0}}
+
+    def test_right_list_of_dicts(self) -> None:
+        left = {"/a.txt": {"content": "a", "modified_at": 1.0}}
+        right = [
+            {"/b.txt": {"content": "b", "modified_at": 2.0}},
+            {"/c.txt": {"content": "c", "modified_at": 3.0}},
+        ]
+        result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+        assert "/a.txt" in result
+        assert "/b.txt" in result
+        assert "/c.txt" in result
+
+    def test_both_lists(self) -> None:
+        left = [{"/a.txt": {"content": "a", "modified_at": 1.0}}]
+        right = [{"/b.txt": {"content": "b", "modified_at": 2.0}}]
+        result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+        assert "/a.txt" in result
+        assert "/b.txt" in result
+
+    def test_both_empty_lists(self) -> None:
+        result = _file_data_reducer([], [])  # type: ignore[arg-type]
+        assert result == {}
+
+
+class TestFilterFilesByPathListHandling:
+    """Tests for _filter_files_by_path handling non-dict input (issue #731)."""
+
+    def test_files_as_empty_list(self) -> None:
+        assert _filter_files_by_path([], "/") == {}  # type: ignore[arg-type]
+
+    def test_files_as_non_empty_list(self) -> None:
+        assert _filter_files_by_path([{"/a.txt": {}}], "/") == {}  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("file_format", ["v1", "v2"])


### PR DESCRIPTION
## Summary

`_file_data_reducer` crashes with `TypeError: 'list' object is not a mapping` when the `files` channel receives a list instead of a dict. This occurs when using `astream()` with a checkpointer, where LangGraph's channel update mechanism can pass `[]` to the reducer.

Fixes #731

## Changes

- **`deepagents/middleware/filesystem.py`** — `_file_data_reducer`: convert list `left`/`right` to dict before processing (empty list → `None`/empty dict; list of dicts → merged into single dict)
- **`deepagents/backends/utils.py`** — `_filter_files_by_path`: return `{}` early if `files` is not a dict
- **`deepagents/backends/state.py`** — `StateBackend.ls_info`: convert `files` to `{}` if not a dict
- **`tests/unit_tests/test_file_system_tools.py`** — 8 new tests covering list inputs for both the reducer and `_filter_files_by_path`

## How I verified

- `make format` — passed
- `make lint` — passed (ruff + ty)
- `make test` — 897 passed, 0 failed

## Test plan

- [x] Reducer handles `left` as empty list
- [x] Reducer handles `left` as list of dicts
- [x] Reducer handles `right` as empty list
- [x] Reducer handles `right` as list of dicts
- [x] Reducer handles both sides as lists
- [x] `_filter_files_by_path` returns empty dict for list input
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)