### PR TITLE
chore(evals): remove duplicate models from set1

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -256,10 +256,8 @@ REGISTRY: tuple[Model, ...] = (
         "ollama:glm-5",
         frozenset(
             {
-                "eval:set1",
                 "eval:set2",
                 "eval:ollama",
-                "harbor:set1",
                 "harbor:set2",
                 "harbor:ollama",
             }
@@ -269,10 +267,8 @@ REGISTRY: tuple[Model, ...] = (
         "ollama:minimax-m2.5",
         frozenset(
             {
-                "eval:set1",
                 "eval:set2",
                 "eval:ollama",
-                "harbor:set1",
                 "harbor:set2",
                 "harbor:ollama",
             }


### PR DESCRIPTION
Remove duplicate model coverage from `set1` in the eval/harbor model registry. GLM-5 and MiniMax-M2.5 were each represented twice in `set1` — once via Baseten and once via Ollama. Since the Baseten-hosted variants already cover these models, the Ollama entries are redundant and waste CI minutes.