### PR TITLE
fix(evals): add diagnostic for missing eval report on cancelled CI jobs

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -221,8 +221,16 @@ jobs:
       - name: "📊 Run Evals"
         run: make evals
 
+      - name: "🔍 Check eval report"
+        if: '!cancelled()'
+        run: |
+          if [ ! -f evals_report.json ]; then
+            echo "::error::evals_report.json not found. pytest likely crashed before sessionfinish could write the report. Check the 'Run Evals' step logs for errors."
+            exit 1
+          fi
+
       - name: "📤 Upload eval report"
-        if: always()
+        if: '!cancelled()'
         uses: actions/upload-artifact@v7
         with:
           name: evals-report-${{ strategy.job-index }}


### PR DESCRIPTION
When an eval job is cancelled mid-run (e.g., timeout or manual cancellation), pytest never reaches `sessionfinish` so `evals_report.json` is never written. The upload step runs unconditionally via `if: always()` and fails with a generic "No files were found" error from `actions/upload-artifact`, giving no indication of *why* the report is missing.