### PR TITLE
chore(cli): pass `--benchmark-disable` instead of suppressing warning

### DIFF
--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -18,7 +18,7 @@ PYTEST_EXTRA ?=
 
 test: ## Run unit tests
 test tests:
-	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(PYTEST_EXTRA) $(TEST_FILE) \
+	uv run --group test pytest -n auto --benchmark-disable --disable-socket --allow-unix-socket $(PYTEST_EXTRA) $(TEST_FILE) \
 		$(COV_ARGS)
 
 coverage: ## Run unit tests with coverage
@@ -30,7 +30,7 @@ coverage: ## Run unit tests with coverage
 
 integration_test: ## Run integration tests
 integration_test integration_tests:
-	uv run --group test pytest -n auto -vvv --timeout 30 $(TEST_FILE)
+	uv run --group test pytest -n auto --benchmark-disable -vvv --timeout 30 $(TEST_FILE)
 
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -266,13 +266,5 @@ timeout = 30  # Default timeout for all tests (can be overridden per-test)
 
 addopts = "--strict-markers --strict-config --durations=5"
 markers = ["benchmark: marks tests as benchmarks (select with '-m benchmark')"]
-# pytest-benchmark warns once per xdist worker that benchmarks are disabled
-# under parallel execution. Both plugins are needed: xdist for `make test`,
-# benchmark for `make benchmark`. Suppress the noise here.
-# Use a message-match filter so the import of pytest_benchmark isn't required
-# when the plugin is not installed.
-filterwarnings = [
-    "ignore:.*pytest.benchmark.*:pytest.PytestConfigWarning",
-]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
Pass `--benchmark-disable` explicitly to pytest in the Makefile instead of suppressing the `PytestConfigWarning` that `pytest-benchmark` emits under `xdist`. The warning filter was a workaround for noise in parallel test runs — this is cleaner since it tells pytest-benchmark to skip benchmarks upfront rather than silencing the complaint after the fact.