### PR TITLE
fix(sdk): preserve wrapped lines across read_file pagination

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -708,6 +708,14 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
             return content
 
+        def _truncate_for_token_limit(content: str, file_path: str) -> str:
+            if token_limit and len(content) >= NUM_CHARS_PER_TOKEN * token_limit:
+                truncation_msg = READ_FILE_TRUNCATION_MSG.format(file_path=file_path)
+                max_content_length = NUM_CHARS_PER_TOKEN * token_limit - len(truncation_msg)
+                content = content[:max_content_length] + truncation_msg
+
+            return content
+
         def _handle_read_result(
             read_result: ReadResult | str,
             validated_path: str,
@@ -749,9 +757,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 return empty_msg
 
             content = format_content_with_line_numbers(content, start_line=offset + 1)
-            # We apply truncation again after formatting content as continuation lines
-            # can increase line count
-            return _truncate(content, validated_path, limit)
+            return _truncate_for_token_limit(content, validated_path)
 
         def sync_read_file(
             file_path: Annotated[str, "Absolute path to the file to read. Must be absolute, not relative."],

--- a/libs/deepagents/tests/unit_tests/test_file_system_tools.py
+++ b/libs/deepagents/tests/unit_tests/test_file_system_tools.py
@@ -599,3 +599,63 @@ def test_ls_with_invalid_path_returns_error_message() -> None:
 
     error_message = tool_messages[0].content
     assert error_message == "Error: Path traversal not allowed: ../../../etc"
+
+
+def test_read_file_pagination_keeps_lines_after_wrapped_long_line() -> None:
+    long_line = "x" * 15000
+    file_content = f"line1\n{long_line}\nimportant instruction\nline4"
+
+    fake_model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"file_path": "/wrapped.txt", "content": file_content},
+                            "id": "call_write_wrapped",
+                            "type": "tool_call",
+                        },
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "read_file",
+                            "args": {"file_path": "/wrapped.txt", "offset": 0, "limit": 3},
+                            "id": "call_read_wrapped_page_1",
+                            "type": "tool_call",
+                        },
+                    ],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "read_file",
+                            "args": {"file_path": "/wrapped.txt", "offset": 3, "limit": 3},
+                            "id": "call_read_wrapped_page_2",
+                            "type": "tool_call",
+                        },
+                    ],
+                ),
+                AIMessage(content="I have read both pages."),
+            ]
+        )
+    )
+
+    agent = create_deep_agent(
+        model=fake_model,
+        checkpointer=InMemorySaver(),
+        backend=StateBackend(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage(content="Write and paginate the wrapped file")]},
+        config={"configurable": {"thread_id": "test_thread_wrapped_read_file"}},
+    )
+
+    tool_messages = [m.content for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert any("important instruction" in str(message) for message in tool_messages)


### PR DESCRIPTION
## Summary
- stop reapplying the line-count limit after formatting wrapped `read_file` output with continuation rows
- preserve logical lines that follow a very long wrapped line so paginated reads no longer skip content between pages
- add a focused SDK regression that exercises paginated reads across a wrapped long line

Fixes #2453.

AI-generated with Codex and manually verified.

## Testing
- `cd libs/deepagents && uv run --group test pytest tests/unit_tests/test_file_system_tools.py -k pagination_keeps_lines_after_wrapped_long_line`
- `cd libs/deepagents && uv run --group test ruff check deepagents/middleware/filesystem.py tests/unit_tests/test_file_system_tools.py`