### PR TITLE
feat(cli): `/auto-update` to toggle auto-updates

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1514,7 +1514,8 @@ class DeepAgentsApp(App):
                 cmd = upgrade_command()
                 self.notify(
                     f"Update available: v{latest} (current: v{cli_version}). "
-                    f"Run: {cmd}",
+                    f"Run: {cmd}\n"
+                    f"Enable auto-updates: /auto-update",
                     severity="information",
                     timeout=15,
                     markup=False,
@@ -1600,6 +1601,42 @@ class DeepAgentsApp(App):
             logger.warning("/update command failed", exc_info=True)
             await self._mount_message(
                 ErrorMessage(f"Update failed: {type(exc).__name__}: {exc}")
+            )
+
+    async def _handle_auto_update_toggle(self) -> None:
+        """Handle the `/auto-update` slash command — persist toggle immediately."""
+        try:
+            from deepagents_cli.config import _is_editable_install
+            from deepagents_cli.update_check import (
+                is_auto_update_enabled,
+                set_auto_update,
+            )
+
+            if await asyncio.to_thread(_is_editable_install):
+                self.notify(
+                    "Auto-updates are not available for editable installs.",
+                    severity="warning",
+                    timeout=5,
+                )
+                return
+
+            currently_enabled = await asyncio.to_thread(is_auto_update_enabled)
+            new_state = not currently_enabled
+            await asyncio.to_thread(set_auto_update, new_state)
+            label = "enabled" if new_state else "disabled"
+            self.notify(
+                f"Auto-updates {label}.",
+                severity="information",
+                timeout=5,
+                markup=False,
+            )
+        except Exception as exc:
+            logger.warning("/auto-update command failed", exc_info=True)
+            self.notify(
+                f"Auto-update toggle failed: {type(exc).__name__}: {exc}",
+                severity="warning",
+                timeout=5,
+                markup=False,
             )
 
     def on_scroll_up(self, _event: ScrollUp) -> None:
@@ -2520,7 +2557,7 @@ class DeepAgentsApp(App):
                 "/model [--model-params JSON] [--default], /reload, "
                 "/skill:<name>, /remember, /skill-creator, /theme, /tokens, "
                 "/threads, /trace, "
-                "/update, /changelog, /docs, /feedback, /help\n\n"
+                "/update, /auto-update, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
                 f"  {newline_shortcut():<15} Insert newline\n"
@@ -2599,6 +2636,8 @@ class DeepAgentsApp(App):
             await self._handle_trace_command(command)
         elif cmd == "/update":
             await self._handle_update_command()
+        elif cmd == "/auto-update":
+            await self._handle_auto_update_toggle()
         elif cmd == "/tokens":
             await self._mount_message(UserMessage(command))
             if self._token_tracker and self._token_tracker.current_context > 0:

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -130,6 +130,11 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="upgrade",
     ),
     SlashCommand(
+        name="/auto-update",
+        description="Toggle automatic updates on or off",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+    ),
+    SlashCommand(
         name="/changelog",
         description="Open changelog in browser",
         bypass_tier=BypassTier.SIDE_EFFECT_FREE,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1595,7 +1595,10 @@ def cli_main() -> None:
             # Warn about available update on exit
             try:
                 if result.update_available[0]:
-                    from deepagents_cli.update_check import upgrade_command
+                    from deepagents_cli.update_check import (
+                        is_auto_update_enabled,
+                        upgrade_command,
+                    )
 
                     latest = result.update_available[1]
                     console.print()
@@ -1605,6 +1608,10 @@ def cli_main() -> None:
                     cmd_hint = Text("Run: ", style="dim")
                     cmd_hint.append(upgrade_command(), style="cyan")
                     console.print(cmd_hint)
+                    if not is_auto_update_enabled():
+                        auto_hint = Text("Enable auto-updates: ", style="dim")
+                        auto_hint.append("/auto-update", style="cyan")
+                        console.print(auto_hint)
             except Exception:
                 logger.debug("Failed to display exit update banner", exc_info=True)
     except KeyboardInterrupt:

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -3,8 +3,9 @@
 Handles version checking against PyPI (with caching), install-method detection,
 auto-upgrade execution, config-driven opt-in/out, and "what's new" tracking.
 
-Public entry points never raise; errors are caught and logged to avoid
-disrupting user experience.
+Most public entry points absorb errors and return sentinel values.
+`set_auto_update` raises on write failures so callers can surface
+actionable feedback.
 """
 
 from __future__ import annotations
@@ -352,6 +353,42 @@ def is_auto_update_enabled() -> bool:
     if os.environ.get("DEEPAGENTS_AUTO_UPDATE", "").lower() in {"1", "true", "yes"}:
         return True
     return _read_update_config().get("auto_update", False)
+
+
+def set_auto_update(enabled: bool) -> None:
+    """Persist the auto-update preference to `config.toml`.
+
+    Writes `[update].auto_update` so the setting survives across sessions.
+
+    Args:
+        enabled: Whether auto-update should be enabled.
+    """
+    import contextlib
+    import tempfile
+    from pathlib import Path
+
+    import tomli_w
+
+    DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if DEFAULT_CONFIG_PATH.exists():
+        with DEFAULT_CONFIG_PATH.open("rb") as f:
+            data = tomllib.load(f)
+    else:
+        data = {}
+
+    if "update" not in data:
+        data["update"] = {}
+    data["update"]["auto_update"] = enabled
+
+    fd, tmp_path = tempfile.mkstemp(dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            tomli_w.dump(data, f)
+        Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            Path(tmp_path).unlink()
+        raise
 
 
 def _read_update_config() -> dict[str, bool]:

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -39,6 +39,7 @@ _TIPS: list[str] = [
     "Type /update to check for and install updates",
     "Use /theme to customize the CLI colors and style",
     "Use /skill-creator to build reusable agent skills",
+    "Use /auto-update to toggle automatic CLI updates",
 ]
 """Rotating tips shown in the welcome footer.
 

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+import tomllib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,7 +15,9 @@ from deepagents_cli.update_check import (
     _latest_from_releases,
     _parse_version,
     get_latest_version,
+    is_auto_update_enabled,
     is_update_available,
+    set_auto_update,
 )
 
 
@@ -378,3 +381,102 @@ class TestIsUpdateAvailable:
 
         assert available is False
         assert latest is None
+
+
+class TestSetAutoUpdate:
+    @pytest.fixture
+    def config_path(self, tmp_path):
+        """Override DEFAULT_CONFIG_PATH to use a temporary file."""
+        path = tmp_path / "config.toml"
+        with patch("deepagents_cli.update_check.DEFAULT_CONFIG_PATH", path):
+            yield path
+
+    def test_enable_creates_config(self, config_path) -> None:
+        """Creates config.toml with auto_update = true when file doesn't exist."""
+        set_auto_update(True)
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["update"]["auto_update"] is True
+
+    def test_disable(self, config_path) -> None:
+        """Sets auto_update = false."""
+        set_auto_update(True)
+        set_auto_update(False)
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["update"]["auto_update"] is False
+
+    def test_preserves_existing_config(self, config_path) -> None:
+        """Doesn't clobber unrelated config sections."""
+        import tomli_w
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("wb") as f:
+            tomli_w.dump({"ui": {"theme": "monokai"}}, f)
+
+        set_auto_update(True)
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["ui"]["theme"] == "monokai"
+        assert data["update"]["auto_update"] is True
+
+    def test_preserves_sibling_update_keys(self, config_path) -> None:
+        """Doesn't clobber sibling keys in [update] section."""
+        import tomli_w
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("wb") as f:
+            tomli_w.dump({"update": {"check": False}}, f)
+
+        set_auto_update(True)
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["update"]["check"] is False
+        assert data["update"]["auto_update"] is True
+
+    def test_round_trip_with_is_auto_update_enabled(self, config_path) -> None:  # noqa: ARG002
+        """set_auto_update(True) makes is_auto_update_enabled() return True."""
+        set_auto_update(True)
+        with (
+            patch("deepagents_cli.config._is_editable_install", return_value=False),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            import os
+
+            os.environ.pop("DEEPAGENTS_AUTO_UPDATE", None)
+            assert is_auto_update_enabled() is True
+
+
+class TestIsAutoUpdateEnabled:
+    @pytest.fixture
+    def config_path(self, tmp_path):
+        """Override DEFAULT_CONFIG_PATH to use a temporary file."""
+        path = tmp_path / "config.toml"
+        with patch("deepagents_cli.update_check.DEFAULT_CONFIG_PATH", path):
+            yield path
+
+    def test_default_is_false(self, config_path) -> None:  # noqa: ARG002
+        """Auto-update defaults to disabled."""
+        with (
+            patch("deepagents_cli.config._is_editable_install", return_value=False),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            import os
+
+            os.environ.pop("DEEPAGENTS_AUTO_UPDATE", None)
+            assert is_auto_update_enabled() is False
+
+    def test_env_var_enables(self, config_path) -> None:  # noqa: ARG002
+        """DEEPAGENTS_AUTO_UPDATE=1 enables auto-update."""
+        with (
+            patch("deepagents_cli.config._is_editable_install", return_value=False),
+            patch.dict("os.environ", {"DEEPAGENTS_AUTO_UPDATE": "1"}),
+        ):
+            assert is_auto_update_enabled() is True
+
+    def test_editable_install_always_disabled(self, config_path) -> None:
+        """Editable installs never auto-update, even with config set."""
+        set_auto_update(True)
+        assert config_path.exists()
+        with patch("deepagents_cli.config._is_editable_install", return_value=True):
+            assert is_auto_update_enabled() is False


### PR DESCRIPTION
Auto-update for the CLI is opt-in (`[update].auto_update` in `config.toml` or `DEEPAGENTS_AUTO_UPDATE=1`), but there was no user-facing way to discover or toggle it. Add a `/auto-update` slash command and surface the opt-in hint in update notifications.