### PR TITLE
fix(cli-gha): enforce minimum cli version in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,15 @@ runs:
       env:
         INPUT_CLI_VERSION: ${{ inputs.cli_version }}
       run: |
+        # Action requires --agent, --shell-allow-list, -n (available since 0.0.31)
+        MIN_CLI_VERSION="0.0.31"
+
         if [ -n "$INPUT_CLI_VERSION" ]; then
+          if ! printf '%s\n%s' "$MIN_CLI_VERSION" "$INPUT_CLI_VERSION" \
+               | sort -V | head -1 | grep -qx "$MIN_CLI_VERSION"; then
+            echo "::error::cli_version '${INPUT_CLI_VERSION}' is below the minimum '${MIN_CLI_VERSION}' required by this action"
+            exit 1
+          fi
           uvx --from "deepagents-cli==${INPUT_CLI_VERSION}" deepagents --version
         else
           uvx --from deepagents-cli deepagents --version


### PR DESCRIPTION
The action's `cli_version` input accepts any version string with no lower bound. Pinning an old version that predates required flags (`--agent`, `--shell-allow-list`, `-n`) causes a confusing argparse failure instead of an actionable error.

## Changes
- Add a `MIN_CLI_VERSION="0.0.31"` guard in the "Install deepagents-cli" step of `action.yml` — when `cli_version` is explicitly set, `sort -V` validates it meets the floor before installing, and emits a `::error::` annotation with the required minimum on failure
