### PR TITLE
fix(cli): remove duplicate server failure notification

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1060,12 +1060,6 @@ class DeepAgentsApp(App):
         """Handle background server startup failure."""
         self._connecting = False
         logger.error("Server startup failed: %s", event.error, exc_info=event.error)
-        self.notify(
-            f"Failed to start server: {event.error}",
-            severity="error",
-            timeout=30,
-            markup=False,
-        )
         # Update banner to show persistent failure state
         try:
             banner = self.query_one("#welcome-banner", WelcomeBanner)


### PR DESCRIPTION
When the server fails to start, the error was shown twice — once as a toast notification via `self.notify()` and once persistently in the welcome banner via `WelcomeBanner.set_failed()`. The banner already displays the full error message inline, making the toast redundant and noisy.