### PR TITLE
feat(cli): persist token count in graph state across sessions

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -1005,6 +1005,13 @@ def create_cli_agent(
     agent_middleware = []
     agent_middleware.append(ConfigurableModelMiddleware())
 
+    # Token state: adds _context_tokens to graph state (checkpointed, not
+    # passed to model).  Must be registered before any middleware that might
+    # read the channel.
+    from deepagents_cli.token_state import TokenStateMiddleware
+
+    agent_middleware.append(TokenStateMiddleware())
+
     # Add ask_user middleware (must be early so its tool is available)
     if enable_ask_user:
         from deepagents_cli.ask_user import AskUserMiddleware

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -897,7 +897,7 @@ class DeepAgentsApp(App):
             sync_message_content=self._sync_message_content,
             request_ask_user=self._request_ask_user,
         )
-        # Wire token display callbacks (lightweight, no imports)
+        # Wire token display callbacks
         self._ui_adapter._on_tokens_update = self._on_tokens_update
         self._ui_adapter._on_tokens_hide = self._hide_tokens
         self._ui_adapter._on_tokens_show = self._show_tokens
@@ -1642,7 +1642,7 @@ class DeepAgentsApp(App):
         This is the callback wired to the adapter's `_on_tokens_update`.
 
         Args:
-            count: Total context token count from `usage_metadata`.
+            count: Total context token count to cache and display.
         """
         self._context_tokens = count
         self._update_tokens(count)
@@ -3164,17 +3164,9 @@ class DeepAgentsApp(App):
             )
 
             self._on_tokens_update(result.tokens_after)
-            try:
-                await self._agent.aupdate_state(
-                    config, {"_context_tokens": result.tokens_after}
-                )
-            except Exception:  # non-critical persistence
-                logger.warning(
-                    "Failed to persist _context_tokens=%d after offload; "
-                    "token count may be stale on resume",
-                    result.tokens_after,
-                    exc_info=True,
-                )
+            from deepagents_cli.textual_adapter import _persist_context_tokens
+
+            await _persist_context_tokens(self._agent, config, result.tokens_after)
 
         except OffloadModelError as exc:
             logger.warning("Offload model creation failed: %s", exc, exc_info=True)
@@ -3549,7 +3541,10 @@ class DeepAgentsApp(App):
             context-token count.
         """
         state_values = await self._get_thread_state_values(thread_id)
-        context_tokens = state_values.get("_context_tokens", 0) or 0
+        raw_tokens = state_values.get("_context_tokens")
+        context_tokens = (
+            raw_tokens if isinstance(raw_tokens, int) and raw_tokens >= 0 else 0
+        )
         messages = state_values.get("messages", [])
 
         if not messages:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -363,42 +363,15 @@ class DeferredAction:
     """Async callable that performs the actual work."""
 
 
-class TextualTokenTracker:
-    """Token tracker that updates the status bar."""
+@dataclass(frozen=True, slots=True)
+class _ThreadHistoryPayload:
+    """Data returned by `_fetch_thread_history_data`."""
 
-    def __init__(
-        self,
-        update_callback: Callable[[int], None],
-        hide_callback: Callable[[], None] | None = None,
-    ) -> None:
-        """Initialize with callbacks to update the display."""
-        self._update_callback = update_callback
-        self._hide_callback = hide_callback
-        self.current_context = 0
+    messages: list[MessageData]
+    """Converted message data ready for bulk loading."""
 
-    def add(self, total_tokens: int, _output_tokens: int = 0) -> None:
-        """Update token count from a response.
-
-        Args:
-            total_tokens: Total context tokens (input + output from usage_metadata)
-            _output_tokens: Unused, kept for backwards compatibility
-        """
-        self.current_context = total_tokens
-        self._update_callback(self.current_context)
-
-    def reset(self) -> None:
-        """Reset token count."""
-        self.current_context = 0
-        self._update_callback(0)
-
-    def hide(self) -> None:
-        """Hide the token display (e.g., during streaming)."""
-        if self._hide_callback:
-            self._hide_callback()
-
-    def show(self) -> None:
-        """Show the token display with current value (e.g., after interrupt)."""
-        self._update_callback(self.current_context)
+    context_tokens: int
+    """Persisted `_context_tokens` from the checkpoint (0 if absent)."""
 
 
 def _new_thread_id() -> str:
@@ -676,7 +649,12 @@ class DeepAgentsApp(App):
 
         self._loading_widget: LoadingWidget | None = None
 
-        self._token_tracker: TextualTokenTracker | None = None
+        self._context_tokens: int = 0
+        """Local cache of the last total-context token count.
+
+        Source of truth is `_context_tokens` in graph state; this is a sync
+        copy for the status bar.
+        """
 
         self._last_typed_at: float | None = None
         """Typing-aware approval deferral state."""
@@ -904,11 +882,6 @@ class DeepAgentsApp(App):
         Everything here is non-blocking: workers and thread-offloaded calls
         so the UI stays responsive.
         """
-        # Create token tracker (lightweight, no imports)
-        self._token_tracker = TextualTokenTracker(
-            self._update_tokens, self._hide_tokens
-        )
-
         # Create UI adapter unconditionally — it only holds UI callbacks and
         # doesn't depend on the agent. The agent is injected later at
         # execute_task_textual() call time.
@@ -924,7 +897,10 @@ class DeepAgentsApp(App):
             sync_message_content=self._sync_message_content,
             request_ask_user=self._request_ask_user,
         )
-        self._ui_adapter.set_token_tracker(self._token_tracker)
+        # Wire token display callbacks (lightweight, no imports)
+        self._ui_adapter._on_tokens_update = self._on_tokens_update
+        self._ui_adapter._on_tokens_hide = self._hide_tokens
+        self._ui_adapter._on_tokens_show = self._show_tokens
 
         # Fire-and-forget workers — none of these block the event loop.
 
@@ -1649,9 +1625,31 @@ class DeepAgentsApp(App):
             self._status_bar.set_status_message(message)
 
     def _update_tokens(self, count: int) -> None:
-        """Update the token count in status bar."""
+        """Update the token count in the status bar.
+
+        Low-level helper — only touches the UI.  Callers that also need to
+        update the local cache should use `_on_tokens_update` instead.
+
+        Args:
+            count: Total context token count.
+        """
         if self._status_bar:
             self._status_bar.set_tokens(count)
+
+    def _on_tokens_update(self, count: int) -> None:
+        """Update the local cache *and* the status bar.
+
+        This is the callback wired to the adapter's `_on_tokens_update`.
+
+        Args:
+            count: Total context token count from `usage_metadata`.
+        """
+        self._context_tokens = count
+        self._update_tokens(count)
+
+    def _show_tokens(self) -> None:
+        """Restore the status bar to the cached token value."""
+        self._update_tokens(self._context_tokens)
 
     def _hide_tokens(self) -> None:
         """Hide the token display during streaming."""
@@ -2643,8 +2641,8 @@ class DeepAgentsApp(App):
             self._pending_messages.clear()
             self._queued_widgets.clear()
             await self._clear_messages()
-            if self._token_tracker:
-                self._token_tracker.reset()
+            self._context_tokens = 0
+            self._update_tokens(0)
             # Clear status message (e.g., "Interrupted" from previous session)
             self._update_status("")
             # Reset thread to start fresh conversation
@@ -2673,8 +2671,8 @@ class DeepAgentsApp(App):
             await self._handle_auto_update_toggle()
         elif cmd == "/tokens":
             await self._mount_message(UserMessage(command))
-            if self._token_tracker and self._token_tracker.current_context > 0:
-                count = self._token_tracker.current_context
+            if self._context_tokens > 0:
+                count = self._context_tokens
                 formatted = format_token_count(count)
 
                 model_name = settings.model_name
@@ -3106,9 +3104,7 @@ class DeepAgentsApp(App):
                 model_spec=(f"{settings.model_provider}:{settings.model_name}"),
                 profile_overrides=self._profile_override,
                 context_limit=settings.model_context_limit,
-                total_context_tokens=(
-                    self._token_tracker.current_context if self._token_tracker else 0
-                ),
+                total_context_tokens=self._context_tokens,
                 backend=self._backend,
             )
 
@@ -3167,8 +3163,18 @@ class DeepAgentsApp(App):
                 )
             )
 
-            if self._token_tracker:
-                self._token_tracker.add(result.tokens_after)
+            self._on_tokens_update(result.tokens_after)
+            try:
+                await self._agent.aupdate_state(
+                    config, {"_context_tokens": result.tokens_after}
+                )
+            except Exception:  # non-critical persistence
+                logger.warning(
+                    "Failed to persist _context_tokens=%d after offload; "
+                    "token count may be stale on resume",
+                    result.tokens_after,
+                    exc_info=True,
+                )
 
         except OffloadModelError as exc:
             logger.warning("Offload model creation failed: %s", exc, exc_info=True)
@@ -3344,8 +3350,7 @@ class DeepAgentsApp(App):
             self._chat_input.set_cursor_active(active=True)
 
         # Ensure token display is restored (in case of early cancellation)
-        if self._token_tracker:
-            self._token_tracker.show()
+        self._show_tokens()
 
         try:
             await self._maybe_drain_deferred()
@@ -3521,9 +3526,14 @@ class DeepAgentsApp(App):
             and "_summarization_event" in fallback_values
         ):
             values["_summarization_event"] = fallback_values["_summarization_event"]
+        if (
+            values.get("_context_tokens") is None
+            and "_context_tokens" in fallback_values
+        ):
+            values["_context_tokens"] = fallback_values["_context_tokens"]
         return values
 
-    async def _fetch_thread_history_data(self, thread_id: str) -> list[MessageData]:
+    async def _fetch_thread_history_data(self, thread_id: str) -> _ThreadHistoryPayload:
         """Fetch and convert stored messages for a thread.
 
         In server mode the LangGraph dev server starts with an empty thread
@@ -3535,13 +3545,15 @@ class DeepAgentsApp(App):
             thread_id: Thread ID to fetch from checkpoint storage.
 
         Returns:
-            Converted message data ready for bulk loading.
+            Payload containing converted message data and the persisted
+            context-token count.
         """
         state_values = await self._get_thread_state_values(thread_id)
+        context_tokens = state_values.get("_context_tokens", 0) or 0
         messages = state_values.get("messages", [])
 
         if not messages:
-            return []
+            return _ThreadHistoryPayload([], context_tokens)
 
         # Server mode / direct checkpointer may return dicts; convert to
         # LangChain message objects so _convert_messages_to_data works.
@@ -3551,7 +3563,8 @@ class DeepAgentsApp(App):
             messages = convert_to_messages(messages)
 
         # Offload conversion so large histories don't block the UI loop.
-        return await asyncio.to_thread(self._convert_messages_to_data, messages)
+        data = await asyncio.to_thread(self._convert_messages_to_data, messages)
+        return _ThreadHistoryPayload(data, context_tokens)
 
     @staticmethod
     async def _read_channel_values_from_checkpointer(thread_id: str) -> dict[str, Any]:
@@ -3656,12 +3669,12 @@ class DeepAgentsApp(App):
         self,
         *,
         thread_id: str | None = None,
-        preloaded_data: list[MessageData] | None = None,
+        preloaded_payload: _ThreadHistoryPayload | None = None,
     ) -> None:
         """Load and render message history when resuming a thread.
 
-        When `preloaded_data` is provided (e.g., from `_resume_thread`), this
-        reuses that payload. Otherwise, it fetches checkpoint state from the
+        When `preloaded_payload` is provided (e.g., from `_resume_thread`),
+        this reuses that data. Otherwise, it fetches checkpoint state from the
         agent and converts stored messages into lightweight `MessageData`
         objects. The method then bulk-loads into the `MessageStore` and mounts
         only the last `WINDOW_SIZE` widgets to reduce DOM operations on large
@@ -3671,13 +3684,14 @@ class DeepAgentsApp(App):
             thread_id: Optional explicit thread ID to load.
 
                 Defaults to current.
-            preloaded_data: Optional pre-fetched history data for the thread.
+            preloaded_payload: Optional pre-fetched history payload for the
+                thread.
         """
         history_thread_id = thread_id or self._lc_thread_id
         if not history_thread_id:
             logger.debug("Skipping history load: no thread ID available")
             return
-        if preloaded_data is None and not self._agent:
+        if preloaded_payload is None and not self._agent:
             logger.debug(
                 "Skipping history load for %s: no active agent and no preloaded data",
                 history_thread_id,
@@ -3686,16 +3700,20 @@ class DeepAgentsApp(App):
 
         try:
             # Fetch + convert, or reuse preloaded payload on thread switch.
-            all_data = (
-                preloaded_data
-                if preloaded_data is not None
+            payload = (
+                preloaded_payload
+                if preloaded_payload is not None
                 else await self._fetch_thread_history_data(history_thread_id)
             )
-            if not all_data:
+            if not payload.messages:
                 return
 
+            # Seed token cache from persisted state
+            if payload.context_tokens > 0:
+                self._on_tokens_update(payload.context_tokens)
+
             # 3. Bulk load into store (sets visible window)
-            _archived, visible = self._message_store.bulk_load(all_data)
+            _archived, visible = self._message_store.bulk_load(payload.messages)
 
             # 5. Cache container ref (single query)
             try:
@@ -4599,17 +4617,17 @@ class DeepAgentsApp(App):
         if self._chat_input:
             self._chat_input.set_cursor_active(active=False)
 
-        prefetched_history: list[MessageData] | None = None
+        prefetched_payload: _ThreadHistoryPayload | None = None
         try:
             self._update_status(f"Loading thread: {thread_id}")
-            prefetched_history = await self._fetch_thread_history_data(thread_id)
+            prefetched_payload = await self._fetch_thread_history_data(thread_id)
 
             # Clear conversation (similar to /clear, without creating a new thread)
             self._pending_messages.clear()
             self._queued_widgets.clear()
             await self._clear_messages()
-            if self._token_tracker:
-                self._token_tracker.reset()
+            self._context_tokens = 0
+            self._update_tokens(0)
             self._update_status("")
 
             # Switch to the selected thread
@@ -4625,10 +4643,10 @@ class DeepAgentsApp(App):
             # Load thread history
             await self._load_thread_history(
                 thread_id=thread_id,
-                preloaded_data=prefetched_history,
+                preloaded_payload=prefetched_payload,
             )
         except Exception as exc:
-            if prefetched_history is None:
+            if prefetched_payload is None:
                 logger.exception("Failed to prefetch history for thread %s", thread_id)
                 await self._mount_message(
                     AppMessage(

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -197,55 +198,6 @@ class TextualUIAdapter:
     Textual UI, allowing streaming output to be rendered as widgets.
     """
 
-    _mount_message: Callable[..., Awaitable[None]]
-    """Async callback to mount a message widget to the chat."""
-
-    _update_status: Callable[[str], None]
-    """Callback to update the status bar text."""
-
-    _request_approval: Callable[..., Awaitable[Any]]
-    """Async callback that returns a Future for HITL approval."""
-
-    _on_auto_approve_enabled: Callable[[], None] | None
-    """Callback invoked when auto-approve is enabled via the HITL approval menu.
-
-    Fired when the user selects "Auto-approve all" from an approval dialog,
-    allowing the app to sync its status bar and session state.
-    """
-
-    _request_ask_user: (
-        Callable[
-            [list[Question]],
-            Awaitable[asyncio.Future[AskUserWidgetResult] | None],
-        ]
-        | None
-    )
-    """Async callback for `ask_user` interrupts.
-
-    When awaited, returns a `Future` that resolves to user answers.
-    """
-
-    _set_spinner: Callable[[SpinnerStatus], Awaitable[None]] | None
-    """Callback to show/hide loading spinner."""
-
-    _set_active_message: Callable[[str | None], None] | None
-    """Callback to set the active streaming message ID (pass `None` to clear)."""
-
-    _sync_message_content: Callable[[str, str], None] | None
-    """Callback to sync final message content back to the store after streaming."""
-
-    _current_tool_messages: dict[str, ToolCallMessage]
-    """Map of tool call IDs to their message widgets."""
-
-    _on_tokens_update: Callable[[int], None] | None
-    """Called with total context tokens after each LLM response."""
-
-    _on_tokens_hide: Callable[[], None] | None
-    """Called to hide the token display during streaming."""
-
-    _on_tokens_show: Callable[[], None] | None
-    """Called to restore the token display with the cached value."""
-
     def __init__(
         self,
         mount_message: Callable[..., Awaitable[None]],
@@ -263,40 +215,50 @@ class TextualUIAdapter:
             | None
         ) = None,
     ) -> None:
-        """Initialize the adapter.
-
-        Args:
-            mount_message: Async callable to mount a message widget.
-            update_status: Callable to update the status bar message.
-            request_approval: Async callable that returns a Future for HITL approval.
-            on_auto_approve_enabled: Callback fired when the user selects
-                "Auto-approve all" from an approval dialog.
-
-                Used by the app to sync the status bar indicator and session state.
-            set_spinner: Callback to show/hide loading spinner (pass `None` to hide).
-            set_active_message: Callback to set the active streaming message ID.
-            sync_message_content: Callback to sync final content back to the
-                message store after streaming completes.
-            request_ask_user: Async callable that displays an `ask_user` widget
-                and returns a `Future` resolving to user answers.
-        """
+        """Initialize the adapter."""
         self._mount_message = mount_message
+        """Async callback to mount a message widget to the chat."""
+
         self._update_status = update_status
+        """Callback to update the status bar text."""
+
         self._request_approval = request_approval
+        """Async callback that returns a Future for HITL approval."""
+
         self._on_auto_approve_enabled = on_auto_approve_enabled
+        """Callback invoked when auto-approve is enabled via the HITL approval
+        menu.
+
+        Fired when the user selects "Auto-approve all" from an approval dialog,
+        allowing the app to sync its status bar and session state.
+        """
+
         self._set_spinner = set_spinner
+        """Callback to show/hide loading spinner."""
+
         self._set_active_message = set_active_message
+        """Callback to set the active streaming message ID (pass `None` to clear)."""
+
         self._sync_message_content = sync_message_content
+        """Callback to sync final message content back to the store after streaming."""
+
         self._request_ask_user = request_ask_user
+        """Async callback for `ask_user` interrupts.
+
+        When awaited, returns a `Future` that resolves to user answers.
+        """
 
         # State tracking
         self._current_tool_messages: dict[str, ToolCallMessage] = {}
+        """Map of tool call IDs to their message widgets."""
 
         # Token display callbacks (set by the app after construction)
         self._on_tokens_update: Callable[[int], None] | None = None
-        """Called with the total context token count after each LLM response."""
+        """Called with total context tokens after each LLM response."""
+
         self._on_tokens_hide: Callable[[], None] | None = None
         """Called to hide the token display during streaming."""
+
         self._on_tokens_show: Callable[[], None] | None = None
         """Called to restore the token display with the cached value."""
 
@@ -487,6 +449,22 @@ async def execute_task_textual(
     if turn_stats is None:
         turn_stats = SessionStats()
     start_time = time.monotonic()
+
+    # Warn if token display callbacks are only partially wired — all three
+    # should be set together to avoid inconsistent status-bar behavior.
+    token_cbs = (
+        adapter._on_tokens_update,
+        adapter._on_tokens_hide,
+        adapter._on_tokens_show,
+    )
+    if any(token_cbs) and not all(token_cbs):
+        logger.warning(
+            "Token callbacks partially wired (update=%s, hide=%s, show=%s); "
+            "token display may behave inconsistently",
+            adapter._on_tokens_update is not None,
+            adapter._on_tokens_hide is not None,
+            adapter._on_tokens_show is not None,
+        )
 
     # Show spinner
     if adapter._set_spinner:
@@ -1207,12 +1185,14 @@ async def execute_task_textual(
 
         # Report tokens even on interrupt (or restore display if none captured)
         turn_stats.wall_time_seconds = time.monotonic() - start_time
-        if captured_input_tokens or captured_output_tokens:
-            if adapter._on_tokens_update:
-                adapter._on_tokens_update(captured_input_tokens)
-            await _persist_context_tokens(agent, config, captured_input_tokens)
-        elif adapter._on_tokens_show:
-            adapter._on_tokens_show()
+        await _report_and_persist_tokens(
+            adapter,
+            agent,
+            config,
+            captured_input_tokens,
+            captured_output_tokens,
+            shield=True,
+        )
         return turn_stats
 
     except KeyboardInterrupt:
@@ -1254,22 +1234,25 @@ async def execute_task_textual(
 
         # Report tokens even on interrupt (or restore display if none captured)
         turn_stats.wall_time_seconds = time.monotonic() - start_time
-        if captured_input_tokens or captured_output_tokens:
-            if adapter._on_tokens_update:
-                adapter._on_tokens_update(captured_input_tokens)
-            await _persist_context_tokens(agent, config, captured_input_tokens)
-        elif adapter._on_tokens_show:
-            adapter._on_tokens_show()
+        await _report_and_persist_tokens(
+            adapter,
+            agent,
+            config,
+            captured_input_tokens,
+            captured_output_tokens,
+            shield=True,
+        )
         return turn_stats
 
     # Update token count and return stats
     turn_stats.wall_time_seconds = time.monotonic() - start_time
-    if captured_input_tokens or captured_output_tokens:
-        if adapter._on_tokens_update:
-            adapter._on_tokens_update(captured_input_tokens)
-        await _persist_context_tokens(agent, config, captured_input_tokens)
-    elif adapter._on_tokens_show:
-        adapter._on_tokens_show()  # Restore previous value
+    await _report_and_persist_tokens(
+        adapter,
+        agent,
+        config,
+        captured_input_tokens,
+        captured_output_tokens,
+    )
     return turn_stats
 
 
@@ -1293,6 +1276,39 @@ async def _persist_context_tokens(
             tokens,
             exc_info=True,
         )
+
+
+async def _report_and_persist_tokens(
+    adapter: TextualUIAdapter,
+    agent: Any,  # noqa: ANN401  # Dynamic agent graph type
+    config: RunnableConfig,
+    captured_input_tokens: int,
+    captured_output_tokens: int,
+    *,
+    shield: bool = False,
+) -> None:
+    """Update the token display and best-effort persist to graph state.
+
+    Args:
+        adapter: UI adapter with token callbacks.
+        agent: The LangGraph agent.
+        config: Runnable config with `thread_id` in its configurable dict.
+        captured_input_tokens: Total input tokens captured during the turn.
+        captured_output_tokens: Total output tokens captured during the turn.
+        shield: When `True`, suppress all exceptions (including `BaseException`)
+            from the persist call so that cancellation handlers can safely await
+            this without re-raising.
+    """
+    if captured_input_tokens or captured_output_tokens:
+        if adapter._on_tokens_update:
+            adapter._on_tokens_update(captured_input_tokens)
+        if shield:
+            with contextlib.suppress(BaseException):
+                await _persist_context_tokens(agent, config, captured_input_tokens)
+        else:
+            await _persist_context_tokens(agent, config, captured_input_tokens)
+    elif adapter._on_tokens_show:
+        adapter._on_tokens_show()
 
 
 async def _flush_assistant_text_ns(

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         RejectDecision,
     )
     from langchain_core.messages import AIMessage
+    from langchain_core.runnables import RunnableConfig
     from langgraph.types import Command, Interrupt
     from pydantic import TypeAdapter
     from rich.console import Console
@@ -236,8 +237,14 @@ class TextualUIAdapter:
     _current_tool_messages: dict[str, ToolCallMessage]
     """Map of tool call IDs to their message widgets."""
 
-    _token_tracker: Any
-    """Token usage tracker for displaying counts."""
+    _on_tokens_update: Callable[[int], None] | None
+    """Called with total context tokens after each LLM response."""
+
+    _on_tokens_hide: Callable[[], None] | None
+    """Called to hide the token display during streaming."""
+
+    _on_tokens_show: Callable[[], None] | None
+    """Called to restore the token display with the cached value."""
 
     def __init__(
         self,
@@ -284,11 +291,14 @@ class TextualUIAdapter:
 
         # State tracking
         self._current_tool_messages: dict[str, ToolCallMessage] = {}
-        self._token_tracker: Any = None
 
-    def set_token_tracker(self, tracker: Any) -> None:  # noqa: ANN401  # Dynamic tracker type from Textual
-        """Set the token tracker for usage tracking."""
-        self._token_tracker = tracker
+        # Token display callbacks (set by the app after construction)
+        self._on_tokens_update: Callable[[int], None] | None = None
+        """Called with the total context token count after each LLM response."""
+        self._on_tokens_hide: Callable[[], None] | None = None
+        """Called to hide the token display during streaming."""
+        self._on_tokens_show: Callable[[], None] | None = None
+        """Called to restore the token display with the cached value."""
 
     def finalize_pending_tools_with_error(self, error: str) -> None:
         """Mark all pending/running tool widgets as error and clear tracking.
@@ -483,8 +493,8 @@ async def execute_task_textual(
         await adapter._set_spinner("Thinking")
 
     # Hide token display during streaming (will be shown with accurate count at end)
-    if adapter._token_tracker:
-        adapter._token_tracker.hide()
+    if adapter._on_tokens_hide:
+        adapter._on_tokens_hide()
 
     file_op_tracker = FileOpTracker(assistant_id=assistant_id, backend=backend)
     displayed_tool_ids: set[str] = set()
@@ -1197,13 +1207,12 @@ async def execute_task_textual(
 
         # Report tokens even on interrupt (or restore display if none captured)
         turn_stats.wall_time_seconds = time.monotonic() - start_time
-        if adapter._token_tracker:
-            if captured_input_tokens or captured_output_tokens:
-                adapter._token_tracker.add(
-                    captured_input_tokens, captured_output_tokens
-                )
-            else:
-                adapter._token_tracker.show()  # Restore previous value
+        if captured_input_tokens or captured_output_tokens:
+            if adapter._on_tokens_update:
+                adapter._on_tokens_update(captured_input_tokens)
+            await _persist_context_tokens(agent, config, captured_input_tokens)
+        elif adapter._on_tokens_show:
+            adapter._on_tokens_show()
         return turn_stats
 
     except KeyboardInterrupt:
@@ -1245,20 +1254,45 @@ async def execute_task_textual(
 
         # Report tokens even on interrupt (or restore display if none captured)
         turn_stats.wall_time_seconds = time.monotonic() - start_time
-        if adapter._token_tracker:
-            if captured_input_tokens or captured_output_tokens:
-                adapter._token_tracker.add(
-                    captured_input_tokens, captured_output_tokens
-                )
-            else:
-                adapter._token_tracker.show()  # Restore previous value
+        if captured_input_tokens or captured_output_tokens:
+            if adapter._on_tokens_update:
+                adapter._on_tokens_update(captured_input_tokens)
+            await _persist_context_tokens(agent, config, captured_input_tokens)
+        elif adapter._on_tokens_show:
+            adapter._on_tokens_show()
         return turn_stats
 
-    # Update token tracker and return stats
+    # Update token count and return stats
     turn_stats.wall_time_seconds = time.monotonic() - start_time
-    if adapter._token_tracker and (captured_input_tokens or captured_output_tokens):
-        adapter._token_tracker.add(captured_input_tokens, captured_output_tokens)
+    if captured_input_tokens or captured_output_tokens:
+        if adapter._on_tokens_update:
+            adapter._on_tokens_update(captured_input_tokens)
+        await _persist_context_tokens(agent, config, captured_input_tokens)
+    elif adapter._on_tokens_show:
+        adapter._on_tokens_show()  # Restore previous value
     return turn_stats
+
+
+async def _persist_context_tokens(
+    agent: Any,  # noqa: ANN401  # Dynamic agent graph type
+    config: RunnableConfig,
+    tokens: int,
+) -> None:
+    """Best-effort persist of the context token count into graph state.
+
+    Args:
+        agent: The LangGraph agent (must support `aupdate_state`).
+        config: Runnable config with `thread_id`.
+        tokens: Total context tokens to persist.
+    """
+    try:
+        await agent.aupdate_state(config, {"_context_tokens": tokens})
+    except Exception:  # non-critical; stale count on resume is acceptable
+        logger.warning(
+            "Failed to persist _context_tokens=%d; token count may be stale on resume",
+            tokens,
+            exc_info=True,
+        )
 
 
 async def _flush_assistant_text_ns(

--- a/libs/cli/deepagents_cli/token_state.py
+++ b/libs/cli/deepagents_cli/token_state.py
@@ -2,8 +2,9 @@
 
 The field is checkpointed (survives across sessions) but not passed to the
 model (`PrivateStateAttr`).  The CLI writes the latest total-context token
-count here after every LLM response and reads it back when resuming a thread
-so that `/tokens` and the status bar show accurate values immediately.
+count here after every LLM response and context offload, and reads it back
+when resuming a thread so that `/tokens` and the status bar show accurate
+values immediately.
 """
 
 from __future__ import annotations
@@ -25,6 +26,6 @@ class TokenTrackingState(AgentState):
 
 
 class TokenStateMiddleware(AgentMiddleware):
-    """No-op middleware that registers `_context_tokens` in the state schema."""
+    """Schema-only middleware that registers `_context_tokens` in the state schema."""
 
     state_schema = TokenTrackingState

--- a/libs/cli/deepagents_cli/token_state.py
+++ b/libs/cli/deepagents_cli/token_state.py
@@ -1,0 +1,30 @@
+"""Middleware that adds a `_context_tokens` channel to the graph state.
+
+The field is checkpointed (survives across sessions) but not passed to the
+model (`PrivateStateAttr`).  The CLI writes the latest total-context token
+count here after every LLM response and reads it back when resuming a thread
+so that `/tokens` and the status bar show accurate values immediately.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, NotRequired
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    PrivateStateAttr,
+)
+
+
+class TokenTrackingState(AgentState):
+    """Extends agent state with a persisted context-token counter."""
+
+    _context_tokens: Annotated[NotRequired[int], PrivateStateAttr]
+    """Total context tokens reported by the model's last `usage_metadata`."""
+
+
+class TokenStateMiddleware(AgentMiddleware):
+    """No-op middleware that registers `_context_tokens` in the state schema."""
+
+    state_schema = TokenTrackingState

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2401,15 +2401,15 @@ class TestFetchThreadHistoryData:
         mock_agent.aget_state.return_value = state
 
         app = DeepAgentsApp(agent=mock_agent, thread_id="t-1")
-        result = await app._fetch_thread_history_data("t-1")
+        payload = await app._fetch_thread_history_data("t-1")
 
-        assert len(result) == 2
-        assert isinstance(result[0], MessageData)
-        assert result[0].type == MessageType.USER
-        assert result[0].content == "hello"
-        assert isinstance(result[1], MessageData)
-        assert result[1].type == MessageType.ASSISTANT
-        assert result[1].content == "Hi there!"
+        assert len(payload.messages) == 2
+        assert isinstance(payload.messages[0], MessageData)
+        assert payload.messages[0].type == MessageType.USER
+        assert payload.messages[0].content == "hello"
+        assert isinstance(payload.messages[1], MessageData)
+        assert payload.messages[1].type == MessageType.ASSISTANT
+        assert payload.messages[1].content == "Hi there!"
 
     async def test_server_mode_falls_back_to_checkpointer(self) -> None:
         """When the server returns empty state, read SQLite checkpointer directly."""
@@ -2438,13 +2438,13 @@ class TestFetchThreadHistoryData:
             "_read_channel_values_from_checkpointer",
             return_value={"messages": checkpointer_msgs},
         ):
-            result = await app._fetch_thread_history_data("t-1")
+            payload = await app._fetch_thread_history_data("t-1")
 
-        assert len(result) == 2
-        assert result[0].type == MessageType.USER
-        assert result[0].content == "hello"
-        assert result[1].type == MessageType.ASSISTANT
-        assert result[1].content == "world"
+        assert len(payload.messages) == 2
+        assert payload.messages[0].type == MessageType.USER
+        assert payload.messages[0].content == "hello"
+        assert payload.messages[1].type == MessageType.ASSISTANT
+        assert payload.messages[1].content == "world"
 
 
 class TestRemoteAgent:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2446,6 +2446,36 @@ class TestFetchThreadHistoryData:
         assert payload.messages[1].type == MessageType.ASSISTANT
         assert payload.messages[1].content == "world"
 
+    async def test_server_mode_fallback_includes_context_tokens(self) -> None:
+        """Server-mode fallback should merge `_context_tokens` from the checkpointer."""
+        from langchain_core.messages import HumanMessage
+
+        from deepagents_cli.remote_client import RemoteAgent
+        from deepagents_cli.widgets.message_store import MessageType
+
+        empty_state = MagicMock()
+        empty_state.values = {}
+
+        mock_agent = MagicMock(spec=RemoteAgent)
+        mock_agent.aget_state = AsyncMock(return_value=empty_state)
+
+        app = DeepAgentsApp(agent=mock_agent, thread_id="t-1")
+
+        checkpointer_data = {
+            "messages": [HumanMessage(content="hi", id="h1")],
+            "_context_tokens": 5000,
+        }
+        with patch.object(
+            DeepAgentsApp,
+            "_read_channel_values_from_checkpointer",
+            return_value=checkpointer_data,
+        ):
+            payload = await app._fetch_thread_history_data("t-1")
+
+        assert payload.context_tokens == 5000
+        assert len(payload.messages) == 1
+        assert payload.messages[0].type == MessageType.USER
+
 
 class TestRemoteAgent:
     """Tests for DeepAgentsApp._remote_agent()."""

--- a/libs/cli/tests/unit_tests/test_offload.py
+++ b/libs/cli/tests/unit_tests/test_offload.py
@@ -256,7 +256,8 @@ class TestOffloadSuccess:
                 await pilot.pause()
 
             mock_agent = app._agent
-            assert mock_agent.aupdate_state.call_count == 1  # type: ignore[union-attr]
+            # Two aupdate_state calls: _summarization_event + _context_tokens
+            assert mock_agent.aupdate_state.call_count == 2  # type: ignore[union-attr]
 
             update_values = mock_agent.aupdate_state.call_args_list[0][0][1]  # type: ignore[union-attr]
             event = update_values["_summarization_event"]
@@ -284,14 +285,12 @@ class TestOffloadSuccess:
             msgs = app.query(AppMessage)
             assert any("Offloaded 4 older messages" in str(w._content) for w in msgs)
 
-    async def test_offload_updates_token_tracker(self) -> None:
-        """Should update token tracker after offload."""
+    async def test_offload_updates_context_tokens(self) -> None:
+        """Should update _context_tokens after offload."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             _setup_offload_app(app)
-            app._token_tracker = MagicMock()
-
             result = _make_offload_result(tokens_after=500)
 
             with patch(
@@ -302,7 +301,7 @@ class TestOffloadSuccess:
                 await app._handle_offload()
                 await pilot.pause()
 
-            app._token_tracker.add.assert_called_once_with(500)
+            assert app._context_tokens == 500
 
     async def test_no_ui_clear_reload(self) -> None:
         """Should NOT clear/reload UI since messages stay in state."""
@@ -413,8 +412,7 @@ class TestOffloadEdgeCases:
         async with app.run_test() as pilot:
             await pilot.pause()
             messages = _setup_offload_app(app, n_messages=10)
-            app._token_tracker = MagicMock()
-            app._token_tracker.current_context = 7500
+            app._context_tokens = 7500
             app._profile_override = {"temperature": 0.5}
 
             result = _make_offload_result()
@@ -483,7 +481,7 @@ class TestReOffload:
                 await pilot.pause()
 
             mock_agent = app._agent
-            assert mock_agent.aupdate_state.call_count == 1  # type: ignore[union-attr]
+            assert mock_agent.aupdate_state.call_count == 2  # type: ignore[union-attr]
 
             update_values = mock_agent.aupdate_state.call_args_list[0][0][1]  # type: ignore[union-attr]
             event = update_values["_summarization_event"]
@@ -568,7 +566,7 @@ class TestOffloadErrorHandling:
                 await pilot.pause()
 
             mock_agent = app._agent
-            assert mock_agent.aupdate_state.call_count == 1  # type: ignore[union-attr]
+            assert mock_agent.aupdate_state.call_count == 2  # type: ignore[union-attr]
 
             update_values = mock_agent.aupdate_state.call_args_list[0][0][1]  # type: ignore[union-attr]
             event = update_values["_summarization_event"]
@@ -1074,8 +1072,8 @@ class TestOffloadProfileOverride:
                 await app._handle_offload()
                 await pilot.pause()
 
-            # State should have been updated (offload happened)
-            app._agent.aupdate_state.assert_called_once()  # type: ignore[union-attr]
+            # State should have been updated (offload + _context_tokens)
+            assert app._agent.aupdate_state.call_count == 2  # type: ignore[union-attr]
             kwargs = mock_perform.call_args.kwargs
             assert kwargs["context_limit"] == 4096
 

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -80,26 +80,40 @@ class TestTextualUIAdapterInit:
         )
         assert adapter._current_tool_messages == {}
 
-    def test_token_tracker_initialized_none(self) -> None:
-        """Verify `_token_tracker` is initialized as `None`."""
+    def test_token_callbacks_initialized_none(self) -> None:
+        """Verify token callbacks are initialized as `None`."""
         adapter = TextualUIAdapter(
             mount_message=_mock_mount,
             update_status=_noop_status,
             request_approval=_mock_approval,
         )
-        assert adapter._token_tracker is None
+        assert adapter._on_tokens_update is None
+        assert adapter._on_tokens_hide is None
+        assert adapter._on_tokens_show is None
 
-    def test_set_token_tracker(self) -> None:
-        """Verify `set_token_tracker` stores the tracker."""
+    def test_set_token_callbacks(self) -> None:
+        """Verify token callbacks can be assigned."""
         adapter = TextualUIAdapter(
             mount_message=_mock_mount,
             update_status=_noop_status,
             request_approval=_mock_approval,
         )
 
-        mock_tracker = object()
-        adapter.set_token_tracker(mock_tracker)
-        assert adapter._token_tracker is mock_tracker
+        def update_cb(count: int) -> None:
+            pass
+
+        def hide_cb() -> None:
+            pass
+
+        def show_cb() -> None:
+            pass
+
+        adapter._on_tokens_update = update_cb
+        adapter._on_tokens_hide = hide_cb
+        adapter._on_tokens_show = show_cb
+        assert adapter._on_tokens_update is update_cb
+        assert adapter._on_tokens_hide is hide_cb
+        assert adapter._on_tokens_show is show_cb
 
     def test_finalize_pending_tools_with_error_marks_and_clears(self) -> None:
         """Pending tool widgets should be marked error and then cleared."""

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -2120,9 +2120,11 @@ class TestResumeThread:
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
         app._clear_messages = AsyncMock()  # type: ignore[assignment]
-        app._token_tracker = MagicMock()
         app._update_status = MagicMock()  # type: ignore[assignment]
-        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
+        mock_payload = MagicMock()
+        mock_payload.messages = []
+        mock_payload.context_tokens = 0
+        app._fetch_thread_history_data = AsyncMock(return_value=mock_payload)  # type: ignore[assignment]
         app._load_thread_history = AsyncMock()  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
         app.query_one = MagicMock(side_effect=_NoMatches())  # type: ignore[assignment]
@@ -2134,11 +2136,11 @@ class TestResumeThread:
         app._pending_messages.clear.assert_called_once()
         app._queued_widgets.clear.assert_called_once()
         app._clear_messages.assert_awaited_once()
-        app._token_tracker.reset.assert_called_once()
+        assert app._context_tokens == 0
         app._fetch_thread_history_data.assert_awaited_once_with("new-thread")
         app._load_thread_history.assert_awaited_once_with(
             thread_id="new-thread",
-            preloaded_data=[],
+            preloaded_payload=mock_payload,
         )
 
     async def test_failure_restores_previous_thread_ids(self) -> None:
@@ -2151,7 +2153,10 @@ class TestResumeThread:
         app._session_state.thread_id = "old-thread"
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
-        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
+        from deepagents_cli.app import _ThreadHistoryPayload
+
+        mock_payload = _ThreadHistoryPayload(messages=[], context_tokens=0)
+        app._fetch_thread_history_data = AsyncMock(return_value=mock_payload)  # type: ignore[assignment]
         app._clear_messages = AsyncMock(side_effect=RuntimeError("UI gone"))  # type: ignore[assignment]
         app._update_status = MagicMock()  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
@@ -2177,9 +2182,11 @@ class TestResumeThread:
         app._session_state.thread_id = "old-thread"
         app._pending_messages = MagicMock()
         app._queued_widgets = MagicMock()
-        app._fetch_thread_history_data = AsyncMock(return_value=[])  # type: ignore[assignment]
+        mock_payload = MagicMock()
+        mock_payload.messages = []
+        mock_payload.context_tokens = 0
+        app._fetch_thread_history_data = AsyncMock(return_value=mock_payload)  # type: ignore[assignment]
         app._clear_messages = AsyncMock()  # type: ignore[assignment]
-        app._token_tracker = MagicMock()
         app._update_status = MagicMock()  # type: ignore[assignment]
         app._load_thread_history = AsyncMock(  # type: ignore[assignment]
             side_effect=[RuntimeError("checkpoint corrupt"), None]
@@ -2280,9 +2287,10 @@ class TestFetchThreadHistoryData:
         app = DeepAgentsApp()
         app._agent = None
 
-        result = await app._fetch_thread_history_data("tid-1")
+        payload = await app._fetch_thread_history_data("tid-1")
 
-        assert result == []
+        assert payload.messages == []
+        assert payload.context_tokens == 0
 
     async def test_returns_empty_when_state_missing(self) -> None:
         """Missing checkpoint state should return an empty history payload."""
@@ -2290,9 +2298,10 @@ class TestFetchThreadHistoryData:
         app._agent = MagicMock()
         app._agent.aget_state = AsyncMock(return_value=None)
 
-        result = await app._fetch_thread_history_data("tid-1")
+        payload = await app._fetch_thread_history_data("tid-1")
 
-        assert result == []
+        assert payload.messages == []
+        assert payload.context_tokens == 0
         app._agent.aget_state.assert_awaited_once_with(
             {"configurable": {"thread_id": "tid-1"}}
         )
@@ -2305,9 +2314,10 @@ class TestFetchThreadHistoryData:
         state.values = {}
         app._agent.aget_state = AsyncMock(return_value=state)
 
-        result = await app._fetch_thread_history_data("tid-1")
+        payload = await app._fetch_thread_history_data("tid-1")
 
-        assert result == []
+        assert payload.messages == []
+        assert payload.context_tokens == 0
 
     async def test_offloads_conversion_to_thread(self) -> None:
         """Message conversion should be offloaded via `asyncio.to_thread`."""
@@ -2326,9 +2336,9 @@ class TestFetchThreadHistoryData:
             new_callable=AsyncMock,
             return_value=converted,
         ) as to_thread_mock:
-            result = await app._fetch_thread_history_data("tid-1")
+            payload = await app._fetch_thread_history_data("tid-1")
 
-        assert result == converted
+        assert payload.messages == converted
         to_thread_mock.assert_awaited_once()
         await_args = to_thread_mock.await_args
         assert await_args is not None
@@ -2357,13 +2367,45 @@ class TestLoadThreadHistory:
         messages_container.mount = AsyncMock()
         app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
 
-        preloaded = [MessageData(type=MessageType.USER, content="hello")]
-        await app._load_thread_history(thread_id="tid-1", preloaded_data=preloaded)
+        from deepagents_cli.app import _ThreadHistoryPayload
+
+        preloaded = _ThreadHistoryPayload(
+            messages=[MessageData(type=MessageType.USER, content="hello")],
+            context_tokens=0,
+        )
+        await app._load_thread_history(thread_id="tid-1", preloaded_payload=preloaded)
 
         fetch_history_mock.assert_not_awaited()
         messages_container.mount.assert_awaited_once()
         mount_message_mock.assert_awaited_once()
         schedule_link_mock.assert_called_once()
+
+    async def test_resume_seeds_context_tokens_from_state(self) -> None:
+        """Resuming a thread with persisted tokens should seed the local cache."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp(thread_id="tid-1")
+
+        mount_message_mock = AsyncMock()
+        schedule_link_mock = MagicMock()
+        app._remove_spacer = AsyncMock()  # type: ignore[assignment]
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+        app._schedule_thread_message_link = schedule_link_mock  # type: ignore[assignment]
+        app.set_timer = MagicMock()  # type: ignore[assignment]
+
+        messages_container = MagicMock()
+        messages_container.mount = AsyncMock()
+        app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
+
+        from deepagents_cli.app import _ThreadHistoryPayload
+
+        preloaded = _ThreadHistoryPayload(
+            messages=[MessageData(type=MessageType.USER, content="hello")],
+            context_tokens=8500,
+        )
+        await app._load_thread_history(thread_id="tid-1", preloaded_payload=preloaded)
+
+        assert app._context_tokens == 8500
 
     async def test_fallback_fetch_path_used_without_preloaded_data(self) -> None:
         """History should be fetched when preloaded data is not provided."""
@@ -2371,7 +2413,12 @@ class TestLoadThreadHistory:
 
         app = DeepAgentsApp(thread_id="tid-1")
         app._agent = MagicMock()
-        fetched = [MessageData(type=MessageType.USER, content="hello")]
+        from deepagents_cli.app import _ThreadHistoryPayload
+
+        fetched = _ThreadHistoryPayload(
+            messages=[MessageData(type=MessageType.USER, content="hello")],
+            context_tokens=0,
+        )
         fetch_history_mock = AsyncMock(return_value=fetched)
         mount_message_mock = AsyncMock()
         schedule_link_mock = MagicMock()
@@ -2410,10 +2457,15 @@ class TestLoadThreadHistory:
         messages_container.mount = AsyncMock()
         app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
 
-        preloaded = [
-            MessageData(type=MessageType.ASSISTANT, content="ok"),
-            MessageData(type=MessageType.ASSISTANT, content="fail"),
-        ]
+        from deepagents_cli.app import _ThreadHistoryPayload
+
+        preloaded = _ThreadHistoryPayload(
+            messages=[
+                MessageData(type=MessageType.ASSISTANT, content="ok"),
+                MessageData(type=MessageType.ASSISTANT, content="fail"),
+            ],
+            context_tokens=0,
+        )
 
         def _set_content_side_effect(content: str) -> None:
             if content == "fail":
@@ -2426,7 +2478,9 @@ class TestLoadThreadHistory:
             new_callable=AsyncMock,
             side_effect=_set_content_side_effect,
         ) as set_content_mock:
-            await app._load_thread_history(thread_id="tid-1", preloaded_data=preloaded)
+            await app._load_thread_history(
+                thread_id="tid-1", preloaded_payload=preloaded
+            )
 
         assert set_content_mock.await_count == 2
         mount_message_mock.assert_awaited_once()

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -2344,6 +2344,48 @@ class TestFetchThreadHistoryData:
         assert await_args is not None
         assert await_args.args[1] == raw_messages
 
+    async def test_extracts_nonzero_context_tokens(self) -> None:
+        """Persisted _context_tokens should propagate to the payload."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        raw_messages = [object()]
+        state = MagicMock()
+        state.values = {"messages": raw_messages, "_context_tokens": 12000}
+        app._agent.aget_state = AsyncMock(return_value=state)
+        converted = [MessageData(type=MessageType.USER, content="hello")]
+
+        with patch(
+            "deepagents_cli.app.asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=converted,
+        ):
+            payload = await app._fetch_thread_history_data("tid-1")
+
+        assert payload.context_tokens == 12000
+
+    async def test_none_context_tokens_coerced_to_zero(self) -> None:
+        """`_context_tokens: None` in checkpoint should coerce to 0."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        raw_messages = [object()]
+        state = MagicMock()
+        state.values = {"messages": raw_messages, "_context_tokens": None}
+        app._agent.aget_state = AsyncMock(return_value=state)
+        converted = [MessageData(type=MessageType.USER, content="hello")]
+
+        with patch(
+            "deepagents_cli.app.asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=converted,
+        ):
+            payload = await app._fetch_thread_history_data("tid-1")
+
+        assert payload.context_tokens == 0
+
 
 class TestLoadThreadHistory:
     """Tests for DeepAgentsApp._load_thread_history."""
@@ -2406,6 +2448,34 @@ class TestLoadThreadHistory:
         await app._load_thread_history(thread_id="tid-1", preloaded_payload=preloaded)
 
         assert app._context_tokens == 8500
+
+    async def test_zero_context_tokens_does_not_overwrite_cache(self) -> None:
+        """Loading a payload with 0 tokens should not reset an existing cache."""
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app = DeepAgentsApp(thread_id="tid-1")
+        app._context_tokens = 5000  # pre-existing cache from a previous thread
+
+        mount_message_mock = AsyncMock()
+        schedule_link_mock = MagicMock()
+        app._remove_spacer = AsyncMock()  # type: ignore[assignment]
+        app._mount_message = mount_message_mock  # type: ignore[assignment]
+        app._schedule_thread_message_link = schedule_link_mock  # type: ignore[assignment]
+        app.set_timer = MagicMock()  # type: ignore[assignment]
+
+        messages_container = MagicMock()
+        messages_container.mount = AsyncMock()
+        app.query_one = MagicMock(return_value=messages_container)  # type: ignore[assignment]
+
+        from deepagents_cli.app import _ThreadHistoryPayload
+
+        preloaded = _ThreadHistoryPayload(
+            messages=[MessageData(type=MessageType.USER, content="hello")],
+            context_tokens=0,
+        )
+        await app._load_thread_history(thread_id="tid-1", preloaded_payload=preloaded)
+
+        assert app._context_tokens == 5000
 
     async def test_fallback_fetch_path_used_without_preloaded_data(self) -> None:
         """History should be fetched when preloaded data is not provided."""

--- a/libs/cli/tests/unit_tests/test_token_tracker.py
+++ b/libs/cli/tests/unit_tests/test_token_tracker.py
@@ -1,54 +1,104 @@
-"""Tests for TextualTokenTracker."""
+"""Tests for token state persistence and display callbacks."""
 
-from deepagents_cli.app import TextualTokenTracker
+from deepagents_cli.token_state import TokenStateMiddleware, TokenTrackingState
 
 
-class TestTextualTokenTracker:
-    def test_add_updates_context_and_calls_callback(self):
-        """Token add() should update current_context with total tokens."""
-        called_with = []
-        tracker = TextualTokenTracker(lambda x: called_with.append(x))
+class TestTokenTrackingState:
+    def test_state_has_context_tokens_field(self):
+        """TokenTrackingState declares the `_context_tokens` channel."""
+        annotations = TokenTrackingState.__annotations__
+        assert "_context_tokens" in annotations
 
-        tracker.add(1700)  # total_tokens from usage_metadata
+    def test_middleware_exposes_state_schema(self):
+        """TokenStateMiddleware registers the correct state schema."""
+        assert TokenStateMiddleware.state_schema is TokenTrackingState
 
-        assert tracker.current_context == 1700
-        assert called_with == [1700]
 
-    def test_reset_clears_context_and_calls_callback_with_zero(self):
-        """Token reset() should set context to 0 and call callback with 0."""
-        called_with = []
-        tracker = TextualTokenTracker(lambda x: called_with.append(x))
-        tracker.add(1500, 200)
-        called_with.clear()
+class TestTokenDisplayCallbacks:
+    """Verify the callback-based token tracking that replaced TextualTokenTracker."""
 
-        tracker.reset()
+    def test_on_tokens_update_sets_cache_and_calls_display(self):
+        """_on_tokens_update should set the local cache and update the status bar."""
+        display_calls: list[int] = []
 
-        assert tracker.current_context == 0
-        assert called_with == [0]
+        class FakeApp:
+            _context_tokens: int = 0
+            _status_bar = None
 
-    def test_hide_calls_hide_callback(self):
-        """Token hide() should call the hide callback."""
-        hide_called = []
-        tracker = TextualTokenTracker(
-            lambda _: None, hide_callback=lambda: hide_called.append(True)
-        )
+            def _update_tokens(self, count: int) -> None:
+                display_calls.append(count)
 
-        tracker.hide()
+            def _on_tokens_update(self, count: int) -> None:
+                self._context_tokens = count
+                self._update_tokens(count)
 
-        assert hide_called == [True]
+        app = FakeApp()
+        app._on_tokens_update(4200)
 
-    def test_hide_without_callback_is_noop(self):
-        """Token hide() should be safe when no hide callback provided."""
-        tracker = TextualTokenTracker(lambda _: None)
-        tracker.hide()  # Should not raise
+        assert app._context_tokens == 4200
+        assert display_calls == [4200]
 
-    def test_show_restores_current_value(self):
-        """Token show() should restore display with current value."""
-        called_with = []
-        tracker = TextualTokenTracker(lambda x: called_with.append(x))
-        tracker.add(1500)
-        called_with.clear()
+    def test_show_tokens_restores_cached_value(self):
+        """_show_tokens should re-display the cached value."""
+        display_calls: list[int] = []
 
-        tracker.show()
+        class FakeApp:
+            _context_tokens: int = 1500
 
-        assert called_with == [1500]  # Shows current_context value
+            def _update_tokens(self, count: int) -> None:
+                display_calls.append(count)
+
+            def _show_tokens(self) -> None:
+                self._update_tokens(self._context_tokens)
+
+        app = FakeApp()
+        app._show_tokens()
+
+        assert display_calls == [1500]
+
+    def test_reset_clears_cache(self):
+        """Resetting (e.g. /clear) should zero the cache and display."""
+        display_calls: list[int] = []
+
+        class FakeApp:
+            _context_tokens: int = 3000
+
+            def _update_tokens(self, count: int) -> None:
+                display_calls.append(count)
+
+        app = FakeApp()
+        app._context_tokens = 0
+        app._update_tokens(0)
+
+        assert app._context_tokens == 0
+        assert display_calls == [0]
+
+
+class TestPersistContextTokens:
+    """Tests for the `_persist_context_tokens` helper."""
+
+    async def test_calls_aupdate_state_with_token_count(self):
+        """Happy path: persists the count via `aupdate_state`."""
+        from unittest.mock import AsyncMock
+
+        from deepagents_cli.textual_adapter import _persist_context_tokens
+
+        agent = AsyncMock()
+        config = {"configurable": {"thread_id": "t-1"}}
+
+        await _persist_context_tokens(agent, config, 4200)  # type: ignore[arg-type]
+
+        agent.aupdate_state.assert_awaited_once_with(config, {"_context_tokens": 4200})
+
+    async def test_suppresses_exceptions(self):
+        """Failures should be swallowed (non-critical persistence)."""
+        from unittest.mock import AsyncMock
+
+        from deepagents_cli.textual_adapter import _persist_context_tokens
+
+        agent = AsyncMock()
+        agent.aupdate_state.side_effect = RuntimeError("checkpointer down")
+        config = {"configurable": {"thread_id": "t-1"}}
+
+        # Should not raise
+        await _persist_context_tokens(agent, config, 1000)  # type: ignore[arg-type]


### PR DESCRIPTION
The CLI's token count (`/tokens`, status bar) was stored only in memory via `TextualTokenTracker`, so resuming a thread with `-r` always showed "No token usage yet" — even though `/offload` independently counted ~291 tokens from messages. This persists the count in the LangGraph graph state so it survives across sessions and both commands agree.

## Changes (TL;DR)

- Store the token count in the graph's checkpointed state so it survives across sessions, using a private field the model never sees
- Replace the dedicated `TextualTokenTracker` class with a simple integer on the app plus three callbacks for updating the UI
- After each LLM response, persist the token count to graph state
- When resuming a thread, load the saved token count alongside the message history so the display is immediately correct

## Changes (detailed)

- Add `_context_tokens` as a `PrivateStateAttr` field on a new `TokenTrackingState` schema, registered via a no-op `TokenStateMiddleware` in `create_cli_agent` — checkpointed but hidden from the model
- Remove the `TextualTokenTracker` class from `app.py`; replace with a plain `_context_tokens: int` cache on the app and three typed callbacks (`_on_tokens_update`, `_on_tokens_hide`, `_on_tokens_show`) wired to the `TextualUIAdapter`
- After each LLM response, `_persist_context_tokens` writes the count to graph state via `aupdate_state`; failures log at `warning` level rather than silently disappearing
- On thread resume, `_fetch_thread_history_data` now returns a `_ThreadHistoryPayload` that bundles messages + the persisted token count; `_load_thread_history` seeds the local cache from it
- `/tokens`, `/clear`, `/offload`, and thread-switch all read/write `self._context_tokens` instead of the removed tracker
- `_get_thread_state_values` fallback (server mode) now recovers `_context_tokens` from the SQLite checkpointer alongside `_summarization_event`
