### PR TITLE
feat(evals): include model name in experiment suffix

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: "Model set to run. Set definitions: .github/scripts/models.py. Use models_override for individual models."
-        required: true
-        default: "set0"
+        description: "Model set to run. Set definitions: .github/scripts/models.py. Leave empty to use models_override instead. Defaults to all models if both are empty."
+        required: false
+        default: ""
         type: choice
         options:
+          - ""
           - all
           - set0
           - set1
@@ -283,7 +284,7 @@ jobs:
       - name: "🧪 Create LangSmith experiment"
         id: langsmith
         run: |
-          experiment_name=$(uv run python scripts/harbor_langsmith.py create-experiment "$HARBOR_DATASET_NAME")
+          experiment_name=$(uv run python scripts/harbor_langsmith.py create-experiment "$HARBOR_DATASET_NAME" --model "$HARBOR_MODEL")
           echo "experiment_name=$experiment_name" >> "$GITHUB_OUTPUT"
           echo "LANGSMITH_EXPERIMENT=$experiment_name" >> "$GITHUB_ENV"
 

--- a/libs/evals/deepagents_harbor/langsmith.py
+++ b/libs/evals/deepagents_harbor/langsmith.py
@@ -274,6 +274,7 @@ async def create_experiment_async(
     dataset_name: str,
     experiment_name: str | None = None,
     *,
+    model: str | None = None,
     metadata: dict[str, str] | None = None,
 ) -> str:
     """Create a LangSmith experiment session for the given dataset.
@@ -282,6 +283,12 @@ async def create_experiment_async(
         dataset_name: Name of the LangSmith dataset to create experiment for.
         experiment_name: Optional name for the experiment (auto-generated if
             not provided).
+        model: Optional model identifier (e.g. `anthropic:claude-sonnet-4-6`).
+
+            Used as the suffix in auto-generated experiment names.
+
+            If not provided, a random suffix will be used to avoid
+            name collisions.
         metadata: Optional metadata to attach to the experiment session.
 
     Returns:
@@ -296,7 +303,7 @@ async def create_experiment_async(
 
         if experiment_name is None:
             timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d_%H-%M-%S")
-            suffix = uuid.uuid4().hex[:8]
+            suffix = model or uuid.uuid4().hex[:8]
             experiment_name = f"{dataset_name}-{timestamp}-{suffix}"
 
         experiment_metadata = metadata or {}
@@ -327,6 +334,7 @@ def create_experiment(
     dataset_name: str,
     experiment_name: str | None = None,
     *,
+    model: str | None = None,
     metadata: dict[str, str] | None = None,
 ) -> str:
     """Synchronous wrapper for `create_experiment_async`."""
@@ -334,6 +342,7 @@ def create_experiment(
         create_experiment_async(
             dataset_name,
             experiment_name,
+            model=model,
             metadata=metadata,
         )
     )

--- a/libs/evals/scripts/harbor_langsmith.py
+++ b/libs/evals/scripts/harbor_langsmith.py
@@ -97,6 +97,11 @@ def main() -> int:
         help="Name for the experiment (auto-generated if not provided)",
     )
     experiment_parser.add_argument(
+        "--model",
+        type=str,
+        help="Model identifier used as suffix in auto-generated experiment names (e.g. 'anthropic:claude-sonnet-4-6')",
+    )
+    experiment_parser.add_argument(
         "--metadata",
         type=str,
         default="{}",
@@ -154,6 +159,7 @@ def main() -> int:
         name = create_experiment(
             dataset_name=args.dataset_name,
             experiment_name=args.name,
+            model=args.model,
             metadata={str(key): str(value) for key, value in metadata.items()},
         )
         print(name)


### PR DESCRIPTION
Auto-generated experiment names now include the model identifier as a suffix instead of a random UUID, making it easy to identify which model produced a given experiment in the LangSmith UI. The `models` dropdown in the Harbor workflow is also made optional — leaving it empty lets you use `models_override` directly without picking a dummy set first.

## Changes
- Add a `model` parameter to `create_experiment_async` and `create_experiment` in `deepagents_harbor/langsmith.py` — when provided, it replaces the random `uuid4` hex suffix in the auto-generated experiment name (`{dataset}-{timestamp}-{model}`)
- Wire `--model "$HARBOR_MODEL"` through the CI workflow's `create-experiment` step and expose a corresponding `--model` CLI flag in `scripts/harbor_langsmith.py`
- Make the `models` workflow input optional with an empty default, allowing runs that rely solely on `models_override`