### PR TITLE
fix(cli): don't resume after ask_user cancel

### DIFF
--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -915,6 +915,7 @@ async def execute_task_textual(
             # Handle HITL after stream completes
             if interrupt_occurred:
                 any_rejected = False
+                ask_user_cancelled = False
                 resume_payload: dict[str, Any] = {}
 
                 for interrupt_id, ask_req in list(pending_ask_user.items()):
@@ -989,11 +990,24 @@ async def execute_task_textual(
                                 }
                                 any_rejected = True
                         elif result_type == "cancelled":
+                            # Esc cancelling an ask_user dialog should stop the
+                            # current turn instead of resuming generation.
+                            ask_user_cancelled = True
+
+                            tool_id = ask_req["tool_call_id"]
+                            if tool_id in adapter._current_tool_messages:
+                                tool_msg = adapter._current_tool_messages[tool_id]
+                                tool_msg.set_rejected()
+                                adapter._current_tool_messages.pop(tool_id, None)
+
+                            # Keep a resume payload for completeness, but we
+                            # intentionally do not resume this turn.
                             resume_payload[interrupt_id] = {
                                 "status": "cancelled",
                                 "answers": ["" for _ in questions],
                             }
                             any_rejected = True
+                            break
                         else:
                             error_text = result.get("error")
                             if not isinstance(error_text, str) or not error_text:
@@ -1016,6 +1030,9 @@ async def execute_task_textual(
                         }
 
                 for interrupt_id, hitl_request in list(pending_interrupts.items()):
+                    if ask_user_cancelled:
+                        break
+
                     action_requests = hitl_request["action_requests"]
 
                     if session_state.auto_approve:
@@ -1140,6 +1157,13 @@ async def execute_task_textual(
                 suppress_resumed_output = any_rejected
 
             if interrupt_occurred and resume_payload:
+                if ask_user_cancelled:
+                    await adapter._mount_message(
+                        AppMessage("Cancelled. Tell the agent what you'd like instead.")
+                    )
+                    turn_stats.wall_time_seconds = time.monotonic() - start_time
+                    return turn_stats
+
                 if suppress_resumed_output and not pending_ask_user:
                     await adapter._mount_message(
                         AppMessage(

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -880,6 +880,49 @@ class TestExecuteTaskTextualAskUser:
         assert ask_user_resume["error"] == "ask_user not supported by this UI"
         assert ask_user_resume["answers"] == [""]
 
+    async def test_request_ask_user_cancelled_does_not_resume(self) -> None:
+        """Cancelling an ask_user prompt should stop the current turn."""
+
+        async def request_ask_user(
+            _questions: list[Any],
+        ) -> asyncio.Future[object] | None:
+            await asyncio.sleep(0)
+            future: Future[object] = Future()
+            future.set_result({"type": "cancelled"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(
+                        {
+                            "type": "ask_user",
+                            "questions": [{"question": "Name?", "type": "text"}],
+                            "tool_call_id": "tool-1",
+                        }
+                    )
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=request_ask_user,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        # Should not send a resume Command back to the agent.
+        assert len(agent.stream_inputs) == 1
+
     async def test_invalid_ask_user_interrupt_payload_raises_validation_error(
         self,
     ) -> None:


### PR DESCRIPTION
Fixes #2165.

### What
When the `ask_user` prompt is cancelled (Esc), the Textual adapter previously resumed the graph with a `status=cancelled` payload, causing the model to continue generation immediately.

This change treats ask_user cancellation as a turn-level cancel:
- mark the ask_user tool call as rejected
- do **not** send a resume `Command` for the turn
- show a short cancellation message

### Tests
- `python3 -m pytest libs/cli/tests/unit_tests/test_textual_adapter.py`