### PR TITLE
style(cli): defer mode glyph and popup updates atomically, update input bg

### DIFF
--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -270,6 +270,19 @@ ToolCallMessage.-ascii:hover {
     margin: 1 1 0 1;
 }
 
+/* ChatTextArea: override TextArea's built-in $surface background */
+ChatTextArea {
+    background: transparent;
+
+    & .text-area--cursor-line {
+        background: transparent;
+    }
+
+    & .text-area--cursor-gutter {
+        background: transparent;
+    }
+}
+
 /* Completion popup styling (used by ChatInput) - appears BELOW input */
 #completion-popup {
     height: auto;
@@ -278,6 +291,5 @@ ToolCallMessage.-ascii:hover {
     margin-left: 3;
     margin-top: 0;
     padding: 0;
-    background: $background;
     color: $text;
 }

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -23,7 +23,6 @@ from deepagents_cli.config import (
     MODE_DISPLAY_GLYPHS,
     MODE_PREFIXES,
     PREFIX_TO_MODE,
-    get_glyphs,
     is_ascii_mode,
 )
 from deepagents_cli.input import IMAGE_PLACEHOLDER_PATTERN, VIDEO_PLACEHOLDER_PATTERN
@@ -136,19 +135,15 @@ class CompletionOption(Static):
 
     def _update_display(self) -> None:
         """Update the display text and styling."""
-        glyphs = get_glyphs()
-        cursor = f"{glyphs.cursor} " if self._is_selected else "  "
-
+        display_label = self._label.removeprefix("/")
         if self._description:
             content = Content.from_markup(
-                f"{cursor}[bold]$label[/bold]  [dim]$desc[/dim]",
-                label=self._label,
+                "[bold]$label[/bold]  [dim]$desc[/dim]",
+                label=display_label,
                 desc=self._description,
             )
         else:
-            content = Content.from_markup(
-                f"{cursor}[bold]$label[/bold]", label=self._label
-            )
+            content = Content.from_markup("[bold]$label[/bold]", label=display_label)
 
         self.update(content)
 
@@ -1055,7 +1050,12 @@ class ChatInput(Vertical):
                 if self.mode != detected:
                     self.mode = detected
                 self._strip_mode_prefix()
-                return
+                # Fall through to update completion suggestions in the same
+                # refresh cycle as the mode/glyph change rather than waiting
+                # for the next text-change event caused by the prefix strip.
+                # Note: the strip's text-change event will also call
+                # on_text_changed (idempotently) since _stripping_prefix only
+                # skips mode detection, not the completion block below.
         # Update completion suggestions using completion-space text/cursor.
         if self._completion_manager and self._text_area:
             if is_path_payload:
@@ -1573,7 +1573,13 @@ class ChatInput(Vertical):
             and self.mode != "normal"
             and self._get_cursor_offset() == 0
         ):
-            self._completion_manager.reset()
+            # Defer the popup reset so it coalesces with the glyph update
+            # that watch_mode schedules via call_after_refresh.
+            def _deferred_reset() -> None:
+                if self._completion_manager is not None:
+                    self._completion_manager.reset()
+
+            self.call_after_refresh(_deferred_reset)
             self.mode = "normal"
             event.prevent_default()
             event.stop()
@@ -1621,25 +1627,31 @@ class ChatInput(Vertical):
         return offset + min(col, len(lines[row]))
 
     def watch_mode(self, mode: str) -> None:
-        """Post mode changed message and update prompt indicator."""
-        try:
-            prompt = self.query_one("#prompt", Static)
-        except NoMatches:
-            logger.warning("watch_mode: #prompt widget not found")
-            self.post_message(self.ModeChanged(mode))
-            return
-        self.remove_class("mode-shell", "mode-command")
+        """Post mode changed message and update prompt indicator.
+
+        The prompt glyph update is deferred via `call_after_refresh` so that
+        callers which also schedule deferred work (e.g. the completion popup)
+        can coalesce both visual changes into a single refresh.
+        """
         glyph = MODE_DISPLAY_GLYPHS.get(mode)
-        if glyph:
-            prompt.update(glyph)
-            self.add_class(f"mode-{mode}")
-        else:
-            if mode != "normal":
-                logger.warning(
-                    "No display glyph for mode %r; falling back to '>'",
-                    mode,
-                )
-            prompt.update(">")
+        if not glyph and mode != "normal":
+            logger.warning(
+                "No display glyph for mode %r; falling back to '>'",
+                mode,
+            )
+
+        def _apply() -> None:
+            self.remove_class("mode-shell", "mode-command")
+            if glyph:
+                self.add_class(f"mode-{mode}")
+            try:
+                prompt = self.query_one("#prompt", Static)
+            except NoMatches:
+                logger.warning("watch_mode._apply: #prompt widget not found")
+                return
+            prompt.update(glyph or ">")
+
+        self.call_after_refresh(_apply)
         self.post_message(self.ModeChanged(mode))
 
     def focus_input(self) -> None:

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -200,7 +200,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     ModelSelectorScreen .model-detail-footer {
         height: 4;
         padding: 0 2;
-        border-top: solid $primary-lighten-2;
+        margin-top: 1;
     }
     """
 


### PR DESCRIPTION
Fix visual timing between mode glyph and completion popup by deferring both CSS class mutations and prompt updates into `call_after_refresh` callbacks. Previously, `watch_mode` applied CSS classes synchronously but updated the glyph in a deferred callback, creating a one-frame desync. The backspace-exits-mode path had the same category of issue — resetting the completion popup synchronously while the glyph change was deferred.

Remove selection arrow and leading slashes for slash command selector.

Remove `ChatTextArea` background.

Remove top border in model switcher's metadata section.


<details>
<summary>chat input - before</summary>

<img width="233" height="282" alt="Screenshot 14" src="https://github.com/user-attachments/assets/134b76cf-82e3-4fff-9cd7-e387505ce956" />

</details>

<details>
<summary>chat input - after</summary>

<img width="363" height="278" alt="Screenshot 10" src="https://github.com/user-attachments/assets/6883afb5-13ac-459d-aa2b-6f26595829f4" />

</details>

<details>
<summary>model switcher - before</summary>

<img width="728" height="166" alt="Screenshot 15" src="https://github.com/user-attachments/assets/a3b5e0ea-5274-435a-a808-43eff14ff113" />

</details>

<details>
<summary>model switcher - after</summary>

<img width="687" height="181" alt="Screenshot 13" src="https://github.com/user-attachments/assets/16ca34f6-ca08-4ad6-9c44-954550f93959" />

</details>