### PR TITLE
fix(cli): resolve conflicting langsmith env var precedence

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -213,14 +213,14 @@ def _ensure_bootstrap() -> None:
                     # Propagate (including empty string for explicit disable).
                     os.environ[canonical] = prefixed_val
                 elif os.environ[canonical] != prefixed_val:
+                    os.environ[canonical] = prefixed_val
                     logger.warning(
                         "Both %s and %s are set with different values; "
-                        "the LangSmith SDK will use %s while the CLI "
-                        "prefers %s. Unset one to avoid confusion.",
+                        "using %s. Unset %s to silence this warning.",
                         canonical,
                         prefixed,
-                        canonical,
                         prefixed,
+                        canonical,
                     )
         except Exception:
             logger.exception(

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -2136,10 +2136,10 @@ class TestLazyModuleAttributes:
             config_mod._bootstrap_done = original_done
             config_mod._original_langsmith_project = original_ls
 
-    def test_bootstrap_does_not_overwrite_canonical_langsmith_vars(
+    def test_bootstrap_overrides_canonical_with_prefixed_value(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Canonical LangSmith vars are preserved when already set."""
+        """Prefixed value wins when both canonical and prefixed vars are set."""
         import deepagents_cli.config as config_mod
         from deepagents_cli.config import _ensure_bootstrap
 
@@ -2163,8 +2163,8 @@ class TestLazyModuleAttributes:
 
             import os
 
-            # Canonical value preserved — propagation does not overwrite.
-            assert os.environ["LANGSMITH_API_KEY"] == "lsv2_original"
+            # Prefixed value wins — canonical is overwritten.
+            assert os.environ["LANGSMITH_API_KEY"] == "lsv2_override"
         finally:
             config_mod._bootstrap_done = original_done
             config_mod._original_langsmith_project = original_ls


### PR DESCRIPTION
When both a `DEEPAGENTS_CLI_`-prefixed env var and its canonical counterpart (e.g., `LANGSMITH_API_KEY`) were set with different values, the bootstrap code warned but left both in place. The LangSmith SDK would silently use one key while the CLI used the other — traces could land in the wrong workspace with no visible error. Now the prefixed value always wins: `_ensure_bootstrap` overwrites the canonical var before warning, keeping the SDK and CLI in sync.