### PR TITLE
docs(evals): fix stale category references

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -100,7 +100,7 @@ on:
         default: ""
         type: string
       eval_categories:
-        description: "Comma-separated eval categories to run (e.g. 'memory,hitl,tool_usage'). Categories defined in libs/evals/deepagents_evals/categories.json. Leave empty to run all."
+        description: "Comma-separated eval categories to run (e.g. 'memory,tool_use,retrieval'). Categories defined in libs/evals/deepagents_evals/categories.json. Leave empty to run all."
         required: false
         default: ""
         type: string

--- a/libs/evals/README.md
+++ b/libs/evals/README.md
@@ -65,22 +65,23 @@ scorer = (
 
 ### Test suites
 
-| File | What it evaluates |
-|---|---|
-| `test_file_operations.py` | File tool usage (read/write/edit/ls/grep/glob), parallel reads & writes, seeded file state |
-| `test_skills.py` | Skill discovery, reading, and application from `SKILL.md` files |
-| `test_hitl.py` | Human-in-the-loop via `interrupt_on` approvals, subagent HITL, custom interrupt configs |
-| `test_memory.py` | Memory recall and behavior guidance from `AGENTS.md` files, preference persistence, composite backends |
-| `test_memory_multiturn.py` | Multi-turn memory: implicit preference extraction, explicit remember instructions, transient info filtering |
-| `test_summarization.py` | Summarization middleware triggers, post-summarization task continuation, history offload to filesystem |
-| `test_subagents.py` | Subagent delegation behavior |
-| `test_system_prompt.py` | System prompt adherence |
-| `test_tool_usage_relational.py` | Multi-step tool chaining with dependent data lookups (user -> location -> weather) |
-| `test_tool_selection.py` | Picking the right tool from intent (direct, indirect, multi-step) with independent mock tools |
-| `test_followup_quality.py` | Followup question relevance for underspecified requests (LLM judge) |
-| `test_external_benchmarks.py` | Curated hard cases from FRAMES (multi-hop retrieval), Nexus (nested function composition), and BFCL v3 (multi-turn stateful tool calling) |
-| `memory_agent_bench/test_memory_agent_bench.py` | MemoryAgentBench (ICLR 2026): long-context memory recall and QA over chunked context |
-| `tau2_airline/test_tau2_airline.py` | [tau2-bench](https://github.com/sierra-research/tau-bench) airline tasks: multi-turn agent-user conversations scored on DB state accuracy and communicate info |
+| File | Category | What it evaluates |
+|---|---|---|
+| `test_file_operations.py` | `file_operations`, `retrieval` | File tool usage (read/write/edit/ls), parallel reads & writes, grep/glob search, seeded file state |
+| `test_tool_selection.py` | `tool_use` | Picking the right tool from intent (direct, indirect, multi-step) with independent mock tools |
+| `test_tool_usage_relational.py` | `tool_use` | Multi-step tool chaining with dependent data lookups (user -> location -> weather) |
+| `test_todos.py` | `tool_use` | Todo list tool usage for task planning |
+| `test_external_benchmarks.py` | `retrieval`, `tool_use` | FRAMES (multi-hop retrieval), Nexus (nested function composition), BFCL v3 (multi-turn stateful tool calling) |
+| `test_memory.py` | `memory` | Memory recall and behavior guidance from `AGENTS.md` files, preference persistence, composite backends |
+| `test_memory_multiturn.py` | `memory` | Multi-turn memory: implicit preference extraction, explicit remember instructions, transient info filtering |
+| `memory_agent_bench/test_memory_agent_bench.py` | `memory` | MemoryAgentBench (ICLR 2026): long-context memory recall and QA over chunked context |
+| `test_followup_quality.py` | `conversation` | Followup question relevance for underspecified requests (LLM judge) |
+| `tau2_airline/test_tau2_airline.py` | `conversation` | [tau2-bench](https://github.com/sierra-research/tau-bench) airline tasks: multi-turn agent-user conversations scored on DB state accuracy and communicate info |
+| `test_summarization.py` | `summarization` | Summarization middleware triggers, post-summarization task continuation, history offload to filesystem |
+| `test_hitl.py` | `unit_test` | Human-in-the-loop via `interrupt_on` approvals, subagent HITL, custom interrupt configs |
+| `test_subagents.py` | `unit_test` | Subagent delegation behavior |
+| `test_system_prompt.py` | `unit_test` | System prompt adherence |
+| `test_skills.py` | `unit_test` | Skill discovery, reading, and application from `SKILL.md` files |
 
 ## Writing a new eval
 
@@ -184,8 +185,8 @@ python scripts/generate_radar.py --toy -o charts/radar.png
 
 ### Adding a new category
 
-1. Add the category name and label to `deepagents_evals/categories.json`
-2. Tag test(s) with `pytestmark = [pytest.mark.eval_category("your_category")]`
+1. Add the category name and label to `deepagents_evals/categories.json` — add it to `categories` (all), and also to `radar_categories` if it measures model capability (not SDK plumbing)
+2. Tag test(s) with `pytestmark = [pytest.mark.eval_category("your_category")]` for single-category files, or per-function `@pytest.mark.eval_category("your_category")` decorators for files with mixed categories
 3. Add the category to `EXPECTED_CATEGORY_MODULES` in `tests/unit_tests/test_category_tagging.py`
 4. Run `make test` — drift tests will catch any mismatch
 

--- a/libs/evals/deepagents_evals/radar.py
+++ b/libs/evals/deepagents_evals/radar.py
@@ -1,7 +1,7 @@
 """Radar chart generation for eval results.
 
 Produces per-model radar (spider) charts where each axis represents an
-eval category (e.g. file_operations, memory, hitl) and the radial position
+eval category (e.g. file_operations, memory, tool_use) and the radial position
 encodes the score (0-1 correctness).
 """
 

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -59,7 +59,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--eval-category",
         action="append",
         default=[],
-        help="Run only evals tagged with this category (repeatable). E.g. --eval-category memory --eval-category hitl",
+        help="Run only evals tagged with this category (repeatable). E.g. --eval-category memory --eval-category tool_use",
     )
     parser.addoption(
         "--openrouter-provider",


### PR DESCRIPTION
Follow-up to #2200 — that PR restructured eval categories from origin-based to capability-based names but left stale references to the old category names (`hitl`, `tool_usage`) in help strings, CI workflow descriptions, and the README test suite table.

## Changes
- Replace stale `hitl` and `tool_usage` examples with current category names (`tool_use`, `retrieval`) in the `--eval-category` help text in `conftest.py`, the `radar.py` module docstring, and the `evals.yml` workflow input description
- Rewrite the README test suite table: add a `Category` column showing current category assignments, reorder rows by category, and add the previously missing `test_todos.py` entry
- Update the "Adding a new category" guide to document the `radar_categories` vs `categories` distinction in `categories.json` and the per-function `@pytest.mark.eval_category(...)` decorator pattern for mixed-category files
