### PR TITLE
feat(sdk): add structured compaction prompt for session summarization

### DIFF
--- a/libs/deepagents/deepagents/middleware/structured_compaction.py
+++ b/libs/deepagents/deepagents/middleware/structured_compaction.py
@@ -1,0 +1,263 @@
+"""Structured session compaction with enhanced LLM summarization.
+
+Provides a structured compaction prompt that guides the LLM to produce
+high-quality, section-based summaries. Also handles summary formatting
+(stripping analysis blocks) and continuation message generation for
+seamless session resumption after compaction.
+"""
+
+from __future__ import annotations
+
+import re
+
+COMPACT_CONTINUATION_PREAMBLE = (
+    "This session is being continued from a previous conversation that ran "
+    "out of context. The summary below covers the earlier portion of the "
+    "conversation."
+)
+
+COMPACT_RECENT_MESSAGES_NOTE = "Recent messages are preserved verbatim."
+
+COMPACT_DIRECT_RESUME_INSTRUCTION = (
+    "Continue the conversation from where it left off without asking the "
+    "user any further questions. Resume directly — do not acknowledge the "
+    "summary, do not recap what was happening, do not preface with "
+    '"I\'ll continue" or similar. Pick up the last task as if the break '
+    "never happened."
+)
+
+
+_DETAILED_ANALYSIS_INSTRUCTION = """\
+Before providing your final summary, wrap your analysis in <analysis> tags \
+to organize your thoughts and ensure you've covered all necessary points. \
+In your analysis process:
+
+1. Chronologically analyze each message and section of the conversation. \
+For each section thoroughly identify:
+   - The user's explicit requests and intents
+   - Your approach to addressing the user's requests
+   - Key decisions, technical concepts and code patterns
+   - Specific details like:
+     - file names
+     - full code snippets
+     - function signatures
+     - file edits
+   - Errors that you ran into and how you fixed them
+   - Pay special attention to specific user feedback that you received, \
+especially if the user told you to do something differently.
+2. Double-check for technical accuracy and completeness, addressing each \
+required element thoroughly."""
+
+
+COMPACT_SUMMARY_PROMPT = """\
+Your task is to create a detailed summary of the conversation so far, \
+paying close attention to the user's explicit requests and your previous \
+actions.
+This summary should be thorough in capturing technical details, code \
+patterns, and architectural decisions that would be essential for \
+continuing development work without losing context.
+
+{analysis_instruction}
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: Capture all of the user's explicit \
+requests and intents in detail
+2. Key Technical Concepts: List all important technical concepts, \
+technologies, and frameworks discussed.
+3. Files and Code Sections: Enumerate specific files and code sections \
+examined, modified, or created. Pay special attention to the most recent \
+messages and include full code snippets where applicable and include a \
+summary of why this file read or edit is important.
+4. Errors and fixes: List all errors that you ran into, and how you \
+fixed them. Pay special attention to specific user feedback that you \
+received, especially if the user told you to do something differently.
+5. Problem Solving: Document problems solved and any ongoing \
+troubleshooting efforts.
+6. All user messages: List ALL user messages that are not tool results. \
+These are critical for understanding the users' feedback and changing \
+intent.
+7. Pending Tasks: Outline any pending tasks that you have explicitly \
+been asked to work on.
+8. Current Work: Describe in detail precisely what was being worked on \
+immediately before this summary request, paying special attention to the \
+most recent messages from both user and assistant. Include file names \
+and code snippets where applicable.
+9. Optional Next Step: List the next step that you will take that is \
+related to the most recent work you were doing. IMPORTANT: ensure that \
+this step is DIRECTLY in line with the user's most recent explicit \
+requests, and the task you were working on immediately before this \
+summary request. If your last task was concluded, then only list next \
+steps if they are explicitly in line with the users request. Do not \
+start on tangential requests or really old requests that were already \
+completed without confirming with the user first. \
+If there is a next step, include direct quotes from the most recent \
+conversation showing exactly what task you were working on and where \
+you left off. This should be verbatim to ensure there's no drift in \
+task interpretation.
+
+Here's an example of how your output should be structured:
+
+<example>
+<analysis>
+[Your thought process, ensuring all points are covered thoroughly and accurately]
+</analysis>
+
+<summary>
+1. Primary Request and Intent:
+   [Detailed description]
+
+2. Key Technical Concepts:
+   - [Concept 1]
+   - [Concept 2]
+   - [...]
+
+3. Files and Code Sections:
+   - [File Name 1]
+      - [Summary of why this file is important]
+      - [Summary of the changes made to this file, if any]
+      - [Important Code Snippet]
+   - [File Name 2]
+      - [Important Code Snippet]
+   - [...]
+
+4. Errors and fixes:
+    - [Detailed description of error 1]:
+      - [How you fixed the error]
+      - [User feedback on the error if any]
+    - [...]
+
+5. Problem Solving:
+   [Description of solved problems and ongoing troubleshooting]
+
+6. All user messages:
+    - [Detailed non tool use user message]
+    - [...]
+
+7. Pending Tasks:
+   - [Task 1]
+   - [Task 2]
+   - [...]
+
+8. Current Work:
+   [Precise description of current work]
+
+9. Optional Next Step:
+   [Optional Next step to take]
+
+</summary>
+</example>
+
+Please provide your summary based on the conversation so far, following \
+this structure and ensuring precision and thoroughness in your response.
+
+There may be additional summarization instructions provided in the \
+included context. If so, remember to follow these instructions when \
+creating the above summary. Examples of instructions include:
+<example>
+## Compact Instructions
+When summarizing the conversation focus on typescript code changes and \
+also remember the mistakes you made and how you fixed them.
+</example>
+
+<example>
+# Summary instructions
+When you are using compact - please focus on test output and code \
+changes. Include file reads verbatim.
+</example>
+"""
+
+
+def get_compact_prompt(custom_instructions: str | None = None) -> str:
+    """Build the full compaction prompt for the LLM.
+
+    Args:
+        custom_instructions: Optional user-provided instructions to append.
+
+    Returns:
+        The complete prompt string to send as the summarization request.
+    """
+    prompt = COMPACT_SUMMARY_PROMPT.format(
+        analysis_instruction=_DETAILED_ANALYSIS_INSTRUCTION,
+    )
+
+    if custom_instructions and custom_instructions.strip():
+        prompt += f"\n\nAdditional Instructions:\n{custom_instructions}"
+
+    return prompt
+
+
+def format_compact_summary(summary: str) -> str:
+    """Format a raw LLM summary by stripping drafting blocks and XML tags.
+
+    - Removes ``<analysis>...</analysis>`` scratchpad (improves quality but
+      has no informational value once the summary is written).
+    - Replaces ``<summary>...</summary>`` tags with a ``Summary:`` header.
+    - Collapses excessive blank lines.
+
+    Args:
+        summary: Raw LLM output potentially containing XML tags.
+
+    Returns:
+        Cleaned summary text.
+    """
+    # Strip analysis section
+    formatted = re.sub(r"<analysis>[\s\S]*?</analysis>", "", summary)
+
+    # Extract and format summary section
+    match = re.search(r"<summary>([\s\S]*?)</summary>", formatted)
+    if match:
+        content = match.group(1).strip()
+        formatted = re.sub(
+            r"<summary>[\s\S]*?</summary>",
+            f"Summary:\n{content}",
+            formatted,
+        )
+
+    # Collapse multiple blank lines
+    formatted = re.sub(r"\n\n+", "\n\n", formatted)
+
+    return formatted.strip()
+
+
+def get_compact_continuation_message(
+    summary: str,
+    *,
+    suppress_follow_up_questions: bool = True,
+    transcript_path: str | None = None,
+    recent_messages_preserved: bool = False,
+) -> str:
+    """Build the continuation message inserted after compaction.
+
+    This message replaces the compacted conversation and gives the LLM
+    context to resume seamlessly.
+
+    Args:
+        summary: The formatted summary text.
+        suppress_follow_up_questions: If ``True``, instruct the model to
+            resume without asking questions.
+        transcript_path: Optional path to the full conversation transcript.
+        recent_messages_preserved: Whether recent messages are kept verbatim
+            after the summary.
+
+    Returns:
+        The continuation message content string.
+    """
+    formatted = format_compact_summary(summary)
+
+    base = f"{COMPACT_CONTINUATION_PREAMBLE}\n\n{formatted}"
+
+    if transcript_path:
+        base += (
+            f"\n\nIf you need specific details from before compaction "
+            f"(like exact code snippets, error messages, or content you "
+            f"generated), read the full transcript at: {transcript_path}"
+        )
+
+    if recent_messages_preserved:
+        base += f"\n\n{COMPACT_RECENT_MESSAGES_NOTE}"
+
+    if suppress_follow_up_questions:
+        base += f"\n{COMPACT_DIRECT_RESUME_INSTRUCTION}"
+
+    return base

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -268,6 +268,13 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
             )
             ```
         """
+        # Use the structured compaction prompt when the caller hasn't
+        # provided a custom summary_prompt (i.e. is using the default).
+        if summary_prompt is DEFAULT_SUMMARY_PROMPT:
+            from deepagents.middleware.structured_compaction import get_compact_prompt  # noqa: PLC0415
+
+            summary_prompt = get_compact_prompt()
+
         # Initialize langchain helper for core summarization logic
         self._lc_helper = LCSummarizationMiddleware(
             model=model,
@@ -445,19 +452,16 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         Returns:
             List containing the summary `HumanMessage`.
         """
-        if file_path is not None:
-            content = f"""\
-You are in the middle of a conversation that has been summarized.
+        from deepagents.middleware.structured_compaction import (  # noqa: PLC0415
+            get_compact_continuation_message,
+        )
 
-The full conversation history has been saved to {file_path} should you need to refer back to it for details.
-
-A condensed summary follows:
-
-<summary>
-{summary}
-</summary>"""
-        else:
-            content = f"Here is a summary of the conversation to date:\n\n{summary}"
+        content = get_compact_continuation_message(
+            summary,
+            suppress_follow_up_questions=True,
+            transcript_path=file_path,
+            recent_messages_preserved=True,
+        )
 
         return [
             HumanMessage(

--- a/libs/deepagents/tests/unit_tests/middleware/test_structured_compaction.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_structured_compaction.py
@@ -1,0 +1,159 @@
+"""Unit tests for structured session compaction."""
+
+from deepagents.middleware.structured_compaction import (
+    COMPACT_CONTINUATION_PREAMBLE,
+    COMPACT_DIRECT_RESUME_INSTRUCTION,
+    COMPACT_RECENT_MESSAGES_NOTE,
+    COMPACT_SUMMARY_PROMPT,
+    format_compact_summary,
+    get_compact_continuation_message,
+    get_compact_prompt,
+)
+
+
+class TestGetCompactPrompt:
+    """Tests for the compaction prompt builder."""
+
+    def test_contains_nine_sections(self):
+        prompt = get_compact_prompt()
+        for section in [
+            "1. Primary Request and Intent",
+            "2. Key Technical Concepts",
+            "3. Files and Code Sections",
+            "4. Errors and fixes",
+            "5. Problem Solving",
+            "6. All user messages",
+            "7. Pending Tasks",
+            "8. Current Work",
+            "9. Optional Next Step",
+        ]:
+            assert section in prompt
+
+    def test_contains_analysis_instruction(self):
+        prompt = get_compact_prompt()
+        assert "<analysis>" in prompt
+        assert "Chronologically analyze" in prompt
+
+    def test_contains_example_structure(self):
+        prompt = get_compact_prompt()
+        assert "<example>" in prompt
+        assert "</example>" in prompt
+        assert "<summary>" in prompt
+
+    def test_custom_instructions_appended(self):
+        prompt = get_compact_prompt("Focus on database changes.")
+        assert "Focus on database changes." in prompt
+        assert "Additional Instructions:" in prompt
+
+    def test_empty_custom_instructions_ignored(self):
+        prompt = get_compact_prompt("")
+        assert "Additional Instructions:" not in prompt
+
+    def test_none_custom_instructions_ignored(self):
+        prompt = get_compact_prompt(None)
+        assert "Additional Instructions:" not in prompt
+
+
+class TestFormatCompactSummary:
+    """Tests for summary formatting."""
+
+    def test_strips_analysis_block(self):
+        raw = "<analysis>Thinking...</analysis>\n<summary>The result</summary>"
+        result = format_compact_summary(raw)
+        assert "Thinking..." not in result
+        assert "The result" in result
+
+    def test_replaces_summary_tags_with_header(self):
+        raw = "<summary>Some content here</summary>"
+        result = format_compact_summary(raw)
+        assert result == "Summary:\nSome content here"
+
+    def test_plain_text_passthrough(self):
+        raw = "Just plain text without XML tags"
+        result = format_compact_summary(raw)
+        assert result == "Just plain text without XML tags"
+
+    def test_collapses_multiple_blank_lines(self):
+        raw = "<summary>line1\n\n\n\nline2</summary>"
+        result = format_compact_summary(raw)
+        assert "\n\n\n" not in result
+        assert "line1" in result
+        assert "line2" in result
+
+    def test_handles_empty_analysis(self):
+        raw = "<analysis></analysis><summary>Content</summary>"
+        result = format_compact_summary(raw)
+        assert result == "Summary:\nContent"
+
+    def test_multiline_analysis_stripped(self):
+        raw = "<analysis>\nStep 1: think\nStep 2: more thinking\n</analysis>\n<summary>\n1. Primary Request:\n   User wanted X\n</summary>"
+        result = format_compact_summary(raw)
+        assert "think" not in result
+        assert "Primary Request" in result
+
+
+class TestGetCompactContinuationMessage:
+    """Tests for continuation message generation."""
+
+    def test_includes_preamble(self):
+        msg = get_compact_continuation_message("Test summary")
+        assert msg.startswith(COMPACT_CONTINUATION_PREAMBLE)
+
+    def test_formats_summary(self):
+        msg = get_compact_continuation_message("<summary>My summary content</summary>")
+        assert "Summary:\nMy summary content" in msg
+
+    def test_includes_resume_instruction_by_default(self):
+        msg = get_compact_continuation_message("Test")
+        assert COMPACT_DIRECT_RESUME_INSTRUCTION in msg
+
+    def test_suppress_follow_up_false(self):
+        msg = get_compact_continuation_message("Test", suppress_follow_up_questions=False)
+        assert COMPACT_DIRECT_RESUME_INSTRUCTION not in msg
+
+    def test_includes_transcript_path(self):
+        msg = get_compact_continuation_message("Test", transcript_path="/history/session.md")
+        assert "/history/session.md" in msg
+        assert "read the full transcript" in msg
+
+    def test_no_transcript_path(self):
+        msg = get_compact_continuation_message("Test", transcript_path=None)
+        assert "read the full transcript" not in msg
+
+    def test_recent_messages_preserved(self):
+        msg = get_compact_continuation_message("Test", recent_messages_preserved=True)
+        assert COMPACT_RECENT_MESSAGES_NOTE in msg
+
+    def test_recent_messages_not_preserved(self):
+        msg = get_compact_continuation_message("Test", recent_messages_preserved=False)
+        assert COMPACT_RECENT_MESSAGES_NOTE not in msg
+
+    def test_full_message_structure(self):
+        """Verify the complete structure matches the expected format."""
+        msg = get_compact_continuation_message(
+            "<summary>Full test</summary>",
+            suppress_follow_up_questions=True,
+            transcript_path="/conv/thread.md",
+            recent_messages_preserved=True,
+        )
+        # Order: preamble → summary → transcript → recent note → resume
+        preamble_idx = msg.index(COMPACT_CONTINUATION_PREAMBLE)
+        summary_idx = msg.index("Summary:\nFull test")
+        transcript_idx = msg.index("/conv/thread.md")
+        recent_idx = msg.index(COMPACT_RECENT_MESSAGES_NOTE)
+        resume_idx = msg.index(COMPACT_DIRECT_RESUME_INSTRUCTION)
+
+        assert preamble_idx < summary_idx < transcript_idx < recent_idx < resume_idx
+
+
+class TestPromptConstantsIntegrity:
+    """Verify prompt constants haven't been accidentally truncated."""
+
+    def test_summary_prompt_has_substantial_content(self):
+        assert len(COMPACT_SUMMARY_PROMPT) > 1000
+
+    def test_preamble_is_non_empty(self):
+        assert len(COMPACT_CONTINUATION_PREAMBLE) > 50
+
+    def test_resume_instruction_is_non_empty(self):
+        assert len(COMPACT_DIRECT_RESUME_INSTRUCTION) > 50

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -585,14 +585,12 @@ class TestSummaryMessageFormat:
         # Get the summary message (first in modified messages list)
         summary_msg = modified_request.messages[0]
 
-        # Should include the file path reference
-        assert "full conversation history has been saved to" in summary_msg.content
+        # Should include the file path reference (as transcript path)
         assert "/conversation_history/test-thread.md" in summary_msg.content
+        assert "read the full transcript" in summary_msg.content
 
-        # Should include the summary in XML tags
-        assert "<summary>" in summary_msg.content
+        # Should include the summary content (formatted, XML tags stripped)
         assert "Test summary content" in summary_msg.content
-        assert "</summary>" in summary_msg.content
 
     def test_summary_has_lc_source_marker(self) -> None:
         """Test that summary message has `lc_source=summarization` marker."""
@@ -694,14 +692,12 @@ class TestSummaryMessageFormat:
         # The summary message should be the first message
         summary_msg = modified_request.messages[0]
 
-        # Should include the file path reference
-        assert "full conversation history has been saved to" in summary_msg.content
+        # Should include the file path reference (as transcript path)
         assert "/conversation_history/multi-summarize-thread.md" in summary_msg.content
+        assert "read the full transcript" in summary_msg.content
 
-        # Should include the summary in XML tags
-        assert "<summary>" in summary_msg.content
+        # Should include the summary content (formatted, XML tags stripped)
         assert "Second summary content" in summary_msg.content
-        assert "</summary>" in summary_msg.content
 
         # Should have lc_source marker
         assert summary_msg.additional_kwargs.get("lc_source") == "summarization"
@@ -2401,8 +2397,8 @@ def test_profile_inference_triggers_summary() -> None:
     assert modified_request is not None
     summary_message = modified_request.messages[0]
     assert isinstance(summary_message, HumanMessage)
-    assert "summarized" in summary_message.content.lower()
-    assert "<summary>" in summary_message.content
+    # The continuation message starts with the compaction preamble
+    assert "continued from a previous conversation" in summary_message.content.lower()
 
     # Should preserve last 2 messages (keep=0.5 * 1000 = 500 tokens, 500/200 = 2.5 messages)
     preserved_messages = modified_request.messages[1:]


### PR DESCRIPTION
## Summary

The default summarization prompt produces unstructured summaries that lose critical technical context (file paths, code snippets, error history, user feedback) after compaction. This makes it difficult for the agent to resume work accurately in long sessions.

This PR replaces the default prompt with a structured 9-section compaction prompt that
guides the LLM to preserve:
- User requests and intent
- Files and code sections with snippets
- Errors encountered and how they were fixed
- Pending tasks and current work state
- All user messages (critical for tracking changing intent)

It also updates the post-compaction continuation message to include a transcript path reference and a direct resume instruction, so the agent picks up exactly where it left off without recapping or asking follow-up questions.

Backward-compatible: callers who pass a custom `summary_prompt` are unaffected.

## Changes

- **New module**: `deepagents/middleware/structured_compaction.py`
  - `get_compact_prompt()` — builds the 9-section LLM summary prompt with optional custom instructions
  - `format_compact_summary()` — strips `<analysis>` scratchpad blocks and formats `<summary>` tags
  - `get_compact_continuation_message()` — builds the session continuation message with transcript path and resume instruction
- **Modified**: `deepagents/middleware/summarization.py`
  - Replace `DEFAULT_SUMMARY_PROMPT` with structured compaction prompt when no custom prompt is provided
  - Update `_build_new_messages_with_path()` to use continuation message format
- **New tests**: `tests/unit_tests/middleware/test_structured_compaction.py` (25 tests)
- **Updated tests**: `test_summarization_middleware.py` — 3 assertions updated to match new message format

## How did you verify your code works?

- `make format`, `make lint`, `make test` all passing (240 tests, 0 failures)
- Verified prompt structure contains all 9 required sections
- Verified `format_compact_summary` correctly strips `<analysis>` blocks and formats `<summary>` tags
- Verified continuation message ordering (preamble → summary → transcript → recent note → resume instruction)
- Cross-verified prompt content and formatting logic against the reference implementation

Resolves #2389