### PR TITLE
fix(evals): show diff in stale catalog check and regenerate

### DIFF
--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -4,7 +4,7 @@
 Quick reference for every eval, grouped by category.
 Source of truth: [`tests/evals/`](tests/evals/).
 
-**84 evals** across **7 categories**
+**85 evals** across **7 categories**
 
 ## File Ops (`file_operations`) (13 evals)
 
@@ -64,11 +64,12 @@ Source of truth: [`tests/evals/`](tests/evals/).
 - [`test_four_steps_find_user_city_weather_time_and_food_details`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_tool_usage_relational.py#L1028) — `tests/evals/test_tool_usage_relational.py:1028`
 - [`test_four_steps_find_user_email_city_foods_calories_and_allergies`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_tool_usage_relational.py#L1097) — `tests/evals/test_tool_usage_relational.py:1097`
 
-## Memory (`memory`) (16 evals)
+## Memory (`memory`) (17 evals)
 
-- [`test_conflict_resolution`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L255) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:255`
-- [`test_time_learning`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L285) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:285`
-- [`test_memory_agent_bench_ci`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L314) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:314`
+- [`test_conflict_resolution`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L350) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:350`
+- [`test_time_learning`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L380) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:380`
+- [`test_memory_agent_bench_ci`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L409) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:409`
+- [`test_memory_agent_bench_ci_fileseeded`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/memory_agent_bench/test_memory_agent_bench.py#L438) — `tests/evals/memory_agent_bench/test_memory_agent_bench.py:438`
 - [`test_memory_basic_recall`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_memory.py#L38) — `tests/evals/test_memory.py:38`
 - [`test_memory_guided_behavior_naming_convention`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_memory.py#L70) — `tests/evals/test_memory.py:70`
 - [`test_memory_influences_file_content`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_memory.py#L113) — `tests/evals/test_memory.py:113`

--- a/libs/evals/scripts/generate_eval_catalog.py
+++ b/libs/evals/scripts/generate_eval_catalog.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import difflib
 import json
 from pathlib import Path
 
@@ -160,11 +161,22 @@ def main() -> None:
     if args.check:
         if not _OUTPUT.exists():
             print(f"MISSING: {_OUTPUT}")
+            print("Run `make eval-catalog` from libs/evals/ to regenerate.")
             raise SystemExit(1)
         actual = _OUTPUT.read_text(encoding="utf-8")
         if actual != expected:
-            print(f"STALE: {_OUTPUT}")
-            print("Run `make eval-catalog` from libs/evals/ to regenerate.")
+            diff = difflib.unified_diff(
+                actual.splitlines(),
+                expected.splitlines(),
+                fromfile="EVAL_CATALOG.md (on disk)",
+                tofile="EVAL_CATALOG.md (expected)",
+                lineterm="",
+            )
+            print(f"STALE: {_OUTPUT}\n")
+            print("\n".join(diff))
+            print(
+                "\nRun `make eval-catalog` from libs/evals/ to regenerate."
+            )
             raise SystemExit(1)
         print(f"OK: {_OUTPUT} is up-to-date")
     else:

--- a/libs/evals/tests/unit_tests/test_eval_catalog.py
+++ b/libs/evals/tests/unit_tests/test_eval_catalog.py
@@ -23,7 +23,7 @@ def test_eval_catalog_up_to_date() -> None:
         timeout=30,
     )
     assert result.returncode == 0, (
-        f"EVAL_CATALOG.md is out of date.\n"
-        f"Run `make eval-catalog` from libs/evals/ to regenerate.\n"
-        f"{result.stdout}{result.stderr}"
+        f"EVAL_CATALOG.md is out of date. "
+        f"Run `make eval-catalog` from libs/evals/ to regenerate.\n\n"
+        f"{result.stdout}"
     )


### PR DESCRIPTION
The `EVAL_CATALOG.md` drift test was failing CI because the catalog was stale after new memory evals landed. The `--check` mode only printed "STALE" with no indication of what diverged, making it hard to tell whether your PR caused the staleness or it was pre-existing. The script now emits a unified diff so the exact discrepancy is visible inline in the CI log.