### PR TITLE
feat(evals): auto-regenerate eval catalog on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: evals
         name: format and lint evals
         language: system
-        entry: make -C libs/evals format lint
+        entry: make -C libs/evals format eval-catalog lint
         files: ^libs/evals/
         pass_filenames: false
       - id: acp

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -91,6 +91,7 @@ lint lint_diff:
 		fi; \
 	fi
 	$(MAKE) type PYTHON_FILES="$(PYTHON_FILES)"
+	uv run python scripts/generate_eval_catalog.py --check
 
 type: ## Run type checker (eval + harbor source + unit tests)
 type typecheck:


### PR DESCRIPTION
- Wire `eval-catalog` into the evals pre-commit hook so `EVAL_CATALOG.md` is
  auto-regenerated whenever eval files change — no manual step needed.
- Add `--check` to the `lint` target as a CI backstop that fails on a stale
  catalog.

### Changes

- `.pre-commit-config.yaml`: evals hook now runs `format eval-catalog lint`
  (was `format lint`)
- `libs/evals/Makefile`: `lint` target appends
  `generate_eval_catalog.py --check`