### PR TITLE
ci(evals): log openrouter provider override in summary

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -152,6 +152,7 @@ jobs:
           MODELS: ${{ inputs.models }}
           MODELS_OVERRIDE: ${{ inputs.models_override || '(empty)' }}
           EVAL_CATEGORIES: ${{ inputs.eval_categories_override || inputs.eval_categories || '(all)' }}
+          OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
         run: |
           echo "### 📊 Eval dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -185,6 +186,9 @@ jobs:
               done
               echo "| \`eval_categories\` (expanded) | ${bulleted} |" >> "$GITHUB_STEP_SUMMARY"
             fi
+          fi
+          if [ -n "${OPENROUTER_PROVIDER}" ]; then
+            echo "| \`openrouter_provider\` | \`${OPENROUTER_PROVIDER}\` |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Log the `openrouter_provider` workflow_dispatch input in the "📝 Log dispatch inputs" step summary table. Previously this value was consumed silently by the provider-pin step but never surfaced in the run summary, making it hard to tell after the fact whether solo routing was active.