### PR TITLE
fix(cli): prevent session stats loss on mid-turn exit

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -689,6 +689,16 @@ class DeepAgentsApp(App):
         self._session_stats: SessionStats = SessionStats()
         """Cumulative usage stats across all turns in this session."""
 
+        self._inflight_turn_stats: SessionStats | None = None
+        """Stats for the currently executing turn.
+
+        Held here so `exit()` can merge them synchronously before the event loop
+        tears down (e.g. `Ctrl+D` during a pending tool call).
+        """
+
+        self._inflight_turn_start: float = 0.0
+        """Monotonic timestamp when the current turn started."""
+
         self._pending_messages: deque[QueuedMessage] = deque()
         """User message queue for sequential processing."""
 
@@ -3166,9 +3176,14 @@ class DeepAgentsApp(App):
             return
         from deepagents_cli.textual_adapter import execute_task_textual
 
-        turn_stats: SessionStats | None = None
+        # Create the stats object up-front and store on the app so
+        # exit() can merge it synchronously if the worker is cancelled
+        # before this method can return (e.g. Ctrl+D during HITL).
+        turn_stats = SessionStats()
+        self._inflight_turn_stats = turn_stats
+        self._inflight_turn_start = time.monotonic()
         try:
-            turn_stats = await execute_task_textual(
+            await execute_task_textual(
                 user_input=message,
                 agent=self._agent,
                 assistant_id=self._assistant_id,
@@ -3182,6 +3197,7 @@ class DeepAgentsApp(App):
                     model=self._model_override,
                     model_params=self._model_params_override or {},
                 ),
+                turn_stats=turn_stats,
             )
         except Exception as e:  # Resilient tool rendering
             logger.exception("Agent execution failed")
@@ -3196,12 +3212,15 @@ class DeepAgentsApp(App):
                     "Could not mount error message (app closing?)", exc_info=True
                 )
         finally:
-            # Clean up loading widget and agent state
+            # Merge turn stats before cleanup — _cleanup_agent_task may raise
+            # during teardown (widget removal on a torn-down DOM), and stats
+            # should ideally be captured regardless.
+            # exit() clears _inflight_turn_stats when it merges, so
+            # checking for None prevents double-counting.
+            if self._inflight_turn_stats is not None:
+                self._session_stats.merge(turn_stats)
+                self._inflight_turn_stats = None
             await self._cleanup_agent_task()
-
-        # Accumulate stats across all turns; printed once at session end
-        if isinstance(turn_stats, SessionStats):
-            self._session_stats.merge(turn_stats)
 
     async def _process_next_from_queue(self) -> None:
         """Process the next message from the queue if any exist.
@@ -4038,11 +4057,25 @@ class DeepAgentsApp(App):
             return_code: Exit code (non-zero for errors).
             message: Optional message to display on exit.
         """
+        # Merge in-flight turn stats before any cleanup that might raise.
+        # When the agent worker is cancelled (e.g. Ctrl+D during a pending tool
+        # call), the worker's finally block will see _inflight_turn_stats is
+        # already None and skip the merge.
+        inflight = self._inflight_turn_stats
+        if inflight is not None:
+            self._inflight_turn_stats = None
+            if not inflight.wall_time_seconds:
+                inflight.wall_time_seconds = (
+                    time.monotonic() - self._inflight_turn_start
+                )
+            self._session_stats.merge(inflight)
+
         # Discard queued messages so _cleanup_agent_task won't try to
         # process them after the event loop is torn down, and cancel
         # active workers so their subprocesses are terminated
         # (SIGTERM → SIGKILL) instead of being orphaned.
         self._discard_queue()
+
         if self._shell_running and self._shell_worker:
             self._shell_worker.cancel()
         if self._agent_running and self._agent_worker:

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -385,6 +385,7 @@ async def execute_task_textual(
     *,
     sandbox_type: str | None = None,
     message_kwargs: dict[str, Any] | None = None,
+    turn_stats: SessionStats | None = None,
 ) -> SessionStats:
     """Execute a task with output directed to Textual UI.
 
@@ -406,6 +407,12 @@ async def execute_task_textual(
         message_kwargs: Extra fields merged into the stream input message
             dict (e.g., `additional_kwargs` for persisting skill metadata
             in the checkpoint).
+        turn_stats: Pre-created `SessionStats` to accumulate into.
+
+            When the caller holds a reference to the same object, stats are
+            available even if this coroutine is cancelled before it can return.
+
+            If `None`, a new instance is created internally.
 
     Returns:
         Stats accumulated over this turn (request count, token counts,
@@ -469,7 +476,8 @@ async def execute_task_textual(
 
     captured_input_tokens = 0
     captured_output_tokens = 0
-    turn_stats = SessionStats()
+    if turn_stats is None:
+        turn_stats = SessionStats()
     start_time = time.monotonic()
 
     # Show spinner


### PR DESCRIPTION
Fix a race condition where session stats from the active agent turn are lost when the user exits mid-turn (e.g., `Ctrl+D` during a pending tool call). Previously, `execute_task_textual` created `SessionStats` internally and returned it — but if the worker was cancelled before returning, the stats were silently dropped. Now the caller owns the stats object from the start.