### PR TITLE
feat(cli): allow color overrides on built-in themes, default dark to false

### DIFF
--- a/libs/cli/deepagents_cli/theme.py
+++ b/libs/cli/deepagents_cli/theme.py
@@ -13,9 +13,11 @@ Code that needs custom CSS variable values should call
 up the `ThemeColors` instance via `ThemeEntry.REGISTRY`.
 
 Users can define custom themes in `~/.deepagents/config.toml` under
-`[themes.<name>]` sections. Each section must include `label` (str) and `dark`
-(bool); color fields are optional and fall back to the built-in dark/light
-palette based on the `dark` flag. See `_load_user_themes()` for details.
+`[themes.<name>]` sections. Each new theme section must include `label` (str);
+`dark` (bool) defaults to `False` if omitted (set to `True` for dark themes).
+Color fields are optional and fall back to the built-in dark/light palette based
+on the `dark` flag. Sections whose name matches a built-in theme override its
+colors without replacing it. See `_load_user_themes()` for details.
 """
 
 from __future__ import annotations
@@ -474,9 +476,11 @@ def _builtin_themes() -> dict[str, ThemeEntry]:
 
 
 _BUILTIN_NAMES: frozenset[str] = frozenset(_builtin_themes())
-"""Names reserved for built-in themes — user themes cannot shadow these.
+"""Names of built-in themes.
 
-Derived from `_builtin_themes()` to stay in sync automatically.
+User `[themes.<name>]` sections matching a built-in name override its colors
+rather than creating a new theme. Derived from `_builtin_themes()` to stay in
+sync automatically.
 """
 
 
@@ -487,29 +491,43 @@ def _load_user_themes(
 ) -> None:
     """Load user-defined themes from `config.toml` into `builtins` (mutated).
 
-    Each `[themes.<name>]` section must have:
+    **New themes** — each `[themes.<name>]` section (where `<name>` is not a
+    built-in) must have:
 
     - `label` (str) — human-readable name shown in the theme picker.
-    - `dark` (bool) — whether this is a dark-mode variant.
+    - `dark` (bool, optional) — whether this is a dark-mode variant.
 
-    All `ThemeColors` fields are optional; omitted fields fall back to the
-    built-in dark or light palette based on the `dark` flag.
+        Defaults to `False` (light).
 
-    Invalid themes (bad hex, missing required keys, name collision with
-    built-ins) are logged as warnings and skipped — they never crash startup.
+    **Built-in overrides** — if `<name>` matches a built-in theme, only color
+    fields are read; `label` and `dark` are inherited from the built-in.
+
+    All `ThemeColors` fields are optional. For new themes, omitted fields
+    fall back to the built-in dark or light palette based on the `dark` flag.
+
+    For built-in overrides, omitted fields retain the existing built-in colors.
+
+    Invalid themes (bad hex, missing required keys) are logged as warnings
+    and skipped — they never crash startup.
 
     Example `config.toml` snippet:
 
     ```toml
+    # New custom theme
     [themes.my-solarized]
     label = "My Solarized"
     dark = true
     primary = "#268BD2"
     warning = "#B58900"
+
+    # Override built-in theme colors
+    [themes.langchain]
+    primary = "#FF5500"
     ```
 
     Args:
-        builtins: Mutable dict to append user themes into.
+        builtins: Mutable dict to update (new themes are added, built-in
+            overrides replace existing entries).
         config_path: Override for the config file path (testing).
     """
     if config_path is None:
@@ -539,36 +557,15 @@ def _load_user_themes(
     if not isinstance(themes_section, dict) or not themes_section:
         return
 
+    valid_color_names = {f.name for f in fields(ThemeColors)}
+    reserved = {"label", "dark"}
+
     for name, section in themes_section.items():
         if not isinstance(section, dict):
             logger.warning("Ignoring non-table [themes.%s]", name)
             continue
 
-        if name in _BUILTIN_NAMES:
-            logger.warning(
-                "User theme '%s' shadows a built-in theme and will be ignored",
-                name,
-            )
-            continue
-
-        label = section.get("label")
-        dark = section.get("dark")
-        if not isinstance(label, str) or not label.strip():
-            logger.warning(
-                "User theme '%s' missing required 'label' (str); skipping",
-                name,
-            )
-            continue
-        if not isinstance(dark, bool):
-            logger.warning(
-                "User theme '%s' missing required 'dark' (bool); skipping",
-                name,
-            )
-            continue
-
-        base = DARK_COLORS if dark else LIGHT_COLORS
-        valid_color_names = {f.name for f in fields(ThemeColors)}
-        reserved = {"label", "dark"}
+        # --- Parse color overrides (shared by built-in overrides & new themes)
         color_overrides: dict[str, str] = {}
         for k, v in section.items():
             if k in reserved:
@@ -590,6 +587,55 @@ def _load_user_themes(
                     k,
                 )
 
+        # --- Built-in override: merge color tweaks into the existing entry
+        if name in _BUILTIN_NAMES:
+            existing = builtins.get(name)
+            if existing is None:
+                logger.warning(
+                    "Built-in theme '%s' not in builtins dict; skipping override",
+                    name,
+                )
+                continue
+            if not color_overrides:
+                continue
+            try:
+                colors = ThemeColors.merged(existing.colors, color_overrides)
+            except ValueError as exc:
+                logger.warning(
+                    "Built-in theme '%s' color override invalid: %s; skipping",
+                    name,
+                    exc,
+                )
+                continue
+            builtins[name] = ThemeEntry(
+                label=existing.label,
+                dark=existing.dark,
+                colors=colors,
+                custom=existing.custom,
+            )
+            continue
+
+        # --- New custom theme: label required, dark defaults to False (light)
+        label = section.get("label")
+        if not isinstance(label, str) or not label.strip():
+            logger.warning(
+                "User theme '%s' missing required 'label' (str); skipping",
+                name,
+            )
+            continue
+
+        dark = section.get("dark", False)
+        if not isinstance(dark, bool):
+            logger.warning(
+                "User theme '%s': 'dark' must be true or false, got %s (%r);"
+                " defaulting to light",
+                name,
+                type(dark).__name__,
+                dark,
+            )
+            dark = False
+
+        base = DARK_COLORS if dark else LIGHT_COLORS
         try:
             colors = ThemeColors.merged(base, color_overrides)
         except ValueError as exc:

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -606,19 +606,24 @@ primary = "#FF0000"
         _load_user_themes(builtins, config_path=config)
         assert "bad" not in builtins
 
-    def test_missing_dark_skipped(self, tmp_path: Path) -> None:
+    def test_missing_dark_defaults_to_false(self, tmp_path: Path) -> None:
         config = tmp_path / "config.toml"
         _write_config(
             config,
             """
-[themes.bad]
-label = "Bad Theme"
+[themes.my-light]
+label = "My Light"
 primary = "#FF0000"
 """,
         )
         builtins: dict[str, ThemeEntry] = {}
         _load_user_themes(builtins, config_path=config)
-        assert "bad" not in builtins
+        assert "my-light" in builtins
+        entry = builtins["my-light"]
+        assert entry.dark is False
+        assert entry.colors.primary == "#FF0000"
+        # Falls back to LIGHT_COLORS since dark defaults to False
+        assert entry.colors.muted == LIGHT_COLORS.muted
 
     def test_invalid_hex_skipped(self, tmp_path: Path) -> None:
         config = tmp_path / "config.toml"
@@ -635,19 +640,43 @@ primary = "not-a-color"
         _load_user_themes(builtins, config_path=config)
         assert "bad-hex" not in builtins
 
-    def test_builtin_name_shadowing_skipped(self, tmp_path: Path) -> None:
+    def test_builtin_color_override_merges(self, tmp_path: Path) -> None:
         config = tmp_path / "config.toml"
         _write_config(
             config,
             """
 [themes.langchain]
-label = "Fake LangChain"
-dark = true
+primary = "#FF0000"
 """,
         )
-        builtins: dict[str, ThemeEntry] = {}
+        builtins = _builtin_themes()
+        original_label = builtins["langchain"].label
+        original_dark = builtins["langchain"].dark
+        original_custom = builtins["langchain"].custom
         _load_user_themes(builtins, config_path=config)
-        assert "langchain" not in builtins
+        entry = builtins["langchain"]
+        # Color overridden
+        assert entry.colors.primary == "#FF0000"
+        # Other colors unchanged
+        assert entry.colors.muted == DARK_COLORS.muted
+        # Label, dark, custom preserved from built-in
+        assert entry.label == original_label
+        assert entry.dark is original_dark
+        assert entry.custom is original_custom
+
+    def test_builtin_override_without_colors_is_noop(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        _write_config(
+            config,
+            """
+[themes.langchain]
+label = "My LangChain"
+""",
+        )
+        builtins = _builtin_themes()
+        original = builtins["langchain"]
+        _load_user_themes(builtins, config_path=config)
+        assert builtins["langchain"] is original
 
     def test_multiple_user_themes(self, tmp_path: Path) -> None:
         config = tmp_path / "config.toml"
@@ -775,6 +804,53 @@ dark = false
         assert "good" in builtins
         assert "also-good" in builtins
         assert "bad" not in builtins
+
+    def test_non_bool_dark_defaults_to_false(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        _write_config(
+            config,
+            """
+[themes.stringy]
+label = "Stringy Dark"
+dark = "yes"
+""",
+        )
+        builtins: dict[str, ThemeEntry] = {}
+        _load_user_themes(builtins, config_path=config)
+        assert "stringy" in builtins
+        assert builtins["stringy"].dark is False
+
+    def test_builtin_override_invalid_hex_skipped(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        _write_config(
+            config,
+            """
+[themes.langchain]
+primary = "not-a-color"
+""",
+        )
+        builtins = _builtin_themes()
+        original = builtins["langchain"]
+        _load_user_themes(builtins, config_path=config)
+        # Invalid override skipped — original preserved
+        assert builtins["langchain"] is original
+
+    def test_builtin_override_preserves_custom_flag(self, tmp_path: Path) -> None:
+        """Textual built-in themes keep custom=False after color override."""
+        config = tmp_path / "config.toml"
+        _write_config(
+            config,
+            """
+[themes.dracula]
+muted = "#AABBCC"
+""",
+        )
+        builtins = _builtin_themes()
+        assert builtins["dracula"].custom is False
+        _load_user_themes(builtins, config_path=config)
+        entry = builtins["dracula"]
+        assert entry.colors.muted == "#AABBCC"
+        assert entry.custom is False
 
     def test_non_string_color_value_uses_base_fallback(self, tmp_path: Path) -> None:
         config = tmp_path / "config.toml"


### PR DESCRIPTION
Two changes to `_load_user_themes()` in the theme system: the `dark` field now defaults to `False` instead of being required (only set `dark = true` for dark themes), and `[themes.<name>]` sections that match a built-in theme name now merge color overrides into the existing entry instead of being rejected. Previously, built-in names were reserved and any user section matching one was silently skipped.