### PR TITLE
ci(evals): suppress harbor first-run tip

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -178,6 +178,11 @@ jobs:
           echo "experiment_name=$experiment_name" >> "$GITHUB_OUTPUT"
           echo "LANGSMITH_EXPERIMENT=$experiment_name" >> "$GITHUB_ENV"
 
+      - name: "🔇 Suppress Harbor first-run tips"
+        run: |
+          mkdir -p ~/.cache/harbor
+          echo '{"seen":["registry-datasets-hint"]}' > ~/.cache/harbor/notifications.json
+
       - name: "⚓ Run Harbor"
         run: |
           n_tasks_flag=""


### PR DESCRIPTION
Pre-seed Harbor's `~/.cache/harbor/notifications.json` in CI so the one-time "datasets list" tip doesn't pollute workflow logs. Harbor shows this on first invocation per environment, and CI runners are always fresh.

## Changes
- Add a step in `harbor.yml` before `Run Harbor` that writes the `registry-datasets-hint` key to Harbor's notification state file, matching the format in Harbor's `notifications.py`