### PR TITLE
fix(cli): deduplicate mcp servers in approval prompt across config files

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1093,12 +1093,16 @@ def _check_mcp_project_trust(*, trust_flag: bool = False) -> bool | None:
     if not project_configs:
         return None
 
-    # Collect all stdio servers across project configs
-    all_stdio: list[tuple[str, str, list[str]]] = []
+    # Collect all stdio servers across project configs, deduplicating by name.
+    # Later configs have higher precedence, so they overwrite earlier entries
+    # for the same server name (mirrors merge_mcp_configs behaviour).
+    seen: dict[str, tuple[str, str, list[str]]] = {}
     for path in project_configs:
         cfg = load_mcp_config_lenient(path)
         if cfg is not None:
-            all_stdio.extend(extract_stdio_server_commands(cfg))
+            for entry in extract_stdio_server_commands(cfg):
+                seen[entry[0]] = entry
+    all_stdio = list(seen.values())
 
     if not all_stdio:
         return None

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import inspect
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -12,6 +13,7 @@ import pytest
 from deepagents_cli.app import AppResult, DeepAgentsApp, run_textual_app
 from deepagents_cli.config import build_langsmith_thread_url, reset_langsmith_url_cache
 from deepagents_cli.main import (
+    _check_mcp_project_trust,
     _ripgrep_install_hint,
     check_optional_tools,
     format_tool_warning_cli,
@@ -636,3 +638,114 @@ class TestRunTextualCliAsyncModelConfigError:
             result = await run_textual_cli_async("agent", model_name="openai:gpt-4o")
 
         assert result.return_code == 0
+
+
+class TestCheckMcpProjectTrustDeduplication:
+    """Verify MCP server deduplication when multiple project config files overlap.
+
+    Regression test for https://github.com/langchain-ai/deepagents/issues/2374.
+    When both `.deepagents/.mcp.json` and `.mcp.json` define the same server,
+    the approval prompt must list the server only once.
+    """
+
+    def _make_server_cfg(self, cmd: str = "npx", args: list[str] | None = None) -> dict:
+        return {"command": cmd, "args": args or ["-y", "some-server"]}
+
+    def test_duplicate_server_name_across_configs_shown_once(
+        self, tmp_path: Path
+    ) -> None:
+        """Servers with identical names in both config files appear once in prompt."""
+        shared_server_config = self._make_server_cfg()
+        cfg = {"mcpServers": {"my-server": shared_server_config}}
+
+        deepagents_dir = tmp_path / ".deepagents"
+        deepagents_dir.mkdir()
+        project_mcp = deepagents_dir / ".mcp.json"
+        root_mcp = tmp_path / ".mcp.json"
+
+        project_mcp.write_text(json.dumps(cfg))
+        root_mcp.write_text(json.dumps(cfg))
+
+        from deepagents_cli.project_utils import ProjectContext
+
+        project_context = ProjectContext(project_root=tmp_path, user_cwd=tmp_path)
+
+        shown_servers: list[str] = []
+
+        def fake_input(_prompt: str) -> str:
+            return "n"
+
+        with (
+            patch(
+                "deepagents_cli.main.ProjectContext.from_user_cwd",
+                return_value=project_context,
+            ),
+            patch("deepagents_cli.mcp_tools.find_project_root", return_value=tmp_path),
+            patch("deepagents_cli.main.Path.cwd", return_value=tmp_path),
+            patch("builtins.input", side_effect=fake_input),
+            patch(
+                "deepagents_cli.mcp_trust.is_project_mcp_trusted", return_value=False
+            ),
+            patch(
+                "deepagents_cli.mcp_trust.compute_config_fingerprint",
+                return_value="fp",
+            ),
+            patch("rich.console.Console.print") as mock_print,
+        ):
+            _check_mcp_project_trust()
+
+        # Collect all server-name occurrences from rich print calls
+        for call in mock_print.call_args_list:
+            args = call[0]
+            if args and '"my-server"' in str(args[0]):
+                shown_servers.append("my-server")
+
+        assert shown_servers == ["my-server"], (
+            f"Expected exactly one entry for 'my-server', got: {shown_servers}"
+        )
+
+    def test_unique_servers_across_configs_both_shown(self, tmp_path: Path) -> None:
+        """Servers with different names in each config both appear in prompt."""
+        cfg_a = {"mcpServers": {"server-a": self._make_server_cfg()}}
+        cfg_b = {"mcpServers": {"server-b": self._make_server_cfg(cmd="node")}}
+
+        deepagents_dir = tmp_path / ".deepagents"
+        deepagents_dir.mkdir()
+        (deepagents_dir / ".mcp.json").write_text(json.dumps(cfg_a))
+        (tmp_path / ".mcp.json").write_text(json.dumps(cfg_b))
+
+        from deepagents_cli.project_utils import ProjectContext
+
+        project_context = ProjectContext(project_root=tmp_path, user_cwd=tmp_path)
+        shown_servers: list[str] = []
+
+        with (
+            patch(
+                "deepagents_cli.main.ProjectContext.from_user_cwd",
+                return_value=project_context,
+            ),
+            patch("deepagents_cli.mcp_tools.find_project_root", return_value=tmp_path),
+            patch("deepagents_cli.main.Path.cwd", return_value=tmp_path),
+            patch("builtins.input", return_value="n"),
+            patch(
+                "deepagents_cli.mcp_trust.is_project_mcp_trusted", return_value=False
+            ),
+            patch(
+                "deepagents_cli.mcp_trust.compute_config_fingerprint",
+                return_value="fp",
+            ),
+            patch("rich.console.Console.print") as mock_print,
+        ):
+            _check_mcp_project_trust()
+
+        for call in mock_print.call_args_list:
+            args = call[0]
+            line = str(args[0]) if args else ""
+            if '"server-a"' in line:
+                shown_servers.append("server-a")
+            if '"server-b"' in line:
+                shown_servers.append("server-b")
+
+        assert "server-a" in shown_servers
+        assert "server-b" in shown_servers
+        assert len(shown_servers) == 2


### PR DESCRIPTION
Fixes #2374

When both `.deepagents/.mcp.json` and `.mcp.json` define the same MCP server (common with tools like rulesync that mirror configs), `_check_mcp_project_trust` iterated over every config file and extended the approval list without deduplication, so each server appeared once per file it was defined in.

## What changed

In `_check_mcp_project_trust` (`libs/cli/deepagents_cli/main.py`), replaced the naive `list.extend` accumulation with a dict keyed on server name. Later configs (higher precedence, consistent with `merge_mcp_configs`) overwrite earlier entries for the same name. The approval prompt now shows exactly one entry per unique server name.

## Why this solution

The deduplication strategy mirrors the existing `merge_mcp_configs` behaviour — highest-precedence config wins for a given name — so what the user approves matches what actually runs.

## Verification

Two new unit tests added in `TestCheckMcpProjectTrustDeduplication`:
- `test_duplicate_server_name_across_configs_shown_once`: same server in both `.deepagents/.mcp.json` and `.mcp.json` → appears once in prompt.
- `test_unique_servers_across_configs_both_shown`: different server in each file → both appear (no over-deduplication).

No breaking API changes.
