### PR TITLE
feat(sdk): show remaining lines after paginated read_file

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -334,14 +334,15 @@ class FilesystemBackend(BackendProtocol):
                 return ReadResult(file_data=create_file_data(empty_msg))
 
             lines = content.splitlines()
+            total = len(lines)
             start_idx = offset
-            end_idx = min(start_idx + limit, len(lines))
+            end_idx = min(start_idx + limit, total)
 
-            if start_idx >= len(lines):
-                return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
+            if start_idx >= total:
+                return ReadResult(error=f"Line offset {offset} exceeds file length ({total} lines)")
 
             selected_lines = lines[start_idx:end_idx]
-            return ReadResult(file_data=create_file_data("\n".join(selected_lines)))
+            return ReadResult(file_data=create_file_data("\n".join(selected_lines)), total_lines=total)
         except OSError as e:
             return ReadResult(error=f"Error reading file '{file_path}': {e}")
 

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -145,10 +145,13 @@ class ReadResult:
     Attributes:
         error: Error message on failure, None on success.
         file_data: FileData dict on success, None on failure.
+        total_lines: Total number of lines in the file. Used by the
+            middleware to show a remaining-lines notice after paginated reads.
     """
 
     error: str | None = None
     file_data: FileData | None = None
+    total_lines: int | None = None
 
 
 @dataclass

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -198,8 +198,10 @@ except UnicodeDecodeError:
     content = base64.b64encode(raw).decode('ascii')
     encoding = 'base64'
 
+total_lines = None
 if encoding == 'utf-8' and file_type == 'text':
     lines = content.splitlines()
+    total_lines = len(lines)
     start_idx = offset
     end_idx = offset + limit
     if start_idx >= len(lines):
@@ -208,7 +210,10 @@ if encoding == 'utf-8' and file_type == 'text':
     selected = lines[start_idx:end_idx]
     content = '\\n'.join(selected)
 
-print(json.dumps({{'encoding': encoding, 'content': content}}))
+result = {{'encoding': encoding, 'content': content}}
+if total_lines is not None:
+    result['total_lines'] = total_lines
+print(json.dumps(result))
 " <<'__DEEPAGENTS_EOF__'
 {payload_b64}
 __DEEPAGENTS_EOF__\n"""
@@ -308,7 +313,10 @@ except PermissionError:
         if "error" in data:
             return ReadResult(error=data["error"])
 
-        return ReadResult(file_data=create_file_data(data["content"], encoding=data.get("encoding", "utf-8")))
+        return ReadResult(
+            file_data=create_file_data(data["content"], encoding=data.get("encoding", "utf-8")),
+            total_lines=data.get("total_lines"),
+        )
 
     def write(
         self,

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -263,8 +263,9 @@ def slice_read_response(
 ) -> str | ReadResult:
     """Slice file data to the requested line range without formatting.
 
-    Returns raw text for the requested window. Line-number formatting
-    is applied downstream by the middleware layer.
+    Returns a ``ReadResult`` with raw text for the requested window and
+    ``total_lines`` set so the middleware can display a remaining-lines
+    notice.  Line-number formatting is applied downstream.
 
     Args:
         file_data: FileData dict.
@@ -272,8 +273,10 @@ def slice_read_response(
         limit: Maximum number of lines.
 
     Returns:
-        Raw sliced content string on success, or `ReadResult` with
-        `error` set when the offset exceeds the file length.
+        ``ReadResult`` on success (with ``file_data`` and ``total_lines``),
+        or ``ReadResult`` with ``error`` when the offset exceeds the file length.
+        May also return a plain ``str`` for empty/whitespace-only content
+        (legacy compatibility).
     """
     content = file_data_to_string(file_data)
 
@@ -281,14 +284,23 @@ def slice_read_response(
         return content
 
     lines = content.splitlines()
+    total = len(lines)
     start_idx = offset
-    end_idx = min(start_idx + limit, len(lines))
+    end_idx = min(start_idx + limit, total)
 
-    if start_idx >= len(lines):
-        return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
+    if start_idx >= total:
+        return ReadResult(error=f"Line offset {offset} exceeds file length ({total} lines)")
 
     selected_lines = lines[start_idx:end_idx]
-    return "\n".join(selected_lines)
+    return ReadResult(
+        file_data=FileData(
+            content="\n".join(selected_lines),
+            encoding=file_data.get("encoding", "utf-8"),
+            created_at=file_data.get("created_at", ""),
+            modified_at=file_data.get("modified_at", ""),
+        ),
+        total_lines=total,
+    )
 
 
 def format_read_response(

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -627,7 +627,22 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             content = format_content_with_line_numbers(content, start_line=offset + 1)
             # We apply truncation again after formatting content as continuation lines
             # can increase line count
-            return _truncate(content, validated_path, limit)
+            content = _truncate(content, validated_path, limit)
+
+            # Append remaining-lines notice when the read window doesn't cover
+            # the full file, so the agent knows whether to paginate further.
+            total_lines = read_result.total_lines
+            if total_lines is not None:
+                end_line = min(offset + limit, total_lines)
+                lines_read = end_line - offset
+                remaining = total_lines - end_line
+                if remaining > 0:
+                    content += (
+                        f"\n\n[Read {lines_read} lines (lines {offset + 1}-{end_line} "
+                        f"of {total_lines} total). {remaining} lines remaining.]"
+                    )
+
+            return content
 
         def sync_read_file(
             file_path: Annotated[str, "Absolute path to the file to read. Must be absolute, not relative."],

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -173,3 +173,61 @@ def test_get_file_type_non_text_values_are_valid_content_block_types() -> None:
     for file_type in _EXTENSION_TO_FILE_TYPE.values():
         block = {"type": file_type, "base64": "dGVzdA==", "mime_type": "application/octet-stream"}
         _content_block_adapter.validate_python(block)
+
+
+class TestSliceReadResponse:
+    """Tests for slice_read_response with total_lines support."""
+
+    def test_returns_total_lines_for_paginated_read(self) -> None:
+        """slice_read_response should return a ReadResult with total_lines."""
+        from deepagents.backends.protocol import ReadResult
+        from deepagents.backends.utils import create_file_data, slice_read_response
+
+        content = "\n".join(f"line {i}" for i in range(500))
+        file_data = create_file_data(content)
+        result = slice_read_response(file_data, offset=0, limit=100)
+
+        assert isinstance(result, ReadResult)
+        assert result.total_lines == 500
+        assert result.error is None
+        assert result.file_data is not None
+        # Should contain only the first 100 lines
+        lines = result.file_data["content"].splitlines()
+        assert len(lines) == 100
+
+    def test_returns_total_lines_with_offset(self) -> None:
+        """total_lines should reflect full file length regardless of offset."""
+        from deepagents.backends.protocol import ReadResult
+        from deepagents.backends.utils import create_file_data, slice_read_response
+
+        content = "\n".join(f"line {i}" for i in range(200))
+        file_data = create_file_data(content)
+        result = slice_read_response(file_data, offset=150, limit=100)
+
+        assert isinstance(result, ReadResult)
+        assert result.total_lines == 200
+        # Should contain only lines 150-199
+        lines = result.file_data["content"].splitlines()
+        assert len(lines) == 50
+
+    def test_offset_exceeds_length_returns_error(self) -> None:
+        """Offset beyond file length should return error with line count."""
+        from deepagents.backends.protocol import ReadResult
+        from deepagents.backends.utils import create_file_data, slice_read_response
+
+        content = "line1\nline2\nline3"
+        file_data = create_file_data(content)
+        result = slice_read_response(file_data, offset=10, limit=100)
+
+        assert isinstance(result, ReadResult)
+        assert result.error is not None
+        assert "3 lines" in result.error
+
+    def test_empty_content_returns_string(self) -> None:
+        """Empty file content should return empty string (legacy compat)."""
+        from deepagents.backends.utils import create_file_data, slice_read_response
+
+        file_data = create_file_data("")
+        result = slice_read_response(file_data, offset=0, limit=100)
+        assert isinstance(result, str)
+        assert result == ""

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1366,6 +1366,72 @@ class TestFilesystemMiddleware:
         assert isinstance(result, str)
         assert result == EMPTY_CONTENT_WARNING
 
+    def test_read_file_shows_remaining_lines_notice(self):
+        """Read_file should append a notice showing remaining lines on paginated reads."""
+        middleware = FilesystemMiddleware()
+        content = "\n".join(f"line {i}" for i in range(500))
+        state = FilesystemState(messages=[], files={"/big.txt": create_file_data(content)})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="read-remaining",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke(
+            {"file_path": "/big.txt", "offset": 0, "limit": 100, "runtime": runtime}
+        )
+
+        assert isinstance(result, str)
+        assert "[Read 100 lines (lines 1-100 of 500 total). 400 lines remaining.]" in result
+
+    def test_read_file_no_remaining_notice_when_all_lines_read(self):
+        """Read_file should NOT append remaining notice when reading the full file."""
+        middleware = FilesystemMiddleware()
+        content = "\n".join(f"line {i}" for i in range(50))
+        state = FilesystemState(messages=[], files={"/small.txt": create_file_data(content)})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="read-all",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke(
+            {"file_path": "/small.txt", "offset": 0, "limit": 100, "runtime": runtime}
+        )
+
+        assert isinstance(result, str)
+        assert "remaining" not in result
+
+    def test_read_file_remaining_lines_with_offset(self):
+        """Read_file should correctly compute remaining lines when offset is used."""
+        middleware = FilesystemMiddleware()
+        content = "\n".join(f"line {i}" for i in range(300))
+        state = FilesystemState(messages=[], files={"/offset.txt": create_file_data(content)})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="read-offset",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke(
+            {"file_path": "/offset.txt", "offset": 200, "limit": 50, "runtime": runtime}
+        )
+
+        assert isinstance(result, str)
+        assert "[Read 50 lines (lines 201-250 of 300 total). 50 lines remaining.]" in result
+
     def test_execute_tool_returns_error_when_backend_doesnt_support(self):
         """Test that execute tool returns friendly error instead of raising exception."""
         state = FilesystemState(messages=[], files={})


### PR DESCRIPTION
## Summary
- `read_file` now appends a remaining-lines notice when the read window doesn't cover the full file
- Example: `[Read 100 lines (lines 1-100 of 500 total). 400 lines remaining.]`
- Helps the agent decide whether to paginate further or whether it has seen the entire file

## Changes
- `backends/protocol.py`: add `total_lines: int | None` to `ReadResult`
- `backends/utils.py`: `slice_read_response` now returns `ReadResult` with `total_lines`
- `backends/filesystem.py`: populate `total_lines` in `FilesystemBackend.read()`
- `backends/sandbox.py`: populate `total_lines` in sandbox read script + parse it
- `middleware/filesystem.py`: append remaining-lines notice in `_handle_read_result`
- Tests: 4 unit tests for `slice_read_response`, 3 for middleware remaining-lines behavior

## Test plan
- [x] Paginated read (offset=0, limit=100 on 500-line file) shows remaining notice
- [x] Full-file read (50 lines, limit=100) does NOT show remaining notice
- [x] Offset read (offset=200, limit=50 on 300-line file) shows correct remaining count
- [x] Empty file returns empty string (no crash)
- [x] Offset exceeding file length returns error with line count

Closes #2142