### PR TITLE
fix(sdk): use concrete `ToolRuntime` types for middleware tools

### DIFF
--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -124,6 +124,16 @@ class AsyncSubAgentState(AgentState):
     async_tasks: Annotated[NotRequired[dict[str, AsyncTask]], _tasks_reducer]
 
 
+AsyncSubAgentToolRuntime = ToolRuntime[object, AsyncSubAgentState]
+"""Tool runtime for async subagent tools.
+
+Async subagent tools receive injected runtime from LangChain and persist task
+metadata in `AsyncSubAgentState`. The agent context is intentionally typed as
+`object` so non-`None` caller context values can flow through validation and
+serialization without producing spurious Pydantic warnings.
+"""
+
+
 ASYNC_TASK_TOOL_DESCRIPTION = """Start an async subagent on a remote LangGraph server. The subagent runs in the background and returns a task ID immediately.
 
 Available async agent types:
@@ -238,7 +248,7 @@ def _build_start_tool(
     def start_async_task(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
         subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types listed in the tool description."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         error = _validate_agent_type(agent_map, subagent_type)
         if error:
@@ -278,7 +288,7 @@ def _build_start_tool(
     async def astart_async_task(
         description: Annotated[str, "A detailed description of the task for the async subagent to perform."],
         subagent_type: Annotated[str, "The type of async subagent to use. Must be one of the available types listed in the tool description."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         error = _validate_agent_type(agent_map, subagent_type)
         if error:
@@ -373,7 +383,7 @@ def _build_check_command(
 
 def _resolve_tracked_task(
     task_id: str,
-    runtime: ToolRuntime,
+    runtime: AsyncSubAgentToolRuntime,
 ) -> AsyncTask | str:
     """Look up a tracked task from state by its `task_id` (`thread_id`).
 
@@ -394,7 +404,7 @@ def _build_check_tool(  # noqa: C901  # complexity from necessary error handling
 
     def check_async_task(
         task_id: Annotated[str, "The exact task_id string returned by start_async_task. Pass it verbatim."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         task = _resolve_tracked_task(task_id, runtime)
         if isinstance(task, str):
@@ -419,7 +429,7 @@ def _build_check_tool(  # noqa: C901  # complexity from necessary error handling
 
     async def acheck_async_task(
         task_id: Annotated[str, "The exact task_id string returned by start_async_task. Pass it verbatim."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         task = _resolve_tracked_task(task_id, runtime)
         if isinstance(task, str):
@@ -465,7 +475,7 @@ def _build_update_tool(
     def update_async_task(
         task_id: Annotated[str, "The exact task_id string returned by start_async_task. Pass it verbatim."],
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         tracked = _resolve_tracked_task(task_id, runtime)
         if isinstance(tracked, str):
@@ -504,7 +514,7 @@ def _build_update_tool(
     async def aupdate_async_task(
         task_id: Annotated[str, "The exact task_id string returned by start_async_task. Pass it verbatim."],
         message: Annotated[str, "Follow-up instructions or context to send to the subagent."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         tracked = _resolve_tracked_task(task_id, runtime)
         if isinstance(tracked, str):
@@ -559,7 +569,7 @@ def _build_cancel_tool(
 
     def cancel_async_task(
         task_id: Annotated[str, "The exact task_id string returned by start_async_task. Pass it verbatim."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         tracked = _resolve_tracked_task(task_id, runtime)
         if isinstance(tracked, str):
@@ -591,7 +601,7 @@ def _build_cancel_tool(
 
     async def acancel_async_task(
         task_id: Annotated[str, "The exact task_id string returned by start_async_task. Pass it verbatim."],
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
     ) -> str | Command:
         tracked = _resolve_tracked_task(task_id, runtime)
         if isinstance(tracked, str):
@@ -703,7 +713,7 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
     """Build the list_async_tasks tool."""
 
     def list_async_tasks(
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
         status_filter: Annotated[
             str | None,
             "Filter tasks by status. One of: 'running', 'success', 'error', 'cancelled', 'all'. Defaults to 'all'.",
@@ -738,7 +748,7 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
         )
 
     async def alist_async_tasks(
-        runtime: ToolRuntime,
+        runtime: AsyncSubAgentToolRuntime,
         status_filter: Annotated[
             str | None,
             "Filter tasks by status. One of: 'running', 'success', 'error', 'cancelled', 'all'. Defaults to 'all'.",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -120,6 +120,20 @@ class FilesystemState(AgentState):
     """Files in the filesystem."""
 
 
+FilesystemToolRuntime = ToolRuntime[object, FilesystemState]
+"""Tool runtime for filesystem tools.
+
+The filesystem tools do not inspect or depend on the agent context, but LangChain
+validates and serializes injected runtime arguments through the generated
+`args_schema`. Using `ToolRuntime[None, FilesystemState]` causes Pydantic to warn
+when the agent is invoked with a non-`None` context, because the injected runtime
+contains the caller-provided context value at execution time.
+
+`object` keeps the runtime context unconstrained for validation/serialization while
+preserving the concrete filesystem state type these tools depend on.
+"""
+
+
 LIST_FILES_TOOL_DESCRIPTION = """Lists all files in a directory.
 
 This is useful for exploring the filesystem and finding the right file to read or edit.
@@ -572,7 +586,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_description = self._custom_tool_descriptions.get("ls") or LIST_FILES_TOOL_DESCRIPTION
 
         def sync_ls(
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             path: Annotated[str, "Absolute path to the directory to list. Must be absolute, not relative."],
         ) -> str:
             """Synchronous wrapper for ls tool."""
@@ -600,7 +614,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             return str(result)
 
         async def async_ls(
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             path: Annotated[str, "Absolute path to the directory to list. Must be absolute, not relative."],
         ) -> str:
             """Asynchronous wrapper for ls tool."""
@@ -699,7 +713,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         def sync_read_file(
             file_path: Annotated[str, "Absolute path to the file to read. Must be absolute, not relative."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             offset: Annotated[int, "Line number to start reading from (0-indexed). Use for pagination of large files."] = DEFAULT_READ_OFFSET,
             limit: Annotated[int, "Maximum number of lines to read. Use for pagination of large files."] = DEFAULT_READ_LIMIT,
         ) -> ToolMessage | str:
@@ -715,7 +729,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         async def async_read_file(
             file_path: Annotated[str, "Absolute path to the file to read. Must be absolute, not relative."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             offset: Annotated[int, "Line number to start reading from (0-indexed). Use for pagination of large files."] = DEFAULT_READ_OFFSET,
             limit: Annotated[int, "Maximum number of lines to read. Use for pagination of large files."] = DEFAULT_READ_LIMIT,
         ) -> ToolMessage | str:
@@ -743,7 +757,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         def sync_write_file(
             file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
         ) -> Command | str:
             """Synchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
@@ -772,7 +786,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         async def async_write_file(
             file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
         ) -> Command | str:
             """Asynchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
@@ -813,7 +827,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             file_path: Annotated[str, "Absolute path to the file to edit. Must be absolute, not relative."],
             old_string: Annotated[str, "The exact text to find and replace. Must be unique in the file unless replace_all is True."],
             new_string: Annotated[str, "The text to replace old_string with. Must be different from old_string."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             *,
             replace_all: Annotated[bool, "If True, replace all occurrences of old_string. If False (default), old_string must be unique."] = False,
         ) -> Command | str:
@@ -844,7 +858,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             file_path: Annotated[str, "Absolute path to the file to edit. Must be absolute, not relative."],
             old_string: Annotated[str, "The exact text to find and replace. Must be unique in the file unless replace_all is True."],
             new_string: Annotated[str, "The text to replace old_string with. Must be different from old_string."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             *,
             replace_all: Annotated[bool, "If True, replace all occurrences of old_string. If False (default), old_string must be unique."] = False,
         ) -> Command | str:
@@ -884,7 +898,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         def sync_glob(
             pattern: Annotated[str, "Glob pattern to match files (e.g., '**/*.py', '*.txt', '/subdir/**/*.md')."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             path: Annotated[str, "Base directory to search from. Defaults to root '/'."] = "/",
         ) -> str:
             """Synchronous wrapper for glob tool."""
@@ -918,7 +932,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         async def async_glob(
             pattern: Annotated[str, "Glob pattern to match files (e.g., '**/*.py', '*.txt', '/subdir/**/*.md')."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             path: Annotated[str, "Base directory to search from. Defaults to root '/'."] = "/",
         ) -> str:
             """Asynchronous wrapper for glob tool."""
@@ -964,7 +978,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         def sync_grep(
             pattern: Annotated[str, "Text pattern to search for (literal string, not regex)."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             path: Annotated[str | None, "Directory to search in. Defaults to current working directory."] = None,
             glob: Annotated[str | None, "Glob pattern to filter which files to search (e.g., '*.py')."] = None,
             output_mode: Annotated[
@@ -1002,7 +1016,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         async def async_grep(
             pattern: Annotated[str, "Text pattern to search for (literal string, not regex)."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             path: Annotated[str | None, "Directory to search in. Defaults to current working directory."] = None,
             glob: Annotated[str | None, "Glob pattern to filter which files to search (e.g., '*.py')."] = None,
             output_mode: Annotated[
@@ -1051,7 +1065,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         def sync_execute(  # noqa: PLR0911 - early returns for distinct error conditions
             command: Annotated[str, "Shell command to execute in the sandbox environment."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             timeout: Annotated[
                 int | None,
                 "Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it.",
@@ -1105,7 +1119,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         async def async_execute(  # noqa: PLR0911 - early returns for distinct error conditions
             command: Annotated[str, "Shell command to execute in the sandbox environment."],
-            runtime: ToolRuntime[None, FilesystemState],
+            runtime: FilesystemToolRuntime,
             # ASYNC109 - timeout is a semantic parameter forwarded to the
             # backend's implementation, not an asyncio.timeout() contract.
             timeout: Annotated[  # noqa: ASYNC109

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, NotRequired, TypedDict, Unpack, cast
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig
-from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, ModelResponse, ResponseT
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ModelRequest, ModelResponse, ResponseT
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, ToolMessage
@@ -110,6 +110,14 @@ class CompiledSubAgent(TypedDict):
 
 
 DEFAULT_SUBAGENT_PROMPT = "In order to complete the objective that the user asks of you, you have access to a number of standard tools."
+
+SubAgentToolRuntime = ToolRuntime[object, AgentState]
+"""Tool runtime for subagent tools.
+
+The task tool accepts arbitrary agent context and forwards the current state to
+subagents, so the runtime needs an unconstrained context type while still
+advertising that it is an injected tool argument.
+"""
 
 # State keys that are excluded when passing state to subagents and when returning
 # updates from subagents.
@@ -418,7 +426,11 @@ def _build_task_tool(  # noqa: C901
             }
         )
 
-    def _validate_and_prepare_state(subagent_type: str, description: str, runtime: ToolRuntime) -> tuple[Runnable, dict]:
+    def _validate_and_prepare_state(
+        subagent_type: str,
+        description: str,
+        runtime: SubAgentToolRuntime,
+    ) -> tuple[Runnable, dict]:
         """Prepare state for invocation."""
         subagent = subagent_graphs[subagent_type]
         # Create a new state dict to avoid mutating the original
@@ -432,7 +444,7 @@ def _build_task_tool(  # noqa: C901
             "A detailed description of the task for the subagent to perform autonomously. Include all necessary context and specify the expected output format.",  # noqa: E501
         ],
         subagent_type: Annotated[str, "The type of subagent to use. Must be one of the available agent types listed in the tool description."],
-        runtime: ToolRuntime,
+        runtime: SubAgentToolRuntime,
     ) -> str | Command:
         if subagent_type not in subagent_graphs:
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
@@ -450,7 +462,7 @@ def _build_task_tool(  # noqa: C901
             "A detailed description of the task for the subagent to perform autonomously. Include all necessary context and specify the expected output format.",  # noqa: E501
         ],
         subagent_type: Annotated[str, "The type of subagent to use. Must be one of the available agent types listed in the tool description."],
-        runtime: ToolRuntime,
+        runtime: SubAgentToolRuntime,
     ) -> str | Command:
         if subagent_type not in subagent_graphs:
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -152,6 +152,16 @@ class SummarizationState(AgentState):
     """Private field storing the most recent summarization event."""
 
 
+SummarizationToolRuntime = ToolRuntime[object, SummarizationState]
+"""Tool runtime for summarization tools.
+
+The summarization tool reads and updates `SummarizationState` while receiving
+injected runtime context from LangChain. Using `object` for the context type
+keeps caller-provided context values unconstrained during validation and
+serialization, which avoids warnings for valid non-`None` context.
+"""
+
+
 class SummarizationDefaults(TypedDict):
     """Default settings computed from model profile."""
 
@@ -1220,7 +1230,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
         self._summarization = summarization
         self.tools: list[BaseTool] = [self._create_compact_tool()]
 
-    def _resolve_backend(self, runtime: ToolRuntime) -> BackendProtocol:
+    def _resolve_backend(self, runtime: SummarizationToolRuntime) -> BackendProtocol:
         """Resolve backend from instance or factory using a `ToolRuntime`.
 
         Args:
@@ -1231,7 +1241,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
         """
         backend = self._summarization._backend
         if callable(backend):
-            return backend(runtime)  # ty: ignore[call-top-callable]
+            return cast("Callable[[SummarizationToolRuntime], BackendProtocol]", backend)(runtime)
         return backend
 
     def _create_compact_tool(self) -> BaseTool:
@@ -1244,10 +1254,10 @@ class SummarizationToolMiddleware(AgentMiddleware):
 
         mw = self
 
-        def sync_compact(runtime: ToolRuntime) -> Command:
+        def sync_compact(runtime: SummarizationToolRuntime) -> Command:
             return mw._run_compact(runtime)
 
-        async def async_compact(runtime: ToolRuntime) -> Command:
+        async def async_compact(runtime: SummarizationToolRuntime) -> Command:
             return await mw._arun_compact(runtime)
 
         return StructuredTool.from_function(
@@ -1264,7 +1274,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
 
     def _build_compact_result(
         self,
-        runtime: ToolRuntime,
+        runtime: SummarizationToolRuntime,
         to_summarize: list[AnyMessage],
         summary: str,
         file_path: str | None,
@@ -1394,7 +1404,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
                     return True
         return False
 
-    def _run_compact(self, runtime: ToolRuntime) -> Command:
+    def _run_compact(self, runtime: SummarizationToolRuntime) -> Command:
         """Synchronous compact implementation called by the compact tool.
 
         Args:
@@ -1428,7 +1438,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
 
         return self._build_compact_result(runtime, to_summarize, summary, file_path, event, cutoff)
 
-    async def _arun_compact(self, runtime: ToolRuntime) -> Command:
+    async def _arun_compact(self, runtime: SummarizationToolRuntime) -> Command:
         """Async variant of `_run_compact`. See that method for details.
 
         Args:

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
@@ -1,9 +1,32 @@
 """Unit tests for tool schema validation."""
 
+import warnings
+
+from langchain.tools import ToolRuntime
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import StructuredTool
 
 from deepagents.backends.state import StateBackend
-from deepagents.middleware.filesystem import FilesystemMiddleware
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware, AsyncSubAgentState
+from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemState
+from deepagents.middleware.subagents import CompiledSubAgent, SubAgentMiddleware
+from deepagents.middleware.summarization import SummarizationMiddleware, SummarizationState, SummarizationToolMiddleware
+
+
+def _assert_model_dump_has_no_warnings(
+    tool: StructuredTool,
+    payload: dict[str, object],
+    runtime: ToolRuntime,
+) -> None:
+    """Assert a tool args model can dump injected runtime without warnings."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validated = tool.args_schema.model_validate({**payload, "runtime": runtime})
+        validated.model_dump()
+
+    assert caught == []
 
 
 class TestFilesystemToolSchemas:
@@ -82,3 +105,104 @@ class TestFilesystemToolSchemas:
                 f"Sync schema: {sync_schema}\n"
                 f"Async schema: {async_schema}"
             )
+
+    def test_runtime_schema_accepts_non_none_context_without_serialization_warning(self) -> None:
+        """Verify injected runtime context does not warn during args schema serialization."""
+        backend = StateBackend(None)  # type: ignore[arg-type]
+        middleware = FilesystemMiddleware(backend=backend)
+        tool = next(tool for tool in middleware.tools if tool.name == "ls")
+
+        runtime = ToolRuntime(
+            state=FilesystemState(messages=[]),
+            context={"foo": "bar"},
+            config={},
+            stream_writer=lambda _chunk: None,
+            tool_call_id="tool-call-1",
+            store=None,
+        )
+
+        _assert_model_dump_has_no_warnings(tool, {"path": "/"}, runtime)
+
+
+class TestOtherMiddlewareToolSchemas:
+    """Test runtime schema serialization for non-filesystem middleware tools."""
+
+    def test_subagent_task_runtime_schema_accepts_non_none_context_without_warning(self) -> None:
+        """Verify task tool runtime serialization accepts arbitrary context."""
+        compiled_subagent: CompiledSubAgent = {
+            "name": "general",
+            "description": "General purpose subagent",
+            "runnable": RunnableLambda(lambda _state: {"messages": [AIMessage(content="done")]}),
+        }
+        middleware = SubAgentMiddleware(
+            backend=StateBackend,
+            subagents=[compiled_subagent],
+        )
+        tool = middleware.tools[0]
+        runtime = ToolRuntime(
+            state={"messages": []},
+            context={"foo": "bar"},
+            config={},
+            stream_writer=lambda _chunk: None,
+            tool_call_id="tool-call-1",
+            store=None,
+        )
+
+        _assert_model_dump_has_no_warnings(
+            tool,
+            {
+                "description": "Do the task",
+                "subagent_type": "general",
+            },
+            runtime,
+        )
+
+    def test_async_subagent_runtime_schema_accepts_non_none_context_without_warning(self) -> None:
+        """Verify async subagent tool runtime serialization accepts arbitrary context."""
+        async_subagents: list[AsyncSubAgent] = [
+            {
+                "name": "general",
+                "description": "General purpose async subagent",
+                "graph_id": "graph-id",
+                "url": "https://example.com",
+            }
+        ]
+        middleware = AsyncSubAgentMiddleware(async_subagents=async_subagents)
+        tool = next(tool for tool in middleware.tools if tool.name == "start_async_task")
+        runtime = ToolRuntime(
+            state=AsyncSubAgentState(messages=[]),
+            context={"foo": "bar"},
+            config={},
+            stream_writer=lambda _chunk: None,
+            tool_call_id="tool-call-1",
+            store=None,
+        )
+
+        _assert_model_dump_has_no_warnings(
+            tool,
+            {
+                "description": "Do the task",
+                "subagent_type": "general",
+            },
+            runtime,
+        )
+
+    def test_summarization_runtime_schema_accepts_non_none_context_without_warning(self) -> None:
+        """Verify compact tool runtime serialization accepts arbitrary context."""
+        summarization = SummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="summary")])),
+            backend=StateBackend,
+            trigger=("messages", 10),
+        )
+        middleware = SummarizationToolMiddleware(summarization)
+        tool = middleware.tools[0]
+        runtime = ToolRuntime(
+            state=SummarizationState(messages=[]),
+            context={"foo": "bar"},
+            config={},
+            stream_writer=lambda _chunk: None,
+            tool_call_id="tool-call-1",
+            store=None,
+        )
+
+        _assert_model_dump_has_no_warnings(tool, {}, runtime)


### PR DESCRIPTION
Fixes #2249

## Summary

Use concrete `ToolRuntime[...]` types for middleware tool runtime parameters.

## Why

Several middleware tools accept an injected `runtime` argument. When LangChain validates and serializes tool args during execution, plain `ToolRuntime` can lead to Pydantic serializer warnings when valid runtime values such as non-`None` `context` are present.

Using concrete `ToolRuntime[...]` specializations fixes that while preserving the existing public API and runtime behavior.

## Changes

- keep filesystem tools on `ToolRuntime[object, FilesystemState]`
- update subagent tools to use `ToolRuntime[object, AgentState]`
- update async subagent tools to use `ToolRuntime[object, AsyncSubAgentState]`
- update summarization tools to use `ToolRuntime[object, SummarizationState]`
- add unit coverage for middleware tool arg validation/serialization with non-`None` runtime context