### PR TITLE
fix(evals): include tool calls in LLM judge context for memory evals

### DIFF
--- a/libs/evals/deepagents_harbor/backend.py
+++ b/libs/evals/deepagents_harbor/backend.py
@@ -6,6 +6,7 @@ import shlex
 import tempfile
 from pathlib import Path
 
+from deepagents.backends.filesystem import _map_exception_to_standard_error
 from deepagents.backends.protocol import (
     EditResult,
     ExecuteResponse,
@@ -20,7 +21,6 @@ from deepagents.backends.protocol import (
     SandboxBackendProtocol,
     WriteResult,
 )
-from deepagents.backends.filesystem import _map_exception_to_standard_error
 from deepagents.backends.utils import check_empty_content, create_file_data
 from harbor.environments.base import BaseEnvironment
 

--- a/libs/evals/tests/evals/llm_judge.py
+++ b/libs/evals/tests/evals/llm_judge.py
@@ -22,10 +22,9 @@ from tests.evals.utils import AgentTrajectory, SuccessAssertion
 
 _DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
 
-_CRITERIA_PROMPT = """\
-You are a strict grading assistant. You will receive a series of agent \
-responses and a single criterion. Decide whether the agent's responses \
-satisfy the criterion.
+_RESPONSES_PROMPT = """You are a strict grading assistant. You will receive a
+series of agent responses and a single criterion. Decide whether the agent's
+responses satisfy the criterion.
 
 <criterion>
 {criterion}
@@ -35,20 +34,49 @@ satisfy the criterion.
 {outputs}
 </agent_responses>"""
 
+_TRAJECTORY_PROMPT = """You are a strict grading assistant. You will receive an
+agent trajectory (a sequence of steps) and a single criterion. Decide whether
+the agent's trajectory satisfies the criterion.
+
+Each step may contain:
+- Text responses from the agent (shown as "text: ...")
+- Tool calls the agent made (shown as "- tool_name {{args}}")
+
+Tool calls are real actions the agent executed. Treat them as evidence
+that the action was performed (e.g. an edit_file call means the agent
+wrote to the file).
+
+<criterion>
+{criterion}
+</criterion>
+
+<agent_trajectory>
+{outputs}
+</agent_trajectory>"""
+
 
 @dataclass
 class LLMJudge(SuccessAssertion):
-    """Grade the agent's responses against criteria using openevals LLM judge.
+    """Grade agent output against criteria using openevals LLM judge.
 
     Each criterion is evaluated independently via `create_llm_as_judge`. All
     must pass for the assertion to succeed.
+
+    When `include_tool_calls` is False (default), the judge sees only the
+    agent's text responses — appropriate for criteria about what the agent
+    *said*. When True, the full trajectory (tool calls + text) is shown —
+    needed when criteria reference actions the agent *took* (e.g. writing
+    to a file).
     """
 
     criteria: tuple[str, ...]
-    """Human-readable criteria the agent's responses must satisfy."""
+    """Human-readable criteria the agent's output must satisfy."""
 
     judge_model: str = _DEFAULT_JUDGE_MODEL
     """Model identifier for the judge LLM."""
+
+    include_tool_calls: bool = False
+    """Include tool calls in the context sent to the judge."""
 
     # Single-slot cache so check() and describe_failure() share one judge call.
     _last_results: list[dict[str, Any]] | None = field(
@@ -91,6 +119,22 @@ class LLMJudge(SuccessAssertion):
     # internals
     # ------------------------------------------------------------------
 
+    def _serialize(self, trajectory: AgentTrajectory) -> str:
+        """Serialize the trajectory for the judge prompt.
+
+        Args:
+            trajectory: The agent trajectory to serialize.
+
+        Returns:
+            A string representation of the trajectory.
+        """
+        if self.include_tool_calls:
+            return trajectory.pretty()
+
+        return "\n\n".join(
+            f"[Agent]: {step.action.text}" for step in trajectory.steps if step.action.text
+        )
+
     def _grade(self, trajectory: AgentTrajectory) -> list[dict[str, Any]]:
         """Call openevals judge per criterion and return results.
 
@@ -100,18 +144,17 @@ class LLMJudge(SuccessAssertion):
         Returns:
             A list of `EvaluatorResult` dicts, one per criterion.
         """
-        conversation = "\n\n".join(
-            f"[Agent]: {step.action.text}" for step in trajectory.steps if step.action.text
-        )
-        if not conversation:
+        conversation = self._serialize(trajectory)
+        if not conversation.strip():
             msg = (
-                "Cannot grade trajectory: no steps contain text content. "
-                "The LLM judge requires at least one text response to evaluate."
+                "Cannot grade trajectory: no steps contain content. "
+                "The LLM judge requires at least one step to evaluate."
             )
             raise ValueError(msg)
 
+        prompt = _TRAJECTORY_PROMPT if self.include_tool_calls else _RESPONSES_PROMPT
         evaluator = create_llm_as_judge(
-            prompt=_CRITERIA_PROMPT,
+            prompt=prompt,
             feedback_key="llm_judge_criterion",
             model=self.judge_model,
         )
@@ -159,16 +202,21 @@ class LLMJudge(SuccessAssertion):
 def llm_judge(
     *criteria: str,
     judge_model: str = _DEFAULT_JUDGE_MODEL,
+    include_tool_calls: bool = False,
 ) -> LLMJudge:
     """Create an `LLMJudge` success assertion.
 
     Wraps `openevals.llm.create_llm_as_judge` to evaluate each criterion
-    independently against the agent's trajectory. All criteria must pass for the
+    independently against the agent's output. All criteria must pass for the
     assertion to succeed.
 
     Args:
         *criteria: One or more human-readable criteria strings.
         judge_model: Model identifier for the judge LLM.
+        include_tool_calls: When True, the judge sees the full trajectory
+            (tool calls + text).
+
+            When False (default), only text responses.
 
     Returns:
         An `LLMJudge` assertion instance.
@@ -176,4 +224,8 @@ def llm_judge(
     Raises:
         ValueError: If no criteria are provided.
     """
-    return LLMJudge(criteria=tuple(criteria), judge_model=judge_model)
+    return LLMJudge(
+        criteria=tuple(criteria),
+        judge_model=judge_model,
+        include_tool_calls=include_tool_calls,
+    )

--- a/libs/evals/tests/evals/test_memory_multiturn.py
+++ b/libs/evals/tests/evals/test_memory_multiturn.py
@@ -216,7 +216,7 @@ def test_implicit_preference_remembered(model: BaseChatModel, case: dict[str, An
             )
             .success(
                 file_contains(MEMORY_PATH, case["should_contain"]),
-                llm_judge(*case["criteria"]),
+                llm_judge(*case["criteria"], include_tool_calls=True),
             )
         ),
     )
@@ -243,7 +243,7 @@ def test_explicit_preference_remembered(model: BaseChatModel, case: dict[str, An
             )
             .success(
                 file_contains(MEMORY_PATH, case["should_contain"]),
-                llm_judge(*case["criteria"]),
+                llm_judge(*case["criteria"], include_tool_calls=True),
             )
         ),
     )

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -60,8 +60,8 @@ class AgentTrajectory:
                     name = tc.get("name")
                     args = tc.get("args")
                     lines.append(f"  - {name} {args}")
-            else:
-                text = step.action.text
+            text = step.action.text
+            if text and text.strip():
                 text_preview = text.strip().replace("\n", "\\n")
                 lines.append(f"  text: {text_preview}")
         return "\n".join(lines)

--- a/libs/evals/tests/unit_tests/test_trajectory.py
+++ b/libs/evals/tests/unit_tests/test_trajectory.py
@@ -1,0 +1,110 @@
+"""Tests for AgentTrajectory.pretty() serialization.
+
+Ensures tool-call steps are always visible in the serialised output so that
+downstream consumers (e.g. the LLM judge) see the full trajectory.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage
+
+from tests.evals.utils import AgentStep, AgentTrajectory
+
+
+def _traj(*steps: AgentStep) -> AgentTrajectory:
+    return AgentTrajectory(steps=list(steps), files={})
+
+
+class TestPrettyTextOnly:
+    """Steps with only text content."""
+
+    def test_single_text_step(self) -> None:
+        t = _traj(AgentStep(index=1, action=AIMessage(content="hello"), observations=[]))
+        assert "text: hello" in t.pretty()
+
+    def test_multiline_text_escaped(self) -> None:
+        t = _traj(AgentStep(index=1, action=AIMessage(content="line1\nline2"), observations=[]))
+        out = t.pretty()
+        assert r"line1\nline2" in out
+
+
+class TestPrettyToolCallsOnly:
+    """Steps with only tool calls (no text)."""
+
+    def test_tool_call_visible(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[{"name": "edit_file", "args": {"file_path": "/a.md"}, "id": "1"}],
+        )
+        t = _traj(AgentStep(index=1, action=msg, observations=[]))
+        out = t.pretty()
+        assert "edit_file" in out
+        assert "/a.md" in out
+
+    def test_empty_text_not_shown(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[{"name": "read_file", "args": {}, "id": "1"}],
+        )
+        t = _traj(AgentStep(index=1, action=msg, observations=[]))
+        out = t.pretty()
+        assert "text:" not in out
+
+
+class TestPrettyMixed:
+    """Steps with both tool calls and text."""
+
+    def test_both_tool_call_and_text_present(self) -> None:
+        msg = AIMessage(
+            content="I'll update the file now.",
+            tool_calls=[{"name": "edit_file", "args": {"file_path": "/a.md"}, "id": "1"}],
+        )
+        t = _traj(AgentStep(index=1, action=msg, observations=[]))
+        out = t.pretty()
+        assert "edit_file" in out
+        assert "I'll update the file now." in out
+
+
+class TestPrettyMultiStep:
+    """Multi-step trajectories matching the memory_multiturn pattern."""
+
+    def test_read_edit_text_all_visible(self) -> None:
+        steps = [
+            AgentStep(
+                index=1,
+                action=AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "read_file", "args": {"file_path": "/AGENTS.md"}, "id": "1"}
+                    ],
+                ),
+                observations=[],
+            ),
+            AgentStep(
+                index=2,
+                action=AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "edit_file",
+                            "args": {
+                                "file_path": "/AGENTS.md",
+                                "new_string": "## Preferences\n- formal language",
+                            },
+                            "id": "2",
+                        }
+                    ],
+                ),
+                observations=[],
+            ),
+            AgentStep(
+                index=3,
+                action=AIMessage(content="Done, preference saved."),
+                observations=[],
+            ),
+        ]
+        out = _traj(*steps).pretty()
+        assert "read_file" in out
+        assert "edit_file" in out
+        assert "formal language" in out
+        assert "Done, preference saved." in out


### PR DESCRIPTION
The LLM-as-judge evaluator was silently dropping tool-call-only steps from the context sent to the judge, causing false negatives on memory evals where the criteria asked whether the agent *wrote to a file*. The agent did call `edit_file`, but the judge never saw it.

Rather than globally switching to trajectory mode (which would change semantics for response-only evals like `test_followup_quality`), this adds an `include_tool_calls` flag that lets each call site opt in.