### PR TITLE
feat(sdk): add completion notifier middleware for async subagents

### DIFF
--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -974,6 +974,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -984,6 +985,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -3,7 +3,6 @@
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
-from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
@@ -12,7 +11,6 @@ __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
-    "CompletionNotifierMiddleware",
     "FilesystemMiddleware",
     "MemoryMiddleware",
     "SubAgent",

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -3,6 +3,7 @@
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
@@ -11,6 +12,7 @@ __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
+    "CompletionNotifierMiddleware",
     "FilesystemMiddleware",
     "MemoryMiddleware",
     "SubAgent",

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -3,6 +3,7 @@
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.completion_callback import CompletionCallbackMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
@@ -11,6 +12,7 @@ __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
+    "CompletionCallbackMiddleware",
     "FilesystemMiddleware",
     "MemoryMiddleware",
     "SubAgent",

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -48,6 +48,7 @@ Use a **plain tool** when:
 """
 
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
@@ -62,6 +63,7 @@ __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
+    "CompletionNotifierMiddleware",
     "FilesystemMiddleware",
     "MemoryMiddleware",
     "SkillsMiddleware",

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -48,7 +48,7 @@ Use a **plain tool** when:
 """
 
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
-from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
+from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
@@ -63,7 +63,7 @@ __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
-    "CompletionNotifierMiddleware",
+    "CompletionCallbackMiddleware",
     "FilesystemMiddleware",
     "MemoryMiddleware",
     "SkillsMiddleware",

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -48,7 +48,7 @@ Use a **plain tool** when:
 """
 
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
-from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
+from deepagents.middleware.completion_callback import CompletionCallbackMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.skills import SkillsMiddleware

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -274,7 +274,7 @@ def _build_start_tool(
                 assistant_id=spec["graph_id"],
                 input={
                     "messages": [{"role": "user", "content": description}],
-                    **parent_context,
+                    **callback_context,
                 },
             )
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
@@ -318,7 +318,7 @@ def _build_start_tool(
                 assistant_id=spec["graph_id"],
                 input={
                     "messages": [{"role": "user", "content": description}],
-                    **parent_context,
+                    **callback_context,
                 },
             )
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -233,7 +233,7 @@ def _extract_callback_context(runtime: ToolRuntime) -> dict[str, str]:
 
     The thread ID is included in the subagent's input state so the subagent
     can notify the parent when it completes (via
-    `CompletionNotifierMiddleware`).
+    `CompletionCallbackMiddleware`).
 
     Returns:
         Dict with `parent_thread_id` if available. Empty dict otherwise.

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -229,29 +229,23 @@ def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -
 
 
 def _extract_parent_context(runtime: ToolRuntime) -> dict[str, str]:
-    """Extract the supervisor's thread and assistant IDs from the tool runtime.
+    """Extract the supervisor's thread ID from the tool runtime.
 
-    These are included in the subagent's input state so the subagent can
-    notify the supervisor when it completes (via `CompletionNotifierMiddleware`).
+    The thread ID is included in the subagent's input state so the subagent
+    can notify the supervisor when it completes (via
+    `CompletionNotifierMiddleware`).
 
     Returns:
-        Dict with `parent_thread_id` and/or `parent_assistant_id` if available.
-        Empty dict if neither is available.
+        Dict with `parent_thread_id` if available. Empty dict otherwise.
     """
-    context: dict[str, str] = {}
     config = runtime.config or {}
     configurable = config.get("configurable") or {}
-    metadata = config.get("metadata") or {}
 
     thread_id = configurable.get("thread_id")
     if thread_id:
-        context["parent_thread_id"] = str(thread_id)
+        return {"parent_thread_id": str(thread_id)}
 
-    assistant_id = metadata.get("assistant_id")
-    if assistant_id:
-        context["parent_assistant_id"] = str(assistant_id)
-
-    return context
+    return {}
 
 
 def _build_start_tool(
@@ -280,7 +274,6 @@ def _build_start_tool(
                 assistant_id=spec["graph_id"],
                 input={
                     "messages": [{"role": "user", "content": description}],
-                    "task_id": task_id,
                     **parent_context,
                 },
             )
@@ -325,7 +318,6 @@ def _build_start_tool(
                 assistant_id=spec["graph_id"],
                 input={
                     "messages": [{"role": "user", "content": description}],
-                    "task_id": task_id,
                     **parent_context,
                 },
             )

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -228,11 +228,11 @@ def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -
     return None
 
 
-def _extract_parent_context(runtime: ToolRuntime) -> dict[str, str]:
-    """Extract the supervisor's thread ID from the tool runtime.
+def _extract_callback_context(runtime: ToolRuntime) -> dict[str, str]:
+    """Extract the parent thread ID from the tool runtime.
 
     The thread ID is included in the subagent's input state so the subagent
-    can notify the supervisor when it completes (via
+    can notify the parent when it completes (via
     `CompletionNotifierMiddleware`).
 
     Returns:
@@ -264,7 +264,7 @@ def _build_start_tool(
         if error:
             return error
         spec = agent_map[subagent_type]
-        parent_context = _extract_parent_context(runtime)
+        callback_context = _extract_callback_context(runtime)
         try:
             client = clients.get_sync(subagent_type)
             thread = client.threads.create()
@@ -308,7 +308,7 @@ def _build_start_tool(
         if error:
             return error
         spec = agent_map[subagent_type]
-        parent_context = _extract_parent_context(runtime)
+        callback_context = _extract_callback_context(runtime)
         try:
             client = clients.get_async(subagent_type)
             thread = await client.threads.create()

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -228,6 +228,32 @@ def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -
     return None
 
 
+def _extract_parent_context(runtime: ToolRuntime) -> dict[str, str]:
+    """Extract the supervisor's thread and assistant IDs from the tool runtime.
+
+    These are included in the subagent's input state so the subagent can
+    notify the supervisor when it completes (via `CompletionNotifierMiddleware`).
+
+    Returns:
+        Dict with `parent_thread_id` and/or `parent_assistant_id` if available.
+        Empty dict if neither is available.
+    """
+    context: dict[str, str] = {}
+    config = runtime.config or {}
+    configurable = config.get("configurable") or {}
+    metadata = config.get("metadata") or {}
+
+    thread_id = configurable.get("thread_id")
+    if thread_id:
+        context["parent_thread_id"] = str(thread_id)
+
+    assistant_id = metadata.get("assistant_id")
+    if assistant_id:
+        context["parent_assistant_id"] = str(assistant_id)
+
+    return context
+
+
 def _build_start_tool(
     agent_map: dict[str, AsyncSubAgent],
     clients: _ClientCache,
@@ -244,18 +270,23 @@ def _build_start_tool(
         if error:
             return error
         spec = agent_map[subagent_type]
+        parent_context = _extract_parent_context(runtime)
         try:
             client = clients.get_sync(subagent_type)
             thread = client.threads.create()
+            task_id = thread["thread_id"]
             run = client.runs.create(
-                thread_id=thread["thread_id"],
+                thread_id=task_id,
                 assistant_id=spec["graph_id"],
-                input={"messages": [{"role": "user", "content": description}]},
+                input={
+                    "messages": [{"role": "user", "content": description}],
+                    "task_id": task_id,
+                    **parent_context,
+                },
             )
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
             return f"Failed to launch async subagent '{subagent_type}': {e}"
-        task_id = thread["thread_id"]
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         task: AsyncTask = {
             "task_id": task_id,
@@ -284,18 +315,23 @@ def _build_start_tool(
         if error:
             return error
         spec = agent_map[subagent_type]
+        parent_context = _extract_parent_context(runtime)
         try:
             client = clients.get_async(subagent_type)
             thread = await client.threads.create()
+            task_id = thread["thread_id"]
             run = await client.runs.create(
-                thread_id=thread["thread_id"],
+                thread_id=task_id,
                 assistant_id=spec["graph_id"],
-                input={"messages": [{"role": "user", "content": description}]},
+                input={
+                    "messages": [{"role": "user", "content": description}],
+                    "task_id": task_id,
+                    **parent_context,
+                },
             )
         except Exception as e:  # noqa: BLE001  # LangGraph SDK raises untyped errors
             logger.warning("Failed to launch async subagent '%s': %s", subagent_type, e)
             return f"Failed to launch async subagent '{subagent_type}': {e}"
-        task_id = thread["thread_id"]
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         task: AsyncTask = {
             "task_id": task_id,

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -268,9 +268,9 @@ def _build_start_tool(
         try:
             client = clients.get_sync(subagent_type)
             thread = client.threads.create()
-            task_id = thread["thread_id"]
+            thread_id = thread["thread_id"]
             run = client.runs.create(
-                thread_id=task_id,
+                thread_id=thread_id,
                 assistant_id=spec["graph_id"],
                 input={
                     "messages": [{"role": "user", "content": description}],
@@ -282,20 +282,20 @@ def _build_start_tool(
             return f"Failed to launch async subagent '{subagent_type}': {e}"
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         task: AsyncTask = {
-            "task_id": task_id,
+            "task_id": thread_id,
             "agent_name": subagent_type,
-            "thread_id": task_id,
+            "thread_id": thread_id,
             "run_id": run["run_id"],
             "status": "running",
             "created_at": now,
             "last_checked_at": now,
             "last_updated_at": now,
         }
-        msg = f"Launched async subagent. task_id: {task_id}"
+        msg = f"Launched async subagent. task_id: {thread_id}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_tasks": {task_id: task},
+                "async_tasks": {thread_id: task},
             }
         )
 
@@ -312,9 +312,9 @@ def _build_start_tool(
         try:
             client = clients.get_async(subagent_type)
             thread = await client.threads.create()
-            task_id = thread["thread_id"]
+            thread_id = thread["thread_id"]
             run = await client.runs.create(
-                thread_id=task_id,
+                thread_id=thread_id,
                 assistant_id=spec["graph_id"],
                 input={
                     "messages": [{"role": "user", "content": description}],
@@ -326,20 +326,20 @@ def _build_start_tool(
             return f"Failed to launch async subagent '{subagent_type}': {e}"
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         task: AsyncTask = {
-            "task_id": task_id,
+            "task_id": thread_id,
             "agent_name": subagent_type,
-            "thread_id": task_id,
+            "thread_id": thread_id,
             "run_id": run["run_id"],
             "status": "running",
             "created_at": now,
             "last_checked_at": now,
             "last_updated_at": now,
         }
-        msg = f"Launched async subagent. task_id: {task_id}"
+        msg = f"Launched async subagent. task_id: {thread_id}"
         return Command(
             update={
                 "messages": [ToolMessage(msg, tool_call_id=runtime.tool_call_id)],
-                "async_tasks": {task_id: task},
+                "async_tasks": {thread_id: task},
             }
         )
 

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -229,21 +229,21 @@ def _validate_agent_type(agent_map: dict[str, AsyncSubAgent], agent_type: str) -
 
 
 def _extract_callback_context(runtime: ToolRuntime) -> dict[str, str]:
-    """Extract the parent thread ID from the tool runtime.
+    """Extract the callback thread ID from the tool runtime.
 
     The thread ID is included in the subagent's input state so the subagent
     can notify the parent when it completes (via
     `CompletionCallbackMiddleware`).
 
     Returns:
-        Dict with `parent_thread_id` if available. Empty dict otherwise.
+        Dict with `callback_thread_id` if available. Empty dict otherwise.
     """
     config = runtime.config or {}
     configurable = config.get("configurable") or {}
 
     thread_id = configurable.get("thread_id")
     if thread_id:
-        return {"parent_thread_id": str(thread_id)}
+        return {"callback_thread_id": str(thread_id)}
 
     return {}
 

--- a/libs/deepagents/deepagents/middleware/completion_callback.py
+++ b/libs/deepagents/deepagents/middleware/completion_callback.py
@@ -164,9 +164,10 @@ async def _notify_parent(
 
 
 _MAX_MESSAGE_LENGTH = 500
+_TRUNCATION_SUFFIX = "... [full result truncated]"
 
 
-def _extract_last_message(state: dict[str, Any]) -> str:
+def _extract_last_message(state: dict[str, Any], *, task_id: str | None = None) -> str:
     """Extract a summary from the subagent's final message.
 
     Returns at most 500 characters from the last message's content.
@@ -183,7 +184,9 @@ def _extract_last_message(state: dict[str, Any]) -> str:
 
     text_content = last.text
     if len(text_content) > _MAX_MESSAGE_LENGTH:
-        text_content = text_content[:_MAX_MESSAGE_LENGTH] + "... [full result truncated]"
+        text_content = text_content[:_MAX_MESSAGE_LENGTH] + _TRUNCATION_SUFFIX
+        if task_id:
+            text_content += f" Result truncated. Use `check_async_task(task_id={task_id!r})` to retrieve the full result if needed."
     return text_content
 
 
@@ -269,7 +272,9 @@ class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, Cont
         """After-agent hook for successful subagent completion."""
         state_dict = cast("dict[str, Any]", state)
         callback_thread_id = state_dict[_CALLBACK_THREAD_ID_KEY]
-        summary = _extract_last_message(state_dict)
+        config = get_config()
+        task_id = (config.get("configurable") or {}).get("thread_id")
+        summary = _extract_last_message(state_dict, task_id=task_id if isinstance(task_id, str) else None)
         notification = self._format_notification(f"Completed. Result: {summary}")
         await self._send_notification(callback_thread_id, notification)
         return None

--- a/libs/deepagents/deepagents/middleware/completion_callback.py
+++ b/libs/deepagents/deepagents/middleware/completion_callback.py
@@ -51,7 +51,7 @@ structured output from the subagent.
 Add this middleware to the subagent's middleware stack:
 
 ```python
-from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
+from deepagents.middleware.completion_callback import CompletionCallbackMiddleware
 
 # Same deployment (ASGI transport -- callback agent and subagent share a server):
 notifier = CompletionCallbackMiddleware(callback_graph_id="supervisor")
@@ -69,9 +69,9 @@ graph = create_agent(
 )
 ```
 
-The middleware will read `callback_thread_id` from the agent's state at the
-end of execution. This is injected automatically by the parent's
-`start_async_task` tool when it creates the run.
+The middleware reads `callback_thread_id` from the agent state at the end of
+execution. This value is injected by the parent's `start_async_task` tool when
+it creates the run.
 """
 
 from __future__ import annotations
@@ -91,18 +91,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# State key where the launch tool stores callback context.
 _CALLBACK_THREAD_ID_KEY = "callback_thread_id"
 
 
 class CompletionCallbackState(AgentState):
-    """State extension for subagents that use the completion notifier.
+    """State extension for subagents that use completion callbacks.
 
     !!! warning "Experimental"
         This state schema is experimental and may change in future releases.
 
-    `callback_thread_id` is written by the parent's `start_async_task`
-    tool and read by `CompletionCallbackMiddleware` when sending callback
+    `callback_thread_id` is written by the parent's `start_async_task` tool
+    and read by `CompletionCallbackMiddleware` when sending callback
     notifications.
     """
 
@@ -164,7 +163,7 @@ async def _notify_parent(
         )
 
 
-_MAX_MESSAGE_LENGTH = 500  # max characters to include in notification summary
+_MAX_MESSAGE_LENGTH = 500
 
 
 def _extract_last_message(state: dict[str, Any]) -> str:
@@ -183,44 +182,39 @@ def _extract_last_message(state: dict[str, Any]) -> str:
         raise TypeError(msg)
 
     text_content = last.text
-
     if len(text_content) > _MAX_MESSAGE_LENGTH:
         text_content = text_content[:_MAX_MESSAGE_LENGTH] + "... [full result truncated]"
     return text_content
 
 
 class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, ContextT, ResponseT]):
-    """Notifies another agent when work is complete.
+    """Send callback notifications when a subagent finishes.
 
     !!! warning "Experimental"
         This middleware is experimental and may change in future releases.
 
-    This middleware is added to a subagent's middleware stack. When the
-    subagent finishes (success or error), it sends a message to the callback
-    thread via `runs.create()`, waking the callback agent so it can
-    proactively relay results.
+    This middleware is added to a subagent's middleware stack. On success or
+    model-call error, it sends a notification to the configured callback
+    thread by calling `runs.create()`.
 
-    The `callback_thread_id` is read from the subagent's own state
-    (injected by the callback agent's `start_async_task` tool at launch time).
-    The `callback_graph_id` is provided as a constructor argument since it's
-    static configuration known at deployment time.
+    The callback destination is configured with `callback_graph_id` and
+    optional `url` and `headers`. The target thread is read from
+    `callback_thread_id` in the subagent state.
 
-    If `callback_thread_id` is not present in state, the middleware silently
-    does nothing.
+    If `callback_thread_id` is not present in state, the middleware does
+    nothing.
 
     Args:
-        callback_graph_id: The callback graph ID (or assistant ID). Used
-            as the `assistant_id` parameter when calling `runs.create()` to
-            send notifications to the callback destination.
-        url: URL of the callback LangGraph server (e.g.,
-            `"https://my-deployment.langsmith.dev"`). Omit to use ASGI
-            transport for same-deployment communication.
-        headers: Additional headers to include in requests to the
-            callback server.
+        callback_graph_id: Callback graph or assistant identifier used as the
+            `assistant_id` argument in `runs.create()`.
+        url: URL of the callback LangGraph server. Omit to use same-deployment
+            ASGI transport.
+        headers: Additional headers to include in requests to the callback
+            server.
 
     Example:
         ```python
-        from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
+        from deepagents.middleware.completion_callback import CompletionCallbackMiddleware
 
         notifier = CompletionCallbackMiddleware(callback_graph_id="supervisor")
 
@@ -272,10 +266,7 @@ class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, Cont
         state: StateT,
         runtime: Runtime[ContextT],  # noqa: ARG002
     ) -> dict[str, Any] | None:
-        """After-agent hook: fires when the subagent completes successfully.
-
-        Extracts the last message as a summary and sends it to the callback destination.
-        """
+        """After-agent hook for successful subagent completion."""
         state_dict = cast("dict[str, Any]", state)
         callback_thread_id = state_dict[_CALLBACK_THREAD_ID_KEY]
         summary = _extract_last_message(state_dict)
@@ -288,11 +279,7 @@ class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, Cont
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
     ) -> ModelResponse[ResponseT]:
-        """Wrap model calls to catch errors and notify the callback destination.
-
-        If a model call raises an exception, the error is reported before
-        re-raising so the callback agent can inform the user.
-        """
+        """Wrap model calls to send callback notifications on model-call errors."""
         try:
             return await handler(request)
         except Exception:
@@ -301,6 +288,3 @@ class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, Cont
                 notification = self._format_notification("The agent encountered an error while calling the model.")
                 await self._send_notification(callback_thread_id, notification)
             raise
-
-
-a

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -1,0 +1,266 @@
+"""Completion notifier middleware for async subagents.
+
+When an async subagent finishes (success or error), this middleware sends a
+message back to the **supervisor's** thread so the supervisor wakes up and can
+proactively relay results to the user -- without the user having to poll via
+`check_async_task`.
+
+## Architecture
+
+The async subagent protocol is inherently fire-and-forget: the supervisor
+launches a job via `start_async_task` and only learns about completion
+when someone calls `check_async_task`.
+
+The notifier calls `runs.create()` on the supervisor's thread and assistant
+ID, which queues a new run. From the supervisor's perspective, it looks like
+a new user message arrived -- except the content is a structured notification
+from the subagent.
+
+## How parent context is propagated
+
+The supervisor's `start_async_task` tool includes the parent's
+`thread_id` and `assistant_id` in the subagent's input state. The notifier
+reads these from the subagent's own state, which means:
+
+- The IDs survive thread interrupts and updates (they're in state, not config)
+- If the IDs are not present, the notifier silently no-ops
+
+## Usage
+
+Add this middleware to the subagent's middleware stack:
+
+```python
+import contextlib
+
+from langchain.agents import create_agent
+from langchain_core.runnables import RunnableConfig
+
+from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
+
+
+@contextlib.asynccontextmanager
+async def graph(config: RunnableConfig):
+    yield create_agent(
+        model=model,
+        tools=[...],
+        middleware=[CompletionNotifierMiddleware(subagent_name="researcher")],
+    )
+```
+
+The middleware will read `parent_thread_id` and `parent_assistant_id` from
+the agent's state at the end of execution. These are injected automatically
+by the supervisor's `start_async_task` tool when it creates the run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, NotRequired
+
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ContextT, ModelRequest, ModelResponse, ResponseT, Runtime
+
+
+# State keys where the supervisor's launch tool stores parent context.
+_PARENT_THREAD_ID_KEY = "parent_thread_id"
+_PARENT_ASSISTANT_ID_KEY = "parent_assistant_id"
+_TASK_ID_KEY = "task_id"
+
+
+class CompletionNotifierState(AgentState):
+    """State extension for subagents that use the completion notifier.
+
+    These fields are injected by the supervisor's `launch_async_subagent`
+    tool and read by `CompletionNotifierMiddleware` to send notifications
+    back to the supervisor's thread.
+    """
+
+    parent_thread_id: NotRequired[str | None]
+    """The supervisor's thread ID. Used to address the notification."""
+
+    parent_assistant_id: NotRequired[str | None]
+    """The supervisor's assistant ID. Used to create a run on the supervisor's thread."""
+
+    task_id: NotRequired[str | None]
+    """The task ID assigned by the supervisor.
+
+    This is the subagent's thread ID, which the supervisor uses to track
+    the job. Included in notifications so the supervisor can correlate
+    completions back to specific jobs when multiple tasks of the same
+    subagent type are running concurrently.
+    """
+
+
+async def _notify_parent(
+    parent_thread_id: str,
+    parent_assistant_id: str,
+    notification: str,
+    subagent_name: str,
+) -> None:
+    """Send a notification run to the parent supervisor's thread.
+
+    Uses `get_client()` with no URL, which resolves to ASGI transport when
+    running in the same LangGraph deployment. For split deployments, the
+    subagent needs network access back to the supervisor.
+
+    Args:
+        parent_thread_id: The supervisor's thread ID.
+        parent_assistant_id: The supervisor's assistant ID.
+        notification: The message content to send.
+        subagent_name: Human-readable name for logging.
+    """
+    from langgraph_sdk import get_client  # noqa: PLC0415  # deferred to avoid import cost at module level
+
+    try:
+        client = get_client()
+        await client.runs.create(
+            thread_id=parent_thread_id,
+            assistant_id=parent_assistant_id,
+            input={
+                "messages": [{"role": "user", "content": notification}],
+            },
+        )
+        logger.info(
+            "Notified parent thread %s that subagent '%s' finished",
+            parent_thread_id,
+            subagent_name,
+        )
+    except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
+        logger.warning(
+            "Failed to notify parent thread %s",
+            parent_thread_id,
+            exc_info=True,
+        )
+
+
+def _extract_last_message(state: dict[str, Any]) -> str:
+    """Extract a summary from the subagent's final message.
+
+    Returns at most 500 characters from the last message's content.
+    """
+    messages = state.get("messages", [])
+    if not messages:
+        return "(no output)"
+    last = messages[-1]
+    if hasattr(last, "content"):
+        content = last.content
+        return content[:500] if isinstance(content, str) else str(content)[:500]
+    if isinstance(last, dict):
+        return str(last.get("content", ""))[:500]
+    return str(last)[:500]
+
+
+class CompletionNotifierMiddleware(AgentMiddleware):
+    """Notifies the supervisor when an async subagent completes or errors.
+
+    This middleware is added to the **subagent's** middleware stack (not the
+    supervisor's). When the subagent finishes, it sends a message to the
+    supervisor's thread via `runs.create()`, waking the supervisor so it can
+    proactively relay results.
+
+    The supervisor's thread ID and assistant ID are read from the subagent's
+    own state (keys `parent_thread_id` and `parent_assistant_id`). These are
+    injected by the supervisor's `launch_async_subagent` tool at launch time.
+
+    If the parent context is not present in state (e.g., the subagent was
+    launched manually without a supervisor), the middleware silently does
+    nothing.
+
+    Args:
+        subagent_name: Human-readable name used in notification messages
+            and logs. Helps the supervisor identify which subagent sent
+            the notification.
+
+    Example:
+        ```python
+        from deepagents.middleware.completion_notifier import (
+            CompletionNotifierMiddleware,
+        )
+
+        notifier = CompletionNotifierMiddleware(subagent_name="researcher")
+
+        graph = create_agent(
+            model=model,
+            tools=[...],
+            middleware=[notifier],
+        )
+        ```
+    """
+
+    state_schema = CompletionNotifierState
+
+    def __init__(self, subagent_name: str = "subagent") -> None:
+        """Initialize the `CompletionNotifierMiddleware`."""
+        super().__init__()
+        self.subagent_name = subagent_name
+        self._notified = False
+
+    def _get_parent_ids(self, state: dict[str, Any]) -> tuple[str | None, str | None]:
+        """Extract parent thread and assistant IDs from the subagent's state."""
+        return (
+            state.get(_PARENT_THREAD_ID_KEY),
+            state.get(_PARENT_ASSISTANT_ID_KEY),
+        )
+
+    def _should_notify(self, state: dict[str, Any]) -> bool:
+        """Check whether we should send a notification."""
+        if self._notified:
+            return False
+        parent_thread_id, parent_assistant_id = self._get_parent_ids(state)
+        return bool(parent_thread_id) and bool(parent_assistant_id)
+
+    async def _send_notification(self, state: dict[str, Any], message: str) -> None:
+        """Send a notification to the parent if conditions are met."""
+        if not self._should_notify(state):
+            return
+        self._notified = True
+        parent_thread_id, parent_assistant_id = self._get_parent_ids(state)
+        await _notify_parent(
+            parent_thread_id,  # type: ignore[arg-type]
+            parent_assistant_id,  # type: ignore[arg-type]
+            message,
+            self.subagent_name,
+        )
+
+    def _format_notification(self, state: dict[str, Any], body: str) -> str:
+        """Build a notification string with task_id and subagent name."""
+        task_id = state.get(_TASK_ID_KEY)
+        prefix = f"[task_id={task_id}]" if task_id else ""
+        return f"{prefix}[subagent={self.subagent_name}] {body}"
+
+    async def aafter_agent(
+        self,
+        state: dict[str, Any],
+        runtime: Runtime,  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        """After-agent hook: fires when the subagent completes successfully.
+
+        Extracts the last message as a summary and sends it to the supervisor.
+        """
+        summary = _extract_last_message(state)
+        notification = self._format_notification(state, f"Completed. Result: {summary}")
+        await self._send_notification(state, notification)
+        return None
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """Wrap model calls to catch errors and notify the supervisor.
+
+        If a model call raises an exception, the error is reported to the
+        supervisor before re-raising so the supervisor can inform the user.
+        """
+        try:
+            return await handler(request)
+        except Exception as e:
+            notification = self._format_notification(request.state, f"Error: {e!s}")
+            await self._send_notification(request.state, notification)
+            raise

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -51,10 +51,7 @@ Add this middleware to the subagent's middleware stack:
 ```python
 from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 
-notifier = CompletionNotifierMiddleware(
-    parent_graph_id="supervisor",
-    subagent_name="researcher",
-)
+notifier = CompletionNotifierMiddleware(parent_graph_id="supervisor")
 
 graph = create_agent(
     model=model,
@@ -106,7 +103,6 @@ async def _notify_parent(
     parent_thread_id: str,
     parent_graph_id: str,
     notification: str,
-    subagent_name: str,
 ) -> None:
     """Send a notification run to the parent supervisor's thread.
 
@@ -119,7 +115,6 @@ async def _notify_parent(
         parent_graph_id: The supervisor's graph ID (used as `assistant_id`
             in the `runs.create` call).
         notification: The message content to send.
-        subagent_name: Human-readable name for logging.
     """
     from langgraph_sdk import get_client  # noqa: PLC0415  # deferred to avoid import cost at module level
 
@@ -133,9 +128,9 @@ async def _notify_parent(
             },
         )
         logger.info(
-            "Notified parent thread %s that subagent '%s' finished",
+            "Notified parent thread %s via graph '%s'",
             parent_thread_id,
-            subagent_name,
+            parent_graph_id,
         )
     except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
         logger.warning(
@@ -186,9 +181,6 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         parent_graph_id: The supervisor's graph ID (or assistant ID). Used
             as the `assistant_id` parameter when calling `runs.create()` to
             send notifications back to the supervisor.
-        subagent_name: Human-readable name used in notification messages
-            and logs. Helps the supervisor identify which subagent sent
-            the notification.
 
     Example:
         ```python
@@ -196,10 +188,7 @@ class CompletionNotifierMiddleware(AgentMiddleware):
             CompletionNotifierMiddleware,
         )
 
-        notifier = CompletionNotifierMiddleware(
-            parent_graph_id="supervisor",
-            subagent_name="researcher",
-        )
+        notifier = CompletionNotifierMiddleware(parent_graph_id="supervisor")
 
         graph = create_agent(
             model=model,
@@ -211,11 +200,10 @@ class CompletionNotifierMiddleware(AgentMiddleware):
 
     state_schema = CompletionNotifierState
 
-    def __init__(self, parent_graph_id: str, subagent_name: str = "subagent") -> None:
+    def __init__(self, parent_graph_id: str) -> None:
         """Initialize the `CompletionNotifierMiddleware`."""
         super().__init__()
         self.parent_graph_id = parent_graph_id
-        self.subagent_name = subagent_name
         self._notified = False
 
     def _should_notify(self, state: dict[str, Any]) -> bool:
@@ -233,7 +221,6 @@ class CompletionNotifierMiddleware(AgentMiddleware):
             state[_PARENT_THREAD_ID_KEY],
             self.parent_graph_id,
             message,
-            self.subagent_name,
         )
 
     @staticmethod
@@ -255,7 +242,7 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         """Build a notification string with task_id and subagent name."""
         task_id = self._get_task_id()
         prefix = f"[task_id={task_id}]" if task_id else ""
-        return f"{prefix}[subagent={self.subagent_name}] {body}"
+        return f"{prefix}{body}"
 
     async def aafter_agent(
         self,

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -84,7 +84,9 @@ from langchain.agents.middleware.types import AgentMiddleware, AgentState
 from langchain.messages import AIMessage
 
 if TYPE_CHECKING:
-    from langchain.agents.middleware.types import Runtime
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ContextT, ModelRequest, ModelResponse, ResponseT, Runtime
 
 logger = logging.getLogger(__name__)
 

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -39,6 +39,9 @@ from the subagent.
 - `parent_graph_id` is passed as a **constructor argument** to the middleware.
   This is the supervisor's graph ID (or assistant ID), which the subagent
   developer knows at configuration time.
+- `url` and `headers` are optional constructor arguments for reaching the
+  supervisor on a remote deployment. Omit `url` for same-deployment ASGI
+  transport.
 - `parent_thread_id` is injected into the subagent's input state by the
   supervisor's `start_async_task` tool. It survives thread interrupts and
   updates because it lives in state, not config.
@@ -51,7 +54,14 @@ Add this middleware to the subagent's middleware stack:
 ```python
 from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 
+# Same deployment (ASGI transport -- supervisor and subagent share a server):
 notifier = CompletionNotifierMiddleware(parent_graph_id="supervisor")
+
+# Remote deployment (supervisor on a different server):
+notifier = CompletionNotifierMiddleware(
+    parent_graph_id="supervisor",
+    url="https://supervisor.langsmith.dev",
+)
 
 graph = create_agent(
     model=model,
@@ -99,27 +109,40 @@ class CompletionNotifierState(AgentState):
     """The supervisor's thread ID. Used to address the notification."""
 
 
+def _resolve_headers(headers: dict[str, str] | None) -> dict[str, str]:
+    """Build headers for the supervisor's LangGraph server.
+
+    Ensures `x-auth-scheme: langsmith` is present unless explicitly overridden.
+    """
+    resolved: dict[str, str] = dict(headers or {})
+    if "x-auth-scheme" not in resolved:
+        resolved["x-auth-scheme"] = "langsmith"
+    return resolved
+
+
 async def _notify_parent(
     parent_thread_id: str,
     parent_graph_id: str,
     notification: str,
+    *,
+    url: str | None = None,
+    headers: dict[str, str] | None = None,
 ) -> None:
     """Send a notification run to the parent supervisor's thread.
-
-    Uses `get_client()` with no URL, which resolves to ASGI transport when
-    running in the same LangGraph deployment. For split deployments, the
-    subagent needs network access back to the supervisor.
 
     Args:
         parent_thread_id: The supervisor's thread ID.
         parent_graph_id: The supervisor's graph ID (used as `assistant_id`
             in the `runs.create` call).
         notification: The message content to send.
+        url: URL of the supervisor's LangGraph server. Omit for ASGI
+            transport (same deployment).
+        headers: Additional headers for the request.
     """
     from langgraph_sdk import get_client  # noqa: PLC0415  # deferred to avoid import cost at module level
 
     try:
-        client = get_client()
+        client = get_client(url=url, headers=_resolve_headers(headers))
         await client.runs.create(
             thread_id=parent_thread_id,
             assistant_id=parent_graph_id,
@@ -181,6 +204,11 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         parent_graph_id: The supervisor's graph ID (or assistant ID). Used
             as the `assistant_id` parameter when calling `runs.create()` to
             send notifications back to the supervisor.
+        url: URL of the supervisor's LangGraph server (e.g.,
+            `"https://my-deployment.langsmith.dev"`). Omit to use ASGI
+            transport for same-deployment communication.
+        headers: Additional headers to include in requests to the
+            supervisor's server.
 
     Example:
         ```python
@@ -188,7 +216,14 @@ class CompletionNotifierMiddleware(AgentMiddleware):
             CompletionNotifierMiddleware,
         )
 
+        # Same deployment (ASGI transport):
         notifier = CompletionNotifierMiddleware(parent_graph_id="supervisor")
+
+        # Remote deployment:
+        notifier = CompletionNotifierMiddleware(
+            parent_graph_id="supervisor",
+            url="https://supervisor.langsmith.dev",
+        )
 
         graph = create_agent(
             model=model,
@@ -200,10 +235,18 @@ class CompletionNotifierMiddleware(AgentMiddleware):
 
     state_schema = CompletionNotifierState
 
-    def __init__(self, parent_graph_id: str) -> None:
+    def __init__(
+        self,
+        parent_graph_id: str,
+        *,
+        url: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         """Initialize the `CompletionNotifierMiddleware`."""
         super().__init__()
         self.parent_graph_id = parent_graph_id
+        self.url = url
+        self.headers = headers
         self._notified = False
 
     def _should_notify(self, state: dict[str, Any]) -> bool:
@@ -221,6 +264,8 @@ class CompletionNotifierMiddleware(AgentMiddleware):
             state[_PARENT_THREAD_ID_KEY],
             self.parent_graph_id,
             message,
+            url=self.url,
+            headers=self.headers,
         )
 
     @staticmethod

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -54,7 +54,7 @@ Add this middleware to the subagent's middleware stack:
 from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
 
 # Same deployment (ASGI transport -- callback agent and subagent share a server):
-notifier = CompletionNotifierMiddleware(callback_graph_id="supervisor")
+notifier = CompletionCallbackMiddleware(callback_graph_id="supervisor")
 
 # Remote deployment (callback destination on a different server):
 notifier = CompletionCallbackMiddleware(
@@ -101,9 +101,9 @@ class CompletionCallbackState(AgentState):
     !!! warning "Experimental"
         This state schema is experimental and may change in future releases.
 
-    These fields are injected by the parent's `start_async_task`
-    tool and read by `CompletionNotifierMiddleware` to send notifications
-    back to the parent's thread.
+    `callback_thread_id` is written by the parent's `start_async_task`
+    tool and read by `CompletionCallbackMiddleware` when sending callback
+    notifications.
     """
 
     callback_thread_id: NotRequired[str | None]
@@ -111,7 +111,7 @@ class CompletionCallbackState(AgentState):
 
 
 def _resolve_headers(headers: dict[str, str] | None) -> dict[str, str]:
-    """Build headers for the parent's LangGraph server.
+    """Build headers for the callback LangGraph server.
 
     Ensures `x-auth-scheme: langsmith` is present unless explicitly overridden.
     """
@@ -222,14 +222,7 @@ class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, Cont
         ```python
         from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
 
-        # Same deployment (ASGI transport):
-        notifier = CompletionNotifierMiddleware(callback_graph_id="supervisor")
-
-        # Remote deployment:
-        notifier = CompletionCallbackMiddleware(
-            callback_graph_id="supervisor",
-            url="https://supervisor.langsmith.dev",
-        )
+        notifier = CompletionCallbackMiddleware(callback_graph_id="supervisor")
 
         graph = create_agent(
             model=model,
@@ -308,3 +301,6 @@ class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, Cont
                 notification = self._format_notification("The agent encountered an error while calling the model.")
                 await self._send_notification(callback_thread_id, notification)
             raise
+
+
+a

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -1,18 +1,19 @@
-"""Completion notifier middleware for async subagents.
+"""Callback middleware for async subagents.
 
 !!! warning "Experimental"
     This middleware is experimental and may change in future releases.
 
-When an async subagent finishes (success or error), this middleware sends a
-message back to the callback thread so the callback agent wakes up and can
-proactively relay results to the user -- without the user having to poll via
+This middleware sends a notification to a callback thread when a subagent
+completes successfully or raises an error. The callback agent can then
+process that notification instead of relying only on polling via
 `check_async_task`.
 
 ## Architecture
 
-The async subagent protocol is inherently fire-and-forget: the parent agent
-launches a job via `start_async_task` and only learns about completion
-when someone calls `check_async_task`. This middleware closes that gap.
+A parent agent launches a subagent with `start_async_task` and can later
+inspect task state with `check_async_task`. This middleware adds an optional
+completion signal by creating a run on the callback thread when the subagent
+finishes.
 
 ```
 Parent                        Subagent
@@ -26,39 +27,37 @@ Parent                        Subagent
     |      callback_thread,      |
     |      "completed: ...")     |
     |                            |
-    |  (wakes up, sees result)   |
+    |  (processes result)        |
 ```
 
-The notifier calls `runs.create()` on the callback thread, which
-queues a new run. From the callback agent's perspective, it looks like a new
-user message arrived -- except the content is a structured notification
-from the subagent.
+The middleware calls `runs.create()` on the callback thread. From the
+callback agent's perspective, this appears as a new user message containing
+structured output from the subagent.
 
-## How callback context is propagated
+## Callback context
 
-- `callback_graph_id` is passed as a **constructor argument** to the middleware.
-  This is the parent graph ID (or assistant ID), which the subagent
-  developer knows at configuration time.
-- `url` and `headers` are optional constructor arguments for reaching the
-  callback destination on a remote deployment. Omit `url` for same-deployment
-  ASGI transport.
-- `callback_thread_id` is injected into the subagent's input state by the
-  parent's `start_async_task` tool. It survives thread interrupts and
-  updates because it lives in state, not config.
-- If `callback_thread_id` is not present in state, the notifier silently no-ops.
+- `callback_graph_id` identifies the callback graph or assistant. It is
+  provided when the middleware is constructed.
+- `url` and `headers` optionally configure a remote callback destination.
+  Omit `url` for same-deployment ASGI transport.
+- `callback_thread_id` is stored in the subagent state by the parent's
+  `start_async_task` tool. Because it is stored in state rather than config,
+  it survives thread updates and interrupts.
+- If `callback_thread_id` is not present in state, the middleware does
+  nothing.
 
 ## Usage
 
 Add this middleware to the subagent's middleware stack:
 
 ```python
-from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
+from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
 
 # Same deployment (ASGI transport -- callback agent and subagent share a server):
 notifier = CompletionNotifierMiddleware(callback_graph_id="supervisor")
 
 # Remote deployment (callback destination on a different server):
-notifier = CompletionNotifierMiddleware(
+notifier = CompletionCallbackMiddleware(
     callback_graph_id="supervisor",
     url="url to your langsmith deployment",
 )
@@ -96,7 +95,7 @@ logger = logging.getLogger(__name__)
 _CALLBACK_THREAD_ID_KEY = "callback_thread_id"
 
 
-class CompletionNotifierState(AgentState):
+class CompletionCallbackState(AgentState):
     """State extension for subagents that use the completion notifier.
 
     !!! warning "Experimental"
@@ -190,7 +189,7 @@ def _extract_last_message(state: dict[str, Any]) -> str:
     return text_content
 
 
-class CompletionNotifierMiddleware(AgentMiddleware[CompletionNotifierState, ContextT, ResponseT]):
+class CompletionCallbackMiddleware(AgentMiddleware[CompletionCallbackState, ContextT, ResponseT]):
     """Notifies another agent when work is complete.
 
     !!! warning "Experimental"
@@ -221,13 +220,13 @@ class CompletionNotifierMiddleware(AgentMiddleware[CompletionNotifierState, Cont
 
     Example:
         ```python
-        from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
+        from deepagents.middleware.completion_notifier import CompletionCallbackMiddleware
 
         # Same deployment (ASGI transport):
         notifier = CompletionNotifierMiddleware(callback_graph_id="supervisor")
 
         # Remote deployment:
-        notifier = CompletionNotifierMiddleware(
+        notifier = CompletionCallbackMiddleware(
             callback_graph_id="supervisor",
             url="https://supervisor.langsmith.dev",
         )
@@ -240,7 +239,7 @@ class CompletionNotifierMiddleware(AgentMiddleware[CompletionNotifierState, Cont
         ```
     """
 
-    state_schema = CompletionNotifierState
+    state_schema = CompletionCallbackState
 
     def __init__(
         self,
@@ -249,7 +248,7 @@ class CompletionNotifierMiddleware(AgentMiddleware[CompletionNotifierState, Cont
         url: str | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
-        """Initialize the `CompletionNotifierMiddleware`."""
+        """Initialize the `CompletionCallbackMiddleware`."""
         super().__init__()
         self.callback_graph_id = callback_graph_id
         self.url = url

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -1,5 +1,8 @@
 """Completion notifier middleware for async subagents.
 
+!!! warning "Experimental"
+    This middleware is experimental and may change in future releases.
+
 When an async subagent finishes (success or error), this middleware sends a
 message back to the **supervisor's** thread so the supervisor wakes up and can
 proactively relay results to the user -- without the user having to poll via
@@ -9,47 +12,60 @@ proactively relay results to the user -- without the user having to poll via
 
 The async subagent protocol is inherently fire-and-forget: the supervisor
 launches a job via `start_async_task` and only learns about completion
-when someone calls `check_async_task`.
+when someone calls `check_async_task`. This middleware closes that gap.
 
-The notifier calls `runs.create()` on the supervisor's thread and assistant
-ID, which queues a new run. From the supervisor's perspective, it looks like
-a new user message arrived -- except the content is a structured notification
+```
+Supervisor                    Subagent
+    |                            |
+    |--- start_async_task -----> |
+    |<-- task_id (immediately) - |
+    |                            |  (working...)
+    |                            |  (done!)
+    |                            |
+    |<-- runs.create(            |
+    |      supervisor_thread,    |
+    |      "completed: ...")     |
+    |                            |
+    |  (wakes up, sees result)   |
+```
+
+The notifier calls `runs.create()` on the supervisor's thread, which
+queues a new run. From the supervisor's perspective, it looks like a new
+user message arrived -- except the content is a structured notification
 from the subagent.
 
 ## How parent context is propagated
 
-The supervisor's `start_async_task` tool includes the parent's
-`thread_id` and `assistant_id` in the subagent's input state. The notifier
-reads these from the subagent's own state, which means:
-
-- The IDs survive thread interrupts and updates (they're in state, not config)
-- If the IDs are not present, the notifier silently no-ops
+- `parent_graph_id` is passed as a **constructor argument** to the middleware.
+  This is the supervisor's graph ID (or assistant ID), which the subagent
+  developer knows at configuration time.
+- `parent_thread_id` is injected into the subagent's input state by the
+  supervisor's `start_async_task` tool. It survives thread interrupts and
+  updates because it lives in state, not config.
+- If `parent_thread_id` is not present in state, the notifier silently no-ops.
 
 ## Usage
 
 Add this middleware to the subagent's middleware stack:
 
 ```python
-import contextlib
-
-from langchain.agents import create_agent
-from langchain_core.runnables import RunnableConfig
-
 from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 
+notifier = CompletionNotifierMiddleware(
+    parent_graph_id="supervisor",
+    subagent_name="researcher",
+)
 
-@contextlib.asynccontextmanager
-async def graph(config: RunnableConfig):
-    yield create_agent(
-        model=model,
-        tools=[...],
-        middleware=[CompletionNotifierMiddleware(subagent_name="researcher")],
-    )
+graph = create_agent(
+    model=model,
+    tools=[...],
+    middleware=[notifier],
+)
 ```
 
-The middleware will read `parent_thread_id` and `parent_assistant_id` from
-the agent's state at the end of execution. These are injected automatically
-by the supervisor's `start_async_task` tool when it creates the run.
+The middleware will read `parent_thread_id` from the agent's state at the
+end of execution. This is injected automatically by the supervisor's
+`start_async_task` tool when it creates the run.
 """
 
 from __future__ import annotations
@@ -69,14 +85,15 @@ if TYPE_CHECKING:
 
 # State keys where the supervisor's launch tool stores parent context.
 _PARENT_THREAD_ID_KEY = "parent_thread_id"
-_PARENT_ASSISTANT_ID_KEY = "parent_assistant_id"
-_TASK_ID_KEY = "task_id"
 
 
 class CompletionNotifierState(AgentState):
     """State extension for subagents that use the completion notifier.
 
-    These fields are injected by the supervisor's `launch_async_subagent`
+    !!! warning "Experimental"
+        This state schema is experimental and may change in future releases.
+
+    These fields are injected by the supervisor's `start_async_task`
     tool and read by `CompletionNotifierMiddleware` to send notifications
     back to the supervisor's thread.
     """
@@ -84,22 +101,10 @@ class CompletionNotifierState(AgentState):
     parent_thread_id: NotRequired[str | None]
     """The supervisor's thread ID. Used to address the notification."""
 
-    parent_assistant_id: NotRequired[str | None]
-    """The supervisor's assistant ID. Used to create a run on the supervisor's thread."""
-
-    task_id: NotRequired[str | None]
-    """The task ID assigned by the supervisor.
-
-    This is the subagent's thread ID, which the supervisor uses to track
-    the job. Included in notifications so the supervisor can correlate
-    completions back to specific jobs when multiple tasks of the same
-    subagent type are running concurrently.
-    """
-
 
 async def _notify_parent(
     parent_thread_id: str,
-    parent_assistant_id: str,
+    parent_graph_id: str,
     notification: str,
     subagent_name: str,
 ) -> None:
@@ -111,7 +116,8 @@ async def _notify_parent(
 
     Args:
         parent_thread_id: The supervisor's thread ID.
-        parent_assistant_id: The supervisor's assistant ID.
+        parent_graph_id: The supervisor's graph ID (used as `assistant_id`
+            in the `runs.create` call).
         notification: The message content to send.
         subagent_name: Human-readable name for logging.
     """
@@ -121,7 +127,7 @@ async def _notify_parent(
         client = get_client()
         await client.runs.create(
             thread_id=parent_thread_id,
-            assistant_id=parent_assistant_id,
+            assistant_id=parent_graph_id,
             input={
                 "messages": [{"role": "user", "content": notification}],
             },
@@ -159,20 +165,27 @@ def _extract_last_message(state: dict[str, Any]) -> str:
 class CompletionNotifierMiddleware(AgentMiddleware):
     """Notifies the supervisor when an async subagent completes or errors.
 
+    !!! warning "Experimental"
+        This middleware is experimental and may change in future releases.
+
     This middleware is added to the **subagent's** middleware stack (not the
     supervisor's). When the subagent finishes, it sends a message to the
     supervisor's thread via `runs.create()`, waking the supervisor so it can
     proactively relay results.
 
-    The supervisor's thread ID and assistant ID are read from the subagent's
-    own state (keys `parent_thread_id` and `parent_assistant_id`). These are
-    injected by the supervisor's `launch_async_subagent` tool at launch time.
+    The supervisor's `parent_thread_id` is read from the subagent's own state
+    (injected by the supervisor's `start_async_task` tool at launch time).
+    The `parent_graph_id` is provided as a constructor argument since it's
+    static configuration known at deployment time.
 
-    If the parent context is not present in state (e.g., the subagent was
+    If `parent_thread_id` is not present in state (e.g., the subagent was
     launched manually without a supervisor), the middleware silently does
     nothing.
 
     Args:
+        parent_graph_id: The supervisor's graph ID (or assistant ID). Used
+            as the `assistant_id` parameter when calling `runs.create()` to
+            send notifications back to the supervisor.
         subagent_name: Human-readable name used in notification messages
             and logs. Helps the supervisor identify which subagent sent
             the notification.
@@ -183,7 +196,10 @@ class CompletionNotifierMiddleware(AgentMiddleware):
             CompletionNotifierMiddleware,
         )
 
-        notifier = CompletionNotifierMiddleware(subagent_name="researcher")
+        notifier = CompletionNotifierMiddleware(
+            parent_graph_id="supervisor",
+            subagent_name="researcher",
+        )
 
         graph = create_agent(
             model=model,
@@ -195,42 +211,49 @@ class CompletionNotifierMiddleware(AgentMiddleware):
 
     state_schema = CompletionNotifierState
 
-    def __init__(self, subagent_name: str = "subagent") -> None:
+    def __init__(self, parent_graph_id: str, subagent_name: str = "subagent") -> None:
         """Initialize the `CompletionNotifierMiddleware`."""
         super().__init__()
+        self.parent_graph_id = parent_graph_id
         self.subagent_name = subagent_name
         self._notified = False
-
-    def _get_parent_ids(self, state: dict[str, Any]) -> tuple[str | None, str | None]:
-        """Extract parent thread and assistant IDs from the subagent's state."""
-        return (
-            state.get(_PARENT_THREAD_ID_KEY),
-            state.get(_PARENT_ASSISTANT_ID_KEY),
-        )
 
     def _should_notify(self, state: dict[str, Any]) -> bool:
         """Check whether we should send a notification."""
         if self._notified:
             return False
-        parent_thread_id, parent_assistant_id = self._get_parent_ids(state)
-        return bool(parent_thread_id) and bool(parent_assistant_id)
+        return bool(state.get(_PARENT_THREAD_ID_KEY))
 
     async def _send_notification(self, state: dict[str, Any], message: str) -> None:
         """Send a notification to the parent if conditions are met."""
         if not self._should_notify(state):
             return
         self._notified = True
-        parent_thread_id, parent_assistant_id = self._get_parent_ids(state)
         await _notify_parent(
-            parent_thread_id,  # type: ignore[arg-type]
-            parent_assistant_id,  # type: ignore[arg-type]
+            state[_PARENT_THREAD_ID_KEY],
+            self.parent_graph_id,
             message,
             self.subagent_name,
         )
 
-    def _format_notification(self, state: dict[str, Any], body: str) -> str:
+    @staticmethod
+    def _get_task_id() -> str | None:
+        """Read the subagent's own thread_id from config.
+
+        The subagent's `thread_id` is the same as the `task_id` from the
+        supervisor's perspective. Available via `get_config()` at runtime.
+        """
+        try:
+            from langgraph.config import get_config  # noqa: PLC0415
+
+            config = get_config()
+            return (config.get("configurable") or {}).get("thread_id")
+        except RuntimeError:
+            return None
+
+    def _format_notification(self, body: str) -> str:
         """Build a notification string with task_id and subagent name."""
-        task_id = state.get(_TASK_ID_KEY)
+        task_id = self._get_task_id()
         prefix = f"[task_id={task_id}]" if task_id else ""
         return f"{prefix}[subagent={self.subagent_name}] {body}"
 
@@ -244,7 +267,7 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         Extracts the last message as a summary and sends it to the supervisor.
         """
         summary = _extract_last_message(state)
-        notification = self._format_notification(state, f"Completed. Result: {summary}")
+        notification = self._format_notification(f"Completed. Result: {summary}")
         await self._send_notification(state, notification)
         return None
 
@@ -261,6 +284,6 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         try:
             return await handler(request)
         except Exception as e:
-            notification = self._format_notification(request.state, f"Error: {e!s}")
+            notification = self._format_notification(f"Error: {e!s}")
             await self._send_notification(request.state, notification)
             raise

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -190,7 +190,7 @@ def _extract_last_message(state: dict[str, Any]) -> str:
     return text_content
 
 
-class CompletionNotifierMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
+class CompletionNotifierMiddleware(AgentMiddleware[CompletionNotifierState, ContextT, ResponseT]):
     """Notifies another agent when work is complete.
 
     !!! warning "Experimental"

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -4,18 +4,18 @@
     This middleware is experimental and may change in future releases.
 
 When an async subagent finishes (success or error), this middleware sends a
-message back to the **supervisor's** thread so the supervisor wakes up and can
+message back to the callback thread so the callback agent wakes up and can
 proactively relay results to the user -- without the user having to poll via
 `check_async_task`.
 
 ## Architecture
 
-The async subagent protocol is inherently fire-and-forget: the supervisor
+The async subagent protocol is inherently fire-and-forget: the parent agent
 launches a job via `start_async_task` and only learns about completion
 when someone calls `check_async_task`. This middleware closes that gap.
 
 ```
-Supervisor                    Subagent
+Parent                        Subagent
     |                            |
     |--- start_async_task -----> |
     |<-- task_id (immediately) - |
@@ -23,29 +23,29 @@ Supervisor                    Subagent
     |                            |  (done!)
     |                            |
     |<-- runs.create(            |
-    |      supervisor_thread,    |
+    |      callback_thread,      |
     |      "completed: ...")     |
     |                            |
     |  (wakes up, sees result)   |
 ```
 
-The notifier calls `runs.create()` on the supervisor's thread, which
-queues a new run. From the supervisor's perspective, it looks like a new
+The notifier calls `runs.create()` on the callback thread, which
+queues a new run. From the callback agent's perspective, it looks like a new
 user message arrived -- except the content is a structured notification
 from the subagent.
 
-## How parent context is propagated
+## How callback context is propagated
 
-- `parent_graph_id` is passed as a **constructor argument** to the middleware.
-  This is the supervisor's graph ID (or assistant ID), which the subagent
+- `callback_graph_id` is passed as a **constructor argument** to the middleware.
+  This is the parent graph ID (or assistant ID), which the subagent
   developer knows at configuration time.
 - `url` and `headers` are optional constructor arguments for reaching the
-  supervisor on a remote deployment. Omit `url` for same-deployment ASGI
-  transport.
-- `parent_thread_id` is injected into the subagent's input state by the
-  supervisor's `start_async_task` tool. It survives thread interrupts and
+  callback destination on a remote deployment. Omit `url` for same-deployment
+  ASGI transport.
+- `callback_thread_id` is injected into the subagent's input state by the
+  parent's `start_async_task` tool. It survives thread interrupts and
   updates because it lives in state, not config.
-- If `parent_thread_id` is not present in state, the notifier silently no-ops.
+- If `callback_thread_id` is not present in state, the notifier silently no-ops.
 
 ## Usage
 
@@ -54,13 +54,13 @@ Add this middleware to the subagent's middleware stack:
 ```python
 from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 
-# Same deployment (ASGI transport -- supervisor and subagent share a server):
-notifier = CompletionNotifierMiddleware(parent_graph_id="supervisor")
+# Same deployment (ASGI transport -- callback agent and subagent share a server):
+notifier = CompletionNotifierMiddleware(callback_graph_id="supervisor")
 
-# Remote deployment (supervisor on a different server):
+# Remote deployment (callback destination on a different server):
 notifier = CompletionNotifierMiddleware(
-    parent_graph_id="supervisor",
-    url="https://supervisor.langsmith.dev",
+    callback_graph_id="supervisor",
+    url="url to your langsmith deployment",
 )
 
 graph = create_agent(
@@ -70,8 +70,8 @@ graph = create_agent(
 )
 ```
 
-The middleware will read `parent_thread_id` from the agent's state at the
-end of execution. This is injected automatically by the supervisor's
+The middleware will read `callback_thread_id` from the agent's state at the
+end of execution. This is injected automatically by the parent's
 `start_async_task` tool when it creates the run.
 """
 
@@ -81,17 +81,16 @@ import logging
 from typing import TYPE_CHECKING, Any, NotRequired
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.messages import AIMessage
+
+if TYPE_CHECKING:
+    from langchain.agents.middleware.types import Runtime
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
 
-    from langchain.agents.middleware.types import ContextT, ModelRequest, ModelResponse, ResponseT, Runtime
-
-
-# State keys where the supervisor's launch tool stores parent context.
-_PARENT_THREAD_ID_KEY = "parent_thread_id"
+# State key where the launch tool stores callback context.
+_CALLBACK_THREAD_ID_KEY = "callback_thread_id"
 
 
 class CompletionNotifierState(AgentState):
@@ -100,17 +99,17 @@ class CompletionNotifierState(AgentState):
     !!! warning "Experimental"
         This state schema is experimental and may change in future releases.
 
-    These fields are injected by the supervisor's `start_async_task`
+    These fields are injected by the parent's `start_async_task`
     tool and read by `CompletionNotifierMiddleware` to send notifications
-    back to the supervisor's thread.
+    back to the parent's thread.
     """
 
-    parent_thread_id: NotRequired[str | None]
-    """The supervisor's thread ID. Used to address the notification."""
+    callback_thread_id: NotRequired[str | None]
+    """The callback thread ID. Used to address the notification."""
 
 
 def _resolve_headers(headers: dict[str, str] | None) -> dict[str, str]:
-    """Build headers for the supervisor's LangGraph server.
+    """Build headers for the parent's LangGraph server.
 
     Ensures `x-auth-scheme: langsmith` is present unless explicitly overridden.
     """
@@ -121,21 +120,21 @@ def _resolve_headers(headers: dict[str, str] | None) -> dict[str, str]:
 
 
 async def _notify_parent(
-    parent_thread_id: str,
-    parent_graph_id: str,
+    callback_graph_id: str,
+    callback_thread_id: str,
     notification: str,
     *,
     url: str | None = None,
     headers: dict[str, str] | None = None,
 ) -> None:
-    """Send a notification run to the parent supervisor's thread.
+    """Send a notification run to the callback thread.
 
     Args:
-        parent_thread_id: The supervisor's thread ID.
-        parent_graph_id: The supervisor's graph ID (used as `assistant_id`
-            in the `runs.create` call).
+        callback_graph_id: The callback graph ID used as `assistant_id`
+            in the `runs.create` call.
+        callback_thread_id: The callback thread ID.
         notification: The message content to send.
-        url: URL of the supervisor's LangGraph server. Omit for ASGI
+        url: URL of the callback LangGraph server. Omit for ASGI
             transport (same deployment).
         headers: Additional headers for the request.
     """
@@ -144,23 +143,26 @@ async def _notify_parent(
     try:
         client = get_client(url=url, headers=_resolve_headers(headers))
         await client.runs.create(
-            thread_id=parent_thread_id,
-            assistant_id=parent_graph_id,
+            thread_id=callback_thread_id,
+            assistant_id=callback_graph_id,
             input={
                 "messages": [{"role": "user", "content": notification}],
             },
         )
         logger.info(
-            "Notified parent thread %s via graph '%s'",
-            parent_thread_id,
-            parent_graph_id,
+            "Notified callback thread %s via graph '%s'",
+            callback_thread_id,
+            callback_graph_id,
         )
     except Exception:  # noqa: BLE001  # LangGraph SDK raises untyped errors
         logger.warning(
-            "Failed to notify parent thread %s",
-            parent_thread_id,
+            "Failed to notify callback thread %s",
+            callback_thread_id,
             exc_info=True,
         )
+
+
+_MAX_MESSAGE_LENGTH = 500  # max characters to include in notification summary
 
 
 def _extract_last_message(state: dict[str, Any]) -> str:
@@ -170,58 +172,60 @@ def _extract_last_message(state: dict[str, Any]) -> str:
     """
     messages = state.get("messages", [])
     if not messages:
-        return "(no output)"
+        msg = f"Expected at least one message in state {state}"
+        raise AssertionError(msg)
     last = messages[-1]
-    if hasattr(last, "content"):
-        content = last.content
-        return content[:500] if isinstance(content, str) else str(content)[:500]
-    if isinstance(last, dict):
-        return str(last.get("content", ""))[:500]
-    return str(last)[:500]
+
+    if not isinstance(last, AIMessage):
+        msg = f"Expected an AIMessage, got {type(last)} instead"
+        raise TypeError(msg)
+
+    text_content = last.text
+
+    if len(text_content) > _MAX_MESSAGE_LENGTH:
+        text_content = text_content[:_MAX_MESSAGE_LENGTH] + "... [full result truncated]"
+    return text_content
 
 
 class CompletionNotifierMiddleware(AgentMiddleware):
-    """Notifies the supervisor when an async subagent completes or errors.
+    """Notifies another agent when work is complete.
 
     !!! warning "Experimental"
         This middleware is experimental and may change in future releases.
 
-    This middleware is added to the **subagent's** middleware stack (not the
-    supervisor's). When the subagent finishes, it sends a message to the
-    supervisor's thread via `runs.create()`, waking the supervisor so it can
+    This middleware is added to a subagent's middleware stack. When the
+    subagent finishes (success or error), it sends a message to the callback
+    thread via `runs.create()`, waking the callback agent so it can
     proactively relay results.
 
-    The supervisor's `parent_thread_id` is read from the subagent's own state
-    (injected by the supervisor's `start_async_task` tool at launch time).
-    The `parent_graph_id` is provided as a constructor argument since it's
+    The `callback_thread_id` is read from the subagent's own state
+    (injected by the callback agent's `start_async_task` tool at launch time).
+    The `callback_graph_id` is provided as a constructor argument since it's
     static configuration known at deployment time.
 
-    If `parent_thread_id` is not present in state (e.g., the subagent was
-    launched manually without a supervisor), the middleware silently does
-    nothing.
+    If `callback_thread_id` is not present in state, the middleware silently
+    does nothing.
 
     Args:
-        parent_graph_id: The supervisor's graph ID (or assistant ID). Used
+        callback_graph_id: The callback graph ID (or assistant ID). Used
             as the `assistant_id` parameter when calling `runs.create()` to
-            send notifications back to the supervisor.
-        url: URL of the supervisor's LangGraph server (e.g.,
+            send notifications to the callback destination.
+        url: URL of the callback LangGraph server (e.g.,
             `"https://my-deployment.langsmith.dev"`). Omit to use ASGI
             transport for same-deployment communication.
         headers: Additional headers to include in requests to the
-            supervisor's server.
+            callback server.
 
     Example:
         ```python
-        from deepagents.middleware.completion_notifier import (
-            CompletionNotifierMiddleware,
-        )
+        from deepagents.middleware.completion_notifier import CompletionNotifierMiddleware
 
         # Same deployment (ASGI transport):
-        notifier = CompletionNotifierMiddleware(parent_graph_id="supervisor")
+        notifier = CompletionNotifierMiddleware(callback_graph_id="supervisor")
 
         # Remote deployment:
         notifier = CompletionNotifierMiddleware(
-            parent_graph_id="supervisor",
+            callback_graph_id="supervisor",
             url="https://supervisor.langsmith.dev",
         )
 
@@ -237,14 +241,14 @@ class CompletionNotifierMiddleware(AgentMiddleware):
 
     def __init__(
         self,
-        parent_graph_id: str,
+        callback_graph_id: str,
         *,
         url: str | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
         """Initialize the `CompletionNotifierMiddleware`."""
         super().__init__()
-        self.parent_graph_id = parent_graph_id
+        self.callback_graph_id = callback_graph_id
         self.url = url
         self.headers = headers
         self._notified = False
@@ -253,16 +257,13 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         """Check whether we should send a notification."""
         if self._notified:
             return False
-        return bool(state.get(_PARENT_THREAD_ID_KEY))
+        return bool(state.get(_CALLBACK_THREAD_ID_KEY))
 
-    async def _send_notification(self, state: dict[str, Any], message: str) -> None:
-        """Send a notification to the parent if conditions are met."""
-        if not self._should_notify(state):
-            return
-        self._notified = True
+    async def _send_notification(self, callback_thread_id: str, message: str) -> None:
+        """Send a notification to the callback destination if conditions are met."""
         await _notify_parent(
-            state[_PARENT_THREAD_ID_KEY],
-            self.parent_graph_id,
+            self.callback_graph_id,
+            callback_thread_id,
             message,
             url=self.url,
             headers=self.headers,
@@ -273,7 +274,7 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         """Read the subagent's own thread_id from config.
 
         The subagent's `thread_id` is the same as the `task_id` from the
-        supervisor's perspective. Available via `get_config()` at runtime.
+        callback agent's perspective. Available via `get_config()` at runtime.
         """
         try:
             from langgraph.config import get_config  # noqa: PLC0415
@@ -296,11 +297,15 @@ class CompletionNotifierMiddleware(AgentMiddleware):
     ) -> dict[str, Any] | None:
         """After-agent hook: fires when the subagent completes successfully.
 
-        Extracts the last message as a summary and sends it to the supervisor.
+        Extracts the last message as a summary and sends it to the callback destination.
         """
+        if not self._should_notify(state):
+            return None
+        self._notified = True
+        callback_thread_id = state[_CALLBACK_THREAD_ID_KEY]
         summary = _extract_last_message(state)
         notification = self._format_notification(f"Completed. Result: {summary}")
-        await self._send_notification(state, notification)
+        await self._send_notification(callback_thread_id, notification)
         return None
 
     async def awrap_model_call(
@@ -308,14 +313,17 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
     ) -> ModelResponse[ResponseT]:
-        """Wrap model calls to catch errors and notify the supervisor.
+        """Wrap model calls to catch errors and notify the callback destination.
 
-        If a model call raises an exception, the error is reported to the
-        supervisor before re-raising so the supervisor can inform the user.
+        If a model call raises an exception, the error is reported before
+        re-raising so the callback agent can inform the user.
         """
         try:
             return await handler(request)
         except Exception as e:
-            notification = self._format_notification(f"Error: {e!s}")
-            await self._send_notification(request.state, notification)
+            if self._should_notify(request.state):
+                self._notified = True
+                callback_thread_id = request.state[_CALLBACK_THREAD_ID_KEY]
+                notification = self._format_notification(f"Error: {e!s}")
+                await self._send_notification(callback_thread_id, notification)
             raise

--- a/libs/deepagents/deepagents/middleware/completion_notifier.py
+++ b/libs/deepagents/deepagents/middleware/completion_notifier.py
@@ -78,15 +78,16 @@ end of execution. This is injected automatically by the parent's
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, NotRequired
+from typing import TYPE_CHECKING, Any, NotRequired, cast
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ResponseT, StateT
 from langchain.messages import AIMessage
+from langgraph.config import get_config
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from langchain.agents.middleware.types import ContextT, ModelRequest, ModelResponse, ResponseT, Runtime
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse, Runtime
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,7 @@ def _resolve_headers(headers: dict[str, str] | None) -> dict[str, str]:
 async def _notify_parent(
     callback_graph_id: str,
     callback_thread_id: str,
-    notification: str,
+    message: str,
     *,
     url: str | None = None,
     headers: dict[str, str] | None = None,
@@ -135,7 +136,7 @@ async def _notify_parent(
         callback_graph_id: The callback graph ID used as `assistant_id`
             in the `runs.create` call.
         callback_thread_id: The callback thread ID.
-        notification: The message content to send.
+        message: The message content to send.
         url: URL of the callback LangGraph server. Omit for ASGI
             transport (same deployment).
         headers: Additional headers for the request.
@@ -148,7 +149,7 @@ async def _notify_parent(
             thread_id=callback_thread_id,
             assistant_id=callback_graph_id,
             input={
-                "messages": [{"role": "user", "content": notification}],
+                "messages": [{"role": "user", "content": message}],
             },
         )
         logger.info(
@@ -189,7 +190,7 @@ def _extract_last_message(state: dict[str, Any]) -> str:
     return text_content
 
 
-class CompletionNotifierMiddleware(AgentMiddleware):
+class CompletionNotifierMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
     """Notifies another agent when work is complete.
 
     !!! warning "Experimental"
@@ -253,13 +254,6 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         self.callback_graph_id = callback_graph_id
         self.url = url
         self.headers = headers
-        self._notified = False
-
-    def _should_notify(self, state: dict[str, Any]) -> bool:
-        """Check whether we should send a notification."""
-        if self._notified:
-            return False
-        return bool(state.get(_CALLBACK_THREAD_ID_KEY))
 
     async def _send_notification(self, callback_thread_id: str, message: str) -> None:
         """Send a notification to the callback destination if conditions are met."""
@@ -271,41 +265,28 @@ class CompletionNotifierMiddleware(AgentMiddleware):
             headers=self.headers,
         )
 
-    @staticmethod
-    def _get_task_id() -> str | None:
-        """Read the subagent's own thread_id from config.
-
-        The subagent's `thread_id` is the same as the `task_id` from the
-        callback agent's perspective. Available via `get_config()` at runtime.
-        """
-        try:
-            from langgraph.config import get_config  # noqa: PLC0415
-
-            config = get_config()
-            return (config.get("configurable") or {}).get("thread_id")
-        except RuntimeError:
-            return None
-
     def _format_notification(self, body: str) -> str:
         """Build a notification string with task_id and subagent name."""
-        task_id = self._get_task_id()
-        prefix = f"[task_id={task_id}]" if task_id else ""
+        config = get_config()
+        thread_id = (config.get("configurable") or {}).get("thread_id")
+        if not isinstance(thread_id, str):
+            msg = f"Expected `thread_id` to be str, got {type(thread_id)}"
+            raise TypeError(msg)
+        prefix = f"[task_id={thread_id}]" if thread_id else ""
         return f"{prefix}{body}"
 
     async def aafter_agent(
         self,
-        state: dict[str, Any],
-        runtime: Runtime,  # noqa: ARG002
+        state: StateT,
+        runtime: Runtime[ContextT],  # noqa: ARG002
     ) -> dict[str, Any] | None:
         """After-agent hook: fires when the subagent completes successfully.
 
         Extracts the last message as a summary and sends it to the callback destination.
         """
-        if not self._should_notify(state):
-            return None
-        self._notified = True
-        callback_thread_id = state[_CALLBACK_THREAD_ID_KEY]
-        summary = _extract_last_message(state)
+        state_dict = cast("dict[str, Any]", state)
+        callback_thread_id = state_dict[_CALLBACK_THREAD_ID_KEY]
+        summary = _extract_last_message(state_dict)
         notification = self._format_notification(f"Completed. Result: {summary}")
         await self._send_notification(callback_thread_id, notification)
         return None
@@ -322,10 +303,9 @@ class CompletionNotifierMiddleware(AgentMiddleware):
         """
         try:
             return await handler(request)
-        except Exception as e:
-            if self._should_notify(request.state):
-                self._notified = True
-                callback_thread_id = request.state[_CALLBACK_THREAD_ID_KEY]
-                notification = self._format_notification(f"Error: {e!s}")
+        except Exception:
+            callback_thread_id = request.state.get(_CALLBACK_THREAD_ID_KEY)
+            if isinstance(callback_thread_id, str):
+                notification = self._format_notification("The agent encountered an error while calling the model.")
                 await self._send_notification(callback_thread_id, notification)
             raise

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "langchain>=1.2.11,<2.0.0",
     "langchain-anthropic>=1.4.0,<2.0.0",
     "langchain-google-genai>=4.2.0,<5.0.0",
+    "langgraph-sdk>=0.1.51",
     "wcmatch",
 ]
 

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -260,10 +260,7 @@ class TestLaunchTool:
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
             assistant_id="my_graph",
-            input={
-                "messages": [{"role": "user", "content": "analyze data"}],
-                "task_id": "thread_abc",
-            },
+            input={"messages": [{"role": "user", "content": "analyze data"}]},
         )
 
 
@@ -890,19 +887,20 @@ class TestExtractParentContext:
         ctx = _extract_parent_context(runtime)
         assert ctx["parent_thread_id"] == "thread-supervisor-123"
 
-    def test_extracts_assistant_id_from_metadata(self) -> None:
+    def test_skips_none_thread_id(self) -> None:
         runtime = ToolRuntime(
             state={},
             context=None,
             tool_call_id="tc_test",
             store=None,
             stream_writer=lambda _: None,
-            config={"metadata": {"assistant_id": "asst-supervisor-456"}},
+            config={"configurable": {"thread_id": None}},
         )
         ctx = _extract_parent_context(runtime)
-        assert ctx["parent_assistant_id"] == "asst-supervisor-456"
+        assert ctx == {}
 
-    def test_extracts_both_ids(self) -> None:
+    def test_ignores_metadata(self) -> None:
+        """_extract_parent_context only extracts thread_id, not assistant_id."""
         runtime = ToolRuntime(
             state={},
             context=None,
@@ -915,31 +913,13 @@ class TestExtractParentContext:
             },
         )
         ctx = _extract_parent_context(runtime)
-        assert ctx == {
-            "parent_thread_id": "thread-123",
-            "parent_assistant_id": "asst-456",
-        }
-
-    def test_skips_none_values(self) -> None:
-        runtime = ToolRuntime(
-            state={},
-            context=None,
-            tool_call_id="tc_test",
-            store=None,
-            stream_writer=lambda _: None,
-            config={
-                "configurable": {"thread_id": None},
-                "metadata": {"assistant_id": "asst-456"},
-            },
-        )
-        ctx = _extract_parent_context(runtime)
-        assert "parent_thread_id" not in ctx
-        assert ctx["parent_assistant_id"] == "asst-456"
+        assert ctx == {"parent_thread_id": "thread-123"}
+        assert "parent_assistant_id" not in ctx
 
 
 class TestLaunchToolPassesParentContext:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_launch_includes_parent_context_in_input(self, mock_get_client: MagicMock) -> None:
+    def test_launch_includes_parent_thread_id_in_input(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
         mock_client.runs.create.return_value = {"run_id": "run_xyz"}
@@ -956,7 +936,6 @@ class TestLaunchToolPassesParentContext:
             stream_writer=lambda _: None,
             config={
                 "configurable": {"thread_id": "supervisor-thread"},
-                "metadata": {"assistant_id": "supervisor-asst"},
             },
         )
 
@@ -972,15 +951,13 @@ class TestLaunchToolPassesParentContext:
             assistant_id="my_graph",
             input={
                 "messages": [{"role": "user", "content": "analyze data"}],
-                "task_id": "thread_abc",
                 "parent_thread_id": "supervisor-thread",
-                "parent_assistant_id": "supervisor-asst",
             },
         )
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_launch_omits_parent_context_when_not_available(self, mock_get_client: MagicMock) -> None:
-        """When the supervisor config has no thread_id/assistant_id, input has only task_id."""
+        """When the supervisor config has no thread_id, input stays clean."""
         mock_client = MagicMock()
         mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
         mock_client.runs.create.return_value = {"run_id": "run_xyz"}
@@ -999,8 +976,5 @@ class TestLaunchToolPassesParentContext:
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
             assistant_id="my_graph",
-            input={
-                "messages": [{"role": "user", "content": "analyze data"}],
-                "task_id": "thread_abc",
-            },
+            input={"messages": [{"role": "user", "content": "analyze data"}]},
         )

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -885,7 +885,7 @@ class TestExtractCallbackContext:
             config={"configurable": {"thread_id": "thread-supervisor-123"}},
         )
         ctx = _extract_callback_context(runtime)
-        assert ctx["parent_thread_id"] == "thread-supervisor-123"
+        assert ctx["callback_thread_id"] == "thread-supervisor-123"
 
     def test_skips_none_thread_id(self) -> None:
         runtime = ToolRuntime(
@@ -913,13 +913,13 @@ class TestExtractCallbackContext:
             },
         )
         ctx = _extract_callback_context(runtime)
-        assert ctx == {"parent_thread_id": "thread-123"}
+        assert ctx == {"callback_thread_id": "thread-123"}
         assert "parent_assistant_id" not in ctx
 
 
 class TestLaunchToolPassesParentContext:
     @patch("deepagents.middleware.async_subagents.get_sync_client")
-    def test_launch_includes_parent_thread_id_in_input(self, mock_get_client: MagicMock) -> None:
+    def test_launch_includes_callback_thread_id_in_input(self, mock_get_client: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
         mock_client.runs.create.return_value = {"run_id": "run_xyz"}
@@ -951,7 +951,7 @@ class TestLaunchToolPassesParentContext:
             assistant_id="my_graph",
             input={
                 "messages": [{"role": "user", "content": "analyze data"}],
-                "parent_thread_id": "supervisor-thread",
+                "callback_thread_id": "supervisor-thread",
             },
         )
 

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -14,6 +14,7 @@ from deepagents.middleware.async_subagents import (
     AsyncSubAgentState,
     AsyncTask,
     _build_async_subagent_tools,
+    _extract_parent_context,
     _resolve_headers,
     _tasks_reducer,
 )
@@ -259,7 +260,10 @@ class TestLaunchTool:
         mock_client.runs.create.assert_called_once_with(
             thread_id="thread_abc",
             assistant_id="my_graph",
-            input={"messages": [{"role": "user", "content": "analyze data"}]},
+            input={
+                "messages": [{"role": "user", "content": "analyze data"}],
+                "task_id": "thread_abc",
+            },
         )
 
 
@@ -867,3 +871,136 @@ class TestCheckEdgeCases:
         assert parsed["status"] == "success"
         # result should show empty-messages fallback since thread values couldn't be fetched
         assert "no output" in parsed["result"].lower()
+
+
+class TestExtractParentContext:
+    def test_empty_config_returns_empty_dict(self) -> None:
+        runtime = _make_runtime()
+        assert _extract_parent_context(runtime) == {}
+
+    def test_extracts_thread_id_from_configurable(self) -> None:
+        runtime = ToolRuntime(
+            state={},
+            context=None,
+            tool_call_id="tc_test",
+            store=None,
+            stream_writer=lambda _: None,
+            config={"configurable": {"thread_id": "thread-supervisor-123"}},
+        )
+        ctx = _extract_parent_context(runtime)
+        assert ctx["parent_thread_id"] == "thread-supervisor-123"
+
+    def test_extracts_assistant_id_from_metadata(self) -> None:
+        runtime = ToolRuntime(
+            state={},
+            context=None,
+            tool_call_id="tc_test",
+            store=None,
+            stream_writer=lambda _: None,
+            config={"metadata": {"assistant_id": "asst-supervisor-456"}},
+        )
+        ctx = _extract_parent_context(runtime)
+        assert ctx["parent_assistant_id"] == "asst-supervisor-456"
+
+    def test_extracts_both_ids(self) -> None:
+        runtime = ToolRuntime(
+            state={},
+            context=None,
+            tool_call_id="tc_test",
+            store=None,
+            stream_writer=lambda _: None,
+            config={
+                "configurable": {"thread_id": "thread-123"},
+                "metadata": {"assistant_id": "asst-456"},
+            },
+        )
+        ctx = _extract_parent_context(runtime)
+        assert ctx == {
+            "parent_thread_id": "thread-123",
+            "parent_assistant_id": "asst-456",
+        }
+
+    def test_skips_none_values(self) -> None:
+        runtime = ToolRuntime(
+            state={},
+            context=None,
+            tool_call_id="tc_test",
+            store=None,
+            stream_writer=lambda _: None,
+            config={
+                "configurable": {"thread_id": None},
+                "metadata": {"assistant_id": "asst-456"},
+            },
+        )
+        ctx = _extract_parent_context(runtime)
+        assert "parent_thread_id" not in ctx
+        assert ctx["parent_assistant_id"] == "asst-456"
+
+
+class TestLaunchToolPassesParentContext:
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_launch_includes_parent_context_in_input(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
+        mock_client.runs.create.return_value = {"run_id": "run_xyz"}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("alpha")])
+        launch = tools[0]
+
+        runtime = ToolRuntime(
+            state={},
+            context=None,
+            tool_call_id="tc_launch",
+            store=None,
+            stream_writer=lambda _: None,
+            config={
+                "configurable": {"thread_id": "supervisor-thread"},
+                "metadata": {"assistant_id": "supervisor-asst"},
+            },
+        )
+
+        result = launch.func(
+            description="analyze data",
+            subagent_type="alpha",
+            runtime=runtime,
+        )
+
+        assert isinstance(result, Command)
+        mock_client.runs.create.assert_called_once_with(
+            thread_id="thread_abc",
+            assistant_id="my_graph",
+            input={
+                "messages": [{"role": "user", "content": "analyze data"}],
+                "task_id": "thread_abc",
+                "parent_thread_id": "supervisor-thread",
+                "parent_assistant_id": "supervisor-asst",
+            },
+        )
+
+    @patch("deepagents.middleware.async_subagents.get_sync_client")
+    def test_launch_omits_parent_context_when_not_available(self, mock_get_client: MagicMock) -> None:
+        """When the supervisor config has no thread_id/assistant_id, input has only task_id."""
+        mock_client = MagicMock()
+        mock_client.threads.create.return_value = {"thread_id": "thread_abc"}
+        mock_client.runs.create.return_value = {"run_id": "run_xyz"}
+        mock_get_client.return_value = mock_client
+
+        tools = _build_async_subagent_tools([_make_spec("alpha")])
+        launch = tools[0]
+
+        result = launch.func(
+            description="analyze data",
+            subagent_type="alpha",
+            runtime=_make_runtime("tc_launch"),
+        )
+
+        assert isinstance(result, Command)
+        mock_client.runs.create.assert_called_once_with(
+            thread_id="thread_abc",
+            assistant_id="my_graph",
+            input={
+                "messages": [{"role": "user", "content": "analyze data"}],
+                "task_id": "thread_abc",
+            },
+        )

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -14,7 +14,7 @@ from deepagents.middleware.async_subagents import (
     AsyncSubAgentState,
     AsyncTask,
     _build_async_subagent_tools,
-    _extract_parent_context,
+    _extract_callback_context,
     _resolve_headers,
     _tasks_reducer,
 )
@@ -870,10 +870,10 @@ class TestCheckEdgeCases:
         assert "no output" in parsed["result"].lower()
 
 
-class TestExtractParentContext:
+class TestExtractCallbackContext:
     def test_empty_config_returns_empty_dict(self) -> None:
         runtime = _make_runtime()
-        assert _extract_parent_context(runtime) == {}
+        assert _extract_callback_context(runtime) == {}
 
     def test_extracts_thread_id_from_configurable(self) -> None:
         runtime = ToolRuntime(
@@ -884,7 +884,7 @@ class TestExtractParentContext:
             stream_writer=lambda _: None,
             config={"configurable": {"thread_id": "thread-supervisor-123"}},
         )
-        ctx = _extract_parent_context(runtime)
+        ctx = _extract_callback_context(runtime)
         assert ctx["parent_thread_id"] == "thread-supervisor-123"
 
     def test_skips_none_thread_id(self) -> None:
@@ -896,7 +896,7 @@ class TestExtractParentContext:
             stream_writer=lambda _: None,
             config={"configurable": {"thread_id": None}},
         )
-        ctx = _extract_parent_context(runtime)
+        ctx = _extract_callback_context(runtime)
         assert ctx == {}
 
     def test_ignores_metadata(self) -> None:
@@ -912,7 +912,7 @@ class TestExtractParentContext:
                 "metadata": {"assistant_id": "asst-456"},
             },
         )
-        ctx = _extract_parent_context(runtime)
+        ctx = _extract_callback_context(runtime)
         assert ctx == {"parent_thread_id": "thread-123"}
         assert "parent_assistant_id" not in ctx
 

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage
 
-from deepagents.middleware.completion_notifier import (
+from deepagents.middleware.completion_callback import (
     CompletionCallbackMiddleware,
     CompletionCallbackState,
     _extract_last_message,
@@ -163,8 +163,8 @@ class TestCompletionCallbackMiddleware:
 
 
 class TestAfterAgent:
-    @patch("deepagents.middleware.completion_notifier.get_config")
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback.get_config")
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_sends_completion_notification(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware(callback_graph_id="parent-agent")
         state = _make_state(
@@ -183,8 +183,8 @@ class TestAfterAgent:
         notification = mock_notify.call_args[0][2]
         assert notification == "[task_id=task-789]Completed. Result: Here is the result"
 
-    @patch("deepagents.middleware.completion_notifier.get_config")
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback.get_config")
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_notification_includes_task_id_from_config(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         state = _make_state(
@@ -199,8 +199,8 @@ class TestAfterAgent:
         notification = mock_notify.call_args[0][2]
         assert "[task_id=task-789]" in notification
 
-    @patch("deepagents.middleware.completion_notifier.get_config")
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback.get_config")
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_aafter_agent_raises_outside_runnable_context(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         state = _make_state(
@@ -215,7 +215,7 @@ class TestAfterAgent:
 
         mock_notify.assert_not_awaited()
 
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_aafter_agent_raises_without_callback_thread_id(self, mock_notify: AsyncMock) -> None:
         mw = _make_middleware()
         state = _make_state(messages=[AIMessage(content="result")])
@@ -228,7 +228,7 @@ class TestAfterAgent:
 
 
 class TestWrapModelCall:
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_passes_through_on_success(self, mock_notify: AsyncMock) -> None:
         mw = _make_middleware()
         mock_response = MagicMock()
@@ -243,8 +243,8 @@ class TestWrapModelCall:
         handler.assert_awaited_once_with(request)
         mock_notify.assert_not_awaited()
 
-    @patch("deepagents.middleware.completion_notifier.get_config")
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback.get_config")
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_sends_generic_error_notification_on_exception(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
@@ -261,7 +261,7 @@ class TestWrapModelCall:
         assert "The agent encountered an error while calling the model." in notification
         assert "model crashed" not in notification
 
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_no_error_notification_without_callback_thread_id(self, mock_notify: AsyncMock) -> None:
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
@@ -274,8 +274,8 @@ class TestWrapModelCall:
 
         mock_notify.assert_not_awaited()
 
-    @patch("deepagents.middleware.completion_notifier.get_config")
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    @patch("deepagents.middleware.completion_callback.get_config")
+    @patch("deepagents.middleware.completion_callback._notify_parent", new_callable=AsyncMock)
     async def test_error_notification_on_each_exception(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("fail"))

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -17,8 +17,6 @@ from deepagents.middleware.completion_notifier import (
 def _make_state(
     *,
     parent_thread_id: str | None = None,
-    parent_assistant_id: str | None = None,
-    task_id: str | None = None,
     messages: list | None = None,
 ) -> dict[str, Any]:
     state: dict[str, Any] = {}
@@ -26,11 +24,14 @@ def _make_state(
         state["messages"] = messages
     if parent_thread_id is not None:
         state["parent_thread_id"] = parent_thread_id
-    if parent_assistant_id is not None:
-        state["parent_assistant_id"] = parent_assistant_id
-    if task_id is not None:
-        state["task_id"] = task_id
     return state
+
+
+def _make_middleware(**kwargs: Any) -> CompletionNotifierMiddleware:
+    """Create a middleware with sensible defaults."""
+    kwargs.setdefault("parent_graph_id", "supervisor")
+    kwargs.setdefault("subagent_name", "coder")
+    return CompletionNotifierMiddleware(**kwargs)
 
 
 class TestExtractLastMessage:
@@ -73,14 +74,14 @@ class TestNotifyParent:
 
         await _notify_parent(
             parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
+            parent_graph_id="supervisor",
             notification="Job completed",
             subagent_name="researcher",
         )
 
         mock_client.runs.create.assert_awaited_once_with(
             thread_id="thread-123",
-            assistant_id="asst-456",
+            assistant_id="supervisor",
             input={
                 "messages": [{"role": "user", "content": "Job completed"}],
             },
@@ -95,61 +96,51 @@ class TestNotifyParent:
         # Should not raise
         await _notify_parent(
             parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
+            parent_graph_id="supervisor",
             notification="Job completed",
             subagent_name="researcher",
         )
 
 
 class TestCompletionNotifierMiddleware:
+    def test_parent_graph_id_is_required(self):
+        with pytest.raises(TypeError):
+            CompletionNotifierMiddleware()  # type: ignore[call-arg]
+
+    def test_stores_parent_graph_id(self):
+        mw = _make_middleware(parent_graph_id="my-supervisor")
+        assert mw.parent_graph_id == "my-supervisor"
+
     def test_default_subagent_name(self):
-        mw = CompletionNotifierMiddleware()
+        mw = CompletionNotifierMiddleware(parent_graph_id="supervisor")
         assert mw.subagent_name == "subagent"
 
     def test_custom_subagent_name(self):
-        mw = CompletionNotifierMiddleware(subagent_name="researcher")
+        mw = _make_middleware(subagent_name="researcher")
         assert mw.subagent_name == "researcher"
 
-    def test_should_notify_false_when_no_parent_ids(self):
-        mw = CompletionNotifierMiddleware()
+    def test_should_notify_false_when_no_parent_thread_id(self):
+        mw = _make_middleware()
         assert not mw._should_notify({})
 
-    def test_should_notify_false_when_only_thread_id(self):
-        mw = CompletionNotifierMiddleware()
+    def test_should_notify_true_when_parent_thread_id_present(self):
+        mw = _make_middleware()
         state = _make_state(parent_thread_id="thread-123")
-        assert not mw._should_notify(state)
-
-    def test_should_notify_false_when_only_assistant_id(self):
-        mw = CompletionNotifierMiddleware()
-        state = _make_state(parent_assistant_id="asst-456")
-        assert not mw._should_notify(state)
-
-    def test_should_notify_true_when_both_present(self):
-        mw = CompletionNotifierMiddleware()
-        state = _make_state(
-            parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
-        )
         assert mw._should_notify(state)
 
     def test_should_notify_false_after_already_notified(self):
-        mw = CompletionNotifierMiddleware()
+        mw = _make_middleware()
         mw._notified = True
-        state = _make_state(
-            parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
-        )
+        state = _make_state(parent_thread_id="thread-123")
         assert not mw._should_notify(state)
 
 
 class TestAfterAgent:
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_sends_completion_notification_with_task_id(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+    async def test_sends_completion_notification(self, mock_notify):
+        mw = _make_middleware(parent_graph_id="supervisor")
         state = _make_state(
             parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
-            task_id="task-789",
             messages=[AIMessage(content="Here is the result")],
         )
         runtime = MagicMock()
@@ -158,30 +149,52 @@ class TestAfterAgent:
 
         assert result is None
         mock_notify.assert_awaited_once()
+        assert mock_notify.call_args[0][0] == "thread-123"
+        assert mock_notify.call_args[0][1] == "supervisor"
         notification = mock_notify.call_args[0][2]
-        assert "[task_id=task-789]" in notification
         assert "[subagent=coder]" in notification
         assert "Here is the result" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_notification_without_task_id_omits_prefix(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+    async def test_notification_includes_task_id_from_config(self, mock_notify):
+        mw = _make_middleware()
         state = _make_state(
             parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
 
-        await mw.aafter_agent(state, runtime)
+        with patch(
+            "deepagents.middleware.completion_notifier.CompletionNotifierMiddleware._get_task_id",
+            return_value="task-789",
+        ):
+            await mw.aafter_agent(state, runtime)
+
+        notification = mock_notify.call_args[0][2]
+        assert "[task_id=task-789]" in notification
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_notification_without_task_id_omits_prefix(self, mock_notify):
+        mw = _make_middleware()
+        state = _make_state(
+            parent_thread_id="thread-123",
+            messages=[AIMessage(content="result")],
+        )
+        runtime = MagicMock()
+
+        with patch(
+            "deepagents.middleware.completion_notifier.CompletionNotifierMiddleware._get_task_id",
+            return_value=None,
+        ):
+            await mw.aafter_agent(state, runtime)
 
         notification = mock_notify.call_args[0][2]
         assert "[task_id=" not in notification
         assert "[subagent=coder]" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_no_notification_without_parent_ids(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+    async def test_no_notification_without_parent_thread_id(self, mock_notify):
+        mw = _make_middleware()
         state = _make_state(messages=[AIMessage(content="result")])
         runtime = MagicMock()
 
@@ -191,10 +204,9 @@ class TestAfterAgent:
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
     async def test_notifies_only_once(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        mw = _make_middleware()
         state = _make_state(
             parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
@@ -208,15 +220,12 @@ class TestAfterAgent:
 class TestWrapModelCall:
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
     async def test_passes_through_on_success(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        mw = _make_middleware()
         mock_response = MagicMock()
         handler = AsyncMock(return_value=mock_response)
 
         request = MagicMock()
-        request.state = _make_state(
-            parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
-        )
+        request.state = _make_state(parent_thread_id="thread-123")
 
         result = await mw.awrap_model_call(request, handler)
 
@@ -226,28 +235,23 @@ class TestWrapModelCall:
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
     async def test_sends_error_notification_on_exception(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
 
         request = MagicMock()
-        request.state = _make_state(
-            parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
-            task_id="task-789",
-        )
+        request.state = _make_state(parent_thread_id="thread-123")
 
         with pytest.raises(ValueError, match="model crashed"):
             await mw.awrap_model_call(request, handler)
 
         mock_notify.assert_awaited_once()
         notification = mock_notify.call_args[0][2]
-        assert "[task_id=task-789]" in notification
         assert "[subagent=coder]" in notification
         assert "model crashed" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_no_error_notification_without_parent_ids(self, mock_notify):
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+    async def test_no_error_notification_without_parent_thread_id(self, mock_notify):
+        mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
 
         request = MagicMock()
@@ -261,14 +265,11 @@ class TestWrapModelCall:
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
     async def test_error_notification_only_once(self, mock_notify):
         """If wrap_model_call is retried externally, error notification fires only once."""
-        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("fail"))
 
         request = MagicMock()
-        request.state = _make_state(
-            parent_thread_id="thread-123",
-            parent_assistant_id="asst-456",
-        )
+        request.state = _make_state(parent_thread_id="thread-123")
 
         with pytest.raises(ValueError, match="fail"):
             await mw.awrap_model_call(request, handler)
@@ -276,17 +277,46 @@ class TestWrapModelCall:
         with pytest.raises(ValueError, match="fail"):
             await mw.awrap_model_call(request, handler)
 
-        # Only one notification even though two errors
         assert mock_notify.await_count == 1
+
+
+class TestGetTaskId:
+    def test_returns_thread_id_from_config(self):
+        mw = _make_middleware()
+        with patch(
+            "langgraph.config.get_config",
+            return_value={
+                "configurable": {"thread_id": "thread-abc"},
+            },
+        ):
+            assert mw._get_task_id() == "thread-abc"
+
+    def test_returns_none_outside_runnable_context(self):
+        mw = _make_middleware()
+        # get_config raises RuntimeError outside a runnable context
+        assert mw._get_task_id() is None
+
+    def test_returns_none_when_no_thread_id(self):
+        mw = _make_middleware()
+        with patch(
+            "langgraph.config.get_config",
+            return_value={
+                "configurable": {},
+            },
+        ):
+            assert mw._get_task_id() is None
 
 
 class TestStateSchema:
     def test_middleware_has_state_schema(self):
-        mw = CompletionNotifierMiddleware()
+        mw = _make_middleware()
         assert hasattr(mw, "state_schema")
 
-    def test_state_schema_includes_parent_fields(self):
+    def test_state_schema_includes_parent_thread_id(self):
         annotations = CompletionNotifierState.__annotations__
         assert "parent_thread_id" in annotations
-        assert "parent_assistant_id" in annotations
-        assert "task_id" in annotations
+
+    def test_state_schema_does_not_include_removed_fields(self):
+        annotations = CompletionNotifierState.__annotations__
+        assert "parent_assistant_id" not in annotations
+        assert "task_id" not in annotations

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -30,7 +30,6 @@ def _make_state(
 def _make_middleware(**kwargs: Any) -> CompletionNotifierMiddleware:
     """Create a middleware with sensible defaults."""
     kwargs.setdefault("parent_graph_id", "supervisor")
-    kwargs.setdefault("subagent_name", "coder")
     return CompletionNotifierMiddleware(**kwargs)
 
 
@@ -76,7 +75,6 @@ class TestNotifyParent:
             parent_thread_id="thread-123",
             parent_graph_id="supervisor",
             notification="Job completed",
-            subagent_name="researcher",
         )
 
         mock_client.runs.create.assert_awaited_once_with(
@@ -98,7 +96,6 @@ class TestNotifyParent:
             parent_thread_id="thread-123",
             parent_graph_id="supervisor",
             notification="Job completed",
-            subagent_name="researcher",
         )
 
 
@@ -110,14 +107,6 @@ class TestCompletionNotifierMiddleware:
     def test_stores_parent_graph_id(self):
         mw = _make_middleware(parent_graph_id="my-supervisor")
         assert mw.parent_graph_id == "my-supervisor"
-
-    def test_default_subagent_name(self):
-        mw = CompletionNotifierMiddleware(parent_graph_id="supervisor")
-        assert mw.subagent_name == "subagent"
-
-    def test_custom_subagent_name(self):
-        mw = _make_middleware(subagent_name="researcher")
-        assert mw.subagent_name == "researcher"
 
     def test_should_notify_false_when_no_parent_thread_id(self):
         mw = _make_middleware()
@@ -152,7 +141,6 @@ class TestAfterAgent:
         assert mock_notify.call_args[0][0] == "thread-123"
         assert mock_notify.call_args[0][1] == "supervisor"
         notification = mock_notify.call_args[0][2]
-        assert "[subagent=coder]" in notification
         assert "Here is the result" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
@@ -190,7 +178,6 @@ class TestAfterAgent:
 
         notification = mock_notify.call_args[0][2]
         assert "[task_id=" not in notification
-        assert "[subagent=coder]" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
     async def test_no_notification_without_parent_thread_id(self, mock_notify):
@@ -246,7 +233,6 @@ class TestWrapModelCall:
 
         mock_notify.assert_awaited_once()
         notification = mock_notify.call_args[0][2]
-        assert "[subagent=coder]" in notification
         assert "model crashed" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
@@ -285,9 +271,7 @@ class TestGetTaskId:
         mw = _make_middleware()
         with patch(
             "langgraph.config.get_config",
-            return_value={
-                "configurable": {"thread_id": "thread-abc"},
-            },
+            return_value={"configurable": {"thread_id": "thread-abc"}},
         ):
             assert mw._get_task_id() == "thread-abc"
 
@@ -300,9 +284,7 @@ class TestGetTaskId:
         mw = _make_middleware()
         with patch(
             "langgraph.config.get_config",
-            return_value={
-                "configurable": {},
-            },
+            return_value={"configurable": {}},
         ):
             assert mw._get_task_id() is None
 

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -1,4 +1,4 @@
-"""Tests for the CompletionNotifierMiddleware."""
+"""Tests for the CompletionCallbackMiddleware."""
 
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -7,8 +7,8 @@ import pytest
 from langchain_core.messages import AIMessage
 
 from deepagents.middleware.completion_notifier import (
-    CompletionNotifierMiddleware,
-    CompletionNotifierState,
+    CompletionCallbackMiddleware,
+    CompletionCallbackState,
     _extract_last_message,
     _notify_parent,
     _resolve_headers,
@@ -28,10 +28,10 @@ def _make_state(
     return state
 
 
-def _make_middleware(**kwargs: Any) -> CompletionNotifierMiddleware:
+def _make_middleware(**kwargs: Any) -> CompletionCallbackMiddleware:
     """Create a middleware with sensible defaults."""
     kwargs.setdefault("callback_graph_id", "parent-agent")
-    return CompletionNotifierMiddleware(**kwargs)
+    return CompletionCallbackMiddleware(**kwargs)
 
 
 class TestExtractLastMessage:
@@ -136,10 +136,10 @@ class TestNotifyParent:
         )
 
 
-class TestCompletionNotifierMiddleware:
+class TestCompletionCallbackMiddleware:
     def test_callback_graph_id_is_required(self) -> None:
         with pytest.raises(TypeError):
-            CompletionNotifierMiddleware()  # type: ignore[call-arg]
+            CompletionCallbackMiddleware()  # type: ignore[call-arg]
 
     def test_stores_callback_graph_id(self) -> None:
         mw = _make_middleware(callback_graph_id="my-parent")
@@ -299,10 +299,10 @@ class TestStateSchema:
         assert hasattr(mw, "state_schema")
 
     def test_state_schema_includes_callback_thread_id(self) -> None:
-        annotations = CompletionNotifierState.__annotations__
+        annotations = CompletionCallbackState.__annotations__
         assert "callback_thread_id" in annotations
 
     def test_state_schema_does_not_include_removed_fields(self) -> None:
-        annotations = CompletionNotifierState.__annotations__
+        annotations = CompletionCallbackState.__annotations__
         assert "parent_assistant_id" not in annotations
         assert "task_id" not in annotations

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -11,6 +11,7 @@ from deepagents.middleware.completion_notifier import (
     CompletionNotifierState,
     _extract_last_message,
     _notify_parent,
+    _resolve_headers,
 )
 
 
@@ -65,6 +66,19 @@ class TestExtractLastMessage:
         assert _extract_last_message(state) == "42"
 
 
+class TestResolveHeaders:
+    def test_adds_auth_scheme_by_default(self):
+        assert _resolve_headers(None) == {"x-auth-scheme": "langsmith"}
+
+    def test_preserves_custom_headers(self):
+        result = _resolve_headers({"x-custom": "value"})
+        assert result == {"x-custom": "value", "x-auth-scheme": "langsmith"}
+
+    def test_does_not_override_explicit_auth_scheme(self):
+        result = _resolve_headers({"x-auth-scheme": "custom"})
+        assert result == {"x-auth-scheme": "custom"}
+
+
 class TestNotifyParent:
     @patch("langgraph_sdk.get_client")
     async def test_sends_run_to_parent_thread(self, mock_get_client):
@@ -77,12 +91,31 @@ class TestNotifyParent:
             notification="Job completed",
         )
 
+        mock_get_client.assert_called_once_with(url=None, headers={"x-auth-scheme": "langsmith"})
         mock_client.runs.create.assert_awaited_once_with(
             thread_id="thread-123",
             assistant_id="supervisor",
             input={
                 "messages": [{"role": "user", "content": "Job completed"}],
             },
+        )
+
+    @patch("langgraph_sdk.get_client")
+    async def test_passes_url_and_headers(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        await _notify_parent(
+            parent_thread_id="thread-123",
+            parent_graph_id="supervisor",
+            notification="done",
+            url="https://supervisor.langsmith.dev",
+            headers={"x-custom": "val"},
+        )
+
+        mock_get_client.assert_called_once_with(
+            url="https://supervisor.langsmith.dev",
+            headers={"x-custom": "val", "x-auth-scheme": "langsmith"},
         )
 
     @patch("langgraph_sdk.get_client")
@@ -107,6 +140,22 @@ class TestCompletionNotifierMiddleware:
     def test_stores_parent_graph_id(self):
         mw = _make_middleware(parent_graph_id="my-supervisor")
         assert mw.parent_graph_id == "my-supervisor"
+
+    def test_url_defaults_to_none(self):
+        mw = _make_middleware()
+        assert mw.url is None
+
+    def test_stores_url(self):
+        mw = _make_middleware(url="https://supervisor.langsmith.dev")
+        assert mw.url == "https://supervisor.langsmith.dev"
+
+    def test_headers_defaults_to_none(self):
+        mw = _make_middleware()
+        assert mw.headers is None
+
+    def test_stores_headers(self):
+        mw = _make_middleware(headers={"x-custom": "val"})
+        assert mw.headers == {"x-custom": "val"}
 
     def test_should_notify_false_when_no_parent_thread_id(self):
         mw = _make_middleware()

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -1,0 +1,292 @@
+"""Tests for the CompletionNotifierMiddleware."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from deepagents.middleware.completion_notifier import (
+    CompletionNotifierMiddleware,
+    CompletionNotifierState,
+    _extract_last_message,
+    _notify_parent,
+)
+
+
+def _make_state(
+    *,
+    parent_thread_id: str | None = None,
+    parent_assistant_id: str | None = None,
+    task_id: str | None = None,
+    messages: list | None = None,
+) -> dict[str, Any]:
+    state: dict[str, Any] = {}
+    if messages is not None:
+        state["messages"] = messages
+    if parent_thread_id is not None:
+        state["parent_thread_id"] = parent_thread_id
+    if parent_assistant_id is not None:
+        state["parent_assistant_id"] = parent_assistant_id
+    if task_id is not None:
+        state["task_id"] = task_id
+    return state
+
+
+class TestExtractLastMessage:
+    def test_no_messages_returns_no_output(self):
+        assert _extract_last_message({}) == "(no output)"
+        assert _extract_last_message({"messages": []}) == "(no output)"
+
+    def test_dict_message_extracts_content(self):
+        state = {"messages": [{"content": "hello world"}]}
+        assert _extract_last_message(state) == "hello world"
+
+    def test_object_message_extracts_content(self):
+        msg = AIMessage(content="test result")
+        state = {"messages": [msg]}
+        assert _extract_last_message(state) == "test result"
+
+    def test_long_content_truncated_to_500_chars(self):
+        long_content = "x" * 1000
+        state = {"messages": [{"content": long_content}]}
+        result = _extract_last_message(state)
+        assert len(result) == 500
+
+    def test_non_string_content_converted_to_string(self):
+        msg = MagicMock()
+        msg.content = ["block1", "block2"]
+        state = {"messages": [msg]}
+        result = _extract_last_message(state)
+        assert "block1" in result
+
+    def test_plain_value_message_converted_to_string(self):
+        state = {"messages": [42]}
+        assert _extract_last_message(state) == "42"
+
+
+class TestNotifyParent:
+    @patch("langgraph_sdk.get_client")
+    async def test_sends_run_to_parent_thread(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        await _notify_parent(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+            notification="Job completed",
+            subagent_name="researcher",
+        )
+
+        mock_client.runs.create.assert_awaited_once_with(
+            thread_id="thread-123",
+            assistant_id="asst-456",
+            input={
+                "messages": [{"role": "user", "content": "Job completed"}],
+            },
+        )
+
+    @patch("langgraph_sdk.get_client")
+    async def test_swallows_exceptions(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.runs.create.side_effect = Exception("network error")
+        mock_get_client.return_value = mock_client
+
+        # Should not raise
+        await _notify_parent(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+            notification="Job completed",
+            subagent_name="researcher",
+        )
+
+
+class TestCompletionNotifierMiddleware:
+    def test_default_subagent_name(self):
+        mw = CompletionNotifierMiddleware()
+        assert mw.subagent_name == "subagent"
+
+    def test_custom_subagent_name(self):
+        mw = CompletionNotifierMiddleware(subagent_name="researcher")
+        assert mw.subagent_name == "researcher"
+
+    def test_should_notify_false_when_no_parent_ids(self):
+        mw = CompletionNotifierMiddleware()
+        assert not mw._should_notify({})
+
+    def test_should_notify_false_when_only_thread_id(self):
+        mw = CompletionNotifierMiddleware()
+        state = _make_state(parent_thread_id="thread-123")
+        assert not mw._should_notify(state)
+
+    def test_should_notify_false_when_only_assistant_id(self):
+        mw = CompletionNotifierMiddleware()
+        state = _make_state(parent_assistant_id="asst-456")
+        assert not mw._should_notify(state)
+
+    def test_should_notify_true_when_both_present(self):
+        mw = CompletionNotifierMiddleware()
+        state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+        )
+        assert mw._should_notify(state)
+
+    def test_should_notify_false_after_already_notified(self):
+        mw = CompletionNotifierMiddleware()
+        mw._notified = True
+        state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+        )
+        assert not mw._should_notify(state)
+
+
+class TestAfterAgent:
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_sends_completion_notification_with_task_id(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+            task_id="task-789",
+            messages=[AIMessage(content="Here is the result")],
+        )
+        runtime = MagicMock()
+
+        result = await mw.aafter_agent(state, runtime)
+
+        assert result is None
+        mock_notify.assert_awaited_once()
+        notification = mock_notify.call_args[0][2]
+        assert "[task_id=task-789]" in notification
+        assert "[subagent=coder]" in notification
+        assert "Here is the result" in notification
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_notification_without_task_id_omits_prefix(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+            messages=[AIMessage(content="result")],
+        )
+        runtime = MagicMock()
+
+        await mw.aafter_agent(state, runtime)
+
+        notification = mock_notify.call_args[0][2]
+        assert "[task_id=" not in notification
+        assert "[subagent=coder]" in notification
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_no_notification_without_parent_ids(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        state = _make_state(messages=[AIMessage(content="result")])
+        runtime = MagicMock()
+
+        await mw.aafter_agent(state, runtime)
+
+        mock_notify.assert_not_awaited()
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_notifies_only_once(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+            messages=[AIMessage(content="result")],
+        )
+        runtime = MagicMock()
+
+        await mw.aafter_agent(state, runtime)
+        await mw.aafter_agent(state, runtime)
+
+        assert mock_notify.await_count == 1
+
+
+class TestWrapModelCall:
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_passes_through_on_success(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        mock_response = MagicMock()
+        handler = AsyncMock(return_value=mock_response)
+
+        request = MagicMock()
+        request.state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+        )
+
+        result = await mw.awrap_model_call(request, handler)
+
+        assert result is mock_response
+        handler.assert_awaited_once_with(request)
+        mock_notify.assert_not_awaited()
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_sends_error_notification_on_exception(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        handler = AsyncMock(side_effect=ValueError("model crashed"))
+
+        request = MagicMock()
+        request.state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+            task_id="task-789",
+        )
+
+        with pytest.raises(ValueError, match="model crashed"):
+            await mw.awrap_model_call(request, handler)
+
+        mock_notify.assert_awaited_once()
+        notification = mock_notify.call_args[0][2]
+        assert "[task_id=task-789]" in notification
+        assert "[subagent=coder]" in notification
+        assert "model crashed" in notification
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_no_error_notification_without_parent_ids(self, mock_notify):
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        handler = AsyncMock(side_effect=ValueError("model crashed"))
+
+        request = MagicMock()
+        request.state = _make_state()
+
+        with pytest.raises(ValueError, match="model crashed"):
+            await mw.awrap_model_call(request, handler)
+
+        mock_notify.assert_not_awaited()
+
+    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
+    async def test_error_notification_only_once(self, mock_notify):
+        """If wrap_model_call is retried externally, error notification fires only once."""
+        mw = CompletionNotifierMiddleware(subagent_name="coder")
+        handler = AsyncMock(side_effect=ValueError("fail"))
+
+        request = MagicMock()
+        request.state = _make_state(
+            parent_thread_id="thread-123",
+            parent_assistant_id="asst-456",
+        )
+
+        with pytest.raises(ValueError, match="fail"):
+            await mw.awrap_model_call(request, handler)
+
+        with pytest.raises(ValueError, match="fail"):
+            await mw.awrap_model_call(request, handler)
+
+        # Only one notification even though two errors
+        assert mock_notify.await_count == 1
+
+
+class TestStateSchema:
+    def test_middleware_has_state_schema(self):
+        mw = CompletionNotifierMiddleware()
+        assert hasattr(mw, "state_schema")
+
+    def test_state_schema_includes_parent_fields(self):
+        annotations = CompletionNotifierState.__annotations__
+        assert "parent_thread_id" in annotations
+        assert "parent_assistant_id" in annotations
+        assert "task_id" in annotations

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -17,20 +17,20 @@ from deepagents.middleware.completion_notifier import (
 
 def _make_state(
     *,
-    parent_thread_id: str | None = None,
+    callback_thread_id: str | None = None,
     messages: list | None = None,
 ) -> dict[str, Any]:
     state: dict[str, Any] = {}
     if messages is not None:
         state["messages"] = messages
-    if parent_thread_id is not None:
-        state["parent_thread_id"] = parent_thread_id
+    if callback_thread_id is not None:
+        state["callback_thread_id"] = callback_thread_id
     return state
 
 
 def _make_middleware(**kwargs: Any) -> CompletionNotifierMiddleware:
     """Create a middleware with sensible defaults."""
-    kwargs.setdefault("parent_graph_id", "supervisor")
+    kwargs.setdefault("callback_graph_id", "parent-agent")
     return CompletionNotifierMiddleware(**kwargs)
 
 
@@ -86,15 +86,15 @@ class TestNotifyParent:
         mock_get_client.return_value = mock_client
 
         await _notify_parent(
-            parent_thread_id="thread-123",
-            parent_graph_id="supervisor",
+            callback_graph_id="parent-agent",
+            callback_thread_id="thread-123",
             notification="Job completed",
         )
 
         mock_get_client.assert_called_once_with(url=None, headers={"x-auth-scheme": "langsmith"})
         mock_client.runs.create.assert_awaited_once_with(
             thread_id="thread-123",
-            assistant_id="supervisor",
+            assistant_id="parent-agent",
             input={
                 "messages": [{"role": "user", "content": "Job completed"}],
             },
@@ -106,15 +106,15 @@ class TestNotifyParent:
         mock_get_client.return_value = mock_client
 
         await _notify_parent(
-            parent_thread_id="thread-123",
-            parent_graph_id="supervisor",
+            callback_graph_id="parent-agent",
+            callback_thread_id="thread-123",
             notification="done",
-            url="https://supervisor.langsmith.dev",
+            url="https://parent.langsmith.dev",
             headers={"x-custom": "val"},
         )
 
         mock_get_client.assert_called_once_with(
-            url="https://supervisor.langsmith.dev",
+            url="https://parent.langsmith.dev",
             headers={"x-custom": "val", "x-auth-scheme": "langsmith"},
         )
 
@@ -126,28 +126,28 @@ class TestNotifyParent:
 
         # Should not raise
         await _notify_parent(
-            parent_thread_id="thread-123",
-            parent_graph_id="supervisor",
+            callback_graph_id="parent-agent",
+            callback_thread_id="thread-123",
             notification="Job completed",
         )
 
 
 class TestCompletionNotifierMiddleware:
-    def test_parent_graph_id_is_required(self):
+    def test_callback_graph_id_is_required(self):
         with pytest.raises(TypeError):
             CompletionNotifierMiddleware()  # type: ignore[call-arg]
 
-    def test_stores_parent_graph_id(self):
-        mw = _make_middleware(parent_graph_id="my-supervisor")
-        assert mw.parent_graph_id == "my-supervisor"
+    def test_stores_callback_graph_id(self):
+        mw = _make_middleware(callback_graph_id="my-parent")
+        assert mw.callback_graph_id == "my-parent"
 
     def test_url_defaults_to_none(self):
         mw = _make_middleware()
         assert mw.url is None
 
     def test_stores_url(self):
-        mw = _make_middleware(url="https://supervisor.langsmith.dev")
-        assert mw.url == "https://supervisor.langsmith.dev"
+        mw = _make_middleware(url="https://parent.langsmith.dev")
+        assert mw.url == "https://parent.langsmith.dev"
 
     def test_headers_defaults_to_none(self):
         mw = _make_middleware()
@@ -157,28 +157,28 @@ class TestCompletionNotifierMiddleware:
         mw = _make_middleware(headers={"x-custom": "val"})
         assert mw.headers == {"x-custom": "val"}
 
-    def test_should_notify_false_when_no_parent_thread_id(self):
+    def test_should_notify_false_when_no_callback_thread_id(self):
         mw = _make_middleware()
         assert not mw._should_notify({})
 
-    def test_should_notify_true_when_parent_thread_id_present(self):
+    def test_should_notify_true_when_callback_thread_id_present(self):
         mw = _make_middleware()
-        state = _make_state(parent_thread_id="thread-123")
+        state = _make_state(callback_thread_id="thread-123")
         assert mw._should_notify(state)
 
     def test_should_notify_false_after_already_notified(self):
         mw = _make_middleware()
         mw._notified = True
-        state = _make_state(parent_thread_id="thread-123")
+        state = _make_state(callback_thread_id="thread-123")
         assert not mw._should_notify(state)
 
 
 class TestAfterAgent:
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
     async def test_sends_completion_notification(self, mock_notify):
-        mw = _make_middleware(parent_graph_id="supervisor")
+        mw = _make_middleware(callback_graph_id="parent-agent")
         state = _make_state(
-            parent_thread_id="thread-123",
+            callback_thread_id="thread-123",
             messages=[AIMessage(content="Here is the result")],
         )
         runtime = MagicMock()
@@ -187,8 +187,8 @@ class TestAfterAgent:
 
         assert result is None
         mock_notify.assert_awaited_once()
-        assert mock_notify.call_args[0][0] == "thread-123"
-        assert mock_notify.call_args[0][1] == "supervisor"
+        assert mock_notify.call_args[0][0] == "parent-agent"
+        assert mock_notify.call_args[0][1] == "thread-123"
         notification = mock_notify.call_args[0][2]
         assert "Here is the result" in notification
 
@@ -196,7 +196,7 @@ class TestAfterAgent:
     async def test_notification_includes_task_id_from_config(self, mock_notify):
         mw = _make_middleware()
         state = _make_state(
-            parent_thread_id="thread-123",
+            callback_thread_id="thread-123",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
@@ -214,7 +214,7 @@ class TestAfterAgent:
     async def test_notification_without_task_id_omits_prefix(self, mock_notify):
         mw = _make_middleware()
         state = _make_state(
-            parent_thread_id="thread-123",
+            callback_thread_id="thread-123",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
@@ -229,7 +229,7 @@ class TestAfterAgent:
         assert "[task_id=" not in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_no_notification_without_parent_thread_id(self, mock_notify):
+    async def test_no_notification_without_callback_thread_id(self, mock_notify):
         mw = _make_middleware()
         state = _make_state(messages=[AIMessage(content="result")])
         runtime = MagicMock()
@@ -242,7 +242,7 @@ class TestAfterAgent:
     async def test_notifies_only_once(self, mock_notify):
         mw = _make_middleware()
         state = _make_state(
-            parent_thread_id="thread-123",
+            callback_thread_id="thread-123",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
@@ -261,7 +261,7 @@ class TestWrapModelCall:
         handler = AsyncMock(return_value=mock_response)
 
         request = MagicMock()
-        request.state = _make_state(parent_thread_id="thread-123")
+        request.state = _make_state(callback_thread_id="thread-123")
 
         result = await mw.awrap_model_call(request, handler)
 
@@ -275,7 +275,7 @@ class TestWrapModelCall:
         handler = AsyncMock(side_effect=ValueError("model crashed"))
 
         request = MagicMock()
-        request.state = _make_state(parent_thread_id="thread-123")
+        request.state = _make_state(callback_thread_id="thread-123")
 
         with pytest.raises(ValueError, match="model crashed"):
             await mw.awrap_model_call(request, handler)
@@ -285,7 +285,7 @@ class TestWrapModelCall:
         assert "model crashed" in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_no_error_notification_without_parent_thread_id(self, mock_notify):
+    async def test_no_error_notification_without_callback_thread_id(self, mock_notify):
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
 
@@ -304,7 +304,7 @@ class TestWrapModelCall:
         handler = AsyncMock(side_effect=ValueError("fail"))
 
         request = MagicMock()
-        request.state = _make_state(parent_thread_id="thread-123")
+        request.state = _make_state(callback_thread_id="thread-123")
 
         with pytest.raises(ValueError, match="fail"):
             await mw.awrap_model_call(request, handler)
@@ -343,9 +343,9 @@ class TestStateSchema:
         mw = _make_middleware()
         assert hasattr(mw, "state_schema")
 
-    def test_state_schema_includes_parent_thread_id(self):
+    def test_state_schema_includes_callback_thread_id(self):
         annotations = CompletionNotifierState.__annotations__
-        assert "parent_thread_id" in annotations
+        assert "callback_thread_id" in annotations
 
     def test_state_schema_does_not_include_removed_fields(self):
         annotations = CompletionNotifierState.__annotations__

--- a/libs/deepagents/tests/unit_tests/test_completion_notifier.py
+++ b/libs/deepagents/tests/unit_tests/test_completion_notifier.py
@@ -35,60 +35,65 @@ def _make_middleware(**kwargs: Any) -> CompletionNotifierMiddleware:
 
 
 class TestExtractLastMessage:
-    def test_no_messages_returns_no_output(self):
-        assert _extract_last_message({}) == "(no output)"
-        assert _extract_last_message({"messages": []}) == "(no output)"
+    def test_no_messages_raises_assertion_error(self) -> None:
+        with pytest.raises(AssertionError, match="Expected at least one message"):
+            _extract_last_message({})
 
-    def test_dict_message_extracts_content(self):
+        with pytest.raises(AssertionError, match="Expected at least one message"):
+            _extract_last_message({"messages": []})
+
+    def test_dict_message_raises_type_error(self) -> None:
         state = {"messages": [{"content": "hello world"}]}
-        assert _extract_last_message(state) == "hello world"
+        with pytest.raises(TypeError, match="Expected an AIMessage"):
+            _extract_last_message(state)
 
-    def test_object_message_extracts_content(self):
+    def test_object_message_extracts_content(self) -> None:
         msg = AIMessage(content="test result")
         state = {"messages": [msg]}
         assert _extract_last_message(state) == "test result"
 
-    def test_long_content_truncated_to_500_chars(self):
+    def test_long_content_truncated_to_ellipsis_suffix(self) -> None:
         long_content = "x" * 1000
-        state = {"messages": [{"content": long_content}]}
+        state = {"messages": [AIMessage(content=long_content)]}
         result = _extract_last_message(state)
-        assert len(result) == 500
+        assert result == ("x" * 500) + "... [full result truncated]"
 
-    def test_non_string_content_converted_to_string(self):
+    def test_non_ai_message_raises_type_error(self) -> None:
         msg = MagicMock()
         msg.content = ["block1", "block2"]
         state = {"messages": [msg]}
-        result = _extract_last_message(state)
-        assert "block1" in result
+        with pytest.raises(TypeError, match="Expected an AIMessage"):
+            _extract_last_message(state)
 
-    def test_plain_value_message_converted_to_string(self):
+    def test_plain_value_message_raises_type_error(self) -> None:
         state = {"messages": [42]}
-        assert _extract_last_message(state) == "42"
+        with pytest.raises(TypeError, match="Expected an AIMessage"):
+            _extract_last_message(state)
 
 
 class TestResolveHeaders:
-    def test_adds_auth_scheme_by_default(self):
+    def test_adds_auth_scheme_by_default(self) -> None:
         assert _resolve_headers(None) == {"x-auth-scheme": "langsmith"}
 
-    def test_preserves_custom_headers(self):
+    def test_preserves_custom_headers(self) -> None:
         result = _resolve_headers({"x-custom": "value"})
         assert result == {"x-custom": "value", "x-auth-scheme": "langsmith"}
 
-    def test_does_not_override_explicit_auth_scheme(self):
+    def test_does_not_override_explicit_auth_scheme(self) -> None:
         result = _resolve_headers({"x-auth-scheme": "custom"})
         assert result == {"x-auth-scheme": "custom"}
 
 
 class TestNotifyParent:
     @patch("langgraph_sdk.get_client")
-    async def test_sends_run_to_parent_thread(self, mock_get_client):
+    async def test_sends_run_to_parent_thread(self, mock_get_client: MagicMock) -> None:
         mock_client = AsyncMock()
         mock_get_client.return_value = mock_client
 
         await _notify_parent(
             callback_graph_id="parent-agent",
             callback_thread_id="thread-123",
-            notification="Job completed",
+            message="Job completed",
         )
 
         mock_get_client.assert_called_once_with(url=None, headers={"x-auth-scheme": "langsmith"})
@@ -101,14 +106,14 @@ class TestNotifyParent:
         )
 
     @patch("langgraph_sdk.get_client")
-    async def test_passes_url_and_headers(self, mock_get_client):
+    async def test_passes_url_and_headers(self, mock_get_client: MagicMock) -> None:
         mock_client = AsyncMock()
         mock_get_client.return_value = mock_client
 
         await _notify_parent(
             callback_graph_id="parent-agent",
             callback_thread_id="thread-123",
-            notification="done",
+            message="done",
             url="https://parent.langsmith.dev",
             headers={"x-custom": "val"},
         )
@@ -119,69 +124,55 @@ class TestNotifyParent:
         )
 
     @patch("langgraph_sdk.get_client")
-    async def test_swallows_exceptions(self, mock_get_client):
+    async def test_swallows_exceptions(self, mock_get_client: MagicMock) -> None:
         mock_client = AsyncMock()
         mock_client.runs.create.side_effect = Exception("network error")
         mock_get_client.return_value = mock_client
 
-        # Should not raise
         await _notify_parent(
             callback_graph_id="parent-agent",
             callback_thread_id="thread-123",
-            notification="Job completed",
+            message="Job completed",
         )
 
 
 class TestCompletionNotifierMiddleware:
-    def test_callback_graph_id_is_required(self):
+    def test_callback_graph_id_is_required(self) -> None:
         with pytest.raises(TypeError):
             CompletionNotifierMiddleware()  # type: ignore[call-arg]
 
-    def test_stores_callback_graph_id(self):
+    def test_stores_callback_graph_id(self) -> None:
         mw = _make_middleware(callback_graph_id="my-parent")
         assert mw.callback_graph_id == "my-parent"
 
-    def test_url_defaults_to_none(self):
+    def test_url_defaults_to_none(self) -> None:
         mw = _make_middleware()
         assert mw.url is None
 
-    def test_stores_url(self):
+    def test_stores_url(self) -> None:
         mw = _make_middleware(url="https://parent.langsmith.dev")
         assert mw.url == "https://parent.langsmith.dev"
 
-    def test_headers_defaults_to_none(self):
+    def test_headers_defaults_to_none(self) -> None:
         mw = _make_middleware()
         assert mw.headers is None
 
-    def test_stores_headers(self):
+    def test_stores_headers(self) -> None:
         mw = _make_middleware(headers={"x-custom": "val"})
         assert mw.headers == {"x-custom": "val"}
 
-    def test_should_notify_false_when_no_callback_thread_id(self):
-        mw = _make_middleware()
-        assert not mw._should_notify({})
-
-    def test_should_notify_true_when_callback_thread_id_present(self):
-        mw = _make_middleware()
-        state = _make_state(callback_thread_id="thread-123")
-        assert mw._should_notify(state)
-
-    def test_should_notify_false_after_already_notified(self):
-        mw = _make_middleware()
-        mw._notified = True
-        state = _make_state(callback_thread_id="thread-123")
-        assert not mw._should_notify(state)
-
 
 class TestAfterAgent:
+    @patch("deepagents.middleware.completion_notifier.get_config")
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_sends_completion_notification(self, mock_notify):
+    async def test_sends_completion_notification(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware(callback_graph_id="parent-agent")
         state = _make_state(
             callback_thread_id="thread-123",
             messages=[AIMessage(content="Here is the result")],
         )
         runtime = MagicMock()
+        mock_get_config.return_value = {"configurable": {"thread_id": "task-789"}}
 
         result = await mw.aafter_agent(state, runtime)
 
@@ -190,72 +181,55 @@ class TestAfterAgent:
         assert mock_notify.call_args[0][0] == "parent-agent"
         assert mock_notify.call_args[0][1] == "thread-123"
         notification = mock_notify.call_args[0][2]
-        assert "Here is the result" in notification
+        assert notification == "[task_id=task-789]Completed. Result: Here is the result"
 
+    @patch("deepagents.middleware.completion_notifier.get_config")
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_notification_includes_task_id_from_config(self, mock_notify):
+    async def test_notification_includes_task_id_from_config(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         state = _make_state(
             callback_thread_id="thread-123",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
+        mock_get_config.return_value = {"configurable": {"thread_id": "task-789"}}
 
-        with patch(
-            "deepagents.middleware.completion_notifier.CompletionNotifierMiddleware._get_task_id",
-            return_value="task-789",
-        ):
-            await mw.aafter_agent(state, runtime)
+        await mw.aafter_agent(state, runtime)
 
         notification = mock_notify.call_args[0][2]
         assert "[task_id=task-789]" in notification
 
+    @patch("deepagents.middleware.completion_notifier.get_config")
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_notification_without_task_id_omits_prefix(self, mock_notify):
+    async def test_aafter_agent_raises_outside_runnable_context(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         state = _make_state(
             callback_thread_id="thread-123",
             messages=[AIMessage(content="result")],
         )
         runtime = MagicMock()
+        mock_get_config.side_effect = RuntimeError("Called get_config outside of a runnable context")
 
-        with patch(
-            "deepagents.middleware.completion_notifier.CompletionNotifierMiddleware._get_task_id",
-            return_value=None,
-        ):
+        with pytest.raises(RuntimeError, match="Called get_config outside of a runnable context"):
             await mw.aafter_agent(state, runtime)
-
-        notification = mock_notify.call_args[0][2]
-        assert "[task_id=" not in notification
-
-    @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_no_notification_without_callback_thread_id(self, mock_notify):
-        mw = _make_middleware()
-        state = _make_state(messages=[AIMessage(content="result")])
-        runtime = MagicMock()
-
-        await mw.aafter_agent(state, runtime)
 
         mock_notify.assert_not_awaited()
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_notifies_only_once(self, mock_notify):
+    async def test_aafter_agent_raises_without_callback_thread_id(self, mock_notify: AsyncMock) -> None:
         mw = _make_middleware()
-        state = _make_state(
-            callback_thread_id="thread-123",
-            messages=[AIMessage(content="result")],
-        )
+        state = _make_state(messages=[AIMessage(content="result")])
         runtime = MagicMock()
 
-        await mw.aafter_agent(state, runtime)
-        await mw.aafter_agent(state, runtime)
+        with pytest.raises(KeyError, match="callback_thread_id"):
+            await mw.aafter_agent(state, runtime)
 
-        assert mock_notify.await_count == 1
+        mock_notify.assert_not_awaited()
 
 
 class TestWrapModelCall:
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_passes_through_on_success(self, mock_notify):
+    async def test_passes_through_on_success(self, mock_notify: AsyncMock) -> None:
         mw = _make_middleware()
         mock_response = MagicMock()
         handler = AsyncMock(return_value=mock_response)
@@ -269,23 +243,26 @@ class TestWrapModelCall:
         handler.assert_awaited_once_with(request)
         mock_notify.assert_not_awaited()
 
+    @patch("deepagents.middleware.completion_notifier.get_config")
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_sends_error_notification_on_exception(self, mock_notify):
+    async def test_sends_generic_error_notification_on_exception(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
 
         request = MagicMock()
         request.state = _make_state(callback_thread_id="thread-123")
+        mock_get_config.return_value = {"configurable": {"thread_id": "task-789"}}
 
         with pytest.raises(ValueError, match="model crashed"):
             await mw.awrap_model_call(request, handler)
 
         mock_notify.assert_awaited_once()
         notification = mock_notify.call_args[0][2]
-        assert "model crashed" in notification
+        assert "The agent encountered an error while calling the model." in notification
+        assert "model crashed" not in notification
 
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_no_error_notification_without_callback_thread_id(self, mock_notify):
+    async def test_no_error_notification_without_callback_thread_id(self, mock_notify: AsyncMock) -> None:
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("model crashed"))
 
@@ -297,14 +274,15 @@ class TestWrapModelCall:
 
         mock_notify.assert_not_awaited()
 
+    @patch("deepagents.middleware.completion_notifier.get_config")
     @patch("deepagents.middleware.completion_notifier._notify_parent", new_callable=AsyncMock)
-    async def test_error_notification_only_once(self, mock_notify):
-        """If wrap_model_call is retried externally, error notification fires only once."""
+    async def test_error_notification_on_each_exception(self, mock_notify: AsyncMock, mock_get_config: MagicMock) -> None:
         mw = _make_middleware()
         handler = AsyncMock(side_effect=ValueError("fail"))
 
         request = MagicMock()
         request.state = _make_state(callback_thread_id="thread-123")
+        mock_get_config.return_value = {"configurable": {"thread_id": "task-789"}}
 
         with pytest.raises(ValueError, match="fail"):
             await mw.awrap_model_call(request, handler)
@@ -312,42 +290,19 @@ class TestWrapModelCall:
         with pytest.raises(ValueError, match="fail"):
             await mw.awrap_model_call(request, handler)
 
-        assert mock_notify.await_count == 1
-
-
-class TestGetTaskId:
-    def test_returns_thread_id_from_config(self):
-        mw = _make_middleware()
-        with patch(
-            "langgraph.config.get_config",
-            return_value={"configurable": {"thread_id": "thread-abc"}},
-        ):
-            assert mw._get_task_id() == "thread-abc"
-
-    def test_returns_none_outside_runnable_context(self):
-        mw = _make_middleware()
-        # get_config raises RuntimeError outside a runnable context
-        assert mw._get_task_id() is None
-
-    def test_returns_none_when_no_thread_id(self):
-        mw = _make_middleware()
-        with patch(
-            "langgraph.config.get_config",
-            return_value={"configurable": {}},
-        ):
-            assert mw._get_task_id() is None
+        assert mock_notify.await_count == 2
 
 
 class TestStateSchema:
-    def test_middleware_has_state_schema(self):
+    def test_middleware_has_state_schema(self) -> None:
         mw = _make_middleware()
         assert hasattr(mw, "state_schema")
 
-    def test_state_schema_includes_callback_thread_id(self):
+    def test_state_schema_includes_callback_thread_id(self) -> None:
         annotations = CompletionNotifierState.__annotations__
         assert "callback_thread_id" in annotations
 
-    def test_state_schema_does_not_include_removed_fields(self):
+    def test_state_schema_does_not_include_removed_fields(self) -> None:
         annotations = CompletionNotifierState.__annotations__
         assert "parent_assistant_id" not in annotations
         assert "task_id" not in annotations

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -419,6 +419,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -448,6 +449,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1073,6 +1073,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -1083,6 +1084,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -638,6 +638,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -648,6 +649,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -584,6 +584,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -594,6 +595,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4.0"
 
 [manifest]
@@ -411,6 +411,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -421,6 +422,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -392,6 +392,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langgraph-sdk" },
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
@@ -402,6 +403,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.19,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
+    { name = "langgraph-sdk", specifier = ">=0.1.51" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]


### PR DESCRIPTION
## Summary

Adds a pre-bundled `CompletionNotifierMiddleware` that async subagents can use to proactively notify their supervisor when they complete or error -- closing the gap where the supervisor only learns about completion when someone calls `check_async_task`.

## Why

The async subagent protocol is fire-and-forget: the supervisor launches a task and only discovers its outcome when it (or the user) polls via `check_async_task`. This means the supervisor can't proactively relay results -- the user has to ask. The completion notifier solves this by having the subagent push a notification to the supervisor's thread when it finishes.

This is an opt-in middleware added to the **subagent's** stack, not the supervisor's. If the subagent doesn't use it, the extra input keys are silently ignored by LangGraph (verified against both in-process `invoke()` and `langgraph dev` via SDK).

## Architecture

```
Supervisor                    Subagent
    |                            |
    |--- start_async_task -----> |
    |<-- task_id (immediately) - |
    |                            |  (working...)
    |                            |  (done!)
    |                            |
    |<-- runs.create(            |
    |      supervisor_thread,    |
    |      "completed: ...")     |
    |                            |
    |  (wakes up, sees result)   |
```

**Parent context propagation:** The supervisor's `start_async_task` tool now includes `parent_thread_id`, `parent_assistant_id`, and `task_id` in the subagent's input state. The notifier reads these from state (not config), which means they survive thread interrupts and `update_async_task` calls. If the subagent doesn't have the middleware, these keys are silently dropped.

**Notification format:** Includes `task_id` so the supervisor can correlate notifications back to specific tracked jobs when multiple tasks of the same subagent type run concurrently:
```
[task_id=thread_abc][subagent=researcher] Completed. Result: <summary>
[task_id=thread_abc][subagent=researcher] Error: <error message>
```

## Changes

### New: `CompletionNotifierMiddleware` (`deepagents/middleware/completion_notifier.py`)
- `aafter_agent` hook sends a completion notification with result summary (truncated to 500 chars)
- `awrap_model_call` hook catches errors and sends an error notification before re-raising
- `CompletionNotifierState` adds `parent_thread_id`, `parent_assistant_id`, and `task_id` to the subagent's state schema
- Notifies only once per run (guards against duplicates)
- Silently no-ops if parent context is missing (subagent launched without a supervisor)
- Uses `get_client()` with no URL (ASGI transport for same-deployment)

### Modified: `async_subagents.py`
- Added `_extract_parent_context()` to read supervisor's thread_id and assistant_id from tool runtime config
- `start_async_task` (sync + async) now includes `task_id`, `parent_thread_id`, `parent_assistant_id` in the subagent's input

### Modified: `pyproject.toml`
- Added `langgraph-sdk>=0.1.51` as a required dependency (was already imported unconditionally)

### Exports
- `CompletionNotifierMiddleware` exported from `deepagents.middleware` and top-level `deepagents`

## Open questions

- **`assistant_id` availability:** Need to validate that `config.metadata.assistant_id` is always present in deployed contexts. If there are cases where it's missing, the notifier silently no-ops (safe), but the notification won't fire.
- **Divergence from JS:** The JS reference implementation passes parent IDs as constructor args at graph factory time (from config). The Python implementation reads them from state, which is a deliberate improvement (survives interrupts, no dynamic factory needed) but a divergence.

## How to review

The core middleware is in `completion_notifier.py` -- start there. The `async_subagents.py` changes are mechanical (extract parent context, spread into input). Tests cover all the hooks, edge cases, and the parent context propagation.

---

> [!NOTE]
> This PR was developed with assistance from an AI coding agent.