### PR TITLE
refactor(evals): add section headings to model groups

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -448,51 +448,55 @@ REGISTRY: tuple[Model, ...] = (
 
 # ---------------------------------------------------------------------------
 # Preset definitions — map preset names to tag filters per workflow.
-# None means "any tag with the workflow prefix" (i.e. the "all" preset).
+#
+# _PRESET_SECTIONS is the single source of truth for preset names, doc
+# ordering, and section grouping.
+# Each entry is (section_name, [(preset_name, tag_suffix | None), ...]).
+#   - section_name = None  → no heading is emitted for that group.
+#   - tag_suffix = None    → matches any tag with the workflow prefix
+#                            (i.e. the "all" preset).
 # ---------------------------------------------------------------------------
-_EVAL_PRESETS: dict[str, str | None] = {
-    "all": None,
-    # -- Model groups --
-    "set0": "eval:set0",
-    "set1": "eval:set1",
-    "set2": "eval:set2",
-    "frontier": "eval:frontier",
-    "fast": "eval:fast",
-    "open": "eval:open",
-    # -- Provider groups --
-    "anthropic": "eval:anthropic",
-    "openai": "eval:openai",
-    "google_genai": "eval:google_genai",
-    "openrouter": "eval:openrouter",
-    "baseten": "eval:baseten",
-    "fireworks": "eval:fireworks",
-    "ollama": "eval:ollama",
-    "groq": "eval:groq",
-    "xai": "eval:xai",
-    "nvidia": "eval:nvidia",
-}
+_PRESET_SECTIONS: list[tuple[str | None, list[tuple[str, str | None]]]] = [
+    ("Model groups", [
+        ("set0", "set0"),
+        ("set1", "set1"),
+        ("set2", "set2"),
+        ("frontier", "frontier"),
+        ("fast", "fast"),
+        ("open", "open"),
+    ]),
+    ("Provider groups", [
+        ("anthropic", "anthropic"),
+        ("baseten", "baseten"),
+        ("fireworks", "fireworks"),
+        ("google_genai", "google_genai"),
+        ("groq", "groq"),
+        ("nvidia", "nvidia"),
+        ("ollama", "ollama"),
+        ("openai", "openai"),
+        ("openrouter", "openrouter"),
+        ("xai", "xai"),
+    ]),
+    (None, [
+        ("all", None),
+    ]),
+]
 
-_HARBOR_PRESETS: dict[str, str | None] = {
-    "all": None,
-    # -- Model groups (mirror eval sets) --
-    "set0": "harbor:set0",
-    "set1": "harbor:set1",
-    "set2": "harbor:set2",
-    "frontier": "harbor:frontier",
-    "fast": "harbor:fast",
-    "open": "harbor:open",
-    # -- Provider groups --
-    "anthropic": "harbor:anthropic",
-    "openai": "harbor:openai",
-    "google_genai": "harbor:google_genai",
-    "openrouter": "harbor:openrouter",
-    "baseten": "harbor:baseten",
-    "fireworks": "harbor:fireworks",
-    "ollama": "harbor:ollama",
-    "groq": "harbor:groq",
-    "xai": "harbor:xai",
-    "nvidia": "harbor:nvidia",
-}
+
+def _build_presets(prefix: str) -> dict[str, str | None]:
+    """Derive a flat preset lookup dict from `_PRESET_SECTIONS`."""
+    return {
+        name: f"{prefix}:{suffix}" if suffix is not None else None
+        for _, presets in _PRESET_SECTIONS
+        for name, suffix in presets
+    }
+
+
+_EVAL_PRESETS: dict[str, str | None] = _build_presets("eval")
+"""Flat preset name → `eval:{tag}` mapping for the evals workflow."""
+
+_HARBOR_PRESETS: dict[str, str | None] = _build_presets("harbor")
+"""Flat preset name → `harbor:{tag}` mapping for the Harbor workflow."""
 
 _WORKFLOW_CONFIG: dict[str, tuple[str, dict[str, str | None]]] = {
     "eval": ("EVAL_MODELS", _EVAL_PRESETS),

--- a/libs/evals/MODEL_GROUPS.md
+++ b/libs/evals/MODEL_GROUPS.md
@@ -5,6 +5,180 @@ Quick reference for the model sets available in the
 [evals workflow](../../.github/workflows/evals.yml).
 Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 
+## Model groups
+
+### `set0` (33 models)
+
+- `anthropic:claude-haiku-4-5-20251001`
+- `anthropic:claude-sonnet-4-20250514`
+- `anthropic:claude-sonnet-4-5-20250929`
+- `anthropic:claude-sonnet-4-6`
+- `anthropic:claude-opus-4-1`
+- `anthropic:claude-opus-4-5-20251101`
+- `anthropic:claude-opus-4-6`
+- `baseten:zai-org/GLM-5`
+- `baseten:MiniMaxAI/MiniMax-M2.5`
+- `baseten:moonshotai/Kimi-K2.5`
+- `baseten:nvidia/Nemotron-120B-A12B`
+- `baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct`
+- `fireworks:fireworks/deepseek-v3p2`
+- `fireworks:fireworks/deepseek-v3-0324`
+- `fireworks:fireworks/qwen3-vl-235b-a22b-thinking`
+- `fireworks:fireworks/minimax-m2p1`
+- `fireworks:fireworks/kimi-k2p5`
+- `fireworks:fireworks/glm-5`
+- `fireworks:fireworks/minimax-m2p5`
+- `google_genai:gemini-2.5-flash`
+- `google_genai:gemini-2.5-pro`
+- `google_genai:gemini-3-flash-preview`
+- `google_genai:gemini-3.1-pro-preview`
+- `ollama:minimax-m2.7:cloud`
+- `openai:gpt-4o`
+- `openai:gpt-4o-mini`
+- `openai:gpt-4.1`
+- `openai:o3`
+- `openai:o4-mini`
+- `openai:gpt-5.1-codex`
+- `openai:gpt-5.2-codex`
+- `openai:gpt-5.4`
+- `openai:gpt-5.4-mini`
+
+### `set1` (12 models)
+
+- `anthropic:claude-haiku-4-5-20251001`
+- `anthropic:claude-sonnet-4-6`
+- `anthropic:claude-opus-4-6`
+- `baseten:zai-org/GLM-5`
+- `baseten:MiniMaxAI/MiniMax-M2.5`
+- `fireworks:fireworks/qwen3-vl-235b-a22b-thinking`
+- `google_genai:gemini-2.5-pro`
+- `google_genai:gemini-3.1-pro-preview`
+- `ollama:qwen3.5:397b-cloud`
+- `openai:gpt-4.1`
+- `openai:gpt-5.2-codex`
+- `openai:gpt-5.4`
+
+### `set2` (16 models)
+
+- `groq:openai/gpt-oss-120b`
+- `groq:qwen/qwen3-32b`
+- `groq:moonshotai/kimi-k2-instruct`
+- `ollama:glm-5`
+- `ollama:minimax-m2.5`
+- `ollama:qwen3.5:397b-cloud`
+- `ollama:nemotron-3-nano:30b`
+- `ollama:nemotron-3-super`
+- `ollama:cogito-2.1:671b`
+- `ollama:devstral-2:123b`
+- `ollama:ministral-3:14b`
+- `ollama:qwen3-next:80b`
+- `ollama:qwen3-coder:480b-cloud`
+- `ollama:deepseek-v3.2:cloud`
+- `xai:grok-4`
+- `xai:grok-3-mini-fast`
+
+### `frontier` (3 models)
+
+- `anthropic:claude-opus-4-6`
+- `google_genai:gemini-3.1-pro-preview`
+- `openai:gpt-5.4`
+
+### `fast` (3 models)
+
+- `anthropic:claude-sonnet-4-6`
+- `google_genai:gemini-3-flash-preview`
+- `openai:gpt-5.4-mini`
+
+### `open` (3 models)
+
+- `baseten:zai-org/GLM-5`
+- `ollama:minimax-m2.7:cloud`
+- `ollama:nemotron-3-super`
+
+## Provider groups
+
+### `anthropic` (7 models)
+
+- `anthropic:claude-haiku-4-5-20251001`
+- `anthropic:claude-sonnet-4-20250514`
+- `anthropic:claude-sonnet-4-5-20250929`
+- `anthropic:claude-sonnet-4-6`
+- `anthropic:claude-opus-4-1`
+- `anthropic:claude-opus-4-5-20251101`
+- `anthropic:claude-opus-4-6`
+
+### `baseten` (5 models)
+
+- `baseten:zai-org/GLM-5`
+- `baseten:MiniMaxAI/MiniMax-M2.5`
+- `baseten:moonshotai/Kimi-K2.5`
+- `baseten:nvidia/Nemotron-120B-A12B`
+- `baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct`
+
+### `fireworks` (7 models)
+
+- `fireworks:fireworks/deepseek-v3p2`
+- `fireworks:fireworks/deepseek-v3-0324`
+- `fireworks:fireworks/qwen3-vl-235b-a22b-thinking`
+- `fireworks:fireworks/minimax-m2p1`
+- `fireworks:fireworks/kimi-k2p5`
+- `fireworks:fireworks/glm-5`
+- `fireworks:fireworks/minimax-m2p5`
+
+### `google_genai` (4 models)
+
+- `google_genai:gemini-2.5-flash`
+- `google_genai:gemini-2.5-pro`
+- `google_genai:gemini-3-flash-preview`
+- `google_genai:gemini-3.1-pro-preview`
+
+### `groq` (3 models)
+
+- `groq:openai/gpt-oss-120b`
+- `groq:qwen/qwen3-32b`
+- `groq:moonshotai/kimi-k2-instruct`
+
+### `nvidia` (1 model)
+
+- `nvidia:nvidia/nemotron-3-super-120b-a12b`
+
+### `ollama` (12 models)
+
+- `ollama:glm-5`
+- `ollama:minimax-m2.5`
+- `ollama:minimax-m2.7:cloud`
+- `ollama:qwen3.5:397b-cloud`
+- `ollama:nemotron-3-nano:30b`
+- `ollama:nemotron-3-super`
+- `ollama:cogito-2.1:671b`
+- `ollama:devstral-2:123b`
+- `ollama:ministral-3:14b`
+- `ollama:qwen3-next:80b`
+- `ollama:qwen3-coder:480b-cloud`
+- `ollama:deepseek-v3.2:cloud`
+
+### `openai` (9 models)
+
+- `openai:gpt-4o`
+- `openai:gpt-4o-mini`
+- `openai:gpt-4.1`
+- `openai:o3`
+- `openai:o4-mini`
+- `openai:gpt-5.1-codex`
+- `openai:gpt-5.2-codex`
+- `openai:gpt-5.4`
+- `openai:gpt-5.4-mini`
+
+### `openrouter` (2 models)
+
+- `openrouter:minimax/minimax-m2.7`
+- `openrouter:nvidia/nemotron-3-super-120b-a12b`
+
+### `xai` (2 models)
+
+- `xai:grok-4`
+- `xai:grok-3-mini-fast`
+
 ## `all` (52 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
@@ -59,173 +233,3 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openrouter:nvidia/nemotron-3-super-120b-a12b`
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`
-
-## `set0` (33 models)
-
-- `anthropic:claude-haiku-4-5-20251001`
-- `anthropic:claude-sonnet-4-20250514`
-- `anthropic:claude-sonnet-4-5-20250929`
-- `anthropic:claude-sonnet-4-6`
-- `anthropic:claude-opus-4-1`
-- `anthropic:claude-opus-4-5-20251101`
-- `anthropic:claude-opus-4-6`
-- `baseten:zai-org/GLM-5`
-- `baseten:MiniMaxAI/MiniMax-M2.5`
-- `baseten:moonshotai/Kimi-K2.5`
-- `baseten:nvidia/Nemotron-120B-A12B`
-- `baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct`
-- `fireworks:fireworks/deepseek-v3p2`
-- `fireworks:fireworks/deepseek-v3-0324`
-- `fireworks:fireworks/qwen3-vl-235b-a22b-thinking`
-- `fireworks:fireworks/minimax-m2p1`
-- `fireworks:fireworks/kimi-k2p5`
-- `fireworks:fireworks/glm-5`
-- `fireworks:fireworks/minimax-m2p5`
-- `google_genai:gemini-2.5-flash`
-- `google_genai:gemini-2.5-pro`
-- `google_genai:gemini-3-flash-preview`
-- `google_genai:gemini-3.1-pro-preview`
-- `ollama:minimax-m2.7:cloud`
-- `openai:gpt-4o`
-- `openai:gpt-4o-mini`
-- `openai:gpt-4.1`
-- `openai:o3`
-- `openai:o4-mini`
-- `openai:gpt-5.1-codex`
-- `openai:gpt-5.2-codex`
-- `openai:gpt-5.4`
-- `openai:gpt-5.4-mini`
-
-## `set1` (12 models)
-
-- `anthropic:claude-haiku-4-5-20251001`
-- `anthropic:claude-sonnet-4-6`
-- `anthropic:claude-opus-4-6`
-- `baseten:zai-org/GLM-5`
-- `baseten:MiniMaxAI/MiniMax-M2.5`
-- `fireworks:fireworks/qwen3-vl-235b-a22b-thinking`
-- `google_genai:gemini-2.5-pro`
-- `google_genai:gemini-3.1-pro-preview`
-- `ollama:qwen3.5:397b-cloud`
-- `openai:gpt-4.1`
-- `openai:gpt-5.2-codex`
-- `openai:gpt-5.4`
-
-## `set2` (16 models)
-
-- `groq:openai/gpt-oss-120b`
-- `groq:qwen/qwen3-32b`
-- `groq:moonshotai/kimi-k2-instruct`
-- `ollama:glm-5`
-- `ollama:minimax-m2.5`
-- `ollama:qwen3.5:397b-cloud`
-- `ollama:nemotron-3-nano:30b`
-- `ollama:nemotron-3-super`
-- `ollama:cogito-2.1:671b`
-- `ollama:devstral-2:123b`
-- `ollama:ministral-3:14b`
-- `ollama:qwen3-next:80b`
-- `ollama:qwen3-coder:480b-cloud`
-- `ollama:deepseek-v3.2:cloud`
-- `xai:grok-4`
-- `xai:grok-3-mini-fast`
-
-## `frontier` (3 models)
-
-- `anthropic:claude-opus-4-6`
-- `google_genai:gemini-3.1-pro-preview`
-- `openai:gpt-5.4`
-
-## `fast` (3 models)
-
-- `anthropic:claude-sonnet-4-6`
-- `google_genai:gemini-3-flash-preview`
-- `openai:gpt-5.4-mini`
-
-## `open` (3 models)
-
-- `baseten:zai-org/GLM-5`
-- `ollama:minimax-m2.7:cloud`
-- `ollama:nemotron-3-super`
-
-## `anthropic` (7 models)
-
-- `anthropic:claude-haiku-4-5-20251001`
-- `anthropic:claude-sonnet-4-20250514`
-- `anthropic:claude-sonnet-4-5-20250929`
-- `anthropic:claude-sonnet-4-6`
-- `anthropic:claude-opus-4-1`
-- `anthropic:claude-opus-4-5-20251101`
-- `anthropic:claude-opus-4-6`
-
-## `openai` (9 models)
-
-- `openai:gpt-4o`
-- `openai:gpt-4o-mini`
-- `openai:gpt-4.1`
-- `openai:o3`
-- `openai:o4-mini`
-- `openai:gpt-5.1-codex`
-- `openai:gpt-5.2-codex`
-- `openai:gpt-5.4`
-- `openai:gpt-5.4-mini`
-
-## `google_genai` (4 models)
-
-- `google_genai:gemini-2.5-flash`
-- `google_genai:gemini-2.5-pro`
-- `google_genai:gemini-3-flash-preview`
-- `google_genai:gemini-3.1-pro-preview`
-
-## `openrouter` (2 models)
-
-- `openrouter:minimax/minimax-m2.7`
-- `openrouter:nvidia/nemotron-3-super-120b-a12b`
-
-## `baseten` (5 models)
-
-- `baseten:zai-org/GLM-5`
-- `baseten:MiniMaxAI/MiniMax-M2.5`
-- `baseten:moonshotai/Kimi-K2.5`
-- `baseten:nvidia/Nemotron-120B-A12B`
-- `baseten:Qwen/Qwen3-Coder-480B-A35B-Instruct`
-
-## `fireworks` (7 models)
-
-- `fireworks:fireworks/deepseek-v3p2`
-- `fireworks:fireworks/deepseek-v3-0324`
-- `fireworks:fireworks/qwen3-vl-235b-a22b-thinking`
-- `fireworks:fireworks/minimax-m2p1`
-- `fireworks:fireworks/kimi-k2p5`
-- `fireworks:fireworks/glm-5`
-- `fireworks:fireworks/minimax-m2p5`
-
-## `ollama` (12 models)
-
-- `ollama:glm-5`
-- `ollama:minimax-m2.5`
-- `ollama:minimax-m2.7:cloud`
-- `ollama:qwen3.5:397b-cloud`
-- `ollama:nemotron-3-nano:30b`
-- `ollama:nemotron-3-super`
-- `ollama:cogito-2.1:671b`
-- `ollama:devstral-2:123b`
-- `ollama:ministral-3:14b`
-- `ollama:qwen3-next:80b`
-- `ollama:qwen3-coder:480b-cloud`
-- `ollama:deepseek-v3.2:cloud`
-
-## `groq` (3 models)
-
-- `groq:openai/gpt-oss-120b`
-- `groq:qwen/qwen3-32b`
-- `groq:moonshotai/kimi-k2-instruct`
-
-## `xai` (2 models)
-
-- `xai:grok-4`
-- `xai:grok-3-mini-fast`
-
-## `nvidia` (1 model)
-
-- `nvidia:nvidia/nemotron-3-super-120b-a12b`

--- a/libs/evals/scripts/generate_model_groups.py
+++ b/libs/evals/scripts/generate_model_groups.py
@@ -42,24 +42,34 @@ def generate() -> str:
     """Return the full markdown content for MODEL_GROUPS.md."""
     mod = _import_models()
     registry: tuple = mod.REGISTRY
-    presets: dict[str, str | None] = mod._EVAL_PRESETS  # noqa: SLF001
+    sections: list[tuple[str | None, list[tuple[str, str | None]]]] = (
+        mod._PRESET_SECTIONS  # noqa: SLF001
+    )
 
     lines: list[str] = [_HEADER]
 
-    for preset_name, tag in presets.items():
-        if tag is not None:
-            models = [m.spec for m in registry if tag in m.groups]
-        else:
-            # "all" — every model with any eval: tag
-            models = [
-                m.spec for m in registry if any(g.startswith("eval:") for g in m.groups)
-            ]
+    for section_name, presets in sections:
+        if section_name is not None:
+            lines.append(f"## {section_name}\n")
 
-        count = len(models)
-        label = "model" if count == 1 else "models"
-        lines.append(f"## `{preset_name}` ({count} {label})\n")
-        lines.extend(f"- `{spec}`" for spec in models)
-        lines.append("")
+        for preset_name, tag_suffix in presets:
+            if tag_suffix is not None:
+                tag = f"eval:{tag_suffix}"
+                models = [m.spec for m in registry if tag in m.groups]
+            else:
+                # "all" — every model with any eval: tag
+                models = [
+                    m.spec
+                    for m in registry
+                    if any(g.startswith("eval:") for g in m.groups)
+                ]
+
+            count = len(models)
+            label = "model" if count == 1 else "models"
+            heading = "##" if section_name is None else "###"
+            lines.append(f"{heading} `{preset_name}` ({count} {label})\n")
+            lines.extend(f"- `{spec}`" for spec in models)
+            lines.append("")
 
     return "\n".join(lines)
 


### PR DESCRIPTION
Add section headings ("Model groups", "Provider groups") to the generated `MODEL_GROUPS.md` so presets are organized by category rather than listed flat. The duplicated `_EVAL_PRESETS` / `_HARBOR_PRESETS` dicts are replaced with a single `_PRESET_SECTIONS` structure that encodes both ordering and grouping, with `_build_presets()` deriving the flat dicts for runtime use. Provider groups are now alphabetically sorted, and `all` moves to the end.