### PR TITLE
feat(sdk,cli): add package version metadata to traces

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -492,6 +492,110 @@ MAX_ARG_LENGTH = 150
 # Agent configuration
 config: RunnableConfig = {"recursion_limit": 1000}
 
+# ---------------------------------------------------------------------------
+# Stream config builder (consolidates textual_adapter + non_interactive)
+# ---------------------------------------------------------------------------
+
+_git_branch_cache: dict[str, str | None] = {}
+
+
+def _get_git_branch() -> str | None:
+    """Return the current git branch name, or `None` if not in a repo."""
+    import subprocess  # noqa: S404
+
+    try:
+        cwd = str(Path.cwd())
+    except OSError:
+        logger.debug("Could not determine cwd for git branch lookup", exc_info=True)
+        return None
+    if cwd in _git_branch_cache:
+        return _git_branch_cache[cwd]
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip() or None
+            _git_branch_cache[cwd] = branch
+            return branch
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        logger.debug("Could not determine git branch", exc_info=True)
+    _git_branch_cache[cwd] = None
+    return None
+
+
+def build_stream_config(
+    thread_id: str,
+    assistant_id: str | None,
+    *,
+    sandbox_type: str | None = None,
+) -> RunnableConfig:
+    """Build the LangGraph stream config dict.
+
+    Injects CLI and SDK versions into `metadata["versions"]` so LangSmith traces
+    can be correlated with specific releases.
+
+    Why the CLI sets *both* versions:
+
+    * `create_deep_agent` bakes `versions: {"deepagents": "X.Y.Z"}` into the
+        compiled graph via `with_config`. At stream time, LangGraph merges
+        the graph config with the runtime config passed here. Because the
+        metadata merge is shallow (effectively `{**graph_meta, **runtime_meta}`
+        for top-level keys), both configs containing a `versions` key means
+        the runtime dict **replaces** the graph dict entirely — the SDK
+        version would be lost.
+    * Including the SDK version here ensures it survives the merge.
+
+    Args:
+        thread_id: The CLI session thread identifier.
+        assistant_id: The agent/assistant identifier, if any.
+        sandbox_type: Sandbox provider name for trace metadata, or `None` if no
+            sandbox is active.
+
+    Returns:
+        Config dict with `configurable` and `metadata` keys.
+    """
+    import contextlib
+    import importlib.metadata as importlib_metadata
+    from datetime import UTC, datetime
+
+    try:
+        cwd = str(Path.cwd())
+    except OSError:
+        logger.warning("Could not determine working directory", exc_info=True)
+        cwd = ""
+
+    # Include SDK version alongside CLI version — see docstring for why.
+    versions: dict[str, str] = {"deepagents-cli": __version__}
+    with contextlib.suppress(importlib_metadata.PackageNotFoundError):
+        versions["deepagents"] = importlib_metadata.version("deepagents")
+
+    metadata: dict[str, Any] = {"versions": versions}
+    if cwd:
+        metadata["cwd"] = cwd
+    if assistant_id:
+        metadata.update(
+            {
+                "assistant_id": assistant_id,
+                "agent_name": assistant_id,
+                "updated_at": datetime.now(UTC).isoformat(),
+            }
+        )
+    branch = _get_git_branch()
+    if branch:
+        metadata["git_branch"] = branch
+    if sandbox_type and sandbox_type != "none":
+        metadata["sandbox_type"] = sandbox_type
+    return {
+        "configurable": {"thread_id": thread_id},
+        "metadata": metadata,
+    }
+
 
 class _ShellAllowAll(list):  # noqa: FURB189  # sentinel type, not a general-purpose list subclass
     """Sentinel subclass for unrestricted shell access.

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -193,8 +193,13 @@ class CharsetMode(StrEnum):
     """Character set mode for TUI display."""
 
     UNICODE = "unicode"
+    """Always use Unicode glyphs (e.g. `⏺`, `✓`, `…`)."""
+
     ASCII = "ascii"
+    """Always use ASCII-safe fallbacks (e.g. `(*)`, `[OK]`, `...`)."""
+
     AUTO = "auto"
+    """Detect charset support at runtime and pick Unicode or ASCII."""
 
 
 @dataclass(frozen=True)
@@ -254,6 +259,7 @@ UNICODE_GLYPHS = Glyphs(
     gutter_bar="▌",
     git_branch="↗",
 )
+"""Glyph set for terminals with full Unicode support."""
 
 ASCII_GLYPHS = Glyphs(
     tool_prefix="(*)",
@@ -279,6 +285,7 @@ ASCII_GLYPHS = Glyphs(
     gutter_bar="|",
     git_branch="git:",
 )
+"""Glyph set for terminals limited to 7-bit ASCII."""
 
 _glyphs_cache: Glyphs | None = None
 """Module-level cache for detected glyphs."""
@@ -421,8 +428,6 @@ def newline_shortcut() -> str:
     return "Option+Enter" if sys.platform == "darwin" else "Ctrl+J"
 
 
-# Text art banners (Unicode and ASCII variants)
-
 _UNICODE_BANNER = f"""
 ██████╗  ███████╗ ███████╗ ██████╗    ▄▓▓▄
 ██╔══██╗ ██╔════╝ ██╔════╝ ██╔══██╗  ▓•███▙
@@ -462,7 +467,8 @@ def get_banner() -> str:
 
     Returns:
         The text art banner string (Unicode or ASCII based on charset mode).
-        Includes "(local)" suffix when installed in editable mode.
+
+            Includes "(local)" suffix when installed in editable mode.
     """
     if _detect_charset_mode() == CharsetMode.ASCII:
         banner = _ASCII_BANNER
@@ -475,28 +481,27 @@ def get_banner() -> str:
     return banner
 
 
-# Interactive commands
-COMMANDS = {
-    "clear": "Clear screen and reset conversation",
-    "help": "Show help information",
-    "remember": "Review conversation and update memory/skills",
-    "tokens": "Show token usage for current thread",
-    "quit": "Exit the CLI",
-    "exit": "Exit the CLI",
-}
-
-
-# Maximum argument length for display
 MAX_ARG_LENGTH = 150
+"""Character limit for tool argument values in the UI.
 
-# Agent configuration
+Longer values are truncated with an ellipsis by `truncate_value`
+in `tool_display`.
+"""
+
 config: RunnableConfig = {"recursion_limit": 1000}
+"""Default LangGraph runnable config with a high recursion limit.
 
-# ---------------------------------------------------------------------------
-# Stream config builder (consolidates textual_adapter + non_interactive)
-# ---------------------------------------------------------------------------
+Sets `recursion_limit` to 1000 to accommodate deeply nested agent graphs without
+hitting the default LangGraph ceiling.
+"""
 
 _git_branch_cache: dict[str, str | None] = {}
+"""Per-cwd cache of resolved git branch names.
+
+Avoids repeated `git rev-parse` subprocess calls within the same session. Keyed
+by `str(Path.cwd())`; `None` values indicate the directory is not inside a git
+repository.
+"""
 
 
 def _get_git_branch() -> str | None:
@@ -679,50 +684,46 @@ class Settings:
     - Current project information
     - Tool availability (e.g., Tavily)
     - File system paths
-
-    Attributes:
-        openai_api_key: OpenAI API key if available.
-        anthropic_api_key: Anthropic API key if available.
-        google_api_key: Google API key if available.
-        nvidia_api_key: NVIDIA API key if available.
-        tavily_api_key: Tavily API key if available.
-        google_cloud_project: Google Cloud project ID for VertexAI
-            authentication.
-        deepagents_langchain_project: LangSmith project name for deepagents
-            agent tracing.
-        user_langchain_project: Original LANGSMITH_PROJECT from environment
-            (for user code).
-        model_name: Currently active model name (set after model creation).
-        model_provider: Provider identifier (e.g., openai, anthropic, google_genai).
-        model_context_limit: Maximum input token count from the model profile.
-        project_root: Current project root directory (if in a git project).
-        shell_allow_list: List of shell commands that don't require approval.
     """
 
-    # API keys
     openai_api_key: str | None
+    """OpenAI API key if available."""
+
     anthropic_api_key: str | None
+    """Anthropic API key if available."""
+
     google_api_key: str | None
+    """Google API key if available."""
+
     nvidia_api_key: str | None
+    """NVIDIA API key if available."""
+
     tavily_api_key: str | None
+    """Tavily API key if available."""
 
-    # Google Cloud configuration (for VertexAI)
     google_cloud_project: str | None
+    """Google Cloud project ID for VertexAI authentication."""
 
-    # LangSmith configuration
-    deepagents_langchain_project: str | None  # For deepagents agent tracing
-    user_langchain_project: str | None  # Original LANGSMITH_PROJECT for user code
+    deepagents_langchain_project: str | None
+    """LangSmith project name for deepagents agent tracing."""
 
-    # Model configuration
-    model_name: str | None = None  # Currently active model name
-    model_provider: str | None = None  # Provider name (see PROVIDER_API_KEY_ENV)
-    model_context_limit: int | None = None  # Max input tokens from model profile
+    user_langchain_project: str | None
+    """Original `LANGSMITH_PROJECT` from environment (for user code)."""
 
-    # Project information
+    model_name: str | None = None
+    """Currently active model name, set after model creation."""
+
+    model_provider: str | None = None
+    """Provider identifier (e.g., `openai`, `anthropic`, `google_genai`)."""
+
+    model_context_limit: int | None = None
+    """Maximum input token count from the model profile."""
+
     project_root: Path | None = None
+    """Current project root directory, or `None` if not in a git project."""
 
-    # Shell command allow-list for auto-approval
     shell_allow_list: list[str] | None = None
+    """Shell commands that don't require user approval."""
 
     @classmethod
     def from_environment(cls, *, start_path: Path | None = None) -> Settings:
@@ -1195,28 +1196,13 @@ DANGEROUS_SHELL_PATTERNS = (
     "<",  # Input redirect
     "${",  # Variable expansion with braces (can run commands via ${var:-$(cmd)})
 )
+"""Literal substrings that indicate shell injection risk.
 
-# Recommended safe shell commands for non-interactive mode.
-# These commands are primarily read-only and do not modify the filesystem
-# when used without shell redirection operators (which the dangerous-patterns
-# check blocks).
-#
-# EXCLUDED (dangerous - listed on GTFOBins/LOOBins or can modify system):
-# - All shells: bash, sh, zsh, fish, dash, ksh, csh, tcsh, etc.
-# - Editors: vim, vi, nano, emacs, ed, etc. (can spawn shells)
-# - Interpreters: python, perl, ruby, node, php, lua, awk, gawk, etc.
-# - Package managers: pip, npm, gem, apt, yum, brew, etc.
-# - Compilers: gcc, cc, make, cmake, etc.
-# - Network tools: curl, wget, nc, ssh, scp, ftp, telnet, etc.
-# - Archivers with shell escape: tar, zip, 7z, etc.
-# - System modifiers: chmod, chown, chattr, mv, rm, cp, dd, etc.
-# - Privilege tools: sudo, su, doas, pkexec, etc.
-# - Process tools: env, xargs, find (with -exec), etc.
-# - Git (can run hooks), docker, kubectl, etc.
-#
-# SAFE commands included below are primarily readers/formatters. File write and
-# injection are prevented by the dangerous-patterns check that blocks redirects,
-# command substitution, and other shell metacharacters.
+Used by `contains_dangerous_patterns` to reject commands that embed arbitrary
+execution via redirects, substitution operators, or control characters — even
+when the base command is on the allow-list.
+"""
+
 RECOMMENDED_SAFE_SHELL_COMMANDS = (
     # Directory listing
     "ls",
@@ -1251,6 +1237,13 @@ RECOMMENDED_SAFE_SHELL_COMMANDS = (
     # Process viewing (read-only)
     "ps",
 )
+"""Read-only commands auto-approved in non-interactive mode.
+
+Only includes readers and formatters — shells, editors, interpreters, package
+managers, network tools, archivers, and anything on GTFOBins/LOOBins is
+intentionally excluded. File-write and injection vectors are blocked separately
+by `DANGEROUS_SHELL_PATTERNS`.
+"""
 
 
 def contains_dangerous_patterns(command: str) -> bool:

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -24,8 +24,6 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain.agents.middleware.human_in_the_loop import ActionRequest, HITLRequest
@@ -823,30 +821,11 @@ async def run_non_interactive(
     result.apply_to_settings()
     thread_id = generate_thread_id()
 
-    try:
-        cwd = str(Path.cwd())
-    except OSError:
-        logger.warning("Could not determine working directory", exc_info=True)
-        cwd = ""
-    metadata: dict[str, str] = {
-        "assistant_id": assistant_id,
-        "agent_name": assistant_id,
-        "updated_at": datetime.now(UTC).isoformat(),
-    }
-    if cwd:
-        metadata["cwd"] = cwd
-    if sandbox_type and sandbox_type != "none":
-        metadata["sandbox_type"] = sandbox_type
-    from deepagents_cli.textual_adapter import _get_git_branch
+    from deepagents_cli.config import build_stream_config
 
-    branch = _get_git_branch()
-    if branch:
-        metadata["git_branch"] = branch
-
-    config: RunnableConfig = {
-        "configurable": {"thread_id": thread_id},
-        "metadata": metadata,
-    }
+    config: RunnableConfig = build_stream_config(
+        thread_id, assistant_id, sandbox_type=sandbox_type
+    )
 
     thread_url_lookup: ThreadUrlLookupState | None = None
     if not quiet:

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -8,12 +8,11 @@ import json
 import logging
 import time
 import uuid
-from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from pathlib import Path
 
     from langchain.agents.middleware.human_in_the_loop import (
         ApproveDecision,
@@ -38,6 +37,7 @@ from deepagents_cli._session_stats import (
     SpinnerStatus as SpinnerStatus,
     format_token_count as format_token_count,
 )
+from deepagents_cli.config import build_stream_config
 from deepagents_cli.file_ops import FileOpTracker
 from deepagents_cli.hooks import dispatch_hook
 from deepagents_cli.input import MediaTracker, parse_file_mentions
@@ -53,9 +53,6 @@ from deepagents_cli.widgets.messages import (
 
 logger = logging.getLogger(__name__)
 configure_debug_logging(logger)
-
-_git_branch_cache: dict[str, str | None] = {}
-"""Cache git-branch lookups by current working directory."""
 
 _hitl_adapter_cache: TypeAdapter | None = None
 """Lazy singleton for the HITL request validator."""
@@ -175,83 +172,6 @@ if TYPE_CHECKING:
 
 _ASK_USER_INTERRUPT_ADAPTER = TypeAdapter(AskUserRequest)
 """Validator for incoming `ask_user` interrupt payloads."""
-
-
-def _get_git_branch() -> str | None:
-    """Return the current git branch name, or None if not in a repo."""
-    import subprocess  # noqa: S404
-
-    try:
-        cwd = str(Path.cwd())
-    except OSError:
-        logger.debug("Could not determine cwd for git branch lookup", exc_info=True)
-        return None
-    if cwd in _git_branch_cache:
-        return _git_branch_cache[cwd]
-
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip() or None
-            _git_branch_cache[cwd] = branch
-            return branch
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        logger.debug("Could not determine git branch", exc_info=True)
-    _git_branch_cache[cwd] = None
-    return None
-
-
-def _build_stream_config(
-    thread_id: str,
-    assistant_id: str | None,
-    *,
-    sandbox_type: str | None = None,
-) -> dict[str, Any]:
-    """Build the LangGraph stream config dict.
-
-    The `thread_id` in `configurable` is automatically propagated as run
-    metadata by LangGraph, so it can be used for LangSmith filtering without
-    a separate metadata key. Includes the current working directory (`cwd`),
-    git branch, and sandbox type in metadata when available.
-
-    Args:
-        thread_id: The CLI session thread identifier.
-        assistant_id: The agent/assistant identifier, if any.
-        sandbox_type: Sandbox provider name for trace metadata, or `None`
-            if no sandbox is active.
-
-    Returns:
-        Config dict with `configurable` and `metadata` keys.
-    """
-    try:
-        cwd = str(Path.cwd())
-    except OSError:
-        logger.warning("Could not determine working directory", exc_info=True)
-        cwd = ""
-    metadata: dict[str, str] = {"cwd": cwd} if cwd else {}
-    if assistant_id:
-        metadata.update(
-            {
-                "assistant_id": assistant_id,
-                "agent_name": assistant_id,
-                "updated_at": datetime.now(UTC).isoformat(),
-            }
-        )
-    branch = _get_git_branch()
-    if branch:
-        metadata["git_branch"] = branch
-    if sandbox_type and sandbox_type != "none":
-        metadata["sandbox_type"] = sandbox_type
-    return {
-        "configurable": {"thread_id": thread_id},
-        "metadata": metadata,
-    }
 
 
 def _is_summarization_chunk(metadata: dict | None) -> bool:
@@ -539,7 +459,7 @@ async def execute_task_textual(
         message_content = final_input
 
     thread_id = session_state.thread_id
-    config = _build_stream_config(thread_id, assistant_id, sandbox_type=sandbox_type)
+    config = build_stream_config(thread_id, assistant_id, sandbox_type=sandbox_type)
 
     await dispatch_hook("session.start", {"thread_id": thread_id})
 

--- a/libs/cli/tests/integration_tests/test_compact_resume.py
+++ b/libs/cli/tests/integration_tests/test_compact_resume.py
@@ -37,9 +37,9 @@ def _build_long_prompt(turn: int) -> str:
 
 async def _run_turn(agent, *, thread_id: str, assistant_id: str, prompt: str) -> None:
     """Execute one real remote agent turn and drain the stream to completion."""
-    from deepagents_cli.textual_adapter import _build_stream_config
+    from deepagents_cli.config import build_stream_config
 
-    config = _build_stream_config(thread_id, assistant_id)
+    config = build_stream_config(thread_id, assistant_id)
     stream_input = {"messages": [{"role": "user", "content": prompt}]}
     async for _chunk in agent.astream(
         stream_input,

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -16,13 +16,13 @@ from langgraph.types import Command
 from pydantic import ValidationError
 from rich.console import Console
 
-from deepagents_cli import textual_adapter
+from deepagents_cli import config as config_module
+from deepagents_cli.config import build_stream_config
 from deepagents_cli.textual_adapter import (
     ModelStats,
     SessionStats,
     TextualUIAdapter,
     _build_interrupted_ai_message,
-    _build_stream_config,
     _format_duration,
     _is_summarization_chunk,
     execute_task_textual,
@@ -125,15 +125,15 @@ class TestTextualUIAdapterInit:
 
 
 class TestBuildStreamConfig:
-    """Tests for `_build_stream_config` metadata construction."""
+    """Tests for `build_stream_config` metadata construction."""
 
     def setup_method(self) -> None:
         """Clear the git-branch cache between tests."""
-        textual_adapter._git_branch_cache.clear()
+        config_module._git_branch_cache.clear()
 
     def test_assistant_fields_present(self) -> None:
         """Assistant-specific metadata should be present when `assistant_id` is set."""
-        config = _build_stream_config("t-456", assistant_id="my-agent")
+        config = build_stream_config("t-456", assistant_id="my-agent")
         assert config["metadata"]["assistant_id"] == "my-agent"
         assert config["metadata"]["agent_name"] == "my-agent"
         assert "updated_at" in config["metadata"]
@@ -141,7 +141,7 @@ class TestBuildStreamConfig:
 
     def test_updated_at_is_valid_iso_timestamp(self) -> None:
         """`updated_at` should be a valid timezone-aware ISO 8601 timestamp."""
-        config = _build_stream_config("t-456", assistant_id="my-agent")
+        config = build_stream_config("t-456", assistant_id="my-agent")
         raw = config["metadata"]["updated_at"]
         assert isinstance(raw, str)
         parsed = datetime.fromisoformat(raw)
@@ -149,7 +149,7 @@ class TestBuildStreamConfig:
 
     def test_no_assistant_fields_when_none(self) -> None:
         """Assistant-specific fields should be absent when `assistant_id` is `None`."""
-        config = _build_stream_config("t-789", assistant_id=None)
+        config = build_stream_config("t-789", assistant_id=None)
         metadata = config["metadata"]
         assert "assistant_id" not in metadata
         assert "agent_name" not in metadata
@@ -158,7 +158,7 @@ class TestBuildStreamConfig:
 
     def test_no_assistant_fields_when_empty_string(self) -> None:
         """Empty-string `assistant_id` should be treated as absent."""
-        config = _build_stream_config("t-000", assistant_id="")
+        config = build_stream_config("t-000", assistant_id="")
         metadata = config["metadata"]
         assert "assistant_id" not in metadata
         assert "agent_name" not in metadata
@@ -168,46 +168,76 @@ class TestBuildStreamConfig:
     def test_git_branch_included_when_available(self) -> None:
         """Git branch should be included in metadata when in a git repo."""
         with patch(
-            "deepagents_cli.textual_adapter._get_git_branch",
+            "deepagents_cli.config._get_git_branch",
             return_value="feature-branch",
         ):
-            config = _build_stream_config("t-git", assistant_id="agent")
+            config = build_stream_config("t-git", assistant_id="agent")
         assert config["metadata"]["git_branch"] == "feature-branch"
 
     def test_git_branch_absent_when_not_in_repo(self) -> None:
         """Git branch should be absent when not in a git repo."""
         with patch(
-            "deepagents_cli.textual_adapter._get_git_branch",
+            "deepagents_cli.config._get_git_branch",
             return_value=None,
         ):
-            config = _build_stream_config("t-nogit", assistant_id="agent")
+            config = build_stream_config("t-nogit", assistant_id="agent")
         assert "git_branch" not in config["metadata"]
 
     def test_configurable_thread_id(self) -> None:
         """`configurable.thread_id` should match the provided thread ID."""
-        config = _build_stream_config("t-abc", assistant_id=None)
+        config = build_stream_config("t-abc", assistant_id=None)
         assert config["configurable"]["thread_id"] == "t-abc"
 
     def test_sandbox_type_included_when_set(self) -> None:
         """Sandbox type should appear in metadata when provided."""
-        config = _build_stream_config("t-sb", assistant_id=None, sandbox_type="daytona")
+        config = build_stream_config("t-sb", assistant_id=None, sandbox_type="daytona")
         assert config["metadata"]["sandbox_type"] == "daytona"
 
     def test_sandbox_type_absent_when_none(self) -> None:
         """Sandbox type should be absent from metadata when not provided."""
-        config = _build_stream_config("t-nosb", assistant_id=None)
+        config = build_stream_config("t-nosb", assistant_id=None)
         assert "sandbox_type" not in config["metadata"]
 
     def test_sandbox_type_none_string_excluded(self) -> None:
         """The argparse sentinel `"none"` should not leak into metadata."""
-        config = _build_stream_config("t-none", assistant_id=None, sandbox_type="none")
+        config = build_stream_config("t-none", assistant_id=None, sandbox_type="none")
         assert "sandbox_type" not in config["metadata"]
 
     def test_no_model_keys_in_configurable(self) -> None:
         """Model/model_params should not be in configurable."""
-        config = _build_stream_config("t-no-model", assistant_id=None)
+        config = build_stream_config("t-no-model", assistant_id=None)
         assert "model" not in config["configurable"]
         assert "model_params" not in config["configurable"]
+
+    def test_versions_contains_cli_version(self) -> None:
+        """CLI version should always be present in metadata.versions."""
+        from deepagents_cli._version import __version__
+
+        config = build_stream_config("t-ver", assistant_id=None)
+        assert config["metadata"]["versions"]["deepagents-cli"] == __version__
+
+    def test_versions_contains_sdk_version_when_installed(self) -> None:
+        """SDK version should be in versions when deepagents is installed."""
+        with patch(
+            "importlib.metadata.version",
+            return_value="0.5.0",
+        ):
+            config = build_stream_config("t-sdk", assistant_id=None)
+        assert config["metadata"]["versions"]["deepagents"] == "0.5.0"
+
+    def test_versions_omits_sdk_when_not_installed(self) -> None:
+        """SDK version key should be absent when deepagents is not installed."""
+        from importlib.metadata import PackageNotFoundError
+
+        with patch(
+            "importlib.metadata.version",
+            side_effect=PackageNotFoundError("deepagents"),
+        ):
+            config = build_stream_config("t-nosdk", assistant_id=None)
+        assert "deepagents" not in config["metadata"]["versions"]
+        from deepagents_cli._version import __version__
+
+        assert config["metadata"]["versions"]["deepagents-cli"] == __version__
 
 
 class TestGetGitBranch:
@@ -215,7 +245,7 @@ class TestGetGitBranch:
 
     def setup_method(self) -> None:
         """Clear the git-branch cache between tests."""
-        textual_adapter._git_branch_cache.clear()
+        config_module._git_branch_cache.clear()
 
     def test_reuses_cached_branch_for_same_working_directory(self) -> None:
         """Repeated lookups in one repo should only spawn `git` once."""
@@ -223,13 +253,13 @@ class TestGetGitBranch:
 
         with (
             patch(
-                "deepagents_cli.textual_adapter.Path.cwd",
+                "deepagents_cli.config.Path.cwd",
                 return_value=Path("/tmp/repo"),
             ),
             patch("subprocess.run", return_value=result) as mock_run,
         ):
-            assert textual_adapter._get_git_branch() == "feature-branch"
-            assert textual_adapter._get_git_branch() == "feature-branch"
+            assert config_module._get_git_branch() == "feature-branch"
+            assert config_module._get_git_branch() == "feature-branch"
 
         assert mock_run.call_count == 1
 
@@ -239,31 +269,31 @@ class TestGetGitBranchOSError:
 
     def setup_method(self) -> None:
         """Clear the git-branch cache between tests."""
-        textual_adapter._git_branch_cache.clear()
+        config_module._git_branch_cache.clear()
 
     def test_returns_none_on_cwd_oserror(self) -> None:
         """_get_git_branch should return None when cwd is inaccessible."""
         with patch(
-            "deepagents_cli.textual_adapter.Path.cwd",
+            "deepagents_cli.config.Path.cwd",
             side_effect=OSError("deleted"),
         ):
-            assert textual_adapter._get_git_branch() is None
+            assert config_module._get_git_branch() is None
 
 
 class TestBuildStreamConfigOSError:
-    """Tests for _build_stream_config when Path.cwd() raises OSError."""
+    """Tests for build_stream_config when Path.cwd() raises OSError."""
 
     def setup_method(self) -> None:
         """Clear the git-branch cache between tests."""
-        textual_adapter._git_branch_cache.clear()
+        config_module._git_branch_cache.clear()
 
     def test_cwd_absent_on_oserror(self) -> None:
         """Cwd should be absent from metadata when Path.cwd() raises."""
         with patch(
-            "deepagents_cli.textual_adapter.Path.cwd",
+            "deepagents_cli.config.Path.cwd",
             side_effect=OSError("deleted"),
         ):
-            config = _build_stream_config("t-err", assistant_id="agent")
+            config = build_stream_config("t-err", assistant_id="agent")
         assert "cwd" not in config["metadata"]
 
 

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -18,6 +18,7 @@ from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
 from deepagents._models import resolve_model
+from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
@@ -325,6 +326,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             "recursion_limit": 1000,
             "metadata": {
                 "ls_integration": "deepagents",
+                "versions": {"deepagents": __version__},
             },
         }
     )

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -1,0 +1,26 @@
+"""Unit tests for deepagents.graph module."""
+
+from langchain_core.messages import AIMessage
+
+from deepagents._version import __version__
+from deepagents.graph import create_deep_agent
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+class TestCreateDeepAgentMetadata:
+    """Tests for metadata on the compiled graph."""
+
+    def test_versions_metadata_contains_sdk_version(self) -> None:
+        """`create_deep_agent` should attach SDK version in metadata.versions."""
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        agent = create_deep_agent(model=model)
+        assert agent.config is not None
+        versions = agent.config["metadata"]["versions"]
+        assert versions["deepagents"] == __version__
+
+    def test_ls_integration_metadata_preserved(self) -> None:
+        """`ls_integration` should still be present alongside versions."""
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        agent = create_deep_agent(model=model)
+        assert agent.config is not None
+        assert agent.config["metadata"]["ls_integration"] == "deepagents"


### PR DESCRIPTION
Stamp `metadata.versions` on traces to surface the `deepagents` and `deepagents-cli` versions that produced a run.

Consolidates the duplicated stream config builder from `textual_adapter.py` and `non_interactive.py` into a single `build_stream_config` in `config.py`.

Upstream `langchain-core` [#35295](https://github.com/langchain-ai/langchain/pull/35295) is **not required** — this PR is self-contained. Once it lands, inner LLM call traces will additionally carry `langchain-core` / `langchain-anthropic` / etc. versions via `_add_version()`, and the `add_metadata` deep-merge in callbacks will preserve them alongside the graph-level versions set here.

## Changes
- `build_stream_config` injects both `deepagents-cli` and `deepagents` SDK versions into `metadata["versions"]` — the CLI must include both because LangGraph shallow-merges metadata dicts, so the CLI's `versions` dict replaces the SDK's at stream time
- SDK version is resolved via `importlib.metadata.version("deepagents")` (not a direct import) to avoid pulling the heavy SDK package into the CLI's startup path

## How version metadata flows through a trace

`create_deep_agent` bakes `versions: {"deepagents": "X.Y.Z"}` into the compiled graph via `with_config`. The CLI adds `{"deepagents-cli": "X.Y.Z"}` via `build_stream_config`. LangGraph propagates this config metadata down to every node in the graph.

With `langchain-core` [#35295](https://github.com/langchain-ai/langchain/pull/35295), each chat model will also stamps its own versions (`langchain-core`, `langchain-anthropic`, etc.) on `self.metadata` via `_add_version()` in the constructor. The `add_metadata` deep-merge in callbacks ensures these survive alongside the inherited graph-level versions. The final inner LLM call trace carries all versions:

```json
{
  "ls_integration": "deepagents",
  "versions": {
    "deepagents": "0.5.0",
    "deepagents-cli": "0.0.34",
    "langchain-core": "0.3.42",
    "langchain-anthropic": "1.3.3"
  }
}
```