### PR TITLE
fix(sdk): handle list type in _file_data_reducer to prevent TypeError

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -95,6 +95,21 @@ def _file_data_reducer(left: dict[str, FileData] | None, right: dict[str, FileDa
         # Result: {"/file1.txt": FileData(...), "/file3.txt": FileData(...)}
         ```
     """
+    # Handle list inputs from LangGraph's parallel channel updates
+    if isinstance(left, list):
+        merged: dict[str, FileData] = {}
+        for item in left:
+            if isinstance(item, dict):
+                merged.update(item)
+        left = merged or None
+
+    if isinstance(right, list):
+        merged_right: dict[str, FileData | None] = {}
+        for item in right:
+            if isinstance(item, dict):
+                merged_right.update(item)
+        right = merged_right
+
     if left is None:
         return {k: v for k, v in right.items() if v is not None}
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_file_data_reducer.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_file_data_reducer.py
@@ -1,0 +1,82 @@
+"""Unit tests for _file_data_reducer list-type handling.
+
+Regression tests for https://github.com/langchain-ai/deepagents/issues/731
+"""
+
+from deepagents.middleware.filesystem import FileData, _file_data_reducer
+
+
+def _make_file_data(content: str) -> FileData:
+    return FileData(
+        content=content,
+        encoding="utf-8",
+        created_at="2026-01-01T00:00:00Z",
+        modified_at="2026-01-01T00:00:00Z",
+    )
+
+
+def test_reducer_handles_left_as_list_of_dicts() -> None:
+    """When left is a list of dicts (from parallel channel updates), merge them."""
+    left = [
+        {"/a.txt": _make_file_data("a")},
+        {"/b.txt": _make_file_data("b")},
+    ]
+    right = {"/c.txt": _make_file_data("c")}
+    result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+    assert set(result.keys()) == {"/a.txt", "/b.txt", "/c.txt"}
+
+
+def test_reducer_handles_right_as_list_of_dicts() -> None:
+    """When right is a list of dicts, merge them before applying updates."""
+    left = {"/a.txt": _make_file_data("a")}
+    right = [
+        {"/b.txt": _make_file_data("b")},
+        {"/c.txt": _make_file_data("c")},
+    ]
+    result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+    assert set(result.keys()) == {"/a.txt", "/b.txt", "/c.txt"}
+
+
+def test_reducer_handles_empty_list_as_none() -> None:
+    """An empty list for left should behave like None (initialization)."""
+    left: list = []  # type: ignore[type-arg]
+    right = {"/a.txt": _make_file_data("a")}
+    result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+    assert result == {"/a.txt": _make_file_data("a")}
+
+
+def test_reducer_handles_both_as_lists() -> None:
+    """Both left and right as lists should work."""
+    left = [{"/a.txt": _make_file_data("a")}]
+    right = [{"/b.txt": _make_file_data("b")}]
+    result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+    assert set(result.keys()) == {"/a.txt", "/b.txt"}
+
+
+def test_reducer_list_last_write_wins() -> None:
+    """When a list contains duplicate keys, last write wins."""
+    left = [
+        {"/a.txt": _make_file_data("old")},
+        {"/a.txt": _make_file_data("new")},
+    ]
+    right = {"/b.txt": _make_file_data("b")}
+    result = _file_data_reducer(left, right)  # type: ignore[arg-type]
+    assert result["/a.txt"]["content"] == "new"
+
+
+def test_reducer_normal_dict_inputs_unchanged() -> None:
+    """Normal dict inputs still work as before."""
+    left = {"/a.txt": _make_file_data("a")}
+    right = {"/a.txt": _make_file_data("updated"), "/b.txt": _make_file_data("b")}
+    result = _file_data_reducer(left, right)
+    assert result["/a.txt"]["content"] == "updated"
+    assert result["/b.txt"]["content"] == "b"
+
+
+def test_reducer_deletion_still_works() -> None:
+    """None values in right still trigger deletion."""
+    left = {"/a.txt": _make_file_data("a"), "/b.txt": _make_file_data("b")}
+    right = {"/a.txt": None}
+    result = _file_data_reducer(left, right)
+    assert "/a.txt" not in result
+    assert "/b.txt" in result


### PR DESCRIPTION
Fixes #731

Adds defensive type guards in `_file_data_reducer` to convert list inputs to dicts before processing. LangGraph's channel update mechanism can pass accumulated state as a list (instead of a dict) when using `astream()` with a checkpointer, causing `TypeError: 'list' object is not a mapping`.

Also adds 7 unit tests covering list inputs, empty lists, and existing dict behavior.

Verified with `make format`, `make lint`, and `make test` (885 passed).

AI disclaimer: This contribution was developed with assistance from Claude (Anthropic).