### PR TITLE
ci(evals): verbose pytest output and print LangSmith links in CI

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -237,7 +237,23 @@ jobs:
           echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS}${flags}" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
-        run: make evals
+        run: |
+          # Print LangSmith link for monitoring results as they arrive
+          tenant_id=$(curl -sf \
+            -H "x-api-key: $LANGSMITH_API_KEY" \
+            "https://api.smith.langchain.com/sessions?limit=1" \
+            | python3 -c "import sys, json; d = json.load(sys.stdin); print(d[0]['tenant_id'] if d else '')" \
+            2>/dev/null) || true
+          if [ -n "$tenant_id" ]; then
+            echo "LangSmith experiment: $LANGSMITH_EXPERIMENT"
+            echo "  View results at: https://smith.langchain.com/o/${tenant_id}/testing"
+            echo ""
+          else
+            echo "::warning::Could not resolve LangSmith tenant ID for experiment URL"
+          fi
+
+          # Run evals
+          make evals
 
       - name: "🔍 Check eval report"
         if: "!cancelled()"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -307,6 +307,7 @@ jobs:
           echo "experiment_name=$experiment_name" >> "$GITHUB_OUTPUT"
           echo "experiment_url=$experiment_url" >> "$GITHUB_OUTPUT"
           echo "LANGSMITH_EXPERIMENT=$experiment_name" >> "$GITHUB_ENV"
+          echo "LANGSMITH_EXPERIMENT_URL=$experiment_url" >> "$GITHUB_ENV"
 
       - name: "🔇 Suppress Harbor first-run tips"
         run: |
@@ -315,6 +316,12 @@ jobs:
 
       - name: "⚓ Run Harbor"
         run: |
+          # Print LangSmith experiment link
+          echo "LangSmith experiment: $LANGSMITH_EXPERIMENT"
+          echo "  View at: $LANGSMITH_EXPERIMENT_URL"
+          echo ""
+
+          # Run Harbor
           n_tasks_flag=""
           if [ "$HARBOR_N_TASKS" != "0" ]; then
             n_tasks_flag="--n-tasks $HARBOR_N_TASKS"

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -14,7 +14,7 @@ test: ## Run unit tests
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 evals: ## Run evals
-	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest tests/evals
+	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest tests/evals -v --tb=short $(PYTEST_EXTRA)
 
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw . -- $(TEST_FILE)


### PR DESCRIPTION
Default the `make evals` target to verbose output (`-v --tb=short`) so individual test names and concise failure tracebacks are always visible. Also print the LangSmith experiment URL at the top of CI eval and Harbor runs so results can be monitored in real time without digging through logs.