### PR TITLE
feat(cli): add `deepagents deploy` command

### DIFF
--- a/examples/deploy-demo/.deepagents/AGENTS.md
+++ b/examples/deploy-demo/.deepagents/AGENTS.md
@@ -1,0 +1,9 @@
+# Demo Agent
+
+You are a helpful coding assistant deployed via deepagents deploy.
+
+## Guidelines
+
+- Write clean, well-documented code
+- Follow the project's existing patterns
+- Run tests before considering a task complete

--- a/examples/deploy-demo/.deepagents/skills/code-review/SKILL.md
+++ b/examples/deploy-demo/.deepagents/skills/code-review/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: code-review
+description: Perform a thorough code review with actionable feedback
+---
+
+# Code Review Skill
+
+## When to Use
+When the user asks you to review code, a PR, or a diff.
+
+## Steps
+1. Read the files or diff carefully
+2. Check for bugs, security issues, and performance problems
+3. Verify code follows project conventions
+4. Provide specific, actionable feedback with line references
+5. Suggest improvements where appropriate

--- a/examples/deploy-demo/custom_tools.py
+++ b/examples/deploy-demo/custom_tools.py
@@ -1,0 +1,36 @@
+"""Example custom tools for the deploy demo.
+
+This file is referenced by deepagents.json as "custom": "./custom_tools.py:tools"
+and gets bundled into the deployment.
+"""
+
+from langchain_core.tools import tool
+
+
+@tool
+def get_project_info() -> str:
+    """Get information about the current project configuration."""
+    return "Project: deploy-demo | Framework: deepagents | Status: deployed"
+
+
+@tool
+def check_code_style(code: str) -> str:
+    """Check if the given code follows basic style guidelines.
+
+    Args:
+        code: The code to check.
+    """
+    issues = []
+    lines = code.split("\n")
+    for i, line in enumerate(lines, 1):
+        if len(line) > 120:
+            issues.append(f"Line {i}: exceeds 120 characters ({len(line)} chars)")
+        if line.rstrip() != line:
+            issues.append(f"Line {i}: trailing whitespace")
+    if not issues:
+        return "No style issues found."
+    return "Style issues:\n" + "\n".join(issues)
+
+
+# This is what deepagents deploy imports via the "custom_tools.py:tools" reference
+tools = [get_project_info, check_code_style]

--- a/examples/deploy-demo/deepagents.json
+++ b/examples/deploy-demo/deepagents.json
@@ -1,0 +1,38 @@
+{
+  "agent": "demo-agent",
+  "description": "Demo deployment of a coding assistant",
+  "model": "anthropic:claude-sonnet-4-6",
+
+  "memory": {
+    "scope": "user",
+    "sources": [".deepagents/AGENTS.md"]
+  },
+
+  "skills": {
+    "sources": [".deepagents/skills"]
+  },
+
+  "tools": {
+    "shell": true,
+    "web_search": true,
+    "fetch_url": true,
+    "http_request": true,
+    "custom": "./custom_tools.py:tools"
+  },
+
+  "backend": {
+    "type": "store",
+    "namespace": {
+      "scope": "user",
+      "prefix": "filesystem"
+    }
+  },
+
+  "sandbox": {
+    "provider": "langsmith",
+    "scope": "thread"
+  },
+
+  "env": ".env",
+  "python_version": "3.12"
+}

--- a/libs/cli/deepagents_cli/deploy/__init__.py
+++ b/libs/cli/deepagents_cli/deploy/__init__.py
@@ -1,0 +1,18 @@
+"""Deploy module for deepagents CLI.
+
+Public API:
+- execute_deploy_command: Run the deploy workflow
+- setup_deploy_parser: Setup argparse configuration for the deploy subcommand
+
+All other components are internal implementation details.
+"""
+
+from deepagents_cli.deploy.commands import (
+    execute_deploy_command,
+    setup_deploy_parser,
+)
+
+__all__ = [
+    "execute_deploy_command",
+    "setup_deploy_parser",
+]

--- a/libs/cli/deepagents_cli/deploy/bundle.py
+++ b/libs/cli/deepagents_cli/deploy/bundle.py
@@ -1,0 +1,328 @@
+"""Artifact bundler for deepagents deploy.
+
+Assembles a deployment directory containing all files needed to deploy
+the agent via ``langgraph deploy``:
+
+- ``langgraph.json`` — LangGraph server configuration
+- ``deploy_graph.py`` — server-side graph entry point
+- ``deploy_config.json`` — serialized DeployConfig for runtime
+- ``pyproject.toml`` — Python dependencies
+- ``agents/`` — AGENTS.md files
+- ``skills/`` — skill directories
+- ``.env`` — environment variables (if configured)
+- Custom tool modules (if configured)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from deepagents_cli.deploy.config import DeployConfig
+
+logger = logging.getLogger(__name__)
+
+
+def bundle_deploy_artifacts(
+    config: DeployConfig,
+    *,
+    project_root: Path | None = None,
+) -> Path:
+    """Bundle all deployment artifacts into a temporary directory.
+
+    Args:
+        config: Parsed deploy configuration.
+        project_root: Project root directory for resolving relative paths.
+            Defaults to the current working directory.
+
+    Returns:
+        Path to the temporary deploy directory.
+    """
+    if project_root is None:
+        project_root = Path.cwd()
+
+    deploy_dir = Path(tempfile.mkdtemp(prefix="deepagents_deploy_"))
+    logger.info("Bundling deploy artifacts in %s", deploy_dir)
+
+    # 1. Copy the deploy graph entry point
+    _write_deploy_graph(deploy_dir)
+
+    # 2. Serialize the config for runtime consumption
+    _write_deploy_config(deploy_dir, config)
+
+    # 3. Bundle AGENTS.md files
+    _bundle_memory(deploy_dir, config, project_root)
+
+    # 4. Bundle skills
+    _bundle_skills(deploy_dir, config, project_root)
+
+    # 5. Bundle custom tools module
+    _bundle_custom_tools(deploy_dir, config, project_root)
+
+    # 6. Bundle MCP config
+    _bundle_mcp_config(deploy_dir, config, project_root)
+
+    # 7. Bundle .env file
+    _bundle_env_file(deploy_dir, config, project_root)
+
+    # 8. Write pyproject.toml
+    _write_pyproject(deploy_dir, config)
+
+    # 9. Generate langgraph.json
+    _write_langgraph_json(deploy_dir, config)
+
+    return deploy_dir
+
+
+def _write_deploy_graph(deploy_dir: Path) -> None:
+    """Copy the deploy graph entry point into the bundle."""
+    src = Path(__file__).parent / "deploy_graph.py"
+    dst = deploy_dir / "deploy_graph.py"
+    shutil.copy2(src, dst)
+
+
+def _write_deploy_config(deploy_dir: Path, config: DeployConfig) -> None:
+    """Serialize the deploy config as JSON for runtime loading."""
+    # Serialize the full config so the deploy graph can reconstruct it
+    data: dict[str, Any] = {
+        "agent": config.agent,
+        "description": config.description,
+        "model": config.model,
+        "model_params": config.model_params,
+        "prompt": config.prompt,
+        "memory": {
+            "scope": config.memory.scope,
+            "sources": config.memory.sources,
+        },
+        "skills": {
+            "sources": config.skills.sources,
+        },
+        "tools": {
+            "shell": config.tools.shell,
+            "shell_allow_list": config.tools.shell_allow_list,
+            "web_search": config.tools.web_search,
+            "fetch_url": config.tools.fetch_url,
+            "http_request": config.tools.http_request,
+            "mcp": str(config.tools.mcp) if config.tools.mcp else False,
+            "custom": config.tools.custom,
+        },
+        "backend": {
+            "type": config.backend.type,
+            "namespace": {
+                "scope": config.backend.namespace.scope,
+                "prefix": config.backend.namespace.prefix,
+            },
+            "path": config.backend.path,
+        },
+    }
+
+    if config.sandbox is not None:
+        data["sandbox"] = {
+            "provider": config.sandbox.provider,
+            "scope": config.sandbox.scope,
+            "template": config.sandbox.template,
+            "image": config.sandbox.image,
+            "setup_script": config.sandbox.setup_script,
+        }
+    else:
+        data["sandbox"] = None
+
+    (deploy_dir / "deploy_config.json").write_text(json.dumps(data, indent=2))
+
+
+def _resolve_source_path(source: str, project_root: Path) -> Path | None:
+    """Resolve a source path, expanding ~ and making relative paths absolute.
+
+    Returns None if the resolved path does not exist.
+    """
+    path = Path(source).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    path = path.resolve()
+    if not path.exists():
+        logger.warning("Source path does not exist: %s (resolved from %s)", path, source)
+        return None
+    return path
+
+
+def _bundle_memory(deploy_dir: Path, config: DeployConfig, project_root: Path) -> None:
+    """Copy AGENTS.md files into the bundle."""
+    agents_dir = deploy_dir / "agents"
+    agents_dir.mkdir(exist_ok=True)
+
+    bundled_sources: list[str] = []
+    for i, source in enumerate(config.memory.sources):
+        resolved = _resolve_source_path(source, project_root)
+        if resolved is None:
+            continue
+        # Use index prefix to avoid name collisions
+        dest_name = f"{i}_{resolved.name}"
+        shutil.copy2(resolved, agents_dir / dest_name)
+        bundled_sources.append(f"agents/{dest_name}")
+        logger.info("Bundled memory source: %s -> %s", source, dest_name)
+
+    # Update the config's memory sources to point to bundled paths
+    # (written separately in deploy_config.json)
+    if bundled_sources:
+        config_path = deploy_dir / "deploy_config.json"
+        data = json.loads(config_path.read_text())
+        data["memory"]["_bundled_sources"] = bundled_sources
+        config_path.write_text(json.dumps(data, indent=2))
+
+
+def _bundle_skills(deploy_dir: Path, config: DeployConfig, project_root: Path) -> None:
+    """Copy skill directories into the bundle."""
+    skills_dir = deploy_dir / "skills"
+    skills_dir.mkdir(exist_ok=True)
+
+    bundled_sources: list[str] = []
+    for source in config.skills.sources:
+        resolved = _resolve_source_path(source, project_root)
+        if resolved is None:
+            continue
+        if not resolved.is_dir():
+            logger.warning("Skills source is not a directory: %s", resolved)
+            continue
+        # Copy each skill subdirectory
+        for skill_subdir in resolved.iterdir():
+            if skill_subdir.is_dir() and (skill_subdir / "SKILL.md").exists():
+                dest = skills_dir / skill_subdir.name
+                if dest.exists():
+                    logger.warning("Skill name collision, skipping: %s", skill_subdir.name)
+                    continue
+                shutil.copytree(skill_subdir, dest)
+                logger.info("Bundled skill: %s", skill_subdir.name)
+        bundled_sources.append("skills")
+
+    if bundled_sources:
+        config_path = deploy_dir / "deploy_config.json"
+        data = json.loads(config_path.read_text())
+        data["skills"]["_bundled_sources"] = list(set(bundled_sources))
+        config_path.write_text(json.dumps(data, indent=2))
+
+
+def _bundle_custom_tools(
+    deploy_dir: Path, config: DeployConfig, project_root: Path
+) -> None:
+    """Copy custom tools module into the bundle."""
+    if not config.tools.custom:
+        return
+
+    # Parse "module.py:variable" format
+    parts = config.tools.custom.split(":")
+    module_path_str = parts[0]
+
+    resolved = _resolve_source_path(module_path_str, project_root)
+    if resolved is None:
+        msg = f"Custom tools module not found: {module_path_str}"
+        raise FileNotFoundError(msg)
+
+    dest = deploy_dir / resolved.name
+    shutil.copy2(resolved, dest)
+
+    # Update config to point to bundled path
+    config_path = deploy_dir / "deploy_config.json"
+    data = json.loads(config_path.read_text())
+    variable = parts[1] if len(parts) > 1 else "tools"
+    data["tools"]["_bundled_custom"] = f"./{resolved.name}:{variable}"
+    config_path.write_text(json.dumps(data, indent=2))
+    logger.info("Bundled custom tools: %s", config.tools.custom)
+
+
+def _bundle_mcp_config(
+    deploy_dir: Path, config: DeployConfig, project_root: Path
+) -> None:
+    """Copy MCP configuration file into the bundle."""
+    if not config.tools.mcp or config.tools.mcp is True:
+        return
+
+    mcp_path = str(config.tools.mcp)
+    resolved = _resolve_source_path(mcp_path, project_root)
+    if resolved is None:
+        logger.warning("MCP config not found: %s", mcp_path)
+        return
+
+    shutil.copy2(resolved, deploy_dir / ".mcp.json")
+    logger.info("Bundled MCP config: %s", mcp_path)
+
+
+def _bundle_env_file(
+    deploy_dir: Path, config: DeployConfig, project_root: Path
+) -> None:
+    """Copy .env file into the bundle."""
+    resolved = _resolve_source_path(config.env, project_root)
+    if resolved is None:
+        return
+
+    shutil.copy2(resolved, deploy_dir / ".env")
+    logger.info("Bundled env file: %s", config.env)
+
+
+def _write_pyproject(deploy_dir: Path, config: DeployConfig) -> None:
+    """Write a pyproject.toml for the deployment."""
+    # Determine extra dependencies based on sandbox provider
+    extras: list[str] = []
+    if config.sandbox is not None:
+        provider = config.sandbox.provider
+        if provider == "langsmith":
+            extras.append('"langsmith-sandbox"')
+        elif provider == "modal":
+            extras.append('"deepagents-modal"')
+        elif provider == "daytona":
+            extras.append('"deepagents-daytona"')
+        elif provider == "runloop":
+            extras.append('"deepagents-runloop"')
+
+    if config.tools.web_search:
+        extras.append('"tavily-python"')
+
+    extra_deps = ""
+    if extras:
+        extra_deps = "\n" + "\n".join(f"    {e}," for e in extras)
+
+    content = f"""\
+[project]
+name = "deepagents-deploy"
+version = "0.0.1"
+requires-python = ">={config.python_version}"
+dependencies = [
+    "deepagents-cli",{extra_deps}
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"""
+    (deploy_dir / "pyproject.toml").write_text(content)
+
+
+def _write_langgraph_json(deploy_dir: Path, config: DeployConfig) -> None:
+    """Generate the langgraph.json configuration for deployment."""
+    langgraph_config: dict[str, Any] = {
+        "dependencies": ["."],
+        "graphs": {
+            "agent": "./deploy_graph.py:graph",
+        },
+        "python_version": config.python_version,
+    }
+
+    # Env file
+    if (deploy_dir / ".env").exists():
+        langgraph_config["env"] = ".env"
+
+    # Store config for semantic search indexing
+    if config.backend.type == "store":
+        langgraph_config["store"] = {
+            "index": {
+                "embed": "openai:text-embedding-3-small",
+                "dims": 1536,
+                "fields": ["$"],
+            },
+        }
+
+    (deploy_dir / "langgraph.json").write_text(json.dumps(langgraph_config, indent=2))
+    logger.info("Generated langgraph.json")

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -1,0 +1,476 @@
+"""CLI commands for ``deepagents deploy``.
+
+Provides the ``deploy`` subcommand that bundles agent artifacts and
+deploys them to LangGraph Cloud via ``langgraph deploy``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+import subprocess  # noqa: S404
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def setup_deploy_parser(
+    subparsers: Any,
+    *,
+    make_help_action: Callable[..., type[argparse.Action]],
+    add_output_args: Callable[..., None],
+) -> None:
+    """Register the ``deploy`` subcommand with the CLI argument parser.
+
+    Args:
+        subparsers: The subparsers action from the parent parser.
+        make_help_action: Factory for custom help actions.
+        add_output_args: Adds ``--output`` argument to a parser.
+    """
+    deploy_parser = subparsers.add_parser(
+        "deploy",
+        help="Deploy agent to LangGraph Cloud",
+        add_help=False,
+    )
+    deploy_parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        default=False,
+        help="Show help for the deploy command",
+    )
+
+    deploy_parser.add_argument(
+        "-c",
+        "--config",
+        metavar="PATH",
+        default=None,
+        help="Path to deepagents.json config file (default: ./deepagents.json)",
+    )
+
+    deploy_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Generate the deploy bundle without deploying. "
+        "Prints the bundle directory and langgraph.json.",
+    )
+
+    deploy_parser.add_argument(
+        "--wait",
+        action="store_true",
+        default=False,
+        help="Wait for the deployment to complete before exiting.",
+    )
+
+    # Override config fields via CLI flags
+    deploy_parser.add_argument(
+        "-a",
+        "--agent",
+        metavar="NAME",
+        default=None,
+        help="Agent name (overrides deepagents.json 'agent' field)",
+    )
+    deploy_parser.add_argument(
+        "-M",
+        "--model",
+        metavar="MODEL",
+        default=None,
+        help="Model to deploy (overrides deepagents.json 'model' field)",
+    )
+    deploy_parser.add_argument(
+        "--sandbox",
+        choices=["langsmith", "modal", "daytona", "runloop", "none"],
+        default=None,
+        metavar="PROVIDER",
+        help="Sandbox provider (default: langsmith)",
+    )
+    deploy_parser.add_argument(
+        "--sandbox-scope",
+        choices=["assistant", "user", "thread", "user+thread"],
+        default=None,
+        help="Sandbox lifecycle scope (default: thread)",
+    )
+    deploy_parser.add_argument(
+        "--backend-scope",
+        choices=["assistant", "user", "thread", "user+thread"],
+        default=None,
+        help="Store backend namespace scope (default: assistant)",
+    )
+    deploy_parser.add_argument(
+        "--memory-scope",
+        choices=["assistant", "user", "thread", "user+thread"],
+        default=None,
+        help="Memory (AGENTS.md) namespace scope (default: assistant)",
+    )
+    deploy_parser.add_argument(
+        "--revision-id",
+        metavar="ID",
+        default=None,
+        help="Deployment revision identifier",
+    )
+
+    add_output_args(deploy_parser)
+
+
+def execute_deploy_command(args: argparse.Namespace) -> None:
+    """Execute the ``deploy`` subcommand.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    if getattr(args, "help", False):
+        _show_deploy_help()
+        return
+
+    from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+    from deepagents_cli.deploy.config import DeployConfig
+
+    # Load config
+    config_path = Path(args.config).resolve() if args.config else None
+    try:
+        config = DeployConfig.load(config_path)
+    except (ValueError, OSError) as exc:
+        print(f"Error loading config: {exc}", file=sys.stderr)  # noqa: T201
+        sys.exit(1)
+
+    # Apply CLI overrides
+    config = _apply_cli_overrides(config, args)
+
+    # Print config summary
+    _print_config_summary(config)
+
+    # Resolve project root: use config file's parent directory if an explicit
+    # config path was provided, otherwise use the current working directory.
+    project_root = config_path.parent if config_path is not None else Path.cwd()
+
+    # Bundle artifacts
+    try:
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+    except (FileNotFoundError, OSError) as exc:
+        print(f"Error bundling artifacts: {exc}", file=sys.stderr)  # noqa: T201
+        sys.exit(1)
+
+    if args.dry_run:
+        _handle_dry_run(deploy_dir, config)
+        return
+
+    # Run langgraph deploy
+    _run_langgraph_deploy(
+        deploy_dir,
+        wait=args.wait,
+        revision_id=getattr(args, "revision_id", None),
+    )
+
+
+def _apply_cli_overrides(config: DeployConfig, args: argparse.Namespace) -> DeployConfig:
+    """Apply CLI flag overrides to the config.
+
+    Creates a new DeployConfig with overridden fields. Uses object.__setattr__
+    on the frozen dataclass since we're constructing the final config.
+    """
+    from deepagents_cli.deploy.config import (
+        BackendConfig,
+        DeployConfig,
+        MemoryConfig,
+        NamespaceConfig,
+        SandboxConfig,
+    )
+
+    overrides: dict[str, Any] = {}
+
+    if args.agent is not None:
+        overrides["agent"] = args.agent
+    if args.model is not None:
+        overrides["model"] = args.model
+
+    # Sandbox overrides
+    if args.sandbox is not None:
+        if args.sandbox == "none":
+            overrides["sandbox"] = None
+        else:
+            sandbox_scope = args.sandbox_scope or (config.sandbox.scope if config.sandbox else "thread")
+            overrides["sandbox"] = SandboxConfig(
+                provider=args.sandbox,
+                scope=sandbox_scope,
+                template=config.sandbox.template if config.sandbox else None,
+                image=config.sandbox.image if config.sandbox else None,
+                setup_script=config.sandbox.setup_script if config.sandbox else None,
+            )
+    elif args.sandbox_scope is not None and config.sandbox is not None:
+        overrides["sandbox"] = SandboxConfig(
+            provider=config.sandbox.provider,
+            scope=args.sandbox_scope,
+            template=config.sandbox.template,
+            image=config.sandbox.image,
+            setup_script=config.sandbox.setup_script,
+        )
+
+    # Backend scope override
+    if args.backend_scope is not None:
+        overrides["backend"] = BackendConfig(
+            type=config.backend.type,
+            namespace=NamespaceConfig(
+                scope=args.backend_scope,
+                prefix=config.backend.namespace.prefix,
+            ),
+            path=config.backend.path,
+        )
+
+    # Memory scope override
+    if args.memory_scope is not None:
+        overrides["memory"] = MemoryConfig(
+            scope=args.memory_scope,
+            sources=config.memory.sources,
+        )
+
+    if not overrides:
+        return config
+
+    # Reconstruct with overrides
+    from dataclasses import asdict
+
+    config_dict = asdict(config)
+    config_dict.update(overrides)
+
+    # Need to reconstruct properly since asdict flattens nested dataclasses
+    return DeployConfig(
+        agent=overrides.get("agent", config.agent),
+        description=config.description,
+        model=overrides.get("model", config.model),
+        model_params=config.model_params,
+        prompt=config.prompt,
+        memory=overrides.get("memory", config.memory),
+        skills=config.skills,
+        tools=config.tools,
+        backend=overrides.get("backend", config.backend),
+        sandbox=overrides["sandbox"] if "sandbox" in overrides else config.sandbox,
+        env=config.env,
+        python_version=config.python_version,
+    )
+
+
+def _print_config_summary(config: DeployConfig) -> None:
+    """Print a summary of the deployment configuration."""
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        console = Console(stderr=True)
+
+        table = Table(title="Deploy Configuration", show_header=False, border_style="dim")
+        table.add_column("Key", style="bold")
+        table.add_column("Value")
+
+        table.add_row("Agent", config.agent)
+        table.add_row("Model", config.model)
+        table.add_row("Backend", f"{config.backend.type} (scope: {config.backend.namespace.scope})")
+        if config.sandbox:
+            table.add_row("Sandbox", f"{config.sandbox.provider} (scope: {config.sandbox.scope})")
+        else:
+            table.add_row("Sandbox", "disabled")
+        table.add_row("Memory", f"scope: {config.memory.scope}, sources: {len(config.memory.sources)}")
+        table.add_row("Skills", f"sources: {len(config.skills.sources)}")
+
+        tools_enabled = []
+        if config.tools.shell:
+            tools_enabled.append("shell")
+        if config.tools.web_search:
+            tools_enabled.append("web_search")
+        if config.tools.fetch_url:
+            tools_enabled.append("fetch_url")
+        if config.tools.http_request:
+            tools_enabled.append("http_request")
+        if config.tools.custom:
+            tools_enabled.append(f"custom({config.tools.custom})")
+        table.add_row("Tools", ", ".join(tools_enabled) if tools_enabled else "none")
+
+        console.print(table)
+    except ImportError:
+        # Fallback without rich
+        print(f"Deploying agent '{config.agent}' with model '{config.model}'")  # noqa: T201
+        print(f"  Backend: {config.backend.type} (scope: {config.backend.namespace.scope})")  # noqa: T201
+        if config.sandbox:
+            print(f"  Sandbox: {config.sandbox.provider} (scope: {config.sandbox.scope})")  # noqa: T201
+
+
+def _handle_dry_run(deploy_dir: Path, config: DeployConfig) -> None:
+    """Handle --dry-run: print bundle contents and exit."""
+    try:
+        from rich.console import Console
+        from rich.syntax import Syntax
+        from rich.tree import Tree
+
+        console = Console(stderr=True)
+        console.print(f"\n[bold]Deploy bundle:[/bold] {deploy_dir}\n")
+
+        # Show directory tree
+        tree = Tree(f"[bold]{deploy_dir.name}/[/bold]")
+        for item in sorted(deploy_dir.rglob("*")):
+            if item.is_file():
+                rel = item.relative_to(deploy_dir)
+                tree.add(str(rel))
+        console.print(tree)
+
+        # Show langgraph.json
+        lg_json = deploy_dir / "langgraph.json"
+        if lg_json.exists():
+            console.print("\n[bold]langgraph.json:[/bold]")
+            console.print(Syntax(lg_json.read_text(), "json", theme="monokai"))
+
+        # Show deploy_config.json
+        dc_json = deploy_dir / "deploy_config.json"
+        if dc_json.exists():
+            console.print("\n[bold]deploy_config.json:[/bold]")
+            console.print(Syntax(dc_json.read_text(), "json", theme="monokai"))
+
+    except ImportError:
+        print(f"Deploy bundle: {deploy_dir}")  # noqa: T201
+        lg_json = deploy_dir / "langgraph.json"
+        if lg_json.exists():
+            print(f"\nlanggraph.json:\n{lg_json.read_text()}")  # noqa: T201
+
+
+def _run_langgraph_deploy(
+    deploy_dir: Path,
+    *,
+    wait: bool = False,
+    revision_id: str | None = None,
+) -> None:
+    """Shell out to ``langgraph deploy`` to push the bundle.
+
+    Args:
+        deploy_dir: Path to the deployment bundle directory.
+        wait: Whether to wait for deployment to complete.
+        revision_id: Optional revision identifier.
+    """
+    # Check that langgraph CLI is available
+    langgraph_bin = shutil.which("langgraph")
+    if langgraph_bin is None:
+        # Try as a Python module
+        try:
+            subprocess.run(  # noqa: S603
+                [sys.executable, "-m", "langgraph_cli", "--help"],
+                capture_output=True,
+                check=True,
+            )
+            cmd_prefix = [sys.executable, "-m", "langgraph_cli"]
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            print(  # noqa: T201
+                "Error: langgraph CLI not found. Install with: pip install langgraph-cli",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        cmd_prefix = [langgraph_bin]
+
+    # Build the deploy command
+    cmd = [*cmd_prefix, "deploy", "--config", str(deploy_dir / "langgraph.json")]
+
+    if wait:
+        cmd.append("--wait")
+    if revision_id:
+        cmd.extend(["--revision-id", revision_id])
+
+    try:
+        from rich.console import Console
+
+        console = Console(stderr=True)
+        console.print(f"\n[bold]Running:[/bold] {' '.join(cmd)}\n")
+    except ImportError:
+        print(f"Running: {' '.join(cmd)}")  # noqa: T201
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            cwd=str(deploy_dir),
+            check=False,
+        )
+        sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        print("\nDeploy cancelled.", file=sys.stderr)  # noqa: T201
+        sys.exit(130)
+
+
+def _show_deploy_help() -> None:
+    """Display help text for the deploy command."""
+    try:
+        from rich.console import Console
+        from rich.markdown import Markdown
+
+        console = Console(stderr=True)
+        help_text = """\
+# deepagents deploy
+
+Deploy your agent to LangGraph Cloud.
+
+## Usage
+
+```
+deepagents deploy [options]
+```
+
+## Configuration
+
+Create a `deepagents.json` file in your project root:
+
+```json
+{
+  "agent": "agent",
+  "model": "anthropic:claude-sonnet-4-6",
+  "memory": {
+    "scope": "user",
+    "sources": [".deepagents/AGENTS.md"]
+  },
+  "skills": {
+    "sources": [".deepagents/skills"]
+  },
+  "tools": {
+    "shell": true,
+    "web_search": true,
+    "custom": "./my_tools.py:tools"
+  },
+  "backend": {
+    "type": "store",
+    "namespace": { "scope": "user", "prefix": "filesystem" }
+  },
+  "sandbox": {
+    "provider": "langsmith",
+    "scope": "thread"
+  }
+}
+```
+
+If no config file is found, defaults are used.
+
+## Scoping
+
+Each resource (backend, memory, sandbox) can be scoped independently:
+
+- **assistant**: Shared across all users and threads
+- **user**: Per-user, persists across threads
+- **thread**: Per-conversation, isolated
+- **user+thread**: Per-user per-conversation
+
+## Options
+
+- `-c, --config PATH`: Path to config file
+- `--dry-run`: Show what would be deployed without deploying
+- `--wait`: Wait for deployment to complete
+- `-a, --agent NAME`: Override agent name
+- `-M, --model MODEL`: Override model
+- `--sandbox PROVIDER`: Override sandbox provider
+- `--sandbox-scope SCOPE`: Override sandbox lifecycle scope
+- `--backend-scope SCOPE`: Override backend namespace scope
+- `--memory-scope SCOPE`: Override memory namespace scope
+- `--revision-id ID`: Set deployment revision ID
+"""
+        console.print(Markdown(help_text))
+    except ImportError:
+        print("deepagents deploy - Deploy your agent to LangGraph Cloud")  # noqa: T201
+        print("Usage: deepagents deploy [--config PATH] [--dry-run] [options]")  # noqa: T201

--- a/libs/cli/deepagents_cli/deploy/config.py
+++ b/libs/cli/deepagents_cli/deploy/config.py
@@ -1,0 +1,294 @@
+"""Deploy configuration model for deepagents.
+
+Reads and validates a ``deepagents.json`` deployment manifest. The config
+is a high-level description of an agent deployment that gets compiled down
+to a ``langgraph.json`` plus supporting files at deploy time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default scope for namespace resolution
+DEFAULT_NAMESPACE_SCOPE = "assistant"
+DEFAULT_NAMESPACE_PREFIX = "filesystem"
+DEFAULT_SANDBOX_PROVIDER = "langsmith"
+DEFAULT_SANDBOX_SCOPE = "thread"
+DEFAULT_PYTHON_VERSION = "3.12"
+DEFAULT_BACKEND_TYPE = "store"
+
+
+@dataclass(frozen=True)
+class NamespaceConfig:
+    """Namespace scoping configuration for the Store backend.
+
+    The scope determines how namespaces are resolved at runtime:
+    - ``"assistant"``: ``(assistant_id, prefix)`` — shared across all users/threads
+    - ``"user"``: ``(user_id, prefix)`` — per-user, persists across threads
+    - ``"thread"``: ``(thread_id, prefix)`` — per-conversation, isolated
+    - ``"user+thread"``: ``(user_id, thread_id, prefix)`` — per-user per-conversation
+    """
+
+    scope: str = DEFAULT_NAMESPACE_SCOPE
+    prefix: str = DEFAULT_NAMESPACE_PREFIX
+
+    def __post_init__(self) -> None:
+        valid_scopes = {"assistant", "user", "thread", "user+thread"}
+        if self.scope not in valid_scopes:
+            msg = f"Invalid namespace scope {self.scope!r}. Must be one of: {', '.join(sorted(valid_scopes))}"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> NamespaceConfig:
+        if data is None:
+            return cls()
+        return cls(
+            scope=data.get("scope", DEFAULT_NAMESPACE_SCOPE),
+            prefix=data.get("prefix", DEFAULT_NAMESPACE_PREFIX),
+        )
+
+
+@dataclass(frozen=True)
+class BackendConfig:
+    """Backend configuration for file storage.
+
+    The backend type determines how files are stored:
+    - ``"store"``: LangGraph Store (persistent cross-thread, default)
+    - ``"sandbox"``: Files live inside the sandbox filesystem
+    - ``"custom"``: Custom backend via ``module:variable`` import path
+    """
+
+    type: str = DEFAULT_BACKEND_TYPE
+    namespace: NamespaceConfig = field(default_factory=NamespaceConfig)
+    path: str | None = None  # For custom backends: "module.py:factory"
+
+    def __post_init__(self) -> None:
+        valid_types = {"store", "sandbox", "custom"}
+        if self.type not in valid_types:
+            msg = f"Invalid backend type {self.type!r}. Must be one of: {', '.join(sorted(valid_types))}"
+            raise ValueError(msg)
+        if self.type == "custom" and not self.path:
+            msg = "Custom backend requires a 'path' field (e.g., './my_backend.py:create_backend')"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> BackendConfig:
+        if data is None:
+            return cls()
+        return cls(
+            type=data.get("type", DEFAULT_BACKEND_TYPE),
+            namespace=NamespaceConfig.from_dict(data.get("namespace")),
+            path=data.get("path"),
+        )
+
+
+@dataclass(frozen=True)
+class MemoryConfig:
+    """Memory (AGENTS.md) configuration."""
+
+    scope: str = DEFAULT_NAMESPACE_SCOPE
+    sources: list[str] = field(default_factory=lambda: [".deepagents/AGENTS.md"])
+
+    def __post_init__(self) -> None:
+        valid_scopes = {"assistant", "user", "thread", "user+thread"}
+        if self.scope not in valid_scopes:
+            msg = f"Invalid memory scope {self.scope!r}. Must be one of: {', '.join(sorted(valid_scopes))}"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> MemoryConfig:
+        if data is None:
+            return cls()
+        return cls(
+            scope=data.get("scope", DEFAULT_NAMESPACE_SCOPE),
+            sources=data.get("sources", [".deepagents/AGENTS.md"]),
+        )
+
+
+@dataclass(frozen=True)
+class SkillsConfig:
+    """Skills configuration."""
+
+    sources: list[str] = field(default_factory=lambda: [".deepagents/skills"])
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> SkillsConfig:
+        if data is None:
+            return cls()
+        return cls(
+            sources=data.get("sources", [".deepagents/skills"]),
+        )
+
+
+@dataclass(frozen=True)
+class ToolsConfig:
+    """Tools configuration."""
+
+    shell: bool = True
+    shell_allow_list: list[str] | None = None
+    web_search: bool = True
+    fetch_url: bool = True
+    http_request: bool = True
+    mcp: str | bool = False  # Path to .mcp.json or False to disable
+    custom: str | None = None  # "module.py:variable" for custom tools
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> ToolsConfig:
+        if data is None:
+            return cls()
+
+        shell_allow_list = data.get("shell_allow_list")
+        if isinstance(shell_allow_list, str):
+            shell_allow_list = [s.strip() for s in shell_allow_list.split(",")]
+
+        return cls(
+            shell=data.get("shell", True),
+            shell_allow_list=shell_allow_list,
+            web_search=data.get("web_search", True),
+            fetch_url=data.get("fetch_url", True),
+            http_request=data.get("http_request", True),
+            mcp=data.get("mcp", False),
+            custom=data.get("custom"),
+        )
+
+
+@dataclass(frozen=True)
+class SandboxConfig:
+    """Sandbox configuration for code execution.
+
+    The scope determines sandbox lifecycle:
+    - ``"assistant"``: One sandbox shared across all threads
+    - ``"user"``: Per-user sandbox, persists across threads
+    - ``"thread"``: Fresh sandbox per conversation (default)
+    - ``"user+thread"``: Per-user per-thread sandbox
+    """
+
+    provider: str = DEFAULT_SANDBOX_PROVIDER
+    scope: str = DEFAULT_SANDBOX_SCOPE
+    template: str | None = None
+    image: str | None = None
+    setup_script: str | None = None
+
+    def __post_init__(self) -> None:
+        valid_providers = {"langsmith", "modal", "daytona", "runloop"}
+        if self.provider not in valid_providers:
+            msg = f"Invalid sandbox provider {self.provider!r}. Must be one of: {', '.join(sorted(valid_providers))}"
+            raise ValueError(msg)
+        valid_scopes = {"assistant", "user", "thread", "user+thread"}
+        if self.scope not in valid_scopes:
+            msg = f"Invalid sandbox scope {self.scope!r}. Must be one of: {', '.join(sorted(valid_scopes))}"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> SandboxConfig | None:
+        """Parse sandbox config. Returns None if sandbox is explicitly disabled."""
+        if data is None:
+            # Default: langsmith sandbox with thread scope
+            return cls()
+        if data is False:
+            return None
+        return cls(
+            provider=data.get("provider", DEFAULT_SANDBOX_PROVIDER),
+            scope=data.get("scope", DEFAULT_SANDBOX_SCOPE),
+            template=data.get("template"),
+            image=data.get("image"),
+            setup_script=data.get("setup_script"),
+        )
+
+
+@dataclass(frozen=True)
+class DeployConfig:
+    """Full deployment configuration.
+
+    Read from ``deepagents.json`` at the project root.
+    """
+
+    # Identity
+    agent: str = "agent"
+    description: str = ""
+
+    # Model
+    model: str = "anthropic:claude-sonnet-4-6"
+    model_params: dict[str, Any] = field(default_factory=dict)
+
+    # Prompt
+    prompt: str | None = None  # Override BASE_AGENT_PROMPT
+
+    # Components
+    memory: MemoryConfig = field(default_factory=MemoryConfig)
+    skills: SkillsConfig = field(default_factory=SkillsConfig)
+    tools: ToolsConfig = field(default_factory=ToolsConfig)
+    backend: BackendConfig = field(default_factory=BackendConfig)
+    sandbox: SandboxConfig | None = field(default_factory=SandboxConfig)
+
+    # Environment
+    env: str = ".env"
+    python_version: str = DEFAULT_PYTHON_VERSION
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeployConfig:
+        """Parse a deploy config from a dict (typically loaded from JSON)."""
+        return cls(
+            agent=data.get("agent", "agent"),
+            description=data.get("description", ""),
+            model=data.get("model", "anthropic:claude-sonnet-4-6"),
+            model_params=data.get("model_params", {}),
+            prompt=data.get("prompt"),
+            memory=MemoryConfig.from_dict(data.get("memory")),
+            skills=SkillsConfig.from_dict(data.get("skills")),
+            tools=ToolsConfig.from_dict(data.get("tools")),
+            backend=BackendConfig.from_dict(data.get("backend")),
+            sandbox=SandboxConfig.from_dict(data.get("sandbox")),
+            env=data.get("env", ".env"),
+            python_version=data.get("python_version", DEFAULT_PYTHON_VERSION),
+        )
+
+    @classmethod
+    def load(cls, config_path: Path | None = None) -> DeployConfig:
+        """Load deploy config from a file.
+
+        Args:
+            config_path: Path to ``deepagents.json``. If None, searches for
+                ``deepagents.json`` in the current directory.
+
+        Returns:
+            Parsed deploy configuration.
+        """
+        if config_path is None:
+            config_path = Path.cwd() / "deepagents.json"
+
+        if not config_path.exists():
+            logger.info(
+                "No %s found, using defaults",
+                config_path.name,
+            )
+            return cls()
+
+        try:
+            data = json.loads(config_path.read_text())
+        except json.JSONDecodeError as exc:
+            msg = f"Invalid JSON in {config_path}: {exc}"
+            raise ValueError(msg) from exc
+
+        logger.info("Loaded deploy config from %s", config_path)
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize config to a dict for JSON output."""
+        result: dict[str, Any] = {
+            "agent": self.agent,
+            "model": self.model,
+        }
+        if self.description:
+            result["description"] = self.description
+        if self.model_params:
+            result["model_params"] = self.model_params
+        if self.prompt:
+            result["prompt"] = self.prompt
+        return result

--- a/libs/cli/deepagents_cli/deploy/deploy_graph.py
+++ b/libs/cli/deepagents_cli/deploy/deploy_graph.py
@@ -1,0 +1,298 @@
+"""Server-side graph entry point for ``deepagents deploy``.
+
+This module is referenced by the generated ``langgraph.json`` and exposes the
+agent graph as a module-level variable that the LangGraph server loads and
+serves.
+
+Unlike the local ``server_graph.py`` (which reads ``DA_SERVER_*`` env vars),
+this graph reads a co-located ``deploy_config.json`` that was bundled at deploy
+time. It configures:
+
+- Model and prompt
+- Backend with scoped namespaces (Store backend by default)
+- Sandbox with scoped lifecycle
+- Custom tools
+- Memory and skills
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Namespace resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_scope(scope: str, config: dict[str, Any]) -> tuple[str, ...]:
+    """Resolve a scope string to namespace components from runtime config.
+
+    Args:
+        scope: One of "assistant", "user", "thread", "user+thread".
+        config: The full LangGraph runtime config dict.
+
+    Returns:
+        Tuple of scope identifiers.
+    """
+    c = config.get("configurable", {})
+
+    if scope == "assistant":
+        return (c.get("assistant_id", "default"),)
+    elif scope == "user":
+        auth_user = c.get("langgraph_auth_user", {})
+        user_id = auth_user.get("identity", "default")
+        return (user_id,)
+    elif scope == "thread":
+        return (c.get("thread_id", "default"),)
+    elif scope == "user+thread":
+        auth_user = c.get("langgraph_auth_user", {})
+        user_id = auth_user.get("identity", "default")
+        return (user_id, c.get("thread_id", "default"))
+    else:
+        logger.warning("Unknown scope %r, falling back to assistant", scope)
+        return (c.get("assistant_id", "default"),)
+
+
+def _make_namespace_factory(scope: str, prefix: str) -> Any:
+    """Create a namespace factory for the StoreBackend.
+
+    Returns a callable ``(BackendContext) -> tuple[str, ...]`` that resolves
+    the namespace at runtime based on the configured scope.
+    """
+
+    def namespace_factory(ctx: Any) -> tuple[str, ...]:
+        from langgraph.config import get_config
+
+        config = get_config()
+        scope_parts = _resolve_scope(scope, config)
+        return (*scope_parts, prefix)
+
+    return namespace_factory
+
+
+# ---------------------------------------------------------------------------
+# Tool loading
+# ---------------------------------------------------------------------------
+
+
+def _load_tools(deploy_config: dict[str, Any]) -> list[Any]:
+    """Load tools based on deploy configuration."""
+    tools_config = deploy_config.get("tools", {})
+    tools: list[Any] = []
+
+    if tools_config.get("http_request", True):
+        from deepagents_cli.tools import http_request
+
+        tools.append(http_request)
+
+    if tools_config.get("fetch_url", True):
+        from deepagents_cli.tools import fetch_url
+
+        tools.append(fetch_url)
+
+    if tools_config.get("web_search", True):
+        try:
+            from deepagents_cli.tools import web_search
+
+            tools.append(web_search)
+        except Exception:
+            logger.warning("web_search tool not available (missing TAVILY_API_KEY?)")
+
+    # Load custom tools from bundled module
+    bundled_custom = tools_config.get("_bundled_custom")
+    if bundled_custom:
+        module_ref, var_name = bundled_custom.rsplit(":", 1)
+        module_path = module_ref.lstrip("./")
+        if module_path.endswith(".py"):
+            module_path = module_path[:-3]
+        try:
+            mod = importlib.import_module(module_path)
+            custom_tools = getattr(mod, var_name)
+            if callable(custom_tools):
+                custom_tools = custom_tools()
+            tools.extend(custom_tools)
+            logger.info("Loaded %d custom tool(s) from %s", len(custom_tools), bundled_custom)
+        except Exception:
+            logger.exception("Failed to load custom tools from %s", bundled_custom)
+
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Sandbox setup
+# ---------------------------------------------------------------------------
+
+
+def _create_sandbox_backend(deploy_config: dict[str, Any]) -> Any | None:
+    """Create a sandbox backend if configured.
+
+    Returns a sandbox backend instance, or None if sandbox is disabled.
+    """
+    sandbox_config = deploy_config.get("sandbox")
+    if sandbox_config is None:
+        return None
+
+    provider = sandbox_config.get("provider", "langsmith")
+
+    try:
+        from deepagents_cli.integrations.sandbox_factory import create_sandbox
+
+        # TODO: Implement scoped sandbox lifecycle.
+        #
+        # Currently creates a single sandbox for the server process lifetime
+        # (same as the local CLI). For proper scoping (thread/user/assistant),
+        # the sandbox ID needs to be stored in the LangGraph Store keyed by
+        # the scope, and reconnected on subsequent runs.
+        #
+        # The create-or-reconnect pattern:
+        #   1. Resolve scope key from runtime config
+        #   2. Look up existing sandbox ID in Store
+        #   3. If found, reconnect; if not, create new and store ID
+        #   4. For thread scope, clean up when thread is deleted
+        sandbox_cm = create_sandbox(
+            provider,
+            sandbox_id=None,
+            setup_script_path=sandbox_config.get("setup_script"),
+        )
+        backend = sandbox_cm.__enter__()  # noqa: PLC2801
+
+        import atexit
+
+        def _cleanup() -> None:
+            sandbox_cm.__exit__(None, None, None)
+
+        atexit.register(_cleanup)
+        return backend
+    except ImportError:
+        logger.exception("Sandbox provider '%s' is not installed", provider)
+        return None
+    except Exception:
+        logger.exception("Failed to create sandbox for provider '%s'", provider)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Graph construction
+# ---------------------------------------------------------------------------
+
+
+def make_graph() -> Any:  # noqa: ANN401
+    """Create the deployed agent graph from ``deploy_config.json``.
+
+    Uses ``create_deep_agent`` directly (rather than ``create_cli_agent``)
+    so we can pass a ``StoreBackend`` with the configured namespace factory
+    for scoped file storage.
+    """
+    config_path = Path(__file__).parent / "deploy_config.json"
+    if not config_path.exists():
+        msg = f"deploy_config.json not found at {config_path}. Was the deploy bundle created correctly?"
+        raise FileNotFoundError(msg)
+
+    deploy_config = json.loads(config_path.read_text())
+
+    # --- Model ---
+    from deepagents._models import resolve_model
+
+    model = resolve_model(deploy_config.get("model", "anthropic:claude-sonnet-4-6"))
+
+    # --- Tools ---
+    tools = _load_tools(deploy_config)
+
+    # --- Sandbox ---
+    sandbox_backend = _create_sandbox_backend(deploy_config)
+
+    # --- Backend ---
+    backend_config = deploy_config.get("backend", {})
+    backend_type = backend_config.get("type", "store")
+    ns_config = backend_config.get("namespace", {})
+    ns_scope = ns_config.get("scope", "assistant")
+    ns_prefix = ns_config.get("prefix", "filesystem")
+
+    from deepagents.backends.store import StoreBackend
+
+    if backend_type == "store":
+        # StoreBackend with scoped namespace factory
+        backend: Any = lambda rt: StoreBackend(  # noqa: E731
+            rt,
+            namespace=_make_namespace_factory(ns_scope, ns_prefix),
+        )
+    elif backend_type == "sandbox" and sandbox_backend is not None:
+        # Sandbox IS the backend — file ops go through the sandbox
+        backend = sandbox_backend
+    elif backend_type == "custom":
+        custom_path = backend_config.get("path")
+        if not custom_path:
+            msg = "Custom backend requires a 'path' field"
+            raise ValueError(msg)
+        module_ref, var_name = custom_path.rsplit(":", 1)
+        module_path = module_ref.lstrip("./")
+        if module_path.endswith(".py"):
+            module_path = module_path[:-3]
+        mod = importlib.import_module(module_path)
+        backend = getattr(mod, var_name)
+    else:
+        # Fallback to store
+        backend = lambda rt: StoreBackend(  # noqa: E731
+            rt,
+            namespace=_make_namespace_factory(ns_scope, ns_prefix),
+        )
+
+    # --- Memory sources ---
+    memory_config = deploy_config.get("memory", {})
+    memory_sources = memory_config.get("_bundled_sources", memory_config.get("sources", []))
+    resolved_memory: list[str] = []
+    for source in memory_sources:
+        source_path = Path(__file__).parent / source
+        if source_path.exists():
+            resolved_memory.append(str(source_path))
+        else:
+            logger.warning("Memory source not found: %s", source_path)
+
+    # --- Skills sources ---
+    skills_config = deploy_config.get("skills", {})
+    bundled_skills = skills_config.get("_bundled_sources", [])
+    resolved_skills: list[str] = []
+    for source in bundled_skills:
+        source_path = Path(__file__).parent / source
+        if source_path.exists():
+            resolved_skills.append(str(source_path))
+        else:
+            logger.warning("Skills source not found: %s", source_path)
+
+    # --- System prompt ---
+    system_prompt = deploy_config.get("prompt")
+
+    # --- Build the agent ---
+    from deepagents.graph import create_deep_agent
+
+    agent = create_deep_agent(
+        model=model,
+        tools=tools,
+        system_prompt=system_prompt,
+        backend=backend,
+        memory=resolved_memory or None,
+        skills=resolved_skills or None,
+        interrupt_on={},  # No HITL in deployment — auto-approve everything
+    )
+
+    return agent
+
+
+try:
+    graph = make_graph()
+except Exception as exc:
+    import traceback
+
+    logger.critical("Failed to initialize deploy graph", exc_info=True)
+    print(  # noqa: T201
+        f"Failed to initialize deploy graph: {exc}\n{traceback.format_exc()}",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -343,6 +343,14 @@ def parse_args() -> argparse.Namespace:
         add_output_args=add_json_output_arg,
     )
 
+    from deepagents_cli.deploy import setup_deploy_parser
+
+    setup_deploy_parser(
+        subparsers,
+        make_help_action=_make_help_action,
+        add_output_args=add_json_output_arg,
+    )
+
     threads_parser = subparsers.add_parser(
         "threads",
         help="Manage conversation threads",
@@ -1341,6 +1349,10 @@ def cli_main() -> None:
             from deepagents_cli.skills import execute_skills_command
 
             execute_skills_command(args)
+        elif args.command == "deploy":
+            from deepagents_cli.deploy import execute_deploy_command
+
+            execute_deploy_command(args)
         elif args.command == "threads":
             from deepagents_cli.sessions import (
                 delete_thread_command,

--- a/libs/cli/tests/unit_tests/test_deploy.py
+++ b/libs/cli/tests/unit_tests/test_deploy.py
@@ -1,0 +1,474 @@
+"""Tests for the deploy module: config parsing, bundling, and langgraph.json generation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deepagents_cli.deploy.config import (
+    BackendConfig,
+    DeployConfig,
+    MemoryConfig,
+    NamespaceConfig,
+    SandboxConfig,
+    SkillsConfig,
+    ToolsConfig,
+)
+
+
+# ------------------------------------------------------------------
+# DeployConfig defaults
+# ------------------------------------------------------------------
+
+
+class TestDeployConfigDefaults:
+    def test_default_config(self) -> None:
+        config = DeployConfig()
+        assert config.agent == "agent"
+        assert config.model == "anthropic:claude-sonnet-4-6"
+        assert config.backend.type == "store"
+        assert config.backend.namespace.scope == "assistant"
+        assert config.backend.namespace.prefix == "filesystem"
+        assert config.sandbox is not None
+        assert config.sandbox.provider == "langsmith"
+        assert config.sandbox.scope == "thread"
+        assert config.memory.scope == "assistant"
+        assert config.tools.shell is True
+        assert config.tools.web_search is True
+        assert config.python_version == "3.12"
+
+    def test_empty_dict_gives_defaults(self) -> None:
+        config = DeployConfig.from_dict({})
+        assert config.agent == "agent"
+        assert config.model == "anthropic:claude-sonnet-4-6"
+        assert config.sandbox is not None
+        assert config.sandbox.provider == "langsmith"
+
+
+# ------------------------------------------------------------------
+# DeployConfig from_dict
+# ------------------------------------------------------------------
+
+
+class TestDeployConfigFromDict:
+    def test_full_config(self) -> None:
+        data = {
+            "agent": "researcher",
+            "description": "A research agent",
+            "model": "openai:gpt-5",
+            "model_params": {"temperature": 0.7},
+            "prompt": "You are a research assistant.",
+            "memory": {
+                "scope": "user",
+                "sources": [".deepagents/AGENTS.md", "custom/AGENTS.md"],
+            },
+            "skills": {
+                "sources": [".deepagents/skills", "extra/skills"],
+            },
+            "tools": {
+                "shell": False,
+                "web_search": True,
+                "fetch_url": False,
+                "http_request": True,
+                "mcp": ".mcp.json",
+                "custom": "./my_tools.py:tools",
+            },
+            "backend": {
+                "type": "store",
+                "namespace": {"scope": "user", "prefix": "files"},
+            },
+            "sandbox": {
+                "provider": "modal",
+                "scope": "assistant",
+                "template": "my-template",
+                "image": "my-image:latest",
+                "setup_script": "./setup.sh",
+            },
+            "env": ".env.production",
+            "python_version": "3.13",
+        }
+        config = DeployConfig.from_dict(data)
+        assert config.agent == "researcher"
+        assert config.description == "A research agent"
+        assert config.model == "openai:gpt-5"
+        assert config.model_params == {"temperature": 0.7}
+        assert config.prompt == "You are a research assistant."
+        assert config.memory.scope == "user"
+        assert len(config.memory.sources) == 2
+        assert len(config.skills.sources) == 2
+        assert config.tools.shell is False
+        assert config.tools.custom == "./my_tools.py:tools"
+        assert config.tools.mcp == ".mcp.json"
+        assert config.backend.namespace.scope == "user"
+        assert config.backend.namespace.prefix == "files"
+        assert config.sandbox is not None
+        assert config.sandbox.provider == "modal"
+        assert config.sandbox.scope == "assistant"
+        assert config.sandbox.template == "my-template"
+        assert config.env == ".env.production"
+        assert config.python_version == "3.13"
+
+    def test_sandbox_disabled(self) -> None:
+        config = DeployConfig.from_dict({"sandbox": False})
+        assert config.sandbox is None
+
+    def test_sandbox_none_gives_defaults(self) -> None:
+        config = DeployConfig.from_dict({"sandbox": None})
+        assert config.sandbox is not None
+        assert config.sandbox.provider == "langsmith"
+
+    def test_shell_allow_list_string(self) -> None:
+        config = DeployConfig.from_dict({
+            "tools": {"shell_allow_list": "git, python, pip"},
+        })
+        assert config.tools.shell_allow_list == ["git", "python", "pip"]
+
+    def test_shell_allow_list_as_list(self) -> None:
+        config = DeployConfig.from_dict({
+            "tools": {"shell_allow_list": ["git", "python"]},
+        })
+        assert config.tools.shell_allow_list == ["git", "python"]
+
+
+# ------------------------------------------------------------------
+# Config file loading
+# ------------------------------------------------------------------
+
+
+class TestDeployConfigLoad:
+    def test_load_from_file(self, tmp_path: Path) -> None:
+        config_data = {
+            "agent": "test-agent",
+            "model": "anthropic:claude-haiku-4-5",
+        }
+        config_file = tmp_path / "deepagents.json"
+        config_file.write_text(json.dumps(config_data))
+
+        config = DeployConfig.load(config_file)
+        assert config.agent == "test-agent"
+        assert config.model == "anthropic:claude-haiku-4-5"
+
+    def test_load_missing_file_returns_defaults(self, tmp_path: Path) -> None:
+        config = DeployConfig.load(tmp_path / "nonexistent.json")
+        assert config.agent == "agent"
+        assert config.model == "anthropic:claude-sonnet-4-6"
+
+    def test_load_invalid_json_raises(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "deepagents.json"
+        config_file.write_text("not json {{{")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            DeployConfig.load(config_file)
+
+
+# ------------------------------------------------------------------
+# Namespace validation
+# ------------------------------------------------------------------
+
+
+class TestNamespaceConfig:
+    def test_valid_scopes(self) -> None:
+        for scope in ("assistant", "user", "thread", "user+thread"):
+            ns = NamespaceConfig(scope=scope)
+            assert ns.scope == scope
+
+    def test_invalid_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid namespace scope"):
+            NamespaceConfig(scope="global")
+
+    def test_from_dict_defaults(self) -> None:
+        ns = NamespaceConfig.from_dict(None)
+        assert ns.scope == "assistant"
+        assert ns.prefix == "filesystem"
+
+
+class TestBackendConfig:
+    def test_valid_types(self) -> None:
+        for backend_type in ("store", "sandbox", "custom"):
+            if backend_type == "custom":
+                bc = BackendConfig(type=backend_type, path="./my.py:factory")
+            else:
+                bc = BackendConfig(type=backend_type)
+            assert bc.type == backend_type
+
+    def test_invalid_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid backend type"):
+            BackendConfig(type="redis")
+
+    def test_custom_without_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="Custom backend requires"):
+            BackendConfig(type="custom")
+
+
+class TestSandboxConfig:
+    def test_valid_providers(self) -> None:
+        for provider in ("langsmith", "modal", "daytona", "runloop"):
+            sc = SandboxConfig(provider=provider)
+            assert sc.provider == provider
+
+    def test_invalid_provider_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid sandbox provider"):
+            SandboxConfig(provider="e2b")
+
+    def test_invalid_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid sandbox scope"):
+            SandboxConfig(scope="global")
+
+    def test_from_dict_false_returns_none(self) -> None:
+        assert SandboxConfig.from_dict(False) is None
+
+
+class TestMemoryConfig:
+    def test_invalid_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid memory scope"):
+            MemoryConfig(scope="global")
+
+
+# ------------------------------------------------------------------
+# Bundling
+# ------------------------------------------------------------------
+
+
+class TestBundleArtifacts:
+    def test_basic_bundle(self, tmp_path: Path) -> None:
+        """Test that bundling creates the expected files."""
+        from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+
+        # Create minimal project structure
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        deepagents_dir = project_root / ".deepagents"
+        deepagents_dir.mkdir()
+        (deepagents_dir / "AGENTS.md").write_text("# My Agent\nBe helpful.")
+
+        config = DeployConfig(
+            memory=MemoryConfig(sources=[".deepagents/AGENTS.md"]),
+            skills=SkillsConfig(sources=[]),
+        )
+
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+
+        # Check expected files
+        assert (deploy_dir / "deploy_graph.py").exists()
+        assert (deploy_dir / "deploy_config.json").exists()
+        assert (deploy_dir / "langgraph.json").exists()
+        assert (deploy_dir / "pyproject.toml").exists()
+        assert (deploy_dir / "agents").is_dir()
+
+        # Check langgraph.json
+        lg_config = json.loads((deploy_dir / "langgraph.json").read_text())
+        assert "agent" in lg_config["graphs"]
+        assert lg_config["graphs"]["agent"] == "./deploy_graph.py:graph"
+        assert lg_config["python_version"] == "3.12"
+
+    def test_bundle_with_skills(self, tmp_path: Path) -> None:
+        """Test bundling with skills directories."""
+        from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        # Create a skill
+        skill_dir = project_root / ".deepagents" / "skills" / "code-review"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: code-review\ndescription: Review code\n---\n# Code Review\n"
+        )
+
+        config = DeployConfig(
+            memory=MemoryConfig(sources=[]),
+            skills=SkillsConfig(sources=[".deepagents/skills"]),
+        )
+
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+
+        assert (deploy_dir / "skills" / "code-review" / "SKILL.md").exists()
+
+    def test_bundle_with_custom_tools(self, tmp_path: Path) -> None:
+        """Test bundling with custom tools module."""
+        from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        # Create custom tools file
+        (project_root / "my_tools.py").write_text(
+            "from langchain_core.tools import tool\n\n"
+            "@tool\ndef hello() -> str:\n    return 'hi'\n\n"
+            "tools = [hello]\n"
+        )
+
+        config = DeployConfig(
+            memory=MemoryConfig(sources=[]),
+            skills=SkillsConfig(sources=[]),
+            tools=ToolsConfig(custom="./my_tools.py:tools"),
+        )
+
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+
+        assert (deploy_dir / "my_tools.py").exists()
+        dc = json.loads((deploy_dir / "deploy_config.json").read_text())
+        assert dc["tools"]["_bundled_custom"] == "./my_tools.py:tools"
+
+    def test_bundle_langgraph_json_store_index(self, tmp_path: Path) -> None:
+        """Test that store backend generates store index in langgraph.json."""
+        from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        config = DeployConfig(
+            memory=MemoryConfig(sources=[]),
+            skills=SkillsConfig(sources=[]),
+            backend=BackendConfig(type="store"),
+        )
+
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+
+        lg_config = json.loads((deploy_dir / "langgraph.json").read_text())
+        assert "store" in lg_config
+        assert "index" in lg_config["store"]
+
+    def test_bundle_sandbox_backend_no_store_index(self, tmp_path: Path) -> None:
+        """Test that sandbox backend does NOT generate store index."""
+        from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        config = DeployConfig(
+            memory=MemoryConfig(sources=[]),
+            skills=SkillsConfig(sources=[]),
+            backend=BackendConfig(type="sandbox"),
+        )
+
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+
+        lg_config = json.loads((deploy_dir / "langgraph.json").read_text())
+        assert "store" not in lg_config
+
+    def test_bundle_deploy_config_scoping(self, tmp_path: Path) -> None:
+        """Test that scoping config is properly serialized."""
+        from deepagents_cli.deploy.bundle import bundle_deploy_artifacts
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        config = DeployConfig(
+            memory=MemoryConfig(scope="user", sources=[]),
+            skills=SkillsConfig(sources=[]),
+            backend=BackendConfig(
+                namespace=NamespaceConfig(scope="user+thread", prefix="files"),
+            ),
+            sandbox=SandboxConfig(provider="langsmith", scope="assistant"),
+        )
+
+        deploy_dir = bundle_deploy_artifacts(config, project_root=project_root)
+
+        dc = json.loads((deploy_dir / "deploy_config.json").read_text())
+        assert dc["memory"]["scope"] == "user"
+        assert dc["backend"]["namespace"]["scope"] == "user+thread"
+        assert dc["backend"]["namespace"]["prefix"] == "files"
+        assert dc["sandbox"]["scope"] == "assistant"
+        assert dc["sandbox"]["provider"] == "langsmith"
+
+
+# ------------------------------------------------------------------
+# Namespace factory
+# ------------------------------------------------------------------
+
+
+def _import_deploy_graph_functions() -> tuple:
+    """Import functions from deploy_graph without triggering module-level make_graph().
+
+    The deploy_graph module calls make_graph() and sys.exit(1) at import time
+    if deploy_config.json is missing. We use importlib to load just the functions.
+    """
+    import importlib
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    module_path = (
+        Path(__file__).parent.parent.parent
+        / "deepagents_cli"
+        / "deploy"
+        / "deploy_graph.py"
+    )
+    # Load as a different module name to avoid the cached import
+    spec = importlib.util.spec_from_file_location(
+        "deploy_graph_test_only", module_path, submodule_search_locations=[]
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    # Read the source and extract only the functions we need
+    source = module_path.read_text()
+
+    # Create a minimal module with just the functions
+    import types
+
+    mod = types.ModuleType("deploy_graph_test_only")
+    mod.__file__ = str(module_path)
+
+    # Execute only the function definitions, not the module-level try/except
+    # by stripping the last block
+    lines = source.split("\n")
+    # Find the line "try:" near the end
+    cut_idx = len(lines)
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip() == "try:":
+            cut_idx = i
+            break
+    safe_source = "\n".join(lines[:cut_idx])
+
+    exec(compile(safe_source, str(module_path), "exec"), mod.__dict__)  # noqa: S102
+    return mod._resolve_scope, mod._make_namespace_factory
+
+
+class TestNamespaceFactory:
+    def test_assistant_scope(self) -> None:
+        _resolve_scope, _ = _import_deploy_graph_functions()
+        config = {"configurable": {"assistant_id": "my-agent"}}
+        result = _resolve_scope("assistant", config)
+        assert result == ("my-agent",)
+
+    def test_user_scope(self) -> None:
+        _resolve_scope, _ = _import_deploy_graph_functions()
+        config = {
+            "configurable": {
+                "langgraph_auth_user": {"identity": "user-123"},
+            },
+        }
+        result = _resolve_scope("user", config)
+        assert result == ("user-123",)
+
+    def test_thread_scope(self) -> None:
+        _resolve_scope, _ = _import_deploy_graph_functions()
+        config = {"configurable": {"thread_id": "thread-abc"}}
+        result = _resolve_scope("thread", config)
+        assert result == ("thread-abc",)
+
+    def test_user_thread_scope(self) -> None:
+        _resolve_scope, _ = _import_deploy_graph_functions()
+        config = {
+            "configurable": {
+                "langgraph_auth_user": {"identity": "user-123"},
+                "thread_id": "thread-abc",
+            },
+        }
+        result = _resolve_scope("user+thread", config)
+        assert result == ("user-123", "thread-abc")
+
+    def test_unknown_scope_falls_back(self) -> None:
+        _resolve_scope, _ = _import_deploy_graph_functions()
+        config = {"configurable": {"assistant_id": "fallback"}}
+        result = _resolve_scope("bogus", config)
+        assert result == ("fallback",)
+
+    def test_missing_auth_user_defaults(self) -> None:
+        _resolve_scope, _ = _import_deploy_graph_functions()
+        config = {"configurable": {}}
+        result = _resolve_scope("user", config)
+        assert result == ("default",)


### PR DESCRIPTION
## Summary

- Adds `deepagents deploy` CLI command that bundles agent artifacts and deploys to LangGraph Cloud via `langgraph deploy`
- Introduces `deepagents.json` config file for declarative deployment configuration
- Supports configurable namespace scoping (assistant/user/thread/user+thread) for backend storage, memory, and sandbox lifecycle independently

## Configuration

```json
{
  "agent": "my-agent",
  "model": "anthropic:claude-sonnet-4-6",
  "memory": { "scope": "user", "sources": [".deepagents/AGENTS.md"] },
  "skills": { "sources": [".deepagents/skills"] },
  "tools": { "shell": true, "custom": "./my_tools.py:tools" },
  "backend": { "type": "store", "namespace": { "scope": "user" } },
  "sandbox": { "provider": "langsmith", "scope": "thread" }
}
```

## What's included

| File | Purpose |
|------|---------|
| `deploy/__init__.py` | Module entry point |
| `deploy/config.py` | `DeployConfig` + nested config models with validation |
| `deploy/bundle.py` | Bundles AGENTS.md, skills, tools, .env into deploy dir + generates `langgraph.json` |
| `deploy/deploy_graph.py` | Server-side graph entry point using `StoreBackend` with scoped `NamespaceFactory` |
| `deploy/commands.py` | CLI command, arg parser, dry-run support, shells out to `langgraph deploy` |
| `examples/deploy-demo/` | Working demo with custom tools, skills, and memory |
| `tests/unit_tests/test_deploy.py` | 33 unit tests |

## Key design decisions

- **Scoping is orthogonal**: memory, backend, and sandbox each configure scope independently
- **`create_deep_agent` used directly**: deploy graph bypasses `create_cli_agent` to pass a `StoreBackend` with scoped namespace factory
- **Custom tools via `module:variable`**: bundled into deploy dir, imported at graph construction time
- **`langgraph deploy` as transport**: we generate the bundle, then shell out

## Known TODOs

- Scoped sandbox lifecycle (create-or-reconnect pattern keyed by scope ID in Store)
- Memory scoping via Store (currently uses filesystem-based MemoryMiddleware)

## Test plan

- [x] 33 unit tests for config parsing, defaults, validation, bundling, and namespace resolution
- [x] Manual `--dry-run` testing with demo project and CLI overrides
- [ ] End-to-end deploy to LangGraph Cloud (requires API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)