### PR TITLE
perf(cli): defer pydantic and adapter imports out of startup hot path

### DIFF
--- a/libs/cli/deepagents_cli/_ask_user_types.py
+++ b/libs/cli/deepagents_cli/_ask_user_types.py
@@ -3,14 +3,37 @@
 Extracted from `ask_user` so `textual_adapter` can import `AskUserRequest` at
 module level — and `app` can reference the types at type-check time — without
 pulling in the langchain middleware stack.
+
+`pydantic.Field` is deliberately imported under `TYPE_CHECKING` only.
+With `from __future__ import annotations` the `Annotated[..., Field(...)]`
+expressions are stored as strings and never evaluated at class body time.
+Call sites that need to resolve these annotations at runtime (`TypeAdapter`,
+LangChain `@tool`) must call `ensure_field_available` first to inject
+`Field` into this module's namespace.
 """
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, NotRequired
+from typing import TYPE_CHECKING, Annotated, Literal, NotRequired
 
-from pydantic import Field
 from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from pydantic import Field
+
+
+def ensure_field_available() -> None:
+    """Inject `pydantic.Field` into this module's globals if not already present.
+
+    This is a no-op when `Field` has already been injected.  By the time any
+    caller needs to resolve the `Annotated[..., Field(...)]` string annotations,
+    pydantic is already in `sys.modules` (loaded by LangChain or a `TypeAdapter`
+    import), so the import here is a dict lookup.
+    """
+    if "Field" not in globals():
+        from pydantic import Field
+
+        globals()["Field"] = Field
 
 
 class Choice(TypedDict):
@@ -60,10 +83,13 @@ class AskUserRequest(TypedDict):
     """Request payload sent via interrupt when asking the user questions."""
 
     type: Literal["ask_user"]
+    """Discriminator tag, always `'ask_user'`."""
 
     questions: list[Question]
+    """Questions to present to the user."""
 
     tool_call_id: str
+    """ID of the originating tool call, used to route the response back."""
 
 
 class AskUserAnswered(TypedDict):
@@ -83,5 +109,5 @@ class AskUserCancelled(TypedDict):
     """Discriminator tag, always `'cancelled'`."""
 
 
-# Discriminated union for the ask_user widget Future result.
 AskUserWidgetResult = AskUserAnswered | AskUserCancelled
+"""Discriminated union for the ask_user widget Future result."""

--- a/libs/cli/deepagents_cli/_ask_user_types.py
+++ b/libs/cli/deepagents_cli/_ask_user_types.py
@@ -3,37 +3,14 @@
 Extracted from `ask_user` so `textual_adapter` can import `AskUserRequest` at
 module level — and `app` can reference the types at type-check time — without
 pulling in the langchain middleware stack.
-
-`pydantic.Field` is deliberately imported under `TYPE_CHECKING` only.
-With `from __future__ import annotations` the `Annotated[..., Field(...)]`
-expressions are stored as strings and never evaluated at class body time.
-Call sites that need to resolve these annotations at runtime (`TypeAdapter`,
-LangChain `@tool`) must call `ensure_field_available` first to inject
-`Field` into this module's namespace.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Literal, NotRequired
+from typing import Annotated, Literal, NotRequired
 
+from pydantic import Field
 from typing_extensions import TypedDict
-
-if TYPE_CHECKING:
-    from pydantic import Field
-
-
-def ensure_field_available() -> None:
-    """Inject `pydantic.Field` into this module's globals if not already present.
-
-    This is a no-op when `Field` has already been injected.  By the time any
-    caller needs to resolve the `Annotated[..., Field(...)]` string annotations,
-    pydantic is already in `sys.modules` (loaded by LangChain or a `TypeAdapter`
-    import), so the import here is a dict lookup.
-    """
-    if "Field" not in globals():
-        from pydantic import Field
-
-        globals()["Field"] = Field
 
 
 class Choice(TypedDict):

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -910,7 +910,7 @@ class DeepAgentsApp(App):
         )
 
         # Create UI adapter unconditionally — it only holds UI callbacks and
-        # doesn't depend on the agent.  The agent is injected later at
+        # doesn't depend on the agent. The agent is injected later at
         # execute_task_textual() call time.
         from deepagents_cli.textual_adapter import TextualUIAdapter
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -841,6 +841,15 @@ class DeepAgentsApp(App):
         # Focus the input immediately so the cursor is visible on first paint
         self._chat_input.focus_input()
 
+        # Prewarm heavy imports in a thread while the first frame renders.
+        # The user can't type yet, so GIL contention is harmless.  By the
+        # time _post_paint_init fires its inline imports are dict lookups.
+        self.run_worker(
+            asyncio.to_thread(self._prewarm_deferred_imports),
+            exclusive=True,
+            group="startup-import-prewarm",
+        )
+
         # Start branch resolution immediately — the thread launches now
         # (during on_mount) so by the time the first frame finishes painting
         # the subprocess is already done. _post_paint_init fires the heavier
@@ -900,11 +909,33 @@ class DeepAgentsApp(App):
             self._update_tokens, self._hide_tokens
         )
 
-        # Create UI adapter if agent is provided (deferred when connecting)
-        if self._agent:
-            self._init_agent_adapter()
+        # Create UI adapter unconditionally — it only holds UI callbacks and
+        # doesn't depend on the agent.  The agent is injected later at
+        # execute_task_textual() call time.
+        from deepagents_cli.textual_adapter import TextualUIAdapter
+
+        self._ui_adapter = TextualUIAdapter(
+            mount_message=self._mount_message,
+            update_status=self._update_status,
+            request_approval=self._request_approval,
+            on_auto_approve_enabled=self._on_auto_approve_enabled,
+            set_spinner=self._set_spinner,
+            set_active_message=self._set_active_message,
+            sync_message_content=self._sync_message_content,
+            request_ask_user=self._request_ask_user,
+        )
+        self._ui_adapter.set_token_tracker(self._token_tracker)
 
         # Fire-and-forget workers — none of these block the event loop.
+
+        # Discover skills first so /skill: autocomplete is ready as early
+        # as possible. The heavy filesystem scan runs in a thread.
+        self.run_worker(
+            self._discover_skills(),
+            exclusive=True,
+            group="startup-skill-discovery",
+        )
+
         self.run_worker(self._init_session_state, exclusive=True, group="session-init")
 
         # Server startup (model creation + server process)
@@ -931,13 +962,6 @@ class DeepAgentsApp(App):
                 group="startup-whats-new",
             )
 
-        # Prewarm deferred widget imports in a thread
-        self.run_worker(
-            asyncio.to_thread(self._prewarm_deferred_imports),
-            exclusive=True,
-            group="startup-import-prewarm",
-        )
-
         # Prewarm model discovery and profile caches unconditionally so
         # /model opens instantly even before the agent/server is ready.
         self.run_worker(
@@ -946,18 +970,18 @@ class DeepAgentsApp(App):
             group="startup-model-prewarm",
         )
 
+        # Prewarm thread message counts so /threads opens instantly.
+        self.run_worker(
+            self._prewarm_threads_cache,
+            exclusive=True,
+            group="startup-thread-prewarm",
+        )
+
         # Optional tool warnings in a thread (shutil.which is sync I/O)
         self.run_worker(
             self._check_optional_tools_background,
             exclusive=True,
             group="startup-tool-check",
-        )
-
-        # Discover skills for /skill: autocomplete (filesystem I/O, offloaded)
-        self.run_worker(
-            self._discover_skills(),
-            exclusive=True,
-            group="startup-skill-discovery",
         )
 
         # Auto-submit initial prompt if provided via -m flag.
@@ -1124,29 +1148,6 @@ class DeepAgentsApp(App):
         # symlinks in standard dirs to point outside those dirs.
         roots.extend(d.resolve() for d in settings.get_extra_skills_dirs())
         return skills, roots
-
-    def _init_agent_adapter(self) -> None:
-        """Create the UI adapter and kick off background cache prewarming."""
-        from deepagents_cli.textual_adapter import TextualUIAdapter
-
-        self._ui_adapter = TextualUIAdapter(
-            mount_message=self._mount_message,
-            update_status=self._update_status,
-            request_approval=self._request_approval,
-            on_auto_approve_enabled=self._on_auto_approve_enabled,
-            set_spinner=self._set_spinner,
-            set_active_message=self._set_active_message,
-            sync_message_content=self._sync_message_content,
-            request_ask_user=self._request_ask_user,
-        )
-        if self._token_tracker:
-            self._ui_adapter.set_token_tracker(self._token_tracker)
-
-        self.run_worker(
-            self._prewarm_threads_cache,
-            exclusive=True,
-            group="startup-thread-prewarm",
-        )
 
     async def _resolve_resume_thread(self) -> None:
         """Resolve a `-r` resume intent into a concrete thread ID.
@@ -1318,9 +1319,6 @@ class DeepAgentsApp(App):
         except NoMatches:
             logger.warning("Welcome banner not found during server ready transition")
 
-        # Now that the agent is available, set up the adapter
-        self._init_agent_adapter()
-
         # Handle deferred initial prompt or thread history
         if self._initial_prompt and self._initial_prompt.strip():
             prompt = self._initial_prompt
@@ -1390,7 +1388,8 @@ class DeepAgentsApp(App):
         # Internal modules moved from top-level to local imports — a failure
         # here indicates a packaging or code bug, not a missing optional dep, so
         # we let the exception propagate (the worker catches it and logs
-        # at WARNING).
+        # at WARNING). textual_adapter and update_check are included so
+        # _post_paint_init's inline imports are dict lookups.
         from deepagents_cli.clipboard import (
             copy_selection_to_clipboard,  # noqa: F401
         )
@@ -1398,6 +1397,8 @@ class DeepAgentsApp(App):
         from deepagents_cli.config import settings  # noqa: F401
         from deepagents_cli.hooks import dispatch_hook  # noqa: F401
         from deepagents_cli.model_config import ModelSpec  # noqa: F401
+        from deepagents_cli.textual_adapter import TextualUIAdapter  # noqa: F401
+        from deepagents_cli.update_check import is_update_check_enabled  # noqa: F401
 
         try:
             # Heavy third-party deps deferred from textual_adapter /

--- a/libs/cli/deepagents_cli/ask_user.py
+++ b/libs/cli/deepagents_cli/ask_user.py
@@ -21,7 +21,17 @@ from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from langchain_core.tools import tool
 from langgraph.types import Command, interrupt
 
-from deepagents_cli._ask_user_types import AskUserRequest, Question
+from deepagents_cli._ask_user_types import (
+    AskUserRequest,
+    Question,
+    ensure_field_available,
+)
+
+# Inject pydantic.Field into _ask_user_types' namespace so LangChain's
+# @tool decorator can resolve the Annotated[..., Field(...)] string annotations
+# when generating the tool schema.  By this point langchain has already loaded
+# pydantic, so this is a dict lookup.
+ensure_field_available()
 
 logger = logging.getLogger(__name__)
 

--- a/libs/cli/deepagents_cli/ask_user.py
+++ b/libs/cli/deepagents_cli/ask_user.py
@@ -21,17 +21,7 @@ from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from langchain_core.tools import tool
 from langgraph.types import Command, interrupt
 
-from deepagents_cli._ask_user_types import (
-    AskUserRequest,
-    Question,
-    ensure_field_available,
-)
-
-# Inject pydantic.Field into _ask_user_types' namespace so LangChain's
-# @tool decorator can resolve the Annotated[..., Field(...)] string annotations
-# when generating the tool schema.  By this point langchain has already loaded
-# pydantic, so this is a dict lookup.
-ensure_field_available()
+from deepagents_cli._ask_user_types import AskUserRequest, Question
 
 logger = logging.getLogger(__name__)
 

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -221,15 +221,25 @@ def format_path(path: str | None) -> str:
         return path
 
 
+_db_path: Path | None = None
+
+
 def get_db_path() -> Path:
     """Get path to global database.
+
+    The result is cached after the first successful call to avoid repeated
+    filesystem operations.
 
     Returns:
         Path to the SQLite database file.
     """
+    global _db_path  # noqa: PLW0603  # Module-level cache requires global statement
+    if _db_path is not None:
+        return _db_path
     db_dir = Path.home() / ".deepagents"
     db_dir.mkdir(parents=True, exist_ok=True)
-    return db_dir / "sessions.db"
+    _db_path = db_dir / "sessions.db"
+    return _db_path
 
 
 def generate_thread_id() -> str:
@@ -596,7 +606,7 @@ def _cache_recent_threads(
 
 def _copy_threads(threads: list[ThreadInfo]) -> list[ThreadInfo]:
     """Return shallow-copied thread rows."""
-    return [ThreadInfo(**thread) for thread in threads]
+    return [cast("ThreadInfo", dict(thread)) for thread in threads]
 
 
 async def _count_messages_from_checkpoint(

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -606,7 +606,7 @@ def _cache_recent_threads(
 
 def _copy_threads(threads: list[ThreadInfo]) -> list[ThreadInfo]:
     """Return shallow-copied thread rows."""
-    return [cast("ThreadInfo", dict(thread)) for thread in threads]
+    return [ThreadInfo(**thread) for thread in threads]
 
 
 async def _count_messages_from_checkpoint(

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -166,6 +166,9 @@ def _get_ask_user_adapter() -> TypeAdapter:
     if _ask_user_adapter_cache is None:
         from pydantic import TypeAdapter
 
+        from deepagents_cli._ask_user_types import ensure_field_available
+
+        ensure_field_available()
         _ask_user_adapter_cache = TypeAdapter(AskUserRequest)
     return _ask_user_adapter_cache
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -166,9 +166,6 @@ def _get_ask_user_adapter() -> TypeAdapter:
     if _ask_user_adapter_cache is None:
         from pydantic import TypeAdapter
 
-        from deepagents_cli._ask_user_types import ensure_field_available
-
-        ensure_field_available()
         _ask_user_adapter_cache = TypeAdapter(AskUserRequest)
     return _ask_user_adapter_cache
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -22,11 +22,13 @@ if TYPE_CHECKING:
     )
     from langchain_core.messages import AIMessage
     from langgraph.types import Command, Interrupt
+    from pydantic import TypeAdapter
     from rich.console import Console
 
     from deepagents_cli._ask_user_types import AskUserWidgetResult, Question
 
-from pydantic import TypeAdapter, ValidationError
+    # Type alias matching HITLResponse["decisions"] element type
+    HITLDecision = ApproveDecision | EditDecision | RejectDecision
 
 from deepagents_cli._ask_user_types import AskUserRequest
 from deepagents_cli._cli_context import CLIContext  # noqa: TC001
@@ -73,6 +75,8 @@ def _get_hitl_request_adapter(hitl_request_type: type) -> TypeAdapter:
     """
     global _hitl_adapter_cache  # noqa: PLW0603
     if _hitl_adapter_cache is None:
+        from pydantic import TypeAdapter
+
         _hitl_adapter_cache = TypeAdapter(hitl_request_type)
     return _hitl_adapter_cache
 
@@ -148,12 +152,22 @@ def print_usage_table(
         )
 
 
-if TYPE_CHECKING:
-    # Type alias matching HITLResponse["decisions"] element type
-    HITLDecision = ApproveDecision | EditDecision | RejectDecision
+_ask_user_adapter_cache: TypeAdapter | None = None
+"""Lazy singleton for the `ask_user` interrupt validator."""
 
-_ASK_USER_INTERRUPT_ADAPTER = TypeAdapter(AskUserRequest)
-"""Validator for incoming `ask_user` interrupt payloads."""
+
+def _get_ask_user_adapter() -> TypeAdapter:
+    """Return a cached `TypeAdapter(AskUserRequest)`.
+
+    Returns:
+        Shared `TypeAdapter` instance.
+    """
+    global _ask_user_adapter_cache  # noqa: PLW0603
+    if _ask_user_adapter_cache is None:
+        from pydantic import TypeAdapter
+
+        _ask_user_adapter_cache = TypeAdapter(AskUserRequest)
+    return _ask_user_adapter_cache
 
 
 def _is_summarization_chunk(metadata: dict | None) -> bool:
@@ -410,8 +424,10 @@ async def execute_task_textual(
     )
     from langchain_core.messages import HumanMessage, ToolMessage
     from langgraph.types import Command
+    from pydantic import ValidationError
 
     hitl_request_adapter = _get_hitl_request_adapter(HITLRequest)
+    ask_user_adapter = _get_ask_user_adapter()
 
     # Parse file mentions and inject content if any — offload blocking I/O
     prompt_text, mentioned_files = await asyncio.to_thread(
@@ -537,9 +553,7 @@ async def execute_task_textual(
                                 ):
                                     try:
                                         validated_ask_user = (
-                                            _ASK_USER_INTERRUPT_ADAPTER.validate_python(
-                                                iv
-                                            )
+                                            ask_user_adapter.validate_python(iv)
                                         )
                                         pending_ask_user[interrupt_obj.id] = (
                                             validated_ask_user

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1153,10 +1153,10 @@ class ChatInput(Vertical):
     @staticmethod
     def _is_existing_path_payload(text: str) -> bool:
         """Return whether text is a dropped-path payload for existing files."""
-        from deepagents_cli.input import parse_pasted_path_payload
-
         if len(text) < 2:  # noqa: PLR2004  # Need at least '/' + one char
             return False
+        from deepagents_cli.input import parse_pasted_path_payload
+
         return parse_pasted_path_payload(text, allow_leading_path=True) is not None
 
     def _is_dropped_path_payload(self, text: str) -> bool:

--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -21,10 +21,12 @@ from textual.style import Style as TStyle
 from textual.widgets import Checkbox, Input, Static
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from textual.app import ComposeResult
     from textual.events import Click, Key
+
+    from deepagents_cli.sessions import ThreadInfo
 
 from deepagents_cli import theme
 from deepagents_cli.config import (
@@ -32,7 +34,6 @@ from deepagents_cli.config import (
     get_glyphs,
     is_ascii_mode,
 )
-from deepagents_cli.sessions import ThreadInfo
 from deepagents_cli.widgets._links import open_style_link
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,35 @@ _SWITCH_ID_PREFIX = "thread-column-"
 _SORT_SWITCH_ID = "thread-sort-toggle"
 _RELATIVE_TIME_SWITCH_ID = "thread-relative-time"
 _CELL_PADDING_RIGHT = 1
+
+_FormatFns = tuple[
+    "Callable[[str | None], str]",  # format_path
+    "Callable[[str | None], str]",  # format_relative_timestamp
+    "Callable[[str | None], str]",  # format_timestamp
+]
+"""Cached `(format_path, format_relative_timestamp, format_timestamp)`.
+
+Resolved once on first use via `_get_format_fns()` to avoid the overhead of
+a per-call deferred import inside the hot `_format_column_value` loop.
+"""
+
+_format_fns_cache: _FormatFns | None = None
+"""Cached format functions, populated on first call to `_get_format_fns()`."""
+
+
+def _get_format_fns() -> _FormatFns:
+    """Return cached `(format_path, format_relative_timestamp, format_timestamp)`."""
+    global _format_fns_cache  # noqa: PLW0603
+    if _format_fns_cache is not None:
+        return _format_fns_cache
+    from deepagents_cli.sessions import (
+        format_path,
+        format_relative_timestamp,
+        format_timestamp,
+    )
+
+    _format_fns_cache = (format_path, format_relative_timestamp, format_timestamp)
+    return _format_fns_cache
 
 
 def _apply_column_width(
@@ -191,13 +221,8 @@ def _format_column_value(
     Returns:
         Formatted display text for the column cell.
     """
-    from deepagents_cli.sessions import (
-        format_path,
-        format_relative_timestamp,
-        format_timestamp,
-    )
-
-    fmt = format_relative_timestamp if relative_time else format_timestamp
+    format_path, format_relative_ts, format_ts = _get_format_fns()
+    fmt = format_relative_ts if relative_time else format_ts
 
     value: str
     if key == "thread_id":
@@ -259,6 +284,7 @@ class ThreadOption(Horizontal):
         selected: bool,
         current: bool,
         relative_time: bool = False,
+        cell_text: dict[tuple[str, str], str] | None = None,
         classes: str = "",
     ) -> None:
         """Initialize a thread option row.
@@ -271,6 +297,7 @@ class ThreadOption(Horizontal):
             selected: Whether the row is highlighted.
             current: Whether the row is the active thread.
             relative_time: Use relative timestamps.
+            cell_text: Pre-formatted cell values keyed by `(thread_id, key)`.
             classes: CSS classes for styling.
         """
         super().__init__(classes=classes)
@@ -282,6 +309,7 @@ class ThreadOption(Horizontal):
         self._selected = selected
         self._current = current
         self._relative_time = relative_time
+        self._cell_text = cell_text
 
     class Clicked(Message):
         """Message sent when a thread option is clicked."""
@@ -308,11 +336,16 @@ class ThreadOption(Horizontal):
             classes="thread-cell thread-cell-cursor",
             markup=False,
         )
+        tid = self.thread_id
         for key in _visible_column_keys(self._columns):
-            cell = Static(
-                _format_column_value(
+            if self._cell_text is not None and (tid, key) in self._cell_text:
+                text = self._cell_text[tid, key]
+            else:
+                text = _format_column_value(
                     self.thread, key, relative_time=self._relative_time
-                ),
+                )
+            cell = Static(
+                text,
                 classes=f"thread-cell thread-cell-{key}",
                 expand=key == "initial_prompt",
                 markup=False,
@@ -640,9 +673,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._current_thread = current_thread
         self._thread_limit = thread_limit
         self._threads: list[ThreadInfo] = (
-            [ThreadInfo(**thread) for thread in initial_threads]
-            if initial_threads is not None
-            else []
+            list(initial_threads) if initial_threads is not None else []
         )
         self._filtered_threads: list[ThreadInfo] = list(self._threads)
         self._has_initial_threads = initial_threads is not None
@@ -653,6 +684,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._render_lock = asyncio.Lock()
         self._filter_input: Input | None = None
         self._filter_controls: list[Input | Checkbox] | None = None
+        self._cell_text: dict[tuple[str, str], str] = {}
 
         from deepagents_cli.model_config import load_thread_config
 
@@ -889,10 +921,23 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             if self._current_thread:
                 self._resolve_thread_url()
 
-        # _load_threads replaces self._threads and schedules background
-        # enrichment (message counts, initial prompts) after load completes.
-        # Avoid eagerly scheduling enrichment on stale initial_threads that
-        # will be replaced.
+        if self._has_initial_threads:
+            # Defer by one message cycle so Textual finishes processing
+            # mount messages before we start the DB refresh.
+            self.call_after_refresh(self._start_thread_load)
+        else:
+            # _load_threads replaces self._threads and schedules background
+            # enrichment (message counts, initial prompts) after load
+            # completes.  Launch immediately when there are no cached rows
+            # to render.
+            self.run_worker(
+                self._load_threads, exclusive=True, group="thread-selector-load"
+            )
+
+    def _start_thread_load(self) -> None:
+        """Launch the thread-load worker after the initial layout pass."""
+        if not self.is_attached:
+            return
         self.run_worker(
             self._load_threads, exclusive=True, group="thread-selector-load"
         )
@@ -1049,10 +1094,10 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
     def _compute_column_widths(self) -> dict[str, int | None]:
         """Return effective widths for the current table state.
 
-        The auto-width columns stay dynamic, but they must share one width
-        across the header and all visible rows. Textual's `width: auto`
-        computes per-widget widths, so the screen computes those shared widths
-        from the visible data instead.
+        Textual's `width: auto` computes per-widget widths, so this method
+        derives shared widths from the visible data instead. Also populates
+        `self._cell_text` as a side effect so that `ThreadOption.compose()` can
+        reuse the formatted strings.
 
         Returns:
             Dict mapping column keys to their effective cell widths, with
@@ -1060,7 +1105,8 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         """
         global _column_widths_cache  # noqa: PLW0603  # Module-level cache requires global statement
 
-        visible = frozenset(_visible_column_keys(self._columns))
+        visible_keys = _visible_column_keys(self._columns)
+        visible = frozenset(visible_keys)
         fingerprint = tuple(
             (t["thread_id"], t.get("latest_checkpoint_id"))
             for t in self._filtered_threads
@@ -1068,22 +1114,38 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
 
         if _column_widths_cache is not None:
             fp, vis, rel, cached_widths = _column_widths_cache
-            if fp == fingerprint and vis == visible and rel == self._relative_time:
+            if (
+                fp == fingerprint
+                and vis == visible
+                and rel == self._relative_time
+                and self._cell_text
+            ):
                 return dict(cached_widths)
 
-        widths = dict(_COLUMN_WIDTHS)
+        # Pre-format every visible cell in one pass.
+        cell_text: dict[tuple[str, str], str] = {}
+        for thread in self._filtered_threads:
+            tid = thread["thread_id"]
+            for key in visible_keys:
+                cell_text[tid, key] = _format_column_value(
+                    thread, key, relative_time=self._relative_time
+                )
+        self._cell_text = cell_text
 
+        # Derive auto-widths from the pre-formatted values.
+        widths = dict(_COLUMN_WIDTHS)
         for key in _AUTO_WIDTH_COLUMNS:
-            if not self._columns.get(key):
+            if key not in visible:
                 continue
-            labels = [_format_header_label(key)]
-            labels.extend(
-                _format_column_value(thread, key, relative_time=self._relative_time)
-                for thread in self._filtered_threads
+            header_len = cell_len(_format_header_label(key))
+            max_cell = max(
+                (
+                    cell_len(cell_text[t["thread_id"], key])
+                    for t in self._filtered_threads
+                ),
+                default=0,
             )
-            widths[key] = max((cell_len(label) for label in labels), default=1) + (
-                _CELL_PADDING_RIGHT
-            )
+            widths[key] = max(header_len, max_cell) + _CELL_PADDING_RIGHT
 
         _column_widths_cache = (fingerprint, visible, self._relative_time, widths)
         return widths
@@ -1371,16 +1433,27 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
 
     def _refresh_cell_labels(self) -> None:
         """Update visible cell text in-place without rebuilding the DOM."""
+        visible_keys = _visible_column_keys(self._columns)
+
+        # Recompute because thread data may have changed since
+        # _compute_column_widths populated the cache.
+        cell_text: dict[tuple[str, str], str] = {}
+        for thread in self._filtered_threads:
+            tid = thread["thread_id"]
+            for key in visible_keys:
+                cell_text[tid, key] = _format_column_value(
+                    thread, key, relative_time=self._relative_time
+                )
+        self._cell_text = cell_text
+
         for widget in self._option_widgets:
-            thread = widget.thread
-            for key in _visible_column_keys(self._columns):
+            tid = widget.thread_id
+            for key in visible_keys:
                 try:
                     cell = widget.query_one(f".thread-cell-{key}", Static)
                 except NoMatches:
                     continue
-                cell.update(
-                    _format_column_value(thread, key, relative_time=self._relative_time)
-                )
+                cell.update(cell_text[tid, key])
 
     def _resolve_thread_url(self) -> None:
         """Start exclusive background worker to resolve LangSmith thread URL."""
@@ -1509,6 +1582,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 selected=is_selected,
                 current=is_current,
                 relative_time=self._relative_time,
+                cell_text=self._cell_text or None,
                 classes=classes,
             )
             widgets.append(widget)


### PR DESCRIPTION
- Defer heavy imports (`pydantic`, `textual_adapter`, `update_check`) out of the CLI startup hot path so `deepagents -v` and argument parsing stay fast
- Construct `TextualUIAdapter` eagerly in `_post_paint_init` (no agent dependency) and fire the import-prewarm worker earlier during `on_mount` so inline imports are dict lookups by the time they run
- Cache `get_db_path()` result and thread-selector format functions (`format_path`, `format_timestamp`, `format_relative_timestamp`) to avoid repeated filesystem and deferred-import overhead
- Pre-format all visible thread-selector cells in `_compute_column_widths` and pass the cache through to `ThreadOption.compose()` so each cell is formatted exactly once per render pass