### PR TITLE
fix(sdk): `last_updated_at` field doesn't account for task status changes

### DIFF
--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -103,7 +103,7 @@ class AsyncTask(TypedDict):
     """
 
     last_updated_at: str
-    """ISO-8601 timestamp (UTC) when the task was last updated with a new message.
+    """ISO-8601 timestamp (UTC) when the task status changes or when a follow-up message is sent via the update tool.
 
     Format: `YYYY-MM-DDTHH:MM:SSZ` (e.g., `2024-01-15T10:30:00Z`).
     """
@@ -391,6 +391,7 @@ def _build_check_command(
 ) -> Command:
     """Build the `Command` update for a check result."""
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    last_updated_at = now if task["status"] != result["status"] else task["last_updated_at"]
     updated_task = AsyncTask(
         task_id=task["task_id"],
         agent_name=task["agent_name"],
@@ -399,7 +400,7 @@ def _build_check_command(
         status=result["status"],
         created_at=task["created_at"],
         last_checked_at=now,
-        last_updated_at=task["last_updated_at"],
+        last_updated_at=last_updated_at,
     )
     return Command(
         update={
@@ -621,7 +622,7 @@ def _build_cancel_tool(
             status="cancelled",
             created_at=tracked["created_at"],
             last_checked_at=now,
-            last_updated_at=tracked["last_updated_at"],
+            last_updated_at=now,
         )
         msg = f"Cancelled async subagent task: {tracked['task_id']}"
         return Command(
@@ -653,7 +654,7 @@ def _build_cancel_tool(
             status="cancelled",
             created_at=tracked["created_at"],
             last_checked_at=now,
-            last_updated_at=tracked["last_updated_at"],
+            last_updated_at=now,
         )
         msg = f"Cancelled async subagent task: {tracked['task_id']}"
         return Command(
@@ -760,6 +761,7 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
         for task in filtered:
             status = _fetch_live_status(clients, task)
             entries.append(_format_task_entry(task, status))
+            last_updated_at = now if status != task["status"] else task["last_updated_at"]
             updated_tasks[task["task_id"]] = AsyncTask(
                 task_id=task["task_id"],
                 agent_name=task["agent_name"],
@@ -768,7 +770,7 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
                 status=status,
                 created_at=task["created_at"],
                 last_checked_at=now,
-                last_updated_at=task["last_updated_at"],
+                last_updated_at=last_updated_at,
             )
         msg = f"{len(entries)} tracked task(s):\n" + "\n".join(entries)
         return Command(
@@ -792,6 +794,7 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         for task, status in zip(filtered, statuses, strict=True):
             entries.append(_format_task_entry(task, status))
+            last_updated_at = now if status != task["status"] else task["last_updated_at"]
             updated_tasks[task["task_id"]] = AsyncTask(
                 task_id=task["task_id"],
                 agent_name=task["agent_name"],
@@ -800,7 +803,7 @@ def _build_list_tasks_tool(clients: _ClientCache) -> StructuredTool:
                 status=status,
                 created_at=task["created_at"],
                 last_checked_at=now,
-                last_updated_at=task["last_updated_at"],
+                last_updated_at=last_updated_at,
             )
         msg = f"{len(entries)} tracked task(s):\n" + "\n".join(entries)
         return Command(

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -308,6 +308,7 @@ class TestCheckTool:
 
         tasks = result.update["async_tasks"]
         assert tasks["thread_abc"]["status"] == "running"
+        assert tasks["thread_abc"]["last_updated_at"] == "2024-01-15T10:30:00Z"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_completed_task_returns_result(self, mock_get_client: MagicMock) -> None:
@@ -336,6 +337,7 @@ class TestCheckTool:
 
         tasks = result.update["async_tasks"]
         assert tasks["thread_abc"]["status"] == "success"
+        assert tasks["thread_abc"]["last_updated_at"] != "2024-01-15T10:30:00Z"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_check_errored_task(self, mock_get_client: MagicMock) -> None:
@@ -357,6 +359,7 @@ class TestCheckTool:
 
         tasks = result.update["async_tasks"]
         assert tasks["thread_abc"]["status"] == "error"
+        assert tasks["thread_abc"]["last_updated_at"] != "2024-01-15T10:30:00Z"
 
 
 class TestUpdateTool:
@@ -475,7 +478,9 @@ class TestListTasksTool:
         # state should be updated with fresh statuses
         updated = result.update["async_tasks"]
         assert updated["t1"]["status"] == "success"
+        assert updated["t1"]["last_updated_at"] != "2024-01-15T10:30:00Z"
         assert updated["t2"]["status"] == "running"
+        assert updated["t2"]["last_updated_at"] == "2024-01-15T10:31:00Z"
 
     @patch("deepagents.middleware.async_subagents.get_sync_client")
     def test_skips_sdk_call_for_terminal_statuses(self, mock_get_client: MagicMock) -> None:
@@ -727,6 +732,7 @@ class TestCancelTool:
         assert isinstance(result, Command)
         tasks = result.update["async_tasks"]
         assert tasks["thread_abc"]["status"] == "cancelled"
+        assert tasks["thread_abc"]["last_updated_at"] != "2024-01-15T10:30:00Z"
         assert tasks["thread_abc"]["task_id"] == "thread_abc"
         msgs = result.update["messages"]
         assert msgs[0].tool_call_id == "tc_cancel"


### PR DESCRIPTION
### Description
Currently, the`last_updated_at` field associated with an `AsyncTask` is only updated when the agent uses the `update_async_task` tool. This is a bit misleading since the expectation of `last_updated_at` is that it is updated anytime the async task state updates (status changes, etc.).

This PR updates the logic associated with the`last_updated_at` field so that it is updated on:
- `update_async_task` tool calls
- Async task status changes
- Async task cancellation
