### PR TITLE
fix(evals): exclude `unit_test` category from radar chart

### DIFF
--- a/libs/evals/scripts/generate_radar.py
+++ b/libs/evals/scripts/generate_radar.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 from deepagents_evals.radar import (
+    ALL_CATEGORIES,
     EVAL_CATEGORIES,
     ModelResult,
     generate_individual_radars,
@@ -123,8 +124,11 @@ def main() -> None:
         sys.exit(0)
 
     # Preserve EVAL_CATEGORIES ordering for known categories, append unknown ones.
+    # Categories in ALL_CATEGORIES but not EVAL_CATEGORIES (e.g. unit_test)
+    # are intentionally excluded from radar charts.
     ordered = [c for c in EVAL_CATEGORIES if c in all_cats]
-    ordered.extend(sorted(all_cats - set(ordered)))
+    excluded = set(ALL_CATEGORIES) - set(EVAL_CATEGORIES)
+    ordered.extend(sorted(all_cats - set(ordered) - excluded))
 
     try:
         generate_radar(


### PR DESCRIPTION
The `generate_radar.py` script was adding `unit_test` back to the radar chart despite `categories.json` excluding it from `radar_categories`. The script collects all categories present in result scores, then appends any not already in the ordered list — treating `unit_test` as an "unknown" category rather than a known-excluded one.

## Changes
- Filter known-excluded categories (those in `ALL_CATEGORIES` but not `EVAL_CATEGORIES`) from the fallback append in `generate_radar.py:main()`, so `unit_test` scores no longer sneak onto the radar chart