### PR TITLE
ci(evals): expand harbor model coverage to match evals workflow

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -42,7 +42,7 @@ REGISTRY: tuple[Model, ...] = (
     # -- Anthropic --
     Model(
         "anthropic:claude-haiku-4-5-20251001",
-        frozenset({"eval:set0", "eval:set1"}),
+        frozenset({"eval:set0", "eval:set1", "harbor:anthropic"}),
     ),
     Model(
         "anthropic:claude-sonnet-4-20250514",
@@ -69,32 +69,38 @@ REGISTRY: tuple[Model, ...] = (
         frozenset({"eval:set0", "eval:set1", "harbor:anthropic"}),
     ),
     # -- OpenAI --
-    Model("openai:gpt-4o", frozenset({"eval:set0"})),
-    Model("openai:gpt-4o-mini", frozenset({"eval:set0"})),
+    Model("openai:gpt-4o", frozenset({"eval:set0", "harbor:openai"})),
+    Model("openai:gpt-4o-mini", frozenset({"eval:set0", "harbor:openai"})),
     Model(
         "openai:gpt-4.1",
         frozenset({"eval:set0", "eval:set1", "harbor:openai"}),
     ),
     Model("openai:o3", frozenset({"eval:set0", "harbor:openai"})),
     Model("openai:o4-mini", frozenset({"eval:set0", "harbor:openai"})),
-    Model("openai:gpt-5.1-codex", frozenset({"eval:set0"})),
-    Model("openai:gpt-5.2-codex", frozenset({"eval:set0", "eval:set1"})),
+    Model("openai:gpt-5.1-codex", frozenset({"eval:set0", "harbor:openai"})),
+    Model(
+        "openai:gpt-5.2-codex",
+        frozenset({"eval:set0", "eval:set1", "harbor:openai"}),
+    ),
     Model(
         "openai:gpt-5.4",
         frozenset({"eval:set0", "eval:set1", "harbor:openai"}),
     ),
     # -- Google --
-    Model("google_genai:gemini-2.5-flash", frozenset({"eval:set0"})),
-    Model("google_genai:gemini-2.5-pro", frozenset({"eval:set0", "eval:set1"})),
-    Model("google_genai:gemini-3-flash-preview", frozenset({"eval:set0"})),
+    Model("google_genai:gemini-2.5-flash", frozenset({"eval:set0", "harbor:google_genai"})),
+    Model(
+        "google_genai:gemini-2.5-pro",
+        frozenset({"eval:set0", "eval:set1", "harbor:google_genai"}),
+    ),
+    Model("google_genai:gemini-3-flash-preview", frozenset({"eval:set0", "harbor:google_genai"})),
     Model(
         "google_genai:gemini-3.1-pro-preview",
-        frozenset({"eval:set0", "eval:set1"}),
+        frozenset({"eval:set0", "eval:set1", "harbor:google_genai"}),
     ),
     # -- OpenRouter --
     Model(
         "openrouter:minimax/minimax-m2.7",
-        frozenset({"eval:set0", "eval:open"}),
+        frozenset({"eval:set0", "eval:open", "harbor:openrouter"}),
     ),
     # -- Baseten --
     Model(
@@ -120,36 +126,36 @@ REGISTRY: tuple[Model, ...] = (
     # -- Fireworks --
     Model(
         "fireworks:fireworks/qwen3-vl-235b-a22b-thinking",
-        frozenset({"eval:set0", "eval:set1"}),
+        frozenset({"eval:set0", "eval:set1", "harbor:fireworks"}),
     ),
-    Model("fireworks:fireworks/deepseek-v3-0324", frozenset({"eval:set0"})),
-    Model("fireworks:fireworks/minimax-m2p1", frozenset({"eval:set0"})),
-    Model("fireworks:fireworks/kimi-k2p5", frozenset({"eval:set0"})),
-    Model("fireworks:fireworks/glm-5", frozenset({"eval:set0"})),
-    Model("fireworks:fireworks/minimax-m2p5", frozenset({"eval:set0"})),
+    Model("fireworks:fireworks/deepseek-v3-0324", frozenset({"eval:set0", "harbor:fireworks"})),
+    Model("fireworks:fireworks/minimax-m2p1", frozenset({"eval:set0", "harbor:fireworks"})),
+    Model("fireworks:fireworks/kimi-k2p5", frozenset({"eval:set0", "harbor:fireworks"})),
+    Model("fireworks:fireworks/glm-5", frozenset({"eval:set0", "harbor:fireworks"})),
+    Model("fireworks:fireworks/minimax-m2p5", frozenset({"eval:set0", "harbor:fireworks"})),
     # -- Ollama (SET1 + SET2) --
-    Model("ollama:glm-5", frozenset({"eval:set1", "eval:set2"})),
-    Model("ollama:minimax-m2.5", frozenset({"eval:set1", "eval:set2"})),
-    Model("ollama:qwen3.5:397b-cloud", frozenset({"eval:set1", "eval:set2"})),
+    Model("ollama:glm-5", frozenset({"eval:set1", "eval:set2", "harbor:ollama"})),
+    Model("ollama:minimax-m2.5", frozenset({"eval:set1", "eval:set2", "harbor:ollama"})),
+    Model("ollama:qwen3.5:397b-cloud", frozenset({"eval:set1", "eval:set2", "harbor:ollama"})),
     # -- Groq (SET2) --
-    Model("groq:openai/gpt-oss-120b", frozenset({"eval:set2"})),
-    Model("groq:qwen/qwen3-32b", frozenset({"eval:set2"})),
-    Model("groq:moonshotai/kimi-k2-instruct", frozenset({"eval:set2"})),
+    Model("groq:openai/gpt-oss-120b", frozenset({"eval:set2", "harbor:groq"})),
+    Model("groq:qwen/qwen3-32b", frozenset({"eval:set2", "harbor:groq"})),
+    Model("groq:moonshotai/kimi-k2-instruct", frozenset({"eval:set2", "harbor:groq"})),
     # -- xAI (SET2) --
-    Model("xai:grok-4", frozenset({"eval:set2"})),
-    Model("xai:grok-3-mini-fast", frozenset({"eval:set2"})),
+    Model("xai:grok-4", frozenset({"eval:set2", "harbor:xai"})),
+    Model("xai:grok-3-mini-fast", frozenset({"eval:set2", "harbor:xai"})),
     # -- Ollama (SET2 only) --
-    Model("ollama:nemotron-3-nano:30b", frozenset({"eval:set2"})),
-    Model("ollama:cogito-2.1:671b", frozenset({"eval:set2"})),
-    Model("ollama:devstral-2:123b", frozenset({"eval:set2"})),
-    Model("ollama:ministral-3:14b", frozenset({"eval:set2"})),
-    Model("ollama:qwen3-next:80b", frozenset({"eval:set2"})),
-    Model("ollama:qwen3-coder:480b-cloud", frozenset({"eval:set2"})),
-    Model("ollama:deepseek-v3.2:cloud", frozenset({"eval:set2"})),
+    Model("ollama:nemotron-3-nano:30b", frozenset({"eval:set2", "harbor:ollama"})),
+    Model("ollama:cogito-2.1:671b", frozenset({"eval:set2", "harbor:ollama"})),
+    Model("ollama:devstral-2:123b", frozenset({"eval:set2", "harbor:ollama"})),
+    Model("ollama:ministral-3:14b", frozenset({"eval:set2", "harbor:ollama"})),
+    Model("ollama:qwen3-next:80b", frozenset({"eval:set2", "harbor:ollama"})),
+    Model("ollama:qwen3-coder:480b-cloud", frozenset({"eval:set2", "harbor:ollama"})),
+    Model("ollama:deepseek-v3.2:cloud", frozenset({"eval:set2", "harbor:ollama"})),
     # -- NVIDIA (OPEN) --
     Model(
         "nvidia:nvidia/nemotron-3-super-120b-a12b",
-        frozenset({"eval:open"}),
+        frozenset({"eval:open", "harbor:nvidia"}),
     ),
 )
 
@@ -169,7 +175,14 @@ _HARBOR_PRESETS: dict[str, str | None] = {
     "all": None,
     "anthropic": "harbor:anthropic",
     "openai": "harbor:openai",
+    "google_genai": "harbor:google_genai",
+    "openrouter": "harbor:openrouter",
     "baseten": "harbor:baseten",
+    "fireworks": "harbor:fireworks",
+    "ollama": "harbor:ollama",
+    "groq": "harbor:groq",
+    "xai": "harbor:xai",
+    "nvidia": "harbor:nvidia",
 }
 
 _WORKFLOW_CONFIG: dict[str, tuple[str, dict[str, str | None]]] = {

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -12,22 +12,61 @@ on:
           - all
           - anthropic
           - openai
+          - google_genai
+          - openrouter
           - baseten
+          - fireworks
+          - ollama
+          - groq
+          - xai
+          - nvidia
+          - "anthropic:claude-haiku-4-5-20251001"
           - "anthropic:claude-sonnet-4-20250514"
           - "anthropic:claude-sonnet-4-5-20250929"
           - "anthropic:claude-sonnet-4-6"
           - "anthropic:claude-opus-4-1"
           - "anthropic:claude-opus-4-5-20251101"
           - "anthropic:claude-opus-4-6"
+          - "openai:gpt-4o"
+          - "openai:gpt-4o-mini"
           - "openai:gpt-4.1"
           - "openai:o3"
           - "openai:o4-mini"
+          - "openai:gpt-5.1-codex"
+          - "openai:gpt-5.2-codex"
           - "openai:gpt-5.4"
+          - "google_genai:gemini-2.5-flash"
+          - "google_genai:gemini-2.5-pro"
+          - "google_genai:gemini-3-flash-preview"
+          - "google_genai:gemini-3.1-pro-preview"
+          - "openrouter:minimax/minimax-m2.7"
           - "baseten:zai-org/GLM-5"
           - "baseten:MiniMaxAI/MiniMax-M2.5"
           - "baseten:moonshotai/Kimi-K2.5"
           - "baseten:deepseek-ai/DeepSeek-V3.2"
           - "baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct"
+          - "fireworks:fireworks/qwen3-vl-235b-a22b-thinking"
+          - "fireworks:fireworks/deepseek-v3-0324"
+          - "fireworks:fireworks/minimax-m2p1"
+          - "fireworks:fireworks/kimi-k2p5"
+          - "fireworks:fireworks/glm-5"
+          - "fireworks:fireworks/minimax-m2p5"
+          - "ollama:glm-5"
+          - "ollama:minimax-m2.5"
+          - "ollama:qwen3.5:397b-cloud"
+          - "groq:openai/gpt-oss-120b"
+          - "groq:qwen/qwen3-32b"
+          - "groq:moonshotai/kimi-k2-instruct"
+          - "xai:grok-4"
+          - "xai:grok-3-mini-fast"
+          - "ollama:nemotron-3-nano:30b"
+          - "ollama:cogito-2.1:671b"
+          - "ollama:devstral-2:123b"
+          - "ollama:ministral-3:14b"
+          - "ollama:qwen3-next:80b"
+          - "ollama:qwen3-coder:480b-cloud"
+          - "ollama:deepseek-v3.2:cloud"
+          - "nvidia:nvidia/nemotron-3-super-120b-a12b"
       models_override:
         description: "Override: comma-separated models (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Takes priority over dropdown when non-empty."
         required: false
@@ -150,7 +189,15 @@ jobs:
       LANGSMITH_TRACING_V2: "true"
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+      OLLAMA_HOST: "https://ollama.com"
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
       BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
+      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -194,9 +241,16 @@ jobs:
           # Model provider key (infer from model prefix)
           model_provider="${HARBOR_MODEL%%:*}"
           case "$model_provider" in
-            anthropic) [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY") ;;
-            openai)    [ -z "$OPENAI_API_KEY" ] && missing+=("OPENAI_API_KEY") ;;
-            baseten)   [ -z "$BASETEN_API_KEY" ] && missing+=("BASETEN_API_KEY") ;;
+            anthropic)    [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY") ;;
+            openai)       [ -z "$OPENAI_API_KEY" ] && missing+=("OPENAI_API_KEY") ;;
+            google_genai) [ -z "$GOOGLE_API_KEY" ] && missing+=("GOOGLE_API_KEY") ;;
+            openrouter)   [ -z "$OPENROUTER_API_KEY" ] && missing+=("OPENROUTER_API_KEY") ;;
+            baseten)      [ -z "$BASETEN_API_KEY" ] && missing+=("BASETEN_API_KEY") ;;
+            fireworks)    [ -z "$FIREWORKS_API_KEY" ] && missing+=("FIREWORKS_API_KEY") ;;
+            ollama)       [ -z "$OLLAMA_API_KEY" ] && missing+=("OLLAMA_API_KEY") ;;
+            groq)         [ -z "$GROQ_API_KEY" ] && missing+=("GROQ_API_KEY") ;;
+            xai)          [ -z "$XAI_API_KEY" ] && missing+=("XAI_API_KEY") ;;
+            nvidia)       [ -z "$NVIDIA_API_KEY" ] && missing+=("NVIDIA_API_KEY") ;;
             *)
               echo "::warning::No credential check defined for provider '$model_provider' -- verify secrets manually"
               ;;


### PR DESCRIPTION
Equalize Harbor's model coverage with the evals workflow. Previously Harbor only supported Anthropic, OpenAI, and Baseten (3 providers, ~15 models); every other provider was eval-only. Now both workflows cover the same 47 models across all 10 providers.