### PR TITLE
style(cli): reduce scrollbar width to 1 cell

### DIFF
--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -6,6 +6,11 @@ Screen {
     layers: base autocomplete;
 }
 
+/* Thin scrollbars app-wide */
+* {
+    scrollbar-size-vertical: 1;
+}
+
 /* Main content goes on base layer by default */
 
 /* Chat area - main scrollable messages area */


### PR DESCRIPTION
Reduce vertical scrollbar width from the Textual default (2 cells) to 1 cell across all widgets. The `*` selector in `app.tcss` ensures it applies universally — main chat, model switcher, MCP viewer, thread selector, and any future scrollable containers.