### PR TITLE
feat(cli): default langsmith project to `'deepagents-cli'`

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1545,7 +1545,7 @@ def get_langsmith_project_name() -> str | None:
     `settings.deepagents_langchain_project` (from
     `DEEPAGENTS_LANGSMITH_PROJECT`), then `LANGSMITH_PROJECT` from the
     environment (note: this may already have been overridden at bootstrap time
-    to match `DEEPAGENTS_LANGSMITH_PROJECT`), then `'default'`.
+    to match `DEEPAGENTS_LANGSMITH_PROJECT`), then `'deepagents-cli'`.
 
     Returns:
         Project name string when LangSmith tracing is active, None otherwise.
@@ -1562,7 +1562,7 @@ def get_langsmith_project_name() -> str | None:
     return (
         _get_settings().deepagents_langchain_project
         or os.environ.get("LANGSMITH_PROJECT")
-        or "default"
+        or "deepagents-cli"
     )
 
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -919,7 +919,7 @@ class TestGetLangsmithProjectName:
             assert get_langsmith_project_name() == "env-project"
 
     def test_falls_back_to_default(self) -> None:
-        """Should fall back to 'default' when no project name configured."""
+        """Should fall back to 'deepagents-cli' when no project name configured."""
         env = {
             "LANGSMITH_API_KEY": "lsv2_test",
             "LANGSMITH_TRACING": "true",
@@ -929,7 +929,7 @@ class TestGetLangsmithProjectName:
             patch("deepagents_cli.config.settings") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
-            assert get_langsmith_project_name() == "default"
+            assert get_langsmith_project_name() == "deepagents-cli"
 
     def test_accepts_langchain_api_key(self) -> None:
         """Should accept LANGCHAIN_API_KEY as alternative to LANGSMITH_API_KEY."""
@@ -943,7 +943,7 @@ class TestGetLangsmithProjectName:
             patch("deepagents_cli.config.settings") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
-            assert get_langsmith_project_name() == "default"
+            assert get_langsmith_project_name() == "deepagents-cli"
 
 
 class TestFetchLangsmithProjectUrl:


### PR DESCRIPTION
Change the default LangSmith project name from the generic `"default"` to `"deepagents-cli"` so CLI agent traces are automatically routed to a dedicated project instead of mixing with all other LangSmith traces. Users who explicitly set `DEEPAGENTS_LANGSMITH_PROJECT` or `LANGSMITH_PROJECT` are unaffected.