### PR TITLE
fix(sdk): quick eval for reading the whole skill file

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -593,7 +593,7 @@ User: "Can you research the latest developments in quantum computing?"
 3. Follow the skill's research workflow (search -> organize -> synthesize)
 4. Use any helper scripts with absolute paths
 
-Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!"""
+Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!""" # noqa: E501
 
 
 class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -557,9 +557,7 @@ async def _alist_skills(backend: BackendProtocol, source_path: str) -> list[Skil
     return skills
 
 
-SKILLS_SYSTEM_PROMPT = """
-
-## Skills System
+SKILLS_SYSTEM_PROMPT = """## Skills System
 
 You have access to a skills library that provides specialized capabilities and domain knowledge.
 
@@ -574,7 +572,7 @@ You have access to a skills library that provides specialized capabilities and d
 Skills follow a **progressive disclosure** pattern - you see their name and description above, but only read full instructions when needed:
 
 1. **Recognize when a skill applies**: Check if the user's task matches a skill's description
-2. **Read the skill's full instructions**: Use the path shown in the skill list above
+2. **Read the skill's full instructions**: Use the path shown in the skill list above, and if you decide to use the skill, read the entire `SKILL.md` file rather than stopping at an initial paginated chunk; prefer reading it in large chunks of around 1000 lines at a time until you have the full file
 3. **Follow the skill's instructions**: SKILL.md contains step-by-step workflows, best practices, and examples
 4. **Access supporting files**: Skills may include helper scripts, configs, or reference docs - use absolute paths
 
@@ -595,8 +593,7 @@ User: "Can you research the latest developments in quantum computing?"
 3. Follow the skill's research workflow (search -> organize -> synthesize)
 4. Use any helper scripts with absolute paths
 
-Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!
-"""
+Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!"""
 
 
 class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -67,7 +67,7 @@ You have access to a skills library that provides specialized capabilities and d
 Skills follow a **progressive disclosure** pattern - you see their name and description above, but only read full instructions when needed:
 
 1. **Recognize when a skill applies**: Check if the user's task matches a skill's description
-2. **Read the skill's full instructions**: Use the path shown in the skill list above, and if you decide to use the skill, read the entire `SKILL.md` file before using the skill.
+2. **Read the skill's full instructions**: Use the path shown in the skill list above, and if you decide to use the skill, read the entire `SKILL.md` file rather than stopping at an initial paginated chunk; prefer reading it in large chunks of around 1000 lines at a time until you have the full file
 3. **Follow the skill's instructions**: SKILL.md contains step-by-step workflows, best practices, and examples
 4. **Access supporting files**: Skills may include helper scripts, configs, or reference docs - use absolute paths
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -48,8 +48,6 @@ Writing todos takes time and tokens, use it when it is helpful for managing comp
 - Don't be afraid to revise the To-Do list as you go. New information may reveal new tasks that need to be done, or old tasks that are irrelevant.
 
 
-
-
 ## Skills System
 
 You have access to a skills library that provides specialized capabilities and domain knowledge.
@@ -69,7 +67,7 @@ You have access to a skills library that provides specialized capabilities and d
 Skills follow a **progressive disclosure** pattern - you see their name and description above, but only read full instructions when needed:
 
 1. **Recognize when a skill applies**: Check if the user's task matches a skill's description
-2. **Read the skill's full instructions**: Use the path shown in the skill list above
+2. **Read the skill's full instructions**: Use the path shown in the skill list above, and if you decide to use the skill, read the entire `SKILL.md` file before using the skill.
 3. **Follow the skill's instructions**: SKILL.md contains step-by-step workflows, best practices, and examples
 4. **Access supporting files**: Skills may include helper scripts, configs, or reference docs - use absolute paths
 
@@ -91,7 +89,6 @@ User: "Can you research the latest developments in quantum computing?"
 4. Use any helper scripts with absolute paths
 
 Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!
-
 
 
 ## Following Conventions


### PR DESCRIPTION
Read the whole skill file

Looking at this: https://github.com/langchain-ai/deepagents/issues/2446

We need to run evals on this, but may consider ultimately introduced a special tool for loading skills