### PR TITLE
feat(sdk,cli): add micro-compaction middleware for lightweight token savings

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -1168,10 +1168,14 @@ def create_cli_agent(
             routes={},
         )
 
+    from deepagents.middleware.micro_compaction import MicroCompactionMiddleware
     from deepagents.middleware.summarization import create_summarization_tool_middleware
 
-    agent_middleware.append(
-        create_summarization_tool_middleware(model, composite_backend)
+    agent_middleware.extend(
+        [
+            MicroCompactionMiddleware(),
+            create_summarization_tool_middleware(model, composite_backend),
+        ]
     )
 
     # Create the agent

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -50,6 +50,7 @@ Use a **plain tool** when:
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
+from deepagents.middleware.micro_compaction import MicroCompactionMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 from deepagents.middleware.summarization import (
@@ -64,6 +65,7 @@ __all__ = [
     "CompiledSubAgent",
     "FilesystemMiddleware",
     "MemoryMiddleware",
+    "MicroCompactionMiddleware",
     "SkillsMiddleware",
     "SubAgent",
     "SubAgentMiddleware",

--- a/libs/deepagents/deepagents/middleware/micro_compaction.py
+++ b/libs/deepagents/deepagents/middleware/micro_compaction.py
@@ -1,0 +1,167 @@
+"""Micro-compaction middleware for lightweight token savings without LLM calls.
+
+This module provides `MicroCompactionMiddleware`, which replaces the content of
+stale tool result messages with short stubs based on elapsed time. Unlike
+`SummarizationMiddleware`, it requires no LLM call — content replacement is
+purely rule-based.
+
+## How it works
+
+- Tool results older than `max_age_seconds` (default 5 min) have their
+  `content` replaced with a short stub.
+- Message structure (`role`, `tool_call_id`) is preserved for API compatibility.
+- Error results (`status="error"`) are always preserved.
+- The most recent `preserve_recent` messages are always kept intact.
+- `read_file` results use a specific stub: `[file content cleared — re-read if needed]`
+
+## Middleware stack placement
+
+Place `MicroCompactionMiddleware` *before* `SummarizationToolMiddleware`:
+
+```
+TokenStateMiddleware → ... → MicroCompactionMiddleware → SummarizationToolMiddleware
+```
+
+This reduces token usage so that full LLM-based compaction is needed less often.
+
+## Usage
+
+```python
+from deepagents import create_deep_agent
+from deepagents.middleware.micro_compaction import MicroCompactionMiddleware
+
+agent = create_deep_agent(
+    middleware=[MicroCompactionMiddleware(max_age_seconds=300, preserve_recent=10)],
+)
+```
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AnyMessage, ToolMessage
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+_STALE_STUB = "[content cleared — stale tool result]"
+_FILE_READ_STUB = "[file content cleared — re-read if needed]"
+
+# Tool names whose results use the file-specific stub
+_FILE_READ_TOOLS = frozenset({"read_file", "glob", "grep", "ls"})
+
+
+class MicroCompactionMiddleware(AgentMiddleware):
+    """Lightweight middleware that clears stale tool result content without LLM calls.
+
+    Tool results older than `max_age_seconds` have their content replaced with a
+    short stub. Message structure (`role`, `tool_call_id`) is preserved for API
+    compatibility. Error results are always preserved. The most recent
+    `preserve_recent` messages are always kept intact regardless of age.
+
+    This is a zero-cost alternative to `SummarizationMiddleware` that reduces
+    context window usage for long-running sessions without incurring an LLM call.
+
+    Args:
+        max_age_seconds: Seconds after first observation at which a tool result
+            is considered stale and eligible for compaction.
+        preserve_recent: Number of most-recent messages to always keep intact,
+            regardless of age.
+    """
+
+    def __init__(self, *, max_age_seconds: int = 300, preserve_recent: int = 10) -> None:
+        """Initialize the micro-compaction middleware.
+
+        Args:
+            max_age_seconds: Seconds after first observation at which a tool result
+                is considered stale and eligible for compaction.
+            preserve_recent: Number of most-recent messages to always keep intact,
+                regardless of age.
+        """
+        self._max_age_seconds = max_age_seconds
+        self._preserve_recent = preserve_recent
+        # Maps message id -> monotonic timestamp of first observation
+        self._seen_at: dict[str, float] = {}
+
+    def _compact_messages(self, messages: list[AnyMessage]) -> list[AnyMessage]:
+        """Replace content of stale ToolMessages with lightweight stubs.
+
+        Records the first-seen timestamp for any new ToolMessages, then replaces
+        the content of those older than `max_age_seconds` with a short stub.
+        The most recent `preserve_recent` messages are always left untouched.
+
+        Args:
+            messages: The current message list to process.
+
+        Returns:
+            Messages with stale tool result content replaced by stubs.
+        """
+        now = time.monotonic()
+
+        # Record first-seen timestamp for any new ToolMessages
+        for msg in messages:
+            if isinstance(msg, ToolMessage) and msg.id:
+                self._seen_at.setdefault(msg.id, now)
+
+        # Determine recent messages by object identity (last N messages unconditionally kept)
+        recent_slice = messages[-self._preserve_recent :] if self._preserve_recent > 0 else []
+        recent_obj_ids = {id(m) for m in recent_slice}
+
+        result: list[AnyMessage] = []
+        for msg in messages:
+            if (
+                isinstance(msg, ToolMessage)
+                and id(msg) not in recent_obj_ids
+                and msg.id is not None
+                and msg.status != "error"
+                and (now - self._seen_at.get(msg.id, now)) > self._max_age_seconds
+            ):
+                stub = _FILE_READ_STUB if msg.name in _FILE_READ_TOOLS else _STALE_STUB
+                kwargs: dict[str, Any] = {
+                    "content": stub,
+                    "tool_call_id": msg.tool_call_id,
+                    "name": msg.name,
+                    "id": msg.id,
+                }
+                if msg.status is not None:
+                    kwargs["status"] = msg.status
+                msg = ToolMessage(**kwargs)  # noqa: PLW2901  # intentional replacement in loop
+            result.append(msg)
+        return result
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        """Compact stale tool results before the model call.
+
+        Args:
+            request: Model request being processed.
+            handler: Handler function to call with modified request.
+
+        Returns:
+            Model response from handler.
+        """
+        return handler(request.override(messages=self._compact_messages(request.messages)))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Compact stale tool results before the async model call.
+
+        Args:
+            request: Model request being processed.
+            handler: Async handler function to call with modified request.
+
+        Returns:
+            Model response from handler.
+        """
+        return await handler(request.override(messages=self._compact_messages(request.messages)))

--- a/libs/deepagents/tests/unit_tests/middleware/test_micro_compaction.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_micro_compaction.py
@@ -1,0 +1,332 @@
+"""Unit tests for MicroCompactionMiddleware."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from deepagents.middleware.micro_compaction import (
+    _FILE_READ_STUB,
+    _FILE_READ_TOOLS,
+    _STALE_STUB,
+    MicroCompactionMiddleware,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = 1000.0  # arbitrary monotonic baseline
+
+
+def _make_tool_msg(
+    tool_call_id: str,
+    content: str = "some result",
+    name: str = "my_tool",
+    *,
+    msg_id: str | None = None,
+    status: str | None = None,
+) -> ToolMessage:
+    kwargs: dict = {
+        "content": content,
+        "tool_call_id": tool_call_id,
+        "name": name,
+        "id": msg_id or tool_call_id,
+    }
+    if status is not None:
+        kwargs["status"] = status
+    return ToolMessage(**kwargs)
+
+
+def _make_middleware(**kwargs: int) -> MicroCompactionMiddleware:
+    return MicroCompactionMiddleware(**kwargs)
+
+
+def _make_request(messages: list) -> MagicMock:
+    """Stub ModelRequest that records the messages passed to override()."""
+    req = MagicMock()
+    req.messages = messages
+    req.override.side_effect = lambda **kw: MagicMock(messages=kw["messages"])
+    return req
+
+
+def _make_handler() -> tuple[MagicMock, list]:
+    """Return a (mock handler, captured_requests) pair."""
+    captured: list[MagicMock] = []
+    resp = MagicMock()
+
+    def _handler(request: MagicMock) -> MagicMock:
+        captured.append(request)
+        return resp
+
+    handler = MagicMock(side_effect=_handler)
+    return handler, captured
+
+
+# ---------------------------------------------------------------------------
+# _compact_messages — core logic
+# ---------------------------------------------------------------------------
+
+
+class TestCompactMessages:
+    def test_stale_tool_message_content_replaced(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("c1")
+
+        # First call: registers the message at _NOW
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+
+        # Second call: 301 seconds later — message is now stale
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 301):
+            result = mw._compact_messages([msg])
+
+        assert len(result) == 1
+        assert isinstance(result[0], ToolMessage)
+        assert result[0].content == _STALE_STUB
+
+    def test_fresh_tool_message_content_preserved(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("c2", content="important data")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+
+        # Only 100 seconds later — not stale yet
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 100):
+            result = mw._compact_messages([msg])
+
+        assert result[0].content == "important data"
+
+    def test_preserve_recent_keeps_last_n_messages(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=3)
+
+        old_msgs = [_make_tool_msg(f"old-{i}") for i in range(4)]
+        recent_msgs = [_make_tool_msg(f"recent-{i}") for i in range(3)]
+        all_msgs = old_msgs + recent_msgs
+
+        # Register all at _NOW
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages(all_msgs)
+
+        # 400 seconds later: all messages are old, but the last 3 are "recent"
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 400):
+            result = mw._compact_messages(all_msgs)
+
+        # First 4 messages should be compacted
+        for r in result[:4]:
+            assert r.content == _STALE_STUB, f"expected stub, got: {r.content!r}"
+        # Last 3 are preserved
+        for orig, r in zip(recent_msgs, result[4:], strict=True):
+            assert r.content == orig.content
+
+    def test_error_results_always_preserved(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("err1", content="error details", status="error")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 500):
+            result = mw._compact_messages([msg])
+
+        assert result[0].content == "error details"
+
+    def test_file_read_tools_use_specific_stub(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+
+        for tool_name in _FILE_READ_TOOLS:
+            msg = _make_tool_msg(f"fr-{tool_name}", name=tool_name, msg_id=f"fr-{tool_name}")
+            with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+                mw._compact_messages([msg])
+            with patch(
+                "deepagents.middleware.micro_compaction.time.monotonic",
+                return_value=_NOW + 400,
+            ):
+                result = mw._compact_messages([msg])
+            assert result[0].content == _FILE_READ_STUB, f"tool={tool_name!r}"
+
+    def test_non_file_read_tools_use_generic_stub(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("exec1", name="execute")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 400):
+            result = mw._compact_messages([msg])
+
+        assert result[0].content == _STALE_STUB
+
+    def test_non_tool_messages_not_modified(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        human = HumanMessage(content="hello", id="h1")
+        ai = AIMessage(content="world", id="a1")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([human, ai])
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 500):
+            result = mw._compact_messages([human, ai])
+
+        assert result[0].content == "hello"
+        assert result[1].content == "world"
+
+    def test_tool_message_without_id_not_compacted(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        # ToolMessage with no id cannot be tracked by timestamp
+        msg = ToolMessage(content="untracked", tool_call_id="x", name="my_tool")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 500):
+            result = mw._compact_messages([msg])
+
+        assert result[0].content == "untracked"
+
+    def test_compacted_message_preserves_structure(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("c-struct", content="large output", name="execute", msg_id="id-struct")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 400):
+            (result,) = mw._compact_messages([msg])
+
+        assert isinstance(result, ToolMessage)
+        assert result.tool_call_id == "c-struct"
+        assert result.name == "execute"
+        assert result.id == "id-struct"
+        assert result.content == _STALE_STUB
+
+    def test_message_not_compacted_on_first_observation(self) -> None:
+        """A message first seen right now should never be immediately compacted."""
+        mw = _make_middleware(max_age_seconds=0, preserve_recent=0)
+        msg = _make_tool_msg("c-new")
+
+        # max_age_seconds=0 but elapsed == 0 on first observation
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            result = mw._compact_messages([msg])
+
+        # elapsed == 0, threshold is 0: condition is strictly > so not compacted
+        assert result[0].content == "some result"
+
+    def test_second_observation_same_time_not_compacted(self) -> None:
+        """If re-observed at the same monotonic time, message is not yet stale."""
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("c-sametime")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+            result = mw._compact_messages([msg])
+
+        assert result[0].content == "some result"
+
+
+# ---------------------------------------------------------------------------
+# wrap_model_call / awrap_model_call
+# ---------------------------------------------------------------------------
+
+
+class TestWrapModelCall:
+    def test_wrap_model_call_passes_compacted_messages_to_handler(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("wmc1")
+        request = _make_request([msg])
+        handler, captured = _make_handler()
+
+        # Register message, then advance time
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 400):
+            mw.wrap_model_call(request, handler)
+
+        assert handler.called
+        passed_messages = captured[0].messages
+        assert passed_messages[0].content == _STALE_STUB
+
+    def test_wrap_model_call_uses_override(self) -> None:
+        mw = _make_middleware()
+        msg = HumanMessage(content="hi")
+        request = _make_request([msg])
+        handler = MagicMock(return_value=MagicMock())
+
+        mw.wrap_model_call(request, handler)
+
+        request.override.assert_called_once()
+
+    async def test_awrap_model_call_passes_compacted_messages_to_handler(self) -> None:
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("awmc1")
+        request = _make_request([msg])
+        captured: list[MagicMock] = []
+
+        async def async_handler(req: MagicMock) -> MagicMock:
+            captured.append(req)
+            return MagicMock()
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 400):
+            await mw.awrap_model_call(request, async_handler)
+
+        assert len(captured) == 1
+        assert captured[0].messages[0].content == _STALE_STUB
+
+    async def test_awrap_model_call_uses_override(self) -> None:
+        mw = _make_middleware()
+        msg = HumanMessage(content="async hi")
+        request = _make_request([msg])
+
+        async def async_handler(req: MagicMock) -> MagicMock:  # noqa: ARG001
+            return MagicMock()
+
+        await mw.awrap_model_call(request, async_handler)
+
+        request.override.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_message_list(self) -> None:
+        mw = _make_middleware()
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            result = mw._compact_messages([])
+        assert result == []
+
+    def test_preserve_recent_larger_than_message_list(self) -> None:
+        """preserve_recent > len(messages): all messages kept."""
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=100)
+        msgs = [_make_tool_msg(f"big-{i}") for i in range(5)]
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages(msgs)
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 400):
+            result = mw._compact_messages(msgs)
+
+        for orig, r in zip(msgs, result, strict=True):
+            assert r.content == orig.content
+
+    def test_seen_at_not_overwritten_on_subsequent_calls(self) -> None:
+        """Once a message is registered, its timestamp is not updated."""
+        mw = _make_middleware(max_age_seconds=300, preserve_recent=0)
+        msg = _make_tool_msg("sticky")
+
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW):
+            mw._compact_messages([msg])
+
+        # Fake a later call where it re-appears but still within window
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 200):
+            mw._compact_messages([msg])  # re-observes but should not update timestamp
+
+        # Now 301 seconds after original observation
+        with patch("deepagents.middleware.micro_compaction.time.monotonic", return_value=_NOW + 301):
+            result = mw._compact_messages([msg])
+
+        # Elapsed is 301 from first observation => should be compacted
+        assert result[0].content == _STALE_STUB


### PR DESCRIPTION
Adds `MicroCompactionMiddleware`, a zero-LLM-cost middleware that replaces stale `ToolMessage` content with short stubs based on elapsed time, reducing context window usage for long-running sessions without any model call. It is placed before `SummarizationToolMiddleware` in the CLI agent middleware stack.

Fixes #2390

---

**Verification:** Ran `make format && make lint && make test` from `libs/deepagents/` and `libs/cli/` — all pass. `micro_compaction.py` achieves 100% line coverage.