### PR TITLE
docs(evals): add module and function docstrings to all eval test files

### DIFF
--- a/libs/evals/tests/evals/test_external_benchmarks.py
+++ b/libs/evals/tests/evals/test_external_benchmarks.py
@@ -1,3 +1,13 @@
+"""Eval tests drawn from curated external benchmarks.
+
+Runs a focused hard-set of 15 cases across three public benchmarks:
+- FRAMES: multi-hop retrieval with arithmetic/temporal reasoning
+- Nexus: deeply nested function composition (depth 4-6)
+- BFCL v3: multi-turn stateful tool calling across API domains
+
+Each benchmark's runner and scoring logic lives in external_benchmarks.py.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -1,3 +1,12 @@
+"""Eval tests for file operations and tool efficiency.
+
+Tests whether the agent can correctly use the built-in file tool surface
+(read, write, edit, ls, grep, glob) including parallel invocation,
+pagination recovery for large files, and avoiding unnecessary tool calls.
+
+Written internally for the deepagents eval suite.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/libs/evals/tests/evals/test_hitl.py
+++ b/libs/evals/tests/evals/test_hitl.py
@@ -1,3 +1,12 @@
+"""Unit tests for human-in-the-loop interrupt configuration.
+
+Verifies that the agent's interrupt_on config correctly pauses execution
+for approval, respects per-tool approval/rejection settings, and
+propagates interrupt config through subagent delegation.
+
+These are SDK integration tests, not model capability evals.
+"""
+
 from __future__ import annotations
 
 import uuid

--- a/libs/evals/tests/evals/test_memory.py
+++ b/libs/evals/tests/evals/test_memory.py
@@ -1,3 +1,13 @@
+"""Eval tests for memory recall and persistence.
+
+Tests whether the agent can load context from seeded memory files,
+use that context to guide behavior (naming conventions, code style),
+handle missing memory files gracefully, and correctly distinguish
+durable preferences from transient information.
+
+Written internally for the deepagents eval suite.
+"""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/libs/evals/tests/evals/test_skills.py
+++ b/libs/evals/tests/evals/test_skills.py
@@ -1,3 +1,12 @@
+"""Unit tests for skill discovery and execution.
+
+Verifies that the agent can discover skill files via configured skill
+paths, read SKILL.md content, select the correct skill by name,
+combine information from multiple skills, and edit skill files.
+
+These are SDK integration tests, not model capability evals.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/libs/evals/tests/evals/test_subagents.py
+++ b/libs/evals/tests/evals/test_subagents.py
@@ -1,3 +1,11 @@
+"""Unit tests for subagent delegation via the task tool.
+
+Verifies that the agent can delegate to named subagents and the
+general-purpose subagent via the task tool.
+
+These are SDK integration tests, not model capability evals.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/libs/evals/tests/evals/test_summarization.py
+++ b/libs/evals/tests/evals/test_summarization.py
@@ -1,3 +1,13 @@
+"""Eval tests for context overflow and summarization behavior.
+
+Tests whether the agent handles large files that exceed the context window
+by triggering summarization middleware, offloading conversation history
+to the filesystem, recovering information via needle-in-the-haystack
+follow-ups, and using the compact_conversation tool appropriately.
+
+Written internally for the deepagents eval suite.
+"""
+
 import json
 import re
 import uuid
@@ -230,6 +240,7 @@ def _load_seed_messages() -> list[AnyMessage]:
 
 @pytest.mark.langsmith
 def test_compact_tool_new_task(tmp_path: Path, model: BaseChatModel) -> None:
+    """Agent calls compact_conversation when switching to an unrelated task after a long conversation."""
     agent, _, _ = _setup_summarization_test(tmp_path, model, 35_000, include_compact_tool=True)
 
     seed = _load_seed_messages()
@@ -244,6 +255,7 @@ def test_compact_tool_new_task(tmp_path: Path, model: BaseChatModel) -> None:
 
 @pytest.mark.langsmith
 def test_compact_tool_not_overly_sensitive(tmp_path: Path, model: BaseChatModel) -> None:
+    """Agent does NOT call compact_conversation for a follow-up question related to the prior conversation."""
     agent, _, _ = _setup_summarization_test(tmp_path, model, 35_000, include_compact_tool=True)
 
     seed = _load_seed_messages()
@@ -258,6 +270,7 @@ def test_compact_tool_not_overly_sensitive(tmp_path: Path, model: BaseChatModel)
 
 @pytest.mark.langsmith
 def test_compact_tool_large_reads(tmp_path: Path, model: BaseChatModel) -> None:
+    """Agent calls compact_conversation when asked to read another large file after a long conversation."""
     another_large_file = "https://raw.githubusercontent.com/langchain-ai/deepagents/5c90376c02754c67d448908e55d1e953f54b8acd/libs/deepagents/deepagents/middleware/filesystem.py"
 
     response = requests.get(another_large_file, timeout=30)

--- a/libs/evals/tests/evals/test_system_prompt.py
+++ b/libs/evals/tests/evals/test_system_prompt.py
@@ -1,3 +1,10 @@
+"""Unit test for system prompt passthrough.
+
+Verifies that a custom system prompt provided via create_deep_agent
+is reflected in the agent's response. This is an SDK integration test,
+not a model capability eval.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/libs/evals/tests/evals/test_todos.py
+++ b/libs/evals/tests/evals/test_todos.py
@@ -1,3 +1,11 @@
+"""Eval tests for stateful sequential tool use.
+
+Tests whether the agent can create and incrementally update a todo list
+across multiple sequential tool calls, maintaining correct state at each step.
+
+Written internally for the deepagents eval suite.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING


### PR DESCRIPTION
Add module-level docstrings to 8 eval files that were missing them, and function-level docstrings to 3 summarization tests that lacked them.
Every eval test file now documents what capability area it covers, provenance (internal vs ported vs external benchmark), and whether it's a model capability eval or an SDK integration test.