### PR TITLE
feat(evals): add frontier and fast model group presets

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -67,9 +67,11 @@ REGISTRY: tuple[Model, ...] = (
             {
                 "eval:set0",
                 "eval:set1",
+                "eval:fast",
                 "eval:anthropic",
                 "harbor:set0",
                 "harbor:set1",
+                "harbor:fast",
                 "harbor:anthropic",
             }
         ),
@@ -88,9 +90,11 @@ REGISTRY: tuple[Model, ...] = (
             {
                 "eval:set0",
                 "eval:set1",
+                "eval:frontier",
                 "eval:anthropic",
                 "harbor:set0",
                 "harbor:set1",
+                "harbor:frontier",
                 "harbor:anthropic",
             }
         ),
@@ -206,7 +210,14 @@ REGISTRY: tuple[Model, ...] = (
     Model(
         "google_genai:gemini-3-flash-preview",
         frozenset(
-            {"eval:set0", "eval:google_genai", "harbor:set0", "harbor:google_genai"}
+            {
+                "eval:set0",
+                "eval:fast",
+                "eval:google_genai",
+                "harbor:set0",
+                "harbor:fast",
+                "harbor:google_genai",
+            }
         ),
     ),
     Model(
@@ -215,9 +226,11 @@ REGISTRY: tuple[Model, ...] = (
             {
                 "eval:set0",
                 "eval:set1",
+                "eval:frontier",
                 "eval:google_genai",
                 "harbor:set0",
                 "harbor:set1",
+                "harbor:frontier",
                 "harbor:google_genai",
             }
         ),
@@ -361,9 +374,24 @@ REGISTRY: tuple[Model, ...] = (
             {
                 "eval:set0",
                 "eval:set1",
+                "eval:frontier",
                 "eval:openai",
                 "harbor:set0",
                 "harbor:set1",
+                "harbor:frontier",
+                "harbor:openai",
+            }
+        ),
+    ),
+    Model(
+        "openai:gpt-5.4-mini",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:fast",
+                "eval:openai",
+                "harbor:set0",
+                "harbor:fast",
                 "harbor:openai",
             }
         ),
@@ -412,6 +440,8 @@ _EVAL_PRESETS: dict[str, str | None] = {
     "set0": "eval:set0",
     "set1": "eval:set1",
     "set2": "eval:set2",
+    "frontier": "eval:frontier",
+    "fast": "eval:fast",
     "open": "eval:open",
     # -- Provider groups --
     "anthropic": "eval:anthropic",
@@ -432,6 +462,8 @@ _HARBOR_PRESETS: dict[str, str | None] = {
     "set0": "harbor:set0",
     "set1": "harbor:set1",
     "set2": "harbor:set2",
+    "frontier": "harbor:frontier",
+    "fast": "harbor:fast",
     "open": "harbor:open",
     # -- Provider groups --
     "anthropic": "harbor:anthropic",

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -35,6 +35,8 @@ on:
           - set0
           - set1
           - set2
+          - frontier
+          - fast
           - open
           - anthropic
           - baseten
@@ -91,6 +93,7 @@ on:
           - "openai:gpt-5.1-codex"
           - "openai:gpt-5.2-codex"
           - "openai:gpt-5.4"
+          - "openai:gpt-5.4-mini"
           - "openrouter:minimax/minimax-m2.7"
           - "openrouter:nvidia/nemotron-3-super-120b-a12b"
           - "xai:grok-4"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -14,6 +14,8 @@ on:
           - set0
           - set1
           - set2
+          - frontier
+          - fast
           - open
           - anthropic
           - baseten
@@ -70,6 +72,7 @@ on:
           - "openai:gpt-5.1-codex"
           - "openai:gpt-5.2-codex"
           - "openai:gpt-5.4"
+          - "openai:gpt-5.4-mini"
           - "openrouter:minimax/minimax-m2.7"
           - "openrouter:nvidia/nemotron-3-super-120b-a12b"
           - "xai:grok-4"


### PR DESCRIPTION
Add two new model group presets — `frontier` and `fast` — to the unified model registry. `frontier` targets the strongest reasoning models across providers (`claude-opus-4-6`, `gemini-3.1-pro-preview`, `gpt-5.4`), while `fast` targets high-throughput models optimized for speed (`claude-sonnet-4-6`, `gemini-3-flash-preview`, `gpt-5.4-mini`).

## Changes
- Add `eval:frontier` / `harbor:frontier` tags to `anthropic:claude-opus-4-6`, `google_genai:gemini-3.1-pro-preview`, and `openai:gpt-5.4` in `REGISTRY`
- Add `eval:fast` / `harbor:fast` tags to `anthropic:claude-sonnet-4-6`, `google_genai:gemini-3-flash-preview`, and a new `openai:gpt-5.4-mini` registry entry
- Register `frontier` and `fast` in both `_EVAL_PRESETS` and `_HARBOR_PRESETS`
- Add `frontier`, `fast`, and `openai:gpt-5.4-mini` to the workflow dispatch dropdown options in `evals.yml` and `harbor.yml`
