### PR TITLE
fix(cli): align headless todo guidance with non-interactive mode

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -480,7 +480,7 @@ def get_system_prompt(
 
     Loads the base system prompt template from `system_prompt.md` and
     interpolates dynamic sections (model identity, working directory,
-    skills path, execution mode).
+    skills path, execution mode, and todo-list guidance for interactive vs headless).
 
     Args:
         assistant_id: The agent identifier for path references
@@ -520,6 +520,13 @@ def get_system_prompt(
             "- If the request is ambiguous, ask questions before acting.\n"
             "- If asked how to approach something, explain first, then act."
         )
+        todo_guidance = (
+            "6. When first creating a todo list for a task, ALWAYS ask the user if the plan looks good before starting work\n"
+            '   - Create the todos, let them render, then ask: "Does this plan look good?" or similar\n'
+            "   - Wait for the user's response before marking the first todo as in_progress\n"
+            "   - If they want changes, adjust the plan accordingly\n"
+            "7. Update todo status promptly as you complete each item"
+        )
     else:
         mode_description = (
             "non-interactive (headless) mode — there is no human operator "
@@ -541,6 +548,12 @@ def get_system_prompt(
             "`npm init`, `apt-get install -y` not `apt-get install`, "
             "`yes |` or `--no-input`/`--non-interactive` flags where "
             "available. Never run commands that block waiting for stdin."
+        )
+        todo_guidance = (
+            "6. There is no human operator in this mode — do NOT ask the user to approve your plan or wait for a reply.\n"
+            "   After you create todos for a multi-step task, mark the first item `in_progress` immediately and start work.\n"
+            "   If the plan needs adjustment, revise the todo list yourself; do not block on human confirmation.\n"
+            "7. Update todo status promptly as you complete each item"
         )
 
     model_identity_section = build_model_identity_section(
@@ -598,6 +611,7 @@ def get_system_prompt(
         template.replace("{mode_description}", mode_description)
         .replace("{interactive_preamble}", interactive_preamble)
         .replace("{ambiguity_guidance}", ambiguity_guidance)
+        .replace("{todo_guidance}", todo_guidance)
         .replace("{model_identity_section}", model_identity_section)
         .replace("{working_dir_section}", working_dir_section)
         .replace("{skills_path}", skills_path)

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -480,7 +480,8 @@ def get_system_prompt(
 
     Loads the base system prompt template from `system_prompt.md` and
     interpolates dynamic sections (model identity, working directory,
-    skills path, execution mode, and todo-list guidance for interactive vs headless).
+    skills path, execution mode, and todo-list guidance for
+    interactive vs headless).
 
     Args:
         assistant_id: The agent identifier for path references
@@ -523,11 +524,10 @@ def get_system_prompt(
         todo_guidance = (
             "6. When first creating a todo list for a task, ALWAYS ask the user if "
             "the plan looks good before starting work\n"
-            '   - Create the todos, let them render, then ask: "Does this plan '
+            '   - Create the todos, then ask: "Does this plan '
             'look good?" or similar\n'
             "   - Wait for the user's response before marking the first todo as "
             "in_progress\n"
-            "   - If they want changes, adjust the plan accordingly\n"
             "7. Update todo status promptly as you complete each item"
         )
     else:

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -521,9 +521,12 @@ def get_system_prompt(
             "- If asked how to approach something, explain first, then act."
         )
         todo_guidance = (
-            "6. When first creating a todo list for a task, ALWAYS ask the user if the plan looks good before starting work\n"
-            '   - Create the todos, let them render, then ask: "Does this plan look good?" or similar\n'
-            "   - Wait for the user's response before marking the first todo as in_progress\n"
+            "6. When first creating a todo list for a task, ALWAYS ask the user if "
+            "the plan looks good before starting work\n"
+            '   - Create the todos, let them render, then ask: "Does this plan '
+            'look good?" or similar\n'
+            "   - Wait for the user's response before marking the first todo as "
+            "in_progress\n"
             "   - If they want changes, adjust the plan accordingly\n"
             "7. Update todo status promptly as you complete each item"
         )
@@ -550,9 +553,12 @@ def get_system_prompt(
             "available. Never run commands that block waiting for stdin."
         )
         todo_guidance = (
-            "6. There is no human operator in this mode — do NOT ask the user to approve your plan or wait for a reply.\n"
-            "   After you create todos for a multi-step task, mark the first item `in_progress` immediately and start work.\n"
-            "   If the plan needs adjustment, revise the todo list yourself; do not block on human confirmation.\n"
+            "6. There is no human operator in this mode — do NOT ask the user to "
+            "approve your plan or wait for a reply.\n"
+            "   After you create todos for a multi-step task, mark the first item "
+            "`in_progress` immediately and start work.\n"
+            "   If the plan needs adjustment, revise the todo list yourself; do "
+            "not block on human confirmation.\n"
             "7. Update todo status promptly as you complete each item"
         )
 

--- a/libs/cli/deepagents_cli/system_prompt.md
+++ b/libs/cli/deepagents_cli/system_prompt.md
@@ -238,10 +238,6 @@ When using the write_todos tool:
 3. Don't batch completions — mark each item done as you finish it
 4. If a task reveals sub-tasks, add them right away
 5. For simple 1-step tasks, just do them directly
-6. When first creating a todo list for a task, ALWAYS ask the user if the plan looks good before starting work
-   - Create the todos, let them render, then ask: "Does this plan look good?" or similar
-   - Wait for the user's response before marking the first todo as in_progress
-   - If they want changes, adjust the plan accordingly
-7. Update todo status promptly as you complete each item
+{todo_guidance}
 
 The todo list is a planning tool - use it judiciously to avoid overwhelming the user with excessive task tracking.

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -600,7 +600,8 @@ class TestGetSystemPromptNonInteractive:
         with patch("deepagents_cli.agent.settings", mock_settings):
             prompt = get_system_prompt("test-agent", interactive=False)
 
-        assert "Wait for the user's response before marking the first todo" not in prompt
+        wait_for_user = "Wait for the user's response before marking the first todo"
+        assert wait_for_user not in prompt
         assert "do NOT ask the user to approve your plan" in prompt
         assert "mark the first item `in_progress` immediately" in prompt
 

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -582,6 +582,28 @@ class TestGetSystemPromptNonInteractive:
 
         assert "interactive CLI" in prompt
 
+    def test_interactive_todo_section_asks_user_before_starting(self) -> None:
+        """Interactive mode should require plan approval before first in_progress."""
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=True)
+
+        assert "Wait for the user's response before marking the first todo" in prompt
+
+    def test_non_interactive_todo_section_does_not_wait_for_user(self) -> None:
+        """Headless mode must not contradict 'no human' guidance in todo rules."""
+        mock_settings = Mock()
+        mock_settings.model_name = None
+
+        with patch("deepagents_cli.agent.settings", mock_settings):
+            prompt = get_system_prompt("test-agent", interactive=False)
+
+        assert "Wait for the user's response before marking the first todo" not in prompt
+        assert "do NOT ask the user to approve your plan" in prompt
+        assert "mark the first item `in_progress` immediately" in prompt
+
 
 class TestGetSystemPromptCwdOSError:
     """Tests for Path.cwd() OSError handling in get_system_prompt."""


### PR DESCRIPTION
## Summary

In headless / non-interactive mode, the CLI system prompt told the model not to ask the user for anything (no human in the loop), while the static **Todo list management** section still required asking for plan approval and waiting before the first `in_progress` todo. That produced contradictory instructions for `write_todos` in `--stdin` and similar runs.

## What changed

- Replaced the fixed todo items 6–7 in `system_prompt.md` with a `{todo_guidance}` placeholder.
- `get_system_prompt()` now fills that block from `interactive`: interactive sessions keep the previous “ask and wait” behavior; headless sessions get explicit guidance to proceed without blocking on human confirmation and to adjust the plan autonomously.
- Added unit tests asserting the interactive wait-for-user line appears only when `interactive=True`, and that headless prompts include the new non-blocking todo rules.

Fixes #2458