### PR TITLE
fix(sdk): decode local shell command output bytes

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -7,6 +7,7 @@ on the host machine with full system access.
 
 from __future__ import annotations
 
+import locale
 import os
 import subprocess
 import uuid
@@ -22,6 +23,30 @@ if TYPE_CHECKING:
 
 DEFAULT_EXECUTE_TIMEOUT = 120
 """Default timeout in seconds for shell command execution."""
+
+
+def _decode_command_output(data: str | bytes | None) -> str:
+    """Decode subprocess output without relying on locale-implicit text mode."""
+    if data is None:
+        return ""
+
+    if isinstance(data, str):
+        return data
+
+    preferred_encoding = locale.getpreferredencoding(do_setlocale=False) or "utf-8"
+    candidate_encodings = ["utf-8", preferred_encoding]
+    tried_encodings: set[str] = set()
+
+    for encoding in candidate_encodings:
+        if not encoding or encoding in tried_encodings:
+            continue
+        tried_encodings.add(encoding)
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+
+    return data.decode(preferred_encoding, errors="replace")
 
 
 class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
@@ -301,20 +326,22 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 check=False,
                 shell=True,  # Intentional: designed for LLM-controlled shell execution
                 capture_output=True,
-                text=True,
                 timeout=effective_timeout,
                 env=self._env,
                 cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
             )
 
+            stdout = _decode_command_output(result.stdout)
+            stderr = _decode_command_output(result.stderr)
+
             # Combine stdout and stderr
             # Prefix each stderr line with [stderr] for clear attribution.
             # Example: "hello\n[stderr] error: file not found"  # noqa: ERA001
             output_parts = []
-            if result.stdout:
-                output_parts.append(result.stdout)
-            if result.stderr:
-                stderr_lines = result.stderr.strip().split("\n")
+            if stdout:
+                output_parts.append(stdout)
+            if stderr:
+                stderr_lines = stderr.strip().splitlines()
                 output_parts.extend(f"[stderr] {line}" for line in stderr_lines)
 
             output = "\n".join(output_parts) if output_parts else "<no output>"

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -1,7 +1,9 @@
 """Unit tests for LocalShellBackend."""
 
+import subprocess
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -268,6 +270,53 @@ def test_local_shell_backend_stderr_formatting() -> None:
         assert result.exit_code == 0
         assert "[stderr]" in result.output
         assert "error message" in result.output
+
+
+def test_local_shell_backend_decodes_utf8_stdout_bytes() -> None:
+    """Test that byte stdout is decoded without relying on subprocess text mode."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir, inherit_env=True)
+        completed = subprocess.CompletedProcess(
+            args="echo bytes",
+            returncode=0,
+            stdout="中".encode(),
+            stderr=b"",
+        )
+
+        with patch(
+            "deepagents.backends.local_shell.subprocess.run",
+            return_value=completed,
+        ) as mock_run:
+            result = backend.execute("echo bytes")
+
+        assert result.exit_code == 0
+        assert result.output == "中"
+        assert "text" not in mock_run.call_args.kwargs
+
+
+def test_local_shell_backend_decodes_preferred_encoding_stderr_bytes() -> None:
+    """Test that byte stderr falls back to the preferred locale encoding."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir, inherit_env=True)
+        completed = subprocess.CompletedProcess(
+            args="bad-command",
+            returncode=1,
+            stdout=b"",
+            stderr="中".encode("gbk"),
+        )
+
+        with (
+            patch("locale.getpreferredencoding", return_value="cp936"),
+            patch(
+                "deepagents.backends.local_shell.subprocess.run",
+                return_value=completed,
+            ),
+        ):
+            result = backend.execute("bad-command")
+
+        assert result.exit_code == 1
+        assert "[stderr] 中" in result.output
+        assert "Exit code: 1" in result.output
 
 
 async def test_local_shell_backend_async_execute() -> None:


### PR DESCRIPTION
Fixes #2311

Stops relying on `subprocess.run(..., text=True)` in `LocalShellBackend.execute()` and decodes captured bytes inside the backend instead. This avoids locale-dependent decode failures on Windows while still falling back to the host's preferred encoding for non-UTF-8 command output.

## Why
- Root cause: implicit text-mode decoding can fail in Python's subprocess reader thread when command output encoding differs from the Windows locale.
- This patch keeps the public API unchanged and makes decoding explicit in the backend.

## Verification
- `uv run ruff check deepagents/backends/local_shell.py tests/unit_tests/backends/test_local_shell_backend.py`
- `python -m py_compile deepagents/backends/local_shell.py tests/unit_tests/backends/test_local_shell_backend.py`
- `uv run --group test pytest tests/unit_tests/backends/test_local_shell_backend.py -q -k "execute_simple_command or execute_with_error or stderr_formatting or decodes_utf8_stdout_bytes or decodes_preferred_encoding_stderr_bytes"`

## Review focus
- Whether `utf-8` first, then preferred-locale fallback, is the right decoding order for `LocalShellBackend`.
- Whether maintainers want to keep this as an internal implementation fix rather than introducing a new public encoding parameter.

## AI assistance disclaimer
- This contribution was prepared with the help of an AI coding agent.
- I reviewed the resulting changes and ran the targeted checks above before opening this PR.