### PR TITLE
fix(cli): enforce approval toggle when launched with `-y`

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -731,12 +731,15 @@ async def run_textual_cli_async(
         "profile_overrides": profile_override,
     }
 
-    # Build kwargs for deferred server startup (runs inside the TUI)
+    # Build kwargs for deferred server startup (runs inside the TUI).
+    # Never pass auto_approve to the server — the interactive server must
+    # always configure full HITL interrupts so that Shift+Tab can toggle
+    # approval mode mid-session. The -y flag is handled client-side via
+    # session_state.auto_approve in textual_adapter.py.
     server_kwargs: dict[str, Any] = {
         "assistant_id": assistant_id,
         "model_name": model_name,
         "model_params": model_params,
-        "auto_approve": auto_approve,
         "sandbox_type": sandbox_type,
         "sandbox_id": sandbox_id,
         "sandbox_setup": sandbox_setup,

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -195,6 +195,9 @@ class TestRunTextualCliAsyncMcp:
         assert captured_kwargs["server_kwargs"] is not None
         assert captured_kwargs["server_kwargs"]["assistant_id"] == "agent"
         assert captured_kwargs["server_kwargs"]["interactive"] is True
+        # auto_approve must NOT be in server_kwargs — the interactive server
+        # must always compile with full HITL interrupts so Shift+Tab works.
+        assert "auto_approve" not in captured_kwargs["server_kwargs"]
 
         # MCP preload kwargs forwarded (no_mcp=False by default)
         assert captured_kwargs["mcp_preload_kwargs"] is not None


### PR DESCRIPTION
Launching with `-y`/`--auto-approve` baked `interrupt_on={}` into the compiled LangGraph agent at server startup, permanently disabling HITL interrupts for the session. Toggling back to require-approval via Shift+Tab updated `session_state.auto_approve` on the client side, but the server never fired interrupts in the first place — so the approval check in `textual_adapter.py` never ran. The fix stops passing `auto_approve` to the LangGraph server in the interactive path, so the server always compiles with full HITL interrupts. The `-y` flag still flows to `DeepAgentsApp._auto_approve` → `session_state.auto_approve`, where `textual_adapter.py` checks it at runtime to auto-approve or show the approval widget.