### PR TITLE
fix(cli): mark token count as approximate after interrupted generation

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -656,6 +656,9 @@ class DeepAgentsApp(App):
         copy for the status bar.
         """
 
+        self._tokens_approximate: bool = False
+        """Whether the cached token count is stale (interrupted generation)."""
+
         self._last_typed_at: float | None = None
         """Typing-aware approval deferral state."""
 
@@ -1624,7 +1627,7 @@ class DeepAgentsApp(App):
         if self._status_bar:
             self._status_bar.set_status_message(message)
 
-    def _update_tokens(self, count: int) -> None:
+    def _update_tokens(self, count: int, *, approximate: bool = False) -> None:
         """Update the token count in the status bar.
 
         Low-level helper — only touches the UI.  Callers that also need to
@@ -1632,24 +1635,38 @@ class DeepAgentsApp(App):
 
         Args:
             count: Total context token count.
+            approximate: Append "+" to signal a stale/interrupted count.
         """
         if self._status_bar:
-            self._status_bar.set_tokens(count)
+            self._status_bar.set_tokens(count, approximate=approximate)
 
-    def _on_tokens_update(self, count: int) -> None:
+    def _on_tokens_update(self, count: int, *, approximate: bool = False) -> None:
         """Update the local cache *and* the status bar.
 
         This is the callback wired to the adapter's `_on_tokens_update`.
 
         Args:
             count: Total context token count to cache and display.
+            approximate: Append "+" to signal a stale/interrupted count.
         """
         self._context_tokens = count
-        self._update_tokens(count)
+        self._tokens_approximate = approximate
+        self._update_tokens(count, approximate=approximate)
 
-    def _show_tokens(self) -> None:
-        """Restore the status bar to the cached token value."""
-        self._update_tokens(self._context_tokens)
+    def _show_tokens(self, *, approximate: bool = False) -> None:
+        """Restore the status bar to the cached token value.
+
+        Args:
+            approximate: Append "+" to signal a stale/interrupted count.
+
+                This flag is sticky until `_on_tokens_update` receives a fresh
+                count from the model.
+        """
+        self._tokens_approximate = self._tokens_approximate or approximate
+        self._update_tokens(
+            self._context_tokens,
+            approximate=self._tokens_approximate,
+        )
 
     def _hide_tokens(self) -> None:
         """Hide the token display during streaming."""
@@ -2642,6 +2659,7 @@ class DeepAgentsApp(App):
             self._queued_widgets.clear()
             await self._clear_messages()
             self._context_tokens = 0
+            self._tokens_approximate = False
             self._update_tokens(0)
             # Clear status message (e.g., "Interrupted" from previous session)
             self._update_status("")
@@ -3341,8 +3359,9 @@ class DeepAgentsApp(App):
         if self._chat_input:
             self._chat_input.set_cursor_active(active=True)
 
-        # Ensure token display is restored (in case of early cancellation)
-        self._show_tokens()
+        # Ensure token display is restored (in case of early cancellation).
+        # Pass the cached approximate flag so an interrupted "+" isn't clobbered.
+        self._show_tokens(approximate=self._tokens_approximate)
 
         try:
             await self._maybe_drain_deferred()
@@ -4622,6 +4641,7 @@ class DeepAgentsApp(App):
             self._queued_widgets.clear()
             await self._clear_messages()
             self._context_tokens = 0
+            self._tokens_approximate = False
             self._update_tokens(0)
             self._update_status("")
 

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import time
@@ -14,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from pathlib import Path
+    from typing import Protocol
 
     from langchain.agents.middleware.human_in_the_loop import (
         ApproveDecision,
@@ -31,6 +31,17 @@ if TYPE_CHECKING:
 
     # Type alias matching HITLResponse["decisions"] element type
     HITLDecision = ApproveDecision | EditDecision | RejectDecision
+
+    class _TokensUpdateCallback(Protocol):
+        """Callback signature for `_on_tokens_update`."""
+
+        def __call__(self, count: int, *, approximate: bool = False) -> None: ...
+
+    class _TokensShowCallback(Protocol):
+        """Callback signature for `_on_tokens_show`."""
+
+        def __call__(self, *, approximate: bool = False) -> None: ...
+
 
 from deepagents_cli._ask_user_types import AskUserRequest
 from deepagents_cli._cli_context import CLIContext  # noqa: TC001
@@ -253,13 +264,13 @@ class TextualUIAdapter:
         """Map of tool call IDs to their message widgets."""
 
         # Token display callbacks (set by the app after construction)
-        self._on_tokens_update: Callable[[int], None] | None = None
+        self._on_tokens_update: _TokensUpdateCallback | None = None
         """Called with total context tokens after each LLM response."""
 
         self._on_tokens_hide: Callable[[], None] | None = None
         """Called to hide the token display during streaming."""
 
-        self._on_tokens_show: Callable[[], None] | None = None
+        self._on_tokens_show: _TokensShowCallback | None = None
         """Called to restore the token display with the cached value."""
 
     def finalize_pending_tools_with_error(self, error: str) -> None:
@@ -1146,101 +1157,16 @@ async def execute_task_textual(
                 await dispatch_hook("task.complete", {"thread_id": thread_id})
                 break
 
-    except asyncio.CancelledError:
-        # Clear active message immediately so it won't block pruning
-        # If we don't do this, the store still thinks it's actice and protects
-        # from pruning, which breaks get_messages_to_prune(), potentially
-        # blocking all future pruning
-        if adapter._set_active_message:
-            adapter._set_active_message(None)
-
-        # Hide spinner (may still show "Offloading" if interrupted mid-offload)
-        if adapter._set_spinner:
-            await adapter._set_spinner(None)
-
-        await adapter._mount_message(AppMessage("Interrupted by user"))
-
-        # Save accumulated state before marking tools as rejected (best-effort)
-        # State update failures shouldn't prevent cleanup
-        try:
-            interrupted_msg = _build_interrupted_ai_message(
-                pending_text_by_namespace,
-                adapter._current_tool_messages,
-            )
-            if interrupted_msg:
-                await agent.aupdate_state(config, {"messages": [interrupted_msg]})
-
-            cancellation_msg = HumanMessage(
-                content="[SYSTEM] Task interrupted by user. "
-                "Previous operation was cancelled."
-            )
-            await agent.aupdate_state(config, {"messages": [cancellation_msg]})
-        except Exception:
-            logger.debug("Failed to save interrupted state", exc_info=True)
-
-        # Mark tools as rejected AFTER saving state
-        for tool_msg in list(adapter._current_tool_messages.values()):
-            tool_msg.set_rejected()
-        adapter._current_tool_messages.clear()
-
-        # Report tokens even on interrupt (or restore display if none captured)
-        turn_stats.wall_time_seconds = time.monotonic() - start_time
-        await _report_and_persist_tokens(
-            adapter,
-            agent,
-            config,
-            captured_input_tokens,
-            captured_output_tokens,
-            shield=True,
-        )
-        return turn_stats
-
-    except KeyboardInterrupt:
-        # Clear active message immediately so it won't block pruning
-        # If we don't do this, the store still thinks it's actice and protects
-        # from pruning, which breaks get_messages_to_prune(), potentially
-        # blocking all future pruning
-        if adapter._set_active_message:
-            adapter._set_active_message(None)
-
-        # Hide spinner (may still show "Offloading" if interrupted mid-offload)
-        if adapter._set_spinner:
-            await adapter._set_spinner(None)
-
-        await adapter._mount_message(AppMessage("Interrupted by user"))
-
-        # Save accumulated state before marking tools as rejected (best-effort)
-        # State update failures shouldn't prevent cleanup
-        try:
-            interrupted_msg = _build_interrupted_ai_message(
-                pending_text_by_namespace,
-                adapter._current_tool_messages,
-            )
-            if interrupted_msg:
-                await agent.aupdate_state(config, {"messages": [interrupted_msg]})
-
-            cancellation_msg = HumanMessage(
-                content="[SYSTEM] Task interrupted by user. "
-                "Previous operation was cancelled."
-            )
-            await agent.aupdate_state(config, {"messages": [cancellation_msg]})
-        except Exception:
-            logger.debug("Failed to save interrupted state", exc_info=True)
-
-        # Mark tools as rejected AFTER saving state
-        for tool_msg in list(adapter._current_tool_messages.values()):
-            tool_msg.set_rejected()
-        adapter._current_tool_messages.clear()
-
-        # Report tokens even on interrupt (or restore display if none captured)
-        turn_stats.wall_time_seconds = time.monotonic() - start_time
-        await _report_and_persist_tokens(
-            adapter,
-            agent,
-            config,
-            captured_input_tokens,
-            captured_output_tokens,
-            shield=True,
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        await _handle_interrupt_cleanup(
+            adapter=adapter,
+            agent=agent,
+            config=config,
+            pending_text_by_namespace=pending_text_by_namespace,
+            captured_input_tokens=captured_input_tokens,
+            captured_output_tokens=captured_output_tokens,
+            turn_stats=turn_stats,
+            start_time=start_time,
         )
         return turn_stats
 
@@ -1254,6 +1180,84 @@ async def execute_task_textual(
         captured_output_tokens,
     )
     return turn_stats
+
+
+async def _handle_interrupt_cleanup(
+    *,
+    adapter: TextualUIAdapter,
+    agent: Any,  # noqa: ANN401  # Dynamic agent graph type
+    config: RunnableConfig,
+    pending_text_by_namespace: dict[tuple, str],
+    captured_input_tokens: int,
+    captured_output_tokens: int,
+    turn_stats: SessionStats,
+    start_time: float,
+) -> None:
+    """Shared cleanup for CancelledError and KeyboardInterrupt.
+
+    Args:
+        adapter: UI adapter with display callbacks.
+        agent: The LangGraph agent.
+        config: Runnable config with `thread_id`.
+        pending_text_by_namespace: Accumulated text per namespace.
+        captured_input_tokens: Input tokens captured before interrupt.
+        captured_output_tokens: Output tokens captured before interrupt.
+        turn_stats: Stats for the current turn.
+        start_time: Monotonic timestamp when the turn began.
+    """
+    from langchain_core.messages import HumanMessage
+
+    # Clear active message immediately so it won't block pruning.
+    # If we don't do this, the store still thinks it's active and protects
+    # from pruning, which breaks get_messages_to_prune(), potentially
+    # blocking all future pruning.
+    if adapter._set_active_message:
+        adapter._set_active_message(None)
+
+    # Hide spinner (may still show "Offloading" if interrupted mid-offload)
+    if adapter._set_spinner:
+        await adapter._set_spinner(None)
+
+    await adapter._mount_message(AppMessage("Interrupted by user"))
+
+    interrupted_msg = _build_interrupted_ai_message(
+        pending_text_by_namespace,
+        adapter._current_tool_messages,
+    )
+
+    # Save accumulated state before marking tools as rejected (best-effort).
+    # State update failures shouldn't prevent cleanup.
+    try:
+        if interrupted_msg:
+            await agent.aupdate_state(config, {"messages": [interrupted_msg]})
+
+        cancellation_msg = HumanMessage(
+            content="[SYSTEM] Task interrupted by user. "
+            "Previous operation was cancelled."
+        )
+        await agent.aupdate_state(config, {"messages": [cancellation_msg]})
+    except Exception:
+        logger.warning("Failed to save interrupted state", exc_info=True)
+
+    # Mark tools as rejected AFTER saving state
+    for tool_msg in list(adapter._current_tool_messages.values()):
+        tool_msg.set_rejected()
+    adapter._current_tool_messages.clear()
+
+    # Keep the token count marked stale whenever interrupted state was captured,
+    # including tool-only turns after assistant text was already flushed.
+    approximate = interrupted_msg is not None
+
+    turn_stats.wall_time_seconds = time.monotonic() - start_time
+    await _report_and_persist_tokens(
+        adapter,
+        agent,
+        config,
+        captured_input_tokens,
+        captured_output_tokens,
+        shield=True,
+        approximate=approximate,
+    )
 
 
 async def _persist_context_tokens(
@@ -1286,6 +1290,7 @@ async def _report_and_persist_tokens(
     captured_output_tokens: int,
     *,
     shield: bool = False,
+    approximate: bool = False,
 ) -> None:
     """Update the token display and best-effort persist to graph state.
 
@@ -1295,20 +1300,26 @@ async def _report_and_persist_tokens(
         config: Runnable config with `thread_id` in its configurable dict.
         captured_input_tokens: Total input tokens captured during the turn.
         captured_output_tokens: Total output tokens captured during the turn.
-        shield: When `True`, suppress all exceptions (including `BaseException`)
-            from the persist call so that cancellation handlers can safely await
-            this without re-raising.
+        shield: When `True`, suppress exceptions and `CancelledError` from the
+            persist call so that interrupt handlers can safely await this.
+        approximate: When `True`, signal to the UI that the count is stale
+            (e.g. after an interrupted generation) by appending "+".
     """
     if captured_input_tokens or captured_output_tokens:
         if adapter._on_tokens_update:
-            adapter._on_tokens_update(captured_input_tokens)
+            adapter._on_tokens_update(captured_input_tokens, approximate=approximate)
         if shield:
-            with contextlib.suppress(BaseException):
+            try:
                 await _persist_context_tokens(agent, config, captured_input_tokens)
+            except (Exception, asyncio.CancelledError):
+                logger.debug(
+                    "Token persist suppressed during interrupt cleanup",
+                    exc_info=True,
+                )
         else:
             await _persist_context_tokens(agent, config, captured_input_tokens)
     elif adapter._on_tokens_show:
-        adapter._on_tokens_show()
+        adapter._on_tokens_show(approximate=approximate)
 
 
 async def _flush_assistant_text_ns(

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -332,33 +332,66 @@ class StatusBar(Horizontal):
         """
         self.status_message = message
 
+    _approximate: bool = False
+    """Append "+" to the token count to signal that the displayed value is stale.
+
+    (The actual context is larger because the generation was interrupted before
+    the model reported final usage.)
+    """
+
     def watch_tokens(self, new_value: int) -> None:
         """Update token display when count changes."""
+        self._render_tokens(new_value, approximate=self._approximate)
+
+    def _render_tokens(self, count: int, *, approximate: bool = False) -> None:
+        """Render the token count into the display widget.
+
+        Args:
+            count: Total context token count.
+            approximate: Append "+" suffix to indicate the count is stale
+                (e.g. after an interrupted generation).
+        """
         try:
             display = self.query_one("#tokens-display", Static)
         except NoMatches:
             return
 
-        if new_value > 0:
+        if count > 0:
+            suffix = "+" if approximate else ""
             # Format with K suffix for thousands
-            if new_value >= 1000:  # noqa: PLR2004  # Count formatting threshold
-                display.update(f"{new_value / 1000:.1f}K tokens")
+            if count >= 1000:  # noqa: PLR2004  # Count formatting threshold
+                display.update(f"{count / 1000:.1f}K{suffix} tokens")
             else:
-                display.update(f"{new_value} tokens")
+                display.update(f"{count}{suffix} tokens")
         else:
             display.update("")
 
-    def set_tokens(self, count: int) -> None:
+    def set_tokens(self, count: int, *, approximate: bool = False) -> None:
         """Set the token count.
 
+        Forces a display refresh even when the value is unchanged, because
+        `hide_tokens` clears the widget text without updating the reactive
+        attribute.
+
         Args:
-            count: Current context token count
+            count: Current context token count.
+            approximate: Append "+" to indicate the count is stale.
         """
-        self.tokens = count
+        self._approximate = approximate
+        if self.tokens == count:
+            # Reactive dedup would skip the watcher — call render directly.
+            self._render_tokens(count, approximate=approximate)
+        else:
+            # Reactive assignment triggers watch_tokens, which reads
+            # self._approximate for the suffix.
+            self.tokens = count
 
     def hide_tokens(self) -> None:
         """Hide the token display (e.g., during streaming)."""
-        self.query_one("#tokens-display", Static).update("")
+        try:
+            self.query_one("#tokens-display", Static).update("")
+        except NoMatches:
+            return
 
     def set_model(self, *, provider: str, model: str) -> None:
         """Update the model display text.

--- a/libs/cli/tests/unit_tests/test_status.py
+++ b/libs/cli/tests/unit_tests/test_status.py
@@ -131,3 +131,80 @@ class TestResizePriority:
             model.model = "claude-sonnet-4-5"
             await pilot.pause()
             assert model.display is True
+
+
+class TestTokenDisplay:
+    """Tests for the token count display in the status bar."""
+
+    async def test_set_tokens_updates_display(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert "5.0K" in str(display.render())
+
+    async def test_hide_tokens_clears_display(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5000)
+            await pilot.pause()
+            bar.hide_tokens()
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == ""
+
+    async def test_set_tokens_after_hide_restores_display(self) -> None:
+        """Regression: set_tokens must refresh even when value is unchanged.
+
+        hide_tokens clears the widget text without updating the reactive,
+        so a subsequent set_tokens with the same value must still re-render.
+        """
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5000)
+            await pilot.pause()
+            bar.hide_tokens()
+            await pilot.pause()
+            # Same value — previously skipped by reactive dedup
+            bar.set_tokens(5000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert "5.0K" in str(display.render())
+
+    async def test_approximate_appends_plus(self) -> None:
+        """approximate=True should append '+' to the token count."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5000, approximate=True)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            rendered = str(display.render())
+            assert "5.0K+" in rendered
+
+    async def test_approximate_after_hide_restores_with_plus(self) -> None:
+        """Interrupted restore: same value + approximate should show count with '+'."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5000)
+            await pilot.pause()
+            bar.hide_tokens()
+            await pilot.pause()
+            bar.set_tokens(5000, approximate=True)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            rendered = str(display.render())
+            assert "5.0K+" in rendered
+
+    async def test_exact_count_clears_plus(self) -> None:
+        """A non-approximate set_tokens after an approximate one should drop '+'."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5000, approximate=True)
+            await pilot.pause()
+            bar.set_tokens(8000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            rendered = str(display.render())
+            assert "8.0K" in rendered
+            assert "+" not in rendered

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -8,7 +8,7 @@ from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -23,6 +23,7 @@ from deepagents_cli.textual_adapter import (
     SessionStats,
     TextualUIAdapter,
     _build_interrupted_ai_message,
+    _handle_interrupt_cleanup,
     _is_summarization_chunk,
     execute_task_textual,
     format_token_count,
@@ -99,13 +100,13 @@ class TestTextualUIAdapterInit:
             request_approval=_mock_approval,
         )
 
-        def update_cb(count: int) -> None:
+        def update_cb(count: int, *, approximate: bool = False) -> None:
             pass
 
         def hide_cb() -> None:
             pass
 
-        def show_cb() -> None:
+        def show_cb(*, approximate: bool = False) -> None:
             pass
 
         adapter._on_tokens_update = update_cb
@@ -135,6 +136,69 @@ class TestTextualUIAdapterInit:
         tool_2.set_error.assert_called_once_with("Agent error: boom")
         assert adapter._current_tool_messages == {}
         set_active.assert_called_once_with(None)
+
+
+class TestInterruptCleanup:
+    """Tests for interrupt cleanup token handling."""
+
+    async def test_tool_only_interrupt_marks_tokens_approximate(self) -> None:
+        """Tool-only interrupted turns should keep the stale-token marker."""
+        mounted: list[object] = []
+
+        async def mount_message(widget: object) -> None:
+            mounted.append(widget)
+            await asyncio.sleep(0)
+
+        set_spinner = AsyncMock()
+        set_active = MagicMock()
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=set_spinner,
+            set_active_message=set_active,
+        )
+
+        tool_widget = MagicMock()
+        tool_widget._tool_name = "read_file"
+        tool_widget._args = {"path": "notes.txt"}
+        adapter._current_tool_messages = {"call-1": tool_widget}
+
+        show_calls: list[bool] = []
+
+        def show_cb(*, approximate: bool = False) -> None:
+            show_calls.append(approximate)
+
+        adapter._on_tokens_show = show_cb
+
+        agent = SimpleNamespace(aupdate_state=AsyncMock())
+        turn_stats = SessionStats()
+        config = {"configurable": {"thread_id": "t-1"}}
+
+        with patch("deepagents_cli.textual_adapter.time.monotonic", return_value=101.0):
+            await _handle_interrupt_cleanup(
+                adapter=adapter,
+                agent=agent,
+                config=config,  # type: ignore[arg-type]
+                pending_text_by_namespace={},
+                captured_input_tokens=0,
+                captured_output_tokens=0,
+                turn_stats=turn_stats,
+                start_time=100.0,
+            )
+
+        assert mounted
+        assert show_calls == [True]
+        assert turn_stats.wall_time_seconds == 1.0
+        set_active.assert_called_once_with(None)
+        set_spinner.assert_awaited_once_with(None)
+        tool_widget.set_rejected.assert_called_once_with()
+        assert adapter._current_tool_messages == {}
+
+        interrupted_payload = agent.aupdate_state.await_args_list[0].args[1]
+        interrupted_msg = interrupted_payload["messages"][0]
+        assert interrupted_msg.tool_calls[0]["id"] == "call-1"
+        assert interrupted_msg.tool_calls[0]["name"] == "read_file"
 
 
 class TestBuildStreamConfig:

--- a/libs/cli/tests/unit_tests/test_token_tracker.py
+++ b/libs/cli/tests/unit_tests/test_token_tracker.py
@@ -1,5 +1,8 @@
 """Tests for token state persistence and display callbacks."""
 
+from types import SimpleNamespace
+
+from deepagents_cli.app import DeepAgentsApp
 from deepagents_cli.token_state import TokenStateMiddleware, TokenTrackingState
 
 
@@ -55,6 +58,24 @@ class TestTokenDisplayCallbacks:
         app._show_tokens()
 
         assert display_calls == [1500]
+
+    def test_show_tokens_preserves_approximate_marker_without_fresh_usage(self):
+        """Turns without usage metadata should not clear a stale-token marker."""
+        display_calls: list[tuple[int, bool]] = []
+
+        def update_tokens(count: int, *, approximate: bool = False) -> None:
+            display_calls.append((count, approximate))
+
+        app = SimpleNamespace(
+            _context_tokens=1500,
+            _tokens_approximate=True,
+            _update_tokens=update_tokens,
+        )
+
+        DeepAgentsApp._show_tokens(app, approximate=False)  # type: ignore[arg-type]
+
+        assert app._tokens_approximate is True
+        assert display_calls == [(1500, True)]
 
     def test_reset_clears_cache(self):
         """Resetting (e.g. /clear) should zero the cache and display."""


### PR DESCRIPTION
When a user interrupts generation mid-stream, the status bar previously showed the last-known token count with no indication that the real context is larger. The displayed value is now marked stale with a trailing "+" (e.g. "12.5K+ tokens") until the next model response reports fresh usage. Also deduplicates the identical `CancelledError`/`KeyboardInterrupt` cleanup handlers into a single shared function.