### PR TITLE
chore(sdk): disable benchmark when not running benchmarks

### DIFF
--- a/libs/deepagents/Makefile
+++ b/libs/deepagents/Makefile
@@ -19,7 +19,8 @@ test: ## Run unit tests
 test tests:
 	uv run --group test pytest -n auto -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE) \
 		--cov=deepagents \
-		--cov-report=term-missing
+		--cov-report=term-missing \
+		--benchmark-disable
 
 update-snapshots: ## Update smoke test snapshots
 	# update snapshots for smoke tests


### PR DESCRIPTION
cleans up warnings generated when running unit tests with xdist