### PR TITLE
fix(cli): escape exception text in rich markup error output

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -712,9 +712,11 @@ async def run_textual_cli_async(
     try:
         resolved_spec = model_name or _get_default_model_spec()
     except ModelConfigError as e:
+        from rich.markup import escape
+
         from deepagents_cli.config import console
 
-        console.print(f"[bold red]Error:[/bold red] {e}", highlight=False)
+        console.print(f"[bold red]Error:[/bold red] {escape(str(e))}", highlight=False)
         return AppResult(return_code=1, thread_id=None)
 
     parsed = ModelSpec.try_parse(resolved_spec)
@@ -981,8 +983,12 @@ def apply_stdin_pipe(args: argparse.Namespace) -> None:
         console.print(f"[bold red]Error:[/bold red] {msg}")
         sys.exit(1)
     except (OSError, ValueError) as exc:
-        msg = f"Failed to read piped input: {exc}"
-        console.print(f"[bold red]Error:[/bold red] {msg}")
+        from rich.markup import escape
+
+        console.print(
+            f"[bold red]Error:[/bold red] Failed to read piped input: "
+            f"{escape(str(exc))}"
+        )
         sys.exit(1)
 
     if len(stdin_text) > max_stdin_bytes:
@@ -1475,7 +1481,9 @@ def cli_main() -> None:
                 try:
                     verify_sandbox_deps(args.sandbox)
                 except ImportError as exc:
-                    console.print(f"[bold red]Error:[/bold red] {exc}")
+                    from rich.markup import escape
+
+                    console.print(f"[bold red]Error:[/bold red] {escape(str(exc))}")
                     sys.exit(1)
 
             # Non-interactive mode - execute single task and exit
@@ -1527,7 +1535,9 @@ def cli_main() -> None:
                 try:
                     verify_sandbox_deps(args.sandbox)
                 except ImportError as exc:
-                    console.print(f"[bold red]Error:[/bold red] {exc}")
+                    from rich.markup import escape
+
+                    console.print(f"[bold red]Error:[/bold red] {escape(str(exc))}")
                     sys.exit(1)
 
             # Check project MCP trust before launching TUI


### PR DESCRIPTION
Rich's `console.print()` parses markup by default, so exception messages containing square brackets (like pip extras `[daytona]` or type annotations `list[str]`) get silently interpreted as markup tags and stripped from the output. Users see broken install commands and garbled error messages.

## Changes
- Wrap exception text with `rich.markup.escape()` in four `console.print` error paths in `main.py`: `verify_sandbox_deps` `ImportError` (both interactive and non-interactive), `ModelConfigError` from model init, and `OSError`/`ValueError` from stdin reads

## Before / After

**Before** — `[daytona]` eaten by Rich markup parser:
```
Error: Missing dependencies for 'daytona' sandbox. Install with: pip install 'deepagents-cli'
```

**After** — brackets escaped, full install command visible:
```
Error: Missing dependencies for 'daytona' sandbox. Install with: pip install 'deepagents-cli[daytona]'
```