### PR TITLE
perf(cli): defer `/model` selector data loading off event loop

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -938,6 +938,14 @@ class DeepAgentsApp(App):
             group="startup-import-prewarm",
         )
 
+        # Prewarm model discovery and profile caches unconditionally so
+        # /model opens instantly even before the agent/server is ready.
+        self.run_worker(
+            self._prewarm_model_caches,
+            exclusive=True,
+            group="startup-model-prewarm",
+        )
+
         # Optional tool warnings in a thread (shutil.which is sync I/O)
         self.run_worker(
             self._check_optional_tools_background,
@@ -1138,11 +1146,6 @@ class DeepAgentsApp(App):
             self._prewarm_threads_cache,
             exclusive=True,
             group="startup-thread-prewarm",
-        )
-        self.run_worker(
-            self._prewarm_model_caches,
-            exclusive=True,
-            group="startup-model-prewarm",
         )
 
     async def _resolve_resume_thread(self) -> None:
@@ -1458,7 +1461,7 @@ class DeepAgentsApp(App):
                 get_model_profiles, cli_override=self._profile_override
             )
         except Exception:
-            logger.debug("Could not prewarm model caches", exc_info=True)
+            logger.warning("Could not prewarm model caches", exc_info=True)
 
     async def _check_for_updates(self) -> None:
         """Check PyPI for a newer version and optionally auto-update."""

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -11,6 +11,7 @@ import importlib.util
 import logging
 import os
 import tempfile
+import threading
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -219,6 +220,8 @@ registry fallback.
 _available_models_cache: dict[str, list[str]] | None = None
 _builtin_providers_cache: dict[str, Any] | None = None
 _default_config_cache: ModelConfig | None = None
+_provider_profiles_cache: dict[str, dict[str, Any]] = {}
+_provider_profiles_lock = threading.Lock()
 _profiles_cache: Mapping[str, ModelProfileEntry] | None = None
 _profiles_override_cache: tuple[int, Mapping[str, ModelProfileEntry]] | None = None
 
@@ -232,6 +235,7 @@ def clear_caches() -> None:
     _available_models_cache = None
     _builtin_providers_cache = None
     _default_config_cache = None
+    _provider_profiles_cache.clear()
     _profiles_cache = None
     _profiles_override_cache = None
     invalidate_thread_config_cache()
@@ -292,7 +296,11 @@ def _get_provider_profile_modules() -> list[tuple[str, str]]:
 def _load_provider_profiles(module_path: str) -> dict[str, Any]:
     """Load `_PROFILES` from a provider's data module.
 
-    Locating the package on disk with `importlib.util.find_spec` and load *only*
+    Results are cached by `module_path` so repeated calls (e.g., from both
+    `get_available_models` and `get_model_profiles`) reuse the same dict.
+    Use `clear_caches()` to reset.
+
+    Locates the package on disk with `importlib.util.find_spec` and loads *only*
     the `_profiles.py` file via `spec_from_file_location`.
 
     Args:
@@ -306,41 +314,48 @@ def _load_provider_profiles(module_path: str) -> dict[str, Any]:
         ImportError: If the package is not installed or the profile module
             cannot be found on disk.
     """
-    parts = module_path.split(".")
-    package_root = parts[0]
+    with _provider_profiles_lock:
+        cached = _provider_profiles_cache.get(module_path)
+        if cached is not None:  # `is not None` so empty profile dicts are cached
+            return cached
 
-    spec = importlib.util.find_spec(package_root)
-    if spec is None:
-        msg = f"Package {package_root} is not installed"
-        raise ImportError(msg)
+        parts = module_path.split(".")
+        package_root = parts[0]
 
-    # Determine the package directory from the spec.
-    if spec.origin:
-        package_dir = Path(spec.origin).parent
-    elif spec.submodule_search_locations:
-        package_dir = Path(next(iter(spec.submodule_search_locations)))
-    else:
-        msg = f"Cannot determine location for {package_root}"
-        raise ImportError(msg)
+        spec = importlib.util.find_spec(package_root)
+        if spec is None:
+            msg = f"Package {package_root} is not installed"
+            raise ImportError(msg)
 
-    # Build the path to the target file (e.g., data/_profiles.py).
-    relative_parts = parts[1:]  # ["data", "_profiles"]
-    profiles_path = package_dir.joinpath(
-        *relative_parts[:-1], f"{relative_parts[-1]}.py"
-    )
+        # Determine the package directory from the spec.
+        if spec.origin:
+            package_dir = Path(spec.origin).parent
+        elif spec.submodule_search_locations:
+            package_dir = Path(next(iter(spec.submodule_search_locations)))
+        else:
+            msg = f"Cannot determine location for {package_root}"
+            raise ImportError(msg)
 
-    if not profiles_path.exists():
-        msg = f"Profile module not found: {profiles_path}"
-        raise ImportError(msg)
+        # Build the path to the target file (e.g., data/_profiles.py).
+        relative_parts = parts[1:]  # ["data", "_profiles"]
+        profiles_path = package_dir.joinpath(
+            *relative_parts[:-1], f"{relative_parts[-1]}.py"
+        )
 
-    file_spec = importlib.util.spec_from_file_location(module_path, profiles_path)
-    if file_spec is None or file_spec.loader is None:
-        msg = f"Could not create module spec for {profiles_path}"
-        raise ImportError(msg)
+        if not profiles_path.exists():
+            msg = f"Profile module not found: {profiles_path}"
+            raise ImportError(msg)
 
-    module = importlib.util.module_from_spec(file_spec)
-    file_spec.loader.exec_module(module)
-    return getattr(module, "_PROFILES", {})
+        file_spec = importlib.util.spec_from_file_location(module_path, profiles_path)
+        if file_spec is None or file_spec.loader is None:
+            msg = f"Could not create module spec for {profiles_path}"
+            raise ImportError(msg)
+
+        module = importlib.util.module_from_spec(file_spec)
+        file_spec.loader.exec_module(module)
+        profiles = getattr(module, "_PROFILES", {})
+        _provider_profiles_cache[module_path] = profiles
+        return profiles
 
 
 def _profile_module_from_class_path(class_path: str) -> str | None:

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -17,6 +18,8 @@ from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from textual.app import ComposeResult
 
 from deepagents_cli import theme
@@ -209,6 +212,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     ) -> None:
         """Initialize the ModelSelectorScreen.
 
+        Data loading (model discovery, profiles) is deferred to `on_mount`
+        so the screen pushes instantly and populates asynchronously.
+
         Args:
             current_model: The currently active model name (to highlight).
             current_provider: The provider of the current model.
@@ -220,26 +226,21 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         super().__init__()
         self._current_model = current_model
         self._current_provider = current_provider
+        self._cli_profile_override = cli_profile_override
 
-        # Build list from dynamically discovered models (falls back to defaults)
+        # Model data — populated asynchronously in on_mount via _load_model_data
         self._all_models: list[tuple[str, str]] = []
-        for provider, models in get_available_models().items():
-            for model in models:
-                model_spec = f"{provider}:{model}"
-                self._all_models.append((model_spec, provider))
-
-        self._filtered_models: list[tuple[str, str]] = list(self._all_models)
-        self._selected_index = self._find_current_model_index()
+        self._filtered_models: list[tuple[str, str]] = []
+        self._selected_index = 0
         self._options_container: Container | None = None
         self._option_widgets: list[ModelOption] = []
         self._filter_text = ""
         self._current_spec: str | None = None
         if current_model and current_provider:
             self._current_spec = f"{current_provider}:{current_model}"
-
-        config = ModelConfig.load()
-        self._default_spec: str | None = config.default_model
-        self._profiles = get_model_profiles(cli_override=cli_profile_override)
+        self._default_spec: str | None = None
+        self._profiles: Mapping[str, ModelProfileEntry] = {}
+        self._loaded = False
 
     def _find_current_model_index(self) -> int:
         """Find the index of the current model in the filtered list.
@@ -298,19 +299,88 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             )
             yield Static(help_text, classes="model-selector-help")
 
+    @staticmethod
+    def _load_model_data(
+        cli_override: dict[str, Any] | None,
+    ) -> tuple[
+        list[tuple[str, str]],
+        str | None,
+        Mapping[str, ModelProfileEntry],
+    ]:
+        """Gather model discovery data synchronously.
+
+        Intended to be called via `asyncio.to_thread` so filesystem I/O in
+        `get_available_models` does not block the event loop.
+
+        Returns:
+            Tuple of (all_models, default_spec, profiles) where
+                `all_models` is a list of `(provider:model spec, provider)`
+                pairs, `default_spec` is the configured default model or
+                `None`, and `profiles` maps spec strings to profile entries.
+        """
+        all_models: list[tuple[str, str]] = [
+            (f"{provider}:{model}", provider)
+            for provider, models in get_available_models().items()
+            for model in models
+        ]
+
+        config = ModelConfig.load()
+        profiles = get_model_profiles(cli_override=cli_override)
+        return all_models, config.default_model, profiles
+
     async def on_mount(self) -> None:
-        """Set up the screen on mount."""
+        """Set up the screen on mount.
+
+        Loads model data in a background thread so the screen frame renders
+        immediately, then populates the model list.
+        """
         if is_ascii_mode():
             colors = theme.get_theme_colors(self)
             container = self.query_one(Vertical)
             container.styles.border = ("ascii", colors.success)
 
-        await self._update_display()
-        self._update_footer()
-
-        # Focus the filter input
+        # Focus the filter input immediately so the user can start typing
+        # while model data loads.
         filter_input = self.query_one("#model-filter", Input)
         filter_input.focus()
+
+        # Offload to thread because get_available_models does filesystem I/O
+        try:
+            all_models, default_spec, profiles = await asyncio.to_thread(
+                self._load_model_data, self._cli_profile_override
+            )
+        except Exception:
+            logger.exception("Failed to load model data for /model selector")
+            self._loaded = True
+            if self.is_running:
+                self.notify(
+                    "Could not load model list. "
+                    "Check provider packages and config.toml.",
+                    severity="error",
+                    timeout=10,
+                    markup=False,
+                )
+                await self._update_display()
+                self._update_footer()
+            return
+
+        # Screen may have been dismissed while the thread was running
+        if not self.is_running:
+            return
+
+        self._all_models = all_models
+        self._default_spec = default_spec
+        self._profiles = profiles
+        self._filtered_models = list(self._all_models)
+        self._selected_index = self._find_current_model_index()
+        self._loaded = True
+
+        # Re-apply any filter text the user typed while data was loading
+        if self._filter_text:
+            self._update_filtered_list()
+
+        await self._update_display()
+        self._update_footer()
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Filter models as user types.
@@ -319,6 +389,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             event: The input changed event.
         """
         self._filter_text = event.value
+        if not self._loaded:
+            return  # on_mount will re-apply filter after data loads
         self._update_filtered_list()
         self.call_after_refresh(self._update_display)
 
@@ -390,8 +462,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._option_widgets = []
 
         if not self._filtered_models:
-            no_matches = Static(Content.styled("No matching models", "dim"))
-            await self._options_container.mount(no_matches)
+            msg = "Loading models…" if not self._loaded else "No matching models"
+            await self._options_container.mount(Static(Content.styled(msg, "dim")))
             self._update_footer()
             return
 
@@ -836,8 +908,6 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         If the highlighted model is already the default, clears it.
         Otherwise sets it as the new default.
         """
-        import asyncio
-
         if not self._filtered_models or not self._option_widgets:
             return
 


### PR DESCRIPTION
The `/model` selector was blocking the Textual event loop during `ModelSelectorScreen.__init__` — `get_available_models()` and `get_model_profiles()` do filesystem I/O and (on first call) a ~400ms `langchain.chat_models.base` import. This moves all data loading off the event loop so the modal renders instantly, adds a per-module cache to `_load_provider_profiles` to eliminate duplicate work, and makes the startup prewarm unconditional so caches are warm before the user ever types `/model`.