### PR TITLE
fix(sdk): propagate recursion_limit to subagent invocations

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -77,6 +77,14 @@ class SubAgent(TypedDict):
     skills: NotRequired[list[str]]
     """Skill source paths for SkillsMiddleware."""
 
+    recursion_limit: NotRequired[int]
+    """Override the recursion limit for this subagent.
+
+    If not specified, inherits the parent agent's recursion_limit from its
+    runtime config. LangGraph's default of 25 is too low for most multi-step
+    subagent tasks.
+    """
+
 
 class CompiledSubAgent(TypedDict):
     """A pre-compiled agent spec.
@@ -374,6 +382,7 @@ def _get_subagents_legacy(
 def _build_task_tool(  # noqa: C901
     subagents: list[_SubagentSpec],
     task_description: str | None = None,
+    recursion_limits: dict[str, int] | None = None,
 ) -> BaseTool:
     """Create a task tool from pre-built subagent graphs.
 
@@ -383,10 +392,15 @@ def _build_task_tool(  # noqa: C901
         subagents: List of subagent specs containing name, description, and runnable.
         task_description: Custom description for the task tool. If `None`,
             uses default template. Supports `{available_agents}` placeholder.
+        recursion_limits: Per-subagent recursion limit overrides.
+            If a subagent is not in this mapping, the parent agent's
+            recursion_limit is inherited from the runtime config.
 
     Returns:
         A StructuredTool that can invoke subagents by type.
     """
+    _recursion_limits = recursion_limits or {}
+
     # Build the graphs dict and descriptions from the unified spec list
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
     subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
@@ -427,6 +441,25 @@ def _build_task_tool(  # noqa: C901
         subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state
 
+    def _get_subagent_config(subagent_type: str, runtime: ToolRuntime) -> dict[str, Any]:
+        """Build the config dict for a subagent invocation.
+
+        Propagates the parent's recursion_limit to the subagent, with support
+        for per-subagent overrides via the ``recursion_limits`` mapping.
+        """
+        # Per-subagent override takes highest priority
+        if subagent_type in _recursion_limits:
+            return {"recursion_limit": _recursion_limits[subagent_type]}
+
+        # Inherit from parent's runtime config
+        parent_config = getattr(runtime, "config", None) or {}
+        parent_limit = parent_config.get("recursion_limit")
+        if parent_limit is not None:
+            return {"recursion_limit": parent_limit}
+
+        # Fallback: match create_deep_agent's default
+        return {"recursion_limit": 1000}
+
     def task(
         description: Annotated[
             str,
@@ -442,7 +475,8 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = subagent.invoke(subagent_state)
+        config = _get_subagent_config(subagent_type, runtime)
+        result = subagent.invoke(subagent_state, config=config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     async def atask(
@@ -460,7 +494,8 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = await subagent.ainvoke(subagent_state)
+        config = _get_subagent_config(subagent_type, runtime)
+        result = await subagent.ainvoke(subagent_state, config=config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     return StructuredTool.from_function(
@@ -607,7 +642,15 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             msg = "SubAgentMiddleware requires either `backend` (new API) or `default_model` (deprecated API)"
             raise ValueError(msg)
 
-        task_tool = _build_task_tool(subagent_specs, task_description)
+        # Collect per-subagent recursion_limit overrides
+        recursion_limits: dict[str, int] = {}
+        for spec in subagents or []:
+            if "runnable" not in spec and "graph_id" not in spec:
+                rl = spec.get("recursion_limit")
+                if rl is not None:
+                    recursion_limits[spec["name"]] = rl
+
+        task_tool = _build_task_tool(subagent_specs, task_description, recursion_limits=recursion_limits)
 
         # Build system prompt with available agents
         if system_prompt and subagent_specs:

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -1679,3 +1679,146 @@ class TestSubAgentMiddlewareValidation:
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)
         assert "deprecated" in str(w[0].message).lower()
+
+
+class TestSubAgentRecursionLimit:
+    """Tests for recursion_limit propagation to subagents (issue #1698)."""
+
+    def test_subagent_inherits_parent_recursion_limit(self) -> None:
+        """Test that subagents inherit the parent's recursion_limit from runtime config.
+
+        Prior to this fix, subagents always ran with LangGraph's default
+        recursion_limit=25, regardless of the parent's configuration. This
+        caused GraphRecursionError for subagents performing 13+ tool calls.
+        """
+        # Track the config received by the subagent
+        captured_configs: list[RunnableConfig] = []
+
+        def capture_config_node(state: dict, config: RunnableConfig) -> dict:
+            captured_configs.append(config)
+            return {"messages": [AIMessage(content="done from subagent")]}
+
+        # Build a minimal subagent graph that captures its config
+        builder = StateGraph(dict)
+        builder.add_node("capture", capture_config_node)
+        builder.add_edge(START, "capture")
+        builder.add_edge("capture", END)
+        capture_graph = builder.compile()
+
+        # Parent model: call subagent, then finish
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Do something",
+                                    "subagent_type": "general-purpose",
+                                },
+                                "id": "call_test_rl",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=parent_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                CompiledSubAgent(
+                    name="general-purpose",
+                    description="General-purpose agent.",
+                    runnable=capture_graph,
+                )
+            ],
+        )
+
+        # Invoke with a custom recursion_limit
+        agent.invoke(
+            {"messages": [HumanMessage(content="test")]},
+            config={"configurable": {"thread_id": "test_rl"}, "recursion_limit": 500},
+        )
+
+        # Verify the subagent received the parent's recursion_limit
+        assert len(captured_configs) == 1, "Subagent should have been invoked exactly once"
+        subagent_limit = captured_configs[0].get("recursion_limit")
+        assert subagent_limit == 500, (
+            f"Subagent should inherit parent's recursion_limit=500, got {subagent_limit}"
+        )
+
+    def test_subagent_uses_default_1000_when_parent_has_no_explicit_limit(self) -> None:
+        """Test that subagents fall back to 1000 (create_deep_agent's default)."""
+        captured_configs: list[RunnableConfig] = []
+
+        def capture_config_node(state: dict, config: RunnableConfig) -> dict:
+            captured_configs.append(config)
+            return {"messages": [AIMessage(content="done from subagent")]}
+
+        builder = StateGraph(dict)
+        builder.add_node("capture", capture_config_node)
+        builder.add_edge(START, "capture")
+        builder.add_edge("capture", END)
+        capture_graph = builder.compile()
+
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Do something",
+                                    "subagent_type": "general-purpose",
+                                },
+                                "id": "call_test_default_rl",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=parent_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                CompiledSubAgent(
+                    name="general-purpose",
+                    description="General-purpose agent.",
+                    runnable=capture_graph,
+                )
+            ],
+        )
+
+        # Invoke without explicitly setting recursion_limit (create_deep_agent sets 1000)
+        agent.invoke(
+            {"messages": [HumanMessage(content="test")]},
+            config={"configurable": {"thread_id": "test_default_rl"}},
+        )
+
+        assert len(captured_configs) == 1
+        subagent_limit = captured_configs[0].get("recursion_limit")
+        assert subagent_limit == 1000, (
+            f"Subagent should use create_deep_agent's default recursion_limit=1000, got {subagent_limit}"
+        )
+
+    def test_subagent_recursion_limit_field_in_typedef(self) -> None:
+        """Test that SubAgent TypedDict accepts the recursion_limit field."""
+        spec: SubAgent = {
+            "name": "test-agent",
+            "description": "Test agent.",
+            "system_prompt": "You are a test agent.",
+            "recursion_limit": 200,
+        }
+        assert spec["recursion_limit"] == 200


### PR DESCRIPTION
## Summary
- Subagents now inherit the parent's `recursion_limit` from runtime config instead of silently using LangGraph's default of 25
- Added `recursion_limit` field to `SubAgent` TypedDict for per-subagent overrides
- Fallback to 1000 (create_deep_agent's default) when parent config is absent

## Motivation
Subagents performing multi-step tasks (13+ tool calls) silently hit the default limit of 25, raising `GraphRecursionError` that propagates as `asyncio.CancelledError` — often crashing the entire execution without a clear error.

## Changes
- `middleware/subagents.py`: pass config with `recursion_limit` to `.invoke()` / `.ainvoke()` calls
- `middleware/subagents.py`: add `recursion_limit: NotRequired[int]` to `SubAgent` TypedDict
- `tests/unit_tests/test_subagents.py`: add 3 tests covering inheritance, default fallback, and type validation

## Test plan
- [x] Subagent inherits parent's explicit recursion_limit (500)
- [x] Subagent falls back to 1000 when parent has no explicit limit
- [x] SubAgent TypedDict accepts `recursion_limit` field

Closes #1698