### PR TITLE
fix(cli): exit app on `ctrl+d` when thread list is empty

### DIFF
--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -1725,7 +1725,13 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
 
     def action_delete_thread(self) -> None:
         """Show delete confirmation for the highlighted thread."""
-        if self._confirming_delete or not self._filtered_threads:
+        if self._confirming_delete:
+            return
+        if not self._filtered_threads:
+            # Nothing to delete — fall through to quit. Using exit() instead of
+            # dismiss() is intentional: dismiss() would just close the modal
+            # silently, re-swallowing ctrl+d.
+            self.app.exit()
             return
         self._confirming_delete = True
         thread = self._filtered_threads[self._selected_index]


### PR DESCRIPTION
When `ctrl+d` is pressed on an empty thread list in the `ThreadSelectorScreen`, the action was silently swallowed — the early return fired because `_filtered_threads` was empty, but no exit happened. Now the empty-list branch calls `app.exit()` so the keypress behaves like a normal quit signal instead of doing nothing.