### PR TITLE
fix(sdk): normalize store keys for root directory listings

### DIFF
--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -102,6 +102,23 @@ def _validate_namespace(namespace: tuple[str, ...]) -> tuple[str, ...]:
     return namespace
 
 
+def _normalize_store_key_for_ls(key: str) -> str:
+    """Normalize store keys so directory prefix checks match logical paths.
+
+    Store item keys may omit a leading slash (for example ``test.md`` at the
+    virtual root). ``ls`` compares against a normalized directory prefix such
+    as ``/``; without this step, root-level files are incorrectly excluded.
+
+    Args:
+        key: Raw key from the store.
+
+    Returns:
+        Key string with a leading slash when it was missing.
+    """
+    s = str(key)
+    return s if s.startswith("/") else f"/{s}"
+
+
 class StoreBackend(BackendProtocol):
     """Backend that stores files in LangGraph's BaseStore (persistent).
 
@@ -352,12 +369,13 @@ class StoreBackend(BackendProtocol):
         normalized_path = path if path.endswith("/") else path + "/"
 
         for item in items:
+            key_str = _normalize_store_key_for_ls(item.key)
             # Check if file is in the specified directory or a subdirectory
-            if not str(item.key).startswith(normalized_path):
+            if not key_str.startswith(normalized_path):
                 continue
 
             # Get the relative path after the directory
-            relative = str(item.key)[len(normalized_path) :]
+            relative = key_str[len(normalized_path) :]
 
             # If relative path contains '/', it's in a subdirectory
             if "/" in relative:

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -9,6 +9,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
 from deepagents.backends.store import BackendContext, StoreBackend, _validate_namespace
+from deepagents.backends.utils import create_file_data
 from deepagents.middleware.filesystem import FilesystemMiddleware
 
 
@@ -126,6 +127,26 @@ def test_store_backend_ls_trailing_slash():
     assert listing2 is not None
     assert len(listing1) == len(listing2)
     assert [fi["path"] for fi in listing1] == [fi["path"] for fi in listing2]
+
+
+def test_store_backend_ls_root_store_keys_without_leading_slash() -> None:
+    """Root listing includes files whose keys omit a leading slash (issue #1655)."""
+    rt = make_runtime()
+    be = StoreBackend(rt, namespace=lambda _ctx: ("filesystem",))
+    namespace = ("filesystem",)
+    fd = create_file_data("# Test")
+    store_value = be._convert_file_data_to_store_value(fd)
+    rt.store.put(namespace, "test.md", store_value)
+    rt.store.put(namespace, "subdir/file.txt", store_value)
+
+    root_listing = be.ls("/").entries
+    assert root_listing is not None
+    paths = {fi["path"] for fi in root_listing}
+    is_dir = {fi["path"]: fi.get("is_dir", False) for fi in root_listing}
+    assert "test.md" in paths
+    assert is_dir["test.md"] is False
+    assert "/subdir/" in paths
+    assert is_dir["/subdir/"] is True
 
 
 @pytest.mark.parametrize("file_format", ["v1", "v2"])


### PR DESCRIPTION
## Summary

`StoreBackend.ls_info` prefix-matched store keys against the normalized directory path (e.g. `/`). Keys that omit a leading slash (e.g. `test.md` at the virtual root) failed `startswith("/")` and were excluded from root listings. This adds `_normalize_store_key_for_ls` so keys are compared with a consistent leading slash, and a unit regression test that puts items with slashless keys at the root.

## How to test

From the repository root:

- `make -C libs/deepagents test`
- Or run only the new regression: `uv run --group test pytest libs/deepagents/tests/unit_tests/backends/test_store_backend.py::test_store_backend_ls_root_store_keys_without_leading_slash`

Before opening a PR, run `make format`, `make lint`, and `make test` for each package you changed (see contributing guidelines).

Fixes #1655

---

This contribution was developed with assistance from generative AI (Cursor).
