### PR TITLE
feat(cli): add `deepagents deploy` and `deepagents dev` commands

### DIFF
--- a/libs/cli/deepagents_cli/deploy.py
+++ b/libs/cli/deepagents_cli/deploy.py
@@ -1,0 +1,701 @@
+"""Deploy and dev commands for running deepagents on LangGraph Platform.
+
+Generates deployment artifacts (langgraph.json, deploy_graph.py, pyproject.toml)
+and delegates to `langgraph deploy` or `langgraph dev` for the actual
+build/push/serve lifecycle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess  # noqa: S404
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEPLOY_GRAPH_FILENAME = "deploy_graph.py"
+_LANGGRAPH_JSON_FILENAME = "langgraph.json"
+_PYPROJECT_FILENAME = "pyproject.toml"
+_ENV_FILENAME = ".env"
+_BUNDLED_DIR = "bundled"
+_AGENTS_MD_DIR = "agents_md"
+_SKILLS_DIR = "skills"
+
+
+@dataclass(frozen=True)
+class DeployConfig:
+    """Configuration for a deployment."""
+
+    sandbox_type: str = "langsmith"
+    model: str | None = None
+    agent_name: str = "agent"
+    deployment_name: str | None = None
+    env_file: str | None = None
+    api_key: str | None = None
+    dry_run: bool = False
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+
+def _collect_agents_md(project_root: Path | None) -> list[tuple[str, str]]:
+    """Collect AGENTS.md files from the project.
+
+    Args:
+        project_root: Project root directory.
+
+    Returns:
+        List of `(relative_name, content)` tuples.
+    """
+    files: list[tuple[str, str]] = []
+    if project_root is None:
+        return files
+
+    candidates = [
+        ("AGENTS.md", project_root / "AGENTS.md"),
+        (".deepagents/AGENTS.md", project_root / ".deepagents" / "AGENTS.md"),
+    ]
+    for name, path in candidates:
+        try:
+            if path.exists() and path.is_file():
+                files.append((name, path.read_text(encoding="utf-8")))
+        except OSError:
+            logger.warning("Could not read %s", path, exc_info=True)
+    return files
+
+
+def _collect_skills(project_root: Path | None) -> list[tuple[str, Path]]:
+    """Collect skill directories from the project.
+
+    Args:
+        project_root: Project root directory.
+
+    Returns:
+        List of `(relative_path, absolute_path)` tuples for skill dirs.
+    """
+    dirs: list[tuple[str, Path]] = []
+    if project_root is None:
+        return dirs
+
+    candidates = [
+        (".deepagents/skills", project_root / ".deepagents" / "skills"),
+        (".agents/skills", project_root / ".agents" / "skills"),
+    ]
+    for rel, path in candidates:
+        try:
+            if path.exists() and path.is_dir():
+                dirs.append((rel, path))
+        except OSError:
+            logger.warning("Could not access %s", path, exc_info=True)
+    return dirs
+
+
+def _collect_user_agents_md(agent_name: str) -> str | None:
+    """Read the user-level AGENTS.md for the given agent.
+
+    Args:
+        agent_name: Agent name (e.g. "agent").
+
+    Returns:
+        Content string, or `None` if not found or empty.
+    """
+    user_dir = Path.home() / ".deepagents" / agent_name
+    agent_md = user_dir / "AGENTS.md"
+    try:
+        if agent_md.exists():
+            content = agent_md.read_text(encoding="utf-8").strip()
+            if content:
+                return content
+    except OSError:
+        logger.warning("Could not read user AGENTS.md at %s", agent_md, exc_info=True)
+    return None
+
+
+def _bundle_files(
+    work_dir: Path,
+    *,
+    project_root: Path | None,
+    agent_name: str,
+) -> dict[str, Any]:
+    """Bundle AGENTS.md and skills into the work directory.
+
+    Args:
+        work_dir: Deployment working directory.
+        project_root: Project root directory.
+        agent_name: Agent name.
+
+    Returns:
+        Metadata dict with bundled file info.
+    """
+    bundled_dir = work_dir / _BUNDLED_DIR
+    bundled_dir.mkdir(exist_ok=True)
+
+    metadata: dict[str, Any] = {"agents_md_files": [], "skills_dirs": []}
+
+    agents_md_dir = bundled_dir / _AGENTS_MD_DIR
+    agents_md_dir.mkdir(exist_ok=True)
+
+    project_files = _collect_agents_md(project_root)
+    for name, content in project_files:
+        safe_name = name.replace("/", "_").replace("\\", "_")
+        dest = agents_md_dir / safe_name
+        dest.write_text(content, encoding="utf-8")
+        metadata["agents_md_files"].append(safe_name)
+
+    user_content = _collect_user_agents_md(agent_name)
+    if user_content:
+        dest = agents_md_dir / "user_AGENTS.md"
+        dest.write_text(user_content, encoding="utf-8")
+        metadata["agents_md_files"].append("user_AGENTS.md")
+
+    skills_dirs = _collect_skills(project_root)
+    skills_dest = bundled_dir / _SKILLS_DIR
+    for rel, src_path in skills_dirs:
+        dest = skills_dest / rel.replace("/", "_")
+        try:
+            shutil.copytree(src_path, dest, dirs_exist_ok=True)
+            metadata["skills_dirs"].append(str(dest.relative_to(work_dir)))
+        except OSError:
+            logger.warning("Could not copy skills from %s", src_path, exc_info=True)
+
+    user_skills = Path.home() / ".deepagents" / agent_name / "skills"
+    if user_skills.exists() and user_skills.is_dir():
+        dest = skills_dest / "user_skills"
+        try:
+            shutil.copytree(user_skills, dest, dirs_exist_ok=True)
+            metadata["skills_dirs"].append(str(dest.relative_to(work_dir)))
+        except OSError:
+            logger.warning(
+                "Could not copy user skills from %s", user_skills, exc_info=True
+            )
+
+    built_in_skills = Path(__file__).parent / "built_in_skills"
+    if built_in_skills.exists() and built_in_skills.is_dir():
+        dest = skills_dest / "built_in"
+        try:
+            shutil.copytree(built_in_skills, dest, dirs_exist_ok=True)
+            metadata["skills_dirs"].append(str(dest.relative_to(work_dir)))
+        except OSError:
+            logger.warning(
+                "Could not copy built-in skills from %s",
+                built_in_skills,
+                exc_info=True,
+            )
+
+    return metadata
+
+
+_DEPLOY_GRAPH_TEMPLATE = '''\
+"""Server-side graph factory for deployed deepagents.
+
+This module is referenced by langgraph.json and exposes the agent graph
+via the `get_agent` async factory function. LangGraph Platform calls this
+function per-thread to create an agent with its own sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from langgraph.graph.state import RunnableConfig
+from langgraph.pregel import Pregel
+
+logger = logging.getLogger(__name__)
+
+BUNDLED_DIR = Path(__file__).parent / "bundled"
+AGENTS_MD_DIR = BUNDLED_DIR / "agents_md"
+SKILLS_DIR = BUNDLED_DIR / "skills"
+
+_SANDBOX_BACKENDS: dict[str, Any] = {}
+
+
+def _get_sandbox_type() -> str:
+    return os.getenv("SANDBOX_TYPE", "langsmith")
+
+
+def _create_sandbox(sandbox_id: str | None = None) -> Any:
+    """Create or reconnect to a sandbox."""
+    sandbox_type = _get_sandbox_type()
+
+    if sandbox_type == "langsmith":
+        from deepagents.backends.langsmith import LangSmithSandbox
+        from langsmith.sandbox import Sandbox
+
+        if sandbox_id:
+            sb = Sandbox.connect(sandbox_id)
+        else:
+            sb = Sandbox()
+        return LangSmithSandbox(sb)
+
+    if sandbox_type == "daytona":
+        from langchain_daytona import DaytonaSandbox
+
+        if sandbox_id:
+            return DaytonaSandbox(sandbox_id=sandbox_id)
+        return DaytonaSandbox()
+
+    if sandbox_type == "modal":
+        from langchain_modal import ModalSandbox
+
+        if sandbox_id:
+            return ModalSandbox(sandbox_id=sandbox_id)
+        return ModalSandbox()
+
+    if sandbox_type == "runloop":
+        from langchain_runloop import RunloopSandbox
+
+        if sandbox_id:
+            return RunloopSandbox(sandbox_id=sandbox_id)
+        return RunloopSandbox()
+
+    msg = f"Unsupported sandbox type: {sandbox_type}"
+    raise ValueError(msg)
+
+
+def _load_bundled_agents_md() -> str:
+    """Load all bundled AGENTS.md files into a combined string."""
+    if not AGENTS_MD_DIR.exists():
+        return ""
+    parts: list[str] = []
+    for md_file in sorted(AGENTS_MD_DIR.iterdir()):
+        if md_file.is_file() and md_file.suffix == ".md":
+            try:
+                content = md_file.read_text(encoding="utf-8").strip()
+                if content:
+                    parts.append(content)
+            except OSError:
+                logger.warning("Could not read %s", md_file, exc_info=True)
+    return "\\n\\n".join(parts)
+
+
+def _get_skills_sources() -> list[str]:
+    """Get paths to bundled skill directories."""
+    if not SKILLS_DIR.exists():
+        return []
+    sources: list[str] = []
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if entry.is_dir():
+            sources.append(str(entry))
+    return sources
+
+
+def _get_model() -> Any:
+    """Resolve the model from environment configuration."""
+    model_spec = os.getenv("DEEPAGENTS_DEPLOY_MODEL")
+    if not model_spec:
+        return "anthropic:claude-sonnet-4-6"
+    return model_spec
+
+
+async def get_agent(config: RunnableConfig) -> Pregel:
+    """Create an agent with a sandbox for the given thread.
+
+    This is the graph factory function called by LangGraph Platform
+    for each thread invocation.
+
+    Args:
+        config: LangGraph runtime configuration.
+
+    Returns:
+        Compiled agent graph.
+    """
+    from deepagents import create_deep_agent
+    from deepagents.middleware import MemoryMiddleware, SkillsMiddleware
+    from deepagents.backends.filesystem import FilesystemBackend
+
+    thread_id = config.get("configurable", {}).get("thread_id")
+
+    sandbox_backend = None
+    if thread_id:
+        sandbox_backend = _SANDBOX_BACKENDS.get(thread_id)
+
+    if sandbox_backend is None:
+        try:
+            sandbox_backend = _create_sandbox()
+            if thread_id:
+                _SANDBOX_BACKENDS[thread_id] = sandbox_backend
+        except Exception:
+            logger.exception("Failed to create sandbox")
+            raise
+
+    model = _get_model()
+    agents_md_content = _load_bundled_agents_md()
+    skills_sources = _get_skills_sources()
+
+    middleware: list[Any] = []
+
+    if agents_md_content:
+        agents_md_dir = AGENTS_MD_DIR
+        if agents_md_dir.exists():
+            memory_sources = [
+                str(p) for p in sorted(agents_md_dir.iterdir()) if p.is_file()
+            ]
+            middleware.append(
+                MemoryMiddleware(
+                    backend=FilesystemBackend(),
+                    sources=memory_sources,
+                )
+            )
+
+    if skills_sources:
+        middleware.append(
+            SkillsMiddleware(
+                backend=FilesystemBackend(),
+                sources=skills_sources,
+            )
+        )
+
+    system_prompt = os.getenv("DEEPAGENTS_DEPLOY_SYSTEM_PROMPT", "")
+
+    return create_deep_agent(
+        model=model,
+        system_prompt=system_prompt,
+        tools=[],
+        backend=sandbox_backend,
+        middleware=middleware,
+    ).with_config(config)
+'''
+
+
+def _write_deploy_graph(work_dir: Path) -> Path:
+    """Write the deploy_graph.py server-side entry point.
+
+    Args:
+        work_dir: Deployment working directory.
+
+    Returns:
+        Path to the written file.
+    """
+    dest = work_dir / _DEPLOY_GRAPH_FILENAME
+    dest.write_text(_DEPLOY_GRAPH_TEMPLATE, encoding="utf-8")
+    return dest
+
+
+def _write_langgraph_json(
+    work_dir: Path,
+    *,
+    env_file: str | None = None,
+) -> Path:
+    """Generate the langgraph.json configuration.
+
+    Args:
+        work_dir: Deployment working directory.
+        env_file: Optional path to .env file.
+
+    Returns:
+        Path to the written file.
+    """
+    config: dict[str, Any] = {
+        "dependencies": ["."],
+        "graphs": {
+            "agent": f"./{_DEPLOY_GRAPH_FILENAME}:get_agent",
+        },
+        "python_version": f"3.{sys.version_info.minor}",
+    }
+    if env_file:
+        config["env"] = env_file
+
+    dest = work_dir / _LANGGRAPH_JSON_FILENAME
+    dest.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    return dest
+
+
+def _write_pyproject(work_dir: Path, *, sandbox_type: str = "langsmith") -> Path:
+    """Generate a pyproject.toml for the deployment.
+
+    Args:
+        work_dir: Deployment working directory.
+        sandbox_type: Sandbox provider to include as a dependency.
+
+    Returns:
+        Path to the written file.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+        sdk_version = pkg_version("deepagents")
+    except (PackageNotFoundError, ModuleNotFoundError):
+        sdk_version = "0.4.11"
+
+    deps = [
+        f'"deepagents>={sdk_version}"',
+        '"langchain>=1.2.10"',
+        '"langgraph>=1.1.2"',
+        '"langsmith[sandbox]>=0.7.7"',
+    ]
+
+    sandbox_deps = {
+        "daytona": '"langchain-daytona>=0.0.4"',
+        "modal": '"langchain-modal>=0.0.2"',
+        "runloop": '"langchain-runloop>=0.0.3"',
+    }
+    if sandbox_type in sandbox_deps:
+        deps.append(sandbox_deps[sandbox_type])
+
+    deps_str = ",\n    ".join(deps)
+
+    content = f"""\
+[project]
+name = "deepagents-deploy"
+version = "0.0.1"
+description = "Deployed deepagents agent"
+requires-python = ">=3.11"
+dependencies = [
+    {deps_str},
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"""
+    dest = work_dir / _PYPROJECT_FILENAME
+    dest.write_text(content, encoding="utf-8")
+    return dest
+
+
+def _write_env_file(
+    work_dir: Path,
+    *,
+    config: DeployConfig,
+    user_env_file: str | None = None,
+) -> Path | None:
+    """Generate a .env file for the deployment.
+
+    Args:
+        work_dir: Deployment working directory.
+        config: Deploy configuration.
+        user_env_file: Optional user-provided .env file to merge.
+
+    Returns:
+        Path to the written file, or `None` if no env vars needed.
+    """
+    env_vars: dict[str, str] = {}
+
+    env_vars["SANDBOX_TYPE"] = config.sandbox_type
+
+    if config.model:
+        env_vars["DEEPAGENTS_DEPLOY_MODEL"] = config.model
+
+    api_key = (
+        config.api_key
+        or os.environ.get("LANGSMITH_API_KEY")
+        or os.environ.get("LANGCHAIN_API_KEY")
+    )
+    if api_key:
+        env_vars["LANGSMITH_API_KEY"] = api_key
+
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "DAYTONA_API_KEY",
+        "DAYTONA_SERVER_URL",
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
+        "RUNLOOP_API_KEY",
+    ):
+        val = os.environ.get(key)
+        if val:
+            env_vars[key] = val
+
+    env_vars.update(config.extra_env)
+
+    if user_env_file:
+        user_path = Path(user_env_file).expanduser().resolve()
+        if user_path.exists():
+            for raw_line in user_path.read_text(encoding="utf-8").splitlines():
+                stripped = raw_line.strip()
+                if stripped and not stripped.startswith("#") and "=" in stripped:
+                    k, _, v = stripped.partition("=")
+                    env_vars[k.strip()] = v.strip()
+
+    if not env_vars:
+        return None
+
+    dest = work_dir / _ENV_FILENAME
+    lines = [f"{k}={v}" for k, v in sorted(env_vars.items())]
+    dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return dest
+
+
+def scaffold_deployment(
+    config: DeployConfig,
+    *,
+    project_root: Path | None = None,
+    output_dir: Path | None = None,
+) -> Path:
+    """Generate all deployment artifacts in a working directory.
+
+    Args:
+        config: Deploy configuration.
+        project_root: Project root for discovering AGENTS.md and skills.
+        output_dir: Output directory. Created as a temp dir if `None`.
+
+    Returns:
+        Path to the deployment working directory.
+    """
+    if output_dir is not None:
+        work_dir = output_dir
+        work_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        work_dir = Path(tempfile.mkdtemp(prefix="deepagents_deploy_"))
+
+    _bundle_files(work_dir, project_root=project_root, agent_name=config.agent_name)
+    _write_deploy_graph(work_dir)
+
+    env_path = _write_env_file(work_dir, config=config, user_env_file=config.env_file)
+    env_ref = f"./{_ENV_FILENAME}" if env_path else None
+    _write_langgraph_json(work_dir, env_file=env_ref)
+    _write_pyproject(work_dir, sandbox_type=config.sandbox_type)
+
+    return work_dir
+
+
+def _run_langgraph_command(
+    command: str,
+    work_dir: Path,
+    *,
+    extra_args: list[str] | None = None,
+    api_key: str | None = None,
+) -> int:
+    """Run a langgraph CLI command as a subprocess.
+
+    Args:
+        command: The langgraph subcommand (e.g. "deploy", "dev").
+        work_dir: Working directory containing langgraph.json.
+        extra_args: Additional CLI arguments.
+        api_key: LangSmith API key for deploy.
+
+    Returns:
+        Process exit code.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "langgraph_cli",
+        command,
+        "--config",
+        str(work_dir / _LANGGRAPH_JSON_FILENAME),
+    ]
+
+    if extra_args:
+        cmd.extend(extra_args)
+
+    env = os.environ.copy()
+    if api_key:
+        env["LANGSMITH_API_KEY"] = api_key
+
+    logger.info("Running: %s", " ".join(cmd))
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            cwd=str(work_dir),
+            env=env,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.exception(
+            "langgraph CLI not found. Install with: pip install langgraph-cli"
+        )
+        return 1
+    except KeyboardInterrupt:
+        return 130
+    else:
+        return result.returncode
+
+
+def run_deploy(config: DeployConfig) -> int:
+    """Run the full deploy flow: scaffold artifacts then call `langgraph deploy`.
+
+    Args:
+        config: Deploy configuration.
+
+    Returns:
+        Process exit code.
+    """
+    from deepagents_cli.config import console
+    from deepagents_cli.project_utils import find_project_root
+
+    project_root = find_project_root(Path.cwd())
+
+    console.print("[bold]Preparing deployment artifacts...[/bold]")
+
+    work_dir = scaffold_deployment(config, project_root=project_root)
+
+    console.print(f"  Artifacts generated in: {work_dir}")
+
+    if config.dry_run:
+        console.print("\n[bold green]Dry run complete.[/bold green]")
+        console.print(f"  Inspect artifacts at: {work_dir}")
+        console.print(f"  langgraph.json: {work_dir / _LANGGRAPH_JSON_FILENAME}")
+        console.print(f"  deploy_graph.py: {work_dir / _DEPLOY_GRAPH_FILENAME}")
+        console.print(f"  pyproject.toml: {work_dir / _PYPROJECT_FILENAME}")
+        return 0
+
+    console.print("[bold]Deploying to LangGraph Platform...[/bold]")
+
+    extra_args: list[str] = []
+    if config.deployment_name:
+        extra_args.extend(["--name", config.deployment_name])
+
+    return _run_langgraph_command(
+        "deploy",
+        work_dir,
+        extra_args=extra_args,
+        api_key=config.api_key,
+    )
+
+
+def run_dev(config: DeployConfig, *, port: int = 2024, host: str = "127.0.0.1") -> int:
+    """Run the dev flow: scaffold artifacts then call `langgraph dev`.
+
+    Args:
+        config: Deploy configuration.
+        port: Port for the dev server.
+        host: Host for the dev server.
+
+    Returns:
+        Process exit code.
+    """
+    from deepagents_cli.config import console
+    from deepagents_cli.project_utils import find_project_root
+
+    project_root = find_project_root(Path.cwd())
+
+    console.print("[bold]Preparing development server artifacts...[/bold]")
+
+    work_dir = scaffold_deployment(config, project_root=project_root)
+
+    console.print(f"  Artifacts generated in: {work_dir}")
+
+    if config.dry_run:
+        console.print("\n[bold green]Dry run complete.[/bold green]")
+        console.print(f"  Inspect artifacts at: {work_dir}")
+        return 0
+
+    console.print(f"[bold]Starting LangGraph dev server on {host}:{port}...[/bold]")
+
+    extra_args = [
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--no-browser",
+    ]
+
+    return _run_langgraph_command(
+        "dev",
+        work_dir,
+        extra_args=extra_args,
+        api_key=config.api_key,
+    )

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -404,6 +404,102 @@ def parse_args() -> argparse.Namespace:
     add_json_output_arg(threads_delete)
     threads_delete.add_argument("thread_id", help="Thread ID to delete")
 
+    # ---- deploy subcommand ----
+    deploy_parser = subparsers.add_parser(
+        "deploy",
+        help="Deploy agent to LangGraph Platform",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_deploy_help")),
+    )
+    deploy_parser.add_argument(
+        "--sandbox",
+        choices=["langsmith", "daytona", "modal", "runloop"],
+        default="langsmith",
+        help="Sandbox provider for the deployed agent",
+    )
+    deploy_parser.add_argument(
+        "-M",
+        "--model",
+        metavar="MODEL",
+        help="Model to deploy with (default: claude-sonnet-4-6)",
+    )
+    deploy_parser.add_argument(
+        "-a",
+        "--agent",
+        default=_DEFAULT_AGENT_NAME,
+        metavar="NAME",
+        help="Agent configuration to deploy",
+    )
+    deploy_parser.add_argument(
+        "--name",
+        dest="deployment_name",
+        metavar="NAME",
+        help="Deployment name on LangGraph Platform",
+    )
+    deploy_parser.add_argument(
+        "--env-file",
+        metavar="PATH",
+        help="Additional .env file for deployment secrets",
+    )
+    deploy_parser.add_argument(
+        "--api-key",
+        metavar="KEY",
+        help="LangSmith API key (or set LANGSMITH_API_KEY env var)",
+    )
+    deploy_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate deployment artifacts without deploying",
+    )
+
+    # ---- dev subcommand (deploy-mode dev server) ----
+    dev_parser = subparsers.add_parser(
+        "dev",
+        help="Run deployed agent locally with LangGraph dev server",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_dev_help")),
+    )
+    dev_parser.add_argument(
+        "--sandbox",
+        choices=["langsmith", "daytona", "modal", "runloop"],
+        default="langsmith",
+        help="Sandbox provider for the agent",
+    )
+    dev_parser.add_argument(
+        "-M",
+        "--model",
+        metavar="MODEL",
+        help="Model to use (default: claude-sonnet-4-6)",
+    )
+    dev_parser.add_argument(
+        "-a",
+        "--agent",
+        default=_DEFAULT_AGENT_NAME,
+        metavar="NAME",
+        help="Agent configuration to use",
+    )
+    dev_parser.add_argument(
+        "--env-file",
+        metavar="PATH",
+        help="Additional .env file for secrets",
+    )
+    dev_parser.add_argument(
+        "--port",
+        type=int,
+        default=2024,
+        help="Port for the dev server",
+    )
+    dev_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host for the dev server",
+    )
+    dev_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate artifacts without starting the server",
+    )
+
     # Default interactive mode — argument order here determines the
     # usage line printed by argparse; keep in sync with ui.show_help().
     parser.add_argument(
@@ -1369,6 +1465,36 @@ def cli_main() -> None:
             else:
                 # No subcommand provided, show threads help screen
                 show_threads_help()
+        elif args.command == "deploy":
+            from deepagents_cli.deploy import DeployConfig, run_deploy
+
+            deploy_config = DeployConfig(
+                sandbox_type=getattr(args, "sandbox", "langsmith"),
+                model=getattr(args, "model", None),
+                agent_name=getattr(args, "agent", _DEFAULT_AGENT_NAME),
+                deployment_name=getattr(args, "deployment_name", None),
+                env_file=getattr(args, "env_file", None),
+                api_key=getattr(args, "api_key", None),
+                dry_run=getattr(args, "dry_run", False),
+            )
+            sys.exit(run_deploy(deploy_config))
+        elif args.command == "dev":
+            from deepagents_cli.deploy import DeployConfig, run_dev
+
+            dev_config = DeployConfig(
+                sandbox_type=getattr(args, "sandbox", "langsmith"),
+                model=getattr(args, "model", None),
+                agent_name=getattr(args, "agent", _DEFAULT_AGENT_NAME),
+                env_file=getattr(args, "env_file", None),
+                dry_run=getattr(args, "dry_run", False),
+            )
+            sys.exit(
+                run_dev(
+                    dev_config,
+                    port=getattr(args, "port", 2024),
+                    host=getattr(args, "host", "127.0.0.1"),
+                )
+            )
         elif args.non_interactive_message:
             # Check for optional tools before running agent (stderr so
             # --quiet piped output stays clean)

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -66,6 +66,12 @@ def show_help() -> None:
     console.print(
         "  deepagents threads <list|delete>               Manage conversation threads"
     )
+    console.print(
+        "  deepagents deploy [OPTIONS]                    Deploy to LangGraph Platform"
+    )
+    console.print(
+        "  deepagents dev [OPTIONS]                       Run deployed agent locally"
+    )
     console.print()
 
     console.print("[bold]Options:[/bold]", style=COLORS["primary"])
@@ -137,6 +143,98 @@ def show_help() -> None:
     )
     console.print(
         "  deepagents -n 'Fix tests' -S all           # Any command",
+        style=COLORS["dim"],
+    )
+    console.print()
+
+
+def show_deploy_help() -> None:
+    """Show help information for the `deploy` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents deploy [options]")
+    console.print()
+    console.print(
+        "Deploy the current agent to LangGraph Platform. Bundles AGENTS.md,",
+    )
+    console.print(
+        "skills, and configuration into a deployable package, then builds",
+    )
+    console.print(
+        "and pushes a Docker image via `langgraph deploy`.",
+    )
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print(
+        "  --sandbox TYPE             Sandbox provider: langsmith (default),"
+        " daytona, modal, runloop"
+    )
+    console.print("  -M, --model MODEL          Model to deploy with")
+    console.print("  -a, --agent NAME           Agent configuration to deploy")
+    console.print("  --name NAME                Deployment name on LangGraph Platform")
+    console.print("  --env-file PATH            Additional .env file for secrets")
+    console.print("  --api-key KEY              LangSmith API key")
+    console.print("  --dry-run                  Generate artifacts without deploying")
+    console.print("  -h, --help                 Show this help message")
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
+    console.print(
+        "  deepagents deploy                              # Deploy with defaults",
+        style=COLORS["dim"],
+    )
+    console.print(
+        "  deepagents deploy --sandbox daytona            # Use Daytona sandbox",
+        style=COLORS["dim"],
+    )
+    console.print(
+        "  deepagents deploy --dry-run                    # Inspect artifacts only",
+        style=COLORS["dim"],
+    )
+    console.print()
+
+
+def show_dev_help() -> None:
+    """Show help information for the `dev` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=COLORS["primary"])
+    console.print("  deepagents dev [options]")
+    console.print()
+    console.print(
+        "Run the deployed agent configuration locally using `langgraph dev`.",
+    )
+    console.print(
+        "Bundles the same artifacts as `deploy` but starts a local dev server",
+    )
+    console.print(
+        "instead of pushing to LangGraph Platform.",
+    )
+    console.print()
+    console.print("[bold]Options:[/bold]", style=COLORS["primary"])
+    console.print(
+        "  --sandbox TYPE             Sandbox provider: langsmith (default),"
+        " daytona, modal, runloop"
+    )
+    console.print("  -M, --model MODEL          Model to use")
+    console.print("  -a, --agent NAME           Agent configuration to use")
+    console.print("  --env-file PATH            Additional .env file for secrets")
+    console.print("  --port PORT                Dev server port (default: 2024)")
+    console.print("  --host HOST                Dev server host (default: 127.0.0.1)")
+    console.print(
+        "  --dry-run                  Generate artifacts without starting server"
+    )
+    console.print("  -h, --help                 Show this help message")
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=COLORS["primary"])
+    console.print(
+        "  deepagents dev                                 # Start local dev server",
+        style=COLORS["dim"],
+    )
+    console.print(
+        "  deepagents dev --port 8000                     # Custom port",
+        style=COLORS["dim"],
+    )
+    console.print(
+        "  deepagents dev --sandbox modal                 # Use Modal sandbox",
         style=COLORS["dim"],
     )
     console.print()

--- a/libs/cli/tests/unit_tests/test_deploy.py
+++ b/libs/cli/tests/unit_tests/test_deploy.py
@@ -1,0 +1,358 @@
+"""Tests for the deploy module."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deepagents_cli.deploy import (
+    DeployConfig,
+    _collect_agents_md,
+    _collect_skills,
+    _collect_user_agents_md,
+    _write_deploy_graph,
+    _write_env_file,
+    _write_langgraph_json,
+    _write_pyproject,
+    scaffold_deployment,
+)
+
+
+class TestDeployConfig:
+    def test_defaults(self):
+        config = DeployConfig()
+        assert config.sandbox_type == "langsmith"
+        assert config.model is None
+        assert config.agent_name == "agent"
+        assert config.deployment_name is None
+        assert config.dry_run is False
+
+    def test_custom_values(self):
+        config = DeployConfig(
+            sandbox_type="modal",
+            model="anthropic:claude-opus-4-6",
+            agent_name="coder",
+            deployment_name="my-deploy",
+            dry_run=True,
+        )
+        assert config.sandbox_type == "modal"
+        assert config.model == "anthropic:claude-opus-4-6"
+        assert config.agent_name == "coder"
+        assert config.deployment_name == "my-deploy"
+        assert config.dry_run is True
+
+
+class TestCollectAgentsMd:
+    def test_no_project_root(self):
+        assert _collect_agents_md(None) == []
+
+    def test_with_agents_md(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("# Project instructions")
+        result = _collect_agents_md(tmp_path)
+        assert len(result) == 1
+        assert result[0] == ("AGENTS.md", "# Project instructions")
+
+    def test_with_deepagents_agents_md(self, tmp_path):
+        da_dir = tmp_path / ".deepagents"
+        da_dir.mkdir()
+        (da_dir / "AGENTS.md").write_text("# Deep agents config")
+        result = _collect_agents_md(tmp_path)
+        assert len(result) == 1
+        assert result[0] == (".deepagents/AGENTS.md", "# Deep agents config")
+
+    def test_both_locations(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("# Root")
+        da_dir = tmp_path / ".deepagents"
+        da_dir.mkdir()
+        (da_dir / "AGENTS.md").write_text("# Nested")
+        result = _collect_agents_md(tmp_path)
+        assert len(result) == 2
+
+    def test_no_files(self, tmp_path):
+        assert _collect_agents_md(tmp_path) == []
+
+
+class TestCollectSkills:
+    def test_no_project_root(self):
+        assert _collect_skills(None) == []
+
+    def test_with_deepagents_skills(self, tmp_path):
+        skills_dir = tmp_path / ".deepagents" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "my-skill").mkdir()
+        result = _collect_skills(tmp_path)
+        assert len(result) == 1
+        assert result[0][0] == ".deepagents/skills"
+
+    def test_with_agents_skills(self, tmp_path):
+        skills_dir = tmp_path / ".agents" / "skills"
+        skills_dir.mkdir(parents=True)
+        result = _collect_skills(tmp_path)
+        assert len(result) == 1
+        assert result[0][0] == ".agents/skills"
+
+    def test_no_skills(self, tmp_path):
+        assert _collect_skills(tmp_path) == []
+
+
+class TestCollectUserAgentsMd:
+    def test_no_user_dir(self, tmp_path):
+        with patch("deepagents_cli.deploy.Path.home", return_value=tmp_path):
+            assert _collect_user_agents_md("agent") is None
+
+    def test_with_user_agents_md(self, tmp_path):
+        agent_dir = tmp_path / ".deepagents" / "agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "AGENTS.md").write_text("# User config")
+        with patch("deepagents_cli.deploy.Path.home", return_value=tmp_path):
+            result = _collect_user_agents_md("agent")
+        assert result == "# User config"
+
+    def test_empty_user_agents_md(self, tmp_path):
+        agent_dir = tmp_path / ".deepagents" / "agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "AGENTS.md").write_text("")
+        with patch("deepagents_cli.deploy.Path.home", return_value=tmp_path):
+            assert _collect_user_agents_md("agent") is None
+
+
+class TestWriteDeployGraph:
+    def test_creates_file(self, tmp_path):
+        path = _write_deploy_graph(tmp_path)
+        assert path.exists()
+        assert path.name == "deploy_graph.py"
+        content = path.read_text()
+        assert "async def get_agent" in content
+        assert "create_deep_agent" in content
+        assert "SANDBOX_TYPE" in content
+
+    def test_contains_sandbox_providers(self, tmp_path):
+        path = _write_deploy_graph(tmp_path)
+        content = path.read_text()
+        assert "langsmith" in content
+        assert "daytona" in content
+        assert "modal" in content
+        assert "runloop" in content
+
+
+class TestWriteLanggraphJson:
+    def test_creates_valid_json(self, tmp_path):
+        path = _write_langgraph_json(tmp_path)
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert "graphs" in data
+        assert "agent" in data["graphs"]
+        assert "deploy_graph.py:get_agent" in data["graphs"]["agent"]
+        assert data["dependencies"] == ["."]
+
+    def test_with_env_file(self, tmp_path):
+        path = _write_langgraph_json(tmp_path, env_file="./.env")
+        data = json.loads(path.read_text())
+        assert data["env"] == "./.env"
+
+    def test_python_version(self, tmp_path):
+        path = _write_langgraph_json(tmp_path)
+        data = json.loads(path.read_text())
+        expected = f"3.{sys.version_info.minor}"
+        assert data["python_version"] == expected
+
+
+class TestWritePyproject:
+    def test_creates_file(self, tmp_path):
+        path = _write_pyproject(tmp_path)
+        assert path.exists()
+        content = path.read_text()
+        assert "deepagents-deploy" in content
+        assert "deepagents>=" in content
+        assert "langsmith[sandbox]" in content
+
+    def test_langsmith_sandbox(self, tmp_path):
+        path = _write_pyproject(tmp_path, sandbox_type="langsmith")
+        content = path.read_text()
+        assert "langchain-daytona" not in content
+        assert "langchain-modal" not in content
+
+    def test_daytona_sandbox(self, tmp_path):
+        path = _write_pyproject(tmp_path, sandbox_type="daytona")
+        content = path.read_text()
+        assert "langchain-daytona" in content
+
+    def test_modal_sandbox(self, tmp_path):
+        path = _write_pyproject(tmp_path, sandbox_type="modal")
+        content = path.read_text()
+        assert "langchain-modal" in content
+
+    def test_runloop_sandbox(self, tmp_path):
+        path = _write_pyproject(tmp_path, sandbox_type="runloop")
+        content = path.read_text()
+        assert "langchain-runloop" in content
+
+
+class TestWriteEnvFile:
+    def test_writes_sandbox_type(self, tmp_path):
+        config = DeployConfig(sandbox_type="langsmith")
+        path = _write_env_file(tmp_path, config=config)
+        assert path is not None
+        content = path.read_text()
+        assert "SANDBOX_TYPE=langsmith" in content
+
+    def test_writes_model(self, tmp_path):
+        config = DeployConfig(model="anthropic:claude-opus-4-6")
+        path = _write_env_file(tmp_path, config=config)
+        assert path is not None
+        content = path.read_text()
+        assert "DEEPAGENTS_DEPLOY_MODEL=anthropic:claude-opus-4-6" in content
+
+    def test_picks_up_env_vars(self, tmp_path):
+        config = DeployConfig()
+        with patch.dict(
+            "os.environ",
+            {"ANTHROPIC_API_KEY": "sk-test", "LANGSMITH_API_KEY": "ls-test"},
+            clear=False,
+        ):
+            path = _write_env_file(tmp_path, config=config)
+        assert path is not None
+        content = path.read_text()
+        assert "ANTHROPIC_API_KEY=sk-test" in content
+        assert "LANGSMITH_API_KEY=ls-test" in content
+
+    def test_merges_user_env_file(self, tmp_path):
+        user_env = tmp_path / "user.env"
+        user_env.write_text("CUSTOM_VAR=hello\n# comment\nANOTHER=world\n")
+        config = DeployConfig()
+        path = _write_env_file(tmp_path, config=config, user_env_file=str(user_env))
+        assert path is not None
+        content = path.read_text()
+        assert "CUSTOM_VAR=hello" in content
+        assert "ANOTHER=world" in content
+
+    def test_api_key_from_config(self, tmp_path):
+        config = DeployConfig(api_key="my-key")
+        with patch.dict("os.environ", {}, clear=True):
+            path = _write_env_file(tmp_path, config=config)
+        assert path is not None
+        content = path.read_text()
+        assert "LANGSMITH_API_KEY=my-key" in content
+
+
+class TestScaffoldDeployment:
+    def test_creates_all_artifacts(self, tmp_path):
+        config = DeployConfig()
+        work_dir = scaffold_deployment(config, output_dir=tmp_path)
+        assert (work_dir / "deploy_graph.py").exists()
+        assert (work_dir / "langgraph.json").exists()
+        assert (work_dir / "pyproject.toml").exists()
+        assert (work_dir / "bundled").exists()
+
+    def test_bundles_agents_md(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "AGENTS.md").write_text("# My project")
+
+        output = tmp_path / "output"
+        config = DeployConfig()
+        work_dir = scaffold_deployment(config, project_root=project, output_dir=output)
+        agents_md_dir = work_dir / "bundled" / "agents_md"
+        assert agents_md_dir.exists()
+        assert (agents_md_dir / "AGENTS.md").exists()
+        assert (agents_md_dir / "AGENTS.md").read_text() == "# My project"
+
+    def test_bundles_skills(self, tmp_path):
+        project = tmp_path / "project"
+        skills_dir = project / ".deepagents" / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: my-skill\n---\n# Skill")
+
+        output = tmp_path / "output"
+        config = DeployConfig()
+        work_dir = scaffold_deployment(config, project_root=project, output_dir=output)
+        bundled_skills = work_dir / "bundled" / "skills"
+        assert bundled_skills.exists()
+
+    def test_langgraph_json_valid(self, tmp_path):
+        config = DeployConfig()
+        work_dir = scaffold_deployment(config, output_dir=tmp_path)
+        data = json.loads((work_dir / "langgraph.json").read_text())
+        assert data["graphs"]["agent"] == "./deploy_graph.py:get_agent"
+
+    def test_temp_dir_when_no_output(self):
+        config = DeployConfig()
+        work_dir = scaffold_deployment(config)
+        try:
+            assert work_dir.exists()
+            assert (work_dir / "deploy_graph.py").exists()
+        finally:
+            import shutil
+
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+class TestParseArgs:
+    def test_deploy_subcommand(self):
+        from deepagents_cli.main import parse_args
+
+        with patch.object(sys, "argv", ["deepagents", "deploy"]):
+            args = parse_args()
+        assert args.command == "deploy"
+        assert args.sandbox == "langsmith"
+        assert args.dry_run is False
+
+    def test_deploy_with_options(self):
+        from deepagents_cli.main import parse_args
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "deepagents",
+                "deploy",
+                "--sandbox",
+                "modal",
+                "--model",
+                "gpt-5",
+                "--name",
+                "my-deploy",
+                "--dry-run",
+            ],
+        ):
+            args = parse_args()
+        assert args.command == "deploy"
+        assert args.sandbox == "modal"
+        assert args.model == "gpt-5"
+        assert args.deployment_name == "my-deploy"
+        assert args.dry_run is True
+
+    def test_dev_subcommand(self):
+        from deepagents_cli.main import parse_args
+
+        with patch.object(sys, "argv", ["deepagents", "dev"]):
+            args = parse_args()
+        assert args.command == "dev"
+        assert args.sandbox == "langsmith"
+        assert args.port == 2024
+        assert args.host == "127.0.0.1"
+
+    def test_dev_with_options(self):
+        from deepagents_cli.main import parse_args
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "deepagents",
+                "dev",
+                "--sandbox",
+                "daytona",
+                "--port",
+                "8000",
+                "--host",
+                "0.0.0.0",
+            ],
+        ):
+            args = parse_args()
+        assert args.command == "dev"
+        assert args.sandbox == "daytona"
+        assert args.port == 8000
+        assert args.host == "0.0.0.0"


### PR DESCRIPTION
## Description
Adds `deepagents deploy` and `deepagents dev` CLI subcommands that package the agent (AGENTS.md, skills, model config, sandbox settings) into deployment artifacts and delegate to `langgraph deploy` / `langgraph dev` under the hood.

The deploy flow: discovers project context (AGENTS.md, skills) → bundles files into a temp directory → generates `langgraph.json`, `deploy_graph.py` (server-side graph factory), `pyproject.toml`, and `.env` → calls `langgraph deploy` or `langgraph dev`.

The deployed graph factory (`deploy_graph.py`) creates per-thread sandboxes (defaulting to LangSmith sandboxes, with support for Daytona, Modal, and Runloop), loads bundled AGENTS.md and skills, and calls `create_deep_agent()`.

> [!NOTE]
> This PR was authored by an AI agent.

## Test Plan
- [ ] `deepagents deploy --dry-run` generates correct artifacts (langgraph.json, deploy_graph.py, pyproject.toml, bundled files)
- [ ] `deepagents dev --dry-run` generates correct artifacts
- [ ] `deepagents deploy --sandbox modal --model gpt-5 --name my-deploy` passes correct options
- [ ] `deepagents dev --port 8000 --host 0.0.0.0` passes correct options