### PR TITLE
refactor(cli): extract `format_duration` into shared formatting module

### DIFF
--- a/libs/cli/deepagents_cli/formatting.py
+++ b/libs/cli/deepagents_cli/formatting.py
@@ -1,0 +1,28 @@
+"""Lightweight text-formatting helpers.
+
+Keep this module free of heavy dependencies so it can be imported anywhere
+in the CLI without pulling in large frameworks.
+"""
+
+from __future__ import annotations
+
+
+def format_duration(seconds: float) -> str:
+    """Format a duration in seconds into a human-readable string.
+
+    Args:
+        seconds: Duration in seconds.
+
+    Returns:
+        Formatted string like `"5s"`, `"2.3s"`, `"5m 12s"`, or `"1h 23m 4s"`.
+    """
+    rounded = round(seconds, 1)
+    if rounded < 60:  # noqa: PLR2004
+        if rounded % 1 == 0:
+            return f"{int(rounded)}s"
+        return f"{rounded:.1f}s"
+    minutes, secs = divmod(int(rounded), 60)
+    if minutes < 60:  # noqa: PLR2004
+        return f"{minutes}m {secs}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m {secs}s"

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -39,6 +39,7 @@ from deepagents_cli._session_stats import (
 )
 from deepagents_cli.config import build_stream_config
 from deepagents_cli.file_ops import FileOpTracker
+from deepagents_cli.formatting import format_duration
 from deepagents_cli.hooks import dispatch_hook
 from deepagents_cli.input import MediaTracker, parse_file_mentions
 from deepagents_cli.media_utils import create_multimodal_content
@@ -74,25 +75,6 @@ def _get_hitl_request_adapter(hitl_request_type: type) -> TypeAdapter:
     if _hitl_adapter_cache is None:
         _hitl_adapter_cache = TypeAdapter(hitl_request_type)
     return _hitl_adapter_cache
-
-
-def _format_duration(seconds: float) -> str:
-    """Format a duration in seconds into a human-readable string.
-
-    Args:
-        seconds: Duration in seconds.
-
-    Returns:
-        Formatted string like `"2.3s"`, `"5m 12s"`, or `"1h 23m 4s"`.
-    """
-    rounded = round(seconds, 1)
-    if rounded < 60:  # noqa: PLR2004
-        return f"{rounded:.1f}s"
-    minutes, secs = divmod(int(rounded), 60)
-    if minutes < 60:  # noqa: PLR2004
-        return f"{minutes}m {secs}s"
-    hours, minutes = divmod(minutes, 60)
-    return f"{hours}h {minutes}m {secs}s"
 
 
 def print_usage_table(
@@ -160,7 +142,7 @@ def print_usage_table(
     if has_time:
         console.print()
         console.print(
-            f"Agent active  {_format_duration(wall_time)}",
+            f"Agent active  {format_duration(wall_time)}",
             style="dim",
             highlight=False,
         )

--- a/libs/cli/deepagents_cli/widgets/loading.py
+++ b/libs/cli/deepagents_cli/widgets/loading.py
@@ -10,6 +10,7 @@ from textual.content import Content
 from textual.widgets import Static
 
 from deepagents_cli.config import get_glyphs
+from deepagents_cli.formatting import format_duration
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -134,7 +135,7 @@ class LoadingWidget(Static):
 
         if self._hint_widget and self._start_time is not None:
             elapsed = int(time() - self._start_time)
-            self._hint_widget.update(f"({elapsed}s, esc to interrupt)")
+            self._hint_widget.update(f"({format_duration(elapsed)}, esc to interrupt)")
 
     def set_status(self, status: str) -> None:
         """Update the status text.
@@ -159,7 +160,9 @@ class LoadingWidget(Static):
         if self._status_widget:
             self._status_widget.update(f" {status}... ")
         if self._hint_widget:
-            self._hint_widget.update(f"(paused at {self._paused_elapsed}s)")
+            self._hint_widget.update(
+                f"(paused at {format_duration(self._paused_elapsed)})"
+            )
         if self._spinner_widget:
             self._spinner_widget.update(Content.styled(get_glyphs().pause, "dim"))
 

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -25,6 +25,7 @@ from deepagents_cli.config import (
     get_glyphs,
     is_ascii_mode,
 )
+from deepagents_cli.formatting import format_duration
 from deepagents_cli.input import EMAIL_PREFIX_PATTERN, INPUT_HIGHLIGHT_PATTERN
 from deepagents_cli.tool_display import format_tool_display
 from deepagents_cli.widgets._links import open_style_link
@@ -911,7 +912,7 @@ class ToolCallMessage(Vertical):
         elapsed = ""
         if self._start_time is not None:
             elapsed_secs = int(time() - self._start_time)
-            elapsed = f" ({elapsed_secs}s)"
+            elapsed = f" ({format_duration(elapsed_secs)})"
 
         text = f"{frame} Running...{elapsed}"
         self._status_widget.update(

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -23,7 +23,6 @@ from deepagents_cli.textual_adapter import (
     SessionStats,
     TextualUIAdapter,
     _build_interrupted_ai_message,
-    _format_duration,
     _is_summarization_chunk,
     execute_task_textual,
     format_token_count,
@@ -1227,44 +1226,3 @@ class TestPrintUsageTable:
         print_usage_table(stats, wall_time=0.01, console=console)
         output = buf.getvalue()
         assert output.strip() == ""
-
-
-# ---------------------------------------------------------------------------
-# _format_duration tests
-# ---------------------------------------------------------------------------
-
-
-class TestFormatDuration:
-    """Tests for `_format_duration` human-readable formatter."""
-
-    def test_sub_minute(self) -> None:
-        assert _format_duration(45.3) == "45.3s"
-
-    def test_exactly_one_minute(self) -> None:
-        assert _format_duration(60.0) == "1m 0s"
-
-    def test_minutes_and_seconds(self) -> None:
-        assert _format_duration(125.7) == "2m 5s"
-
-    def test_exactly_one_hour(self) -> None:
-        assert _format_duration(3600.0) == "1h 0m 0s"
-
-    def test_hours_minutes_seconds(self) -> None:
-        # 1383.5s -> 23m 3s
-        assert _format_duration(1383.5) == "23m 3s"
-
-    def test_large_duration(self) -> None:
-        # 2h 30m 45s = 9045s
-        assert _format_duration(9045.0) == "2h 30m 45s"
-
-    def test_zero(self) -> None:
-        assert _format_duration(0.0) == "0.0s"
-
-    def test_fractional_under_minute(self) -> None:
-        assert _format_duration(0.1) == "0.1s"
-
-    def test_rounding_near_minute_boundary(self) -> None:
-        assert _format_duration(59.95) == "1m 0s"
-
-    def test_just_under_minute_no_rounding(self) -> None:
-        assert _format_duration(59.94) == "59.9s"


### PR DESCRIPTION
Extract `format_duration` from `textual_adapter.py` into a standalone `formatting.py` module so the loading widget can reuse it. Previously, `LoadingWidget` displayed raw seconds (`"47s"`) even for multi-minute agent runs; it now shows the same human-readable format (`"2m 5s"`, `"1h 23m 4s"`) used in the session-end usage table. Whole-second values under a minute also drop the redundant decimal (`"5s"` instead of `"5.0s"`).