### PR TITLE
fix(evals): prevent experiment name collisions in concurrent harbor runs

### DIFF
--- a/libs/evals/deepagents_harbor/langsmith.py
+++ b/libs/evals/deepagents_harbor/langsmith.py
@@ -296,7 +296,8 @@ async def create_experiment_async(
 
         if experiment_name is None:
             timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d_%H-%M-%S")
-            experiment_name = f"{dataset_name}-{timestamp}"
+            suffix = uuid.uuid4().hex[:8]
+            experiment_name = f"{dataset_name}-{timestamp}-{suffix}"
 
         experiment_metadata = metadata or {}
 


### PR DESCRIPTION
Auto-generated LangSmith experiment names used only a second-precision timestamp, causing 409 collisions when concurrent Harbor CI matrix jobs hit `create_experiment` within the same second.

## Changes
- Append an 8-char random hex suffix (`uuid.uuid4().hex[:8]`) to the auto-generated experiment name in `create_experiment_async`, producing names like `terminal-bench-2026-03-24_06-38-48-a1b2c3d4`