### PR TITLE
ci(evals): consolidate experiment links and add dynamic run-name

### DIFF
--- a/.github/scripts/aggregate_evals.py
+++ b/.github/scripts/aggregate_evals.py
@@ -152,7 +152,7 @@ def main() -> None:
         lines.extend(cat_table)
 
     # --- LangSmith experiment links ---
-    experiment_entries: list[tuple[str, str, str]] = []  # (model, name, url)
+    experiment_entries: list[tuple[str, str, str, str]] = []  # (model, name, url, public_url)
     for r in rows:
         model = str(r.get("model", ""))
         # Prefer rich experiment_links (name + url); fall back to bare experiment_urls
@@ -163,19 +163,23 @@ def main() -> None:
                 if isinstance(link, dict):
                     name = str(link.get("name", ""))
                     url = str(link.get("url", ""))
+                    public_url = str(link.get("public_url", ""))
                     if url:
-                        experiment_entries.append((model, name or url, url))
+                        experiment_entries.append((model, name or url, url, public_url))
         else:
             raw_urls = r.get("experiment_urls") or []
             if isinstance(raw_urls, list):
                 for url in raw_urls:
-                    experiment_entries.append((model, str(url), str(url)))
+                    experiment_entries.append((model, str(url), str(url), ""))
     if experiment_entries:
         lines.append("")
         lines.append("## LangSmith experiments")
         lines.append("")
-        for model, name, url in experiment_entries:
-            lines.append(f"- **{model}**: [{name}]({url})")
+        for model, name, url, public_url in experiment_entries:
+            if public_url:
+                lines.append(f"- **{model}**: [{name}]({public_url}) ([internal]({url}))")
+            else:
+                lines.append(f"- **{model}**: [{name}]({url})")
 
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_file:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -20,6 +20,8 @@
 #   OPENROUTER_API_KEY — needed for OpenRouter-hosted models
 
 name: "📊 Evals"
+run-name: >-
+  📊 Evals — ${{ inputs.models_override && (contains(inputs.models_override, ',') && 'custom models' || inputs.models_override) || inputs.models || 'all' }}${{ inputs.eval_categories && format(' [{0}]', inputs.eval_categories) || '' }}
 
 on:
   workflow_dispatch:
@@ -145,18 +147,27 @@ jobs:
           else
             echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
           fi
-          # Show each category on its own line within the table cell
+          # Show eval categories as both comma-separated and bulleted list
           if [ "${EVAL_CATEGORIES}" = "(all)" ]; then
             echo "| \`eval_categories\` | (all) |" >> "$GITHUB_STEP_SUMMARY"
           else
-            formatted=""
             IFS=',' read -ra cats <<< "${EVAL_CATEGORIES}"
+            # Comma-separated row
+            comma_list=""
             for cat in "${cats[@]}"; do
               cat=$(echo "$cat" | xargs)
-              [ -n "$formatted" ] && formatted="${formatted}<br>"
-              formatted="${formatted}<code>${cat}</code>"
+              [ -n "$comma_list" ] && comma_list="${comma_list}, "
+              comma_list="${comma_list}\`${cat}\`"
             done
-            echo "| \`eval_categories\` | ${formatted} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| \`eval_categories\` | ${comma_list} |" >> "$GITHUB_STEP_SUMMARY"
+            # Bulleted list row
+            bulleted=""
+            for cat in "${cats[@]}"; do
+              cat=$(echo "$cat" | xargs)
+              [ -n "$bulleted" ] && bulleted="${bulleted}<br>"
+              bulleted="${bulleted}• <code>${cat}</code>"
+            done
+            echo "| \`eval_categories\` (expanded) | ${bulleted} |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -235,39 +246,6 @@ jobs:
             echo "::error::evals_report.json not found. pytest likely crashed before sessionfinish could write the report. Check the 'Run Evals' step logs for errors."
             exit 1
           fi
-
-      - name: "📝 Write workflow summary"
-        if: "!cancelled()"
-        run: |
-          {
-            echo "## Eval run"
-            echo ""
-            echo "- Model: ${{ matrix.model }}"
-            links=$(python -c "
-          import json, sys
-          try:
-              with open('evals_report.json') as f:
-                  data = json.load(f)
-              for link in data.get('experiment_links', []):
-                  name = link.get('name', '')
-                  url = link.get('url', '')
-                  public_url = link.get('public_url', '')
-                  if name and public_url:
-                      print(f'- [{name}]({public_url}) ([private]({url}))')
-                  elif name and url:
-                      print(f'- [{name}]({url})')
-                  elif url:
-                      print(f'- {url}')
-          except Exception as exc:
-              print(f'warning: could not extract experiment links: {exc}', file=sys.stderr)
-            ")
-            if [ -n "$links" ]; then
-              echo ""
-              echo "### LangSmith experiments"
-              echo ""
-              echo "$links"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: "📤 Upload eval report"
         if: "!cancelled()"


### PR DESCRIPTION
Consolidate eval experiment link rendering into the aggregation script and add a dynamic `run-name` to the evals workflow. The per-job workflow summary step was duplicating link-formatting logic that `aggregate_evals.py` already handles — this removes that duplication and surfaces public URLs in the aggregated summary.

## Changes
- Add dynamic `run-name` to the evals workflow that shows the selected model(s) and eval categories at a glance in the GitHub Actions UI
- Surface `public_url` in `aggregate_evals.py` experiment entries — public links render as the primary href with an `(internal)` fallback link alongside
- Replace the `<br>`-separated eval categories display in the parameters table with a comma-separated row plus an expanded bulleted row underneath
- Remove the per-job `📝 Write workflow summary` step (~33 lines) — link rendering is now handled entirely by the aggregation script