### PR TITLE
fix(sdk,cli): align error messages and clean up recent refactors

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -883,7 +883,6 @@ def create_cli_agent(
         # File operations and execute tool are provided by the sandbox backend
 
     # Local context middleware (git info, directory tree, etc.).
-    # Async execution is handled within the middleware when available.
     if isinstance(backend, (_ExecutableBackend, _AsyncExecutableBackend)):
         agent_middleware.append(
             LocalContextMiddleware(backend=backend, mcp_server_info=mcp_server_info)

--- a/libs/cli/deepagents_cli/local_context.py
+++ b/libs/cli/deepagents_cli/local_context.py
@@ -451,11 +451,6 @@ class LocalContextMiddleware(AgentMiddleware):
 
         Args:
             backend: Backend instance that provides shell command execution.
-
-                Backends that only implement async execution (e.g. `HarborSandbox`)
-                are supported via `abefore_agent`. Sync-only backends work via
-                `before_agent` directly or through `asyncio.to_thread` in async
-                contexts.
             mcp_server_info: MCP server metadata to include in the system prompt.
         """
         self.backend = backend
@@ -524,7 +519,7 @@ class LocalContextMiddleware(AgentMiddleware):
             )
             return None
 
-        return self._handle_detect_result(result)
+        return LocalContextMiddleware._handle_detect_result(result)
 
     # override - state parameter is intentionally narrowed from
     # AgentState to LocalContextState for type safety within this middleware.
@@ -621,7 +616,7 @@ class LocalContextMiddleware(AgentMiddleware):
             )
             return None
 
-        return self._handle_detect_result(result)
+        return LocalContextMiddleware._handle_detect_result(result)
 
     async def abefore_agent(  # type: ignore[override]
         self,

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -51,10 +51,9 @@ potentially fix:
 def map_file_operation_error(exc: Exception) -> FileOperationError | None:
     """Map a caught exception to a standardized `FileOperationError` code.
 
-    Classification is based on exception type only (stdlib hierarchy and
-    `ValueError` path-security checks). Returns `None` for any exception
-    that cannot be classified by type, letting callers decide whether to
-    re-raise or fall back to `str(exc)`.
+    Classification is based on exception type only (stdlib hierarchy).
+    Returns `None` for any exception that cannot be classified by type,
+    letting callers decide whether to re-raise or fall back to `str(exc)`.
 
     Args:
         exc: The exception to classify.
@@ -71,12 +70,7 @@ def map_file_operation_error(exc: Exception) -> FileOperationError | None:
     if isinstance(exc, (NotADirectoryError, FileExistsError)):
         return "invalid_path"
     if isinstance(exc, ValueError):
-        # ValueError from path-security checks (e.g. _resolve_path). Only
-        # match known path-related messages to avoid false positives from
-        # unrelated ValueErrors (e.g. encoding, int parsing).
-        vmsg = str(exc).lower()
-        if "path traversal" in vmsg or "outside root" in vmsg or "invalid path" in vmsg:
-            return "invalid_path"
+        return "invalid_path"
     return None
 
 
@@ -85,9 +79,10 @@ class FileDownloadResponse:
     """Result of a single file download operation.
 
     The response is designed to allow partial success in batch operations.
-    Known recoverable errors use `FileOperationError` literals; unknown
-    errors use a descriptive error string so the caller still gets a
-    meaningful message.
+
+    The errors are standardized using `FileOperationError` literals for certain
+    recoverable conditions for use cases that involve LLMs performing
+    file operations.
 
     Examples:
         >>> # Success
@@ -116,9 +111,10 @@ class FileUploadResponse:
     """Result of a single file upload operation.
 
     The response is designed to allow partial success in batch operations.
-    Known recoverable errors use `FileOperationError` literals; unknown
-    errors use a descriptive error string so the caller still gets a
-    meaningful message.
+
+    The errors are standardized using `FileOperationError` literals for certain
+    recoverable conditions for use cases that involve LLMs performing
+    file operations.
 
     Examples:
         >>> # Success

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -4,6 +4,9 @@ File listing, grep, glob, and read use shell commands via `execute()`. Write
 delegates content transfer to `upload_files()`. Edit uses server-side `execute()`
 for payloads under `_EDIT_INLINE_MAX_BYTES` and falls back to uploading old/new
 strings as temp files with a server-side replace script for larger ones.
+
+Concrete subclasses implement `execute()` and `upload_files()`; all other
+operations are derived from those.
 """
 
 from __future__ import annotations
@@ -561,7 +564,7 @@ except PermissionError:
         """Map server-side error codes to `EditResult` objects."""
         if error == "file_not_found":
             return EditResult(
-                error=f"Error: Failed to read '{file_path}': file_not_found",
+                error=f"Error: File '{file_path}' not found",
             )
         if error == "not_a_text_file":
             return EditResult(

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -209,13 +209,8 @@ class TestMapFileOperationError:
         assert map_file_operation_error(RuntimeError("permission denied")) is None
         assert map_file_operation_error(OSError("is a directory")) is None
 
-    def test_unrelated_value_error_returns_none(self) -> None:
-        """ValueError without path-related keywords should not be mapped."""
-        assert map_file_operation_error(ValueError("unexpected encoding")) is None
-        assert map_file_operation_error(ValueError("invalid literal for int()")) is None
-        assert map_file_operation_error(ValueError("permission denied on /foo")) is None
-
-    def test_value_error_path_security_messages(self) -> None:
-        """ValueError with path-security keywords should map to invalid_path."""
+    def test_value_error_maps_to_invalid_path(self) -> None:
+        """All ValueError instances map to invalid_path regardless of message."""
+        assert map_file_operation_error(ValueError("unexpected encoding")) == "invalid_path"
+        assert map_file_operation_error(ValueError("invalid literal for int()")) == "invalid_path"
         assert map_file_operation_error(ValueError("Path traversal not allowed")) == "invalid_path"
-        assert map_file_operation_error(ValueError("Path:/foo outside root directory: /bar")) == "invalid_path"

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -317,7 +317,7 @@ def test_sandbox_edit_inline_file_not_found() -> None:
     result = sandbox.edit("/test/missing.txt", "old", "new")
 
     assert result.error is not None
-    assert "Failed to read" in result.error
+    assert "not found" in result.error.lower()
 
 
 def test_sandbox_edit_inline_string_not_found() -> None:
@@ -442,7 +442,7 @@ def test_sandbox_edit_upload_file_not_found() -> None:
     result = sandbox.edit("/test/missing.txt", large_old, "new")
 
     assert result.error is not None
-    assert "Failed to read" in result.error
+    assert "not found" in result.error.lower()
 
 
 def test_sandbox_edit_upload_replace_all() -> None:


### PR DESCRIPTION
Follow-up fixes from recent sandbox and protocol refactors. The `_map_edit_error` `file_not_found` message diverged from every other backend (`state`, `store`, `filesystem`) — this aligns it back. The `map_file_operation_error` ValueError branch still had message-sniffing despite 38f0f2bb claiming "type-only classification" — now it actually is type-only.