### PR TITLE
feat(cli): agent-friendly ux for scripted/headless workflows

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -216,6 +216,7 @@ def reset_agent(
     agent_name: str,
     source_agent: str | None = None,
     *,
+    dry_run: bool = False,
     output_format: OutputFormat = "text",
 ) -> None:
     """Reset an agent to default or copy from another agent.
@@ -223,7 +224,11 @@ def reset_agent(
     Args:
         agent_name: Name of the agent to reset.
         source_agent: Copy AGENTS.md from this agent instead of default.
+        dry_run: If `True`, print what would happen without making changes.
         output_format: Output format — `'text'` (Rich) or `'json'`.
+
+    Raises:
+        SystemExit: If the source agent is not found.
     """
     agents_dir = settings.user_deepagents_dir
     agent_dir = agents_dir / agent_name
@@ -235,15 +240,35 @@ def reset_agent(
         if not source_md.exists():
             console.print(
                 f"[bold red]Error:[/bold red] Source agent '{source_agent}' not found "
-                "or has no AGENTS.md"
+                "or has no AGENTS.md\n"
+                "  Available agents: deepagents agents list"
             )
-            return
+            raise SystemExit(1)
 
         source_content = source_md.read_text()
         action_desc = f"contents of agent '{source_agent}'"
     else:
         source_content = get_default_coding_instructions()
         action_desc = "default"
+
+    if dry_run:
+        if output_format == "json":
+            from deepagents_cli.output import write_json
+
+            write_json(
+                "reset",
+                {
+                    "agent": agent_name,
+                    "reset_to": source_agent or "default",
+                    "path": str(agent_dir),
+                    "dry_run": True,
+                },
+            )
+            return
+        exists = "remove and recreate" if agent_dir.exists() else "create"
+        console.print(f"Would {exists} {agent_dir} with {action_desc} prompt.")
+        console.print("No changes made.", style=theme.MUTED)
+        return
 
     if agent_dir.exists():
         shutil.rmtree(agent_dir)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -317,24 +317,39 @@ def parse_args() -> argparse.Namespace:
         parents=help_parent(_lazy_help("show_help")),
     )
 
-    subparsers.add_parser(
+    agents_parser = subparsers.add_parser(
+        "agents",
+        help="Manage agents",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_agents_help")),
+    )
+    add_json_output_arg(agents_parser)
+    agents_sub = agents_parser.add_subparsers(dest="agents_command")
+
+    agents_list = agents_sub.add_parser(
         "list",
-        help="List all available agents",
+        aliases=["ls"],
+        help="List all agents",
         add_help=False,
         parents=help_parent(_lazy_help("show_list_help")),
     )
-    add_json_output_arg(subparsers.choices["list"])
+    add_json_output_arg(agents_list)
 
-    reset_parser = subparsers.add_parser(
+    agents_reset = agents_sub.add_parser(
         "reset",
-        help="Reset an agent",
+        help="Reset an agent's prompt to default",
         add_help=False,
         parents=help_parent(_lazy_help("show_reset_help")),
     )
-    add_json_output_arg(reset_parser)
-    reset_parser.add_argument("--agent", required=True, help="Name of agent to reset")
-    reset_parser.add_argument(
+    add_json_output_arg(agents_reset)
+    agents_reset.add_argument("--agent", required=True, help="Name of agent to reset")
+    agents_reset.add_argument(
         "--target", dest="source_agent", help="Copy prompt from another agent"
+    )
+    agents_reset.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes",
     )
 
     setup_skills_parser(
@@ -403,6 +418,19 @@ def parse_args() -> argparse.Namespace:
     )
     add_json_output_arg(threads_delete)
     threads_delete.add_argument("thread_id", help="Thread ID to delete")
+    threads_delete.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes",
+    )
+
+    update_parser = subparsers.add_parser(
+        "update",
+        help="Check for and install CLI updates",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_update_help")),
+    )
+    add_json_output_arg(update_parser)
 
     # Default interactive mode — argument order here determines the
     # usage line printed by argparse; keep in sync with ui.show_help().
@@ -499,6 +527,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Buffer the full response and write it to stdout at once "
         "instead of streaming token-by-token. Requires -n or piped stdin.",
+    )
+
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read input from stdin explicitly (instead of auto-detection)",
     )
 
     add_json_output_arg(parser, default="text")
@@ -903,15 +937,36 @@ def apply_stdin_pipe(args: argparse.Namespace) -> None:
     """
     from deepagents_cli.config import console
 
+    explicit_stdin = args.stdin
+
     if sys.stdin is None:
+        if explicit_stdin:
+            console.print(
+                "[bold red]Error:[/bold red] --stdin was passed but stdin "
+                "is not available."
+            )
+            sys.exit(1)
         return
 
     try:
         is_tty = sys.stdin.isatty()
     except (ValueError, OSError):
+        if explicit_stdin:
+            console.print(
+                "[bold red]Error:[/bold red] --stdin was passed but stdin "
+                "state could not be determined."
+            )
+            sys.exit(1)
         return
 
     if is_tty:
+        if explicit_stdin:
+            console.print(
+                "[bold red]Error:[/bold red] --stdin was passed but stdin "
+                "is a terminal. Pipe input or use -n instead.\n"
+                "  cat prompt.txt | deepagents --stdin -q"
+            )
+            sys.exit(1)
         return
 
     max_stdin_bytes = 10 * 1024 * 1024  # 10 MiB
@@ -1170,7 +1225,12 @@ def cli_main() -> None:
                 sys.exit(1)
 
             if getattr(args, "no_mcp", False) and getattr(args, "mcp_config", None):
-                msg = "Error: --no-mcp and --mcp-config are mutually exclusive\n"
+                msg = (
+                    "Error: --no-mcp and --mcp-config are mutually exclusive."
+                    " Use one or the other.\n"
+                    "  deepagents --mcp-config path/to/config.json\n"
+                    "  deepagents --no-mcp\n"
+                )
                 sys.stderr.write(msg)
                 sys.stderr.flush()
                 sys.exit(2)
@@ -1203,7 +1263,9 @@ def cli_main() -> None:
 
             _Console(stderr=True).print(
                 "[bold red]Error:[/bold red] --no-mcp and --mcp-config "
-                "are mutually exclusive"
+                "are mutually exclusive. Use one or the other.\n"
+                "  deepagents --mcp-config path/to/config.json\n"
+                "  deepagents --no-mcp"
             )
             sys.exit(2)
 
@@ -1221,12 +1283,13 @@ def cli_main() -> None:
             flag = " and ".join(flags)
             _Console(stderr=True).print(
                 f"[bold red]Error:[/bold red] {flag} requires "
-                "--non-interactive (-n) or piped stdin"
+                "--non-interactive (-n) or piped stdin\n"
+                "  deepagents -n 'summarize README.md' --quiet"
             )
             sys.exit(2)
 
-        # Handle --update (headless, no session)
-        if args.update:
+        # Handle --update flag or `update` subcommand (headless, no session)
+        if args.update or args.command == "update":
             try:
                 from rich.markup import escape
 
@@ -1329,14 +1392,22 @@ def cli_main() -> None:
             from deepagents_cli.ui import show_help
 
             show_help()
-        elif args.command == "list":
-            from deepagents_cli.agent import list_agents
+        elif args.command == "agents":
+            from deepagents_cli.agent import list_agents, reset_agent
+            from deepagents_cli.ui import show_agents_help
 
-            list_agents(output_format=output_format)
-        elif args.command == "reset":
-            from deepagents_cli.agent import reset_agent
-
-            reset_agent(args.agent, args.source_agent, output_format=output_format)
+            # "ls" is an argparse alias for "list"
+            if args.agents_command in {"list", "ls"}:
+                list_agents(output_format=output_format)
+            elif args.agents_command == "reset":
+                reset_agent(
+                    args.agent,
+                    args.source_agent,
+                    dry_run=args.dry_run,
+                    output_format=output_format,
+                )
+            else:
+                show_agents_help()
         elif args.command == "skills":
             from deepagents_cli.skills import execute_skills_command
 
@@ -1364,7 +1435,11 @@ def cli_main() -> None:
                 )
             elif args.threads_command == "delete":
                 asyncio.run(
-                    delete_thread_command(args.thread_id, output_format=output_format)
+                    delete_thread_command(
+                        args.thread_id,
+                        dry_run=args.dry_run,
+                        output_format=output_format,
+                    )
                 )
             else:
                 # No subcommand provided, show threads help screen

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -1204,14 +1204,41 @@ async def list_threads_command(
 
 
 async def delete_thread_command(
-    thread_id: str, *, output_format: OutputFormat = "text"
+    thread_id: str,
+    *,
+    dry_run: bool = False,
+    output_format: OutputFormat = "text",
 ) -> None:
     """CLI handler for: deepagents threads delete.
 
     Args:
         thread_id: ID of the thread to delete.
+        dry_run: If `True`, print what would happen without making changes.
         output_format: Output format — `'text'` (Rich) or `'json'`.
     """
+    if dry_run:
+        exists = await thread_exists(thread_id)
+        if output_format == "json":
+            from deepagents_cli.output import write_json
+
+            write_json(
+                "threads delete",
+                {"thread_id": thread_id, "exists": exists, "dry_run": True},
+            )
+            return
+
+        from rich.markup import escape as escape_markup
+
+        from deepagents_cli.config import console
+
+        escaped_id = escape_markup(thread_id)
+        if exists:
+            console.print(f"Would delete thread '{escaped_id}'.")
+        else:
+            console.print(f"Thread '{escaped_id}' not found. Nothing to delete.")
+        console.print("No changes made.", style="dim")
+        return
+
     deleted = await delete_thread(thread_id)
 
     if output_format == "json":
@@ -1222,10 +1249,14 @@ async def delete_thread_command(
 
     from rich.markup import escape as escape_markup
 
+    from deepagents_cli import theme
     from deepagents_cli.config import console
 
     escaped_id = escape_markup(thread_id)
     if deleted:
         console.print(f"[green]Thread '{escaped_id}' deleted.[/green]")
     else:
-        console.print(f"[red]Thread '{escaped_id}' not found.[/red]")
+        console.print(
+            f"Thread '{escaped_id}' not found or already deleted.",
+            style=theme.MUTED,
+        )

--- a/libs/cli/deepagents_cli/skills/commands.py
+++ b/libs/cli/deepagents_cli/skills/commands.py
@@ -411,6 +411,9 @@ def _create(
         project: If True, create in project skills directory.
             If False, create in user skills directory.
         output_format: Output format — `'text'` (Rich) or `'json'`.
+
+    Raises:
+        SystemExit: If the skill name is invalid or the directory cannot be created.
     """
     from deepagents_cli.config import Settings, console, get_glyphs
 
@@ -424,7 +427,7 @@ def _create(
             "Examples: web-research, code-review, data-analysis[/dim]",
             style=theme.MUTED,
         )
-        return
+        raise SystemExit(1)
 
     # Determine target directory
     settings = Settings.from_environment()
@@ -436,13 +439,13 @@ def _create(
                 "in the project root.[/dim]",
                 style=theme.MUTED,
             )
-            return
+            raise SystemExit(1)
         skills_dir = settings.ensure_project_skills_dir()
         if skills_dir is None:
             console.print(
                 "[bold red]Error:[/bold red] Could not create project skills directory."
             )
-            return
+            raise SystemExit(1)
     else:
         skills_dir = settings.ensure_user_skills_dir(agent)
 
@@ -452,12 +455,25 @@ def _create(
     is_valid_path, path_error = _validate_skill_path(skill_dir, skills_dir)
     if not is_valid_path:
         console.print(f"[bold red]Error:[/bold red] {path_error}")
-        return
+        raise SystemExit(1)
 
     if skill_dir.exists():
+        if output_format == "json":
+            from deepagents_cli.output import write_json
+
+            write_json(
+                "skills create",
+                {
+                    "name": skill_name,
+                    "path": str(skill_dir),
+                    "project": project,
+                    "already_existed": True,
+                },
+            )
+            return
         console.print(
-            f"[bold red]Error:[/bold red] Skill '{skill_name}' "
-            f"already exists at {skill_dir}"
+            f"Skill '{skill_name}' already exists at {skill_dir}",
+            style=theme.MUTED,
         )
         return
 
@@ -520,6 +536,9 @@ def _info(
         project: If True, only search in project skills.
             If False, search in both user and project skills.
         output_format: Output format — `'text'` (Rich) or `'json'`.
+
+    Raises:
+        SystemExit: If the skill is not found or not in a project directory.
     """
     from rich.markup import escape as escape_markup
 
@@ -536,7 +555,7 @@ def _info(
     if project:
         if not project_skills_dir:
             console.print("[bold red]Error:[/bold red] Not in a project directory.")
-            return
+            raise SystemExit(1)
         skills = list_skills(
             user_skills_dir=None,
             project_skills_dir=project_skills_dir,
@@ -560,7 +579,7 @@ def _info(
         console.print("\n[dim]Available skills:[/dim]", style=theme.MUTED)
         for s in skills:
             console.print(f"  - {s['name']}", style=theme.MUTED)
-        return
+        raise SystemExit(1)
 
     if output_format == "json":
         from deepagents_cli.output import write_json
@@ -645,6 +664,7 @@ def _delete(
     agent: str = "agent",
     project: bool = False,
     force: bool = False,
+    dry_run: bool = False,
     output_format: OutputFormat = "text",
 ) -> None:
     """Delete a skill directory after validation and optional user confirmation.
@@ -660,6 +680,7 @@ def _delete(
 
             If `False`, search in both user and project skills.
         force: If `True`, skip confirmation prompt.
+        dry_run: If `True`, print what would be removed without deleting.
         output_format: Output format — `'text'` (Rich) or `'json'`.
 
     Raises:
@@ -674,7 +695,7 @@ def _delete(
     is_valid, error_msg = _validate_name(skill_name)
     if not is_valid:
         console.print(f"[bold red]Error:[/bold red] Invalid skill name: {error_msg}")
-        return
+        raise SystemExit(1)
 
     settings = Settings.from_environment()
     user_skills_dir = settings.get_user_skills_dir(agent)
@@ -686,7 +707,7 @@ def _delete(
     if project:
         if not project_skills_dir:
             console.print("[bold red]Error:[/bold red] Not in a project directory.")
-            return
+            raise SystemExit(1)
         skills = list_skills(
             user_skills_dir=None,
             project_skills_dir=project_skills_dir,
@@ -710,7 +731,7 @@ def _delete(
         for s in skills:
             source_tag = "[project]" if s["source"] == "project" else "[user]"
             console.print(f"  - {s['name']} {source_tag}", style=theme.MUTED)
-        return
+        raise SystemExit(1)
 
     skill_path = Path(skill["path"])
     skill_dir = skill_path.parent
@@ -722,10 +743,29 @@ def _delete(
             "[bold red]Error:[/bold red] Cannot determine base skills directory. "
             "Refusing to delete."
         )
-        return
+        raise SystemExit(1)
     is_valid_path, path_error = _validate_skill_path(skill_dir, base_dir)
     if not is_valid_path:
         console.print(f"[bold red]Error:[/bold red] {path_error}")
+        raise SystemExit(1)
+
+    if dry_run:
+        if output_format == "json":
+            from deepagents_cli.output import write_json
+
+            write_json(
+                "skills delete",
+                {
+                    "name": skill_name,
+                    "path": str(skill_dir),
+                    "dry_run": True,
+                },
+            )
+            return
+        console.print(
+            f"Would delete skill '{skill_name}' at {skill_dir}",
+        )
+        console.print("No changes made.", style=theme.MUTED)
         return
 
     # Display confirmation summary (text mode only)
@@ -975,6 +1015,11 @@ def setup_skills_parser(
         action="store_true",
         help="Skip confirmation prompt",
     )
+    delete_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes",
+    )
     return skills_parser
 
 
@@ -983,6 +1028,9 @@ def execute_skills_command(args: argparse.Namespace) -> None:
 
     Args:
         args: Parsed command line arguments with skills_command attribute
+
+    Raises:
+        SystemExit: If the agent name is invalid.
     """
     from deepagents_cli.config import console
 
@@ -998,7 +1046,7 @@ def execute_skills_command(args: argparse.Namespace) -> None:
                 "hyphens, and underscores.[/dim]",
                 style=theme.MUTED,
             )
-            return
+            raise SystemExit(1)
 
     output_format = getattr(args, "output_format", "text")
 
@@ -1026,6 +1074,7 @@ def execute_skills_command(args: argparse.Namespace) -> None:
             agent=args.agent,
             project=args.project,
             force=args.force,
+            dry_run=args.dry_run,
             output_format=output_format,
         )
     else:

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -52,17 +52,15 @@ def show_help() -> None:
     console.print(
         "  deepagents [OPTIONS]                           Start interactive thread"
     )
-    console.print(
-        "  deepagents list                                List all available agents"
-    )
-    console.print(
-        "  deepagents reset --agent AGENT [--target SRC]  Reset an agent's prompt"
-    )
+    console.print("  deepagents agents <list|reset>                 Manage agents")
     console.print(
         "  deepagents skills <list|create|info|delete>    Manage agent skills"
     )
     console.print(
         "  deepagents threads <list|delete>               Manage conversation threads"
+    )
+    console.print(
+        "  deepagents update                              Check for and install updates"
     )
     console.print()
 
@@ -105,6 +103,7 @@ def show_help() -> None:
     console.print(
         "  --no-stream                Buffer full response instead of streaming"
     )
+    console.print("  --stdin                    Read input from stdin explicitly")
     console.print(
         "  --json                     Emit machine-readable JSON for commands"
     )
@@ -138,6 +137,10 @@ def show_help() -> None:
         "  deepagents -n 'Fix tests' -S all           # Any command",
         style=theme.MUTED,
     )
+    console.print(
+        "  cat prompt.txt | deepagents --stdin -q      # Explicit stdin",
+        style=theme.MUTED,
+    )
     console.print()
 
 
@@ -158,6 +161,29 @@ def show_list_help() -> None:
     )
     console.print()
     _print_option_section()
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents list")
+    console.print("  deepagents list --json")
+    console.print()
+
+
+def show_agents_help() -> None:
+    """Show help information for the `agents` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents agents <command> [options]")
+    console.print()
+    console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
+    console.print("  list|ls           List all agents")
+    console.print("  reset             Reset an agent's prompt to default")
+    console.print()
+    _print_option_section()
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents agents list")
+    console.print("  deepagents agents reset --agent coder")
+    console.print("  deepagents agents reset --agent coder --target researcher")
     console.print()
 
 
@@ -180,11 +206,13 @@ def show_reset_help() -> None:
     _print_option_section(
         "  --agent NAME            Agent to reset (required)",
         "  --target SRC            Copy AGENTS.md from another agent instead",
+        "  --dry-run               Show what would happen without making changes",
     )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  deepagents reset --agent coder")
     console.print("  deepagents reset --agent coder --target researcher")
+    console.print("  deepagents reset --agent coder --dry-run")
     console.print()
 
 
@@ -245,6 +273,11 @@ def show_skills_list_help() -> None:
         "  --project               Show only project-level skills",
     )
     console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents skills list")
+    console.print("  deepagents skills list --project")
+    console.print("  deepagents skills list --json")
+    console.print()
 
 
 def show_skills_create_help() -> None:
@@ -276,6 +309,10 @@ def show_skills_info_help() -> None:
         "  --project               Search only in project skills",
     )
     console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents skills info web-research")
+    console.print("  deepagents skills info my-skill --project")
+    console.print()
 
 
 def show_skills_delete_help() -> None:
@@ -288,12 +325,32 @@ def show_skills_delete_help() -> None:
         "  --agent NAME            Agent identifier (default: agent)",
         "  --project               Search only in project skills",
         "  -f, --force             Skip confirmation prompt",
+        "  --dry-run               Show what would happen without making changes",
     )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  deepagents skills delete old-skill")
     console.print("  deepagents skills delete old-skill --force")
     console.print("  deepagents skills delete old-skill --project")
+    console.print("  deepagents skills delete old-skill --dry-run")
+    console.print()
+
+
+def show_update_help() -> None:
+    """Show help information for the `update` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents update [options]")
+    console.print()
+    console.print(
+        "Check for and install CLI updates from PyPI.",
+    )
+    console.print()
+    _print_option_section()
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents update")
+    console.print("  deepagents update --json")
     console.print()
 
 
@@ -327,10 +384,13 @@ def show_threads_delete_help() -> None:
     console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
     console.print("  deepagents threads delete <ID> [options]")
     console.print()
-    _print_option_section()
+    _print_option_section(
+        "  --dry-run               Show what would happen without making changes",
+    )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  deepagents threads delete abc123")
+    console.print("  deepagents threads delete abc123 --dry-run")
     console.print()
 
 

--- a/libs/cli/tests/unit_tests/skills/test_commands.py
+++ b/libs/cli/tests/unit_tests/skills/test_commands.py
@@ -952,7 +952,9 @@ class TestDeleteSkill:
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
             mock_console.print = capture_print
-            _delete("nonexistent-skill", agent="agent", project=False, force=True)
+            with pytest.raises(SystemExit) as exc_info:
+                _delete("nonexistent-skill", agent="agent", project=False, force=True)
+            assert exc_info.value.code == 1
 
         joined = "\n".join(output)
         assert "not found" in joined.lower()
@@ -1085,7 +1087,9 @@ class TestDeleteSkill:
             ):
                 mock_settings_cls.from_environment.return_value = mock_settings
                 mock_console.print = capture_print
-                _delete(invalid_name, agent="agent", project=False, force=True)
+                with pytest.raises(SystemExit) as exc_info:
+                    _delete(invalid_name, agent="agent", project=False, force=True)
+                assert exc_info.value.code == 1
 
             joined = "\n".join(output)
             assert "invalid skill name" in joined.lower(), (
@@ -1129,7 +1133,9 @@ class TestDeleteSkill:
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
             mock_console.print = capture_print
-            _delete("any-skill", agent="agent", project=True, force=True)
+            with pytest.raises(SystemExit) as exc_info:
+                _delete("any-skill", agent="agent", project=True, force=True)
+            assert exc_info.value.code == 1
 
         joined = "\n".join(output)
         assert "not in a project directory" in joined.lower()
@@ -1240,7 +1246,9 @@ class TestDeleteSkill:
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
             mock_console.print = capture_print
-            _delete("orphan-skill", agent="agent", project=False, force=True)
+            with pytest.raises(SystemExit) as exc_info:
+                _delete("orphan-skill", agent="agent", project=False, force=True)
+            assert exc_info.value.code == 1
 
         joined = "\n".join(output)
         assert "cannot determine" in joined.lower() or "refusing" in joined.lower()
@@ -1306,6 +1314,7 @@ class TestDeleteArgparsing:
             agent="agent",
             project=False,
             force=True,
+            dry_run=False,
         )
 
         output: list[str] = []
@@ -1319,7 +1328,9 @@ class TestDeleteArgparsing:
         ):
             mock_settings_cls.from_environment.return_value = mock_settings
             mock_console.print = capture_print
-            execute_skills_command(args)
+            with pytest.raises(SystemExit) as exc_info:
+                execute_skills_command(args)
+            assert exc_info.value.code == 1
 
         # Should have dispatched to _delete and shown "not found"
         # rather than falling through to show_skills_help()

--- a/libs/cli/tests/unit_tests/test_agent_friendly.py
+++ b/libs/cli/tests/unit_tests/test_agent_friendly.py
@@ -1,0 +1,597 @@
+"""Tests for agent-friendly CLI improvements.
+
+Covers: --dry-run, idempotency, --stdin, error messages, agents subcommand,
+update subcommand, and help screen examples.
+"""
+
+import asyncio
+import io
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from deepagents_cli.main import parse_args
+from deepagents_cli.ui import (
+    show_agents_help,
+    show_help,
+    show_list_help,
+    show_reset_help,
+    show_skills_delete_help,
+    show_skills_info_help,
+    show_skills_list_help,
+    show_threads_delete_help,
+    show_update_help,
+)
+
+# ---------------------------------------------------------------------------
+# Section 1: Help screen Examples sections
+# ---------------------------------------------------------------------------
+
+
+class TestHelpScreenExamples:
+    """Verify Examples sections exist in all subcommand help screens."""
+
+    @staticmethod
+    def _render(fn: object) -> str:
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            fn()  # type: ignore[operator]
+        return buf.getvalue()
+
+    def test_list_help_has_examples(self) -> None:
+        text = self._render(show_list_help)
+        assert "Examples:" in text
+        assert "deepagents list" in text
+        assert "deepagents list --json" in text
+
+    def test_skills_list_help_has_examples(self) -> None:
+        text = self._render(show_skills_list_help)
+        assert "Examples:" in text
+        assert "deepagents skills list --project" in text
+        assert "deepagents skills list --json" in text
+
+    def test_skills_info_help_has_examples(self) -> None:
+        text = self._render(show_skills_info_help)
+        assert "Examples:" in text
+        assert "deepagents skills info web-research" in text
+        assert "deepagents skills info my-skill --project" in text
+
+    def test_agents_help_has_examples(self) -> None:
+        text = self._render(show_agents_help)
+        assert "Examples:" in text
+        assert "deepagents agents list" in text
+        assert "deepagents agents reset --agent coder" in text
+
+    def test_update_help_has_examples(self) -> None:
+        text = self._render(show_update_help)
+        assert "Examples:" in text
+        assert "deepagents update" in text
+        assert "deepagents update --json" in text
+
+    def test_reset_help_has_dry_run(self) -> None:
+        text = self._render(show_reset_help)
+        assert "--dry-run" in text
+
+    def test_threads_delete_help_has_dry_run(self) -> None:
+        text = self._render(show_threads_delete_help)
+        assert "--dry-run" in text
+
+    def test_skills_delete_help_has_dry_run(self) -> None:
+        text = self._render(show_skills_delete_help)
+        assert "--dry-run" in text
+
+
+# ---------------------------------------------------------------------------
+# Section 2: --dry-run for reset
+# ---------------------------------------------------------------------------
+
+
+class TestResetDryRun:
+    """Tests for deepagents reset --dry-run."""
+
+    def test_dry_run_text_no_mutation(self, tmp_path: Path) -> None:
+        """--dry-run should not remove the agent directory."""
+        from deepagents_cli.agent import reset_agent
+
+        agent_dir = tmp_path / "coder"
+        agent_dir.mkdir()
+        (agent_dir / "AGENTS.md").write_text("original")
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with (
+            patch("deepagents_cli.agent.settings") as mock_settings,
+            patch("deepagents_cli.agent.console", test_console),
+            patch(
+                "deepagents_cli.agent.get_default_coding_instructions",
+                return_value="default",
+            ),
+        ):
+            mock_settings.user_deepagents_dir = tmp_path
+            reset_agent("coder", dry_run=True)
+
+        assert agent_dir.exists()
+        assert (agent_dir / "AGENTS.md").read_text() == "original"
+        output = buf.getvalue()
+        assert "Would" in output
+        assert "No changes made" in output
+
+    def test_dry_run_json(self, tmp_path: Path) -> None:
+        """--dry-run --json should include dry_run: true."""
+        from deepagents_cli.agent import reset_agent
+
+        agent_dir = tmp_path / "coder"
+        agent_dir.mkdir()
+        (agent_dir / "AGENTS.md").write_text("original")
+
+        stdout_buf = io.StringIO()
+        with (
+            patch("deepagents_cli.agent.settings") as mock_settings,
+            patch("deepagents_cli.agent.console"),
+            patch(
+                "deepagents_cli.agent.get_default_coding_instructions",
+                return_value="default",
+            ),
+            patch("sys.stdout", stdout_buf),
+        ):
+            mock_settings.user_deepagents_dir = tmp_path
+            reset_agent("coder", dry_run=True, output_format="json")
+
+        result = json.loads(stdout_buf.getvalue())
+        assert result["data"]["dry_run"] is True
+        assert agent_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Section 2b: --dry-run for threads delete
+# ---------------------------------------------------------------------------
+
+
+class TestThreadsDeleteDryRun:
+    """Tests for deepagents threads delete --dry-run."""
+
+    def test_dry_run_text_existing(self) -> None:
+        """--dry-run should report what would happen for existing thread."""
+        from deepagents_cli import sessions
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with (
+            patch.object(
+                sessions,
+                "thread_exists",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("deepagents_cli.config.console", test_console),
+        ):
+            asyncio.run(sessions.delete_thread_command("abc123", dry_run=True))
+
+        output = buf.getvalue()
+        assert "Would delete" in output
+        assert "No changes made" in output
+
+    def test_dry_run_text_missing(self) -> None:
+        """--dry-run should report not found for missing thread."""
+        from deepagents_cli import sessions
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with (
+            patch.object(
+                sessions,
+                "thread_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("deepagents_cli.config.console", test_console),
+        ):
+            asyncio.run(sessions.delete_thread_command("missing", dry_run=True))
+
+        output = buf.getvalue()
+        assert "not found" in output
+        assert "No changes made" in output
+
+    def test_dry_run_json(self) -> None:
+        """--dry-run --json should include dry_run: true."""
+        from deepagents_cli import sessions
+
+        stdout_buf = io.StringIO()
+        with (
+            patch.object(
+                sessions,
+                "thread_exists",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("sys.stdout", stdout_buf),
+        ):
+            asyncio.run(
+                sessions.delete_thread_command(
+                    "abc123", dry_run=True, output_format="json"
+                )
+            )
+
+        result = json.loads(stdout_buf.getvalue())
+        assert result["data"]["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Section 3: agents subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsSubcommand:
+    """Tests for the agents resource subcommand."""
+
+    def test_agents_list_parses(self) -> None:
+        """Running `deepagents agents list` should parse correctly."""
+        with patch.object(sys, "argv", ["deepagents", "agents", "list"]):
+            args = parse_args()
+        assert args.command == "agents"
+        assert args.agents_command == "list"
+
+    def test_agents_ls_alias(self) -> None:
+        """Running `deepagents agents ls` should parse as list."""
+        with patch.object(sys, "argv", ["deepagents", "agents", "ls"]):
+            args = parse_args()
+        assert args.command == "agents"
+        assert args.agents_command == "ls"
+
+    def test_agents_reset_parses(self) -> None:
+        """Running `deepagents agents reset --agent coder` should parse."""
+        with patch.object(
+            sys, "argv", ["deepagents", "agents", "reset", "--agent", "coder"]
+        ):
+            args = parse_args()
+        assert args.command == "agents"
+        assert args.agents_command == "reset"
+        assert args.agent == "coder"
+
+    def test_agents_reset_with_target(self) -> None:
+        """Running `deepagents agents reset --agent coder --target researcher`."""
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "deepagents",
+                "agents",
+                "reset",
+                "--agent",
+                "coder",
+                "--target",
+                "researcher",
+            ],
+        ):
+            args = parse_args()
+        assert args.source_agent == "researcher"
+
+    def test_agents_reset_dry_run(self) -> None:
+        """Running `deepagents agents reset --agent coder --dry-run`."""
+        with patch.object(
+            sys,
+            "argv",
+            ["deepagents", "agents", "reset", "--agent", "coder", "--dry-run"],
+        ):
+            args = parse_args()
+        assert args.dry_run is True
+
+    def test_agents_help_exits_clean(self) -> None:
+        """Running `deepagents agents -h` should show help and exit 0."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=120)
+        with (
+            patch.object(sys, "argv", ["deepagents", "agents", "-h"]),
+            patch("deepagents_cli.ui.console", test_console),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code in (0, None)
+        assert "agents" in buf.getvalue().lower()
+
+    def test_top_level_list_rejected(self) -> None:
+        """Top-level `deepagents list` should error — use `agents list` instead."""
+        with (
+            patch.object(sys, "argv", ["deepagents", "list"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Section 4: update subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSubcommand:
+    """Tests for the update subcommand."""
+
+    def test_update_parses(self) -> None:
+        """Running `deepagents update` should parse as command='update'."""
+        with patch.object(sys, "argv", ["deepagents", "update"]):
+            args = parse_args()
+        assert args.command == "update"
+
+    def test_update_help_exits_clean(self) -> None:
+        """Running `deepagents update -h` should show help and exit 0."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=120)
+        with (
+            patch.object(sys, "argv", ["deepagents", "update", "-h"]),
+            patch("deepagents_cli.ui.console", test_console),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code in (0, None)
+        assert "update" in buf.getvalue().lower()
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsCreateIdempotency:
+    """Skills create should be a no-op if skill already exists."""
+
+    def test_already_exists_text_no_error(self, tmp_path: Path) -> None:
+        """Re-creating an existing skill should print informational msg, not error."""
+        from deepagents_cli.skills.commands import _create
+
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("existing")
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        mock_settings = MagicMock()
+        mock_settings.project_root = None
+        mock_settings.ensure_user_skills_dir.return_value = tmp_path
+        with (
+            patch("deepagents_cli.config.Settings") as settings_cls,
+            patch("deepagents_cli.config.console", test_console),
+        ):
+            settings_cls.from_environment.return_value = mock_settings
+            _create("my-skill", "agent")
+
+        output = buf.getvalue()
+        assert "Error" not in output
+        assert "already exists" in output
+
+    def test_already_exists_json(self, tmp_path: Path) -> None:
+        """Re-creating an existing skill in JSON mode returns already_existed."""
+        from deepagents_cli.skills.commands import _create
+
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("existing")
+
+        stdout_buf = io.StringIO()
+        mock_settings = MagicMock()
+        mock_settings.project_root = None
+        mock_settings.ensure_user_skills_dir.return_value = tmp_path
+        with (
+            patch("deepagents_cli.config.Settings") as settings_cls,
+            patch("deepagents_cli.config.console"),
+            patch("sys.stdout", stdout_buf),
+        ):
+            settings_cls.from_environment.return_value = mock_settings
+            _create("my-skill", "agent", output_format="json")
+
+        result = json.loads(stdout_buf.getvalue())
+        assert result["data"]["already_existed"] is True
+
+
+class TestThreadsDeleteIdempotency:
+    """Threads delete should be informational (not error) when thread not found."""
+
+    def test_not_found_not_red(self) -> None:
+        """Not-found message should not contain Error prefix."""
+        from deepagents_cli import sessions
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with (
+            patch.object(
+                sessions,
+                "delete_thread",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("deepagents_cli.config.console", test_console),
+        ):
+            asyncio.run(sessions.delete_thread_command("missing"))
+
+        output = buf.getvalue()
+        assert "Error" not in output
+        assert "not found or already deleted" in output
+
+
+# ---------------------------------------------------------------------------
+# Section 6: --stdin flag
+# ---------------------------------------------------------------------------
+
+
+class TestStdinFlag:
+    """Tests for --stdin explicit flag."""
+
+    def test_stdin_flag_parses(self) -> None:
+        """Verify --stdin sets stdin=True."""
+        with patch.object(sys, "argv", ["deepagents", "--stdin"]):
+            args = parse_args()
+        assert args.stdin is True
+
+    def test_stdin_default_false(self) -> None:
+        """Verify stdin defaults to False."""
+        with patch.object(sys, "argv", ["deepagents"]):
+            args = parse_args()
+        assert args.stdin is False
+
+    def test_stdin_with_tty_errors(self) -> None:
+        """--stdin with a TTY should error."""
+        from deepagents_cli.main import apply_stdin_pipe
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+
+        args = MagicMock()
+        args.stdin = True
+
+        with (
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.config.console"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            apply_stdin_pipe(args)
+
+        assert exc_info.value.code == 1
+
+    def test_stdin_omitted_preserves_auto_detect(self) -> None:
+        """Omitting --stdin with TTY should return without error."""
+        from deepagents_cli.main import apply_stdin_pipe
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+
+        args = MagicMock()
+        args.stdin = False
+        args.non_interactive_message = None
+        args.initial_prompt = None
+
+        with patch.object(sys, "stdin", mock_stdin):
+            apply_stdin_pipe(args)
+
+        # Should not modify args
+        assert args.non_interactive_message is None
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Error messages with corrective hints
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessageHints:
+    """Tests for corrective hints in error messages."""
+
+    def test_no_mcp_conflict_has_hint(self) -> None:
+        """--no-mcp + --mcp-config error should include usage examples."""
+        from deepagents_cli.main import cli_main
+
+        stderr_buf = io.StringIO()
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["deepagents", "--no-mcp", "--mcp-config", "/some/path"],
+            ),
+            patch("deepagents_cli.main.check_cli_dependencies"),
+            patch("deepagents_cli.main.apply_stdin_pipe"),
+            patch("sys.stderr", stderr_buf),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 2
+        output = stderr_buf.getvalue()
+        assert "Use one or the other" in output
+
+    def test_quiet_without_n_has_hint(self) -> None:
+        """--quiet without -n error should include usage example."""
+        from deepagents_cli.main import cli_main
+
+        stderr_buf = io.StringIO()
+        with (
+            patch.object(sys, "argv", ["deepagents", "--quiet"]),
+            patch("deepagents_cli.main.check_cli_dependencies"),
+            patch("deepagents_cli.main.apply_stdin_pipe"),
+            patch("sys.stderr", stderr_buf),
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+
+        output = stderr_buf.getvalue()
+        assert "deepagents -n" in output
+
+    def test_reset_source_not_found_has_hint(self, tmp_path: Path) -> None:
+        """Reset with missing source agent should suggest agents list."""
+        from deepagents_cli.agent import reset_agent
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with (  # separate to satisfy PT012
+            patch("deepagents_cli.agent.settings") as mock_settings,
+            patch("deepagents_cli.agent.console", test_console),
+        ):
+            mock_settings.user_deepagents_dir = tmp_path
+            with pytest.raises(SystemExit):
+                reset_agent("coder", "nonexistent")
+
+        output = buf.getvalue()
+        assert "deepagents agents list" in output
+
+
+# ---------------------------------------------------------------------------
+# Drift detection: new flags in argparse should appear in help screens
+# ---------------------------------------------------------------------------
+
+
+class TestHelpScreenDriftExtended:
+    """Extended drift detection for new subcommands."""
+
+    def test_show_help_includes_agents_subcommand(self) -> None:
+        """show_help should mention the agents subcommand."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            show_help()
+        assert "agents" in buf.getvalue()
+
+    def test_show_help_includes_update_subcommand(self) -> None:
+        """show_help should mention the update subcommand."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            show_help()
+        assert "update" in buf.getvalue()
+
+    def test_show_help_includes_stdin(self) -> None:
+        """show_help should mention --stdin."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            show_help()
+        assert "--stdin" in buf.getvalue()
+
+    def test_all_parser_flags_appear_in_help(self) -> None:
+        """Every top-level --flag in argparse must appear in show_help()."""
+        stderr_buf = io.StringIO()
+        with (
+            patch.object(sys, "argv", ["deepagents", "--_x_"]),
+            patch("sys.stderr", stderr_buf),
+            pytest.raises(SystemExit),
+        ):
+            parse_args()
+        usage_text = stderr_buf.getvalue()
+
+        help_buf = io.StringIO()
+        test_console = Console(file=help_buf, highlight=False, width=200)
+        with patch("deepagents_cli.ui.console", test_console):
+            show_help()
+        help_text = help_buf.getvalue()
+
+        parser_flags = set(re.findall(r"--[\w][\w-]*", usage_text))
+        help_flags = set(re.findall(r"--[\w][\w-]*", help_text))
+        parser_flags.discard("--_x_")
+
+        missing = parser_flags - help_flags
+        assert not missing, (
+            f"Flags in argparse but missing from show_help(): {missing}\n"
+            "Add them to the Options section in ui.show_help()."
+        )

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -162,18 +162,18 @@ class TestSubcommandHelpFlags:
         assert must_contain in output
         assert must_not_contain not in output
 
-    def test_list_help(self) -> None:
-        """Running `deepagents list -h` should show list-specific help."""
+    def test_agents_list_help(self) -> None:
+        """Running `deepagents agents list -h` should show list-specific help."""
         self._run_help(
-            ["deepagents", "list", "-h"],
+            ["deepagents", "agents", "list", "-h"],
             must_contain="List all agents",
             must_not_contain="--sandbox",
         )
 
-    def test_reset_help(self) -> None:
-        """Running `deepagents reset -h` should show reset-specific help."""
+    def test_agents_reset_help(self) -> None:
+        """Running `deepagents agents reset -h` should show reset-specific help."""
         self._run_help(
-            ["deepagents", "reset", "-h"],
+            ["deepagents", "agents", "reset", "-h"],
             must_contain="--agent",
             must_not_contain="Start interactive thread",
         )
@@ -408,16 +408,16 @@ class TestJsonArg:
 
     def test_json_before_subcommand(self) -> None:
         """Verify --json works before a subcommand."""
-        with patch.object(sys, "argv", ["deepagents", "--json", "list"]):
+        with patch.object(sys, "argv", ["deepagents", "--json", "agents", "list"]):
             args = parse_args()
-        assert args.command == "list"
+        assert args.command == "agents"
         assert args.output_format == "json"
 
     def test_json_after_subcommand(self) -> None:
         """Verify --json works after a subcommand."""
-        with patch.object(sys, "argv", ["deepagents", "list", "--json"]):
+        with patch.object(sys, "argv", ["deepagents", "agents", "list", "--json"]):
             args = parse_args()
-        assert args.command == "list"
+        assert args.command == "agents"
         assert args.output_format == "json"
 
     def test_output_format_flag_removed(self) -> None:

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -269,11 +269,13 @@ def _make_args(
     *,
     non_interactive_message: str | None = None,
     initial_prompt: str | None = None,
+    stdin: bool = False,
 ) -> argparse.Namespace:
     """Create a minimal argument namespace for stdin pipe tests."""
     return argparse.Namespace(
         non_interactive_message=non_interactive_message,
         initial_prompt=initial_prompt,
+        stdin=stdin,
     )
 
 


### PR DESCRIPTION
Make the CLI more predictable for scripted and agent-driven workflows: add `--dry-run` to destructive commands, nest agent management under a proper `agents` resource subcommand, promote `update` from a flag to a subcommand, add `--stdin` for explicit pipe detection, and improve error messages with corrective hints so callers don't have to guess what went wrong.

## Changes

- Nest `list` and `reset` under a new `deepagents agents` resource subcommand (`agents list`, `agents ls`, `agents reset`) — top-level `deepagents list` and `deepagents reset` are removed
- Add `--dry-run` to `reset_agent`, `delete_thread_command`, and `skills _delete` — prints what would happen (text or JSON) without mutating state
- Add `deepagents update` subcommand as an alias for the existing `--update` flag, so headless update follows the same `verb noun` pattern as other commands
- Add `--stdin` flag to `apply_stdin_pipe` for explicit pipe detection — errors clearly when stdin is unavailable or is a TTY, instead of silently falling through
- Upgrade error paths in `skills/commands.py` and `agent.py` from silent `return` to `raise SystemExit(1)`, giving callers a non-zero exit code to branch on
- Add corrective hints to error messages: `--no-mcp`/`--mcp-config` conflict now suggests the alternatives, `--quiet` without `-n` shows an example, missing source agent points to `deepagents agents list`
- Make `skills create` idempotent — re-creating an existing skill prints an informational message (or `already_existed: true` in JSON) instead of a red error
- Soften `threads delete` not-found from a red error to a muted "not found or already deleted" message
- Add `Examples:` sections to all subcommand help screens (`list`, `agents`, `reset`, `skills list/info/delete`, `threads delete`, `update`)