### PR TITLE
refactor(cli): migrate `/remember` to skill system, add `/skill-creator` alias

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -43,7 +43,6 @@ from deepagents_cli._session_stats import (
 # after user interaction begins.
 from deepagents_cli._version import CHANGELOG_URL, DOCS_URL
 from deepagents_cli.config import is_ascii_mode
-from deepagents_cli.prompts import REMEMBER_PROMPT
 from deepagents_cli.widgets.chat_input import ChatInput
 from deepagents_cli.widgets.loading import LoadingWidget
 from deepagents_cli.widgets.message_store import (
@@ -2492,7 +2491,8 @@ class DeepAgentsApp(App):
             help_body = (
                 "Commands: /quit, /clear, /offload, /editor, /mcp, "
                 "/model [--model-params JSON] [--default], /reload, "
-                "/skill:<name>, /remember, /theme, /tokens, /threads, /trace, "
+                "/skill:<name>, /remember, /skill-creator, /theme, /tokens, "
+                "/threads, /trace, "
                 "/update, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
@@ -2618,23 +2618,19 @@ class DeepAgentsApp(App):
 
                 await self._mount_message(AppMessage(" · ".join(parts)))
         elif cmd == "/remember" or cmd.startswith("/remember "):
-            # Extract any additional context after /remember
-            additional_context = ""
-            if cmd.startswith("/remember "):
-                additional_context = command.strip()[len("/remember ") :].strip()
-
-            # Build the final prompt
-            if additional_context:
-                final_prompt = (
-                    f"{REMEMBER_PROMPT}\n\n"
-                    f"**Additional context from user:** {additional_context}"
-                )
-            else:
-                final_prompt = REMEMBER_PROMPT
-
-            # Send as a user message to the agent
-            await self._handle_user_message(final_prompt)
-            return  # _handle_user_message already mounts the message
+            # Convenience alias for /skill:remember — shorter and discoverable
+            # before skill loading completes.
+            args = command.strip()[len("/remember") :].strip()
+            rewritten = f"/skill:remember {args}" if args else "/skill:remember"
+            await self._handle_skill_command(rewritten)
+        elif cmd == "/skill-creator" or cmd.startswith("/skill-creator "):
+            # Convenience alias for /skill:skill-creator — shorter and
+            # discoverable before skill loading completes.
+            args = command.strip()[len("/skill-creator") :].strip()
+            rewritten = (
+                f"/skill:skill-creator {args}" if args else "/skill:skill-creator"
+            )
+            await self._handle_skill_command(rewritten)
         elif cmd == "/mcp":
             await self._show_mcp_viewer()
         elif cmd == "/theme":

--- a/libs/cli/deepagents_cli/built_in_skills/remember/SKILL.md
+++ b/libs/cli/deepagents_cli/built_in_skills/remember/SKILL.md
@@ -1,7 +1,11 @@
-# ruff: noqa: E501  # Long prompt strings
-"""Prompt constants for slash commands."""
+---
+name: remember
+description: "Review the current conversation and capture valuable knowledge — best practices, coding conventions, architecture decisions, workflows, and user feedback — into persistent memory (AGENTS.md) or reusable skills. Use when the user says: (1) remember this, (2) save what we learned, (3) update memory, (4) capture learnings."
+license: MIT
+compatibility: designed for deepagents-cli
+---
 
-REMEMBER_PROMPT = """Review our conversation and capture valuable knowledge. Focus especially on **best practices** we discussed or discovered—these are the most important things to preserve.
+Review our conversation and capture valuable knowledge. Focus especially on **best practices** we discussed or discovered—these are the most important things to preserve.
 
 ## Step 1: Identify Best Practices and Key Learnings
 
@@ -112,4 +116,3 @@ Use `edit_file` to update existing files or `write_file` to create new ones.
 List what you captured and where you stored it:
 - Skills created (with key best practices encoded)
 - Memory entries added (with location)
-"""

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -84,9 +84,14 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="compact",
         aliases=("/compact",),
     ),
-    SlashCommand(
+    SlashCommand(  # Static alias; not auto-generated from skill discovery
         name="/remember",
         description="Update memory and skills from conversation",
+        bypass_tier=BypassTier.QUEUED,
+    ),
+    SlashCommand(  # Static alias; not auto-generated from skill discovery
+        name="/skill-creator",
+        description="Guide for creating effective agent skills",
         bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
@@ -238,6 +243,17 @@ def parse_skill_command(command: str) -> tuple[str, str]:
     return skill_name, args
 
 
+_STATIC_SKILL_ALIASES: frozenset[str] = frozenset({"remember", "skill-creator"})
+"""Built-in skill names that have a dedicated top-level slash command.
+
+Only list skills whose `/skill:<name>` form is redundant because a `/<name>`
+convenience alias exists in `COMMANDS`.  Do **not** add every command name
+here — that would silently suppress unrelated user skills that happen to share a
+name with a slash command (e.g., a user skill called `model` should still
+appear as `/skill:model`).
+"""
+
+
 def build_skill_commands(
     skills: list[ExtendedSkillMetadata],
 ) -> list[tuple[str, str, str]]:
@@ -245,6 +261,10 @@ def build_skill_commands(
 
     Each skill becomes a `/skill:<name>` entry with its description
     and the skill name as a hidden keyword for fuzzy matching.
+
+    Skills that already have a dedicated slash command in `COMMANDS`
+    (e.g., `remember` → `/remember`) are excluded to avoid duplicate
+    autocomplete entries.
 
     Args:
         skills: List of discovered skill metadata.
@@ -255,4 +275,5 @@ def build_skill_commands(
     return [
         (f"/skill:{skill['name']}", skill["description"], skill["name"])
         for skill in skills
+        if skill["name"] not in _STATIC_SKILL_ALIASES
     ]

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -38,6 +38,7 @@ _TIPS: list[str] = [
     "Use /skill:<name> to invoke a skill directly",
     "Type /update to check for and install updates",
     "Use /theme to customize the CLI colors and style",
+    "Use /skill-creator to build reusable agent skills",
 ]
 """Rotating tips shown in the welcome footer.
 

--- a/libs/cli/tests/unit_tests/skills/test_load.py
+++ b/libs/cli/tests/unit_tests/skills/test_load.py
@@ -656,6 +656,28 @@ class TestListSkillsBuiltIn:
         assert "deepagents-cli-version" in creator["metadata"]
         assert creator["metadata"]["deepagents-cli-version"] == _cli_version
 
+    def test_real_remember_skill_ships(self) -> None:
+        """Verify the actual built-in remember SKILL.md exists and loads."""
+        built_in_dir = Settings.get_built_in_skills_dir()
+        skill_md = built_in_dir / "remember" / "SKILL.md"
+        assert skill_md.exists(), f"Expected {skill_md} to exist"
+
+        skills = list_skills(
+            built_in_skills_dir=built_in_dir,
+            user_skills_dir=None,
+            project_skills_dir=None,
+        )
+        skill_names = {s["name"] for s in skills}
+        assert "remember" in skill_names
+
+        remember = next(s for s in skills if s["name"] == "remember")
+        assert remember["source"] == "built-in"
+        assert len(remember["description"]) > 0
+        assert remember["license"] == "MIT"
+        assert remember["compatibility"] == "designed for deepagents-cli"
+        assert "deepagents-cli-version" in remember["metadata"]
+        assert remember["metadata"]["deepagents-cli-version"] == _cli_version
+
     def test_oserror_in_one_source_does_not_break_others(self, tmp_path: Path) -> None:
         """An OSError in one source should not prevent other sources from loading.
 

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -131,7 +131,7 @@ class TestHelpBodyDrift:
         assert match, "Could not locate Commands section in help_body"
         commands_section = match.group(1)
 
-        help_cmds = set(re.findall(r"/[a-z]+", commands_section))
+        help_cmds = set(re.findall(r"/[a-z][-a-z]*", commands_section))
         registry_cmds = {cmd.name for cmd in COMMANDS}
 
         # Commands intentionally omitted from the help body

--- a/libs/cli/tests/unit_tests/test_prompts.py
+++ b/libs/cli/tests/unit_tests/test_prompts.py
@@ -1,9 +1,0 @@
-"""Tests for prompts module."""
-
-from deepagents_cli.prompts import REMEMBER_PROMPT
-
-
-def test_remember_prompt_is_nonempty_string() -> None:
-    """`REMEMBER_PROMPT` should be a non-empty string."""
-    assert isinstance(REMEMBER_PROMPT, str)
-    assert len(REMEMBER_PROMPT) > 0

--- a/libs/cli/tests/unit_tests/test_skill_invocation.py
+++ b/libs/cli/tests/unit_tests/test_skill_invocation.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from deepagents_cli.command_registry import build_skill_commands, parse_skill_command
+from deepagents_cli.command_registry import (
+    _STATIC_SKILL_ALIASES,
+    build_skill_commands,
+    parse_skill_command,
+)
 from deepagents_cli.skills.load import load_skill_content
 
 if TYPE_CHECKING:
@@ -157,6 +161,69 @@ class TestBuildSkillCommands:
             assert isinstance(entry, tuple)
             assert len(entry) == 3
             assert all(isinstance(s, str) for s in entry)
+
+    def test_excludes_static_skill_aliases(self) -> None:
+        """Skills with names matching static aliases are excluded."""
+        skills = [
+            {
+                "name": "remember",
+                "description": "Update memory",
+                "path": "/built-in/SKILL.md",
+                "license": "MIT",
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+                "source": "built-in",
+            },
+            {
+                "name": "skill-creator",
+                "description": "Create skills",
+                "path": "/built-in/SKILL.md",
+                "license": "MIT",
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+                "source": "built-in",
+            },
+            {
+                "name": "custom-skill",
+                "description": "A custom skill",
+                "path": "/user/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+                "source": "user",
+            },
+        ]
+        result = build_skill_commands(skills)  # type: ignore[arg-type]
+        names = [r[0] for r in result]
+        assert "/skill:remember" not in names
+        assert "/skill:skill-creator" not in names
+        assert "/skill:custom-skill" in names
+        assert len(result) == 1
+
+    def test_non_alias_command_names_not_suppressed(self) -> None:
+        """Skills named after non-alias commands are NOT excluded."""
+        skills = [
+            {
+                "name": "model",
+                "description": "A model management skill",
+                "path": "/user/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+                "source": "user",
+            },
+        ]
+        result = build_skill_commands(skills)  # type: ignore[arg-type]
+        assert len(result) == 1
+        assert result[0][0] == "/skill:model"
+
+    def test_static_skill_aliases_contains_expected_entries(self) -> None:
+        """Verify the alias set only contains actual skill-backed commands."""
+        assert {"remember", "skill-creator"} == _STATIC_SKILL_ALIASES
 
 
 class TestSkillCommandParsing:


### PR DESCRIPTION
Migrate `/remember` from an inlined `REMEMBER_PROMPT` constant to the built-in skill system, routing it through `_handle_skill_command` like all other skills. Also add `/skill-creator` as a top-level slash command alias for the existing built-in skill-creator skill, and deduplicate autocomplete so `/skill:remember` and `/skill:skill-creator` don't appear alongside their shorter `/<name>` forms.