### PR TITLE
fix(sdk): normalize CRLF line endings in `FilesystemBackend.edit()`

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -414,6 +414,15 @@ class FilesystemBackend(BackendProtocol):
             with os.fdopen(fd, "r", encoding="utf-8") as f:
                 content = f.read()
 
+            # Normalize line endings in old_string/new_string to match the
+            # text-mode read above. Python universal newlines (the default
+            # when newline=None) converts \r\n and bare \r to \n on read.
+            # Callers that obtained content via binary-mode reads (e.g.
+            # download_files) may pass strings with \r\n or \r that would
+            # fail to match the \n-only content.
+            old_string = old_string.replace("\r\n", "\n").replace("\r", "\n")
+            new_string = new_string.replace("\r\n", "\n").replace("\r", "\n")
+
             result = perform_string_replacement(content, old_string, new_string, replace_all)
 
             if isinstance(result, str):

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -602,3 +602,67 @@ class TestWindowsPathHandling:
         assert infos is not None
         for info in infos:
             assert "\\" not in info["path"], f"Backslash in deep path: {info['path']}"
+
+
+class TestEditCrlfNormalization:
+    """Tests for CRLF normalization in edit(). See #2247."""
+
+    def test_edit_normalizes_crlf_in_old_string(self, tmp_path: Path):
+        """edit() should succeed when old_string contains CRLF but file has LF.
+
+        Addresses a bug where download_files() returns raw bytes (binary
+        mode) that may contain CRLF, the caller decodes them and passes
+        to edit(), but edit() reads the file in text mode (LF-normalized).
+        """
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        content = "line1\nline2\nline3\n"
+        be.write("/test.txt", content)
+
+        result = be.edit("/test.txt", "line1\r\nline2\r\n", "replaced\n")
+        assert result.error is None
+        assert result.occurrences == 1
+        assert (tmp_path / "test.txt").read_text() == "replaced\nline3\n"
+
+    def test_edit_normalizes_crlf_in_new_string(self, tmp_path: Path):
+        """edit() should normalize CRLF in new_string too."""
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        be.write("/test.txt", "hello world\n")
+
+        result = be.edit("/test.txt", "hello", "goodbye\r\n")
+        assert result.error is None
+        raw = (tmp_path / "test.txt").read_bytes()
+        assert b"\r" not in raw
+
+    def test_edit_crlf_with_replace_all(self, tmp_path: Path):
+        """edit() should normalize CRLF when replace_all=True."""
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        be.write("/test.txt", "foo\nbar\nfoo\n")
+
+        result = be.edit("/test.txt", "foo\r\n", "baz\n", replace_all=True)
+        assert result.error is None
+        assert result.occurrences == 2
+        assert (tmp_path / "test.txt").read_text() == "baz\nbar\nbaz\n"
+
+    def test_edit_with_download_roundtrip_crlf(self, tmp_path: Path):
+        """Simulate a download-then-edit flow where downloaded content has CRLF.
+
+        1. write() creates a file
+        2. Simulate download_files() returning CRLF bytes (binary-mode read)
+        3. edit() with the CRLF-decoded content as old_string should succeed
+        """
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        original = "## Summary\n\nHuman: hello\nAI: hi\n\n"
+        be.write("/history.md", original)
+
+        crlf_content = original.replace("\n", "\r\n")
+
+        appended = "## Summary 2\n\nHuman: next\nAI: ok\n\n"
+        combined = crlf_content + appended
+
+        result = be.edit("/history.md", crlf_content, combined)
+        assert result.error is None
+        assert result.occurrences == 1
+
+        final = (tmp_path / "history.md").read_text()
+        assert "## Summary 2" in final
+        assert "Human: next" in final


### PR DESCRIPTION
Closes #2247

---

On Windows, Python's text-mode writes translate `\n` → `\r\n` on disk. `FilesystemBackend.edit()` reads files in text mode (universal newlines → `\n`), but callers like `SummarizationMiddleware` obtain existing content via `download_files()`, which reads in binary mode and preserves the `\r\n` bytes as-is. When that CRLF-containing string is passed as `old_string` to `edit()`, `perform_string_replacement()` fails with "String not found in file" because the line endings don't match. This breaks conversation history offload after the first successful write cycle.

This fix normalizes `\r\n` and bare `\r` to `\n` in both `old_string` and `new_string` before replacement, matching the normalization Python's text-mode read already applies to the file content.

This is non-breaking: on Unix the strings already contain only `\n` so the `.replace()` calls are no-ops, and on Windows the normalization makes the caller's strings consistent with what `edit()` actually sees on disk.

Importantly, this does **not** weaken the exact-match semantics of `perform_string_replacement()` (see [#403 (comment)](https://github.com/langchain-ai/deepagents/issues/403#issuecomment-3997938843)). The match is still exact, just performed after both sides agree on line-ending encoding.