### PR TITLE
chore: move root `Makefile` into `libs/`

### DIFF
--- a/.github/workflows/check_lockfiles.yml
+++ b/.github/workflows/check_lockfiles.yml
@@ -33,3 +33,4 @@ jobs:
 
       - name: "🔍 Check all lockfiles"
         run: make lock-check
+        working-directory: libs

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,8 +1,8 @@
-PACKAGE_DIRS := $(sort $(patsubst %/,%,$(dir $(wildcard libs/*/Makefile libs/partners/*/Makefile))))
+PACKAGE_DIRS := $(sort $(patsubst %/,%,$(dir $(wildcard */Makefile partners/*/Makefile))))
 
 # Map package dirs to their required Python version
 # acp requires 3.14, everything else uses 3.12
-python_version = $(if $(filter libs/acp,$1),3.14,3.12)
+python_version = $(if $(filter acp,$1),3.14,3.12)
 
 .PHONY: help lock lock-check lint format
 
@@ -16,18 +16,18 @@ help: ## Show this help message
 
 lock: ## Update all lockfiles
 	@set -e; \
-	for dir in $(PACKAGE_DIRS); do \
-		echo "🔒 Locking $$dir"; \
-		uv lock --directory $$dir --python $(call python_version,$$dir); \
-	done
+	$(foreach pkg,$(PACKAGE_DIRS), \
+		echo "🔒 Locking $(pkg)"; \
+		uv lock --directory $(pkg) --python $(call python_version,$(pkg)); \
+	)
 	@echo "✅ All lockfiles updated!"
 
 lock-check: ## Check all lockfiles are up-to-date
 	@set -e; \
-	for dir in $(PACKAGE_DIRS); do \
-		echo "🔍 Checking $$dir"; \
-		uv lock --check --directory $$dir --python $(call python_version,$$dir); \
-	done
+	$(foreach pkg,$(PACKAGE_DIRS), \
+		echo "🔍 Checking $(pkg)"; \
+		uv lock --check --directory $(pkg) --python $(call python_version,$(pkg)); \
+	)
 	@echo "✅ All lockfiles are up-to-date!"
 
 lint: ## Lint all packages


### PR DESCRIPTION
Move the root `Makefile` into `libs/` so it lives alongside the packages it operates on. The glob patterns (`*/Makefile`, `partners/*/Makefile`) and the `acp` filter condition now resolve relative to `libs/` instead of requiring the `libs/` prefix from the repo root. The CI workflow gets a matching `working-directory: libs` so `make lock-check` keeps working.