### PR TITLE
chore(evals): make model set dropdown optional, clean up ci summary

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -370,7 +370,7 @@ REGISTRY: tuple[Model, ...] = (
         ),
     ),
     Model(
-        "nvidia/nemotron-3-super-120b-a12b",
+        "openrouter:nvidia/nemotron-3-super-120b-a12b",
         frozenset(
             {
                 "eval:openrouter",

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -25,11 +25,12 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: "Model set to evaluate. Set definitions: .github/scripts/models.py. Use models_override for individual models."
-        required: true
-        default: "set0"
+        description: "Model set to evaluate. Set definitions: .github/scripts/models.py. Leave empty to use models_override instead. Defaults to all models if both are empty."
+        required: false
+        default: ""
         type: choice
         options:
+          - ""
           - all
           - set0
           - set1
@@ -127,16 +128,17 @@ jobs:
         env:
           MODELS: ${{ inputs.models }}
           MODELS_OVERRIDE: ${{ inputs.models_override || '(empty)' }}
-          RESOLVED: ${{ inputs.models_override || inputs.models || 'all' }}
           EVAL_CATEGORIES: ${{ inputs.eval_categories || '(all)' }}
         run: |
           echo "### 📊 Eval dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Input | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`models_override\` | \`${MODELS_OVERRIDE}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Resolved**¹ | \`${RESOLVED}\` |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${MODELS_OVERRIDE}" != "(empty)" ]; then
+            echo "| \`models_override\` | \`${MODELS_OVERRIDE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "| \`eval_categories\` (list) | \`${EVAL_CATEGORIES}\` |" >> "$GITHUB_STEP_SUMMARY"
 
           # Build eval_categories as a bullet list
@@ -153,7 +155,6 @@ jobs:
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "> ¹ **Resolved** = \`models_override\` if set, otherwise \`models\` dropdown, otherwise \`all\`." >> "$GITHUB_STEP_SUMMARY"
 
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -129,7 +129,6 @@ jobs:
         env:
           MODELS: ${{ inputs.models }}
           MODELS_OVERRIDE: ${{ inputs.models_override || '(empty)' }}
-          RESOLVED: ${{ inputs.models_override || inputs.models || 'all' }}
           SANDBOX_ENV: ${{ inputs.sandbox_env }}
           N_TASKS: ${{ inputs.n_tasks }}
           CONCURRENCY: ${{ inputs.concurrency }}
@@ -139,9 +138,11 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Input | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| \`models_override\` | \`${MODELS_OVERRIDE}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Resolved**¹ | \`${RESOLVED}\` |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${MODELS_OVERRIDE}" != "(empty)" ]; then
+            echo "| \`models_override\` | \`${MODELS_OVERRIDE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "| \`sandbox_env\` | \`${SANDBOX_ENV}\` |" >> "$GITHUB_STEP_SUMMARY"
           if [ "${N_TASKS}" = "0" ]; then
             echo "| \`n_tasks\` | all |" >> "$GITHUB_STEP_SUMMARY"
@@ -151,7 +152,6 @@ jobs:
           echo "| \`concurrency\` | \`${CONCURRENCY}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| \`agent_mode\` | \`${AGENT_MODE}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "> ¹ **Resolved** = \`models_override\` if set, otherwise \`models\` dropdown, otherwise \`all\`." >> "$GITHUB_STEP_SUMMARY"
 
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6

--- a/libs/evals/scripts/generate_radar.py
+++ b/libs/evals/scripts/generate_radar.py
@@ -101,7 +101,13 @@ def main() -> None:
         sys.exit(1)
 
     if not results:
-        print("error: no results to plot", file=sys.stderr)
+        source = args.summary or args.results or "toy"
+        msg = (
+            f"error: no results to plot from {source}\n"
+            "hint: the summary file may be an empty JSON array (all evals "
+            "cancelled or failed). Check the eval runner logs for details."
+        )
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
     # Detect categories from results (use all categories present across models).


### PR DESCRIPTION
Make the `models` dropdown in the evals workflow optional — when left empty, `models_override` takes precedence, and if both are empty the pipeline evaluates all models. Also cleans up the CI job summary to show only the resolved input (either `models_override` or `models`, not both plus a footnote), and improves the radar script's empty-results error with an actionable hint.

## Changes
- Make the `models` dropdown in `evals.yml` non-required with an empty default, adding `""` as a choice option so users can skip it in favor of `models_override`
- Simplify the job summary table in both `evals.yml` and `harbor.yml` — show only the active input (`models_override` if set, otherwise `models`) instead of dumping both plus a "Resolved" row with footnote
- Fix `openrouter:` prefix missing from `nvidia/nemotron-3-super-120b-a12b` in the model registry
- Improve `generate_radar.py` empty-results error to name the source file and hint at cancelled/failed evals as the likely cause