### PR TITLE
style(cli): add semantic skill and tool color tokens

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -765,8 +765,8 @@ class DeepAgentsApp(App):
 
         Most styling uses Textual's built-in variables (`$primary`,
         `$text-muted`, `$error-muted`, etc.).  This override injects the
-        few app-specific variables (`$mode-bash`, `$mode-command`) that
-        have no Textual equivalent.
+        app-specific variables (`$mode-bash`, `$mode-command`, `$skill`,
+        `$skill-hover`, `$tool`, `$tool-hover`) that have no Textual equivalent.
 
         Returns:
             Dict of CSS variable names to hex color values.

--- a/libs/cli/deepagents_cli/theme.py
+++ b/libs/cli/deepagents_cli/theme.py
@@ -5,8 +5,8 @@ Single source of truth for color values used in Python code (Rich markup,
 Textual CSS variables: built-in variables
 (`$primary`, `$background`, `$text-muted`, `$error-muted`, etc.) are set via
 `register_theme()` in `DeepAgentsApp.__init__`, while the few app-specific
-variables (`$mode-bash`, `$mode-command`) are backed by these constants via
-`App.get_theme_variable_defaults()`.
+variables (`$mode-bash`, `$mode-command`, `$skill`, `$skill-hover`, `$tool`,
+`$tool-hover`) are backed by these constants via `App.get_theme_variable_defaults()`.
 
 Code that needs custom CSS variable values should call
 `get_css_variable_defaults(dark=...)`. For the full semantic color palette, look
@@ -274,13 +274,13 @@ class ThemeColors:
     """Skill invocation accent — border and header text."""
 
     skill_hover: str
-    """Skill invocation hover — lighter variant for interactive feedback."""
+    """Skill invocation hover — contrasting variant for interactive feedback."""
 
     tool: str
     """Tool call accent — border and header text."""
 
     tool_hover: str
-    """Tool call hover — lighter variant for interactive feedback."""
+    """Tool call hover — contrasting variant for interactive feedback."""
 
     foreground: str
     """Primary body text."""
@@ -715,16 +715,11 @@ def _colors_from_textual_theme(app: object) -> ThemeColors:
     base = DARK_COLORS if dark else LIGHT_COLORS
 
     def _hex_or(val: str | None, fallback: str) -> str:
-        """Use the Textual theme value when it is a hex color, else fall back.
-
-        Textual built-in themes (e.g. ANSI) may return non-hex color names
-        like `ansi_blue` that our `ThemeColors` dataclass rejects. This helper
-        detects those and substitutes the base-palette fallback so every field
-        is always a valid `#RRGGBB` string.
+        """Return `val` if it is a valid `#RRGGBB` hex color, else `fallback`.
 
         Args:
-            val: Color string from the active Textual theme (may be None or a
-                non-hex name like `ansi_blue`).
+            val: Color string from the active Textual theme (may be `None` or
+                a non-hex name like `ansi_blue`).
             fallback: Guaranteed-hex value from our base palette.
 
         Returns:
@@ -748,8 +743,10 @@ def _colors_from_textual_theme(app: object) -> ThemeColors:
         # No Textual equivalent — always use base palette.
         skill=base.skill,
         skill_hover=base.skill_hover,
-        # Derived from warning (same semantic color).
+        # Derived from Textual's warning color (shared amber hue).
         tool=_hex_or(ct.warning, base.tool),
+        # No Textual equivalent — always base palette (may diverge from
+        # tool in custom themes that override warning).
         tool_hover=base.tool_hover,
         foreground=_hex_or(ct.foreground, base.foreground),
         background=_hex_or(ct.background, base.background),

--- a/libs/cli/deepagents_cli/theme.py
+++ b/libs/cli/deepagents_cli/theme.py
@@ -67,9 +67,6 @@ LC_AMBER = "#EB8B46"
 LC_PINK = "#F7768E"
 """Error / destructive actions."""
 
-LC_ORANGE = "#FF9E64"
-"""Dev install indicator / warm accent."""
-
 LC_MUTED = "#545C7E"
 """Muted / secondary text."""
 
@@ -81,6 +78,18 @@ LC_PINK_BG = "#2A1F32"
 
 LC_PANEL = "#25283B"
 """Panel — differentiated section background (above surface)."""
+
+LC_SKILL = "#A78BFA"
+"""Skill invocation accent — border and header text."""
+
+LC_SKILL_HOVER = "#C4B5FD"
+"""Skill invocation hover — lighter variant for interactive feedback."""
+
+LC_TOOL = LC_AMBER
+"""Tool call accent — border and header text."""
+
+LC_TOOL_HOVER = "#FFCB91"
+"""Tool call hover — lighter variant for interactive feedback."""
 
 
 # ---------------------------------------------------------------------------
@@ -116,9 +125,6 @@ LC_LIGHT_AMBER = "#B45309"
 LC_LIGHT_PINK = "#BE185D"
 """Error / destructive (darkened for light bg contrast)."""
 
-LC_LIGHT_ORANGE = "#C2410C"
-"""Dev install indicator (darkened for light bg contrast)."""
-
 LC_LIGHT_MUTED = "#6B7280"
 """Muted / secondary text on light backgrounds."""
 
@@ -130,6 +136,18 @@ LC_LIGHT_PINK_BG = "#FEE2E2"
 
 LC_LIGHT_PANEL = "#E0E1E6"
 """Panel for light theme — differentiated section background."""
+
+LC_LIGHT_SKILL = "#7C3AED"
+"""Skill invocation accent (darkened for light bg contrast)."""
+
+LC_LIGHT_SKILL_HOVER = "#6D28D9"
+"""Skill invocation hover (darkened for light bg contrast)."""
+
+LC_LIGHT_TOOL = LC_LIGHT_AMBER
+"""Tool call accent (darkened for light bg contrast)."""
+
+LC_LIGHT_TOOL_HOVER = "#78350F"
+"""Tool call hover (darkened for light bg contrast)."""
 
 
 # ---------------------------------------------------------------------------
@@ -225,9 +243,6 @@ class ThemeColors:
     primary: str
     """Accent for headings, borders, links, and active elements."""
 
-    primary_dev: str
-    """Accent used when running from an editable (dev) install."""
-
     secondary: str
     """Secondary accent for badges, labels, and decorative highlights."""
 
@@ -254,6 +269,18 @@ class ThemeColors:
 
     mode_command: str
     """Command mode indicator — borders, prompts, and message prefixes."""
+
+    skill: str
+    """Skill invocation accent — border and header text."""
+
+    skill_hover: str
+    """Skill invocation hover — lighter variant for interactive feedback."""
+
+    tool: str
+    """Tool call accent — border and header text."""
+
+    tool_hover: str
+    """Tool call hover — lighter variant for interactive feedback."""
 
     foreground: str
     """Primary body text."""
@@ -307,7 +334,6 @@ class ThemeColors:
 
 DARK_COLORS = ThemeColors(
     primary=LC_BLUE,
-    primary_dev=LC_ORANGE,
     secondary=LC_PURPLE,
     accent=LC_GREEN,
     panel=LC_PANEL,
@@ -317,6 +343,10 @@ DARK_COLORS = ThemeColors(
     muted=LC_MUTED,
     mode_bash=LC_PINK,
     mode_command=LC_PURPLE,
+    skill=LC_SKILL,
+    skill_hover=LC_SKILL_HOVER,
+    tool=LC_TOOL,
+    tool_hover=LC_TOOL_HOVER,
     foreground=LC_BODY,
     background=LC_DARK,
     surface=LC_CARD,
@@ -325,7 +355,6 @@ DARK_COLORS = ThemeColors(
 
 LIGHT_COLORS = ThemeColors(
     primary=LC_LIGHT_BLUE,
-    primary_dev=LC_LIGHT_ORANGE,
     secondary=LC_LIGHT_PURPLE,
     accent=LC_LIGHT_GREEN,
     panel=LC_LIGHT_PANEL,
@@ -335,6 +364,10 @@ LIGHT_COLORS = ThemeColors(
     muted=LC_LIGHT_MUTED,
     mode_bash=LC_LIGHT_PINK,
     mode_command=LC_LIGHT_PURPLE,
+    skill=LC_LIGHT_SKILL,
+    skill_hover=LC_LIGHT_SKILL_HOVER,
+    tool=LC_LIGHT_TOOL,
+    tool_hover=LC_LIGHT_TOOL_HOVER,
     foreground=LC_LIGHT_BODY,
     background=LC_LIGHT_BG,
     surface=LC_LIGHT_SURFACE,
@@ -636,6 +669,10 @@ def get_css_variable_defaults(
     return {
         "mode-bash": c.mode_bash,
         "mode-command": c.mode_command,
+        "skill": c.skill,
+        "skill-hover": c.skill_hover,
+        "tool": c.tool,
+        "tool-hover": c.tool_hover,
     }
 
 
@@ -659,8 +696,8 @@ def _colors_from_textual_theme(app: object) -> ThemeColors:
     """Construct `ThemeColors` from the app's active Textual theme.
 
     Reads standard properties (primary, secondary, etc.) from the resolved
-    theme so Python-side styling matches CSS.  `muted` and `primary_dev` fall
-    back to the dark/light base unconditionally (no Textual equivalent).
+    theme so Python-side styling matches CSS.  `muted` falls back to the
+    dark/light base unconditionally (no Textual equivalent).
     `mode_bash` is derived from the theme's `error` color, and `mode_command`
     from `secondary`, falling back to the base palette when non-hex.
 
@@ -678,14 +715,27 @@ def _colors_from_textual_theme(app: object) -> ThemeColors:
     base = DARK_COLORS if dark else LIGHT_COLORS
 
     def _hex_or(val: str | None, fallback: str) -> str:
-        """Return *val* if it is a valid 7-char hex color, else *fallback*."""
+        """Use the Textual theme value when it is a hex color, else fall back.
+
+        Textual built-in themes (e.g. ANSI) may return non-hex color names
+        like `ansi_blue` that our `ThemeColors` dataclass rejects. This helper
+        detects those and substitutes the base-palette fallback so every field
+        is always a valid `#RRGGBB` string.
+
+        Args:
+            val: Color string from the active Textual theme (may be None or a
+                non-hex name like `ansi_blue`).
+            fallback: Guaranteed-hex value from our base palette.
+
+        Returns:
+            `val` if it matches `#RRGGBB`, otherwise `fallback`.
+        """
         if val is not None and _HEX_RE.match(val):
             return val
         return fallback
 
     return ThemeColors(
         primary=_hex_or(ct.primary, base.primary),
-        primary_dev=base.primary_dev,
         secondary=_hex_or(ct.secondary, base.secondary),
         accent=_hex_or(ct.accent, base.accent),
         panel=_hex_or(ct.panel, base.panel),
@@ -695,6 +745,12 @@ def _colors_from_textual_theme(app: object) -> ThemeColors:
         muted=base.muted,
         mode_bash=_hex_or(ct.error, base.mode_bash),
         mode_command=_hex_or(ct.secondary, base.mode_command),
+        # No Textual equivalent — always use base palette.
+        skill=base.skill,
+        skill_hover=base.skill_hover,
+        # Derived from warning (same semantic color).
+        tool=_hex_or(ct.warning, base.tool),
+        tool_hover=base.tool_hover,
         foreground=_hex_or(ct.foreground, base.foreground),
         background=_hex_or(ct.background, base.background),
         surface=_hex_or(ct.surface, base.surface),

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -11,8 +11,11 @@ from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any
 
+from textual import on
 from textual.containers import Vertical
 from textual.content import Content
+from textual.events import Click
+from textual.reactive import var
 from textual.widgets import Static
 
 from deepagents_cli import theme
@@ -29,7 +32,6 @@ from deepagents_cli.widgets.diff import compose_diff_lines
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
-    from textual.events import Click
     from textual.timer import Timer
     from textual.widgets import Markdown
     from textual.widgets._markdown import MarkdownStream
@@ -296,15 +298,22 @@ def _strip_frontmatter(text: str) -> str:
     return stripped[after:].lstrip("\n")
 
 
+class _SkillToggle(Static):
+    """Clickable header/hint area for toggling skill body expansion."""
+
+
 class SkillMessage(Vertical):
     """Widget displaying a skill invocation with collapsible body.
 
     Shows skill name, source badge, description, and user args as a compact
     header. The full SKILL.md body (frontmatter stripped) is hidden behind a
     preview/expand toggle (click or Ctrl+O).  The expanded view renders
-    markdown via Rich's `Markdown` inside a single `Static` widget to avoid
-    the deep DOM tree that Textual's `Markdown` widget creates (which makes
-    click-driven toggles expensive due to hit-testing and reflow).
+    markdown via Rich's `Markdown` inside a single `Static` widget.
+
+    Visibility is driven by a CSS class (`-expanded`) toggled via a Textual
+    reactive `var`. Click handlers are scoped to the header and hint widgets
+    (`_SkillToggle`) so clicks never hit the content body, avoiding expensive
+    DOM hit-testing.
     """
 
     DEFAULT_CSS = """
@@ -330,21 +339,20 @@ class SkillMessage(Vertical):
         margin-top: 0;
     }
 
-    SkillMessage .skill-body-preview {
-        margin-left: 3;
-        margin-top: 0;
-        color: #6b7280;
-    }
-
     SkillMessage #skill-md {
         margin-left: 3;
         margin-top: 0;
         padding: 0;
+        display: none;
     }
 
     SkillMessage .skill-hint {
         margin-left: 3;
         color: #6b7280;
+    }
+
+    SkillMessage.-expanded #skill-md {
+        display: block;
     }
 
     SkillMessage:hover {
@@ -354,6 +362,8 @@ class SkillMessage(Vertical):
 
     _PREVIEW_LINES = 4
     _PREVIEW_CHARS = 300
+
+    _expanded: var[bool] = var(False, toggle_class="-expanded")
 
     def __init__(
         self,
@@ -381,10 +391,8 @@ class SkillMessage(Vertical):
         self._body = body
         self._stripped_body = _strip_frontmatter(body)
         self._args = args
-        self._expanded: bool = False
-        self._preview_widget: Static | None = None
         self._md_widget: Static | None = None
-        self._hint_widget: Static | None = None
+        self._hint_widget: _SkillToggle | None = None
         self._deferred_expanded: bool = False
         self._md_rendered: bool = False
 
@@ -395,7 +403,7 @@ class SkillMessage(Vertical):
             Widgets for header, description, args, and collapsible body.
         """
         source_tag = f" [{self._source}]" if self._source else ""
-        yield Static(
+        yield _SkillToggle(
             Content.from_markup(
                 "[bold #a78bfa]$label[/bold #a78bfa]",
                 label=f"/skill:{self._skill_name}{source_tag}",
@@ -415,52 +423,58 @@ class SkillMessage(Vertical):
                 ),
                 classes="skill-args",
             )
-        yield Static("", classes="skill-body-preview", id="skill-preview")
-        # Single Static widget instead of Textual Markdown — avoids the deep
-        # DOM tree that makes click-to-toggle expensive (hit-test + reflow).
         yield Static("", id="skill-md")
-        yield Static("", classes="skill-hint", id="skill-hint")
+        yield _SkillToggle("", classes="skill-hint", id="skill-hint")
 
     def on_mount(self) -> None:
-        """Cache widget references and set initial display state."""
+        """Cache widget references, render initial state."""
         if is_ascii_mode():
             self.styles.border_left = ("ascii", "#a78bfa")
 
-        self._preview_widget = self.query_one("#skill-preview", Static)
         self._md_widget = self.query_one("#skill-md", Static)
-        self._hint_widget = self.query_one("#skill-hint", Static)
+        self._hint_widget = self.query_one("#skill-hint", _SkillToggle)
 
-        self._preview_widget.display = False
-        self._md_widget.display = False
-        self._hint_widget.display = False
+        body = self._stripped_body.strip()
+        if body:
+            self._prepare_body(body)
 
         if self._deferred_expanded:
             self._expanded = self._deferred_expanded
             self._deferred_expanded = False
 
-        if self._stripped_body.strip():
-            self._update_body_display()
-
-    def toggle_body(self) -> None:
-        """Toggle between preview and full body display."""
-        if not self._stripped_body.strip():
-            return
-        self._expanded = not self._expanded
-        self._update_body_display()
-
-    def on_click(self, event: Click) -> None:
-        """Toggle body expansion, or show timestamp if no body."""
-        event.stop()
-        if self._stripped_body.strip():
-            self.toggle_body()
-        else:
-            _show_timestamp_toast(self)
-
-    def _render_markdown(self, body: str) -> None:
-        """Render markdown body into the Static widget via Rich.
+    def _prepare_body(self, body: str) -> None:
+        """Set initial hint text. Full body render is deferred to first expand.
 
         Args:
-            body: Raw markdown text.
+            body: Stripped markdown body text.
+        """
+        lines = body.split("\n")
+        total_lines = len(lines)
+        needs_truncation = (
+            total_lines > self._PREVIEW_LINES or len(body) > self._PREVIEW_CHARS
+        )
+
+        if needs_truncation:
+            remaining = total_lines - self._PREVIEW_LINES
+            ellipsis = get_glyphs().ellipsis
+            if self._hint_widget:
+                self._hint_widget.update(
+                    Content.styled(
+                        f"{ellipsis} {remaining} more lines"
+                        " — click or Ctrl+O to expand",
+                        "dim",
+                    )
+                )
+        else:
+            # Short body — show fully rendered, no preview needed.
+            self._ensure_md_rendered(body)
+            self._expanded = True
+
+    def _ensure_md_rendered(self, body: str) -> None:
+        """Render markdown into the Static widget on first call, then no-op.
+
+        Args:
+            body: Stripped markdown body text.
         """
         if self._md_rendered or not self._md_widget:
             return
@@ -469,17 +483,22 @@ class SkillMessage(Vertical):
         self._md_widget.update(RichMarkdown(body))
         self._md_rendered = True
 
-    def _update_body_display(self) -> None:
-        """Update the body display based on expanded state.
-
-        Renders the markdown body at most once via Rich; subsequent toggles
-        only flip widget visibility.
-        """
-        if not self._preview_widget or not self._md_widget or not self._hint_widget:
+    def toggle_body(self) -> None:
+        """Toggle between preview and full body display."""
+        if not self._stripped_body.strip():
             return
+        self._expanded = not self._expanded
 
+    def watch__expanded(self, expanded: bool) -> None:
+        """Lazy-render markdown on first expand; update hint text."""
         body = self._stripped_body.strip()
         if not body:
+            return
+
+        if expanded:
+            self._ensure_md_rendered(body)
+
+        if not self._hint_widget:
             return
 
         lines = body.split("\n")
@@ -488,22 +507,16 @@ class SkillMessage(Vertical):
             total_lines > self._PREVIEW_LINES or len(body) > self._PREVIEW_CHARS
         )
 
-        if self._expanded:
-            self._preview_widget.display = False
-            self._render_markdown(body)
-            self._md_widget.display = True
+        if not needs_truncation:
+            # Short body — always fully visible, no hint needed.
+            self._hint_widget.display = False
+            return
+
+        if expanded:
             self._hint_widget.update(
                 Content.styled("click or Ctrl+O to collapse", "dim italic")
             )
-            self._hint_widget.display = True
-        elif needs_truncation:
-            self._md_widget.display = False
-            preview_lines = lines[: self._PREVIEW_LINES]
-            preview = "\n".join(preview_lines)
-            if len(preview) > self._PREVIEW_CHARS:
-                preview = preview[: self._PREVIEW_CHARS]
-            self._preview_widget.update(Content.styled(preview, "dim"))
-            self._preview_widget.display = True
+        else:
             remaining = total_lines - self._PREVIEW_LINES
             ellipsis = get_glyphs().ellipsis
             self._hint_widget.update(
@@ -512,12 +525,15 @@ class SkillMessage(Vertical):
                     "dim",
                 )
             )
-            self._hint_widget.display = True
+
+    @on(Click, "_SkillToggle")
+    def _on_toggle_click(self, event: Click) -> None:
+        """Toggle expansion when header or hint is clicked."""
+        event.stop()
+        if self._stripped_body.strip():
+            self.toggle_body()
         else:
-            self._preview_widget.display = False
-            self._render_markdown(body)
-            self._md_widget.display = True
-            self._hint_widget.display = False
+            _show_timestamp_toast(self)
 
 
 class AssistantMessage(_TimestampClickMixin, Vertical):

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -149,7 +149,7 @@ class UserMessage(_TimestampClickMixin, Static):
     UserMessage {
         height: auto;
         padding: 0 1;
-        margin: 1 0 0 0;
+        margin: 0 0 1 0;
         background: transparent;
         border-left: wide $primary;
     }
@@ -236,7 +236,7 @@ class QueuedUserMessage(Static):
     QueuedUserMessage {
         height: auto;
         padding: 0 1;
-        margin: 1 0 0 0;
+        margin: 0 0 1 0;
         background: transparent;
         border-left: wide $panel;
         opacity: 0.6;
@@ -320,9 +320,9 @@ class SkillMessage(Vertical):
     SkillMessage {
         height: auto;
         padding: 0 1;
-        margin: 1 0 0 0;
+        margin: 0 0 1 0;
         background: transparent;
-        border-left: wide #a78bfa;
+        border-left: wide $skill;
     }
 
     SkillMessage .skill-header {
@@ -330,7 +330,7 @@ class SkillMessage(Vertical):
     }
 
     SkillMessage .skill-description {
-        color: #6b7280;
+        color: $text-muted;
         margin-left: 3;
     }
 
@@ -348,7 +348,7 @@ class SkillMessage(Vertical):
 
     SkillMessage .skill-hint {
         margin-left: 3;
-        color: #6b7280;
+        color: $text-muted;
     }
 
     SkillMessage.-expanded #skill-md {
@@ -356,7 +356,7 @@ class SkillMessage(Vertical):
     }
 
     SkillMessage:hover {
-        border-left: wide #c4b5fd;
+        border-left: wide $skill-hover;
     }
     """
 
@@ -402,16 +402,17 @@ class SkillMessage(Vertical):
         Yields:
             Widgets for header, description, args, and collapsible body.
         """
+        colors = theme.get_theme_colors()
         source_tag = f" [{self._source}]" if self._source else ""
         yield _SkillToggle(
-            Content.from_markup(
-                "[bold #a78bfa]$label[/bold #a78bfa]",
-                label=f"/skill:{self._skill_name}{source_tag}",
+            Content.styled(
+                f"/ skill:{self._skill_name}{source_tag}",
+                f"bold {colors.skill}",
             ),
             classes="skill-header",
         )
         if self._description:
-            yield Static(
+            yield _SkillToggle(
                 Content.styled(self._description, "dim"),
                 classes="skill-description",
             )
@@ -429,7 +430,8 @@ class SkillMessage(Vertical):
     def on_mount(self) -> None:
         """Cache widget references, render initial state."""
         if is_ascii_mode():
-            self.styles.border_left = ("ascii", "#a78bfa")
+            colors = theme.get_theme_colors(self)
+            self.styles.border_left = ("ascii", colors.skill)
 
         self._md_widget = self.query_one("#skill-md", Static)
         self._hint_widget = self.query_one("#skill-hint", _SkillToggle)
@@ -547,7 +549,7 @@ class AssistantMessage(_TimestampClickMixin, Vertical):
     AssistantMessage {
         height: auto;
         padding: 0 1;
-        margin: 1 0 0 0;
+        margin: 0 0 1 0;
     }
 
     AssistantMessage Markdown {
@@ -663,12 +665,12 @@ class ToolCallMessage(Vertical):
         padding: 0 1;
         margin: 0 0 1 0;
         background: transparent;
-        border-left: wide $panel;
+        border-left: wide $tool;
     }
 
     ToolCallMessage .tool-header {
         height: auto;
-        color: $warning;
+        color: $tool;
         text-style: bold;
     }
 
@@ -715,7 +717,7 @@ class ToolCallMessage(Vertical):
     }
 
     ToolCallMessage:hover {
-        border-left: wide $secondary;
+        border-left: wide $tool-hover;
     }
     """
     """Left border tracks tool lifecycle; hover brightens for interactivity."""
@@ -1532,7 +1534,7 @@ class DiffMessage(_TimestampClickMixin, Static):
     DiffMessage {
         height: auto;
         padding: 1;
-        margin: 1 0;
+        margin: 0 0 1 0;
         background: $surface;
         border: solid $primary;
     }
@@ -1604,7 +1606,7 @@ class ErrorMessage(_TimestampClickMixin, Static):
     ErrorMessage {
         height: auto;
         padding: 1;
-        margin: 1 0;
+        margin: 0 0 1 0;
         background: $error-muted;
         color: white;
         border-left: wide $error;
@@ -1655,7 +1657,7 @@ class AppMessage(Static):
     AppMessage {
         height: auto;
         padding: 0 1;
-        margin: 1 0;
+        margin: 0 0 1 0;
         color: $text-muted;
         text-style: italic;
     }
@@ -1690,7 +1692,7 @@ class SummarizationMessage(AppMessage):
     SummarizationMessage {
         height: auto;
         padding: 0 1;
-        margin: 1 0;
+        margin: 0 0 1 0;
         color: $primary;
         background: $surface;
         border-left: wide $primary;

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -302,7 +302,9 @@ class SkillMessage(Vertical):
     Shows skill name, source badge, description, and user args as a compact
     header. The full SKILL.md body (frontmatter stripped) is hidden behind a
     preview/expand toggle (click or Ctrl+O).  The expanded view renders
-    markdown via Textual's `Markdown` widget.
+    markdown via Rich's `Markdown` inside a single `Static` widget to avoid
+    the deep DOM tree that Textual's `Markdown` widget creates (which makes
+    click-driven toggles expensive due to hit-testing and reflow).
     """
 
     DEFAULT_CSS = """
@@ -381,7 +383,7 @@ class SkillMessage(Vertical):
         self._args = args
         self._expanded: bool = False
         self._preview_widget: Static | None = None
-        self._md_widget: Markdown | None = None
+        self._md_widget: Static | None = None
         self._hint_widget: Static | None = None
         self._deferred_expanded: bool = False
         self._md_rendered: bool = False
@@ -392,8 +394,6 @@ class SkillMessage(Vertical):
         Yields:
             Widgets for header, description, args, and collapsible body.
         """
-        from textual.widgets import Markdown as MdWidget
-
         source_tag = f" [{self._source}]" if self._source else ""
         yield Static(
             Content.from_markup(
@@ -416,18 +416,18 @@ class SkillMessage(Vertical):
                 classes="skill-args",
             )
         yield Static("", classes="skill-body-preview", id="skill-preview")
-        yield MdWidget("", id="skill-md")
+        # Single Static widget instead of Textual Markdown — avoids the deep
+        # DOM tree that makes click-to-toggle expensive (hit-test + reflow).
+        yield Static("", id="skill-md")
         yield Static("", classes="skill-hint", id="skill-hint")
 
     def on_mount(self) -> None:
         """Cache widget references and set initial display state."""
-        from textual.widgets import Markdown as MdWidget
-
         if is_ascii_mode():
             self.styles.border_left = ("ascii", "#a78bfa")
 
         self._preview_widget = self.query_one("#skill-preview", Static)
-        self._md_widget = self.query_one("#skill-md", MdWidget)
+        self._md_widget = self.query_one("#skill-md", Static)
         self._hint_widget = self.query_one("#skill-hint", Static)
 
         self._preview_widget.display = False
@@ -456,11 +456,24 @@ class SkillMessage(Vertical):
         else:
             _show_timestamp_toast(self)
 
+    def _render_markdown(self, body: str) -> None:
+        """Render markdown body into the Static widget via Rich.
+
+        Args:
+            body: Raw markdown text.
+        """
+        if self._md_rendered or not self._md_widget:
+            return
+        from rich.markdown import Markdown as RichMarkdown
+
+        self._md_widget.update(RichMarkdown(body))
+        self._md_rendered = True
+
     def _update_body_display(self) -> None:
         """Update the body display based on expanded state.
 
-        Renders the markdown body at most once; subsequent toggles only flip
-        widget visibility to avoid the cost of re-parsing and re-highlighting.
+        Renders the markdown body at most once via Rich; subsequent toggles
+        only flip widget visibility.
         """
         if not self._preview_widget or not self._md_widget or not self._hint_widget:
             return
@@ -477,9 +490,7 @@ class SkillMessage(Vertical):
 
         if self._expanded:
             self._preview_widget.display = False
-            if not self._md_rendered:
-                self._md_widget.update(body)
-                self._md_rendered = True
+            self._render_markdown(body)
             self._md_widget.display = True
             self._hint_widget.update(
                 Content.styled("click or Ctrl+O to collapse", "dim italic")
@@ -504,9 +515,7 @@ class SkillMessage(Vertical):
             self._hint_widget.display = True
         else:
             self._preview_widget.display = False
-            if not self._md_rendered:
-                self._md_widget.update(body)
-                self._md_rendered = True
+            self._render_markdown(body)
             self._md_widget.display = True
             self._hint_widget.display = False
 

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -299,7 +299,11 @@ def _strip_frontmatter(text: str) -> str:
 
 
 class _SkillToggle(Static):
-    """Clickable header/hint area for toggling skill body expansion."""
+    """Clickable header/hint area for toggling skill body expansion.
+
+    Referenced by name in `SkillMessage._on_toggle_click`'s `@on(Click)`
+    CSS selector — rename with care.
+    """
 
 
 class SkillMessage(Vertical):
@@ -312,8 +316,8 @@ class SkillMessage(Vertical):
 
     Visibility is driven by a CSS class (`-expanded`) toggled via a Textual
     reactive `var`. Click handlers are scoped to the header and hint widgets
-    (`_SkillToggle`) so clicks never hit the content body, avoiding expensive
-    DOM hit-testing.
+    (`_SkillToggle`) so clicks on the rendered markdown body do not trigger
+    expansion toggles (preserving text selection, for instance).
     """
 
     DEFAULT_CSS = """
@@ -428,7 +432,12 @@ class SkillMessage(Vertical):
         yield _SkillToggle("", classes="skill-hint", id="skill-hint")
 
     def on_mount(self) -> None:
-        """Cache widget references, render initial state."""
+        """Cache widget references, render initial state.
+
+        Ordering matters: widget refs must be cached before `_prepare_body`
+        or `_deferred_expanded` assignment, because either may set
+        `_expanded` which fires `watch__expanded` synchronously.
+        """
         if is_ascii_mode():
             colors = theme.get_theme_colors(self)
             self.styles.border_left = ("ascii", colors.skill)
@@ -480,9 +489,16 @@ class SkillMessage(Vertical):
         """
         if self._md_rendered or not self._md_widget:
             return
-        from rich.markdown import Markdown as RichMarkdown
+        try:
+            from rich.markdown import Markdown as RichMarkdown
 
-        self._md_widget.update(RichMarkdown(body))
+            self._md_widget.update(RichMarkdown(body))
+        except Exception:
+            logger.warning(
+                "Failed to render skill body as markdown; falling back to plain text",
+                exc_info=True,
+            )
+            self._md_widget.update(body)
         self._md_rendered = True
 
     def toggle_body(self) -> None:

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -188,7 +188,7 @@ class WelcomeBanner(Static):
         )
 
         if not ansi and _is_editable_install():
-            # Only color the version number in dev orange; art stays primary.
+            # Highlight local-install version tag with tool accent; art stays primary.
             dev_style = TStyle(foreground=TColor.parse(colors.tool), bold=True)
             version_tag = f"v{__version__} (local)"
             idx = banner.rfind(version_tag)

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -189,7 +189,7 @@ class WelcomeBanner(Static):
 
         if not ansi and _is_editable_install():
             # Only color the version number in dev orange; art stays primary.
-            dev_style = TStyle(foreground=TColor.parse(colors.primary_dev), bold=True)
+            dev_style = TStyle(foreground=TColor.parse(colors.tool), bold=True)
             version_tag = f"v{__version__} (local)"
             idx = banner.rfind(version_tag)
             if idx >= 0:

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -166,6 +166,10 @@ EXPECTED_CSS_KEYS = frozenset(
     {
         "mode-bash",
         "mode-command",
+        "skill",
+        "skill-hover",
+        "tool",
+        "tool-hover",
     }
 )
 
@@ -309,7 +313,6 @@ class TestGetThemeColors:
         assert colors.primary == "#BD93F9"
         assert colors.background == "#282A36"
         # App-specific fields fall back to base
-        assert colors.primary_dev == DARK_COLORS.primary_dev
         assert colors.muted == DARK_COLORS.muted
 
     def test_builtin_theme_ansi_falls_back(self) -> None:


### PR DESCRIPTION
Introduce dedicated semantic color tokens for skill and tool-call widgets, replacing hardcoded hex values and the overloaded `$panel`/`$secondary`/`$warning` references. Skills get a purple accent and tools get amber — both with distinct hover variants.

The unused `primary_dev` / `LC_ORANGE` color pair is removed since the dev-install banner now reuses the `tool` token.