### PR TITLE
feat(cli): AgentCore Code Interpreter sandbox provider

### DIFF
--- a/examples/ralph_mode/README.md
+++ b/examples/ralph_mode/README.md
@@ -49,7 +49,7 @@ python ralph_mode.py "Create a CLI tool" --model claude-sonnet-4-6
 # With a specific working directory
 python ralph_mode.py "Build a web app" --work-dir ./my-project
 
-# Run in a remote sandbox (Modal, Daytona, or Runloop)
+# Run in a remote sandbox (AgentCore, Modal, Daytona, or Runloop)
 python ralph_mode.py "Build an app" --sandbox modal
 python ralph_mode.py "Build an app" --sandbox daytona --sandbox-setup ./setup.sh
 
@@ -77,7 +77,7 @@ for provider setup (API keys, etc.) and the
 [sandboxes concept guide](https://docs.langchain.com/oss/python/deepagents/sandboxes)
 for architecture details.
 
-Supported providers: **Modal**, **Daytona**, **Runloop**.
+Supported providers: **AgentCore**, **Modal**, **Daytona**, **Runloop**.
 
 ## How It Works
 

--- a/examples/ralph_mode/ralph_mode.py
+++ b/examples/ralph_mode/ralph_mode.py
@@ -75,7 +75,7 @@ async def ralph(
             to auto-detection from environment API keys
             (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`).
         model_params: Additional model parameters (e.g. `{"temperature": 0.5}`).
-        sandbox_type: Sandbox provider (`"none"`, `"modal"`, `"daytona"`, etc.).
+        sandbox_type: Sandbox provider (`"none"`, `"agentcore"`, `"modal"`, `"daytona"`, etc.).
         sandbox_id: Existing sandbox instance ID to reuse.
         sandbox_setup: Path to a setup script to run inside the sandbox.
         stream: Whether to stream model output.
@@ -190,7 +190,7 @@ Examples:
     parser.add_argument(
         "--sandbox",
         default="none",
-        help="Sandbox provider (e.g., modal, daytona). Default: none",
+        help="Sandbox provider (e.g., agentcore, modal, daytona). Default: none",
     )
     parser.add_argument(
         "--sandbox-id",

--- a/libs/README.md
+++ b/libs/README.md
@@ -20,6 +20,7 @@ partners/            # Sandbox provider integrations (see below)
 
 The `partners/` directory contains sandbox provider integrations:
 
+* [AgentCore](https://pypi.org/project/langchain-agentcore-codeinterpreter/)
 * [Daytona](https://pypi.org/project/langchain-daytona/)
 * [Modal](https://pypi.org/project/langchain-modal/)
 * [QuickJS](https://pypi.org/project/langchain-quickjs/)

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -42,7 +42,7 @@ The fastest way to start using Deep Agents. `deepagents-cli` is a pre-built codi
 - **Interactive TUI** — rich terminal interface with streaming responses
 - **Conversation resume** — pick up where you left off across sessions
 - **Web search** — ground responses in live information
-- **Remote sandboxes** — run code in isolated environments (LangSmith, Daytona, Modal, Runloop, & more)
+- **Remote sandboxes** — run code in isolated environments (LangSmith, AgentCore, Daytona, Modal, Runloop, & more)
 - **Persistent memory** — agent remembers context across conversations
 - **Custom skills** — extend the agent with your own slash commands
 - **Headless mode** — run non-interactively for scripting and CI

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -321,7 +321,7 @@ def get_system_prompt(
     Args:
         assistant_id: The agent identifier for path references
         sandbox_type: Type of sandbox provider
-            (`'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
+            (`'agentcore'`, `'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
 
             If `None`, agent is operating in local mode.
         interactive: When `False`, the prompt is tailored for headless
@@ -696,7 +696,7 @@ def create_cli_agent(
 
             If `None`, uses local filesystem + shell.
         sandbox_type: Type of sandbox provider
-            (`'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
+            (`'agentcore'`, `'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
             Used for system prompt generation.
         system_prompt: Override the default system prompt.
 

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -602,16 +602,16 @@ class _RunloopProvider(SandboxProvider):
 class _AgentCoreProvider(SandboxProvider):
     """AgentCore Code Interpreter sandbox provider.
 
-    Manages AgentCore session lifecycle. Sessions cannot be reconnected
-    after the CLI exits — the ``sandbox_id`` parameter is not supported.
+    Manages AgentCore session lifecycle. Sessions cannot be reconnected after
+    the CLI exits — the `sandbox_id` parameter is not supported.
     """
 
     def __init__(self, region: str | None = None) -> None:
         """Initialize AgentCore provider.
 
         Args:
-            region: AWS region (defaults to ``AWS_REGION`` /
-                ``AWS_DEFAULT_REGION`` / ``us-west-2``).
+            region: AWS region (defaults to `AWS_REGION` /
+                `AWS_DEFAULT_REGION` / `us-west-2`).
 
         Raises:
             ValueError: If AWS credentials cannot be resolved.
@@ -651,15 +651,15 @@ class _AgentCoreProvider(SandboxProvider):
         """Create a new AgentCore Code Interpreter session.
 
         Args:
-            sandbox_id: Not supported — raises ``NotImplementedError``
+            sandbox_id: Not supported — raises `NotImplementedError`
                 if provided.
             **kwargs: Additional parameters (unused).
 
         Returns:
-            ``AgentCoreSandbox`` instance wrapping the started interpreter.
+            `AgentCoreSandbox` instance wrapping the started interpreter.
 
         Raises:
-            NotImplementedError: If ``sandbox_id`` is provided.
+            NotImplementedError: If `sandbox_id` is provided.
         """
         if sandbox_id:
             msg = (

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -614,7 +614,8 @@ class _AgentCoreProvider(SandboxProvider):
                 `AWS_DEFAULT_REGION` / `us-west-2`).
 
         Raises:
-            ValueError: If AWS credentials cannot be resolved.
+            ValueError: If boto3 is installed and AWS credentials cannot
+                be resolved.
         """
         self._region = region or os.environ.get(
             "AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
@@ -622,23 +623,27 @@ class _AgentCoreProvider(SandboxProvider):
 
         # Validate AWS credentials early for a clear error message.
         try:
-            import boto3  # ty: ignore[unresolved-import, unused-ignore-comment]
+            import boto3  # ty: ignore[unresolved-import]
 
             session = boto3.Session()
             credentials = session.get_credentials()
             if credentials is None:
                 msg = (
                     "AWS credentials not found. Configure via "
-                    "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SECRET_ACCESS_TOKEN, "
+                    "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN, "
                     "~/.aws/credentials, or an IAM role."
                 )
-                raise ValueError(msg)  # noqa: TRY301
+                raise ValueError(msg)  # noqa: TRY301  # intentional raise for early credential validation
         except ImportError:
-            pass  # boto3 will fail later with a clear message
+            logger.debug("boto3 not installed; skipping credential pre-check")
         except ValueError:
             raise
         except Exception:
-            logger.debug("Could not validate AWS credentials", exc_info=True)
+            logger.warning(
+                "AWS credential pre-validation failed — the session may "
+                "fail to start. Check your AWS configuration.",
+                exc_info=True,
+            )
 
         self._active_interpreters: dict[str, Any] = {}
 
@@ -646,7 +651,7 @@ class _AgentCoreProvider(SandboxProvider):
         self,
         *,
         sandbox_id: str | None = None,
-        **kwargs: Any,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002  # required by SandboxProvider interface
     ) -> SandboxBackendProtocol:
         """Create a new AgentCore Code Interpreter session.
 
@@ -683,13 +688,18 @@ class _AgentCoreProvider(SandboxProvider):
             region=self._region,
             integration_source="deepagents-cli",
         )
-        interpreter.start()
+        try:
+            interpreter.start()
+        except Exception:
+            with contextlib.suppress(Exception):
+                interpreter.stop()
+            raise
 
         backend = agentcore_backend.AgentCoreSandbox(interpreter=interpreter)
         self._active_interpreters[backend.id] = interpreter
         return backend
 
-    def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002
+    def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002  # required by SandboxProvider interface
         """Stop an AgentCore session.
 
         Args:
@@ -703,7 +713,9 @@ class _AgentCoreProvider(SandboxProvider):
                 logger.info("AgentCore session %s stopped", sandbox_id)
             except Exception:
                 logger.warning(
-                    "Failed to stop AgentCore session %s",
+                    "Failed to stop AgentCore session %s — the session may "
+                    "still be running and incurring costs. Check the AWS "
+                    "console to verify.",
                     sandbox_id,
                     exc_info=True,
                 )

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -72,6 +72,7 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
 
 
 _PROVIDER_TO_WORKING_DIR = {
+    "agentcore": "/tmp",  # noqa: S108 # AgentCore Code Interpreter working directory
     "daytona": "/home/daytona",
     "langsmith": "/tmp",  # noqa: S108  # LangSmith sandbox working directory
     "modal": "/workspace",
@@ -93,7 +94,7 @@ def create_sandbox(
     provider abstraction.
 
     Args:
-        provider: Sandbox provider (`'daytona'`, `'langsmith'`,
+        provider: Sandbox provider (`'agentcore'`, `'daytona'`, `'langsmith'`,
             `'modal'`, `'runloop'`)
         sandbox_id: Optional existing sandbox ID to reuse
         setup_script_path: Optional path to setup script to run after sandbox starts
@@ -155,7 +156,7 @@ def get_default_working_dir(provider: str) -> str:
     """Get the default working directory for a given sandbox provider.
 
     Args:
-        provider: Sandbox provider name (`'daytona'`, `'langsmith'`,
+        provider: Sandbox provider name (`'agentcore'`, `'daytona'`, `'langsmith'`,
             `'modal'`, `'runloop'`)
 
     Returns:
@@ -598,11 +599,126 @@ class _RunloopProvider(SandboxProvider):
         self._client.devboxes.shutdown(id=sandbox_id)
 
 
+class _AgentCoreProvider(SandboxProvider):
+    """AgentCore Code Interpreter sandbox provider.
+
+    Manages AgentCore session lifecycle. Sessions cannot be reconnected
+    after the CLI exits — the ``sandbox_id`` parameter is not supported.
+    """
+
+    def __init__(self, region: str | None = None) -> None:
+        """Initialize AgentCore provider.
+
+        Args:
+            region: AWS region (defaults to ``AWS_REGION`` /
+                ``AWS_DEFAULT_REGION`` / ``us-west-2``).
+
+        Raises:
+            ValueError: If AWS credentials cannot be resolved.
+        """
+        self._region = region or os.environ.get(
+            "AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+        )
+
+        # Validate AWS credentials early for a clear error message.
+        try:
+            import boto3
+
+            session = boto3.Session()
+            credentials = session.get_credentials()
+            if credentials is None:
+                msg = (
+                    "AWS credentials not found. Configure via "
+                    "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SECRET_ACCESS_TOKEN, "
+                    "~/.aws/credentials, or an IAM role."
+                )
+                raise ValueError(msg)  # noqa: TRY301
+        except ImportError:
+            pass  # boto3 will fail later with a clear message
+        except ValueError:
+            raise
+        except Exception:
+            logger.debug("Could not validate AWS credentials", exc_info=True)
+
+        self._active_interpreters: dict[str, Any] = {}
+
+    def get_or_create(
+        self,
+        *,
+        sandbox_id: str | None = None,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> SandboxBackendProtocol:
+        """Create a new AgentCore Code Interpreter session.
+
+        Args:
+            sandbox_id: Not supported — raises ``NotImplementedError``
+                if provided.
+            **kwargs: Additional parameters (unused).
+
+        Returns:
+            ``AgentCoreSandbox`` instance wrapping the started interpreter.
+
+        Raises:
+            NotImplementedError: If ``sandbox_id`` is provided.
+        """
+        if sandbox_id:
+            msg = (
+                "AgentCore does not support reconnecting to existing sessions. "
+                "Remove the --sandbox-id option."
+            )
+            raise NotImplementedError(msg)
+
+        agentcore_module = _import_provider_module(
+            "bedrock_agentcore.tools.code_interpreter_client",
+            provider="agentcore",
+            package="langchain-agentcore-codeinterpreter",
+        )
+        agentcore_backend = _import_provider_module(
+            "langchain_agentcore_codeinterpreter",
+            provider="agentcore",
+            package="langchain-agentcore-codeinterpreter",
+        )
+
+        interpreter = agentcore_module.CodeInterpreter(
+            region=self._region,
+            integration_source="deepagents-cli",
+        )
+        interpreter.start()
+
+        backend = agentcore_backend.AgentCoreSandbox(interpreter=interpreter)
+        self._active_interpreters[backend.id] = interpreter
+        return backend
+
+    def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002
+        """Stop an AgentCore session.
+
+        Args:
+            sandbox_id: Session ID to stop.
+            **kwargs: Additional parameters (unused).
+        """
+        interpreter = self._active_interpreters.pop(sandbox_id, None)
+        if interpreter:
+            try:
+                interpreter.stop()
+                logger.info("AgentCore session %s stopped", sandbox_id)
+            except Exception:
+                logger.warning(
+                    "Failed to stop AgentCore session %s",
+                    sandbox_id,
+                    exc_info=True,
+                )
+        else:
+            logger.info(
+                "AgentCore session %s not tracked (may have already expired)",
+                sandbox_id,
+            )
+
+
 def _get_provider(provider_name: str) -> SandboxProvider:
     """Get a `SandboxProvider` instance for the specified provider (internal).
 
     Args:
-        provider_name: Name of the provider (`'daytona'`, `'langsmith'`,
+        provider_name: Name of the provider (`'agentcore'`, `'daytona'`, `'langsmith'`,
             `'modal'`, `'runloop'`)
 
     Returns:
@@ -611,6 +727,8 @@ def _get_provider(provider_name: str) -> SandboxProvider:
     Raises:
         ValueError: If `provider_name` is unknown.
     """
+    if provider_name == "agentcore":
+        return _AgentCoreProvider()
     if provider_name == "daytona":
         return _DaytonaProvider()
     if provider_name == "langsmith":
@@ -647,6 +765,7 @@ def verify_sandbox_deps(provider: str) -> None:
     # Only the backend module is checked because the underlying SDK is a
     # transitive dependency of the backend package.
     backend_modules: dict[str, tuple[str, str]] = {
+        "agentcore": ("langchain_agentcore_codeinterpreter", "agentcore"),
         "daytona": ("langchain_daytona", "daytona"),
         "modal": ("langchain_modal", "modal"),
         "runloop": ("langchain_runloop", "runloop"),

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -622,7 +622,7 @@ class _AgentCoreProvider(SandboxProvider):
 
         # Validate AWS credentials early for a clear error message.
         try:
-            import boto3
+            import boto3  # ty: ignore[unresolved-import, unused-ignore-comment]
 
             session = boto3.Session()
             credentials = session.get_credentials()

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -517,13 +517,13 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument(
         "--sandbox",
-        choices=["none", "modal", "daytona", "runloop", "langsmith"],
+        choices=["none", "agentcore", "modal", "daytona", "runloop", "langsmith"],
         default="none",
         metavar="TYPE",
         help=(
             "Remote sandbox for code execution "
             "(default: none - local only; langsmith is included, "
-            "modal/daytona/runloop require downloading extras)"
+            "agentcore/modal/daytona/runloop require downloading extras)"
         ),
     )
 
@@ -628,7 +628,7 @@ async def run_textual_cli_async(
         assistant_id: Agent identifier for memory storage
         auto_approve: Whether to auto-approve tool usage
         sandbox_type: Type of sandbox
-            ("none", "modal", "runloop", "daytona", "langsmith")
+            ("none", "agentcore", "modal", "runloop", "daytona", "langsmith")
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -782,7 +782,7 @@ async def run_non_interactive(
 
             These override config file values.
         sandbox_type: Type of sandbox (`'none'`, `'modal'`,
-            `'runloop'`, `'daytona'`, `'langsmith'`).
+            `'agentcore'`, `'runloop'`, `'daytona'`, `'langsmith'`).
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -779,8 +779,8 @@ async def run_non_interactive(
         model_params: Extra kwargs from `--model-params` to pass to the model.
 
             These override config file values.
-        sandbox_type: Type of sandbox (`'none'`, `'modal'`,
-            `'agentcore'`, `'runloop'`, `'daytona'`, `'langsmith'`).
+        sandbox_type: Type of sandbox (`'none'`, `'agentcore'`,
+            `'daytona'`, `'langsmith'`, `'modal'`, `'runloop'`).
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -84,7 +84,8 @@ def show_help() -> None:
     )
     console.print("  --sandbox TYPE             Remote sandbox for execution")
     console.print(
-        "                           LangSmith is included; Modal/Daytona/Runloop"
+        "                             LangSmith is included;"
+        " Agentcore/Modal/Daytona/Runloop"
         " require downloading extras"
     )
     console.print(

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -97,11 +97,12 @@ vertexai = ["langchain-google-vertexai>=3.0.0,<4.0.0"]
 xai = ["langchain-xai>=1.0.0,<2.0.0"]
 
 # Sandbox providers
+agentcore = ["langchain-agentcore-codeinterpreter>=0.0.1"]
 daytona = ["langchain-daytona>=0.0.4"]
 modal = ["langchain-modal>=0.0.2"]
 runloop = ["langchain-runloop>=0.0.3"]
 all-sandboxes = [
-    "deepagents-cli[daytona,modal,runloop]",
+    "deepagents-cli[agentcore,daytona,modal,runloop]",
 ]
 
 all-providers = [

--- a/libs/cli/tests/integration_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/integration_tests/test_sandbox_factory.py
@@ -326,3 +326,13 @@ class TestLangSmithIntegration(BaseSandboxIntegrationTest):
         """Provide a LangSmith sandbox instance."""
         with create_sandbox("langsmith") as sandbox:
             yield sandbox
+
+
+class TestAgentCoreIntegration(BaseSandboxIntegrationTest):
+    """Test AgentCore Code Interpreter backend integration."""
+
+    @pytest.fixture(scope="class")
+    def sandbox(self) -> Iterator[BaseSandbox]:
+        """Provide an AgentCore sandbox instance."""
+        with create_sandbox("agentcore") as sandbox:
+            yield sandbox

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -39,12 +39,52 @@ def test_get_provider_raises_helpful_error_for_missing_optional_dependency(
         _get_provider(provider)
 
 
+def test_agentcore_get_or_create_raises_for_missing_dep() -> None:
+    """AgentCore should explain which package to install."""
+    error = (
+        r"The 'agentcore' sandbox provider requires the "
+        r"'langchain-agentcore-codeinterpreter' package"
+    )
+
+    with patch("boto3.Session") as mock_session:
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        provider = _get_provider("agentcore")
+
+    with (
+        patch(
+            "deepagents_cli.integrations.sandbox_factory.importlib.import_module",
+            side_effect=ImportError("missing dependency"),
+        ),
+        pytest.raises(ImportError, match=error),
+    ):
+        provider.get_or_create()
+
+
+def test_agentcore_raises_on_missing_aws_credentials() -> None:
+    """AgentCore should raise ValueError without AWS creds."""
+    with patch("boto3.Session") as mock_session:
+        mock_session.return_value.get_credentials.return_value = None
+        with pytest.raises(ValueError, match="AWS credentials not found"):
+            _get_provider("agentcore")
+
+
+def test_agentcore_rejects_sandbox_id() -> None:
+    """AgentCore should raise NotImplementedError for sandbox_id."""
+    with patch("boto3.Session") as mock_session:
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        provider = _get_provider("agentcore")
+
+    with pytest.raises(NotImplementedError, match="does not support reconnecting"):
+        provider.get_or_create(sandbox_id="some-id")
+
+
 class TestVerifySandboxDeps:
     """Tests for the early sandbox dependency check."""
 
     @pytest.mark.parametrize(
         ("provider", "expected_module"),
         [
+            ("agentcore", "langchain_agentcore_codeinterpreter"),
             ("daytona", "langchain_daytona"),
             ("modal", "langchain_modal"),
             ("runloop", "langchain_runloop"),
@@ -72,7 +112,7 @@ class TestVerifySandboxDeps:
 
     @pytest.mark.parametrize(
         "provider",
-        ["daytona", "modal", "runloop"],
+        ["agentcore", "daytona", "modal", "runloop"],
     )
     def test_passes_when_backend_installed(self, provider: str) -> None:
         """Should not raise when the backend module is found."""

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +10,7 @@ import pytest
 
 from deepagents_cli.integrations.sandbox_factory import (
     _get_provider,
+    get_default_working_dir,
     verify_sandbox_deps,
 )
 
@@ -82,6 +84,171 @@ def test_agentcore_rejects_sandbox_id() -> None:
 
     with pytest.raises(NotImplementedError, match="does not support reconnecting"):
         provider.get_or_create(sandbox_id="some-id")
+
+
+def test_agentcore_init_without_boto3_does_not_raise() -> None:
+    """Provider construction should succeed when boto3 is not installed."""
+    env_clear = dict.fromkeys(("AWS_REGION", "AWS_DEFAULT_REGION"), "")
+    with (
+        patch.dict(sys.modules, {"boto3": None}),
+        patch.dict(os.environ, env_clear, clear=False),
+    ):
+        for k in env_clear:
+            os.environ.pop(k, None)
+        provider = _get_provider("agentcore")
+    assert provider._region == "us-west-2"  # ty: ignore[unresolved-attribute]
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({"AWS_REGION": "eu-west-1"}, "eu-west-1"),
+        ({"AWS_DEFAULT_REGION": "ap-southeast-1"}, "ap-southeast-1"),
+        (
+            {"AWS_REGION": "us-east-1", "AWS_DEFAULT_REGION": "eu-west-1"},
+            "us-east-1",
+        ),
+        ({}, "us-west-2"),
+    ],
+)
+def test_agentcore_region_resolution(env: dict[str, str], expected: str) -> None:
+    """Region should follow AWS_REGION > AWS_DEFAULT_REGION > us-west-2."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with (
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        patch.dict(os.environ, env, clear=False),
+        patch.dict(
+            os.environ,
+            {k: "" for k in ("AWS_REGION", "AWS_DEFAULT_REGION") if k not in env},
+            clear=False,
+        ),
+    ):
+        # Clear env vars not in this test case
+        for k in ("AWS_REGION", "AWS_DEFAULT_REGION"):
+            if k not in env:
+                os.environ.pop(k, None)
+        provider = _get_provider("agentcore")
+    assert provider._region == expected  # ty: ignore[unresolved-attribute]
+
+
+def test_agentcore_get_or_create_happy_path() -> None:
+    """Successful get_or_create should start interpreter and track it."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        provider = _get_provider("agentcore")
+
+    mock_interpreter = MagicMock()
+    mock_backend = MagicMock()
+    mock_backend.id = "session-123"
+
+    mock_ci_module = MagicMock()
+    mock_ci_module.CodeInterpreter.return_value = mock_interpreter
+    mock_backend_module = MagicMock()
+    mock_backend_module.AgentCoreSandbox.return_value = mock_backend
+
+    def fake_import(module_name: str, **_: object) -> MagicMock:
+        if "code_interpreter_client" in module_name:
+            return mock_ci_module
+        return mock_backend_module
+
+    with patch(
+        "deepagents_cli.integrations.sandbox_factory._import_provider_module",
+        side_effect=fake_import,
+    ):
+        result = provider.get_or_create()
+
+    mock_interpreter.start.assert_called_once()
+    assert result is mock_backend
+    assert provider._active_interpreters["session-123"] is mock_interpreter  # ty: ignore[unresolved-attribute]
+
+
+def test_agentcore_start_failure_cleans_up() -> None:
+    """If interpreter.start() fails, interpreter.stop() should be called."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        provider = _get_provider("agentcore")
+
+    mock_interpreter = MagicMock()
+    mock_interpreter.start.side_effect = RuntimeError("connection failed")
+
+    mock_ci_module = MagicMock()
+    mock_ci_module.CodeInterpreter.return_value = mock_interpreter
+
+    def fake_import(module_name: str, **_: object) -> MagicMock:
+        if "code_interpreter_client" in module_name:
+            return mock_ci_module
+        return MagicMock()
+
+    with (
+        patch(
+            "deepagents_cli.integrations.sandbox_factory._import_provider_module",
+            side_effect=fake_import,
+        ),
+        pytest.raises(RuntimeError, match="connection failed"),
+    ):
+        provider.get_or_create()
+
+    mock_interpreter.stop.assert_called_once()
+    assert not provider._active_interpreters  # ty: ignore[unresolved-attribute]
+
+
+def test_agentcore_delete_stops_tracked_interpreter() -> None:
+    """delete() should call stop() on a tracked interpreter."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        provider = _get_provider("agentcore")
+
+    mock_interpreter = MagicMock()
+    provider._active_interpreters["sess-1"] = mock_interpreter  # ty: ignore[unresolved-attribute]
+
+    provider.delete(sandbox_id="sess-1")
+
+    mock_interpreter.stop.assert_called_once()
+    assert "sess-1" not in provider._active_interpreters  # ty: ignore[unresolved-attribute]
+
+
+def test_agentcore_delete_swallows_stop_exception() -> None:
+    """delete() should not propagate if interpreter.stop() raises."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        provider = _get_provider("agentcore")
+
+    mock_interpreter = MagicMock()
+    mock_interpreter.stop.side_effect = RuntimeError("network error")
+    provider._active_interpreters["sess-1"] = mock_interpreter  # ty: ignore[unresolved-attribute]
+
+    provider.delete(sandbox_id="sess-1")  # should not raise
+    assert "sess-1" not in provider._active_interpreters  # ty: ignore[unresolved-attribute]
+
+
+def test_agentcore_delete_untracked_session() -> None:
+    """delete() should not raise for an untracked session ID."""
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
+        provider = _get_provider("agentcore")
+
+    provider.delete(sandbox_id="nonexistent")  # should not raise
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("agentcore", "/tmp"),
+        ("daytona", "/home/daytona"),
+        ("langsmith", "/tmp"),
+        ("modal", "/workspace"),
+        ("runloop", "/home/user"),
+    ],
+)
+def test_get_default_working_dir(provider: str, expected: str) -> None:
+    """Each provider should map to the correct default working directory."""
+    assert get_default_working_dir(provider) == expected
 
 
 class TestVerifySandboxDeps:

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -46,8 +47,9 @@ def test_agentcore_get_or_create_raises_for_missing_dep() -> None:
         r"'langchain-agentcore-codeinterpreter' package"
     )
 
-    with patch("boto3.Session") as mock_session:
-        mock_session.return_value.get_credentials.return_value = MagicMock()
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
         provider = _get_provider("agentcore")
 
     with (
@@ -62,16 +64,20 @@ def test_agentcore_get_or_create_raises_for_missing_dep() -> None:
 
 def test_agentcore_raises_on_missing_aws_credentials() -> None:
     """AgentCore should raise ValueError without AWS creds."""
-    with patch("boto3.Session") as mock_session:
-        mock_session.return_value.get_credentials.return_value = None
-        with pytest.raises(ValueError, match="AWS credentials not found"):
-            _get_provider("agentcore")
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = None
+    with (
+        patch.dict(sys.modules, {"boto3": mock_boto3}),
+        pytest.raises(ValueError, match="AWS credentials not found"),
+    ):
+        _get_provider("agentcore")
 
 
 def test_agentcore_rejects_sandbox_id() -> None:
     """AgentCore should raise NotImplementedError for sandbox_id."""
-    with patch("boto3.Session") as mock_session:
-        mock_session.return_value.get_credentials.return_value = MagicMock()
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value.get_credentials.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": mock_boto3}):
         provider = _get_provider("agentcore")
 
     with pytest.raises(NotImplementedError, match="does not support reconnecting"):

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -290,6 +290,25 @@ wheels = [
 ]
 
 [[package]]
+name = "bedrock-agentcore"
+version = "1.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/5c/2ad1747ff2bc4b6bb8828fdc8e769f6c34daa0c4ca4d853cff603ea04aeb/bedrock_agentcore-1.4.7.tar.gz", hash = "sha256:422805482e47593010128a86495dff644507624b00c6e09950613c7241ae5375", size = 483923, upload-time = "2026-03-18T22:46:37.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/e7/df6cbe814292353460c0988504eee4e90cc08dde03bf5e1da85176b5f0b4/bedrock_agentcore-1.4.7-py3-none-any.whl", hash = "sha256:7515ddf779a4f32fd4a5c8dcf29c9399babe0ea14ea9004d2c69bcad40754622", size = 148250, upload-time = "2026-03-18T22:46:36.662Z" },
+]
+
+[[package]]
 name = "blockbuster"
 version = "1.5.26"
 source = { registry = "https://pypi.org/simple" }
@@ -303,30 +322,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.46"
+version = "1.42.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/87/1ccd436a6815c18107aa74aa2b7b2745dc5a1db83cf58afc591df2755775/boto3-1.42.46.tar.gz", hash = "sha256:c8c82ab34dd8d2d4d93a562d0e75fca164efa644651d3ccddb0f4aa88a481b38", size = 112795, upload-time = "2026-02-10T20:38:10.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8b/d00575be514744ca4839e7d85bf4a8a3c7b6b4574433291e58d14c68ae09/boto3-1.42.73.tar.gz", hash = "sha256:d37b58d6cd452ca808dd6823ae19ca65b6244096c5125ef9052988b337298bae", size = 112775, upload-time = "2026-03-20T19:39:52.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/41/978d749a6604bf93e05e8be56db07eb1402ffe576e1bb9b65aa391ebcb73/boto3-1.42.46-py3-none-any.whl", hash = "sha256:679cf4930e559621653bbd1439cf6e93b138cbaf46e36e5d7d95319999b7a356", size = 140606, upload-time = "2026-02-10T20:38:08.175Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/05/1fcf03d90abaa3d0b42a6bfd10231dd709493ecbacf794aa2eea5eae6841/boto3-1.42.73-py3-none-any.whl", hash = "sha256:1f81b79b873f130eeab14bb556417a7c66d38f3396b7f2fe3b958b3f9094f455", size = 140556, upload-time = "2026-03-20T19:39:50.298Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.46"
+version = "1.42.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/2d/6f6101f567a69c3b2ebe3f1f81bfd56eda9d5f6f466d0d919293499ab050/botocore-1.42.46.tar.gz", hash = "sha256:fc290b33aba6e271f627c4f46b8bcebfa1a94e19157d396732da417404158c01", size = 14948751, upload-time = "2026-02-10T20:37:58.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/23/0c88ca116ef63b1ae77c901cd5d2095d22a8dbde9e80df74545db4a061b4/botocore-1.42.73.tar.gz", hash = "sha256:575858641e4949aaf2af1ced145b8524529edf006d075877af6b82ff96ad854c", size = 15008008, upload-time = "2026-03-20T19:39:40.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/88/5c2f4e65fe8dba7709a219b768e5ac89a112c6dde9527a5009cb82ee9124/botocore-1.42.46-py3-none-any.whl", hash = "sha256:f7459fcf586f38a3b0a242a172d3332141c770a3f5767bbb21e79d810db95d75", size = 14622519, upload-time = "2026-02-10T20:37:54.223Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/65/971f3d55015f4d133a6ff3ad74cd39f4b8dd8f53f7775a3c2ad378ea5145/botocore-1.42.73-py3-none-any.whl", hash = "sha256:7b62e2a12f7a1b08eb7360eecd23bb16fe3b7ab7f5617cf91b25476c6f86a0fe", size = 14681861, upload-time = "2026-03-20T19:39:35.341Z" },
 ]
 
 [[package]]
@@ -1025,6 +1044,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agentcore = [
+    { name = "langchain-agentcore-codeinterpreter" },
+]
 all-providers = [
     { name = "langchain-anthropic" },
     { name = "langchain-aws" },
@@ -1047,6 +1069,7 @@ all-providers = [
     { name = "langchain-xai" },
 ]
 all-sandboxes = [
+    { name = "langchain-agentcore-codeinterpreter" },
     { name = "langchain-daytona" },
     { name = "langchain-modal" },
     { name = "langchain-runloop" },
@@ -1142,10 +1165,11 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-acp", specifier = ">=0.0.4" },
+    { name = "deepagents-cli", extras = ["agentcore", "daytona", "modal", "runloop"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-cli", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
-    { name = "deepagents-cli", extras = ["daytona", "modal", "runloop"], marker = "extra == 'all-sandboxes'" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain", specifier = ">=1.2.10,<2.0.0" },
+    { name = "langchain-agentcore-codeinterpreter", marker = "extra == 'agentcore'", specifier = ">=0.0.1" },
     { name = "langchain-anthropic", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=1.0.0,<2.0.0" },
@@ -1192,7 +1216,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
     { name = "uuid-utils", specifier = ">=0.10.0,<1.0.0" },
 ]
-provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "daytona", "modal", "runloop", "all-sandboxes", "all-providers"]
+provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "agentcore", "daytona", "modal", "runloop", "all-sandboxes", "all-providers"]
 
 [package.metadata.requires-dev]
 test = [
@@ -2451,6 +2475,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/1d/1af2fc0ac084d4781778b7846b1aed62e05006bf2d73fdf84ac3a8f5225c/langchain-1.2.12.tar.gz", hash = "sha256:ed705b5b293799f7e3e394387f398a1b71707542758283206c8c21415759d991", size = 566444, upload-time = "2026-03-11T22:21:00.712Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/51/09bb1cfb0b57ae9440ca56cc576e4dc792f83d030eef7637d2c516dcb0a0/langchain-1.2.12-py3-none-any.whl", hash = "sha256:60eff184b8f92c2610f5a4c9a97ad339a891adb01901e83e4df8e6c9c69cf852", size = 112373, upload-time = "2026-03-11T22:20:59.508Z" },
+]
+
+[[package]]
+name = "langchain-agentcore-codeinterpreter"
+version = "0.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bedrock-agentcore" },
+    { name = "boto3" },
+    { name = "deepagents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/f2/8bafe711f6799baefe9eefce7b7b924bcae2b30246099b61787ad830cb27/langchain_agentcore_codeinterpreter-0.0.1.tar.gz", hash = "sha256:6399952ce45f2762167e769e6cd3ad5c397dd35948f69f9ff798ba7632b1e074", size = 147616, upload-time = "2026-03-20T17:45:13.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9f/9a1f9c88adf73c0740a638db1ba3c21cc62ff189f929b2ddcc1f569428d6/langchain_agentcore_codeinterpreter-0.0.1-py3-none-any.whl", hash = "sha256:9603b8de9d4554b32191e9c2d74dff5e57c2cbeec12f7690d5286b8e13140b10", size = 7277, upload-time = "2026-03-20T17:45:12.522Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -684,8 +684,13 @@ dependencies = [
     { name = "anyio", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
     { name = "mcp", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/03/cf/2bd8d55bab57e458044a5e530a2320fecfcc91ec5546972b2c3db15fd09a/claude_agent_sdk-0.1.49.tar.gz", hash = "sha256:6a93f7e51951623d94c0b35172d1d25d7c44f8dd083568d3252a6ed3ac8719bf", size = 95079, upload-time = "2026-03-20T17:31:09.274Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/08/0e33ede7b3035ba953f5a59597b8cb94ea2f3fb3124e5d6f6e255bf9c025/claude_agent_sdk-0.1.49-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a869330d4a15b12c96ae24144b8e29999ff25315267f248634986179e9536a04", size = 57620663, upload-time = "2026-03-17T00:44:27.792Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dd/0c4fa243e5e1ac794193aeb3a48d834cbe896e9f91666b9d087ec560ff8e/claude_agent_sdk-0.1.49-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:30a5039a0de6577fe15c568182e3f615e652eda5ef7cc247b5bdbc2d94dee391", size = 60418943, upload-time = "2026-03-20T17:30:49.513Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/73/c153e0431ff18deba9ebde6ca190e717c5c5e8306a88f10e454cd9ca265a/claude_agent_sdk-0.1.49-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8414cfbb9fed0eadb429a9443dcdea9b1978b687098d46d37748b6833d4f10ac", size = 74001537, upload-time = "2026-03-20T17:30:54.119Z" },
+    { url = "https://files.pythonhosted.org/packages/41/22/e1377286850a87164ac481935126e78fe29b883bca3a711e589fce21dccf/claude_agent_sdk-0.1.49-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:e4a3c3abac8a2013a40970d0a1d745a64bcb1750f8a62b656e01776715245098", size = 74655236, upload-time = "2026-03-20T17:30:59.552Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/327bca8e5684aad13db6476863fd727c31cecbe3582ca545c881b8cfe231/claude_agent_sdk-0.1.49-py3-none-win_amd64.whl", hash = "sha256:1b5cd34c231055d917c74833b944cf220e08b43b4804969654902f07d0f0957b", size = 75280600, upload-time = "2026-03-20T17:31:05.646Z" },
 ]
 
 [[package]]
@@ -1155,10 +1160,11 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-acp", specifier = ">=0.0.4" },
+    { name = "deepagents-cli", extras = ["agentcore", "daytona", "modal", "runloop"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-cli", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai"], marker = "extra == 'all-providers'" },
-    { name = "deepagents-cli", extras = ["daytona", "modal", "runloop"], marker = "extra == 'all-sandboxes'" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain", specifier = ">=1.2.10,<2.0.0" },
+    { name = "langchain-agentcore-codeinterpreter", marker = "extra == 'agentcore'", specifier = ">=0.0.1" },
     { name = "langchain-anthropic", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=1.0.0,<2.0.0" },
@@ -1205,7 +1211,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
     { name = "uuid-utils", specifier = ">=0.10.0,<1.0.0" },
 ]
-provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "daytona", "modal", "runloop", "all-sandboxes", "all-providers"]
+provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "vertexai", "xai", "agentcore", "daytona", "modal", "runloop", "all-sandboxes", "all-providers"]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
Adds `--sandbox agentcore` support by wiring `langchain-agentcore-codeinterpreter` as a sandbox provider.