### PR TITLE
fix(cli): wire `enable_ask_user` flag to remove tool in non-interactive mode

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -672,6 +672,7 @@ def create_cli_agent(
     system_prompt: str | None = None,
     interactive: bool = True,
     auto_approve: bool = False,
+    enable_ask_user: bool = True,
     enable_memory: bool = True,
     enable_skills: bool = True,
     enable_shell: bool = True,
@@ -710,6 +711,10 @@ def create_cli_agent(
 
             If `False`, tools pause for user confirmation via the approval menu.
             See `_add_interrupt_on` for the full list of gated tools.
+        enable_ask_user: Enable `AskUserMiddleware` so the agent can ask
+            clarifying questions.
+
+            Disabled in non-interactive mode.
         enable_memory: Enable `MemoryMiddleware` for persistent memory
         enable_skills: Enable `SkillsMiddleware` for custom agent skills
         enable_shell: Enable shell execution via `LocalShellBackend`
@@ -795,9 +800,10 @@ def create_cli_agent(
     agent_middleware.append(ConfigurableModelMiddleware())
 
     # Add ask_user middleware (must be early so its tool is available)
-    from deepagents_cli.ask_user import AskUserMiddleware
+    if enable_ask_user:
+        from deepagents_cli.ask_user import AskUserMiddleware
 
-    agent_middleware.append(AskUserMiddleware())
+        agent_middleware.append(AskUserMiddleware())
 
     # Add memory middleware
     if enable_memory:

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -706,6 +706,7 @@ async def run_textual_cli_async(
         "sandbox_type": sandbox_type,
         "sandbox_id": sandbox_id,
         "sandbox_setup": sandbox_setup,
+        "enable_ask_user": True,
         "mcp_config_path": mcp_config_path,
         "no_mcp": no_mcp,
         "trust_project_mcp": trust_project_mcp,

--- a/libs/cli/deepagents_cli/server_graph.py
+++ b/libs/cli/deepagents_cli/server_graph.py
@@ -171,6 +171,7 @@ def make_graph() -> Any:  # noqa: ANN401
         system_prompt=config.system_prompt,
         interactive=config.interactive,
         auto_approve=config.auto_approve,
+        enable_ask_user=config.enable_ask_user,
         enable_memory=config.enable_memory,
         enable_skills=config.enable_skills,
         enable_shell=config.enable_shell,

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -1375,6 +1375,77 @@ class TestMiddlewareStackConformance:
             )
 
 
+class TestEnableAskUser:
+    """Verify enable_ask_user controls AskUserMiddleware inclusion."""
+
+    def _capture_middleware(
+        self, tmp_path: Path, *, enable_ask_user: bool
+    ) -> list[Any]:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir(exist_ok=True)
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir(exist_ok=True)
+
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+
+        captured: list[list[Any]] = []
+
+        def capture(**kwargs: Any) -> Mock:
+            captured.append(kwargs.get("middleware", []))
+            agent = Mock()
+            agent.with_config.return_value = agent
+            return agent
+
+        fake_model = _make_fake_chat_model()
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch(
+                "deepagents_cli.agent.create_deep_agent",
+                side_effect=capture,
+            ),
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_ask_user=enable_ask_user,
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=False,
+            )
+
+        return captured[0]
+
+    def test_ask_user_included_when_enabled(self, tmp_path: Path) -> None:
+        from deepagents_cli.ask_user import AskUserMiddleware
+
+        middleware = self._capture_middleware(tmp_path, enable_ask_user=True)
+        assert any(isinstance(mw, AskUserMiddleware) for mw in middleware)
+
+    def test_ask_user_excluded_when_disabled(self, tmp_path: Path) -> None:
+        from deepagents_cli.ask_user import AskUserMiddleware
+
+        middleware = self._capture_middleware(tmp_path, enable_ask_user=False)
+        assert not any(isinstance(mw, AskUserMiddleware) for mw in middleware)
+
+
 class TestLoadAsyncSubagents:
     def test_returns_empty_when_no_file(self, tmp_path: Path) -> None:
         result = load_async_subagents(tmp_path / "nonexistent.toml")

--- a/libs/cli/tests/unit_tests/test_server_graph.py
+++ b/libs/cli/tests/unit_tests/test_server_graph.py
@@ -120,6 +120,7 @@ class TestServerGraph:
             system_prompt=None,
             interactive=True,
             auto_approve=False,
+            enable_ask_user=False,
             enable_memory=True,
             enable_skills=True,
             enable_shell=True,


### PR DESCRIPTION
Wire the `enable_ask_user` flag from `ServerConfig` through to `create_cli_agent` so non-interactive mode actually removes the `ask_user` tool instead of just setting a config value that nothing read. Previously, `AskUserMiddleware` was unconditionally added to the middleware stack — when the LLM called `ask_user` in headless mode, the adapter synthesized an error response rather than the tool simply not existing.