### PR TITLE
feat(sdk): add `inject_skills_in_prompt` flag to disable skill listing in system prompt

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -87,6 +87,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     middleware: Sequence[AgentMiddleware] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
+    inject_skills_in_prompt: bool = True,
     memory: list[str] | None = None,
     response_format: ResponseFormat | None = None,
     context_schema: type[Any] | None = None,
@@ -174,6 +175,12 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             `invoke(files={...})`. With `FilesystemBackend`, skills are loaded from disk relative
             to the backend's `root_dir`. Later sources override earlier ones for skills with the
             same name (last one wins).
+        inject_skills_in_prompt: Whether to inject skill names and descriptions
+            into the system prompt. When `False`, skills are still loaded and
+            accessible via progressive disclosure (the agent can read `SKILL.md`
+            files on demand) but the system prompt is not modified with the
+            skill listing. Useful when the number of skills is large and the
+            listing would bloat the system prompt unnecessarily.
         memory: Optional list of memory file paths (`AGENTS.md` files) to load
             (e.g., `["/memory/AGENTS.md"]`).
 
@@ -211,7 +218,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         PatchToolCallsMiddleware(),
     ]
     if skills is not None:
-        gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+        gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills, inject_prompt=inject_skills_in_prompt))
     gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     if interrupt_on is not None:
         gp_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
@@ -248,7 +255,8 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             ]
             subagent_skills = spec.get("skills")
             if subagent_skills:
-                subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
+                subagent_inject = spec.get("inject_skills_in_prompt", inject_skills_in_prompt)
+                subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills, inject_prompt=subagent_inject))
             subagent_middleware.extend(spec.get("middleware", []))
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
@@ -271,7 +279,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         TodoListMiddleware(),
     ]
     if skills is not None:
-        deepagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+        deepagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills, inject_prompt=inject_skills_in_prompt))
     deepagent_middleware.extend(
         [
             FilesystemMiddleware(backend=backend),

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -631,7 +631,13 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
 
     state_schema = SkillsState
 
-    def __init__(self, *, backend: BACKEND_TYPES, sources: list[str]) -> None:
+    def __init__(
+        self,
+        *,
+        backend: BACKEND_TYPES,
+        sources: list[str],
+        inject_prompt: bool = True,
+    ) -> None:
         """Initialize the skills middleware.
 
         Args:
@@ -641,9 +647,14 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
                 Use a factory for StateBackend: `lambda rt: StateBackend(rt)`
             sources: List of skill source paths (e.g.,
                 `['/skills/user/', '/skills/project/']`).
+            inject_prompt: Whether to inject skill names and descriptions into
+                the system prompt. When `False`, skills are still loaded and
+                accessible via progressive disclosure but the system prompt is
+                not modified with the skill listing.
         """
         self._backend = backend
         self.sources = sources
+        self.inject_prompt = inject_prompt
         self.system_prompt_template = SKILLS_SYSTEM_PROMPT
 
     def _get_backend(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> BackendProtocol:
@@ -708,12 +719,17 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
     def modify_request(self, request: ModelRequest[ContextT]) -> ModelRequest[ContextT]:
         """Inject skills documentation into a model request's system message.
 
+        Skipped when `inject_prompt` is `False`.
+
         Args:
             request: Model request to modify
 
         Returns:
             New model request with skills documentation injected into system message
         """
+        if not self.inject_prompt:
+            return request
+
         skills_metadata = request.state.get("skills_metadata", [])
         skills_locations = self._format_skills_locations()
         skills_list = self._format_skills_list(skills_metadata)

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -77,6 +77,9 @@ class SubAgent(TypedDict):
     skills: NotRequired[list[str]]
     """Skill source paths for SkillsMiddleware."""
 
+    inject_skills_in_prompt: NotRequired[bool]
+    """Whether to inject skill names/descriptions into the system prompt."""
+
 
 class CompiledSubAgent(TypedDict):
     """A pre-compiled agent spec.

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -1601,3 +1601,154 @@ async def test_skills_middleware_with_store_backend_assistant_id_async() -> None
     assert len(result_4["skills_metadata"]) == 1
     assert result_4["skills_metadata"][0]["name"] == "async-skill-one"
     assert result_4["skills_metadata"][0]["description"] == "Async skill for assistant 1"
+
+
+def test_inject_prompt_false_skips_system_prompt_injection(tmp_path: Path) -> None:
+    """Test that inject_prompt=False prevents skill listing from being added to system prompt."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+    skill_path = str(skills_dir / "test-skill" / "SKILL.md")
+    skill_content = make_skill_content("test-skill", "A test skill")
+
+    backend.upload_files([(skill_path, skill_content.encode("utf-8"))])
+
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Done.")]))
+
+    middleware = SkillsMiddleware(
+        backend=backend,
+        sources=[str(skills_dir)],
+        inject_prompt=False,
+    )
+
+    agent = create_agent(
+        model=fake_model,
+        middleware=[middleware],
+    )
+
+    agent.invoke({"messages": [HumanMessage(content="Hello")]})
+
+    first_call = fake_model.call_history[0]
+    messages = first_call["messages"]
+    system_content = messages[0].text if messages[0].type == "system" else ""
+    assert "Skills System" not in system_content
+    assert "test-skill" not in system_content
+
+
+def test_inject_prompt_true_includes_system_prompt_injection(tmp_path: Path) -> None:
+    """Test that inject_prompt=True (default) includes skill listing in system prompt."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+    skill_path = str(skills_dir / "test-skill" / "SKILL.md")
+    skill_content = make_skill_content("test-skill", "A test skill")
+
+    backend.upload_files([(skill_path, skill_content.encode("utf-8"))])
+
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Done.")]))
+
+    middleware = SkillsMiddleware(
+        backend=backend,
+        sources=[str(skills_dir)],
+        inject_prompt=True,
+    )
+
+    agent = create_agent(
+        model=fake_model,
+        middleware=[middleware],
+    )
+
+    agent.invoke({"messages": [HumanMessage(content="Hello")]})
+
+    first_call = fake_model.call_history[0]
+    messages = first_call["messages"]
+    system_content = messages[0].text
+    assert "Skills System" in system_content
+    assert "test-skill" in system_content
+
+
+def test_inject_prompt_default_is_true() -> None:
+    """Test that inject_prompt defaults to True."""
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=["/skills/user/"],
+    )
+    assert middleware.inject_prompt is True
+
+
+def test_inject_prompt_false_still_loads_skills(tmp_path: Path) -> None:
+    """Test that inject_prompt=False still loads skill metadata via before_agent."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+    skill_path = str(skills_dir / "test-skill" / "SKILL.md")
+    skill_content = make_skill_content("test-skill", "A test skill")
+
+    backend.upload_files([(skill_path, skill_content.encode("utf-8"))])
+
+    middleware = SkillsMiddleware(
+        backend=backend,
+        sources=[str(skills_dir)],
+        inject_prompt=False,
+    )
+
+    result = middleware.before_agent({}, None, {})  # type: ignore[arg-type]
+
+    assert result is not None
+    assert len(result["skills_metadata"]) == 1
+    assert result["skills_metadata"][0]["name"] == "test-skill"
+
+
+async def test_inject_prompt_false_skips_system_prompt_async(tmp_path: Path) -> None:
+    """Test that inject_prompt=False prevents skill listing in async agent invocation."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+    skill_path = str(skills_dir / "async-skill" / "SKILL.md")
+    skill_content = make_skill_content("async-skill", "An async test skill")
+
+    backend.upload_files([(skill_path, skill_content.encode("utf-8"))])
+
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Done.")]))
+
+    middleware = SkillsMiddleware(
+        backend=backend,
+        sources=[str(skills_dir)],
+        inject_prompt=False,
+    )
+
+    agent = create_agent(
+        model=fake_model,
+        middleware=[middleware],
+    )
+
+    await agent.ainvoke({"messages": [HumanMessage(content="Hello")]})
+
+    first_call = fake_model.call_history[0]
+    messages = first_call["messages"]
+    system_content = messages[0].text if messages[0].type == "system" else ""
+    assert "Skills System" not in system_content
+    assert "async-skill" not in system_content
+
+
+def test_create_deep_agent_inject_skills_in_prompt_false(tmp_path: Path) -> None:
+    """Test create_deep_agent with inject_skills_in_prompt=False."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+    skill_path = str(skills_dir / "test-skill" / "SKILL.md")
+    skill_content = make_skill_content("test-skill", "A test skill for deep agents")
+
+    backend.upload_files([(skill_path, skill_content.encode("utf-8"))])
+
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="Done.")]))
+
+    agent = create_deep_agent(
+        backend=backend,
+        skills=[str(skills_dir)],
+        inject_skills_in_prompt=False,
+        model=fake_model,
+    )
+
+    agent.invoke({"messages": [HumanMessage(content="What skills are available?")]})
+
+    first_call = fake_model.call_history[0]
+    messages = first_call["messages"]
+    system_content = messages[0].text
+    assert "Skills System" not in system_content
+    assert "test-skill" not in system_content


### PR DESCRIPTION
## Description
Adds an `inject_skills_in_prompt` parameter to `create_deep_agent` (and `inject_prompt` to `SkillsMiddleware`) that controls whether skill names and descriptions are injected into the system prompt. When set to `False`, skills are still loaded and accessible via progressive disclosure (the agent can read `SKILL.md` files on demand) but the system prompt is not bloated with the full skill listing. This is useful when a workspace has many shared skills but the agent doesn't need them listed in every run.

The flag defaults to `True` to preserve existing behavior. It is also available on the `SubAgent` TypedDict for per-subagent control.

> This PR was authored by an AI agent.

## Test Plan
- [ ] Verify `inject_skills_in_prompt=False` prevents skill listing from appearing in system prompt
- [ ] Verify skills metadata is still loaded when `inject_prompt=False`
- [ ] Verify default behavior (`True`) is unchanged