### PR TITLE
style(cli): hide redundant exit code 0 from tool output

### DIFF
--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -141,6 +141,24 @@ _TOOLS_WITH_HEADER_INFO: set[str] = {
 }
 
 
+_SUCCESS_EXIT_RE = re.compile(r"\n?\[Command succeeded with exit code 0\]\s*$")
+"""Strip the SDK's `[Command succeeded with exit code 0]` trailer from tool output."""
+
+
+def _strip_success_exit_line(text: str) -> str:
+    """Remove the `[Command succeeded with exit code 0]` trailer.
+
+    Non-zero exit codes are left intact (they come through `set_error`).
+
+    Args:
+        text: Raw tool output string.
+
+    Returns:
+        Text with the success exit-code trailer removed, if present.
+    """
+    return _SUCCESS_EXIT_RE.sub("", text)
+
+
 class UserMessage(_TimestampClickMixin, Static):
     """Widget displaying a user message."""
 
@@ -948,7 +966,8 @@ class ToolCallMessage(Vertical):
         """
         self._stop_animation()
         self._status = "success"
-        self._output = result
+        # Strip redundant success trailer — the UI already conveys success
+        self._output = _strip_success_exit_line(result)
         if self._status_widget:
             self._status_widget.remove_class("pending")
             # Hide status on success - output speaks for itself

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -20,6 +20,7 @@ from deepagents_cli.widgets.messages import (
     UserMessage,
     _show_timestamp_toast,
     _strip_frontmatter,
+    _strip_success_exit_line,
 )
 
 # Content that previously caused MarkupError crashes
@@ -757,3 +758,46 @@ class TestSkillMessageMarkupSafety:
         assert msg._expanded is False
         msg._expanded = True
         assert msg._expanded is True
+
+
+class TestStripSuccessExitLine:
+    """Test _strip_success_exit_line helper."""
+
+    def test_strips_success_trailer(self) -> None:
+        text = "hello world\n[Command succeeded with exit code 0]"
+        assert _strip_success_exit_line(text) == "hello world"
+
+    def test_strips_success_trailer_with_trailing_whitespace(self) -> None:
+        text = "output\n[Command succeeded with exit code 0]  \n"
+        assert _strip_success_exit_line(text) == "output"
+
+    def test_preserves_failed_exit_code(self) -> None:
+        text = "error\n[Command failed with exit code 1]"
+        assert _strip_success_exit_line(text) == text
+
+    def test_preserves_non_zero_success_code(self) -> None:
+        """Only exit code 0 is stripped; other codes are untouched."""
+        text = "output\n[Command succeeded with exit code 2]"
+        assert _strip_success_exit_line(text) == text
+
+    def test_empty_string(self) -> None:
+        assert _strip_success_exit_line("") == ""
+
+    def test_no_trailer(self) -> None:
+        text = "just some output"
+        assert _strip_success_exit_line(text) == text
+
+    def test_only_trailer(self) -> None:
+        text = "[Command succeeded with exit code 0]"
+        assert _strip_success_exit_line(text) == ""
+
+    def test_preserves_mid_string_trailer(self) -> None:
+        """Trailer not at end of string should be left intact."""
+        text = "before\n[Command succeeded with exit code 0]\nafter"
+        assert _strip_success_exit_line(text) == text
+
+    def test_set_success_strips_trailer(self) -> None:
+        """Integration: set_success should strip the exit code 0 line."""
+        msg = ToolCallMessage("execute", {"command": "echo hi"})
+        msg.set_success("hi\n[Command succeeded with exit code 0]")
+        assert msg._output == "hi"


### PR DESCRIPTION
The SDK appends `[Command succeeded with exit code 0]` to every successful tool execution result. In the TUI this is visual noise. Strip the trailer in `ToolCallMessage.set_success` so it never renders, while preserving non-zero exit code lines which flow through `set_error` and remain useful for debugging.