### PR TITLE
fix(cli): use utf-8 when reading bundled prompt templates

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -504,7 +504,7 @@ def get_system_prompt(
         ... {CONDITIONAL SECTIONS} ...
         ```
     """
-    template = (Path(__file__).parent / "system_prompt.md").read_text()
+    template = (Path(__file__).parent / "system_prompt.md").read_text(encoding="utf-8")
 
     skills_path = f"~/.deepagents/{assistant_id}/skills"
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1762,7 +1762,7 @@ def get_default_coding_instructions() -> str:
         The default agent instructions as a string.
     """
     default_prompt_path = Path(__file__).parent / "default_agent_prompt.md"
-    return default_prompt_path.read_text()
+    return default_prompt_path.read_text(encoding="utf-8")
 
 
 def detect_provider(model_name: str) -> str | None:

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -2261,3 +2261,18 @@ class TestFindDotenvFromStartPath:
 
         # Should continue past the OSError and find .env in parent
         assert result == env_file
+
+class TestDefaultCodingInstructions:
+    """Tests for bundled default coding instructions loading."""
+
+    def test_reads_default_prompt_as_utf8(self) -> None:
+        """Should read the bundled default prompt with explicit UTF-8."""
+        from deepagents_cli.config import get_default_coding_instructions
+
+        with patch.object(
+            Path, "read_text", return_value="default instructions"
+        ) as mock_read:
+            result = get_default_coding_instructions()
+
+        assert result == "default instructions"
+        mock_read.assert_called_once_with(encoding="utf-8")


### PR DESCRIPTION
Fixes #2356

Use explicit UTF-8 decoding when reading bundled CLI prompt/template files, which makes the CLI more robust on Windows where the platform default encoding may not be UTF-8. This keeps the scope narrow to the concrete read sites identified in the issue and adds a focused unit test for the config prompt-loading path.

How did you verify your code works?

* Ran the directly relevant unit tests in `tests/unit_tests/test_agent.py`
* Added and ran a focused unit test in `tests/unit_tests/test_config.py`
* Verified the CLI still starts normally with `uv run deepagents --help`

AI assistance disclaimer: I used AI tools to help investigate the issue and refine the change, but I reviewed the code changes and tests before submitting this PR.
