### PR TITLE
fix(cli): escape markup in toast notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,8 @@ IMPORTANT: `Content` requires **Textual's** `Style` (`textual.style.Style`) for 
 
 **Decision rule:** if the value could ever come from outside the codebase (user input, tool output, API responses, file contents), use `from_markup` with `$var`. If it's a hardcoded string, glyph, or computed int, `styled` is fine.
 
+**`App.notify()` defaults to `markup=True`:** Textual's `App.notify(message)` parses the message string as Rich markup by default. Any dynamic content (exception messages, file paths, user input, command strings) containing brackets `[]`, ANSI escape codes, or `=` will cause a `MarkupError` crash in Textual's Toast renderer. Always pass `markup=False` when the message contains f-string interpolated variables. Hardcoded string literals are safe with the default.
+
 **Rich `console.print()` and number highlighting:**
 
 `console.print()` defaults to `highlight=True`, which runs `ReprHighlighter` and auto-applies bold + cyan to any detected numbers. This visually overrides subtle styles like `dim` (bold cancels dim in most terminals). Pass `highlight=False` on any `console.print()` call where the content contains numbers and consistent dim/subtle styling matters.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -812,6 +812,7 @@ class DeepAgentsApp(App):
                 format_tool_warning_tui(tool),
                 severity="warning",
                 timeout=15,
+                markup=False,
             )
 
     def _init_agent_adapter(self) -> None:
@@ -889,7 +890,7 @@ class DeepAgentsApp(App):
                         msg = f"No previous threads for '{agent_filter}', starting new."
                     else:
                         msg = "No previous threads, starting new."
-                    self.notify(msg, severity="warning")
+                    self.notify(msg, severity="warning", markup=False)
             elif await thread_exists(resume):
                 self._lc_thread_id = resume
                 if self._assistant_id == default_agent:
@@ -905,7 +906,7 @@ class DeepAgentsApp(App):
                 hint = f"Thread '{resume}' not found."
                 if similar:
                     hint += f" Did you mean: {', '.join(str(t) for t in similar)}?"
-                self.notify(hint, severity="warning")
+                self.notify(hint, severity="warning", markup=False)
         except Exception:
             logger.exception("Failed to resolve resume thread %r", resume)
             self._lc_thread_id = generate_thread_id()
@@ -1063,6 +1064,7 @@ class DeepAgentsApp(App):
             f"Failed to start server: {event.error}",
             severity="error",
             timeout=30,
+            markup=False,
         )
         # Update banner to show persistent failure state
         try:
@@ -1193,6 +1195,7 @@ class DeepAgentsApp(App):
                         f"Auto-update failed. Run manually: {cmd}",
                         severity="warning",
                         timeout=15,
+                        markup=False,
                     )
             else:
                 cmd = upgrade_command()
@@ -1201,6 +1204,7 @@ class DeepAgentsApp(App):
                     f"Run: {cmd}",
                     severity="information",
                     timeout=15,
+                    markup=False,
                 )
         except Exception:
             logger.warning("Auto-update failed unexpectedly", exc_info=True)
@@ -3399,7 +3403,9 @@ class DeepAgentsApp(App):
         """
         self._quit_pending = True
         quit_timeout = 3
-        self.notify(f"Press {shortcut} again to quit", timeout=quit_timeout)
+        self.notify(
+            f"Press {shortcut} again to quit", timeout=quit_timeout, markup=False
+        )
         self.set_timer(quit_timeout, lambda: setattr(self, "_quit_pending", False))
 
     def action_interrupt(self) -> None:

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1460,7 +1460,7 @@ class ChatInput(Vertical):
                 except OSError as exc:
                     logger.debug("Failed to stat media file %s: %s", path, exc)
                     msg = f"Could not attach {label.lower()}: {path.name}"
-                self.app.notify(msg, severity="warning", timeout=5)
+                self.app.notify(msg, severity="warning", timeout=5, markup=False)
 
             # Not a supported media file, keep as path
             logger.debug("Could not load media from dropped path: %s", path)

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -1777,6 +1777,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 f"Failed to delete thread {thread_id[:8]}",
                 severity="error",
                 timeout=3,
+                markup=False,
             )
             with contextlib.suppress(NoMatches):
                 self.query_one("#thread-filter", Input).focus()

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -478,6 +478,7 @@ class TestModalScreenCtrlDHandling:
                     notify_mock.assert_called_once_with(
                         "Press Ctrl+D again to quit",
                         timeout=3,
+                        markup=False,
                     )
                     assert app._quit_pending is True
                     exit_mock.assert_not_called()
@@ -531,6 +532,7 @@ class TestModalScreenCtrlDHandling:
                     notify_mock.assert_called_once_with(
                         "Press Ctrl+C again to quit",
                         timeout=3,
+                        markup=False,
                     )
                     assert app._quit_pending is True
                     exit_mock.assert_not_called()
@@ -678,6 +680,7 @@ class TestModalScreenCtrlCHandling:
                 notify_mock.assert_called_once_with(
                     "Press Ctrl+C again to quit",
                     timeout=3,
+                    markup=False,
                 )
                 assert app._quit_pending is True
                 exit_mock.assert_not_called()
@@ -715,6 +718,7 @@ class TestModalScreenCtrlCHandling:
                 notify_mock.assert_called_once_with(
                     "Press Ctrl+C again to quit",
                     timeout=3,
+                    markup=False,
                 )
                 assert app._quit_pending is True
                 exit_mock.assert_not_called()
@@ -758,6 +762,7 @@ class TestModalScreenCtrlCHandling:
                 notify_mock.assert_called_once_with(
                     "Press Ctrl+C again to quit",
                     timeout=3,
+                    markup=False,
                 )
                 assert app._quit_pending is True
                 exit_mock.assert_not_called()


### PR DESCRIPTION
Textual's `App.notify()` parses its message as Rich markup by default (`markup=True`). Any dynamic content — exception messages, file paths, thread IDs, shell commands — containing square brackets or other Rich markup metacharacters will crash the toast renderer with a `MarkupError`. This adds `markup=False` to every `notify()` call that interpolates runtime values.

## Changes
- Add `markup=False` to all `App.notify()` calls in `app.py`, `chat_input.py`, and `thread_selector.py` where the message string contains f-string interpolated variables (thread IDs, error messages, shell commands, file names)
- Document the `App.notify()` markup default and mitigation in `AGENTS.md` under the CLI's styled-text guidance