### PR TITLE
fix(evals): correct harbor `-n` flag semantics and add agent mode toggle

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -44,11 +44,24 @@ on:
           - langsmith
           - modal
           - runloop
-      task_count:
-        description: "Number of Terminal Bench 2 tasks to run"
+      n_tasks:
+        description: "Maximum number of tasks to run (0 = all tasks in dataset)"
+        required: true
+        default: "0"
+        type: string
+      concurrency:
+        description: "Number of concurrent trials (parallel sandbox slots)"
         required: true
         default: "1"
         type: string
+      agent_mode:
+        description: "Agent implementation to use"
+        required: true
+        default: "sdk"
+        type: choice
+        options:
+          - sdk
+          - cli
 
 permissions:
   contents: read
@@ -110,9 +123,11 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-      HARBOR_TASK_COUNT: ${{ inputs.task_count }}
+      HARBOR_CONCURRENCY: ${{ inputs.concurrency }}
+      HARBOR_N_TASKS: ${{ inputs.n_tasks }}
       HARBOR_SANDBOX_ENV: ${{ inputs.sandbox_env }}
       HARBOR_MODEL: ${{ matrix.model }}
+      HARBOR_AGENT_MODE: ${{ inputs.agent_mode }}
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
@@ -136,14 +151,19 @@ jobs:
 
       - name: "⚓ Run Harbor"
         run: |
+          n_tasks_flag=""
+          if [ "$HARBOR_N_TASKS" != "0" ]; then
+            n_tasks_flag="--n-tasks $HARBOR_N_TASKS"
+          fi
           uv run harbor run \
             --agent-import-path deepagents_harbor:DeepAgentsWrapper \
             --dataset "$HARBOR_DATASET_NAME@$HARBOR_DATASET_VERSION" \
-            -n "$HARBOR_TASK_COUNT" \
+            -n "$HARBOR_CONCURRENCY" \
+            $n_tasks_flag \
             --jobs-dir jobs/terminal-bench \
             --env "$HARBOR_SANDBOX_ENV" \
             --model "$HARBOR_MODEL" \
-            --agent-kwarg use_cli_agent=false
+            --agent-kwarg use_cli_agent=${{ inputs.agent_mode == 'cli' && 'true' || 'false' }}
 
       - name: "🔍 Find latest Harbor job"
         id: latest-job
@@ -183,7 +203,13 @@ jobs:
             echo "- Model: $HARBOR_MODEL"
             echo "- Dataset: ${HARBOR_DATASET_NAME}@${HARBOR_DATASET_VERSION}"
             echo "- Sandbox: ${HARBOR_SANDBOX_ENV}"
-            echo "- Task count: ${HARBOR_TASK_COUNT}"
+            echo "- Concurrency: ${HARBOR_CONCURRENCY}"
+            if [ "$HARBOR_N_TASKS" = "0" ]; then
+              echo "- Max tasks: all"
+            else
+              echo "- Max tasks: ${HARBOR_N_TASKS}"
+            fi
+            echo "- Agent mode: ${HARBOR_AGENT_MODE}"
             echo "- LangSmith experiment: $LANGSMITH_EXPERIMENT_NAME"
             if [ "$LATEST_JOB_OUTCOME" = "success" ]; then
               echo "- Harbor job dir: $HARBOR_JOB_DIR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Release from a non-main branch (danger!) - Only use for hotfixes"
+        description: "Release from a non-main branch (danger!) - Only use for backports and hotfixes"
       dangerous-skip-sdk-pin-check:
         required: false
         type: boolean

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -19,26 +19,32 @@ evals: ## Run evals
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw . -- $(TEST_FILE)
 
-# Run harbor jobs
+# Harbor jobs
+# -n = concurrent trials (parallel sandbox slots), NOT task count
+# -l = max tasks to run (omit for all)
+# AGENT_MODE: cli (local default) or sdk (CI default)
+AGENT_MODE ?= cli
+AGENT_KWARG = --agent-kwarg use_cli_agent=$(if $(filter cli,$(AGENT_MODE)),true,false)
+
 run-hello-world: ## Run hello-world job
 	@mkdir -p jobs/hello-world
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset hello-world --task-name hello-world -n 1 --jobs-dir tmp/hello-world --env docker
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset hello-world --task-name hello-world -n 1 --jobs-dir tmp/hello-world --env docker $(AGENT_KWARG)
 
-run-terminal-bench-modal: ## Run terminal-bench on Modal
+run-terminal-bench-modal: ## Run terminal-bench on Modal (4 concurrent)
 	@mkdir -p jobs/terminal-bench
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 4 --jobs-dir jobs/terminal-bench --env modal
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 4 --jobs-dir jobs/terminal-bench --env modal $(AGENT_KWARG)
 
-run-terminal-bench-daytona: ## Run terminal-bench on Daytona
+run-terminal-bench-daytona: ## Run terminal-bench on Daytona (40 concurrent)
 	@mkdir -p jobs/terminal-bench
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 40 --jobs-dir jobs/terminal-bench --env daytona
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 40 --jobs-dir jobs/terminal-bench --env daytona $(AGENT_KWARG)
 
-run-terminal-bench-docker: ## Run terminal-bench on Docker
+run-terminal-bench-docker: ## Run terminal-bench on Docker (sequential)
 	@mkdir -p jobs/terminal-bench
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env docker
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env docker $(AGENT_KWARG)
 
-run-terminal-bench-runloop: ## Run terminal-bench on Runloop
+run-terminal-bench-runloop: ## Run terminal-bench on Runloop (10 concurrent)
 	@mkdir -p jobs/terminal-bench
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 10 --jobs-dir jobs/terminal-bench --env runloop
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 10 --jobs-dir jobs/terminal-bench --env runloop $(AGENT_KWARG)
 
 ######################
 # CHARTS

--- a/libs/evals/README.md
+++ b/libs/evals/README.md
@@ -52,11 +52,11 @@ export LANGSMITH_TRACING_V2=true       # Required: Enable LangSmith tracing
 export LANGSMITH_ENDPOINT="https://api.smith.langchain.com"  # Optional: Default shown
 # export DAYTONA_API_KEY="..."  # Optional: Only if using --env daytona
 
-# Run via Docker (1 task)
+# Run via Docker (sequential, all tasks)
 uv run harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper \
   --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env docker
 
-# Run via Daytona (10 tasks)
+# Run via Daytona (10 concurrent trials)
 uv run harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper \
   --dataset terminal-bench@2.0 -n 10 --jobs-dir jobs/terminal-bench --env daytona
 ```
@@ -95,13 +95,13 @@ python scripts/harbor_langsmith.py create-experiment terminal-bench --name deepa
 ```bash
 # Option 1: For experiments (enables side-by-side comparison in LangSmith)
 export LANGSMITH_EXPERIMENT="deepagents-baseline-v1"
-make run-terminal-bench-daytona  # Runs 10 tasks on Daytona
+make run-terminal-bench-daytona  # 40 concurrent trials on Daytona
 
 # Option 2: For development (simpler project view in LangSmith)
 export LANGSMITH_PROJECT="deepagents-development"
 make run-terminal-bench-daytona
 
-# Option 3: Run harbor directly (customize -n for number of tasks)
+# Option 3: Run harbor directly (-n = concurrency; add -l N to limit tasks)
 export LANGSMITH_EXPERIMENT="deepagents-baseline-v1"
 uv run harbor run \
   --agent-import-path deepagents_harbor:DeepAgentsWrapper \
@@ -150,10 +150,10 @@ Harbor supports multiple sandbox environments. Use the `--env` flag to select:
 
 Makefile shortcuts are available for common workflows:
 
-- `make run-terminal-bench-docker` - Run 1 task locally with Docker
-- `make run-terminal-bench-daytona` - Run 10 tasks on Daytona
-- `make run-terminal-bench-modal` - Run 4 tasks on Modal
-- `make run-terminal-bench-runloop` - Run 10 tasks on Runloop
+- `make run-terminal-bench-docker` - Run on Docker (sequential)
+- `make run-terminal-bench-daytona` - Run on Daytona (40 concurrent)
+- `make run-terminal-bench-modal` - Run on Modal (4 concurrent)
+- `make run-terminal-bench-runloop` - Run on Runloop (10 concurrent)
 
 ## Eval Categories
 


### PR DESCRIPTION
The Harbor CI workflow's `task_count` input was wired to `-n` (`--n-concurrent`), which controls trial parallelism — not the number of tasks to run. A dispatch with `task_count: 1` actually ran all 89 dataset tasks sequentially (6 hours on a GHA runner). This fixes the mislabeling, exposes the real task limiter (`--n-tasks` / `-l`), and adds a CLI/SDK agent mode toggle.

## Changes
- Replace the `task_count` workflow input with two correctly labeled inputs: `concurrency` (maps to `-n`, parallel sandbox slots) and `n_tasks` (maps to `--n-tasks` / `-l`, max tasks from dataset; 0 = all)
- Add `agent_mode` choice input (`sdk`/`cli`) to `harbor.yml`, replacing the hardcoded `--agent-kwarg use_cli_agent=false` — defaults to `sdk` in CI
- Add `AGENT_MODE` Make variable (default `cli`) so local runs can toggle between CLI and SDK agents via `make run-terminal-bench-docker AGENT_MODE=sdk`
- Fix all `-n` descriptions across `README.md` and Makefile `##` help text — "Run N tasks" → concurrency semantics ("4 concurrent", "sequential", etc.)
