### PR TITLE
perf(cli): prewarm markdown stack and cache skill body render

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1400,6 +1400,19 @@ class DeepAgentsApp(App):
         except Exception:
             logger.warning("Could not prewarm third-party imports", exc_info=True)
 
+        # Markdown rendering stack — ~170 ms cold (textual._markdown pulls in
+        # markdown_it, pygments, linkify_it — 438 modules).  Hit on first
+        # SkillMessage compose() and first code-fence highlight.  Warming
+        # here makes the first expand/Ctrl+O instant.
+        import markdown_it  # noqa: F401
+        from pygments.lexers import get_lexer_by_name as _get_lexer
+        from textual.widgets import Markdown  # noqa: F401
+
+        # Instantiate the Python lexer to populate Pygments' internal
+        # lexer cache (~12 ms cold).  Python is the most common fence
+        # language in skill bodies.
+        _get_lexer("python")
+
         # Widgets deferred from app.py module level — a failure here indicates
         # a packaging or code bug (same as the block above), so we let
         # exceptions propagate.

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -384,6 +384,7 @@ class SkillMessage(Vertical):
         self._md_widget: Markdown | None = None
         self._hint_widget: Static | None = None
         self._deferred_expanded: bool = False
+        self._md_rendered: bool = False
 
     def compose(self) -> ComposeResult:
         """Compose the skill message layout.
@@ -456,7 +457,11 @@ class SkillMessage(Vertical):
             _show_timestamp_toast(self)
 
     def _update_body_display(self) -> None:
-        """Update the body display based on expanded state."""
+        """Update the body display based on expanded state.
+
+        Renders the markdown body at most once; subsequent toggles only flip
+        widget visibility to avoid the cost of re-parsing and re-highlighting.
+        """
         if not self._preview_widget or not self._md_widget or not self._hint_widget:
             return
 
@@ -472,7 +477,9 @@ class SkillMessage(Vertical):
 
         if self._expanded:
             self._preview_widget.display = False
-            self._md_widget.update(body)
+            if not self._md_rendered:
+                self._md_widget.update(body)
+                self._md_rendered = True
             self._md_widget.display = True
             self._hint_widget.update(
                 Content.styled("click or Ctrl+O to collapse", "dim italic")
@@ -497,7 +504,9 @@ class SkillMessage(Vertical):
             self._hint_widget.display = True
         else:
             self._preview_widget.display = False
-            self._md_widget.update(body)
+            if not self._md_rendered:
+                self._md_widget.update(body)
+                self._md_rendered = True
             self._md_widget.display = True
             self._hint_widget.display = False
 


### PR DESCRIPTION
Prewarm the markdown rendering stack (`markdown_it`, `pygments`, Textual's `Markdown` widget) during app startup so the first `SkillMessage` expand is instant instead of eating ~170 ms of cold-import time. The `SkillMessage` widget also now renders its markdown body at most once — subsequent expand/collapse toggles just flip `display` visibility, skipping redundant parse + highlight work.

## Changes
- Add `markdown_it`, `pygments`, and `textual.widgets.Markdown` to `_prewarm_deferred_imports` in `app.py`, including a warm instantiation of the Python lexer to seed Pygments' internal cache
- Gate `SkillMessage._update_body_display` behind a `_md_rendered` flag so `Markdown.update(body)` is called only on the first expand — re-collapses and re-expands toggle `display` without re-parsing