### PR TITLE
ci(evals): per-provider concurrency and category dropdown

### DIFF
--- a/.github/scripts/aggregate_evals.py
+++ b/.github/scripts/aggregate_evals.py
@@ -203,6 +203,13 @@ def main() -> None:
             " currently produce these metrics."
         )
 
+    # --- Reference links ---
+    lines.append("")
+    lines.append(
+        "📚 [Eval Catalog](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/EVAL_CATALOG.md)"
+        " | [Model Groups](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/MODEL_GROUPS.md)"
+    )
+
     # --- LangSmith experiment links ---
     experiment_entries: list[
         tuple[str, str, str, str]

--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -555,7 +555,11 @@ def main() -> None:
     env_var, _ = _WORKFLOW_CONFIG[workflow]
     selection = os.environ.get(env_var, "all")
     models = _resolve_models(workflow, selection)
-    matrix = {"model": models}
+    matrix = {
+        "include": [
+            {"model": m, "provider": m.split(":")[0]} for m in models
+        ],
+    }
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     line = f"matrix={json.dumps(matrix, separators=(',', ':'))}"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -21,7 +21,7 @@
 
 name: "📊 Evals"
 run-name: >-
-  📊 Evals — ${{ inputs.models_override && (contains(inputs.models_override, ',') && 'custom models' || inputs.models_override) || inputs.models || 'all' }}${{ inputs.eval_categories && format(' [{0}]', inputs.eval_categories) || '' }}
+  📊 Evals — ${{ inputs.models_override && (contains(inputs.models_override, ',') && 'custom models' || inputs.models_override) || inputs.models || 'all' }}${{ (inputs.eval_categories_override || inputs.eval_categories) && format(' [{0}]', inputs.eval_categories_override || inputs.eval_categories) || '' }}
 
 on:
   workflow_dispatch:
@@ -108,7 +108,21 @@ on:
         default: ""
         type: string
       eval_categories:
-        description: "Comma-separated eval categories to run (e.g. 'memory,tool_use,retrieval'). Full eval listing: libs/evals/EVAL_CATALOG.md. Leave empty to run all."
+        description: "Eval category to run. Full listing: libs/evals/EVAL_CATALOG.md. Leave empty to use eval_categories_override instead. Defaults to all if both are empty."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - conversation
+          - file_operations
+          - memory
+          - retrieval
+          - summarization
+          - tool_use
+          - unit_test
+      eval_categories_override:
+        description: "Custom category list (overrides dropdown). Comma-separated, e.g. 'memory,tool_use,retrieval'. Leave empty to use the preset selection above."
         required: false
         default: ""
         type: string
@@ -120,10 +134,6 @@ on:
 
 permissions:
   contents: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.models_override || inputs.models || 'all' }}
-  cancel-in-progress: false
 
 env:
   UV_NO_SYNC: "true"
@@ -141,7 +151,7 @@ jobs:
         env:
           MODELS: ${{ inputs.models }}
           MODELS_OVERRIDE: ${{ inputs.models_override || '(empty)' }}
-          EVAL_CATEGORIES: ${{ inputs.eval_categories || '(all)' }}
+          EVAL_CATEGORIES: ${{ inputs.eval_categories_override || inputs.eval_categories || '(all)' }}
         run: |
           echo "### 📊 Eval dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -178,6 +188,8 @@ jobs:
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "📚 [Eval Catalog](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/EVAL_CATALOG.md) | [Model Groups](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/MODEL_GROUPS.md)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
@@ -193,6 +205,11 @@ jobs:
     needs: prep
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    # Per-provider concurrency: jobs sharing a provider queue (no cancellation),
+    # jobs on different providers run in parallel.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.provider }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
@@ -233,10 +250,12 @@ jobs:
         run: uv sync --group test
 
       - name: "🏷️ Apply category filter"
-        if: inputs.eval_categories != ''
+        if: inputs.eval_categories_override != '' || inputs.eval_categories != ''
+        env:
+          EVAL_CATEGORIES: ${{ inputs.eval_categories_override || inputs.eval_categories }}
         run: |
           flags=""
-          IFS=',' read -ra cats <<< "${{ inputs.eval_categories }}"
+          IFS=',' read -ra cats <<< "${EVAL_CATEGORIES}"
           for cat in "${cats[@]}"; do
             cat=$(echo "$cat" | xargs)
             flags="$flags --eval-category $cat"

--- a/libs/evals/README.md
+++ b/libs/evals/README.md
@@ -164,6 +164,10 @@ eval_categories: "memory,tool_use,retrieval"
 
 Omit to run all categories.
 
+### CI concurrency
+
+Eval jobs use per-provider concurrency groups. Two jobs hitting the same provider (e.g. both `openai`) queue — the second waits for the first to finish. Jobs on different providers run in parallel, so dispatching `frontier` (anthropic + google_genai + openai) alongside a solo `openrouter` run won't block either side.
+
 ### Per-category reporting
 
 CI runs produce a per-category correctness table in the GitHub Actions step summary, plus a JSON summary artifact (`evals-summary`) for offline analysis.


### PR DESCRIPTION
The evals workflow had two UX gaps: concurrent dispatches with non-overlapping providers blocked each other unnecessarily, and selecting eval categories required typing exact names from memory. This fixes both by moving concurrency control to per-provider job-level groups and splitting the free-text `eval_categories` input into a dropdown + override pair (mirroring the existing `models`/`models_override` pattern).