### PR TITLE
fix(sdk): pass runtime.config to subagent invocations in _build_task_tool

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -452,7 +452,7 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = subagent.invoke(subagent_state)
+        result = subagent.invoke(subagent_state, runtime.config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     async def atask(
@@ -467,7 +467,7 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        result = await subagent.ainvoke(subagent_state)
+        result = await subagent.ainvoke(subagent_state, runtime.config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     return StructuredTool.from_function(


### PR DESCRIPTION
Fixes #2362

## Problem

The `_build_task_tool` function in `SubAgentMiddleware` invokes subagents via `subagent.invoke(subagent_state)` and `subagent.ainvoke(subagent_state)` without passing the parent's `runtime.config`. This means:

- `ToolRuntime.context` is `None` in subagent tools when using `context_schema`
- Callbacks registered in the parent config are not forwarded to subagent model calls (also related to #2315)

## Solution

Pass `runtime.config` as the second argument to both `subagent.invoke()` and `subagent.ainvoke()` calls in the `task` and `atask` inner functions, restoring the behavior originally introduced in PR #602 and lost during the PR #1041 refactor.

```python
# Before
result = subagent.invoke(subagent_state)
result = await subagent.ainvoke(subagent_state)

# After  
result = subagent.invoke(subagent_state, runtime.config)
result = await subagent.ainvoke(subagent_state, runtime.config)
```

## Testing

The existing test `test_subagent_propagates_recursion_limit_to_tool_runtime` covers config propagation and verifies that Pregel correctly merges the passed config with the subagent's own `with_config` settings (subagent's recursion limit takes precedence over parent's). The test `test_context_passed_to_subagent_tool_runtime` covers the context propagation case described in #2362.