### PR TITLE
fix(evals): prevent langsmith auto-capture of raw model fixtures

### DIFF
--- a/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py
+++ b/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py
@@ -58,6 +58,32 @@ def _log_feedback(*, key: str, value: object) -> None:
         t.log_feedback(key=key, value=value)
 
 
+def _log_clean_inputs(model: BaseChatModel, config: DatasetConfig) -> None:
+    """Override auto-captured inputs with clean metadata.
+
+    Must be called before any `pytest.skip()` to prevent
+    `@pytest.mark.langsmith` from serializing the raw `BaseChatModel`
+    fixture as the dataset example inputs.
+
+    Args:
+        model: The chat model under evaluation.
+        config: Dataset configuration for the current benchmark run.
+    """
+    with contextlib.suppress(Exception):
+        t.log_inputs(
+            {
+                "config": {
+                    "split": config.split,
+                    "source": config.source,
+                    "chunk_size": config.chunk_size,
+                    "max_samples": config.max_samples,
+                    "max_questions": config.max_questions,
+                },
+                "model": str(getattr(model, "model", None) or getattr(model, "model_name", "")),
+            }
+        )
+
+
 def _require_memory_agent_bench_dependencies() -> None:
     """Skip the test when optional benchmark dependencies are unavailable."""
     pytest.importorskip("datasets", reason="MemoryAgentBench evals require the `datasets` package.")
@@ -233,6 +259,7 @@ def test_conflict_resolution(model: BaseChatModel, config: DatasetConfig) -> Non
     when facts change or contradict previous statements. Includes both
     single-hop (direct update) and multi-hop (derived update) scenarios.
     """
+    _log_clean_inputs(model, config)
     _require_memory_agent_bench_dependencies()
     samples = load_benchmark_data(
         config.split,
@@ -261,6 +288,7 @@ def test_time_learning(model: BaseChatModel, config: DatasetConfig) -> None:
     Tests the agent's ability to learn new rules, patterns, or classification
     schemes from the context chunks and apply them to unseen examples.
     """
+    _log_clean_inputs(model, config)
     _require_memory_agent_bench_dependencies()
     samples = load_benchmark_data(
         config.split,
@@ -289,6 +317,7 @@ def test_memory_agent_bench_ci(model: BaseChatModel, config: DatasetConfig) -> N
     Includes the smallest Conflict Resolution configs (single-hop and
     multi-hop at 6k) and one Test-Time Learning config to keep cost low.
     """
+    _log_clean_inputs(model, config)
     _require_memory_agent_bench_dependencies()
     samples = load_benchmark_data(
         config.split,

--- a/libs/evals/tests/evals/tau2_airline/test_tau2_airline.py
+++ b/libs/evals/tests/evals/tau2_airline/test_tau2_airline.py
@@ -85,6 +85,14 @@ def test_tau2_airline(model: BaseChatModel, task_id: str) -> None:
         model: The agent's chat model (from --model CLI option).
         task_id: The tau2 task ID to run.
     """
+    # Immediately override @pytest.mark.langsmith auto-capture so the dataset
+    # example records clean metadata even if run_multi_turn() raises.
+    _clean_inputs = {
+        "task_id": task_id,
+        "model": str(getattr(model, "model", None) or getattr(model, "model_name", "")),
+    }
+    t.log_inputs(_clean_inputs)
+
     task = load_task(task_id)
     policy = load_policy()
 
@@ -121,6 +129,10 @@ def test_tau2_airline(model: BaseChatModel, task_id: str) -> None:
         tool_call_log=tool_log,
         max_turns=30,
     )
+
+    # Override per-turn t.log_inputs() calls from run_agent() inside
+    # run_multi_turn() with clean test-level metadata.
+    t.log_inputs(_clean_inputs)
 
     reward = evaluate_task(
         actual_db=db,


### PR DESCRIPTION
`@pytest.mark.langsmith` auto-captures test fixture values as LangSmith dataset inputs via `inspect.signature.bind_partial()`. When a test takes `model: BaseChatModel`, this serializes the full Pydantic model config into the dataset example. Tests that call `run_agent()` (from `tests.evals.utils`) as their first action are protected because `run_agent()` calls `t.log_inputs()` internally, replacing the auto-captured blob. Two test suites were vulnerable: tau2 (multi-turn loop calls `run_agent()` per turn but never set test-level inputs) and memory_agent_bench (can `pytest.skip()` before `run_agent()` ever runs).

## Changes
- Add `_log_clean_inputs()` helper to memory_agent_bench that calls `t.log_inputs()` with a clean `config` + `model` name dict, wrapped in `contextlib.suppress(Exception)` since these tests can run without LangSmith
- Call `_log_clean_inputs()` at the top of `test_conflict_resolution`, `test_time_learning`, and `test_memory_agent_bench_ci` — before `_require_memory_agent_bench_dependencies()` and the `pytest.skip()` on empty samples
- Add `t.log_inputs()` twice in `test_tau2_airline`: once before `run_multi_turn()` (safety net if it raises) and once after (overrides per-turn inputs from `run_agent()` with test-level `task_id` + `model`)
