### PR TITLE
ci(evals): reference `categories.json` in workflow input

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -98,7 +98,7 @@ on:
         default: ""
         type: string
       eval_categories:
-        description: "Comma-separated eval categories to run (e.g. 'memory,hitl,tool_usage'). Leave empty to run all categories."
+        description: "Comma-separated eval categories to run (e.g. 'memory,hitl,tool_usage'). Categories defined in libs/evals/deepagents_evals/categories.json. Leave empty to run all."
         required: false
         default: ""
         type: string


### PR DESCRIPTION
The `eval_categories` workflow input description was vague about where valid categories come from. Point maintainers at the canonical source — `libs/evals/deepagents_evals/categories.json` — directly in the input description so they don't have to grep for it.

## Changes
- Update the `eval_categories` input description in the evals `workflow_dispatch` to reference `libs/evals/deepagents_evals/categories.json` as the source of truth for valid category names