### PR TITLE
feat(cli): add `ls_integration` metadata to langsmith traces

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -475,11 +475,19 @@ Longer values are truncated with an ellipsis by `truncate_value`
 in `tool_display`.
 """
 
-config: RunnableConfig = {"recursion_limit": 1000}
-"""Default LangGraph runnable config with a high recursion limit.
+config: RunnableConfig = {
+    "recursion_limit": 1000,
+    "metadata": {
+        "ls_integration": "deepagents-cli",
+    },
+}
+"""Default LangGraph runnable config.
 
 Sets `recursion_limit` to 1000 to accommodate deeply nested agent graphs without
 hitting the default LangGraph ceiling.
+
+Includes `ls_integration` metadata so LangSmith traces originating from the CLI
+are distinguishable from bare SDK usage.
 """
 
 _git_branch_cache: dict[str, str | None] = {}

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -477,17 +477,11 @@ in `tool_display`.
 
 config: RunnableConfig = {
     "recursion_limit": 1000,
-    "metadata": {
-        "ls_integration": "deepagents-cli",
-    },
 }
 """Default LangGraph runnable config.
 
 Sets `recursion_limit` to 1000 to accommodate deeply nested agent graphs without
 hitting the default LangGraph ceiling.
-
-Includes `ls_integration` metadata so LangSmith traces originating from the CLI
-are distinguishable from bare SDK usage.
 """
 
 _git_branch_cache: dict[str, str | None] = {}
@@ -551,6 +545,9 @@ def build_stream_config(
         version would be lost.
     * Including the SDK version here ensures it survives the merge.
 
+    Includes `ls_integration` metadata so LangSmith traces originating from the CLI
+    are distinguishable from bare SDK usage.
+
     Args:
         thread_id: The CLI session thread identifier.
         assistant_id: The agent/assistant identifier, if any.
@@ -575,7 +572,10 @@ def build_stream_config(
     with contextlib.suppress(importlib_metadata.PackageNotFoundError):
         versions["deepagents"] = importlib_metadata.version("deepagents")
 
-    metadata: dict[str, Any] = {"versions": versions}
+    metadata: dict[str, Any] = {
+        "versions": versions,
+        "ls_integration": "deepagents-cli",
+    }
     if cwd:
         metadata["cwd"] = cwd
     if assistant_id:


### PR DESCRIPTION
Tag CLI traces with `ls_integration` metadata so LangSmith can distinguish runs originating from the Deep Agents CLI versus direct SDK usage. This is the standard integration-identification pattern used across LangChain tooling.