### PR TITLE
chore(evals): sort model registry alphabetically, etc.

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -43,7 +43,14 @@ REGISTRY: tuple[Model, ...] = (
     Model(
         "anthropic:claude-haiku-4-5-20251001",
         frozenset(
-            {"eval:set0", "eval:set1", "eval:anthropic", "harbor:set0", "harbor:set1", "harbor:anthropic"}
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:anthropic",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:anthropic",
+            }
         ),
     ),
     Model(
@@ -57,7 +64,14 @@ REGISTRY: tuple[Model, ...] = (
     Model(
         "anthropic:claude-sonnet-4-6",
         frozenset(
-            {"eval:set0", "eval:set1", "eval:anthropic", "harbor:set0", "harbor:set1", "harbor:anthropic"}
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:anthropic",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:anthropic",
+            }
         ),
     ),
     Model(
@@ -71,74 +85,14 @@ REGISTRY: tuple[Model, ...] = (
     Model(
         "anthropic:claude-opus-4-6",
         frozenset(
-            {"eval:set0", "eval:set1", "eval:anthropic", "harbor:set0", "harbor:set1", "harbor:anthropic"}
-        ),
-    ),
-    # -- OpenAI --
-    Model(
-        "openai:gpt-4o",
-        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
-    ),
-    Model(
-        "openai:gpt-4o-mini",
-        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
-    ),
-    Model(
-        "openai:gpt-4.1",
-        frozenset(
-            {"eval:set0", "eval:set1", "eval:openai", "harbor:set0", "harbor:set1", "harbor:openai"}
-        ),
-    ),
-    Model(
-        "openai:o3",
-        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
-    ),
-    Model(
-        "openai:o4-mini",
-        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
-    ),
-    Model(
-        "openai:gpt-5.1-codex",
-        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
-    ),
-    Model(
-        "openai:gpt-5.2-codex",
-        frozenset(
-            {"eval:set0", "eval:set1", "eval:openai", "harbor:set0", "harbor:set1", "harbor:openai"}
-        ),
-    ),
-    Model(
-        "openai:gpt-5.4",
-        frozenset(
-            {"eval:set0", "eval:set1", "eval:openai", "harbor:set0", "harbor:set1", "harbor:openai"}
-        ),
-    ),
-    # -- Google --
-    Model(
-        "google_genai:gemini-2.5-flash",
-        frozenset({"eval:set0", "eval:google_genai", "harbor:set0", "harbor:google_genai"}),
-    ),
-    Model(
-        "google_genai:gemini-2.5-pro",
-        frozenset(
-            {"eval:set0", "eval:set1", "eval:google_genai", "harbor:set0", "harbor:set1", "harbor:google_genai"}
-        ),
-    ),
-    Model(
-        "google_genai:gemini-3-flash-preview",
-        frozenset({"eval:set0", "eval:google_genai", "harbor:set0", "harbor:google_genai"}),
-    ),
-    Model(
-        "google_genai:gemini-3.1-pro-preview",
-        frozenset(
-            {"eval:set0", "eval:set1", "eval:google_genai", "harbor:set0", "harbor:set1", "harbor:google_genai"}
-        ),
-    ),
-    # -- OpenRouter --
-    Model(
-        "openrouter:minimax/minimax-m2.7",
-        frozenset(
-            {"eval:set0", "eval:open", "eval:openrouter", "harbor:set0", "harbor:open", "harbor:openrouter"}
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:anthropic",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:anthropic",
+            }
         ),
     ),
     # -- Baseten --
@@ -146,14 +100,29 @@ REGISTRY: tuple[Model, ...] = (
         "baseten:zai-org/GLM-5",
         frozenset(
             {
-                "eval:set0", "eval:set1", "eval:open", "eval:baseten",
-                "harbor:set0", "harbor:set1", "harbor:open", "harbor:baseten",
+                "eval:set0",
+                "eval:set1",
+                "eval:open",
+                "eval:baseten",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:open",
+                "harbor:baseten",
             }
         ),
     ),
     Model(
         "baseten:MiniMaxAI/MiniMax-M2.5",
-        frozenset({"eval:set0", "eval:set1", "eval:baseten", "harbor:set0", "harbor:set1", "harbor:baseten"}),
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:baseten",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:baseten",
+            }
+        ),
     ),
     Model(
         "baseten:moonshotai/Kimi-K2.5",
@@ -175,7 +144,14 @@ REGISTRY: tuple[Model, ...] = (
     Model(
         "fireworks:fireworks/qwen3-vl-235b-a22b-thinking",
         frozenset(
-            {"eval:set0", "eval:set1", "eval:fireworks", "harbor:set0", "harbor:set1", "harbor:fireworks"}
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:fireworks",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:fireworks",
+            }
         ),
     ),
     Model(
@@ -194,18 +170,102 @@ REGISTRY: tuple[Model, ...] = (
         "fireworks:fireworks/minimax-m2p5",
         frozenset({"eval:set0", "eval:fireworks", "harbor:set0", "harbor:fireworks"}),
     ),
+    # -- Google --
+    Model(
+        "google_genai:gemini-2.5-flash",
+        frozenset(
+            {"eval:set0", "eval:google_genai", "harbor:set0", "harbor:google_genai"}
+        ),
+    ),
+    Model(
+        "google_genai:gemini-2.5-pro",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:google_genai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:google_genai",
+            }
+        ),
+    ),
+    Model(
+        "google_genai:gemini-3-flash-preview",
+        frozenset(
+            {"eval:set0", "eval:google_genai", "harbor:set0", "harbor:google_genai"}
+        ),
+    ),
+    Model(
+        "google_genai:gemini-3.1-pro-preview",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:google_genai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:google_genai",
+            }
+        ),
+    ),
+    # -- Groq --
+    Model(
+        "groq:openai/gpt-oss-120b",
+        frozenset({"eval:set2", "eval:groq", "harbor:set2", "harbor:groq"}),
+    ),
+    Model(
+        "groq:qwen/qwen3-32b",
+        frozenset({"eval:set2", "eval:groq", "harbor:set2", "harbor:groq"}),
+    ),
+    Model(
+        "groq:moonshotai/kimi-k2-instruct",
+        frozenset({"eval:set2", "eval:groq", "harbor:set2", "harbor:groq"}),
+    ),
+    # -- NVIDIA --
+    Model(
+        "nvidia:nvidia/nemotron-3-super-120b-a12b",
+        frozenset({"eval:open", "eval:nvidia", "harbor:open", "harbor:nvidia"}),
+    ),
     # -- Ollama --
     Model(
         "ollama:glm-5",
-        frozenset({"eval:set1", "eval:set2", "eval:ollama", "harbor:set1", "harbor:set2", "harbor:ollama"}),
+        frozenset(
+            {
+                "eval:set1",
+                "eval:set2",
+                "eval:ollama",
+                "harbor:set1",
+                "harbor:set2",
+                "harbor:ollama",
+            }
+        ),
     ),
     Model(
         "ollama:minimax-m2.5",
-        frozenset({"eval:set1", "eval:set2", "eval:ollama", "harbor:set1", "harbor:set2", "harbor:ollama"}),
+        frozenset(
+            {
+                "eval:set1",
+                "eval:set2",
+                "eval:ollama",
+                "harbor:set1",
+                "harbor:set2",
+                "harbor:ollama",
+            }
+        ),
     ),
     Model(
         "ollama:qwen3.5:397b-cloud",
-        frozenset({"eval:set1", "eval:set2", "eval:ollama", "harbor:set1", "harbor:set2", "harbor:ollama"}),
+        frozenset(
+            {
+                "eval:set1",
+                "eval:set2",
+                "eval:ollama",
+                "harbor:set1",
+                "harbor:set2",
+                "harbor:ollama",
+            }
+        ),
     ),
     Model(
         "ollama:nemotron-3-nano:30b",
@@ -235,18 +295,88 @@ REGISTRY: tuple[Model, ...] = (
         "ollama:deepseek-v3.2:cloud",
         frozenset({"eval:set2", "eval:ollama", "harbor:set2", "harbor:ollama"}),
     ),
-    # -- Groq --
+    # -- OpenAI --
     Model(
-        "groq:openai/gpt-oss-120b",
-        frozenset({"eval:set2", "eval:groq", "harbor:set2", "harbor:groq"}),
+        "openai:gpt-4o",
+        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
     ),
     Model(
-        "groq:qwen/qwen3-32b",
-        frozenset({"eval:set2", "eval:groq", "harbor:set2", "harbor:groq"}),
+        "openai:gpt-4o-mini",
+        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
     ),
     Model(
-        "groq:moonshotai/kimi-k2-instruct",
-        frozenset({"eval:set2", "eval:groq", "harbor:set2", "harbor:groq"}),
+        "openai:gpt-4.1",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:openai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:openai",
+            }
+        ),
+    ),
+    Model(
+        "openai:o3",
+        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
+    ),
+    Model(
+        "openai:o4-mini",
+        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
+    ),
+    Model(
+        "openai:gpt-5.1-codex",
+        frozenset({"eval:set0", "eval:openai", "harbor:set0", "harbor:openai"}),
+    ),
+    Model(
+        "openai:gpt-5.2-codex",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:openai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:openai",
+            }
+        ),
+    ),
+    Model(
+        "openai:gpt-5.4",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:openai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:openai",
+            }
+        ),
+    ),
+    # -- OpenRouter --
+    Model(
+        "openrouter:minimax/minimax-m2.7",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:open",
+                "eval:openrouter",
+                "harbor:set0",
+                "harbor:open",
+                "harbor:openrouter",
+            }
+        ),
+    ),
+    Model(
+        "nvidia/nemotron-3-super-120b-a12b",
+        frozenset(
+            {
+                "eval:openrouter",
+                "harbor:openrouter",
+            }
+        ),
     ),
     # -- xAI --
     Model(
@@ -256,11 +386,6 @@ REGISTRY: tuple[Model, ...] = (
     Model(
         "xai:grok-3-mini-fast",
         frozenset({"eval:set2", "eval:xai", "harbor:set2", "harbor:xai"}),
-    ),
-    # -- NVIDIA --
-    Model(
-        "nvidia:nvidia/nemotron-3-super-120b-a12b",
-        frozenset({"eval:open", "eval:nvidia", "harbor:open", "harbor:nvidia"}),
     ),
 )
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -27,7 +27,7 @@ on:
       models:
         description: "Model set to evaluate. Set definitions: .github/scripts/models.py. Use models_override for individual models."
         required: true
-        default: "all"
+        default: "set0"
         type: choice
         options:
           - all
@@ -36,15 +36,15 @@ on:
           - set2
           - open
           - anthropic
-          - openai
-          - google_genai
-          - openrouter
           - baseten
           - fireworks
-          - ollama
+          - google_genai
           - groq
-          - xai
           - nvidia
+          - openai
+          - ollama
+          - openrouter
+          - xai
           - "anthropic:claude-haiku-4-5-20251001"
           - "anthropic:claude-sonnet-4-20250514"
           - "anthropic:claude-sonnet-4-5-20250929"
@@ -52,19 +52,6 @@ on:
           - "anthropic:claude-opus-4-1"
           - "anthropic:claude-opus-4-5-20251101"
           - "anthropic:claude-opus-4-6"
-          - "openai:gpt-4o"
-          - "openai:gpt-4o-mini"
-          - "openai:gpt-4.1"
-          - "openai:o3"
-          - "openai:o4-mini"
-          - "openai:gpt-5.1-codex"
-          - "openai:gpt-5.2-codex"
-          - "openai:gpt-5.4"
-          - "google_genai:gemini-2.5-flash"
-          - "google_genai:gemini-2.5-pro"
-          - "google_genai:gemini-3-flash-preview"
-          - "google_genai:gemini-3.1-pro-preview"
-          - "openrouter:minimax/minimax-m2.7"
           - "baseten:zai-org/GLM-5"
           - "baseten:MiniMaxAI/MiniMax-M2.5"
           - "baseten:moonshotai/Kimi-K2.5"
@@ -76,6 +63,14 @@ on:
           - "fireworks:fireworks/kimi-k2p5"
           - "fireworks:fireworks/glm-5"
           - "fireworks:fireworks/minimax-m2p5"
+          - "google_genai:gemini-2.5-flash"
+          - "google_genai:gemini-2.5-pro"
+          - "google_genai:gemini-3-flash-preview"
+          - "google_genai:gemini-3.1-pro-preview"
+          - "groq:openai/gpt-oss-120b"
+          - "groq:qwen/qwen3-32b"
+          - "groq:moonshotai/kimi-k2-instruct"
+          - "nvidia:nvidia/nemotron-3-super-120b-a12b"
           - "ollama:glm-5"
           - "ollama:minimax-m2.5"
           - "ollama:qwen3.5:397b-cloud"
@@ -86,12 +81,18 @@ on:
           - "ollama:qwen3-next:80b"
           - "ollama:qwen3-coder:480b-cloud"
           - "ollama:deepseek-v3.2:cloud"
-          - "groq:openai/gpt-oss-120b"
-          - "groq:qwen/qwen3-32b"
-          - "groq:moonshotai/kimi-k2-instruct"
+          - "openai:gpt-4o"
+          - "openai:gpt-4o-mini"
+          - "openai:gpt-4.1"
+          - "openai:o3"
+          - "openai:o4-mini"
+          - "openai:gpt-5.1-codex"
+          - "openai:gpt-5.2-codex"
+          - "openai:gpt-5.4"
+          - "openrouter:minimax/minimax-m2.7"
+          - "openrouter:nvidia/nemotron-3-super-120b-a12b"
           - "xai:grok-4"
           - "xai:grok-3-mini-fast"
-          - "nvidia:nvidia/nemotron-3-super-120b-a12b"
       models_override:
         description: "Custom model list (overrides dropdown). Comma-separated 'provider:model' specs, e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'. Leave empty to use the preset selection above."
         required: false
@@ -222,7 +223,7 @@ jobs:
         run: make evals
 
       - name: "🔍 Check eval report"
-        if: '!cancelled()'
+        if: "!cancelled()"
         run: |
           if [ ! -f evals_report.json ]; then
             echo "::error::evals_report.json not found. pytest likely crashed before sessionfinish could write the report. Check the 'Run Evals' step logs for errors."
@@ -230,7 +231,7 @@ jobs:
           fi
 
       - name: "📤 Upload eval report"
-        if: '!cancelled()'
+        if: "!cancelled()"
         uses: actions/upload-artifact@v7
         with:
           name: evals-report-${{ strategy.job-index }}

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -6,7 +6,7 @@ on:
       models:
         description: "Model set to run. Set definitions: .github/scripts/models.py. Use models_override for individual models."
         required: true
-        default: "all"
+        default: "set0"
         type: choice
         options:
           - all
@@ -15,15 +15,15 @@ on:
           - set2
           - open
           - anthropic
-          - openai
-          - google_genai
-          - openrouter
           - baseten
           - fireworks
-          - ollama
+          - google_genai
           - groq
-          - xai
           - nvidia
+          - openai
+          - ollama
+          - openrouter
+          - xai
           - "anthropic:claude-haiku-4-5-20251001"
           - "anthropic:claude-sonnet-4-20250514"
           - "anthropic:claude-sonnet-4-5-20250929"
@@ -31,19 +31,6 @@ on:
           - "anthropic:claude-opus-4-1"
           - "anthropic:claude-opus-4-5-20251101"
           - "anthropic:claude-opus-4-6"
-          - "openai:gpt-4o"
-          - "openai:gpt-4o-mini"
-          - "openai:gpt-4.1"
-          - "openai:o3"
-          - "openai:o4-mini"
-          - "openai:gpt-5.1-codex"
-          - "openai:gpt-5.2-codex"
-          - "openai:gpt-5.4"
-          - "google_genai:gemini-2.5-flash"
-          - "google_genai:gemini-2.5-pro"
-          - "google_genai:gemini-3-flash-preview"
-          - "google_genai:gemini-3.1-pro-preview"
-          - "openrouter:minimax/minimax-m2.7"
           - "baseten:zai-org/GLM-5"
           - "baseten:MiniMaxAI/MiniMax-M2.5"
           - "baseten:moonshotai/Kimi-K2.5"
@@ -55,6 +42,14 @@ on:
           - "fireworks:fireworks/kimi-k2p5"
           - "fireworks:fireworks/glm-5"
           - "fireworks:fireworks/minimax-m2p5"
+          - "google_genai:gemini-2.5-flash"
+          - "google_genai:gemini-2.5-pro"
+          - "google_genai:gemini-3-flash-preview"
+          - "google_genai:gemini-3.1-pro-preview"
+          - "groq:openai/gpt-oss-120b"
+          - "groq:qwen/qwen3-32b"
+          - "groq:moonshotai/kimi-k2-instruct"
+          - "nvidia:nvidia/nemotron-3-super-120b-a12b"
           - "ollama:glm-5"
           - "ollama:minimax-m2.5"
           - "ollama:qwen3.5:397b-cloud"
@@ -65,12 +60,18 @@ on:
           - "ollama:qwen3-next:80b"
           - "ollama:qwen3-coder:480b-cloud"
           - "ollama:deepseek-v3.2:cloud"
-          - "groq:openai/gpt-oss-120b"
-          - "groq:qwen/qwen3-32b"
-          - "groq:moonshotai/kimi-k2-instruct"
+          - "openai:gpt-4o"
+          - "openai:gpt-4o-mini"
+          - "openai:gpt-4.1"
+          - "openai:o3"
+          - "openai:o4-mini"
+          - "openai:gpt-5.1-codex"
+          - "openai:gpt-5.2-codex"
+          - "openai:gpt-5.4"
+          - "openrouter:minimax/minimax-m2.7"
+          - "openrouter:nvidia/nemotron-3-super-120b-a12b"
           - "xai:grok-4"
           - "xai:grok-3-mini-fast"
-          - "nvidia:nvidia/nemotron-3-super-120b-a12b"
       models_override:
         description: "Override: comma-separated models (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Takes priority over dropdown when non-empty."
         required: false
@@ -104,7 +105,7 @@ on:
         type: choice
         options:
           - sdk
-          - cli
+          # - cli # need to support properly first
 
 permissions:
   contents: read


### PR DESCRIPTION
Sort the model registry and workflow dropdowns alphabetically by provider. The previous ordering was ad-hoc and made it hard to find or verify a specific provider's models. Also changes the default model set from `all` to `set0` and adds `openrouter:nvidia/nemotron-3-super-120b-a12b` as a new eval target.

## Changes
- Reorder `REGISTRY` entries in `models.py` alphabetically by provider (Anthropic → Baseten → Fireworks → … → xAI) and reformat inline frozensets to multi-line for readability
- Add `nvidia/nemotron-3-super-120b-a12b` via OpenRouter as a new eval/harbor target
- Sort the `models` dropdown options in `evals.yml` and `harbor.yml` to match the new registry order, default selection changed from `all` to `set0`
- Comment out the `cli` package option in `harbor.yml` pending proper support