### PR TITLE
feat(evals): add `--openrouter-provider` flag to pin provider routing

### DIFF
--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -79,6 +79,7 @@ class DeepAgentsWrapper(BaseAgent):
         temperature: float = 0.0,
         verbose: bool = True,
         use_cli_agent: bool = True,
+        openrouter_provider: str | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -91,8 +92,16 @@ class DeepAgentsWrapper(BaseAgent):
             verbose: Enable verbose output
             use_cli_agent: If True, use create_cli_agent from deepagents-cli (default).
                 If False, use create_deep_agent from SDK.
+            openrouter_provider: Pin OpenRouter routing to a single provider
+                (e.g. `"MiniMax"`).
+
+                Requires an `openrouter:` model prefix.
         """
         super().__init__(logs_dir, model_name, *args, **kwargs)
+
+        if openrouter_provider and (model_name is None or not model_name.startswith("openrouter:")):
+            msg = "openrouter_provider requires an openrouter: model prefix"
+            raise ValueError(msg)
 
         if model_name is None:
             # Keep Harbor default aligned with the SDK default model.
@@ -104,7 +113,13 @@ class DeepAgentsWrapper(BaseAgent):
             self._model_name = model.model
         else:
             self._model_name = model_name
-            self._model = init_chat_model(model_name, temperature=temperature)
+            model_kwargs: dict[str, Any] = {}
+            if openrouter_provider:
+                model_kwargs["openrouter_provider"] = {
+                    "only": [openrouter_provider],
+                    "allow_fallbacks": False,
+                }
+            self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
 
         self._temperature = temperature
         self._verbose = verbose

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -61,6 +61,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=[],
         help="Run only evals tagged with this category (repeatable). E.g. --eval-category memory --eval-category hitl",
     )
+    parser.addoption(
+        "--openrouter-provider",
+        action="store",
+        default=None,
+        help="Pin OpenRouter to a specific provider. E.g. --openrouter-provider MiniMax",
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -120,5 +126,15 @@ def langsmith_experiment_metadata(request: pytest.FixtureRequest) -> dict[str, A
 
 
 @pytest.fixture
-def model(model_name: str) -> BaseChatModel:
-    return init_chat_model(model_name)
+def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
+    kwargs: dict[str, Any] = {}
+    provider = request.config.getoption("--openrouter-provider")
+    if provider:
+        if not model_name.startswith("openrouter:"):
+            msg = "--openrouter-provider requires an openrouter: model prefix"
+            raise ValueError(msg)
+        kwargs["openrouter_provider"] = {
+            "only": [provider],
+            "allow_fallbacks": False,
+        }
+    return init_chat_model(model_name, **kwargs)


### PR DESCRIPTION
Add `--openrouter-provider` flag to pin OpenRouter model routing to a single upstream provider, preventing silent fallback to alternative hosts. Useful when a model is available from multiple providers on OpenRouter but you need deterministic routing for evals (e.g. running `minimax/minimax-m2.7` only through MiniMax's official endpoint).

## Changes
- Add `--openrouter-provider` pytest option in `conftest.py` that accepts a provider name (e.g. `MiniMax`) and builds `{"only": [provider], "allow_fallbacks": False}` for the `openrouter_provider` kwarg passed to `init_chat_model`
- Guard both entry points — the `model` fixture and `DeepAgentsWrapper.__init__` — with a validation that `openrouter_provider` requires an `openrouter:` model prefix, raising `ValueError` otherwise
- Port the same logic to `DeepAgentsWrapper` as an `openrouter_provider: str | None` constructor param, forwarding it through `init_chat_model` model kwargs
