### PR TITLE
fix(sdk): catch `UnicodeDecodeError` in `FilesystemBackend.read`

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -343,7 +343,7 @@ class FilesystemBackend(BackendProtocol):
 
             selected_lines = lines[start_idx:end_idx]
             return ReadResult(file_data=FileData(content="\n".join(selected_lines), encoding="utf-8"))
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             return ReadResult(error=f"Error reading file '{file_path}': {e}")
 
     def write(

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -206,6 +206,21 @@ def test_filesystem_backend_ls_trailing_slash(tmp_path: Path):
     assert empty.entries == []
 
 
+def test_filesystem_backend_read_non_utf8_file(tmp_path: Path):
+    """FilesystemBackend.read should return an error result, not raise, for non-UTF-8 text files."""
+    root = tmp_path
+    # Write a file with GBK-encoded bytes that are invalid UTF-8 (e.g. 0x87)
+    gbk_file = root / "chinese.txt"
+    gbk_file.write_bytes("中文内容".encode("gbk"))
+
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=False)
+    result = be.read(str(gbk_file))
+
+    assert isinstance(result, ReadResult)
+    assert result.error is not None
+    assert "chinese.txt" in result.error
+
+
 def test_filesystem_backend_intercept_large_tool_result(tmp_path: Path):
     """Test that FilesystemBackend properly handles large tool result interception."""
     root = tmp_path


### PR DESCRIPTION
Fixes #2318

`FilesystemBackend.read()` raises an unhandled `UnicodeDecodeError` when reading a file whose extension passes the `_get_file_type()` "text" check but whose bytes are not valid UTF-8 (e.g. GBK/GB2312-encoded Chinese files, Windows-1252 files). The exception propagates all the way up and surfaces as an agent-level crash.

The fix adds `UnicodeDecodeError` to the existing `except OSError` clause so the method returns a structured `ReadResult(error=...)` instead of raising — consistent with how all other error paths in this method already behave, and consistent with how `grep()` already handles the same error at line 580.

**Changes**
- `libs/deepagents/deepagents/backends/filesystem.py`: extend `except OSError` → `except (OSError, UnicodeDecodeError)` in `read()`
- `libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py`: add `test_filesystem_backend_read_non_utf8_file` that writes a GBK-encoded file and asserts the result is a `ReadResult` with a non-`None` error (not a raised exception)

> 🤖 This PR was created with assistance from Claude Code (claude-sonnet-4-6).