### PR TITLE
refactor(cli): unify file path header in approval widgets

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -454,12 +454,10 @@ def _format_write_file_description(
     """
     args = tool_call["args"]
     file_path = args.get("file_path", "unknown")
-    content = args.get("content", "")
 
     action = "Overwrite" if Path(file_path).exists() else "Create"
-    line_count = len(content.splitlines())
 
-    return f"File: {file_path}\nAction: {action} file\nLines: {line_count}"
+    return f"Action: {action} file"
 
 
 def _format_edit_file_description(
@@ -471,11 +469,10 @@ def _format_edit_file_description(
         Formatted description string for the edit_file tool call.
     """
     args = tool_call["args"]
-    file_path = args.get("file_path", "unknown")
     replace_all = bool(args.get("replace_all", False))
 
     scope = "all occurrences" if replace_all else "single occurrence"
-    return f"File: {file_path}\nAction: Replace text ({scope})"
+    return f"Action: Replace text ({scope})"
 
 
 def _format_web_search_description(

--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -107,11 +107,6 @@ Screen {
     height: auto;
 }
 
-.approval-file-path {
-    color: $primary;
-    text-style: bold;
-}
-
 .approval-description {
     color: $text-muted;
 }

--- a/libs/cli/deepagents_cli/widgets/tool_widgets.py
+++ b/libs/cli/deepagents_cli/widgets/tool_widgets.py
@@ -20,6 +20,80 @@ _MAX_DIFF_LINES = 50
 _MAX_PREVIEW_LINES = 20
 
 
+def _format_stats(additions: int, deletions: int) -> Content:
+    """Format addition/deletion stats as styled Content.
+
+    Args:
+        additions: Number of added lines.
+        deletions: Number of removed lines.
+
+    Returns:
+        Styled Content showing additions and deletions.
+    """
+    colors = theme.get_theme_colors()
+    parts: list[str | tuple[str, str] | Content] = []
+    if additions:
+        parts.append((f"+{additions}", colors.success))
+    if deletions:
+        if parts:
+            parts.append(" ")
+        parts.append((f"-{deletions}", colors.error))
+    return Content.assemble(*parts) if parts else Content("")
+
+
+def _file_header(
+    file_path: str, additions: int = 0, deletions: int = 0
+) -> ComposeResult:
+    """Yield the `File:` path header with optional `+N -M` stats.
+
+    Args:
+        file_path: Path to the file being modified.
+        additions: Number of added lines.
+        deletions: Number of removed lines.
+
+    Yields:
+        Static widgets for the file path header and a spacer line.
+    """
+    stats = _format_stats(additions, deletions)
+    yield Static(
+        Content.assemble(
+            Content.from_markup("[bold cyan]File:[/bold cyan] $path  ", path=file_path),
+            stats,
+        )
+    )
+    yield Static("")
+
+
+def _count_diff_stats(
+    diff_lines: list[str], old_string: str, new_string: str
+) -> tuple[int, int]:
+    """Count additions and deletions from diff data.
+
+    Args:
+        diff_lines: Unified diff output lines.
+        old_string: Original text being replaced (fallback when no diff).
+        new_string: Replacement text (fallback when no diff).
+
+    Returns:
+        Tuple of (additions count, deletions count).
+    """
+    if diff_lines:
+        additions = sum(
+            1
+            for line in diff_lines
+            if line.startswith("+") and not line.startswith("+++")
+        )
+        deletions = sum(
+            1
+            for line in diff_lines
+            if line.startswith("-") and not line.startswith("---")
+        )
+    else:
+        additions = new_string.count("\n") + 1 if new_string else 0
+        deletions = old_string.count("\n") + 1 if old_string else 0
+    return additions, deletions
+
+
 class ToolApprovalWidget(Vertical):
     """Base class for tool approval widgets."""
 
@@ -71,13 +145,12 @@ class WriteFileApprovalWidget(ToolApprovalWidget):
         content = self.data.get("content", "")
         file_extension = self.data.get("file_extension", "text")
 
-        # File path header
-        yield Static(f"File: {file_path}", markup=False, classes="approval-file-path")
-        yield Static("")
-
         # Content with syntax highlighting via Markdown code block
         lines = content.split("\n")
         total_lines = len(lines)
+
+        # File header with line count
+        yield from _file_header(file_path, additions=total_lines if content else 0)
 
         if total_lines > _MAX_LINES:
             # Truncate for display
@@ -105,20 +178,8 @@ class EditFileApprovalWidget(ToolApprovalWidget):
         old_string = self.data.get("old_string", "")
         new_string = self.data.get("new_string", "")
 
-        # Calculate stats first for header
-        additions, deletions = self._count_stats(diff_lines, old_string, new_string)
-
-        # File path header with stats
-        stats_str = self._format_stats(additions, deletions)
-        yield Static(
-            Content.assemble(
-                Content.from_markup(
-                    "[bold cyan]File:[/bold cyan] $path  ", path=file_path
-                ),
-                stats_str,
-            )
-        )
-        yield Static("")
+        additions, deletions = _count_diff_stats(diff_lines, old_string, new_string)
+        yield from _file_header(file_path, additions, deletions)
 
         if not diff_lines and not old_string and not new_string:
             yield Static("No changes to display", classes="approval-description")
@@ -127,50 +188,6 @@ class EditFileApprovalWidget(ToolApprovalWidget):
             yield from self._render_diff_lines_only(diff_lines)
         else:
             yield from self._render_strings_only(old_string, new_string)
-
-    @staticmethod
-    def _count_stats(
-        diff_lines: list[str], old_string: str, new_string: str
-    ) -> tuple[int, int]:
-        """Count additions and deletions from diff data.
-
-        Returns:
-            Tuple of (additions count, deletions count).
-        """
-        if diff_lines:
-            additions = sum(
-                1
-                for line in diff_lines
-                if line.startswith("+") and not line.startswith("+++")
-            )
-            deletions = sum(
-                1
-                for line in diff_lines
-                if line.startswith("-") and not line.startswith("---")
-            )
-        else:
-            additions = new_string.count("\n") + 1 if new_string else 0
-            deletions = old_string.count("\n") + 1 if old_string else 0
-        return additions, deletions
-
-    @staticmethod
-    def _format_stats(additions: int, deletions: int) -> Content:
-        """Format addition/deletion stats as styled Content.
-
-        Returns:
-            Styled Content showing additions and deletions.
-        """
-        colors = theme.get_theme_colors()
-        parts: list[str | tuple[str, str] | Content] = []
-        if additions:
-            if parts:
-                parts.append(" ")
-            parts.append((f"+{additions}", colors.success))
-        if deletions:
-            if parts:
-                parts.append(" ")
-            parts.append((f"-{deletions}", colors.error))
-        return Content.assemble(*parts) if parts else Content("")
 
     def _render_diff_lines_only(self, diff_lines: list[str]) -> ComposeResult:
         """Render unified diff lines without returning stats.

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -55,9 +55,8 @@ def test_format_write_file_description_create_new_file(tmp_path: Path) -> None:
         tool_call, cast("AgentState[Any]", None), cast("Runtime[Any]", None)
     )
 
-    assert f"File: {new_file}" in description
     assert "Action: Create file" in description
-    assert "Lines: 2" in description
+    assert "File:" not in description
 
 
 def test_format_write_file_description_overwrite_existing_file(tmp_path: Path) -> None:
@@ -81,9 +80,8 @@ def test_format_write_file_description_overwrite_existing_file(tmp_path: Path) -
         tool_call, cast("AgentState[Any]", None), cast("Runtime[Any]", None)
     )
 
-    assert f"File: {existing_file}" in description
     assert "Action: Overwrite file" in description
-    assert "Lines: 3" in description
+    assert "File:" not in description
 
 
 def test_format_edit_file_description_single_occurrence():
@@ -106,8 +104,8 @@ def test_format_edit_file_description_single_occurrence():
         tool_call, cast("AgentState[Any]", None), cast("Runtime[Any]", None)
     )
 
-    assert "File: /path/to/file.py" in description
     assert "Action: Replace text (single occurrence)" in description
+    assert "File:" not in description
 
 
 def test_format_edit_file_description_all_occurrences():
@@ -130,8 +128,8 @@ def test_format_edit_file_description_all_occurrences():
         tool_call, cast("AgentState[Any]", None), cast("Runtime[Any]", None)
     )
 
-    assert "File: /path/to/file.py" in description
     assert "Action: Replace text (all occurrences)" in description
+    assert "File:" not in description
 
 
 def test_format_web_search_description():


### PR DESCRIPTION
The `write_file` and `edit_file` approval widgets displayed file path information inconsistently — `write_file` used an unstyled plain-text header while `edit_file` had a styled `File:` header with `+N -M` diff stats. This PR:

- Extracts a shared `_file_header()` helper that renders a styled `File: <path>  +N -M` header consistently across both widgets
- Removes the redundant file path / line-count from the agent's plain-text description strings (it was duplicating what the widget already shows)
- Promotes `_format_stats()` and `_count_diff_stats()` from `EditFileApprovalWidget` static methods to module-level functions for reuse

<details>
<summary><code>write_file</code> — before</summary>

<img width="457" height="338" alt="before_write" src="https://github.com/user-attachments/assets/f106946f-ae96-498c-b142-eae6d252e0f9" />

</details>

<details>
<summary><code>write_file</code> — after</summary>

<img width="454" height="301" alt="after_write" src="https://github.com/user-attachments/assets/60e17f4d-f662-4969-b4d6-d8eb8512aa98" />

</details>

<details>
<summary><code>edit_file</code> — before</summary>

<img width="471" height="511" alt="before_edit" src="https://github.com/user-attachments/assets/062057a3-731b-4fa5-b2e6-14dfff08c416" />

</details>

<details>
<summary><code>edit_file</code> — after</summary>

<img width="473" height="500" alt="after_edit" src="https://github.com/user-attachments/assets/6b24b973-5c04-488b-8b5f-4000a5f71089" />

</details>