### PR TITLE
style(cli): show task subagent type badge with separate description line

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -552,11 +552,10 @@ def _format_task_description(
     warning_msg = "Subagent will have access to file operations and shell commands"
     return (
         f"Subagent Type: {subagent_type}\n\n"
+        f"{glyphs.warning} {warning_msg} {glyphs.warning}\n\n"
         f"Task Instructions:\n"
         f"{separator}\n"
-        f"{description_preview}\n"
-        f"{separator}\n\n"
-        f"{glyphs.warning}  {warning_msg}"
+        f"{description_preview}"
     )
 
 

--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -219,10 +219,12 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             return f'{prefix} {tool_name}("{url}")'
 
     elif tool_name == "task":
-        # Task: show the task description
-        if "description" in tool_args:
-            desc = _sanitize_display_value(tool_args["description"], max_length=100)
-            return f'{prefix} {tool_name}("{desc}")'
+        # Task: show subagent type badge (description gets its own line in the widget)
+        agent_type = tool_args.get("subagent_type", "")
+        if agent_type:
+            agent_type = _sanitize_display_value(agent_type, max_length=40)
+            return f"{prefix} {tool_name} [{agent_type}]"
+        return f"{prefix} {tool_name}"
 
     elif tool_name == "ask_user":
         if "questions" in tool_args and isinstance(tool_args["questions"], list):

--- a/libs/cli/deepagents_cli/tool_display.py
+++ b/libs/cli/deepagents_cli/tool_display.py
@@ -219,7 +219,7 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             return f'{prefix} {tool_name}("{url}")'
 
     elif tool_name == "task":
-        # Task: show subagent type badge (description gets its own line in the widget)
+        # Task: show subagent type badge
         agent_type = tool_args.get("subagent_type", "")
         if agent_type:
             agent_type = _sanitize_display_value(agent_type, max_length=40)

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -690,6 +690,12 @@ class ToolCallMessage(Vertical):
         text-style: bold;
     }
 
+    ToolCallMessage .tool-task-desc {
+        color: $text-muted;
+        margin-left: 3;
+        text-style: italic;
+    }
+
     ToolCallMessage .tool-args {
         color: $text-muted;
         margin-left: 3;
@@ -783,8 +789,19 @@ class ToolCallMessage(Vertical):
         """
         tool_label = format_tool_display(self._tool_name, self._args)
         yield Static(tool_label, markup=False, classes="tool-header")
+        # Task: dedicated description line (dim, truncated)
+        if self._tool_name == "task":
+            desc = self._args.get("description", "")
+            if desc:
+                max_len = 120
+                suffix = "..." if len(desc) > max_len else ""
+                truncated = desc[:max_len].rstrip() + suffix
+                yield Static(
+                    Content.styled(truncated, "dim"),
+                    classes="tool-task-desc",
+                )
         # Only show args for tools where header doesn't capture the key info
-        if self._tool_name not in _TOOLS_WITH_HEADER_INFO:
+        elif self._tool_name not in _TOOLS_WITH_HEADER_INFO:
             args = self._filtered_args()
             if args:
                 args_str = ", ".join(

--- a/libs/cli/deepagents_cli/widgets/tool_renderers.py
+++ b/libs/cli/deepagents_cli/widgets/tool_renderers.py
@@ -16,7 +16,13 @@ if TYPE_CHECKING:
 
 
 class ToolRenderer:
-    """Base renderer for tool approval widgets."""
+    """Strategy for building a tool's HITL approval widget.
+
+    Each renderer maps a tool name to a `(widget_class, data)` pair that
+    controls what the user sees in the approval box. Tools not registered
+    in `_RENDERER_REGISTRY` fall through to the default, which dumps all
+    args as `key: value` lines via `GenericApprovalWidget`.
+    """
 
     @staticmethod
     def get_approval_widget(
@@ -55,6 +61,16 @@ class WriteFileRenderer(ToolRenderer):
             "file_extension": file_extension,
         }
         return WriteFileApprovalWidget, data
+
+
+class TaskRenderer(ToolRenderer):
+    """Renderer for task tool — interrupt description provides full context."""
+
+    @staticmethod
+    def get_approval_widget(  # noqa: D102  # Protocol method — docstring on base class
+        tool_args: dict[str, Any],  # noqa: ARG004  # Unused; interrupt description already formats task args
+    ) -> tuple[type[ToolApprovalWidget], dict[str, Any]]:
+        return GenericApprovalWidget, {}
 
 
 class EditFileRenderer(ToolRenderer):
@@ -107,12 +123,16 @@ class EditFileRenderer(ToolRenderer):
         return diff_list[2:] if len(diff_list) > 2 else diff_list  # noqa: PLR2004  # Column count threshold
 
 
-# Registry mapping tool names to renderers
-# Note: bash/shell use minimal approval (no renderer) - see ApprovalMenu._MINIMAL_TOOLS
 _RENDERER_REGISTRY: dict[str, type[ToolRenderer]] = {
+    "task": TaskRenderer,
     "write_file": WriteFileRenderer,
     "edit_file": EditFileRenderer,
 }
+"""Registry mapping tool names to renderers
+
+Note: bash/shell/execute use minimal approval (no renderer) — see
+ApprovalMenu._MINIMAL_TOOLS
+"""
 
 
 def get_renderer(tool_name: str) -> ToolRenderer:

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -243,10 +243,9 @@ def test_format_task_description():
     assert "Task Instructions:" in description
     assert "Analyze code structure and identify main components." in description
     warning = get_glyphs().warning
-    assert (
-        f"{warning}  Subagent will have access to file operations and shell commands"
-        in description
-    )
+    msg = "Subagent will have access to file operations and shell commands"
+    assert f"{warning} {msg} {warning}" in description
+    assert description.index(warning) < description.index("Task Instructions:")
 
 
 def test_format_task_description_truncates_long_description():

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -149,17 +149,18 @@ class TestToolCallMessageMarkupSafety:
         assert msg._args == args
 
     def test_tool_header_escapes_markup_in_label(self) -> None:
-        """Tool header should safely render label content with markup-like chars."""
+        """Task description widget should safely render bracket content."""
         msg = ToolCallMessage(
             "task",
             {"description": "Search for closing tag [/dim] mismatches"},
         )
 
-        # `task` has no inline args widget, so this validates the header markup.
-        # Header uses markup=False so bracket content is shown verbatim.
-        header = next(iter(msg.compose()))
-        rendered = header.render()
-        assert "[/dim]" in rendered.plain
+        # Header shows subagent type; description is a separate dim widget.
+        widgets = list(msg.compose())
+        # Second widget is the task description line (Static with dim style).
+        # Content.styled() produces a Content object stored on the Static.
+        content = widgets[1]._Static__content  # type: ignore[attr-defined]
+        assert "[/dim]" in content.plain
 
     def test_tool_args_line_escapes_markup_values(self) -> None:
         """Inline args line should escape bracket content in argument values."""


### PR DESCRIPTION
Rework how `task` (subagent) tool calls display in the chat UI. Previously the header crammed a truncated description string into the one-line summary, which was noisy and buried the subagent type. Now the header shows a clean `[subagent_type]` badge, and the full task description renders on its own line below in dim italic — easier to scan when multiple subagents are running in parallel.

<details>
<summary>before</summary>

<img width="661" height="458" alt="Screenshot 5" src="https://github.com/user-attachments/assets/6574c87b-f44f-47be-b561-5c401d84e684" />

</details>

<details>
<summary>after</summary>

<img width="636" height="488" alt="Screenshot 1" src="https://github.com/user-attachments/assets/062fb7d0-7d28-463e-b65c-e521266076d8" />

</details>