### PR TITLE
feat(cli): add `DEEPAGENTS_CLI_` env var prefix and fix dotenv load order

### DIFF
--- a/libs/cli/deepagents_cli/_debug.py
+++ b/libs/cli/deepagents_cli/_debug.py
@@ -1,6 +1,6 @@
 """Shared debug-logging configuration for verbose file-based tracing.
 
-When the `DEEPAGENTS_DEBUG` environment variable is set, modules that handle
+When the `DEEPAGENTS_CLI_DEBUG` environment variable is set, modules that handle
 streaming or remote communication can enable detailed file-based logging. This
 helper centralizes the setup so the env-var name, file path, and format are
 defined in one place.
@@ -12,25 +12,27 @@ import logging
 import os
 from pathlib import Path
 
+from deepagents_cli._env_vars import DEBUG, DEBUG_FILE
+
 
 def configure_debug_logging(target: logging.Logger) -> None:
-    """Attach a file handler to *target* when `DEEPAGENTS_DEBUG` is set.
+    """Attach a file handler to *target* when `DEEPAGENTS_CLI_DEBUG` is set.
 
     The log file defaults to `'/tmp/deepagents_debug.log'` but can be overridden
-    with `DEEPAGENTS_DEBUG_FILE`. The handler appends so that multiple modules
-    share the same log file across a session.
+    with `DEEPAGENTS_CLI_DEBUG_FILE`. The handler appends so that multiple
+    modules share the same log file across a session.
 
-    Does nothing when `DEEPAGENTS_DEBUG` is not set.
+    Does nothing when `DEEPAGENTS_CLI_DEBUG` is not set.
 
     Args:
         target: Logger to configure.
     """
-    if not os.environ.get("DEEPAGENTS_DEBUG"):
+    if not os.environ.get(DEBUG):
         return
 
     debug_path = Path(
         os.environ.get(
-            "DEEPAGENTS_DEBUG_FILE",
+            DEBUG_FILE,
             "/tmp/deepagents_debug.log",  # noqa: S108
         )
     )

--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -1,0 +1,51 @@
+"""Canonical registry of `DEEPAGENTS_CLI_*` environment variables.
+
+Every env var the CLI reads whose name starts with `DEEPAGENTS_CLI_` must
+be defined here as a module-level constant.  A drift-detection test
+(`tests/unit_tests/test_env_vars.py`) fails when a bare string literal
+like `"DEEPAGENTS_CLI_FOO"` appears in source code instead of a constant
+imported from this module.
+
+Import the short-name constants (e.g. `AUTO_UPDATE`, `DEBUG`) and pass
+them to `os.environ.get()` / `resolve_env_var()` instead of using raw
+string literals.  If the env var is ever renamed, only the value here
+changes -- no code-wide grep required.
+
+!!! note
+
+    `resolve_env_var` also supports a dynamic prefix override for API keys
+    and provider credentials: setting `DEEPAGENTS_CLI_{NAME}` takes priority
+    over `{NAME}`.  For example, `DEEPAGENTS_CLI_OPENAI_API_KEY` overrides
+    `OPENAI_API_KEY`. Only call sites that use `resolve_env_var` benefit from
+    this -- direct `os.environ.get` lookups (like the constants below) do not.
+    Dynamic overrides are not listed here because they mirror third-party
+    variable names.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Constants — import these instead of bare string literals.
+# Keep alphabetically sorted by constant name.
+# ---------------------------------------------------------------------------
+
+AUTO_UPDATE = "DEEPAGENTS_CLI_AUTO_UPDATE"
+"""Enable automatic CLI updates ('1', 'true', or 'yes')."""
+
+DEBUG = "DEEPAGENTS_CLI_DEBUG"
+"""Enable verbose debug logging to a file."""
+
+DEBUG_FILE = "DEEPAGENTS_CLI_DEBUG_FILE"
+"""Path for the debug log file (default: `/tmp/deepagents_debug.log`)."""
+
+EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
+"""Colon-separated paths added to the skill containment allowlist."""
+
+LANGSMITH_PROJECT = "DEEPAGENTS_CLI_LANGSMITH_PROJECT"
+"""Override LangSmith project name for agent traces."""
+
+NO_UPDATE_CHECK = "DEEPAGENTS_CLI_NO_UPDATE_CHECK"
+"""Disable automatic update checking when set."""
+
+SHELL_ALLOW_LIST = "DEEPAGENTS_CLI_SHELL_ALLOW_LIST"
+"""Comma-separated shell commands to allow (or 'recommended'/'all')."""

--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -49,3 +49,6 @@ NO_UPDATE_CHECK = "DEEPAGENTS_CLI_NO_UPDATE_CHECK"
 
 SHELL_ALLOW_LIST = "DEEPAGENTS_CLI_SHELL_ALLOW_LIST"
 """Comma-separated shell commands to allow (or 'recommended'/'all')."""
+
+USER_ID = "DEEPAGENTS_CLI_USER_ID"
+"""Attach a user identifier to LangSmith trace metadata."""

--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -6,10 +6,9 @@ be defined here as a module-level constant.  A drift-detection test
 like `"DEEPAGENTS_CLI_FOO"` appears in source code instead of a constant
 imported from this module.
 
-Import the short-name constants (e.g. `AUTO_UPDATE`, `DEBUG`) and pass
-them to `os.environ.get()` / `resolve_env_var()` instead of using raw
-string literals.  If the env var is ever renamed, only the value here
-changes -- no code-wide grep required.
+Import the short-name constants (e.g. `AUTO_UPDATE`, `DEBUG`) and pass them
+to `os.environ.get()` instead of using raw string literals. If the env var is
+ever renamed, only the value here changes.
 
 !!! note
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -190,6 +190,24 @@ def _ensure_bootstrap() -> None:
             deepagents_project = os.environ.get(LANGSMITH_PROJECT)
             if deepagents_project:
                 os.environ["LANGSMITH_PROJECT"] = deepagents_project
+
+            # Propagate prefixed LangSmith env vars to canonical names.
+            # The CLI resolves prefixed vars via resolve_env_var(), but the
+            # LangSmith SDK reads os.environ directly and has no knowledge
+            # of the DEEPAGENTS_CLI_ prefix. Setting canonical vars here
+            # bridges that gap. Only set vars not already present.
+            from deepagents_cli.model_config import _ENV_PREFIX
+
+            for canonical in (
+                "LANGSMITH_API_KEY",
+                "LANGCHAIN_API_KEY",
+                "LANGSMITH_TRACING",
+                "LANGCHAIN_TRACING_V2",
+            ):
+                if canonical not in os.environ:
+                    val = os.environ.get(f"{_ENV_PREFIX}{canonical}")
+                    if val:
+                        os.environ[canonical] = val
         except Exception:
             logger.exception(
                 "Bootstrap failed; .env values and LANGSMITH_PROJECT override "
@@ -1634,7 +1652,14 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
     def _lookup_url() -> None:
         nonlocal result, lookup_error
         try:
-            project = Client().read_project(project_name=project_name)
+            from deepagents_cli.model_config import resolve_env_var
+
+            # Explicit api_key because Client() reads os.environ directly
+            # and doesn't know about the DEEPAGENTS_CLI_ prefix.
+            api_key = resolve_env_var("LANGSMITH_API_KEY") or resolve_env_var(
+                "LANGCHAIN_API_KEY"
+            )
+            project = Client(api_key=api_key).read_project(project_name=project_name)
             result = project.url or None
         except Exception as exc:  # noqa: BLE001  # LangSmith SDK error types are not stable
             lookup_error = exc

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -95,8 +95,9 @@ def _load_dotenv(*, start_path: Path | None = None) -> bool:
 
     !!! note
 
-        To scope credentials to the CLI without colliding with identically-named
-        shell exports, use the `DEEPAGENTS_CLI_` env-var prefix.
+        To scope credentials to the CLI without colliding with
+        identically-named shell exports, use the `DEEPAGENTS_CLI_` env-var
+        prefix (see `resolve_env_var` in `deepagents_cli.model_config`).
 
     Args:
         start_path: Directory to use for project `.env` discovery.
@@ -195,7 +196,7 @@ def _ensure_bootstrap() -> None:
             # The CLI resolves prefixed vars via resolve_env_var(), but the
             # LangSmith SDK reads os.environ directly and has no knowledge
             # of the DEEPAGENTS_CLI_ prefix. Setting canonical vars here
-            # bridges that gap. Only set vars not already present.
+            # bridges that gap.
             from deepagents_cli.model_config import _ENV_PREFIX
 
             for canonical in (
@@ -204,10 +205,23 @@ def _ensure_bootstrap() -> None:
                 "LANGSMITH_TRACING",
                 "LANGCHAIN_TRACING_V2",
             ):
+                prefixed = f"{_ENV_PREFIX}{canonical}"
+                if prefixed not in os.environ:
+                    continue
+                prefixed_val = os.environ[prefixed]
                 if canonical not in os.environ:
-                    val = os.environ.get(f"{_ENV_PREFIX}{canonical}")
-                    if val:
-                        os.environ[canonical] = val
+                    # Propagate (including empty string for explicit disable).
+                    os.environ[canonical] = prefixed_val
+                elif os.environ[canonical] != prefixed_val:
+                    logger.warning(
+                        "Both %s and %s are set with different values; "
+                        "the LangSmith SDK will use %s while the CLI "
+                        "prefers %s. Unset one to avoid confusion.",
+                        canonical,
+                        prefixed,
+                        canonical,
+                        prefixed,
+                    )
         except Exception:
             logger.exception(
                 "Bootstrap failed; .env values and LANGSMITH_PROJECT override "
@@ -898,7 +912,6 @@ class Settings:
             Settings instance with detected configuration
         """
         # Detect API keys (normalize empty strings to None).
-        # resolve_env_var checks DEEPAGENTS_CLI_{name} first, then {name}.
         from deepagents_cli.model_config import resolve_env_var
 
         openai_key = resolve_env_var("OPENAI_API_KEY")
@@ -1893,7 +1906,15 @@ def _get_provider_kwargs(
         result["base_url"] = base_url
     from deepagents_cli.model_config import PROVIDER_API_KEY_ENV, resolve_env_var
 
-    api_key_env = config.get_api_key_env(provider) or PROVIDER_API_KEY_ENV.get(provider)
+    api_key_env = config.get_api_key_env(provider)
+    if not api_key_env:
+        api_key_env = PROVIDER_API_KEY_ENV.get(provider)
+        if api_key_env:
+            logger.debug(
+                "No api_key_env in config.toml for '%s'; using hardcoded env var %s",
+                provider,
+                api_key_env,
+            )
     if api_key_env:
         api_key = resolve_env_var(api_key_env)
         if api_key:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -96,8 +96,7 @@ def _load_dotenv(*, start_path: Path | None = None) -> bool:
     !!! note
 
         To scope credentials to the CLI without colliding with identically-named
-        shell exports, use the `DEEPAGENTS_CLI_` env-var prefix
-        via `resolve_env_var`.
+        shell exports, use the `DEEPAGENTS_CLI_` env-var prefix.
 
     Args:
         start_path: Directory to use for project `.env` discovery.

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -77,26 +77,24 @@ except RuntimeError:
     _GLOBAL_DOTENV_PATH = Path("/nonexistent/.deepagents/.env")
 
 
-def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> bool:
-    """Load environment variables from project and global `.env` files.
+def _load_dotenv(*, start_path: Path | None = None) -> bool:
+    """Load environment variables from global and project `.env` files.
 
-    Loads in order:
+    Loads in order (last write wins):
 
-    1. Project/CWD `.env` — project-specific values (uses caller's `override`)
-    2. `~/.deepagents/.env` — global fallback defaults (always `override=False`)
+    1. `~/.deepagents/.env` — global user defaults
+    2. Project/CWD `.env` — project-specific overrides
 
-    Precedence (highest to lowest):
+    Both layers use `override=True` so that dotenv files always beat
+    shell-exported variables (e.g., from `$ZDOTDIR/.env`). Because project loads
+    second, the effective precedence is:
 
-    - `override=False` (bootstrap): shell env > project `.env` > global `.env`
-    - `override=True` (`/reload`): project `.env` > shell env > global `.env`
-
-    Keys already present in the process environment (e.g., exported in a shell
-    profile) are never overwritten when `override` is `False`.
+    ```text
+    project `.env` > global `.env` > shell env (incl. inline `VAR=x`)
+    ```
 
     Args:
         start_path: Directory to use for project `.env` discovery.
-        override: Whether project `.env` values should override existing
-            env vars (global `.env` always uses `override=False`).
 
     Returns:
         `True` when at least one dotenv file was loaded, `False` otherwise.
@@ -105,30 +103,13 @@ def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> b
 
     loaded = False
 
-    # 1. Project/CWD .env — uses caller's override setting
-    try:
-        if start_path is None:
-            loaded = dotenv.load_dotenv(override=override) or loaded
-        else:
-            dotenv_path = _find_dotenv_from_start_path(start_path)
-            if dotenv_path is not None:
-                loaded = (
-                    dotenv.load_dotenv(dotenv_path=dotenv_path, override=override)
-                    or loaded
-                )
-    except (OSError, ValueError):
-        logger.warning(
-            "Could not read project dotenv at %s; project env vars will not be loaded",
-            start_path,
-            exc_info=True,
-        )
-
-    # 2. Global fallback (~/.deepagents/.env) — never override existing vars.
+    # 1. Global (~/.deepagents/.env) — override shell env so the user's
+    # explicit dotenv config always wins over shell profile exports.
     # try/except wraps both is_file() and load_dotenv() to cover the TOCTOU
     # window where the file can vanish between stat and open.
     try:
         if _GLOBAL_DOTENV_PATH.is_file() and dotenv.load_dotenv(
-            dotenv_path=_GLOBAL_DOTENV_PATH, override=False
+            dotenv_path=_GLOBAL_DOTENV_PATH, override=True
         ):
             loaded = True
             logger.debug("Loaded global dotenv: %s", _GLOBAL_DOTENV_PATH)
@@ -136,6 +117,23 @@ def _load_dotenv(*, start_path: Path | None = None, override: bool = False) -> b
         logger.warning(
             "Could not read global dotenv at %s; global defaults will not be applied",
             _GLOBAL_DOTENV_PATH,
+            exc_info=True,
+        )
+
+    # 2. Project/CWD .env — loads second so project values win over global.
+    try:
+        if start_path is None:
+            loaded = dotenv.load_dotenv(override=True) or loaded
+        else:
+            dotenv_path = _find_dotenv_from_start_path(start_path)
+            if dotenv_path is not None:
+                loaded = (
+                    dotenv.load_dotenv(dotenv_path=dotenv_path, override=True) or loaded
+                )
+    except (OSError, ValueError):
+        logger.warning(
+            "Could not read project dotenv at %s; project env vars will not be loaded",
+            start_path,
             exc_info=True,
         )
 
@@ -871,13 +869,16 @@ class Settings:
         Returns:
             Settings instance with detected configuration
         """
-        # Detect API keys (normalize empty strings to None)
-        openai_key = os.environ.get("OPENAI_API_KEY") or None
-        anthropic_key = os.environ.get("ANTHROPIC_API_KEY") or None
-        google_key = os.environ.get("GOOGLE_API_KEY") or None
-        nvidia_key = os.environ.get("NVIDIA_API_KEY") or None
-        tavily_key = os.environ.get("TAVILY_API_KEY") or None
-        google_cloud_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+        # Detect API keys (normalize empty strings to None).
+        # resolve_env_var checks DEEPAGENTS_CLI_{name} first, then {name}.
+        from deepagents_cli.model_config import resolve_env_var
+
+        openai_key = resolve_env_var("OPENAI_API_KEY")
+        anthropic_key = resolve_env_var("ANTHROPIC_API_KEY")
+        google_key = resolve_env_var("GOOGLE_API_KEY")
+        nvidia_key = resolve_env_var("NVIDIA_API_KEY")
+        tavily_key = resolve_env_var("TAVILY_API_KEY")
+        google_cloud_project = resolve_env_var("GOOGLE_CLOUD_PROJECT")
 
         # Detect LangSmith configuration
         # DEEPAGENTS_LANGSMITH_PROJECT: Project for deepagents agent tracing
@@ -887,7 +888,7 @@ class Settings:
         # LANGSMITH_PROJECT. We use the saved original value, not the
         # current os.environ value. Direct callers should ensure
         # bootstrap has run if they depend on the override.
-        deepagents_langchain_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
+        deepagents_langchain_project = resolve_env_var("DEEPAGENTS_LANGSMITH_PROJECT")
         user_langchain_project = _original_langsmith_project  # Use saved original!
 
         # Detect project
@@ -941,7 +942,7 @@ class Settings:
         Returns:
             A list of human-readable change descriptions.
         """
-        _load_dotenv(start_path=start_path, override=True)
+        _load_dotenv(start_path=start_path)
 
         api_key_fields = {
             "openai_api_key",
@@ -995,14 +996,16 @@ class Settings:
             )
             project_root = previous["project_root"]
 
+        from deepagents_cli.model_config import resolve_env_var
+
         refreshed = {
-            "openai_api_key": os.environ.get("OPENAI_API_KEY") or None,
-            "anthropic_api_key": os.environ.get("ANTHROPIC_API_KEY") or None,
-            "google_api_key": os.environ.get("GOOGLE_API_KEY") or None,
-            "nvidia_api_key": os.environ.get("NVIDIA_API_KEY") or None,
-            "tavily_api_key": os.environ.get("TAVILY_API_KEY") or None,
-            "google_cloud_project": os.environ.get("GOOGLE_CLOUD_PROJECT"),
-            "deepagents_langchain_project": os.environ.get(
+            "openai_api_key": resolve_env_var("OPENAI_API_KEY"),
+            "anthropic_api_key": resolve_env_var("ANTHROPIC_API_KEY"),
+            "google_api_key": resolve_env_var("GOOGLE_API_KEY"),
+            "nvidia_api_key": resolve_env_var("NVIDIA_API_KEY"),
+            "tavily_api_key": resolve_env_var("TAVILY_API_KEY"),
+            "google_cloud_project": resolve_env_var("GOOGLE_CLOUD_PROJECT"),
+            "deepagents_langchain_project": resolve_env_var(
                 "DEEPAGENTS_LANGSMITH_PROJECT"
             ),
             "project_root": project_root,
@@ -1845,7 +1848,9 @@ def _get_provider_kwargs(
         result["base_url"] = base_url
     api_key_env = config.get_api_key_env(provider)
     if api_key_env:
-        api_key = os.environ.get(api_key_env)
+        from deepagents_cli.model_config import resolve_env_var
+
+        api_key = resolve_env_var(api_key_env)
         if api_key:
             result["api_key"] = api_key
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -667,6 +667,11 @@ def build_stream_config(
         "versions": versions,
         "ls_integration": "deepagents-cli",
     }
+    from deepagents_cli._env_vars import USER_ID
+
+    user_id = os.environ.get(USER_ID)
+    if user_id:
+        metadata["user_id"] = user_id
     if cwd:
         metadata["cwd"] = cwd
     if assistant_id:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -78,20 +78,26 @@ except RuntimeError:
 
 
 def _load_dotenv(*, start_path: Path | None = None) -> bool:
-    """Load environment variables from global and project `.env` files.
+    """Load environment variables from project and global `.env` files.
 
-    Loads in order (last write wins):
+    Loads in order (first write wins, `override=False`):
 
-    1. `~/.deepagents/.env` — global user defaults
-    2. Project/CWD `.env` — project-specific overrides
+    1. Project/CWD `.env` — project-specific values
+    2. `~/.deepagents/.env` — global user defaults
 
-    Both layers use `override=True` so that dotenv files always beat
-    shell-exported variables (e.g., from `$ZDOTDIR/.env`). Because project loads
-    second, the effective precedence is:
+    Both layers use `override=False` (the python-dotenv default) so that
+    shell-exported variables always take precedence over dotenv files.
+    Because project loads first, the effective precedence is:
 
     ```text
-    project `.env` > global `.env` > shell env (incl. inline `VAR=x`)
+    shell env (incl. inline `VAR=x`)  >  project `.env`  >  global `.env`
     ```
+
+    !!! note
+
+        To scope credentials to the CLI without colliding with identically-named
+        shell exports, use the `DEEPAGENTS_CLI_` env-var prefix
+        via `resolve_env_var`.
 
     Args:
         start_path: Directory to use for project `.env` discovery.
@@ -103,13 +109,33 @@ def _load_dotenv(*, start_path: Path | None = None) -> bool:
 
     loaded = False
 
-    # 1. Global (~/.deepagents/.env) — override shell env so the user's
-    # explicit dotenv config always wins over shell profile exports.
+    # 1. Project/CWD .env — loads first so project values are set before the
+    # global file, which can only fill in vars not already present.
+    dotenv_path: Path | str | None = None
+    try:
+        if start_path is None:
+            loaded = dotenv.load_dotenv(override=False) or loaded
+        else:
+            dotenv_path = _find_dotenv_from_start_path(start_path)
+            if dotenv_path is not None:
+                loaded = (
+                    dotenv.load_dotenv(dotenv_path=dotenv_path, override=False)
+                    or loaded
+                )
+    except (OSError, ValueError):
+        logger.warning(
+            "Could not read project dotenv at %s; project env vars will not be loaded",
+            dotenv_path or start_path or "cwd",
+            exc_info=True,
+        )
+
+    # 2. Global (~/.deepagents/.env) — fills in any vars not already set by
+    # the shell or the project dotenv.
     # try/except wraps both is_file() and load_dotenv() to cover the TOCTOU
     # window where the file can vanish between stat and open.
     try:
         if _GLOBAL_DOTENV_PATH.is_file() and dotenv.load_dotenv(
-            dotenv_path=_GLOBAL_DOTENV_PATH, override=True
+            dotenv_path=_GLOBAL_DOTENV_PATH, override=False
         ):
             loaded = True
             logger.debug("Loaded global dotenv: %s", _GLOBAL_DOTENV_PATH)
@@ -117,23 +143,6 @@ def _load_dotenv(*, start_path: Path | None = None) -> bool:
         logger.warning(
             "Could not read global dotenv at %s; global defaults will not be applied",
             _GLOBAL_DOTENV_PATH,
-            exc_info=True,
-        )
-
-    # 2. Project/CWD .env — loads second so project values win over global.
-    try:
-        if start_path is None:
-            loaded = dotenv.load_dotenv(override=True) or loaded
-        else:
-            dotenv_path = _find_dotenv_from_start_path(start_path)
-            if dotenv_path is not None:
-                loaded = (
-                    dotenv.load_dotenv(dotenv_path=dotenv_path, override=True) or loaded
-                )
-    except (OSError, ValueError):
-        logger.warning(
-            "Could not read project dotenv at %s; project env vars will not be loaded",
-            start_path,
             exc_info=True,
         )
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -988,6 +988,13 @@ class Settings:
         (`user_langchain_project`) are intentionally preserved -- they are
         not in `reloadable_fields` and are never touched by this method.
 
+        !!! note
+
+            `.env` files are loaded with `override=False`, so shell-exported
+            variables always take precedence.  To override a shell-exported key
+            from `.env`, use the `DEEPAGENTS_CLI_` prefix (e.g.
+            `DEEPAGENTS_CLI_OPENAI_API_KEY`).
+
         Args:
             start_path: Directory to start project detection from (defaults to cwd).
 
@@ -1916,9 +1923,9 @@ def _get_provider_kwargs(
         api_key_env = PROVIDER_API_KEY_ENV.get(provider)
         if api_key_env:
             logger.debug(
-                "No api_key_env in config.toml for '%s'; using hardcoded env var %s",
+                "No api_key_env in config.toml for '%s';"
+                " using hardcoded provider env var",
                 provider,
-                api_key_env,
             )
     if api_key_env:
         api_key = resolve_env_var(api_key_env)

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -177,7 +177,9 @@ def _ensure_bootstrap() -> None:
             # separate project. LangSmith reads LANGSMITH_PROJECT at invocation
             # time, so we override it here and preserve the user's original
             # value for shell commands.
-            deepagents_project = os.environ.get("DEEPAGENTS_LANGSMITH_PROJECT")
+            from deepagents_cli._env_vars import LANGSMITH_PROJECT
+
+            deepagents_project = os.environ.get(LANGSMITH_PROJECT)
             if deepagents_project:
                 os.environ["LANGSMITH_PROJECT"] = deepagents_project
         except Exception:
@@ -764,11 +766,11 @@ def _parse_extra_skills_dirs(
     in user-specified locations without being rejected by the path
     containment check.
 
-    The env var (`DEEPAGENTS_EXTRA_SKILLS_DIRS`, colon-separated) takes
+    The env var (`DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS`, colon-separated) takes
     precedence: when set, `config.toml` values are ignored.
 
     Args:
-        env_raw: Value of `DEEPAGENTS_EXTRA_SKILLS_DIRS` (colon-separated), or
+        env_raw: Value of `DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS` (colon-separated), or
             `None` if unset.
         config_toml_dirs: List of path strings from
             `[skills].extra_allowed_dirs` in `~/.deepagents/config.toml`.
@@ -855,7 +857,7 @@ class Settings:
     locations without being rejected by the containment check
     in `load_skill_content`.
 
-    Set via `DEEPAGENTS_EXTRA_SKILLS_DIRS` env var (colon-separated) or
+    Set via `DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS` env var (colon-separated) or
     `[skills].extra_allowed_dirs` in `~/.deepagents/config.toml`.
     """
 
@@ -881,14 +883,20 @@ class Settings:
         google_cloud_project = resolve_env_var("GOOGLE_CLOUD_PROJECT")
 
         # Detect LangSmith configuration
-        # DEEPAGENTS_LANGSMITH_PROJECT: Project for deepagents agent tracing
+        # DEEPAGENTS_CLI_LANGSMITH_PROJECT: Project for deepagents agent tracing
         # user_langchain_project: User's ORIGINAL LANGSMITH_PROJECT (before override)
         # When accessed via the module-level `settings` singleton,
         # _ensure_bootstrap() has already run and may have overridden
         # LANGSMITH_PROJECT. We use the saved original value, not the
         # current os.environ value. Direct callers should ensure
         # bootstrap has run if they depend on the override.
-        deepagents_langchain_project = resolve_env_var("DEEPAGENTS_LANGSMITH_PROJECT")
+        from deepagents_cli._env_vars import (
+            EXTRA_SKILLS_DIRS,
+            LANGSMITH_PROJECT,
+            SHELL_ALLOW_LIST,
+        )
+
+        deepagents_langchain_project = resolve_env_var(LANGSMITH_PROJECT)
         user_langchain_project = _original_langsmith_project  # Use saved original!
 
         # Detect project
@@ -898,15 +906,15 @@ class Settings:
 
         # Parse shell command allow-list from environment
         # Format: comma-separated list of commands (e.g., "ls,cat,grep,pwd")
-        # Special value "recommended" uses RECOMMENDED_SAFE_SHELL_COMMANDS
-        shell_allow_list_str = os.environ.get("DEEPAGENTS_SHELL_ALLOW_LIST")
+
+        shell_allow_list_str = os.environ.get(SHELL_ALLOW_LIST)
         shell_allow_list = parse_shell_allow_list(shell_allow_list_str)
 
         # Parse extra skill containment roots from env var or config.toml.
         # These extend the path allowlist for load_skill_content but do not
         # add new skill discovery locations.
         extra_skills_dirs = _parse_extra_skills_dirs(
-            os.environ.get("DEEPAGENTS_EXTRA_SKILLS_DIRS"),
+            os.environ.get(EXTRA_SKILLS_DIRS),
             _read_config_toml_skills_dirs(),
         )
 
@@ -975,14 +983,18 @@ class Settings:
 
         previous = {field: getattr(self, field) for field in reloadable_fields}
 
+        from deepagents_cli._env_vars import (
+            EXTRA_SKILLS_DIRS,
+            LANGSMITH_PROJECT,
+            SHELL_ALLOW_LIST,
+        )
+
         try:
-            shell_allow_list = parse_shell_allow_list(
-                os.environ.get("DEEPAGENTS_SHELL_ALLOW_LIST")
-            )
+            shell_allow_list = parse_shell_allow_list(os.environ.get(SHELL_ALLOW_LIST))
         except ValueError:
             logger.warning(
-                "Invalid DEEPAGENTS_SHELL_ALLOW_LIST during reload; "
-                "keeping previous value"
+                "Invalid %s during reload; keeping previous value",
+                SHELL_ALLOW_LIST,
             )
             shell_allow_list = previous["shell_allow_list"]
 
@@ -1005,13 +1017,11 @@ class Settings:
             "nvidia_api_key": resolve_env_var("NVIDIA_API_KEY"),
             "tavily_api_key": resolve_env_var("TAVILY_API_KEY"),
             "google_cloud_project": resolve_env_var("GOOGLE_CLOUD_PROJECT"),
-            "deepagents_langchain_project": resolve_env_var(
-                "DEEPAGENTS_LANGSMITH_PROJECT"
-            ),
+            "deepagents_langchain_project": resolve_env_var(LANGSMITH_PROJECT),
             "project_root": project_root,
             "shell_allow_list": shell_allow_list,
             "extra_skills_dirs": _parse_extra_skills_dirs(
-                os.environ.get("DEEPAGENTS_EXTRA_SKILLS_DIRS"),
+                os.environ.get(EXTRA_SKILLS_DIRS),
                 _read_config_toml_skills_dirs(),
             ),
         }
@@ -1317,7 +1327,7 @@ class Settings:
     def get_extra_skills_dirs(self) -> list[Path]:
         """Get user-configured extra skill directories.
 
-        Set via `DEEPAGENTS_EXTRA_SKILLS_DIRS` (colon-separated paths) or
+        Set via `DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS` (colon-separated paths) or
         `[skills].extra_allowed_dirs` in `~/.deepagents/config.toml`.
 
         Returns:
@@ -1546,17 +1556,19 @@ def get_langsmith_project_name() -> str | None:
     Checks for the required API key and tracing environment variables.
     When both are present, resolves the project name with priority:
     `settings.deepagents_langchain_project` (from
-    `DEEPAGENTS_LANGSMITH_PROJECT`), then `LANGSMITH_PROJECT` from the
+    `DEEPAGENTS_CLI_LANGSMITH_PROJECT`), then `LANGSMITH_PROJECT` from the
     environment (note: this may already have been overridden at bootstrap time
-    to match `DEEPAGENTS_LANGSMITH_PROJECT`), then `'deepagents-cli'`.
+    to match `DEEPAGENTS_CLI_LANGSMITH_PROJECT`), then `'deepagents-cli'`.
 
     Returns:
         Project name string when LangSmith tracing is active, None otherwise.
     """
-    langsmith_key = os.environ.get("LANGSMITH_API_KEY") or os.environ.get(
+    from deepagents_cli.model_config import resolve_env_var
+
+    langsmith_key = resolve_env_var("LANGSMITH_API_KEY") or resolve_env_var(
         "LANGCHAIN_API_KEY"
     )
-    langsmith_tracing = os.environ.get("LANGSMITH_TRACING") or os.environ.get(
+    langsmith_tracing = resolve_env_var("LANGSMITH_TRACING") or resolve_env_var(
         "LANGCHAIN_TRACING_V2"
     )
     if not (langsmith_key and langsmith_tracing):

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1891,10 +1891,10 @@ def _get_provider_kwargs(
     base_url = config.get_base_url(provider)
     if base_url:
         result["base_url"] = base_url
-    api_key_env = config.get_api_key_env(provider)
-    if api_key_env:
-        from deepagents_cli.model_config import resolve_env_var
+    from deepagents_cli.model_config import PROVIDER_API_KEY_ENV, resolve_env_var
 
+    api_key_env = config.get_api_key_env(provider) or PROVIDER_API_KEY_ENV.get(provider)
+    if api_key_env:
         api_key = resolve_env_var(api_key_env)
         if api_key:
             result["api_key"] = api_key

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -481,7 +481,18 @@ class _ModalProvider(SandboxProvider):
         token_id = resolve_env_var("MODAL_TOKEN_ID")
         token_secret = resolve_env_var("MODAL_TOKEN_SECRET")
         if token_id and token_secret:
-            self._client = self._modal.Client.from_credentials(token_id, token_secret)
+            try:
+                self._client = self._modal.Client.from_credentials(
+                    token_id, token_secret
+                )
+            except Exception as exc:
+                msg = (
+                    "Failed to authenticate with Modal using "
+                    "MODAL_TOKEN_ID / MODAL_TOKEN_SECRET "
+                    "(or the DEEPAGENTS_CLI_-prefixed equivalents). "
+                    "Verify your credentials are valid."
+                )
+                raise ValueError(msg) from exc
         elif token_id or token_secret:
             logger.warning(
                 "Only one of MODAL_TOKEN_ID / MODAL_TOKEN_SECRET is set; "

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -240,7 +240,8 @@ class _LangSmithProvider(SandboxProvider):
         if not self._api_key:
             msg = (
                 "No LangSmith sandbox API key found. Set "
-                "LANGSMITH_SANDBOX_API_KEY or LANGSMITH_API_KEY."
+                "LANGSMITH_SANDBOX_API_KEY or LANGSMITH_API_KEY "
+                "(or the DEEPAGENTS_CLI_-prefixed equivalents)."
             )
             raise ValueError(msg)
         self._client: SandboxClient = SandboxClient(api_key=self._api_key)
@@ -394,7 +395,10 @@ class _DaytonaProvider(SandboxProvider):
 
         api_key = resolve_env_var("DAYTONA_API_KEY")
         if not api_key:
-            msg = "DAYTONA_API_KEY environment variable not set"
+            msg = (
+                "No Daytona API key found. Set DAYTONA_API_KEY "
+                "or DEEPAGENTS_CLI_DAYTONA_API_KEY."
+            )
             raise ValueError(msg)
         self._client = daytona_module.Daytona(
             daytona_module.DaytonaConfig(
@@ -478,14 +482,23 @@ class _ModalProvider(SandboxProvider):
         token_secret = resolve_env_var("MODAL_TOKEN_SECRET")
         if token_id and token_secret:
             self._client = self._modal.Client.from_credentials(token_id, token_secret)
+        elif token_id or token_secret:
+            logger.warning(
+                "Only one of MODAL_TOKEN_ID / MODAL_TOKEN_SECRET is set; "
+                "both are required for explicit credential auth. "
+                "Falling back to default Modal authentication.",
+            )
+            self._client = None
         else:
             self._client = None
 
-        self._app = self._modal.App.lookup(
-            name="deepagents-sandbox",
-            create_if_missing=True,
-            client=self._client,
-        )
+        lookup_kwargs: dict[str, Any] = {
+            "name": "deepagents-sandbox",
+            "create_if_missing": True,
+        }
+        if self._client is not None:
+            lookup_kwargs["client"] = self._client
+        self._app = self._modal.App.lookup(**lookup_kwargs)
 
     def get_or_create(
         self,
@@ -513,15 +526,19 @@ class _ModalProvider(SandboxProvider):
             package="langchain-modal",
         )
 
+        client_kwargs: dict[str, Any] = {}
+        if self._client is not None:
+            client_kwargs["client"] = self._client
+
         if sandbox_id:
             sandbox = self._modal.Sandbox.from_id(
                 sandbox_id=sandbox_id,
                 app=self._app,
-                client=self._client,
+                **client_kwargs,
             )
         else:
             sandbox = self._modal.Sandbox.create(
-                app=self._app, workdir="/workspace", client=self._client
+                app=self._app, workdir="/workspace", **client_kwargs
             )
             last_exc: Exception | None = None
             for _ in range(timeout // 2):
@@ -546,9 +563,10 @@ class _ModalProvider(SandboxProvider):
 
     def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002
         """Terminate a Modal sandbox by id."""
-        sandbox = self._modal.Sandbox.from_id(
-            sandbox_id=sandbox_id, app=self._app, client=self._client
-        )
+        del_kwargs: dict[str, Any] = {"sandbox_id": sandbox_id, "app": self._app}
+        if self._client is not None:
+            del_kwargs["client"] = self._client
+        sandbox = self._modal.Sandbox.from_id(**del_kwargs)
         sandbox.terminate()
 
 
@@ -566,7 +584,10 @@ class _RunloopProvider(SandboxProvider):
 
         api_key = resolve_env_var("RUNLOOP_API_KEY")
         if not api_key:
-            msg = "RUNLOOP_API_KEY environment variable not set"
+            msg = (
+                "No Runloop API key found. Set RUNLOOP_API_KEY "
+                "or DEEPAGENTS_CLI_RUNLOOP_API_KEY."
+            )
             raise ValueError(msg)
         self._client = runloop_module.Runloop(bearer_token=api_key)
 

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -222,16 +222,26 @@ class _LangSmithProvider(SandboxProvider):
         """Initialize LangSmith provider.
 
         Args:
-            api_key: LangSmith API key (defaults to `LANGSMITH_API_KEY` env var)
+            api_key: LangSmith API key (defaults to `LANGSMITH_SANDBOX_API_KEY`,
+                then `LANGSMITH_API_KEY` env var).
 
         Raises:
-            ValueError: If `LANGSMITH_API_KEY` environment variable not set
+            ValueError: If no LangSmith API key is found.
         """
         from langsmith.sandbox import SandboxClient
 
-        self._api_key = api_key or os.environ.get("LANGSMITH_API_KEY")
+        from deepagents_cli.model_config import resolve_env_var
+
+        self._api_key = (
+            api_key
+            or resolve_env_var("LANGSMITH_SANDBOX_API_KEY")
+            or resolve_env_var("LANGSMITH_API_KEY")
+        )
         if not self._api_key:
-            msg = "LANGSMITH_API_KEY environment variable not set"
+            msg = (
+                "No LangSmith sandbox API key found. Set "
+                "LANGSMITH_SANDBOX_API_KEY or LANGSMITH_API_KEY."
+            )
             raise ValueError(msg)
         self._client: SandboxClient = SandboxClient(api_key=self._api_key)
 
@@ -380,14 +390,16 @@ class _DaytonaProvider(SandboxProvider):
             package="langchain-daytona",
         )
 
-        api_key = os.environ.get("DAYTONA_API_KEY")
+        from deepagents_cli.model_config import resolve_env_var
+
+        api_key = resolve_env_var("DAYTONA_API_KEY")
         if not api_key:
             msg = "DAYTONA_API_KEY environment variable not set"
             raise ValueError(msg)
         self._client = daytona_module.Daytona(
             daytona_module.DaytonaConfig(
                 api_key=api_key,
-                api_url=os.environ.get("DAYTONA_API_URL"),
+                api_url=resolve_env_var("DAYTONA_API_URL"),
             )
         )
 
@@ -460,9 +472,19 @@ class _ModalProvider(SandboxProvider):
             package="langchain-modal",
         )
 
+        from deepagents_cli.model_config import resolve_env_var
+
+        token_id = resolve_env_var("MODAL_TOKEN_ID")
+        token_secret = resolve_env_var("MODAL_TOKEN_SECRET")
+        if token_id and token_secret:
+            self._client = self._modal.Client.from_credentials(token_id, token_secret)
+        else:
+            self._client = None
+
         self._app = self._modal.App.lookup(
             name="deepagents-sandbox",
             create_if_missing=True,
+            client=self._client,
         )
 
     def get_or_create(
@@ -495,9 +517,12 @@ class _ModalProvider(SandboxProvider):
             sandbox = self._modal.Sandbox.from_id(
                 sandbox_id=sandbox_id,
                 app=self._app,
+                client=self._client,
             )
         else:
-            sandbox = self._modal.Sandbox.create(app=self._app, workdir="/workspace")
+            sandbox = self._modal.Sandbox.create(
+                app=self._app, workdir="/workspace", client=self._client
+            )
             last_exc: Exception | None = None
             for _ in range(timeout // 2):
                 if sandbox.poll() is not None:
@@ -521,7 +546,9 @@ class _ModalProvider(SandboxProvider):
 
     def delete(self, *, sandbox_id: str, **kwargs: Any) -> None:  # noqa: ARG002
         """Terminate a Modal sandbox by id."""
-        sandbox = self._modal.Sandbox.from_id(sandbox_id=sandbox_id, app=self._app)
+        sandbox = self._modal.Sandbox.from_id(
+            sandbox_id=sandbox_id, app=self._app, client=self._client
+        )
         sandbox.terminate()
 
 
@@ -535,7 +562,9 @@ class _RunloopProvider(SandboxProvider):
             package="langchain-runloop",
         )
 
-        api_key = os.environ.get("RUNLOOP_API_KEY")
+        from deepagents_cli.model_config import resolve_env_var
+
+        api_key = resolve_env_var("RUNLOOP_API_KEY")
         if not api_key:
             msg = "RUNLOOP_API_KEY environment variable not set"
             raise ValueError(msg)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1148,7 +1148,7 @@ def cli_main() -> None:
 
     # Note: LANGSMITH_PROJECT override is handled lazily by config.py's
     # _ensure_bootstrap() (triggered on first access of `settings`).
-    # This ensures agent traces use DEEPAGENTS_LANGSMITH_PROJECT while
+    # This ensures agent traces use DEEPAGENTS_CLI_LANGSMITH_PROJECT while
     # shell commands use the user's original LANGSMITH_PROJECT.
 
     # Fast path: print version without loading heavy dependencies

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -32,12 +32,12 @@ def resolve_env_var(name: str) -> str | None:
     """Look up an env var with `DEEPAGENTS_CLI_` prefix override.
 
     Checks `DEEPAGENTS_CLI_{name}` first, then falls back to `{name}`.
-    Empty strings are normalized to `None`.
 
     If the prefixed variable is *present* in the environment (even as an empty
     string), the canonical variable is never consulted. This lets users
-    set `DEEPAGENTS_CLI_X=""` to explicitly disable a key that is
-    set canonically.
+    set `DEEPAGENTS_CLI_X=""` to shadow a canonically-set key -- the function
+    will return `None` (since empty strings are normalized to `None`),
+    effectively suppressing the canonical value.
 
     If `name` already carries the prefix, the double-prefixed lookup is skipped
     to avoid nonsensical `DEEPAGENTS_CLI_DEEPAGENTS_CLI_*` reads
@@ -53,7 +53,16 @@ def resolve_env_var(name: str) -> str | None:
     if not name.startswith(_ENV_PREFIX):
         prefixed = f"{_ENV_PREFIX}{name}"
         if prefixed in os.environ:
-            return os.environ[prefixed] or None
+            val = os.environ[prefixed]
+            if not val and os.environ.get(name):
+                logger.debug(
+                    "%s is set but empty, blocking non-empty %s. "
+                    "Unset %s to use the canonical variable.",
+                    prefixed,
+                    name,
+                    prefixed,
+                )
+            return val or None
     return os.environ.get(name) or None
 
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -25,6 +25,37 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ENV_PREFIX = "DEEPAGENTS_CLI_"
+
+
+def resolve_env_var(name: str) -> str | None:
+    """Look up an env var with `DEEPAGENTS_CLI_` prefix override.
+
+    Checks `DEEPAGENTS_CLI_{name}` first, then falls back to `{name}`.
+    Empty strings are normalized to `None`.
+
+    If the prefixed variable is *present* in the environment (even as an empty
+    string), the canonical variable is never consulted. This lets users
+    set `DEEPAGENTS_CLI_X=""` to explicitly disable a key that is
+    set canonically.
+
+    If `name` already carries the prefix, the double-prefixed lookup is skipped
+    to avoid nonsensical `DEEPAGENTS_CLI_DEEPAGENTS_CLI_*` reads
+    (e.g., when the name comes from a user's `config.toml`).
+
+    Args:
+        name: The canonical environment variable name (e.g.
+            `ANTHROPIC_API_KEY`).
+
+    Returns:
+        The resolved value, or `None` if neither form is set or both are empty.
+    """
+    if not name.startswith(_ENV_PREFIX):
+        prefixed = f"{_ENV_PREFIX}{name}"
+        if prefixed in os.environ:
+            return os.environ[prefixed] or None
+    return os.environ.get(name) or None
+
 
 class ModelConfigError(Exception):
     """Raised when model configuration or creation fails."""
@@ -703,7 +734,7 @@ def has_provider_credentials(provider: str) -> bool | None:
     # Fall back to hardcoded well-known providers.
     env_var = PROVIDER_API_KEY_ENV.get(provider)
     if env_var:
-        return bool(os.environ.get(env_var))
+        return bool(resolve_env_var(env_var))
 
     # Provider not found in config or hardcoded map — credential status is
     # unknown. The provider itself will report auth failures at
@@ -949,7 +980,7 @@ class ModelConfig:
         env_var = provider.get("api_key_env")
         if not env_var:
             return None  # No key configured — can't verify
-        return bool(os.environ.get(env_var))
+        return bool(resolve_env_var(env_var))
 
     def get_base_url(self, provider_name: str) -> str | None:
         """Get custom base URL.

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -48,7 +48,7 @@ def resolve_env_var(name: str) -> str | None:
             `ANTHROPIC_API_KEY`).
 
     Returns:
-        The resolved value, or `None` if neither form is set or both are empty.
+        The resolved value, or `None` when absent or empty.
     """
     if not name.startswith(_ENV_PREFIX):
         prefixed = f"{_ENV_PREFIX}{name}"

--- a/libs/cli/deepagents_cli/skills/load.py
+++ b/libs/cli/deepagents_cli/skills/load.py
@@ -173,10 +173,12 @@ def load_skill_content(
             "Skill path %s is outside all allowed roots, refusing to read",
             skill_path,
         )
+        from deepagents_cli._env_vars import EXTRA_SKILLS_DIRS
+
         msg = (
             f"Skill path {skill_path} resolves outside all allowed skill "
             "directories. If this is a symlink, add the target directory to "
-            "DEEPAGENTS_EXTRA_SKILLS_DIRS or [skills].extra_allowed_dirs "
+            f"{EXTRA_SKILLS_DIRS} or [skills].extra_allowed_dirs "
             "in ~/.deepagents/config.toml."
         )
         raise PermissionError(msg)

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -326,12 +326,14 @@ async def perform_upgrade() -> tuple[bool, str]:
 def is_update_check_enabled() -> bool:
     """Return whether update checks are enabled.
 
-    Checks `DEEPAGENTS_NO_UPDATE_CHECK` env var and the `[update].check` key
+    Checks `DEEPAGENTS_CLI_NO_UPDATE_CHECK` env var and the `[update].check` key
     in `config.toml`.
 
     Defaults to enabled.
     """
-    if os.environ.get("DEEPAGENTS_NO_UPDATE_CHECK"):
+    from deepagents_cli._env_vars import NO_UPDATE_CHECK
+
+    if os.environ.get(NO_UPDATE_CHECK):
         return False
     return _read_update_config().get("check", True)
 
@@ -339,18 +341,19 @@ def is_update_check_enabled() -> bool:
 def is_auto_update_enabled() -> bool:
     """Return whether auto-update is enabled.
 
-    Opt-in via `DEEPAGENTS_AUTO_UPDATE=1` env var or
+    Opt-in via `DEEPAGENTS_CLI_AUTO_UPDATE=1` env var or
     `[update].auto_update = true` in `config.toml`.
 
     Defaults to `False`.
 
     Always disabled for editable installs.
     """
+    from deepagents_cli._env_vars import AUTO_UPDATE
     from deepagents_cli.config import _is_editable_install
 
     if _is_editable_install():
         return False
-    if os.environ.get("DEEPAGENTS_AUTO_UPDATE", "").lower() in {"1", "true", "yes"}:
+    if os.environ.get(AUTO_UPDATE, "").lower() in {"1", "true", "yes"}:
         return True
     return _read_update_config().get("auto_update", False)
 

--- a/libs/cli/tests/integration_tests/test_compact_resume.py
+++ b/libs/cli/tests/integration_tests/test_compact_resume.py
@@ -80,7 +80,7 @@ async def test_compact_resumed_thread_uses_persisted_history(
 
     # Keep config and the global sessions DB fully test-local.
     monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.setenv("DEEPAGENTS_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("DEEPAGENTS_CLI_NO_UPDATE_CHECK", "1")
     monkeypatch.chdir(project_dir)
 
     _write_model_config(home_dir)

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -50,7 +50,7 @@ def _clear_langsmith_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "LANGSMITH_TRACING",
         "LANGCHAIN_TRACING_V2",
         "LANGSMITH_PROJECT",
-        "DEEPAGENTS_LANGSMITH_PROJECT",
+        "DEEPAGENTS_CLI_LANGSMITH_PROJECT",
     ):
         monkeypatch.delenv(key, raising=False)
 

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -51,6 +51,10 @@ def _clear_langsmith_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "LANGCHAIN_TRACING_V2",
         "LANGSMITH_PROJECT",
         "DEEPAGENTS_CLI_LANGSMITH_PROJECT",
+        "DEEPAGENTS_CLI_LANGSMITH_API_KEY",
+        "DEEPAGENTS_CLI_LANGCHAIN_API_KEY",
+        "DEEPAGENTS_CLI_LANGSMITH_TRACING",
+        "DEEPAGENTS_CLI_LANGCHAIN_TRACING_V2",
     ):
         monkeypatch.delenv(key, raising=False)
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -2004,6 +2004,107 @@ class TestLazyModuleAttributes:
             config_mod._bootstrap_done = original_done
             config_mod._original_langsmith_project = original_ls
 
+    def test_bootstrap_propagates_prefixed_langsmith_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prefixed LangSmith vars are copied to canonical names at bootstrap."""
+        import deepagents_cli.config as config_mod
+        from deepagents_cli.config import _ensure_bootstrap
+
+        original_done = config_mod._bootstrap_done
+        original_ls = config_mod._original_langsmith_project
+        config_mod._bootstrap_done = False
+
+        try:
+            monkeypatch.setenv("DEEPAGENTS_CLI_LANGSMITH_API_KEY", "lsv2_test")
+            monkeypatch.setenv("DEEPAGENTS_CLI_LANGSMITH_TRACING", "true")
+            monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+            monkeypatch.delenv("LANGSMITH_TRACING", raising=False)
+            monkeypatch.delenv("DEEPAGENTS_CLI_LANGSMITH_PROJECT", raising=False)
+
+            with (
+                patch("deepagents_cli.config._load_dotenv"),
+                patch(
+                    "deepagents_cli.project_utils.get_server_project_context",
+                    return_value=None,
+                ),
+            ):
+                _ensure_bootstrap()
+
+            import os
+
+            assert os.environ["LANGSMITH_API_KEY"] == "lsv2_test"
+            assert os.environ["LANGSMITH_TRACING"] == "true"
+        finally:
+            config_mod._bootstrap_done = original_done
+            config_mod._original_langsmith_project = original_ls
+
+    def test_bootstrap_does_not_overwrite_canonical_langsmith_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Canonical LangSmith vars are preserved when already set."""
+        import deepagents_cli.config as config_mod
+        from deepagents_cli.config import _ensure_bootstrap
+
+        original_done = config_mod._bootstrap_done
+        original_ls = config_mod._original_langsmith_project
+        config_mod._bootstrap_done = False
+
+        try:
+            monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_original")
+            monkeypatch.setenv("DEEPAGENTS_CLI_LANGSMITH_API_KEY", "lsv2_override")
+            monkeypatch.delenv("DEEPAGENTS_CLI_LANGSMITH_PROJECT", raising=False)
+
+            with (
+                patch("deepagents_cli.config._load_dotenv"),
+                patch(
+                    "deepagents_cli.project_utils.get_server_project_context",
+                    return_value=None,
+                ),
+            ):
+                _ensure_bootstrap()
+
+            import os
+
+            # Canonical value preserved — propagation does not overwrite.
+            assert os.environ["LANGSMITH_API_KEY"] == "lsv2_original"
+        finally:
+            config_mod._bootstrap_done = original_done
+            config_mod._original_langsmith_project = original_ls
+
+    def test_bootstrap_propagates_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty prefixed var propagates to canonical (explicit disable)."""
+        import deepagents_cli.config as config_mod
+        from deepagents_cli.config import _ensure_bootstrap
+
+        original_done = config_mod._bootstrap_done
+        original_ls = config_mod._original_langsmith_project
+        config_mod._bootstrap_done = False
+
+        try:
+            monkeypatch.setenv("DEEPAGENTS_CLI_LANGSMITH_TRACING", "")
+            monkeypatch.delenv("LANGSMITH_TRACING", raising=False)
+            monkeypatch.delenv("DEEPAGENTS_CLI_LANGSMITH_PROJECT", raising=False)
+
+            with (
+                patch("deepagents_cli.config._load_dotenv"),
+                patch(
+                    "deepagents_cli.project_utils.get_server_project_context",
+                    return_value=None,
+                ),
+            ):
+                _ensure_bootstrap()
+
+            import os
+
+            # Empty string propagated — lets user explicitly disable tracing.
+            assert os.environ["LANGSMITH_TRACING"] == ""
+        finally:
+            config_mod._bootstrap_done = original_done
+            config_mod._original_langsmith_project = original_ls
+
 
 class TestFindDotenvFromStartPath:
     """Tests for _find_dotenv_from_start_path."""

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -875,6 +875,8 @@ class TestGetLangsmithProjectName:
         env = {
             "LANGSMITH_API_KEY": "",
             "LANGCHAIN_API_KEY": "",
+            "DEEPAGENTS_CLI_LANGSMITH_API_KEY": "",
+            "DEEPAGENTS_CLI_LANGCHAIN_API_KEY": "",
             "LANGSMITH_TRACING": "true",
         }
         with patch.dict("os.environ", env, clear=False):
@@ -886,6 +888,8 @@ class TestGetLangsmithProjectName:
             "LANGSMITH_API_KEY": "lsv2_test",
             "LANGSMITH_TRACING": "",
             "LANGCHAIN_TRACING_V2": "",
+            "DEEPAGENTS_CLI_LANGSMITH_TRACING": "",
+            "DEEPAGENTS_CLI_LANGCHAIN_TRACING_V2": "",
         }
         with patch.dict("os.environ", env, clear=False):
             assert get_langsmith_project_name() is None

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1938,7 +1938,7 @@ class TestLazyModuleAttributes:
     def test_ensure_bootstrap_langsmith_override(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """_ensure_bootstrap copies DEEPAGENTS_LANGSMITH_PROJECT."""
+        """_ensure_bootstrap copies DEEPAGENTS_CLI_LANGSMITH_PROJECT."""
         import deepagents_cli.config as config_mod
         from deepagents_cli.config import _ensure_bootstrap
 
@@ -1947,7 +1947,7 @@ class TestLazyModuleAttributes:
         config_mod._bootstrap_done = False
 
         try:
-            monkeypatch.setenv("DEEPAGENTS_LANGSMITH_PROJECT", "my-agent-project")
+            monkeypatch.setenv("DEEPAGENTS_CLI_LANGSMITH_PROJECT", "my-agent-project")
             monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
 
             with (
@@ -1980,7 +1980,7 @@ class TestLazyModuleAttributes:
 
         try:
             monkeypatch.setenv("LANGSMITH_PROJECT", "user-project")
-            monkeypatch.setenv("DEEPAGENTS_LANGSMITH_PROJECT", "agent-project")
+            monkeypatch.setenv("DEEPAGENTS_CLI_LANGSMITH_PROJECT", "agent-project")
 
             with (
                 patch("deepagents_cli.config._load_dotenv"),

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1251,12 +1251,13 @@ api_key_env = "FIREWORKS_API_KEY"
         assert kwargs == {}
 
     def test_unconfigured_providers_return_empty(self) -> None:
-        """Providers without config return empty kwargs."""
-        kwargs = _get_provider_kwargs("anthropic")
-        assert kwargs == {}
+        """Providers without config or env credentials return empty kwargs."""
+        with patch.dict("os.environ", {}, clear=True):
+            kwargs = _get_provider_kwargs("anthropic")
+            assert kwargs == {}
 
-        kwargs = _get_provider_kwargs("google_genai")
-        assert kwargs == {}
+            kwargs = _get_provider_kwargs("google_genai")
+            assert kwargs == {}
 
     def test_merges_config_params(self, tmp_path: Path) -> None:
         """Merges params from config with base_url and api_key."""

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1202,6 +1202,29 @@ api_key_env = "TOGETHER_API_KEY"
         assert kwargs["api_key"] == "together-key"
         assert "base_url" not in kwargs
 
+    def test_prefixed_env_var_beats_canonical(self, tmp_path: Path) -> None:
+        """DEEPAGENTS_CLI_ prefixed var overrides canonical in provider kwargs."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.fireworks]
+models = ["llama-v3p1-70b"]
+api_key_env = "FIREWORKS_API_KEY"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict(
+                "os.environ",
+                {
+                    "FIREWORKS_API_KEY": "canonical",
+                    "DEEPAGENTS_CLI_FIREWORKS_API_KEY": "prefixed",
+                },
+                clear=False,
+            ),
+        ):
+            kwargs = _get_provider_kwargs("fireworks")
+
+        assert kwargs["api_key"] == "prefixed"
+
     def test_omits_api_key_when_env_not_set(self, tmp_path: Path) -> None:
         """Omits api_key when the env var is not set."""
         config_path = tmp_path / "config.toml"

--- a/libs/cli/tests/unit_tests/test_debug.py
+++ b/libs/cli/tests/unit_tests/test_debug.py
@@ -11,7 +11,7 @@ from deepagents_cli._debug import configure_debug_logging
 
 class TestConfigureDebugLogging:
     def test_noop_when_env_unset(self) -> None:
-        """No handlers should be added when DEEPAGENTS_DEBUG is unset."""
+        """No handlers should be added when DEEPAGENTS_CLI_DEBUG is unset."""
         logger = logging.getLogger("test.debug.noop")
         original_count = len(logger.handlers)
         with patch.dict(os.environ, {}, clear=True):
@@ -23,7 +23,7 @@ class TestConfigureDebugLogging:
         log_file = tmp_path / "debug.log"
         with patch.dict(
             os.environ,
-            {"DEEPAGENTS_DEBUG": "1", "DEEPAGENTS_DEBUG_FILE": str(log_file)},
+            {"DEEPAGENTS_CLI_DEBUG": "1", "DEEPAGENTS_CLI_DEBUG_FILE": str(log_file)},
         ):
             configure_debug_logging(logger)
         assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
@@ -39,7 +39,7 @@ class TestConfigureDebugLogging:
         log_file = tmp_path / "custom.log"
         with patch.dict(
             os.environ,
-            {"DEEPAGENTS_DEBUG": "1", "DEEPAGENTS_DEBUG_FILE": str(log_file)},
+            {"DEEPAGENTS_CLI_DEBUG": "1", "DEEPAGENTS_CLI_DEBUG_FILE": str(log_file)},
         ):
             configure_debug_logging(logger)
         file_handlers = [
@@ -59,8 +59,8 @@ class TestConfigureDebugLogging:
         with patch.dict(
             os.environ,
             {
-                "DEEPAGENTS_DEBUG": "1",
-                "DEEPAGENTS_DEBUG_FILE": "/nonexistent_dir/debug.log",
+                "DEEPAGENTS_CLI_DEBUG": "1",
+                "DEEPAGENTS_CLI_DEBUG_FILE": "/nonexistent_dir/debug.log",
             },
         ):
             configure_debug_logging(logger)

--- a/libs/cli/tests/unit_tests/test_env_vars.py
+++ b/libs/cli/tests/unit_tests/test_env_vars.py
@@ -1,0 +1,90 @@
+"""Drift-detection tests for the CLI environment variable registry.
+
+These tests ensure that:
+
+1. Every `DEEPAGENTS_CLI_*` constant in `_env_vars.py` has a matching
+   value used somewhere in source code (no stale entries).
+2. No source file outside `_env_vars.py` uses a bare string literal like
+   `"DEEPAGENTS_CLI_FOO"` -- it must import the constant instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import deepagents_cli._env_vars as _mod
+
+_SRC_DIR = Path(__file__).resolve().parents[2] / "deepagents_cli"
+_REGISTRY_FILE = _SRC_DIR / "_env_vars.py"
+
+# Matches a full DEEPAGENTS_CLI_* env var name inside quote characters.
+# The [A-Z] after the prefix avoids matching the bare prefix constant
+# (_ENV_PREFIX = "DEEPAGENTS_CLI_") in model_config.py.
+_ENV_VAR_RE = re.compile(r"""["'](DEEPAGENTS_CLI_[A-Z][A-Z0-9_]+)["']""")
+
+
+def _public_constants() -> list[str]:
+    """Return public constant names from `_env_vars` (alphabetical order)."""
+    return [
+        k
+        for k, v in vars(_mod).items()
+        if isinstance(v, str)
+        and not k.startswith("_")
+        and v.startswith("DEEPAGENTS_CLI_")
+    ]
+
+
+def _registered_values() -> set[str]:
+    """Collect all `DEEPAGENTS_CLI_*` string values from `_env_vars`."""
+    return {getattr(_mod, k) for k in _public_constants()}
+
+
+def _collect_bare_literals(*, include_registry: bool = False) -> dict[str, set[str]]:
+    """Map source files to bare `DEEPAGENTS_CLI_*` string literals found.
+
+    Args:
+        include_registry: When `True`, also scan `_env_vars.py`.
+
+    Returns:
+        `{relative_path: {var_name, ...}}` for files with hits.
+    """
+    hits: dict[str, set[str]] = {}
+    for py_file in _SRC_DIR.rglob("*.py"):
+        if not include_registry and py_file == _REGISTRY_FILE:
+            continue
+        matches = set(_ENV_VAR_RE.findall(py_file.read_text()))
+        if matches:
+            hits[str(py_file.relative_to(_SRC_DIR))] = matches
+    return hits
+
+
+class TestEnvVarRegistryDrift:
+    """Ensure `_env_vars` stays in sync with source code usage."""
+
+    def test_no_bare_literals_outside_registry(self) -> None:
+        """Source files must import constants, not use raw string literals."""
+        hits = _collect_bare_literals()
+        assert not hits, (
+            "Bare DEEPAGENTS_CLI_* string literals found in source "
+            "(import from deepagents_cli._env_vars instead):\n"
+            + "\n".join(f"  {f}: {sorted(v)}" for f, v in sorted(hits.items()))
+        )
+
+    def test_no_stale_registry_entries(self) -> None:
+        """Every constant in `_env_vars` must appear in `_env_vars.py`."""
+        registered = _registered_values()
+        in_registry_file = set(_ENV_VAR_RE.findall(_REGISTRY_FILE.read_text()))
+        stale = registered - in_registry_file
+        assert not stale, (
+            f"Constants whose values don't appear in _env_vars.py: {stale}. "
+            "Remove stale entries from deepagents_cli/_env_vars.py."
+        )
+
+    def test_registry_constants_are_sorted(self) -> None:
+        """Public constant names must be alphabetically sorted."""
+        names = _public_constants()
+        assert names == sorted(names), (
+            "Constants in _env_vars.py are not sorted. Expected order: "
+            + ", ".join(sorted(names))
+        )

--- a/libs/cli/tests/unit_tests/test_env_vars.py
+++ b/libs/cli/tests/unit_tests/test_env_vars.py
@@ -72,7 +72,7 @@ class TestEnvVarRegistryDrift:
         )
 
     def test_no_stale_registry_entries(self) -> None:
-        """Every constant in `_env_vars` must appear in `_env_vars.py`."""
+        """Every registered value must be parseable from `_env_vars.py` source."""
         registered = _registered_values()
         in_registry_file = set(_ENV_VAR_RE.findall(_REGISTRY_FILE.read_text()))
         stale = registered - in_registry_file

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -123,6 +123,15 @@ class TestHasProviderCredentials:
         with patch.dict("os.environ", {}, clear=True):
             assert has_provider_credentials("anthropic") is False
 
+    def test_returns_true_with_prefixed_env_var(self):
+        """Returns True when only the DEEPAGENTS_CLI_ prefixed var is set."""
+        with patch.dict(
+            "os.environ",
+            {"DEEPAGENTS_CLI_ANTHROPIC_API_KEY": "sk-prefixed"},
+            clear=True,
+        ):
+            assert has_provider_credentials("anthropic") is True
+
 
 class TestThreadColumnPersistence:
     """Tests for thread selector column visibility persistence."""
@@ -402,6 +411,70 @@ cwd = true
             invalidate_thread_config_cache()
 
 
+class TestResolveEnvVar:
+    """Tests for resolve_env_var prefix override."""
+
+    def test_returns_canonical_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to the canonical env var when no prefix is set."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-canonical")
+        monkeypatch.delenv("DEEPAGENTS_CLI_ANTHROPIC_API_KEY", raising=False)
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("ANTHROPIC_API_KEY") == "sk-canonical"
+
+    def test_prefix_beats_canonical(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DEEPAGENTS_CLI_ prefixed var takes priority over canonical."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-canonical")
+        monkeypatch.setenv("DEEPAGENTS_CLI_ANTHROPIC_API_KEY", "sk-override")
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("ANTHROPIC_API_KEY") == "sk-override"
+
+    def test_returns_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns None when neither form is set."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("DEEPAGENTS_CLI_ANTHROPIC_API_KEY", raising=False)
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("ANTHROPIC_API_KEY") is None
+
+    def test_empty_string_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty strings are normalized to None."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        monkeypatch.setenv("DEEPAGENTS_CLI_ANTHROPIC_API_KEY", "")
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("ANTHROPIC_API_KEY") is None
+
+    def test_prefix_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Works when only the prefixed var is set."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("DEEPAGENTS_CLI_OPENAI_API_KEY", "sk-prefixed")
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("OPENAI_API_KEY") == "sk-prefixed"
+
+    def test_empty_prefix_blocks_canonical(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty prefix var blocks fallback to canonical (explicit disable)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-real")
+        monkeypatch.setenv("DEEPAGENTS_CLI_ANTHROPIC_API_KEY", "")
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("ANTHROPIC_API_KEY") is None
+
+    def test_skips_double_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Names already carrying the prefix don't get double-prefixed."""
+        monkeypatch.setenv("DEEPAGENTS_CLI_MY_KEY", "direct")
+        monkeypatch.delenv("DEEPAGENTS_CLI_DEEPAGENTS_CLI_MY_KEY", raising=False)
+        from deepagents_cli.model_config import resolve_env_var
+
+        assert resolve_env_var("DEEPAGENTS_CLI_MY_KEY") == "direct"
+
+
 class TestProviderApiKeyEnv:
     """Tests for PROVIDER_API_KEY_ENV constant."""
 
@@ -606,6 +679,23 @@ api_key_env = "ANTHROPIC_API_KEY"
 
         with patch.dict("os.environ", {}, clear=True):
             assert config.has_credentials("anthropic") is False
+
+    def test_returns_true_with_prefixed_env_var(self, tmp_path):
+        """Returns True when only the DEEPAGENTS_CLI_ prefixed var is set."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+models = ["claude-sonnet-4-5"]
+api_key_env = "ANTHROPIC_API_KEY"
+""")
+        config = ModelConfig.load(config_path)
+
+        with patch.dict(
+            "os.environ",
+            {"DEEPAGENTS_CLI_ANTHROPIC_API_KEY": "sk-prefixed"},
+            clear=True,
+        ):
+            assert config.has_credentials("anthropic") is True
 
 
 class TestModelConfigGetBaseUrl:

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -16,12 +16,19 @@ _real_load_dotenv = _dotenv_module.load_dotenv
 
 _RELOAD_ENV_KEYS = (
     "OPENAI_API_KEY",
+    "DEEPAGENTS_CLI_OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
+    "DEEPAGENTS_CLI_ANTHROPIC_API_KEY",
     "GOOGLE_API_KEY",
+    "DEEPAGENTS_CLI_GOOGLE_API_KEY",
     "NVIDIA_API_KEY",
+    "DEEPAGENTS_CLI_NVIDIA_API_KEY",
     "TAVILY_API_KEY",
+    "DEEPAGENTS_CLI_TAVILY_API_KEY",
     "GOOGLE_CLOUD_PROJECT",
+    "DEEPAGENTS_CLI_GOOGLE_CLOUD_PROJECT",
     "DEEPAGENTS_LANGSMITH_PROJECT",
+    "DEEPAGENTS_CLI_DEEPAGENTS_LANGSMITH_PROJECT",
     "DEEPAGENTS_SHELL_ALLOW_LIST",
 )
 
@@ -159,12 +166,13 @@ class TestReloadFromEnvironment:
 
         settings.reload_from_environment(start_path=tmp_path)
 
-        mock_load.assert_called_once_with(dotenv_path=env_file, override=True)
+        # Project .env is the second call (global loads first).
+        mock_load.assert_any_call(dotenv_path=env_file, override=True)
 
     def test_loads_global_dotenv(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Reload should load project dotenv first, then global as fallback."""
+        """Reload should load global dotenv first, then project."""
         settings = Settings.from_environment(start_path=tmp_path)
 
         global_env = tmp_path / "global" / ".env"
@@ -183,8 +191,8 @@ class TestReloadFromEnvironment:
         assert mock_load.call_count == 2
         mock_load.assert_has_calls(
             [
+                call(dotenv_path=global_env, override=True),
                 call(dotenv_path=project_env, override=True),
-                call(dotenv_path=global_env, override=False),
             ]
         )
 
@@ -216,10 +224,10 @@ class TestReloadFromEnvironment:
         # Only the project .env call should happen
         mock_load.assert_called_once_with(dotenv_path=project_env, override=True)
 
-    def test_global_dotenv_precedence_on_reload(
+    def test_project_dotenv_beats_global(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """With `override=True` (`/reload`), project `.env` beats global."""
+        """Project `.env` should always beat global `.env`."""
         from deepagents_cli.config import _load_dotenv
 
         global_dir = tmp_path / "global"
@@ -238,15 +246,15 @@ class TestReloadFromEnvironment:
         )
         monkeypatch.delenv("TEST_PRECEDENCE_KEY", raising=False)
 
-        _load_dotenv(start_path=tmp_path, override=True)
+        _load_dotenv(start_path=tmp_path)
 
         assert os.environ.get("TEST_PRECEDENCE_KEY") == "project-value"
         monkeypatch.delenv("TEST_PRECEDENCE_KEY", raising=False)
 
-    def test_global_dotenv_precedence_at_bootstrap(
+    def test_global_dotenv_beats_shell_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """With `override=False` (bootstrap), project `.env` still beats global."""
+        """Global `~/.deepagents/.env` should override shell-exported vars."""
         from deepagents_cli.config import _load_dotenv
 
         global_dir = tmp_path / "global"
@@ -255,18 +263,22 @@ class TestReloadFromEnvironment:
         global_env.write_text("TEST_BOOT_KEY=global-value\n")
         monkeypatch.setattr("deepagents_cli.config._GLOBAL_DOTENV_PATH", global_env)
 
-        project_env = tmp_path / ".env"
-        project_env.write_text("TEST_BOOT_KEY=project-value\n")
+        # Simulate a shell-exported variable (e.g., from $ZDOTDIR/.env)
+        monkeypatch.setenv("TEST_BOOT_KEY", "shell-value")
 
         monkeypatch.setattr(
             "dotenv.load_dotenv",
             _real_load_dotenv,
         )
-        monkeypatch.delenv("TEST_BOOT_KEY", raising=False)
+        # No project .env
+        monkeypatch.setattr(
+            "deepagents_cli.config._find_dotenv_from_start_path",
+            lambda _: None,
+        )
 
-        _load_dotenv(start_path=tmp_path, override=False)
+        _load_dotenv(start_path=tmp_path)
 
-        assert os.environ.get("TEST_BOOT_KEY") == "project-value"
+        assert os.environ.get("TEST_BOOT_KEY") == "global-value"
         monkeypatch.delenv("TEST_BOOT_KEY", raising=False)
 
     def test_global_only_no_project_dotenv(
@@ -294,7 +306,7 @@ class TestReloadFromEnvironment:
         )
         isolated = tmp_path / "no_project_env"
         isolated.mkdir()
-        result = _load_dotenv(start_path=isolated, override=False)
+        result = _load_dotenv(start_path=isolated)
 
         assert result is True
         assert os.environ.get("TEST_GLOBAL_ONLY") == "global-value"
@@ -322,7 +334,8 @@ class TestReloadFromEnvironment:
         def _fail_on_global(*_args: object, **_kwargs: object) -> bool:
             nonlocal call_count
             call_count += 1
-            if call_count == 2:
+            # Global loads first now; fail on first call
+            if call_count == 1:
                 msg = "read error"
                 raise OSError(msg)
             return True
@@ -349,6 +362,29 @@ class TestReloadFromEnvironment:
         assert len(changes) == 3
         fields = {c.split(":")[0] for c in changes}
         assert fields == {"openai_api_key", "anthropic_api_key", "shell_allow_list"}
+
+    def test_prefixed_env_var_beats_canonical(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """DEEPAGENTS_CLI_ prefixed var should override canonical on reload."""
+        settings = Settings.from_environment(start_path=tmp_path)
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-canonical")
+        monkeypatch.setenv("DEEPAGENTS_CLI_ANTHROPIC_API_KEY", "sk-override")
+        settings.reload_from_environment(start_path=tmp_path)
+
+        assert settings.anthropic_api_key == "sk-override"
+
+    def test_from_environment_uses_prefixed_var(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Settings.from_environment should honour the DEEPAGENTS_CLI_ prefix."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-canonical")
+        monkeypatch.setenv("DEEPAGENTS_CLI_OPENAI_API_KEY", "sk-override")
+
+        settings = Settings.from_environment(start_path=tmp_path)
+
+        assert settings.openai_api_key == "sk-override"
 
 
 class TestReloadErrorPaths:

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -165,13 +165,13 @@ class TestReloadFromEnvironment:
 
         settings.reload_from_environment(start_path=tmp_path)
 
-        # Project .env is the second call (global loads first).
-        mock_load.assert_any_call(dotenv_path=env_file, override=True)
+        # Project .env loads first (before global) with override=False.
+        mock_load.assert_any_call(dotenv_path=env_file, override=False)
 
     def test_loads_global_dotenv(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Reload should load global dotenv first, then project."""
+        """Reload should load project dotenv first, then global."""
         settings = Settings.from_environment(start_path=tmp_path)
 
         global_env = tmp_path / "global" / ".env"
@@ -190,8 +190,8 @@ class TestReloadFromEnvironment:
         assert mock_load.call_count == 2
         mock_load.assert_has_calls(
             [
-                call(dotenv_path=global_env, override=True),
-                call(dotenv_path=project_env, override=True),
+                call(dotenv_path=project_env, override=False),
+                call(dotenv_path=global_env, override=False),
             ]
         )
 
@@ -220,8 +220,8 @@ class TestReloadFromEnvironment:
             settings.reload_from_environment(start_path=tmp_path)
 
         assert any("Could not read global dotenv" in r.message for r in caplog.records)
-        # Only the project .env call should happen
-        mock_load.assert_called_once_with(dotenv_path=project_env, override=True)
+        # Project .env loads first; global failed via is_file OSError
+        mock_load.assert_called_once_with(dotenv_path=project_env, override=False)
 
     def test_project_dotenv_beats_global(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -250,10 +250,37 @@ class TestReloadFromEnvironment:
         assert os.environ.get("TEST_PRECEDENCE_KEY") == "project-value"
         monkeypatch.delenv("TEST_PRECEDENCE_KEY", raising=False)
 
-    def test_global_dotenv_beats_shell_env(
+    def test_shell_env_beats_project_dotenv(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Global `~/.deepagents/.env` should override shell-exported vars."""
+        """Shell-exported vars should beat project `.env`."""
+        from deepagents_cli.config import _load_dotenv
+
+        # No global dotenv
+        monkeypatch.setattr(
+            "deepagents_cli.config._GLOBAL_DOTENV_PATH",
+            tmp_path / "nonexistent" / ".env",
+        )
+
+        project_env = tmp_path / ".env"
+        project_env.write_text("TEST_SHELL_PROJECT_KEY=project-value\n")
+
+        monkeypatch.setenv("TEST_SHELL_PROJECT_KEY", "shell-value")
+
+        monkeypatch.setattr(
+            "dotenv.load_dotenv",
+            _real_load_dotenv,
+        )
+
+        _load_dotenv(start_path=tmp_path)
+
+        assert os.environ.get("TEST_SHELL_PROJECT_KEY") == "shell-value"
+        monkeypatch.delenv("TEST_SHELL_PROJECT_KEY", raising=False)
+
+    def test_shell_env_beats_global_dotenv(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Shell-exported vars should beat global `~/.deepagents/.env`."""
         from deepagents_cli.config import _load_dotenv
 
         global_dir = tmp_path / "global"
@@ -277,7 +304,7 @@ class TestReloadFromEnvironment:
 
         _load_dotenv(start_path=tmp_path)
 
-        assert os.environ.get("TEST_BOOT_KEY") == "global-value"
+        assert os.environ.get("TEST_BOOT_KEY") == "shell-value"
         monkeypatch.delenv("TEST_BOOT_KEY", raising=False)
 
     def test_global_only_no_project_dotenv(
@@ -333,8 +360,8 @@ class TestReloadFromEnvironment:
         def _fail_on_global(*_args: object, **_kwargs: object) -> bool:
             nonlocal call_count
             call_count += 1
-            # Global loads first now; fail on first call
-            if call_count == 1:
+            # Project loads first; global is the second call
+            if call_count == 2:
                 msg = "read error"
                 raise OSError(msg)
             return True

--- a/libs/cli/tests/unit_tests/test_reload.py
+++ b/libs/cli/tests/unit_tests/test_reload.py
@@ -27,9 +27,8 @@ _RELOAD_ENV_KEYS = (
     "DEEPAGENTS_CLI_TAVILY_API_KEY",
     "GOOGLE_CLOUD_PROJECT",
     "DEEPAGENTS_CLI_GOOGLE_CLOUD_PROJECT",
-    "DEEPAGENTS_LANGSMITH_PROJECT",
-    "DEEPAGENTS_CLI_DEEPAGENTS_LANGSMITH_PROJECT",
-    "DEEPAGENTS_SHELL_ALLOW_LIST",
+    "DEEPAGENTS_CLI_LANGSMITH_PROJECT",
+    "DEEPAGENTS_CLI_SHELL_ALLOW_LIST",
 )
 
 
@@ -144,11 +143,11 @@ class TestReloadFromEnvironment:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Reload should update parsed shell allow-list values."""
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "ls,cat")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "ls,cat")
         settings = Settings.from_environment(start_path=tmp_path)
         assert settings.shell_allow_list == ["ls", "cat"]
 
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "ls,grep")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "ls,grep")
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert settings.shell_allow_list == ["ls", "grep"]
@@ -356,7 +355,7 @@ class TestReloadFromEnvironment:
 
         monkeypatch.setenv("OPENAI_API_KEY", "sk-new")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "ls")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "ls")
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert len(changes) == 3
@@ -418,11 +417,11 @@ class TestReloadErrorPaths:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Malformed shell allow-list should fall back to previous value."""
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "ls,cat")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "ls,cat")
         settings = Settings.from_environment(start_path=tmp_path)
         assert settings.shell_allow_list == ["ls", "cat"]
 
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "all,ls")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "all,ls")
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert settings.shell_allow_list == ["ls", "cat"]
@@ -452,12 +451,12 @@ class TestReloadErrorPaths:
     ) -> None:
         """Settings should remain consistent when one field fails to reload."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-original")
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "ls")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "ls")
         settings = Settings.from_environment(start_path=tmp_path)
 
         # Change API key (succeeds) + break shell allow-list (falls back)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-updated")
-        monkeypatch.setenv("DEEPAGENTS_SHELL_ALLOW_LIST", "all,ls")
+        monkeypatch.setenv("DEEPAGENTS_CLI_SHELL_ALLOW_LIST", "all,ls")
         changes = settings.reload_from_environment(start_path=tmp_path)
 
         assert settings.openai_api_key == "sk-updated"

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -238,6 +238,18 @@ class TestBuildStreamConfig:
 
         assert config["metadata"]["versions"]["deepagents-cli"] == __version__
 
+    def test_user_id_included_when_set(self) -> None:
+        """DEEPAGENTS_CLI_USER_ID should appear in metadata when set."""
+        with patch.dict("os.environ", {"DEEPAGENTS_CLI_USER_ID": "mason"}):
+            config = build_stream_config("t-uid", assistant_id=None)
+        assert config["metadata"]["user_id"] == "mason"
+
+    def test_user_id_absent_when_unset(self) -> None:
+        """user_id should be absent from metadata when env var is not set."""
+        with patch.dict("os.environ", {"DEEPAGENTS_CLI_USER_ID": ""}):
+            config = build_stream_config("t-nouid", assistant_id=None)
+        assert "user_id" not in config["metadata"]
+
 
 class TestGetGitBranch:
     """Tests for `_get_git_branch` caching."""

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -443,7 +443,7 @@ class TestSetAutoUpdate:
         ):
             import os
 
-            os.environ.pop("DEEPAGENTS_AUTO_UPDATE", None)
+            os.environ.pop("DEEPAGENTS_CLI_AUTO_UPDATE", None)
             assert is_auto_update_enabled() is True
 
 
@@ -463,14 +463,14 @@ class TestIsAutoUpdateEnabled:
         ):
             import os
 
-            os.environ.pop("DEEPAGENTS_AUTO_UPDATE", None)
+            os.environ.pop("DEEPAGENTS_CLI_AUTO_UPDATE", None)
             assert is_auto_update_enabled() is False
 
     def test_env_var_enables(self, config_path) -> None:  # noqa: ARG002
-        """DEEPAGENTS_AUTO_UPDATE=1 enables auto-update."""
+        """DEEPAGENTS_CLI_AUTO_UPDATE=1 enables auto-update."""
         with (
             patch("deepagents_cli.config._is_editable_install", return_value=False),
-            patch.dict("os.environ", {"DEEPAGENTS_AUTO_UPDATE": "1"}),
+            patch.dict("os.environ", {"DEEPAGENTS_CLI_AUTO_UPDATE": "1"}),
         ):
             assert is_auto_update_enabled() is True
 

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -52,14 +52,29 @@ def _make_banner(
     Returns:
         A `WelcomeBanner` instance ready for testing.
     """
+    import deepagents_cli.config as _cfg
+
     env = {}
     if project_name:
         env["LANGSMITH_API_KEY"] = "fake-key"
         env["LANGSMITH_TRACING"] = "true"
         env["LANGSMITH_PROJECT"] = project_name
+        env["DEEPAGENTS_CLI_LANGSMITH_PROJECT"] = project_name
 
-    with patch.dict("os.environ", env, clear=True):
-        return WelcomeBanner(thread_id=thread_id)
+    # Temporarily clear the cached settings singleton so _get_settings()
+    # re-creates it from the patched env vars inside the context manager.
+    saved = _cfg.__dict__.pop("settings", None)
+    saved_bootstrap = _cfg._bootstrap_done
+    _cfg._bootstrap_done = False
+    try:
+        with patch.dict("os.environ", env, clear=True):
+            return WelcomeBanner(thread_id=thread_id)
+    finally:
+        _cfg._bootstrap_done = saved_bootstrap
+        if saved is not None:
+            _cfg.__dict__["settings"] = saved
+        else:
+            _cfg.__dict__.pop("settings", None)
 
 
 class TestBuildBannerThreadLink:


### PR DESCRIPTION
Add a `DEEPAGENTS_CLI_` env var prefix so users can scope credentials and config to the CLI without colliding with identically-named shell exports.

Simplify dotenv loading: both project and global `.env` files now use `override=False`, making shell-exported variables always take precedence — `/reload` no longer overwrites them.

## Example

You're in the TUI and realize your `.env` has a stale `OPENAI_API_KEY`. Write the new key to your project `.env` using the prefixed form:

```
DEEPAGENTS_CLI_OPENAI_API_KEY=sk-fresh
```

Then type `/reload` in the TUI. The CLI re-reads `.env` files, and since `DEEPAGENTS_CLI_OPENAI_API_KEY` wins over the stale in-process `OPENAI_API_KEY`, the new key is picked up without restarting.

## Changes
- Add `resolve_env_var()` in `model_config.py` — checks `DEEPAGENTS_CLI_{name}` first, falls back to `{name}`, normalizes empty strings to `None`. An empty prefixed var explicitly blocks the canonical one, and names already carrying the prefix skip the double-prefixed lookup
- Create a single-source registry for all `DEEPAGENTS_CLI_*` constants (`AUTO_UPDATE`, `DEBUG`, `DEBUG_FILE`, `EXTRA_SKILLS_DIRS`, `LANGSMITH_PROJECT`, `NO_UPDATE_CHECK`, `SHELL_ALLOW_LIST`, `USER_ID`) with a drift-detection test that catches bare string literals in source
- Route all API key lookups in `Settings.from_environment`, `Settings.reload_from_environment`, `_get_provider_kwargs`, and `get_langsmith_project_name` through `resolve_env_var` instead of raw `os.environ.get`
- Wire `resolve_env_var` into sandbox providers (`_LangSmithProvider`, `_DaytonaProvider`, `_ModalProvider`, `_RunloopProvider`) for credential resolution; `_ModalProvider` additionally plumbs an explicit `client` from `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET`
- Remove the `override` parameter from `_load_dotenv` — both layers now use `override=False`, giving shell env unconditional priority over dotenv files
- Propagate prefixed LangSmith vars (`LANGSMITH_API_KEY`, `LANGSMITH_TRACING`, etc.) to their canonical names at bootstrap so the LangSmith SDK picks them up, with a warning when both forms are set to different values
- Attach `DEEPAGENTS_CLI_USER_ID` to LangSmith trace metadata in `build_stream_config` when set