### PR TITLE
fix: FileSystemMiddleware path normalization for relative paths

### DIFF
--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -379,16 +379,26 @@ def truncate_if_too_long(result: list[str] | str) -> list[str] | str:
     return result
 
 
-def validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -> str:
+def validate_path(
+    path: str,
+    *,
+    allowed_prefixes: Sequence[str] | None = None,
+    virtual_mode: bool | None = None,
+) -> str:
     r"""Validate and normalize file path for security.
 
     Ensures paths are safe to use by preventing directory traversal attacks
     and enforcing consistent formatting. All paths are normalized to use
-    forward slashes and start with a leading slash.
+    forward slashes.
 
-    This function is designed for virtual filesystem paths and rejects
-    Windows absolute paths (e.g., `C:/...`, `F:/...`) to maintain consistency
-    and prevent path format ambiguity.
+    When ``virtual_mode`` is ``True`` or ``None`` (the default), relative
+    paths are converted to absolute virtual paths by prepending ``/``.
+    When ``virtual_mode`` is ``False``, relative paths are preserved as
+    relative so they can be resolved against the current working directory
+    by the backend.
+
+    This function rejects Windows absolute paths (e.g., ``C:/...``,
+    ``F:/...``) to maintain consistency and prevent path format ambiguity.
 
     Args:
         path: The path to validate and normalize.
@@ -396,9 +406,16 @@ def validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -
 
             If provided, the normalized path must start with one of
             these prefixes.
+        virtual_mode: Controls relative-path handling.
+
+            - ``True`` or ``None`` (default): relative paths are converted
+              to absolute virtual paths (backward-compatible behavior).
+            - ``False``: relative paths are kept relative.
 
     Returns:
-        Normalized canonical path starting with `/` and using forward slashes.
+        Normalized canonical path using forward slashes. Starts with ``/``
+        when *virtual_mode* is ``True`` or ``None``; may be relative when
+        *virtual_mode* is ``False``.
 
     Raises:
         ValueError: If path contains traversal sequences (`..` or `~`), is a
@@ -408,6 +425,7 @@ def validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -
     Example:
         ```python
         validate_path("foo/bar")  # Returns: "/foo/bar"
+        validate_path("foo/bar", virtual_mode=False)  # Returns: "foo/bar"
         validate_path("/./foo//bar")  # Returns: "/foo/bar"
         validate_path("../etc/passwd")  # Raises ValueError
         validate_path(r"C:\\Users\\file.txt")  # Raises ValueError
@@ -430,7 +448,9 @@ def validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -
     normalized = os.path.normpath(path)
     normalized = normalized.replace("\\", "/")
 
-    if not normalized.startswith("/"):
+    # In virtual mode (True/None — default), force absolute paths.
+    # In non-virtual mode (False), preserve relative paths as-is.
+    if virtual_mode is not False and not normalized.startswith("/"):
         normalized = f"/{normalized}"
 
     # Defense-in-depth: verify normpath didn't produce traversal

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -510,7 +510,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for ls tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(path)
+                validated_path = validate_path(path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             ls_result = resolved_backend.ls(validated_path)
@@ -538,7 +538,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for ls tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(path)
+                validated_path = validate_path(path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             ls_result = await resolved_backend.als(validated_path)
@@ -638,7 +638,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for read_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(file_path)
+                validated_path = validate_path(file_path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
 
@@ -654,7 +654,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for read_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(file_path)
+                validated_path = validate_path(file_path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
 
@@ -680,7 +680,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(file_path)
+                validated_path = validate_path(file_path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             res: WriteResult = resolved_backend.write(validated_path, content)
@@ -709,7 +709,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(file_path)
+                validated_path = validate_path(file_path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             res: WriteResult = await resolved_backend.awrite(validated_path, content)
@@ -752,7 +752,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for edit_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(file_path)
+                validated_path = validate_path(file_path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             res: EditResult = resolved_backend.edit(validated_path, old_string, new_string, replace_all=replace_all)
@@ -783,7 +783,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for edit_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(file_path)
+                validated_path = validate_path(file_path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             res: EditResult = await resolved_backend.aedit(validated_path, old_string, new_string, replace_all=replace_all)
@@ -822,7 +822,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Synchronous wrapper for glob tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(path)
+                validated_path = validate_path(path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
@@ -856,7 +856,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Asynchronous wrapper for glob tool."""
             resolved_backend = self._get_backend(runtime)
             try:
-                validated_path = validate_path(path)
+                validated_path = validate_path(path, virtual_mode=getattr(resolved_backend, "virtual_mode", None))
             except ValueError as e:
                 return f"Error: {e}"
             try:

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -94,6 +94,26 @@ class TestValidatePath:
         assert validate_path(".") == "/."
         assert validate_path("") == "/."
 
+    def test_virtual_mode_false_preserves_relative_paths(self) -> None:
+        """Test that virtual_mode=False keeps relative paths relative."""
+        assert validate_path("foo/bar", virtual_mode=False) == "foo/bar"
+        assert validate_path("relative/path.txt", virtual_mode=False) == "relative/path.txt"
+        assert validate_path("foo\\bar\\baz", virtual_mode=False) == "foo/bar/baz"
+
+    def test_virtual_mode_false_preserves_absolute_paths(self) -> None:
+        """Test that virtual_mode=False still keeps absolute paths absolute."""
+        assert validate_path("/workspace/file.txt", virtual_mode=False) == "/workspace/file.txt"
+
+    def test_virtual_mode_true_converts_relative_to_absolute(self) -> None:
+        """Test that virtual_mode=True converts relative paths to absolute."""
+        assert validate_path("foo/bar", virtual_mode=True) == "/foo/bar"
+        assert validate_path("relative/path.txt", virtual_mode=True) == "/relative/path.txt"
+
+    def test_virtual_mode_none_defaults_to_virtual(self) -> None:
+        """Test that virtual_mode=None behaves like True (backward compat)."""
+        assert validate_path("foo/bar", virtual_mode=None) == "/foo/bar"
+        assert validate_path("foo/bar") == "/foo/bar"
+
 
 class TestGlobSearchFiles:
     """Tests for _glob_search_files."""


### PR DESCRIPTION
## Summary
- Fixes #518 — `FileSystemMiddleware` incorrectly normalizes relative paths, treating them as root-level files
- Added `virtual_mode` parameter to `validate_path()` so backends with `virtual_mode=False` (e.g., `FilesystemBackend`) preserve relative path semantics
- All middleware call sites now pass the backend's `virtual_mode` through to `validate_path()`
- Default behavior (`virtual_mode=True` or `None`) is unchanged — full backward compatibility

## Changes
- `libs/deepagents/deepagents/backends/utils.py`: Added `virtual_mode` kwarg to `validate_path()`. When `False`, relative paths are no longer force-prefixed with `/`
- `libs/deepagents/deepagents/middleware/filesystem.py`: All 10 `validate_path()` call sites now pass `virtual_mode=getattr(resolved_backend, "virtual_mode", None)`
- `libs/deepagents/tests/unit_tests/backends/test_utils.py`: Added 4 new test methods covering `virtual_mode=False`, `True`, and `None`

## Test plan
- [x] Verified relative paths stay relative when `virtual_mode=False`
- [x] Verified absolute paths are unaffected regardless of `virtual_mode`
- [x] Verified default behavior (`virtual_mode=None`) matches previous behavior (backward compat)
- [x] Verified `virtual_mode=True` explicitly converts relative to absolute
- [x] All existing test assertions still pass

Note: PR #538 addresses the same issue but targets an older code structure with a local `_validate_path` in the middleware. This PR fixes the canonical `validate_path` in `backends/utils.py` which is what the current `main` branch uses.