### PR TITLE
feat(evals): restructure eval categories by capability, not origin

### DIFF
--- a/libs/evals/README.md
+++ b/libs/evals/README.md
@@ -149,16 +149,16 @@ Run only specific categories locally or in CI:
 
 ```bash
 # Single category
-uv run --group test pytest tests/evals --eval-category hitl
+uv run --group test pytest tests/evals --eval-category memory
 
 # Multiple categories
-uv run --group test pytest tests/evals --eval-category memory --eval-category hitl
+uv run --group test pytest tests/evals --eval-category memory --eval-category tool_use
 ```
 
 In the GitHub Actions workflow, pass a comma-separated list via the `eval_categories` input:
 
 ```text
-eval_categories: "memory,hitl,tool_usage"
+eval_categories: "memory,tool_use,retrieval"
 ```
 
 Omit to run all categories.

--- a/libs/evals/deepagents_evals/categories.json
+++ b/libs/evals/deepagents_evals/categories.json
@@ -1,30 +1,28 @@
 {
   "categories": [
     "file_operations",
-    "skills",
-    "hitl",
+    "retrieval",
+    "tool_use",
     "memory",
+    "conversation",
     "summarization",
-    "subagents",
-    "system_prompt",
-    "tool_usage",
-    "followup_quality",
-    "external_benchmarks",
-    "tau2_airline",
-    "memory_agent_bench"
+    "unit_test"
+  ],
+  "radar_categories": [
+    "file_operations",
+    "retrieval",
+    "tool_use",
+    "memory",
+    "conversation",
+    "summarization"
   ],
   "labels": {
     "file_operations": "File Ops",
-    "skills": "Skills",
-    "hitl": "HITL",
+    "retrieval": "Retrieval",
+    "tool_use": "Tool Use",
     "memory": "Memory",
+    "conversation": "Conversation",
     "summarization": "Summarization",
-    "subagents": "Subagents",
-    "system_prompt": "System Prompt",
-    "tool_usage": "Tool Usage",
-    "followup_quality": "Followup Quality",
-    "external_benchmarks": "External Benchmarks",
-    "tau2_airline": "Tau2 Airline",
-    "memory_agent_bench": "MemoryAgentBench"
+    "unit_test": "Unit Test"
   }
 }

--- a/libs/evals/deepagents_evals/radar.py
+++ b/libs/evals/deepagents_evals/radar.py
@@ -31,10 +31,15 @@ except (json.JSONDecodeError, KeyError) as exc:
     msg = f"Failed to parse {_CATEGORIES_JSON}: {exc}"
     raise ValueError(msg) from exc
 
-EVAL_CATEGORIES: list[str] = _categories_raw["categories"]
-"""Canonical eval category names.
+ALL_CATEGORIES: list[str] = _categories_raw["categories"]
+"""All eval category names, including unit tests that don't appear on radar charts."""
+
+EVAL_CATEGORIES: list[str] = _categories_raw.get("radar_categories", _categories_raw["categories"])
+"""Radar-eligible eval category names.
 
 Order determines axis placement on the radar chart (clockwise from top).
+Categories like ``unit_test`` that verify SDK plumbing rather than model
+capability are excluded from this list.
 """
 
 CATEGORY_LABELS: dict[str, str] = _categories_raw["labels"]
@@ -277,68 +282,44 @@ def toy_data() -> list[ModelResult]:
             model="anthropic:claude-sonnet-4-6",
             scores={
                 "file_operations": 0.92,
-                "skills": 0.88,
-                "hitl": 0.95,
+                "retrieval": 0.76,
+                "tool_use": 0.85,
                 "memory": 0.83,
+                "conversation": 0.80,
                 "summarization": 0.90,
-                "subagents": 0.78,
-                "system_prompt": 0.97,
-                "tool_usage": 0.85,
-                "followup_quality": 0.91,
-                "external_benchmarks": 0.76,
-                "tau2_airline": 0.70,
-                "memory_agent_bench": 0.82,
             },
         ),
         ModelResult(
             model="openai:gpt-4.1",
             scores={
                 "file_operations": 0.88,
-                "skills": 0.82,
-                "hitl": 0.80,
+                "retrieval": 0.72,
+                "tool_use": 0.86,
                 "memory": 0.79,
+                "conversation": 0.75,
                 "summarization": 0.85,
-                "subagents": 0.75,
-                "system_prompt": 0.90,
-                "tool_usage": 0.88,
-                "followup_quality": 0.85,
-                "external_benchmarks": 0.72,
-                "tau2_airline": 0.65,
-                "memory_agent_bench": 0.78,
             },
         ),
         ModelResult(
             model="google_genai:gemini-2.5-pro",
             scores={
                 "file_operations": 0.85,
-                "skills": 0.78,
-                "hitl": 0.72,
+                "retrieval": 0.68,
+                "tool_use": 0.80,
                 "memory": 0.80,
+                "conversation": 0.70,
                 "summarization": 0.88,
-                "subagents": 0.70,
-                "system_prompt": 0.85,
-                "tool_usage": 0.82,
-                "followup_quality": 0.80,
-                "external_benchmarks": 0.68,
-                "tau2_airline": 0.60,
-                "memory_agent_bench": 0.75,
             },
         ),
         ModelResult(
             model="anthropic:claude-opus-4-6",
             scores={
                 "file_operations": 0.95,
-                "skills": 0.92,
-                "hitl": 0.93,
+                "retrieval": 0.81,
+                "tool_use": 0.90,
                 "memory": 0.90,
+                "conversation": 0.85,
                 "summarization": 0.94,
-                "subagents": 0.85,
-                "system_prompt": 0.98,
-                "tool_usage": 0.91,
-                "followup_quality": 0.94,
-                "external_benchmarks": 0.81,
-                "tau2_airline": 0.75,
-                "memory_agent_bench": 0.88,
             },
         ),
     ]

--- a/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py
+++ b/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py
@@ -43,7 +43,7 @@ from tests.evals.utils import run_agent
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-pytestmark = [pytest.mark.eval_category("memory_agent_bench")]
+pytestmark = [pytest.mark.eval_category("memory")]
 
 logger = logging.getLogger(__name__)
 

--- a/libs/evals/tests/evals/tau2_airline/test_tau2_airline.py
+++ b/libs/evals/tests/evals/tau2_airline/test_tau2_airline.py
@@ -36,7 +36,7 @@ from tests.evals.tau2_airline.user_sim import UserSimulator
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-pytestmark = [pytest.mark.eval_category("tau2_airline")]
+pytestmark = [pytest.mark.eval_category("conversation")]
 
 logger = logging.getLogger(__name__)
 

--- a/libs/evals/tests/evals/test_external_benchmarks.py
+++ b/libs/evals/tests/evals/test_external_benchmarks.py
@@ -16,13 +16,12 @@ from tests.evals.external_benchmarks import (
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-pytestmark = [pytest.mark.eval_category("external_benchmarks")]
-
 # ---------------------------------------------------------------------------
 # Focused hard-set: 15 examples across 3 benchmarks
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.eval_category("retrieval")
 @pytest.mark.langsmith
 @pytest.mark.parametrize("case", FRAMES_CASES, ids=[case["id"] for case in FRAMES_CASES])
 def test_frames(model: BaseChatModel, case: dict[str, Any]) -> None:
@@ -30,6 +29,7 @@ def test_frames(model: BaseChatModel, case: dict[str, Any]) -> None:
     run_frames_case(case, model)
 
 
+@pytest.mark.eval_category("tool_use")
 @pytest.mark.langsmith
 @pytest.mark.parametrize("case", NEXUS_CASES, ids=[case["id"] for case in NEXUS_CASES])
 def test_nexus(model: BaseChatModel, case: dict[str, Any]) -> None:
@@ -37,6 +37,7 @@ def test_nexus(model: BaseChatModel, case: dict[str, Any]) -> None:
     run_nexus_case(case, model)
 
 
+@pytest.mark.eval_category("tool_use")
 @pytest.mark.langsmith
 @pytest.mark.parametrize("case", BFCL_V3_CASES, ids=[case["id"] for case in BFCL_V3_CASES])
 def test_bfcl_v3(model: BaseChatModel, case: dict[str, Any]) -> None:

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -18,9 +18,8 @@ from tests.evals.utils import (
     tool_call,
 )
 
-pytestmark = [pytest.mark.eval_category("file_operations")]
 
-
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_read_file_seeded_state_backend_file(model: BaseChatModel) -> None:
     """Reads a seeded file and answers a question."""
@@ -39,6 +38,7 @@ def test_read_file_seeded_state_backend_file(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_write_file_simple(model: BaseChatModel) -> None:
     """Writes a file then answers a follow-up."""
@@ -59,6 +59,7 @@ def test_write_file_simple(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_write_files_in_parallel(model: str) -> None:
     """Writes two files in parallel without post-write verification or extra tool calls."""
@@ -89,6 +90,7 @@ def test_write_files_in_parallel(model: str) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_write_files_in_parallel_confirm_with_verification(model: str) -> None:
     """Writes two files in parallel, reads them back in parallel, then replies DONE."""
@@ -122,6 +124,7 @@ def test_write_files_in_parallel_confirm_with_verification(model: str) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_write_files_in_parallel_ambiguous_confirmation(model: BaseChatModel) -> None:
     """Intentionally ambiguous: the user asks for a reply but doesn't constrain verification.
@@ -155,6 +158,7 @@ def test_write_files_in_parallel_ambiguous_confirmation(model: BaseChatModel) ->
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_ls_directory_contains_file_yes_no(model: BaseChatModel) -> None:
     """Uses ls then answers YES/NO about a directory entry."""
@@ -177,6 +181,7 @@ def test_ls_directory_contains_file_yes_no(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_ls_directory_missing_file_yes_no(model: BaseChatModel) -> None:
     """Uses ls then answers YES/NO about a missing directory entry."""
@@ -198,6 +203,7 @@ def test_ls_directory_missing_file_yes_no(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_edit_file_replace_text(model: BaseChatModel) -> None:
     """Edits a file by replacing text, then validates the edit."""
@@ -219,6 +225,7 @@ def test_edit_file_replace_text(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_read_then_write_derived_output(model: BaseChatModel) -> None:
     """Reads a file and writes a derived output file."""
@@ -242,6 +249,7 @@ def test_read_then_write_derived_output(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_avoid_unnecessary_tool_calls(model: BaseChatModel) -> None:
     """Answers a trivial question without using tools."""
@@ -258,6 +266,7 @@ def test_avoid_unnecessary_tool_calls(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_read_files_in_parallel(model: BaseChatModel) -> None:
     """Performs two independent read_file calls in a single agent step."""
@@ -286,6 +295,7 @@ def test_read_files_in_parallel(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("retrieval")
 @pytest.mark.langsmith
 def test_grep_finds_matching_paths(model: BaseChatModel) -> None:
     """Uses grep to find matching files and reports the matching paths."""
@@ -312,6 +322,7 @@ def test_grep_finds_matching_paths(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("retrieval")
 @pytest.mark.langsmith
 def test_glob_lists_markdown_files(model: BaseChatModel) -> None:
     """Uses glob to list files matching a pattern."""
@@ -338,6 +349,7 @@ def test_glob_lists_markdown_files(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("retrieval")
 @pytest.mark.langsmith
 def test_find_magic_phrase_deep_nesting(model: BaseChatModel) -> None:
     """Finds a magic phrase in a deeply nested directory efficiently."""
@@ -372,6 +384,7 @@ def test_find_magic_phrase_deep_nesting(model: BaseChatModel) -> None:
     )
 
 
+@pytest.mark.eval_category("retrieval")
 @pytest.mark.langsmith
 def test_identify_quote_author_from_directory_parallel_reads(
     model: BaseChatModel,
@@ -445,6 +458,7 @@ Clues: about programming readability; software craftsmanship.
     )
 
 
+@pytest.mark.eval_category("retrieval")
 @pytest.mark.langsmith
 def test_identify_quote_author_from_directory_unprompted_efficiency(
     model: BaseChatModel,
@@ -516,6 +530,7 @@ Clues: about programming readability; software craftsmanship.
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_read_file_truncation_recovery_with_pagination(
     model: BaseChatModel,
@@ -552,6 +567,7 @@ def test_read_file_truncation_recovery_with_pagination(
     )
 
 
+@pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_read_file_empty_file_reports_empty(model: BaseChatModel) -> None:
     """Empty files should be reported as empty rather than hallucinated."""

--- a/libs/evals/tests/evals/test_followup_quality.py
+++ b/libs/evals/tests/evals/test_followup_quality.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 from tests.evals.llm_judge import llm_judge
 from tests.evals.utils import TrajectoryScorer, run_agent
 
-pytestmark = [pytest.mark.eval_category("followup_quality")]
+pytestmark = [pytest.mark.eval_category("conversation")]
 
 # ---------------------------------------------------------------------------
 # Test cases — each describes a user request (varying in specificity) and

--- a/libs/evals/tests/evals/test_hitl.py
+++ b/libs/evals/tests/evals/test_hitl.py
@@ -15,7 +15,7 @@ from langgraph.types import Command
 
 from tests.evals.utils import run_agent
 
-pytestmark = [pytest.mark.eval_category("hitl")]
+pytestmark = [pytest.mark.eval_category("unit_test")]
 
 
 @tool(description="Use this tool to get the weather")

--- a/libs/evals/tests/evals/test_skills.py
+++ b/libs/evals/tests/evals/test_skills.py
@@ -18,7 +18,7 @@ from tests.evals.utils import (
     tool_call,
 )
 
-pytestmark = [pytest.mark.eval_category("skills")]
+pytestmark = [pytest.mark.eval_category("unit_test")]
 
 
 def _skill_content(name: str, description: str, body: str) -> str:

--- a/libs/evals/tests/evals/test_subagents.py
+++ b/libs/evals/tests/evals/test_subagents.py
@@ -17,7 +17,7 @@ from tests.evals.utils import (
     tool_call,
 )
 
-pytestmark = [pytest.mark.eval_category("subagents")]
+pytestmark = [pytest.mark.eval_category("unit_test")]
 
 
 @tool

--- a/libs/evals/tests/evals/test_system_prompt.py
+++ b/libs/evals/tests/evals/test_system_prompt.py
@@ -14,7 +14,7 @@ from tests.evals.utils import (
     run_agent,
 )
 
-pytestmark = [pytest.mark.eval_category("system_prompt")]
+pytestmark = [pytest.mark.eval_category("unit_test")]
 
 
 @pytest.mark.langsmith

--- a/libs/evals/tests/evals/test_todos.py
+++ b/libs/evals/tests/evals/test_todos.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from tests.evals.utils import TrajectoryScorer, final_text_contains, run_agent, tool_call
 
-pytestmark = [pytest.mark.eval_category("tool_usage")]
+pytestmark = [pytest.mark.eval_category("tool_use")]
 
 
 @pytest.mark.langsmith

--- a/libs/evals/tests/evals/test_tool_selection.py
+++ b/libs/evals/tests/evals/test_tool_selection.py
@@ -26,7 +26,7 @@ from tests.evals.utils import (
     tool_call,
 )
 
-pytestmark = [pytest.mark.eval_category("tool_usage")]
+pytestmark = [pytest.mark.eval_category("tool_use")]
 
 # ---------------------------------------------------------------------------
 # Mock tools — lightweight stubs that return a fixed string

--- a/libs/evals/tests/evals/test_tool_usage_relational.py
+++ b/libs/evals/tests/evals/test_tool_usage_relational.py
@@ -24,7 +24,7 @@ from tests.evals.utils import (
     tool_call,
 )
 
-pytestmark = [pytest.mark.eval_category("tool_usage")]
+pytestmark = [pytest.mark.eval_category("tool_use")]
 
 # ---------------------------------------------------------------------------
 # Static relational data

--- a/libs/evals/tests/unit_tests/test_category_tagging.py
+++ b/libs/evals/tests/unit_tests/test_category_tagging.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from deepagents_evals.radar import CATEGORY_LABELS, EVAL_CATEGORIES
+from deepagents_evals.radar import ALL_CATEGORIES, CATEGORY_LABELS, EVAL_CATEGORIES
 
 # ---------------------------------------------------------------------------
 # Category definitions consistency
@@ -15,43 +15,69 @@ from deepagents_evals.radar import CATEGORY_LABELS, EVAL_CATEGORIES
 # Maps category name -> list of test module basenames.
 EXPECTED_CATEGORY_MODULES: dict[str, list[str]] = {
     "file_operations": ["test_file_operations"],
-    "skills": ["test_skills"],
-    "hitl": ["test_hitl"],
-    "memory": ["test_memory", "test_memory_multiturn"],
-    "summarization": ["test_summarization"],
-    "subagents": ["test_subagents"],
-    "system_prompt": ["test_system_prompt"],
-    "tool_usage": [
-        "test_tool_usage_relational",
+    "retrieval": ["test_file_operations", "test_external_benchmarks"],
+    "tool_use": [
         "test_tool_selection",
+        "test_tool_usage_relational",
         "test_todos",
+        "test_external_benchmarks",
     ],
-    "followup_quality": ["test_followup_quality"],
-    "external_benchmarks": ["test_external_benchmarks"],
-    "tau2_airline": ["test_tau2_airline"],
-    "memory_agent_bench": ["test_memory_agent_bench"],
+    "memory": ["test_memory", "test_memory_multiturn", "test_memory_agent_bench"],
+    "conversation": ["test_followup_quality", "test_tau2_airline"],
+    "summarization": ["test_summarization"],
+    "unit_test": [
+        "test_system_prompt",
+        "test_hitl",
+        "test_subagents",
+        "test_skills",
+    ],
 }
 
 
 def test_all_categories_have_labels():
-    for cat in EVAL_CATEGORIES:
+    for cat in ALL_CATEGORIES:
         assert cat in CATEGORY_LABELS, f"Missing label for category {cat!r}"
 
 
 def test_all_labeled_categories_are_registered():
     for cat in CATEGORY_LABELS:
-        assert cat in EVAL_CATEGORIES, f"Label defined for unregistered category {cat!r}"
+        assert cat in ALL_CATEGORIES, f"Label defined for unregistered category {cat!r}"
 
 
-def test_expected_categories_match_eval_categories():
-    assert set(EXPECTED_CATEGORY_MODULES.keys()) == set(EVAL_CATEGORIES)
+def test_expected_categories_match_all_categories():
+    assert set(EXPECTED_CATEGORY_MODULES.keys()) == set(ALL_CATEGORIES)
+
+
+def test_radar_categories_are_subset_of_all():
+    assert set(EVAL_CATEGORIES) <= set(ALL_CATEGORIES)
+
+
+def test_unit_test_excluded_from_radar():
+    assert "unit_test" not in EVAL_CATEGORIES
+
+
+def _is_eval_category_call(node: object) -> str | None:
+    """Return the category name if *node* is a ``pytest.mark.eval_category("name")`` call, else ``None``."""
+    import ast
+
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "eval_category"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+    ):
+        return None
+    return str(node.args[0].value)
 
 
 def test_expected_modules_match_filesystem():
-    """Discover pytestmark assignments on disk and assert they match `EXPECTED_CATEGORY_MODULES`.
+    """Discover eval_category markers on disk and assert they match `EXPECTED_CATEGORY_MODULES`.
 
-    Prevents drift when a new eval test file is added but `EXPECTED_CATEGORY_MODULES`
-    is not updated.
+    Scans both module-level ``pytestmark`` assignments and per-function
+    ``@pytest.mark.eval_category(...)`` decorators so that files with
+    mixed per-function categories (e.g. test_external_benchmarks,
+    test_file_operations) are detected correctly.
     """
     import ast
     from pathlib import Path
@@ -59,27 +85,27 @@ def test_expected_modules_match_filesystem():
     evals_dir = Path(__file__).resolve().parent.parent / "evals"
     discovered: dict[str, set[str]] = {}
 
+    def _record(cat: str, stem: str) -> None:
+        discovered.setdefault(cat, set()).add(stem)
+
     for path in sorted(evals_dir.rglob("test_*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.iter_child_nodes(tree):
-            if not isinstance(node, ast.Assign):
-                continue
-            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
-            if "pytestmark" not in targets:
-                continue
-            # Extract category strings from pytest.mark.eval_category("...")
-            for elt in ast.walk(node.value):
-                if (
-                    isinstance(elt, ast.Call)
-                    and isinstance(elt.func, ast.Attribute)
-                    and elt.func.attr == "eval_category"
-                    and elt.args
-                    and isinstance(elt.args[0], ast.Constant)
-                ):
-                    cat = str(elt.args[0].value)
-                    if cat not in discovered:
-                        discovered[cat] = set()
-                    discovered[cat].add(path.stem)
+            # Module-level pytestmark = [pytest.mark.eval_category("...")]
+            if isinstance(node, ast.Assign):
+                targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+                if "pytestmark" in targets:
+                    for elt in ast.walk(node.value):
+                        cat = _is_eval_category_call(elt)
+                        if cat:
+                            _record(cat, path.stem)
+
+            # Function-level decorator: @pytest.mark.eval_category("...")
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                for decorator in node.decorator_list:
+                    cat = _is_eval_category_call(decorator)
+                    if cat:
+                        _record(cat, path.stem)
 
     # Compare as sets so insertion order in EXPECTED_CATEGORY_MODULES doesn't matter.
     expected = {cat: set(modules) for cat, modules in EXPECTED_CATEGORY_MODULES.items()}
@@ -103,15 +129,15 @@ def test_category_scores_computation():
     try:
         _CATEGORY_RESULTS.clear()
         _CATEGORY_RESULTS["memory"] = {"passed": 3, "failed": 1, "total": 4}
-        _CATEGORY_RESULTS["hitl"] = {"passed": 5, "failed": 0, "total": 5}
-        _CATEGORY_RESULTS["tool_usage"] = {"passed": 0, "failed": 2, "total": 2}
+        _CATEGORY_RESULTS["unit_test"] = {"passed": 5, "failed": 0, "total": 5}
+        _CATEGORY_RESULTS["tool_use"] = {"passed": 0, "failed": 2, "total": 2}
 
         scores: dict[str, float] = {}
         for cat, counts in sorted(_CATEGORY_RESULTS.items()):
             if counts["total"] > 0:
                 scores[cat] = round(counts["passed"] / counts["total"], 2)
 
-        assert scores == {"hitl": 1.0, "memory": 0.75, "tool_usage": 0.0}
+        assert scores == {"memory": 0.75, "tool_use": 0.0, "unit_test": 1.0}
     finally:
         _CATEGORY_RESULTS.clear()
         _CATEGORY_RESULTS.update(original)
@@ -128,7 +154,7 @@ def test_load_results_with_category_scores(tmp_path):
     data = [
         {
             "model": "test:model-a",
-            "category_scores": {"memory": 0.90, "hitl": 0.80},
+            "category_scores": {"memory": 0.90, "tool_use": 0.80},
         },
     ]
     path = tmp_path / "summary.json"
@@ -136,7 +162,7 @@ def test_load_results_with_category_scores(tmp_path):
 
     results = load_results_from_summary(path)
     assert len(results) == 1
-    assert results[0].scores == {"memory": 0.90, "hitl": 0.80}
+    assert results[0].scores == {"memory": 0.90, "tool_use": 0.80}
 
 
 def test_load_results_missing_category_scores_raises(tmp_path):

--- a/libs/evals/tests/unit_tests/test_radar.py
+++ b/libs/evals/tests/unit_tests/test_radar.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from deepagents_evals.radar import (
+    ALL_CATEGORIES,
     CATEGORY_LABELS,
     EVAL_CATEGORIES,
     ModelResult,
@@ -30,7 +31,7 @@ def test_toy_data_covers_all_categories():
 
 
 def test_category_labels_cover_all_categories():
-    assert set(CATEGORY_LABELS.keys()) == set(EVAL_CATEGORIES)
+    assert set(CATEGORY_LABELS.keys()) == set(ALL_CATEGORIES)
 
 
 def test_short_model_name_strips_provider():


### PR DESCRIPTION
Retag all evals to reflect what they measure rather than where they came from.

Categories (6 radar axes + 1 non-radar):
- file_operations: file read/write/edit/parallelize/paginate
- retrieval: grep/glob/search + FRAMES multi-hop doc synthesis
- tool_use: tool selection, relational chaining, todos, BFCL, NEXUS
- memory: recall, preference extraction, MemoryAgentBench
- conversation: followup quality + tau2 multi-turn
- summarization: context overflow handling
- unit_test: SDK plumbing (hitl, subagents, system_prompt, skills) — excluded from radar