### PR TITLE
ci: tighten top-level release permissions to `contents: read`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ env:
   UV_FROZEN: "true"
 
 permissions:
-  contents: read # Job-level overrides grant write only where needed (mark-release)
+  contents: read # Job-level overrides grant write only where needed
 
 jobs:
   # Determine working directory from package input


### PR DESCRIPTION
Tighten the top-level `permissions` default in the release workflow from `contents: write` to `contents: read`. Prevents any future job added without explicit permissions from silently inheriting write access.