### PR TITLE
fix(sdk): skip symlinked memory sources

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -1,6 +1,7 @@
 """`FilesystemBackend`: Read and write files directly from the filesystem."""
 
 import base64
+import errno
 import json
 import logging
 import os
@@ -748,14 +749,18 @@ def _map_exception_to_standard_error(exc: Exception) -> FileOperationError | Non
     Returns:
         A `FileOperationError` literal, or `None` if unrecognized.
     """
-    if isinstance(exc, FileNotFoundError):
-        return "file_not_found"
-    if isinstance(exc, PermissionError):
-        return "permission_denied"
-    if isinstance(exc, IsADirectoryError):
-        return "is_directory"
-    if isinstance(exc, (NotADirectoryError, FileExistsError)):
-        return "invalid_path"
-    if isinstance(exc, ValueError):
-        return "invalid_path"
+    if isinstance(exc, OSError) and exc.errno == errno.ELOOP:
+        return "symlink_not_allowed"
+
+    type_to_error: tuple[tuple[type[Exception], FileOperationError], ...] = (
+        (FileNotFoundError, "file_not_found"),
+        (PermissionError, "permission_denied"),
+        (IsADirectoryError, "is_directory"),
+        (NotADirectoryError, "invalid_path"),
+        (FileExistsError, "invalid_path"),
+        (ValueError, "invalid_path"),
+    )
+    for exc_type, error in type_to_error:
+        if isinstance(exc, exc_type):
+            return error
     return None

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -35,6 +35,7 @@ FileOperationError = Literal[
     "permission_denied",
     "is_directory",
     "invalid_path",
+    "symlink_not_allowed",
 ]
 """Standardized error codes for file upload/download operations.
 
@@ -45,6 +46,7 @@ potentially fix:
 - permission_denied: Access denied for the operation
 - is_directory: Attempted to download a directory as a file
 - invalid_path: Path syntax is malformed or contains invalid characters
+- symlink_not_allowed: Path resolves to a symlink and the backend forbids following it
 """
 
 

--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -235,6 +235,27 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         memory_body = "\n\n".join(sections)
         return MEMORY_SYSTEM_PROMPT.format(agent_memory=memory_body)
 
+    @staticmethod
+    def _should_skip_download_error(path: str, error: str) -> bool:
+        """Return whether a memory source download error should be skipped.
+
+        Args:
+            path: Memory source path being loaded.
+            error: Backend-reported download error code or message.
+
+        Returns:
+            `True` when the memory source should be skipped instead of failing.
+        """
+        if error == "file_not_found":
+            return True
+        if error == "symlink_not_allowed":
+            logger.warning(
+                "Skipping memory source %s because symlinked AGENTS.md files are not allowed. Replace the symlink with a regular file copy.",
+                path,
+            )
+            return True
+        return False
+
     def before_agent(self, state: MemoryState, runtime: Runtime, config: RunnableConfig) -> MemoryStateUpdate | None:  # ty: ignore[invalid-method-override]
         """Load memory content before agent execution (synchronous).
 
@@ -259,7 +280,7 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         results = backend.download_files(list(self.sources))
         for path, response in zip(self.sources, results, strict=True):
             if response.error is not None:
-                if response.error == "file_not_found":
+                if self._should_skip_download_error(path, response.error):
                     continue
                 msg = f"Failed to download {path}: {response.error}"
                 raise ValueError(msg)
@@ -293,7 +314,7 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         results = await backend.adownload_files(list(self.sources))
         for path, response in zip(self.sources, results, strict=True):
             if response.error is not None:
-                if response.error == "file_not_found":
+                if self._should_skip_download_error(path, response.error):
                     continue
                 msg = f"Failed to download {path}: {response.error}"
                 raise ValueError(msg)

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -4,6 +4,7 @@ Verifies that unimplemented protocol methods raise NotImplementedError
 instead of silently returning None.
 """
 
+import errno
 import warnings
 
 import pytest
@@ -198,6 +199,7 @@ class TestMapFileOperationError:
             (ValueError("invalid path segment"), "invalid_path"),
             (NotADirectoryError("not a dir"), "invalid_path"),
             (FileExistsError("exists"), "invalid_path"),
+            (OSError(errno.ELOOP, "too many symbolic links"), "symlink_not_allowed"),
         ],
     )
     def test_known_exception_types(self, exc: Exception, expected: str) -> None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware.py
@@ -4,11 +4,13 @@ This module tests the memory middleware using end-to-end tests with fake chat mo
 and temporary directories with the FilesystemBackend in normal (non-virtual) mode.
 """
 
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+import pytest
 from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.checkpoint.memory import InMemorySaver
@@ -18,6 +20,7 @@ if TYPE_CHECKING:
 from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.protocol import FileDownloadResponse
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import StoreBackend
 from deepagents.graph import create_deep_agent
@@ -859,9 +862,21 @@ class _SpyBackend(FilesystemBackend):
         super().__init__(root_dir=root_dir, virtual_mode=False)
         self.download_files_call_count = 0
 
-    def download_files(self, paths: list[str]) -> list:
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
         self.download_files_call_count += 1
         return super().download_files(paths)
+
+
+class _ErrorDownloadBackend:
+    """Backend stub for download_files error handling tests."""
+
+    def __init__(self, responses: list[FileDownloadResponse]) -> None:
+        self._responses = responses
+        self.requested_paths: list[list[str]] = []
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        self.requested_paths.append(paths)
+        return self._responses
 
 
 def test_before_agent_batches_download_into_single_call(tmp_path: Path) -> None:
@@ -904,3 +919,25 @@ def test_before_agent_batch_skips_missing_keeps_found(tmp_path: Path) -> None:
     assert existing_path in result["memory_contents"]
     assert missing_path not in result["memory_contents"]
     assert backend.download_files_call_count == 1
+
+
+def test_before_agent_skips_symlinked_memory_file(caplog: pytest.LogCaptureFixture) -> None:
+    """Symlinked AGENTS.md files should be skipped with a warning."""
+    symlink_path = "/linked/AGENTS.md"
+    real_path = "/real/AGENTS.md"
+    backend = _ErrorDownloadBackend(
+        [
+            FileDownloadResponse(path=symlink_path, content=None, error="symlink_not_allowed"),
+            FileDownloadResponse(path=real_path, content=b"# Real Memory\nUseful context", error=None),
+        ]
+    )
+    middleware = MemoryMiddleware(backend=backend, sources=[symlink_path, real_path])
+
+    with caplog.at_level(logging.WARNING):
+        result = middleware.before_agent({}, None, {})  # type: ignore[arg-type]
+
+    assert result is not None
+    assert result["memory_contents"] == {real_path: "# Real Memory\nUseful context"}
+    assert backend.requested_paths == [[symlink_path, real_path]]
+    assert symlink_path in caplog.text
+    assert "Replace the symlink with a regular file copy" in caplog.text

--- a/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_memory_middleware_async.py
@@ -3,12 +3,15 @@
 This module contains async versions of memory middleware tests.
 """
 
+import logging
 from pathlib import Path
 
+import pytest
 from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, HumanMessage
 
 from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.protocol import FileDownloadResponse
 from deepagents.middleware.memory import MemoryMiddleware
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
@@ -372,9 +375,21 @@ class _AsyncSpyBackend(FilesystemBackend):
         super().__init__(root_dir=root_dir, virtual_mode=False)
         self.adownload_files_call_count = 0
 
-    async def adownload_files(self, paths: list[str]) -> list:
+    async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
         self.adownload_files_call_count += 1
         return self.download_files(paths)
+
+
+class _AsyncErrorDownloadBackend:
+    """Backend stub for adownload_files error handling tests."""
+
+    def __init__(self, responses: list[FileDownloadResponse]) -> None:
+        self._responses = responses
+        self.requested_paths: list[list[str]] = []
+
+    async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        self.requested_paths.append(paths)
+        return self._responses
 
 
 async def test_abefore_agent_batches_download_into_single_call(tmp_path: Path) -> None:
@@ -399,3 +414,27 @@ async def test_abefore_agent_batches_download_into_single_call(tmp_path: Path) -
     assert result is not None
     assert len(result["memory_contents"]) == 3
     assert backend.adownload_files_call_count == 1
+
+
+async def test_abefore_agent_skips_symlinked_memory_file(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Async memory loading should skip symlinked AGENTS.md files with a warning."""
+    symlink_path = "/linked/AGENTS.md"
+    real_path = "/real/AGENTS.md"
+    backend = _AsyncErrorDownloadBackend(
+        [
+            FileDownloadResponse(path=symlink_path, content=None, error="symlink_not_allowed"),
+            FileDownloadResponse(path=real_path, content=b"# Real Memory\nUseful context", error=None),
+        ]
+    )
+    middleware = MemoryMiddleware(backend=backend, sources=[symlink_path, real_path])
+
+    with caplog.at_level(logging.WARNING):
+        result = await middleware.abefore_agent({}, None, {})  # type: ignore[arg-type]
+
+    assert result is not None
+    assert result["memory_contents"] == {real_path: "# Real Memory\nUseful context"}
+    assert backend.requested_paths == [[symlink_path, real_path]]
+    assert symlink_path in caplog.text
+    assert "Replace the symlink with a regular file copy" in caplog.text


### PR DESCRIPTION
Fixes #2255

Handle `OSError(errno.ELOOP)` as `symlink_not_allowed` and skip symlinked `AGENTS.md` memory sources during memory loading so the agent warns instead of crashing. This keeps memory loading resilient when a source points to a symlink while preserving the existing security hardening.

How did you verify your code works?

- `uv run --all-groups ruff format .`
- `uv run --all-groups ruff check .`
- `uv run --all-groups ty check deepagents`
- `uv run --group test pytest -vv tests/unit_tests/backends/test_protocol.py tests/unit_tests/middleware/test_memory_middleware.py tests/unit_tests/middleware/test_memory_middleware_async.py`

I also attempted the full package-equivalent unit test run on Windows, but it currently hits broader async `pytest_socket.SocketBlockedError` failures outside this change.

AI disclaimer: I used AI assistance to prepare this change and reviewed the final patch manually.
