### PR TITLE
fix(evals): add request timeout for OpenRouter models

### DIFF
--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -137,4 +137,9 @@ def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
             "only": [provider],
             "allow_fallbacks": False,
         }
+    if model_name.startswith("openrouter:"):
+        # OpenRouter SDK passes timeout=None to httpx, disabling its default
+        # 5s read timeout. This causes indefinite hangs on TCP stalls.
+        # See: https://github.com/OpenRouterTeam/python-sdk/issues/72
+        kwargs["timeout"] = 120_000  # ms
     return init_chat_model(model_name, **kwargs)


### PR DESCRIPTION
The OpenRouter Python SDK passes `timeout=None` to `httpx.Client.build_request()` when no explicit timeout is configured, which overrides httpx's default 5s read timeout and disables timeouts entirely ([OpenRouterTeam/python-sdk#72](https://github.com/OpenRouterTeam/python-sdk/issues/72)). When a TCP connection stalls during response body reads — reproduced at ~5% rate against `nvidia/nemotron-3-super-120b-a12b` via DeepInfra — eval runs hang indefinitely, burning CI slots until the 6-hour job timeout.
