### PR TITLE
fix(cli): warn agent that local filesystem is inaccessible in sandbox mode

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -425,7 +425,13 @@ def get_system_prompt(
             f"**Important:**\n"
             f"- The CLI is running locally on the user's machine, but you execute "
             f"code remotely\n"
-            f"- Use `{working_dir}` as your working directory for all operations\n\n"
+            f"- Use `{working_dir}` as your working directory for all operations\n"
+            f"- **You do NOT have access to the user's local filesystem.** Paths "
+            f"like `/Users/...`, `/home/<local-user>/...`, `C:\\...`, etc. do not "
+            f"exist in this sandbox. Never reference or attempt to read/write local "
+            f"paths — all files must be within the sandbox at `{working_dir}`\n"
+            f"- When delegating to subagents, ensure they also use sandbox paths "
+            f"(`{working_dir}/...`), not local paths\n\n"
         )
     else:
         if cwd is not None:

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -501,6 +501,49 @@ class TestGetSystemPromptCwdOSError:
         assert "Current Working Directory" in prompt
 
 
+class TestGetSystemPromptSandbox:
+    """Tests for sandbox-specific system prompt content."""
+
+    def test_sandbox_includes_no_local_filesystem_warning(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", sandbox_type="modal")
+
+        assert "do NOT have access to the user's local filesystem" in prompt
+
+    def test_sandbox_includes_working_dir_constraint(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", sandbox_type="modal")
+
+        assert "/workspace" in prompt
+        assert "remote Linux sandbox" in prompt
+
+    def test_sandbox_warns_about_subagent_paths(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", sandbox_type="daytona")
+
+        assert "subagents" in prompt
+        assert "/home/daytona" in prompt
+
+    def test_local_mode_omits_sandbox_warnings(self) -> None:
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent")
+
+        assert "do NOT have access to the user's local filesystem" not in prompt
+        assert "remote Linux sandbox" not in prompt
+
+
 class TestGetSystemPromptPlaceholderValidation:
     """Tests for unreplaced placeholder detection."""
 


### PR DESCRIPTION
When running in a remote sandbox, the agent's system prompt told it to use the sandbox working directory but never explicitly stated that the user's local filesystem is inaccessible. This caused failures when subagents tried to reference local paths like `/Users/mdrxy/...` - the sandbox can't reach the host machine's filesystem, but the model had no instruction telling it so.

The sandbox section of `get_system_prompt` now explicitly warns that local paths (`/Users/...`, `/home/<local-user>/...`, `C:\...`) don't exist in the sandbox and must never be referenced. It also instructs the agent to propagate sandbox paths when delegating to subagents.