### PR TITLE
feat(cli): render ask-user questions as markdown

### DIFF
--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -252,6 +252,11 @@ ToolCallMessage.-ascii:hover {
     padding-left: 2;
 }
 
+.ask-user-menu .ask-user-question-text {
+    margin: 0 0 0 2;
+    padding: 0;
+}
+
 .ask-user-menu .ask-user-choice {
     height: 1;
     padding: 0 1;

--- a/libs/cli/deepagents_cli/widgets/ask_user.py
+++ b/libs/cli/deepagents_cli/widgets/ask_user.py
@@ -9,7 +9,7 @@ from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical
 from textual.content import Content
 from textual.message import Message
-from textual.widgets import Input, Static
+from textual.widgets import Input, Markdown, Static
 
 if TYPE_CHECKING:
     import asyncio
@@ -272,11 +272,11 @@ class _QuestionWidget(Vertical):
 
     def compose(self) -> ComposeResult:
         q_text = self._question.get("question", "")
-        if self._required:
-            markup = "[bold]$num. $text[/bold] [dim](required)[/dim]"
-        else:
-            markup = "[bold]$num. $text[/bold]"
-        yield Static(Content.from_markup(markup, num=self._index + 1, text=q_text))
+        num = self._index + 1
+        suffix = " *(required)*" if self._required else ""
+        # q_text is agent-authored; rendered as markdown intentionally so
+        # agents can use inline formatting, links, and code spans in questions.
+        yield Markdown(f"**{num}.** {q_text}{suffix}", classes="ask-user-question-text")
 
         if self._q_type == "multiple_choice" and self._choices:
             for i, choice in enumerate(self._choices):

--- a/libs/cli/tests/unit_tests/test_ask_user.py
+++ b/libs/cli/tests/unit_tests/test_ask_user.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
-from textual.widgets import Input, Static
+from textual.widgets import Input, Markdown, Static
 
 from deepagents_cli.tool_display import format_tool_display
 from deepagents_cli.widgets.ask_user import AskUserMenu, _QuestionWidget
@@ -420,8 +420,8 @@ class TestAskUserMenu:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             qw = menu._question_widgets[0]
-            rendered = str(qw.query_one(Static).render())
-            assert "required" in rendered
+            md = qw.query_one(Markdown)
+            assert "required" in md.source
 
     async def test_required_label_hidden_for_optional_question(self) -> None:
         """Optional questions do not display a (required) indicator."""
@@ -433,8 +433,8 @@ class TestAskUserMenu:
             await pilot.pause()
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             qw = menu._question_widgets[0]
-            rendered = str(qw.query_one(Static).render())
-            assert "required" not in rendered
+            md = qw.query_one(Markdown)
+            assert "required" not in md.source
 
     async def test_required_is_true_by_default(self) -> None:
         """Questions without explicit required field default to required."""
@@ -445,8 +445,8 @@ class TestAskUserMenu:
             menu = app.query_one("#ask-user-menu", AskUserMenu)
             qw = menu._question_widgets[0]
             assert qw._required is True
-            rendered = str(qw.query_one(Static).render())
-            assert "required" in rendered
+            md = qw.query_one(Markdown)
+            assert "required" in md.source
 
     async def test_optional_question_submits_with_empty_answer(self) -> None:
         """Non-required questions can be submitted with empty answers."""


### PR DESCRIPTION
Switch ask-user question rendering from `Static` with `Content.from_markup` to Textual's `Markdown` widget. Agent-authored questions can now use inline formatting, links, code spans, and other markdown syntax instead of rendering as plain text.

<img width="809" height="612" alt="Screenshot 1" src="https://github.com/user-attachments/assets/0c0beeb7-4080-40ea-b6b7-2438cbdd5d16" />
