### PR TITLE
fix(sdk,cli): propagate runtime model override to subagents

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -1165,5 +1165,6 @@ def create_cli_agent(
         interrupt_on=interrupt_on,
         checkpointer=checkpointer,
         subagents=all_subagents or None,
+        extra_subagent_middleware=[ConfigurableModelMiddleware()],
     ).with_config(config)
     return agent, composite_backend

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -98,6 +98,7 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
+    extra_subagent_middleware: Sequence[AgentMiddleware] | None = None,
 ) -> CompiledStateGraph:
     """Create a deep agent.
 
@@ -197,6 +198,16 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
         debug: Whether to enable debug mode. Passed through to `create_agent`.
         name: The name of the agent. Passed through to `create_agent`.
         cache: The cache to use for the agent. Passed through to `create_agent`.
+        extra_subagent_middleware: Additional middleware injected into every subagent's
+            middleware stack (both the built-in `general-purpose` subagent and any
+            `SubAgent` entries in `subagents`).
+
+            Middleware is inserted just before `AnthropicPromptCachingMiddleware` so
+            that it runs after the base stack but before provider-specific settings
+            are applied.
+
+            Use this to propagate cross-cutting concerns — such as runtime model
+            overrides — to all subagents without modifying each spec individually.
 
     Returns:
         A configured deep agent.
@@ -213,6 +224,8 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
     ]
     if skills is not None:
         gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+    if extra_subagent_middleware:
+        gp_middleware.extend(extra_subagent_middleware)
     gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     if interrupt_on is not None:
         gp_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
@@ -251,6 +264,8 @@ def create_deep_agent(  # noqa: C901, PLR0912  # Complex graph assembly logic wi
             if subagent_skills:
                 subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
             subagent_middleware.extend(spec.get("middleware", []))
+            if extra_subagent_middleware:
+                subagent_middleware.extend(extra_subagent_middleware)
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
             processed_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -452,7 +452,7 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = subagent.invoke(subagent_state)
+        result = subagent.invoke(subagent_state, runtime.config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     async def atask(
@@ -467,7 +467,7 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = await subagent.ainvoke(subagent_state)
+        result = await subagent.ainvoke(subagent_state, runtime.config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     return StructuredTool.from_function(


### PR DESCRIPTION
## Summary

Fixes #2316

When the user switches model via `/model` or starts with `-M provider:model`, subagents invoked through the `task` tool ignored the override and always ran with the **default model**. Two gaps caused this:

- **`subagents.py`**: `_build_task_tool` called `subagent.invoke/ainvoke` without forwarding `runtime.config`, so the subagent graph never received the `CLIContext` that carries the model override.
- **`graph.py` / `agent.py`**: `ConfigurableModelMiddleware` was only in the main agent's middleware stack. Even with the config forwarded, subagents had no middleware to read and apply the override.

**Changes:**
- Forward `runtime.config` on both sync and async subagent invocations in `_build_task_tool` (`subagents.py`).
- Add `extra_subagent_middleware` parameter to `create_deep_agent` (`graph.py`), injected into every subagent's middleware stack (both the built-in `general-purpose` subagent and any `SubAgent` spec) just before `AnthropicPromptCachingMiddleware`.
- Pass `[ConfigurableModelMiddleware()]` via `extra_subagent_middleware` in `create_cli_agent` (`agent.py`) so all subagents honour the runtime model override.

## Test plan

- [ ] Start the CLI with a non-default model (`docagent -M anthropic:claude-opus-4-6`) and ask the agent to delegate a task via the `task` tool — verify the subagent uses `claude-opus-4-6`.
- [ ] Switch model mid-session via `/model`, then trigger a subagent — verify the subagent picks up the new model.
- [ ] Subagents with an explicit `model:` in their `AGENTS.md` should continue to use their configured model (unaffected by the override, since `ConfigurableModelMiddleware` only swaps when the current model doesn't already match the spec).
- [ ] Existing unit tests for `SubAgentMiddleware` and `create_deep_agent` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)