### PR TITLE
feat(cli): surface unsupported input modalities in system prompt

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -430,6 +430,7 @@ def build_model_identity_section(
     name: str | None,
     provider: str | None = None,
     context_limit: int | None = None,
+    unsupported_modalities: frozenset[str] = frozenset(),
 ) -> str:
     """Build the `### Model Identity` section for the system prompt.
 
@@ -437,6 +438,8 @@ def build_model_identity_section(
         name: Model identifier (e.g. `claude-opus-4-6`).
         provider: Provider identifier (e.g. `anthropic`).
         context_limit: Max input tokens from the model profile.
+        unsupported_modalities: Input modalities not indicated as supported by
+            the model profile (e.g. `{"audio", "video"}`).
 
     Returns:
         The section text including the heading and trailing newline,
@@ -450,6 +453,18 @@ def build_model_identity_section(
     section += ".\n"
     if context_limit:
         section += f"Your context window is {context_limit:,} tokens.\n"
+    if unsupported_modalities:
+        items = sorted(unsupported_modalities)
+        if len(items) == 1:
+            joined = items[0]
+        elif len(items) == 2:  # noqa: PLR2004
+            joined = f"{items[0]} and {items[1]}"
+        else:
+            joined = ", ".join(items[:-1]) + f", and {items[-1]}"
+        section += (
+            f"{joined.capitalize()} input may not be available for this model. "
+            "Do not attempt to read or process these content types.\n"
+        )
     section += "\n"
     return section
 
@@ -532,6 +547,7 @@ def get_system_prompt(
         settings.model_name,
         provider=settings.model_provider,
         context_limit=settings.model_context_limit,
+        unsupported_modalities=settings.model_unsupported_modalities,
     )
 
     # Build working directory section (local vs sandbox)

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -887,6 +887,9 @@ class Settings:
     model_context_limit: int | None = None
     """Maximum input token count from the model profile."""
 
+    model_unsupported_modalities: frozenset[str] = frozenset()
+    """Input modalities not indicated as supported by the model profile."""
+
     project_root: Path | None = None
     """Current project root directory, or `None` if not in a git project."""
 
@@ -2082,12 +2085,15 @@ class ModelResult:
         model_name: Resolved model name.
         provider: Resolved provider name.
         context_limit: Max input tokens from the model profile, or `None`.
+        unsupported_modalities: Input modalities not indicated as supported by
+            the model profile (e.g. `{"audio", "video"}`).
     """
 
     model: BaseChatModel
     model_name: str
     provider: str
     context_limit: int | None = None
+    unsupported_modalities: frozenset[str] = frozenset()
 
     def apply_to_settings(self) -> None:
         """Commit this result's metadata to global `settings`."""
@@ -2095,6 +2101,7 @@ class ModelResult:
         s.model_name = self.model_name
         s.model_provider = self.provider
         s.model_context_limit = self.context_limit
+        s.model_unsupported_modalities = self.unsupported_modalities
 
 
 def _apply_profile_overrides(
@@ -2258,17 +2265,30 @@ def create_model(
             raise_on_failure=True,
         )
 
-    # Extract context limit from model profile (if available)
+    # Extract context limit and modality support from model profile
     context_limit: int | None = None
+    unsupported_modalities: frozenset[str] = frozenset()
     profile = getattr(model, "profile", None)
-    if isinstance(profile, dict) and isinstance(profile.get("max_input_tokens"), int):
-        context_limit = profile["max_input_tokens"]
+    if isinstance(profile, dict):
+        if isinstance(profile.get("max_input_tokens"), int):
+            context_limit = profile["max_input_tokens"]
+
+        modality_keys = {
+            "image_inputs": "image",
+            "audio_inputs": "audio",
+            "video_inputs": "video",
+            "pdf_inputs": "pdf",
+        }
+        unsupported_modalities = frozenset(
+            label for key, label in modality_keys.items() if profile.get(key) is False
+        )
 
     return ModelResult(
         model=model,
         model_name=model_name,
         provider=resolved_provider,
         context_limit=context_limit,
+        unsupported_modalities=unsupported_modalities,
     )
 
 

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -125,6 +125,7 @@ def _apply_overrides(request: ModelRequest) -> ModelRequest:
             model_result.model_name,
             provider=model_result.provider,
             context_limit=model_result.context_limit,
+            unsupported_modalities=model_result.unsupported_modalities,
         )
         patched = MODEL_IDENTITY_RE.sub(new_identity, prompt, count=1)
         if patched != prompt:

--- a/libs/cli/deepagents_cli/system_prompt.md
+++ b/libs/cli/deepagents_cli/system_prompt.md
@@ -42,11 +42,13 @@ When the user asks you to do something:
 Keep working until the task is fully complete. Don't stop partway to explain what you would do — do it. Only ask when genuinely blocked.
 
 CRITICAL: Match what the user asked for EXACTLY.
+
 - Field names, paths, schemas, identifiers must match specifications verbatim
 - `value` ≠ `val`, `amount` ≠ `total`, `/app/result.txt` ≠ `/app/results.txt`
 - If the user defines a schema, copy field names verbatim. Do not rename or "improve" them.
 
 **When things go wrong:**
+
 - Think through the issue by working backwards from the user's goal and plan.
 - If something fails repeatedly, stop and analyze *why* — don't keep retrying the same approach. Walk through the chain of failures to find the root cause.
 - If steps are repeatedly failing, make note of what's going wrong and share an updated plan with the user.
@@ -55,6 +57,7 @@ CRITICAL: Match what the user asked for EXACTLY.
 ## Tool Usage
 
 IMPORTANT: Use specialized tools instead of shell commands:
+
 - `read_file` over `cat`/`head`/`tail`
 - `edit_file` over `sed`/`awk`
 - `write_file` over `echo`/heredoc
@@ -109,22 +112,26 @@ Make HTTP requests to APIs (GET, POST, etc.).
 When exploring codebases or reading multiple files, use pagination to prevent context overflow.
 
 **Pattern for codebase exploration:**
+
 1. First scan: `read_file(path, limit=100)` - See file structure and key sections
 2. Targeted read: `read_file(path, offset=100, limit=200)` - Read specific sections
 3. Full read: Only use `read_file(path)` without limit when necessary for editing
 
 **When to paginate:**
+
 - Reading any file >500 lines
 - Exploring unfamiliar codebases (always start with limit=100)
 - Reading multiple files in sequence
 
 **When full read is OK:**
+
 - Small files (<500 lines)
 - Files you need to edit immediately after reading
 
 ## Working with Subagents (task tool)
 
 When delegating to subagents:
+
 - **Use filesystem for large I/O**: If input/output is large (>500 words), communicate via files
 - **Parallelize independent work**: Spawn parallel subagents for independent tasks
 - **Clear specifications**: Tell subagent exactly what format/structure you need
@@ -150,6 +157,7 @@ When delegating to subagents:
 ## Debugging Best Practices
 
 When something isn't working:
+
 - Read the FULL error output — not just the first line or error type. The root cause is often in the middle of a traceback.
 - Reproduce the error before attempting a fix. If you can't reproduce it, you can't verify your fix.
 - Isolate variables: change one thing at a time. Don't make multiple speculative fixes simultaneously.
@@ -176,10 +184,12 @@ When something isn't working:
 
 ## Working with Images
 
-When a task involves visual content (screenshots, diagrams, UI mockups, charts, plots):
+When a task involves visual content (screenshots, diagrams, UI mockups, charts, plots) and your model supports image input:
+
 - Use `read_file(file_path)` to view image files directly — do not use offset/limit parameters for images
 - Read images BEFORE making assumptions about visual content
 - For tasks referencing images: always view them, don't guess from filenames
+- If image input is not available, say so rather than guessing from filenames
 
 ## Code References
 
@@ -202,6 +212,7 @@ Example: `bash python {skills_path}/web-research/script.py`
 ### Human-in-the-Loop Tool Approval
 
 Some tool calls require user approval before execution. When a tool call is rejected by the user:
+
 1. Accept their decision immediately - do NOT retry the same command
 2. Explain that you understand they rejected the action
 3. Suggest an alternative approach or ask for clarification
@@ -212,6 +223,7 @@ Respect the user's decisions and work with them collaboratively.
 ### Web Search Tool Usage
 
 When you use the web_search tool:
+
 1. The tool will return search results with titles, URLs, and content excerpts
 2. You MUST read and process these results, then respond naturally to the user
 3. NEVER show raw JSON or tool results directly to the user
@@ -224,6 +236,7 @@ The user only sees your text responses - not tool results. Always provide a comp
 ### Todo List Management
 
 When using the write_todos tool:
+
 1. Use todos for any task with 2+ steps — they give the user visibility
 2. Mark tasks `in_progress` before starting, `completed` immediately after
 3. Don't batch completions — mark each item done as you finish it

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -21,6 +21,7 @@ from deepagents_cli.agent import (
     _format_task_description,
     _format_web_search_description,
     _format_write_file_description,
+    build_model_identity_section,
     create_cli_agent,
     get_system_prompt,
     list_agents,
@@ -347,6 +348,57 @@ def test_format_fetch_url_description_with_hidden_unicode_in_url():
     assert "\u200b" not in description
 
 
+class TestBuildModelIdentitySection:
+    """Direct tests for build_model_identity_section."""
+
+    def test_empty_when_no_name(self) -> None:
+        assert build_model_identity_section(None) == ""
+
+    def test_basic_name_only(self) -> None:
+        result = build_model_identity_section("gpt-4o")
+        assert "You are running as model `gpt-4o`." in result
+        assert "may not be available" not in result
+
+    def test_unsupported_single(self) -> None:
+        result = build_model_identity_section(
+            "test-model", unsupported_modalities=frozenset({"audio"})
+        )
+        assert "Audio input may not be available for this model." in result
+        assert "Do not attempt to read or process" in result
+
+    def test_unsupported_two_uses_and(self) -> None:
+        result = build_model_identity_section(
+            "test-model",
+            unsupported_modalities=frozenset({"video", "audio"}),
+        )
+        assert "Audio and video input may not be available" in result
+
+    def test_unsupported_multiple_uses_oxford_comma(self) -> None:
+        result = build_model_identity_section(
+            "test-model",
+            unsupported_modalities=frozenset({"video", "audio", "image"}),
+        )
+        assert "Audio, image, and video input may not be available" in result
+
+    def test_unsupported_empty_frozenset_no_warning(self) -> None:
+        result = build_model_identity_section(
+            "test-model", unsupported_modalities=frozenset()
+        )
+        assert "may not be available" not in result
+
+    def test_all_fields(self) -> None:
+        result = build_model_identity_section(
+            "deepseek-r1",
+            provider="deepseek",
+            context_limit=64000,
+            unsupported_modalities=frozenset({"image", "pdf"}),
+        )
+        assert "deepseek-r1" in result
+        assert "(provider: deepseek)" in result
+        assert "64,000 tokens" in result
+        assert "Image and pdf input may not be available" in result
+
+
 class TestGetSystemPromptModelIdentity:
     """Tests for model identity section in get_system_prompt."""
 
@@ -355,6 +407,7 @@ class TestGetSystemPromptModelIdentity:
         mock_settings = Mock()
         mock_settings.model_name = "claude-sonnet-4-6"
         mock_settings.model_provider = "anthropic"
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = 200000
 
         with patch("deepagents_cli.agent.settings", mock_settings):
@@ -370,6 +423,7 @@ class TestGetSystemPromptModelIdentity:
         mock_settings = Mock()
         mock_settings.model_name = None
         mock_settings.model_provider = "anthropic"
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = 200000
 
         with patch("deepagents_cli.agent.settings", mock_settings):
@@ -382,6 +436,7 @@ class TestGetSystemPromptModelIdentity:
         mock_settings = Mock()
         mock_settings.model_name = "gpt-4"
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = 128000
 
         with patch("deepagents_cli.agent.settings", mock_settings):
@@ -397,6 +452,7 @@ class TestGetSystemPromptModelIdentity:
         mock_settings = Mock()
         mock_settings.model_name = "gemini-3-pro"
         mock_settings.model_provider = "google"
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
 
         with patch("deepagents_cli.agent.settings", mock_settings):
@@ -412,6 +468,7 @@ class TestGetSystemPromptModelIdentity:
         mock_settings = Mock()
         mock_settings.model_name = "test-model"
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
 
         with patch("deepagents_cli.agent.settings", mock_settings):
@@ -421,6 +478,47 @@ class TestGetSystemPromptModelIdentity:
         assert "You are running as model `test-model`." in prompt
         assert "(provider:" not in prompt
         assert "context window" not in prompt
+
+    def test_includes_unsupported_modalities_warning(self) -> None:
+        """Test that unsupported modalities are surfaced in the prompt."""
+        mock_settings = Mock()
+        mock_settings.model_name = "deepseek-r1"
+        mock_settings.model_provider = "deepseek"
+        mock_settings.model_unsupported_modalities = frozenset(
+            {"image", "audio", "video", "pdf"}
+        )
+        mock_settings.model_context_limit = 64000
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent")
+
+        assert "Audio, image, pdf, and video input may not be available" in prompt
+
+    def test_single_unsupported_modality(self) -> None:
+        """Test warning with a single unsupported modality."""
+        mock_settings = Mock()
+        mock_settings.model_name = "test-model"
+        mock_settings.model_provider = "test"
+        mock_settings.model_unsupported_modalities = frozenset({"audio"})
+        mock_settings.model_context_limit = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent")
+
+        assert "Audio input may not be available" in prompt
+
+    def test_no_modality_warning_when_all_supported(self) -> None:
+        """Test that no modality warning appears when all modalities supported."""
+        mock_settings = Mock()
+        mock_settings.model_name = "claude-opus-4-6"
+        mock_settings.model_provider = "anthropic"
+        mock_settings.model_unsupported_modalities = frozenset()
+        mock_settings.model_context_limit = 200000
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent")
+
+        assert "may not be available" not in prompt
 
 
 class TestGetSystemPromptNonInteractive:
@@ -597,6 +695,7 @@ class TestCreateCliAgentInteractiveForwarding:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -649,6 +748,7 @@ class TestCreateCliAgentInteractiveForwarding:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -905,6 +1005,7 @@ class TestCreateCliAgentSkillsSources:
         # Needed by get_system_prompt() which formats model identity
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -980,6 +1081,7 @@ class TestCreateCliAgentMemorySources:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = tmp_path
 
@@ -1046,6 +1148,7 @@ class TestCreateCliAgentMemorySources:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -1132,6 +1235,7 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.user_langchain_project = None
@@ -1209,6 +1313,7 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.user_langchain_project = None
@@ -1274,6 +1379,7 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.user_langchain_project = None
@@ -1329,6 +1435,7 @@ class TestCreateCliAgentProjectContext:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -1385,6 +1492,7 @@ class TestMiddlewareStackConformance:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -1450,6 +1558,7 @@ class TestEnableAskUser:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
 
@@ -1818,6 +1927,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
         mock_settings.get_project_agents_dir.return_value = None
         mock_settings.model_name = None
         mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
         mock_settings.model_context_limit = None
         mock_settings.project_root = None
         mock_settings.shell_allow_list = ["ls", "cat"]

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -503,6 +503,102 @@ class TestCreateModelProfileExtraction:
         result = create_model("anthropic:claude-sonnet-4-5")
         assert result.context_limit is None
 
+    @patch("langchain.chat_models.init_chat_model")
+    def test_extracts_unsupported_modalities(self, mock_init_chat_model: Mock) -> None:
+        """Test that explicitly False modality flags are extracted."""
+        mock_model = Mock()
+        mock_model.profile = {
+            "max_input_tokens": 64000,
+            "tool_calling": True,
+            "image_inputs": False,
+            "audio_inputs": False,
+            "video_inputs": False,
+            "pdf_inputs": False,
+        }
+        mock_init_chat_model.return_value = mock_model
+
+        result = create_model("deepseek:deepseek-r1")
+        assert result.unsupported_modalities == frozenset(
+            {"image", "audio", "video", "pdf"}
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_supported_modalities_not_flagged(self, mock_init_chat_model: Mock) -> None:
+        """Test that True modality flags produce empty unsupported set."""
+        mock_model = Mock()
+        mock_model.profile = {
+            "max_input_tokens": 200000,
+            "tool_calling": True,
+            "image_inputs": True,
+            "audio_inputs": True,
+            "video_inputs": True,
+            "pdf_inputs": True,
+        }
+        mock_init_chat_model.return_value = mock_model
+
+        result = create_model("anthropic:claude-sonnet-4-5")
+        assert result.unsupported_modalities == frozenset()
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_missing_modality_keys_not_flagged(
+        self, mock_init_chat_model: Mock
+    ) -> None:
+        """Test that absent modality keys are not treated as unsupported."""
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        result = create_model("openai:gpt-4o")
+        assert result.unsupported_modalities == frozenset()
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_mixed_modality_flags(self, mock_init_chat_model: Mock) -> None:
+        """Test partial modality support extraction."""
+        mock_model = Mock()
+        mock_model.profile = {
+            "tool_calling": True,
+            "image_inputs": True,
+            "audio_inputs": False,
+            "video_inputs": True,
+            "pdf_inputs": False,
+        }
+        mock_init_chat_model.return_value = mock_model
+
+        result = create_model("anthropic:claude-sonnet-4-5")
+        assert result.unsupported_modalities == frozenset({"audio", "pdf"})
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_no_profile_leaves_modalities_empty(
+        self, mock_init_chat_model: Mock
+    ) -> None:
+        """Test that missing profile produces empty unsupported set."""
+        mock_model = Mock(spec=["invoke"])
+        mock_init_chat_model.return_value = mock_model
+
+        result = create_model("anthropic:claude-sonnet-4-5")
+        assert result.unsupported_modalities == frozenset()
+
+
+class TestModelResultApplyToSettings:
+    """Tests for ModelResult.apply_to_settings propagation."""
+
+    def test_propagates_unsupported_modalities(self) -> None:
+        """Test that apply_to_settings writes unsupported_modalities to settings."""
+        model_result = ModelResult(
+            model=Mock(),
+            model_name="deepseek-r1",
+            provider="deepseek",
+            context_limit=64000,
+            unsupported_modalities=frozenset({"image", "audio"}),
+        )
+        original = settings.model_unsupported_modalities
+        try:
+            model_result.apply_to_settings()
+            expected = frozenset({"image", "audio"})
+            assert settings.model_unsupported_modalities == expected
+        finally:
+            settings.model_unsupported_modalities = original
+
 
 class TestCreateModelProfileOverrides:
     """Tests for profile overrides from config.toml in create_model."""

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -56,6 +56,7 @@ def _make_model_result(
     model_name: str = "",
     provider: str = "",
     context_limit: int | None = None,
+    unsupported_modalities: frozenset[str] = frozenset(),
 ) -> SimpleNamespace:
     """Create a mock ModelResult with model metadata."""
     return SimpleNamespace(
@@ -63,6 +64,7 @@ def _make_model_result(
         model_name=model_name or model.model_name,
         provider=provider,
         context_limit=context_limit,
+        unsupported_modalities=unsupported_modalities,
     )
 
 
@@ -569,3 +571,39 @@ class TestModelIdentityPatch:
 
     def test_identity_no_model_name(self) -> None:
         assert build_model_identity_section(None) == ""
+
+    def test_modality_line_replaced_on_swap(self) -> None:
+        """Swapping replaces old modality warning with the new model's."""
+        prompt_with_modality = (
+            "Preamble.\n\n### Model Identity\n\n"
+            "You are running as model `deepseek-r1` (provider: deepseek).\n"
+            "Your context window is 64,000 tokens.\n"
+            "Audio, image, pdf, video input may not be available for this model.\n\n"
+            "### Skills Directory\n\nSkills here.\n"
+        )
+        override = _make_model("claude-sonnet-4-6")
+        result = _make_model_result(
+            override,
+            model_name="claude-sonnet-4-6",
+            provider="anthropic",
+            context_limit=200_000,
+            unsupported_modalities=frozenset(),
+        )
+        request = _make_request(
+            _make_model("deepseek-r1"),
+            context=CLIContext(model="anthropic:claude-sonnet-4-6"),
+            system_prompt=prompt_with_modality,
+        )
+        captured: list[ModelRequest] = []
+        with patch(_PATCH_CREATE, return_value=result):
+            _mw.wrap_model_call(
+                request, lambda r: (captured.append(r), _make_response())[1]
+            )
+
+        patched = captured[0].system_prompt
+        assert patched is not None
+        assert "`claude-sonnet-4-6`" in patched
+        assert "200,000 tokens" in patched
+        assert "may not be available" not in patched
+        assert "`deepseek-r1`" not in patched
+        assert "### Skills Directory" in patched

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -21,16 +21,25 @@ def _make_remote_agent() -> RemoteAgent:
 class _FakeModelResult:
     """Minimal model result for `_switch_model` tests."""
 
-    def __init__(self, *, model_name: str, provider: str, context_limit: int) -> None:
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        provider: str,
+        context_limit: int,
+        unsupported_modalities: frozenset[str] = frozenset(),
+    ) -> None:
         self.model_name = model_name
         self.provider = provider
         self.context_limit = context_limit
+        self.unsupported_modalities = unsupported_modalities
 
     def apply_to_settings(self) -> None:
         """Mirror `ModelResult.apply_to_settings()` for test isolation."""
         settings.model_name = self.model_name
         settings.model_provider = self.provider
         settings.model_context_limit = self.context_limit
+        settings.model_unsupported_modalities = self.unsupported_modalities
 
 
 @pytest.fixture(autouse=True)
@@ -39,10 +48,12 @@ def _restore_settings() -> Iterator[None]:
     original_name = settings.model_name
     original_provider = settings.model_provider
     original_context_limit = settings.model_context_limit
+    original_modalities = settings.model_unsupported_modalities
     yield
     settings.model_name = original_name
     settings.model_provider = original_provider
     settings.model_context_limit = original_context_limit
+    settings.model_unsupported_modalities = original_modalities
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Surface input modality limitations in the system prompt so the agent knows when the underlying model can't handle image, audio, video, or PDF content. Similar to how we already inject context window size, this reads `image_inputs`, `audio_inputs`, `video_inputs`, and `pdf_inputs` from the LangChain model profile and renders a warning in the `### Model Identity` section when any are explicitly `False`.