### PR TITLE
fix: add utf-8 encoding for file operations to fix Windows GBK error

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -504,7 +504,10 @@ def get_system_prompt(
         ... {CONDITIONAL SECTIONS} ...
         ```
     """
-    template = (Path(__file__).parent / "system_prompt.md").read_text()
+    # The prompt templates in this repo are maintained as UTF-8.
+    # On Windows, leaving encoding unspecified can fall back to a non-UTF-8
+    # default (e.g., gbk), causing UnicodeDecodeError during server startup.
+    template = (Path(__file__).parent / "system_prompt.md").read_text(encoding="utf-8")
 
     skills_path = f"~/.deepagents/{assistant_id}/skills"
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1762,7 +1762,9 @@ def get_default_coding_instructions() -> str:
         The default agent instructions as a string.
     """
     default_prompt_path = Path(__file__).parent / "default_agent_prompt.md"
-    return default_prompt_path.read_text()
+    # Repo prompt templates are maintained as UTF-8; pin encoding to avoid
+    # Windows default (e.g., gbk) decoding failures.
+    return default_prompt_path.read_text(encoding="utf-8")
 
 
 def detect_provider(model_name: str) -> str | None:


### PR DESCRIPTION
Fix Windows UnicodeDecodeError when reading prompt template files by explicitly specifying utf-8 encoding.

Fixes #2356

## Verification
- Reproduced the error on Windows 11 (default GBK encoding)
- Added `encoding='utf-8'` to `read_text()` calls in two locations
- Server starts successfully on Windows after the fix
- Ran `make test`, all tests passed
- Verified no regression on WSL2 (Ubuntu)

## Modified files
- `[path/to/your/first_modified_file.py]` - Added `encoding="utf-8"` to `read_text()` in `get_default_coding_instructions()`
- `[path/to/your/second_modified_file.py]` - Added `encoding="utf-8"` to `read_text()` in `get_system_prompt()`

## Code changes
```diff
# First file
- return default_prompt_path.read_text()
+ return default_prompt_path.read_text(encoding="utf-8")

# Second file
- template = (Path(__file__).parent / "system_prompt.md").read_text()
+ template = (Path(__file__).parent / "system_prompt.md").read_text(encoding="utf-8")