### PR TITLE
feat(sdk): evict large HumanMessages

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1523,7 +1523,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         file_path: str | None = None
         if new_eviction_needed:
             backend = self._get_backend_from_runtime(request.state, request.runtime)
-            file_path = f"/large_messages/{uuid.uuid4().hex[:12]}"
+            file_path = f"/conversation_history/{uuid.uuid4().hex[:12]}"
             write_result = backend.write(file_path, _extract_text_from_message(messages[-1]))
 
         return self._apply_eviction_and_truncate(messages, write_result, file_path)
@@ -1549,7 +1549,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         file_path: str | None = None
         if new_eviction_needed:
             backend = self._get_backend_from_runtime(request.state, request.runtime)
-            file_path = f"/large_messages/{uuid.uuid4().hex[:12]}"
+            file_path = f"/conversation_history/{uuid.uuid4().hex[:12]}"
             write_result = await backend.awrite(file_path, _extract_text_from_message(messages[-1]))
 
         return self._apply_eviction_and_truncate(messages, write_result, file_path)

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1365,14 +1365,14 @@ class TestLargeHumanMessageEviction:
         assert msg.content == large_content
         evicted_to = msg.additional_kwargs.get("lc_evicted_to")
         assert evicted_to is not None
-        assert evicted_to.startswith("/large_messages/")
+        assert evicted_to.startswith("/conversation_history/")
 
         assert len(fake_model.call_history) == 1
         model_messages = fake_model.call_history[0]["messages"]
         model_human = [m for m in model_messages if isinstance(m, HumanMessage)]
         assert len(model_human) == 1
         assert len(model_human[0].content) < len(large_content)
-        assert "/large_messages/" in model_human[0].content
+        assert "/conversation_history/" in model_human[0].content
 
     def test_multi_turn_eviction(self) -> None:
         """Tagged messages are truncated on subsequent turns.


### PR DESCRIPTION
- Implemented via `wrap_model_call` in FileSystemMiddleware
- If most recent message is HumanMessage and long, evict and mark with `"lc_evicted_to": "<path>"` in `additional_kwargs`
- Truncate all messages marked with `"lc_evicted_to"` in model request.
- Original message contents preserved in state, only `additional_kwargs` is updated.