### PR TITLE
feat(cli): `--skill` startup invocation

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -517,6 +517,7 @@ class DeepAgentsApp(App):
         thread_id: str | None = None,
         resume_thread: str | None = None,
         initial_prompt: str | None = None,
+        initial_skill: str | None = None,
         mcp_server_info: list[MCPServerInfo] | None = None,
         profile_override: dict[str, Any] | None = None,
         server_proc: ServerProcess | None = None,
@@ -547,6 +548,7 @@ class DeepAgentsApp(App):
 
                 Requires `server_kwargs` to be set; ignored otherwise.
             initial_prompt: Optional prompt to auto-submit when session starts
+            initial_skill: Optional skill name to invoke when session starts.
             mcp_server_info: MCP server metadata for the `/mcp` viewer.
             profile_override: Extra profile fields from `--profile-override`,
                 retained so later profile-aware behavior stays consistent with
@@ -593,6 +595,12 @@ class DeepAgentsApp(App):
         self._resume_thread_intent = resume_thread
 
         self._initial_prompt = initial_prompt
+
+        self._initial_skill = (
+            initial_skill.strip().lower()
+            if initial_skill and initial_skill.strip()
+            else None
+        )
 
         self._mcp_server_info = mcp_server_info
 
@@ -711,8 +719,8 @@ class DeepAgentsApp(App):
         """Cached skill metadata (populated by startup discovery worker,
         refreshed on `/reload`).
 
-        Used by `_handle_skill_command` to skip re-walking all skill directories
-        on every invocation.
+        Used by `_invoke_skill` to skip re-walking all skill directories on
+        every invocation.
         """
 
         self._skill_allowed_roots: list[Path] = []
@@ -970,21 +978,23 @@ class DeepAgentsApp(App):
             group="startup-tool-check",
         )
 
-        # Auto-submit initial prompt if provided via -m flag.
+        # Auto-submit initial prompt or skill if provided via -m / --skill.
         # This check must come first because _lc_thread_id and _agent are
         # always set (even for brand-new sessions), so an elif after the
         # thread-history branch would never execute.
         # When connecting, defer until on_deep_agents_app_server_ready fires.
-        if not self._connecting:
-            if self._initial_prompt and self._initial_prompt.strip():
-                prompt = self._initial_prompt
-                self.call_after_refresh(
-                    lambda: asyncio.create_task(self._handle_user_message(prompt))
-                )
-            elif self._lc_thread_id and self._agent:
-                self.call_after_refresh(
-                    lambda: asyncio.create_task(self._load_thread_history())
-                )
+        # NOTE: _schedule_initial_submission() has a side effect (queues a
+        # task via call_after_refresh); short-circuit ensures it only runs
+        # when not connecting — the deferred path handles the connecting case.
+        if (
+            not self._connecting
+            and not self._schedule_initial_submission()
+            and self._lc_thread_id
+            and self._agent
+        ):
+            self.call_after_refresh(
+                lambda: asyncio.create_task(self._load_thread_history())
+            )
 
     async def _init_session_state(self) -> None:
         """Create session state in a thread (imports deepagents_cli.sessions)."""
@@ -1096,44 +1106,16 @@ class DeepAgentsApp(App):
         """Discover skills and build pre-resolved containment roots.
 
         Shared by `_discover_skills` (startup/reload) and the cache-miss
-        fallback in `_handle_skill_command` to avoid duplicating the
+        fallback in `_invoke_skill` to avoid duplicating the
         `list_skills` call and root-resolution logic.
 
         Returns:
             Tuple of `(skill metadata list, pre-resolved containment roots)`.
         """
-        from deepagents_cli.config import settings
-        from deepagents_cli.skills.load import list_skills
+        from deepagents_cli.skills.invocation import discover_skills_and_roots
 
         assistant_id = self._assistant_id or "agent"
-        skills = list_skills(
-            built_in_skills_dir=settings.get_built_in_skills_dir(),
-            user_skills_dir=settings.get_user_skills_dir(assistant_id),
-            project_skills_dir=settings.get_project_skills_dir(),
-            user_agent_skills_dir=settings.get_user_agent_skills_dir(),
-            project_agent_skills_dir=settings.get_project_agent_skills_dir(),
-            user_claude_skills_dir=settings.get_user_claude_skills_dir(),
-            project_claude_skills_dir=settings.get_project_claude_skills_dir(),
-        )
-        # Pre-resolve containment roots once so _handle_skill_command
-        # doesn't repeat resolve() on every invocation.
-        roots = [
-            d.resolve()
-            for d in (
-                settings.get_built_in_skills_dir(),
-                settings.get_user_skills_dir(assistant_id),
-                settings.get_project_skills_dir(),
-                settings.get_user_agent_skills_dir(),
-                settings.get_project_agent_skills_dir(),
-                settings.get_user_claude_skills_dir(),
-                settings.get_project_claude_skills_dir(),
-            )
-            if d is not None
-        ]
-        # Extra dirs are containment-only (not discovery); they allow
-        # symlinks in standard dirs to point outside those dirs.
-        roots.extend(d.resolve() for d in settings.get_extra_skills_dirs())
-        return skills, roots
+        return discover_skills_and_roots(assistant_id)
 
     async def _resolve_resume_thread(self) -> None:
         """Resolve a `-r` resume intent into a concrete thread ID.
@@ -1305,13 +1287,10 @@ class DeepAgentsApp(App):
         except NoMatches:
             logger.warning("Welcome banner not found during server ready transition")
 
-        # Handle deferred initial prompt or thread history
-        if self._initial_prompt and self._initial_prompt.strip():
-            prompt = self._initial_prompt
-            self.call_after_refresh(
-                lambda: asyncio.create_task(self._handle_user_message(prompt))
-            )
-        elif self._lc_thread_id and self._agent:
+        # Handle deferred initial prompt, skill, or thread history
+        if not self._schedule_initial_submission() and (
+            self._lc_thread_id and self._agent
+        ):
             self.call_after_refresh(
                 lambda: asyncio.create_task(self._load_thread_history())
             )
@@ -1337,10 +1316,8 @@ class DeepAgentsApp(App):
             self.call_after_refresh(lambda: asyncio.create_task(_safe_drain()))
 
         # Drain any messages the user typed while the server was starting.
-        # (If an initial prompt exists, its cleanup path will drain the queue.)
-        if self._pending_messages and not (
-            self._initial_prompt and self._initial_prompt.strip()
-        ):
+        # (If an initial submission exists, its cleanup path will drain the queue.)
+        if self._pending_messages and not self._has_initial_submission():
             self.call_after_refresh(
                 lambda: asyncio.create_task(self._process_next_from_queue())
             )
@@ -2185,6 +2162,45 @@ class DeepAgentsApp(App):
             logger.warning("Unrecognized input mode %r, treating as normal", mode)
             await self._handle_user_message(value)
 
+    def _has_initial_submission(self) -> bool:
+        """Return whether startup should auto-submit a prompt or skill."""
+        return self._initial_skill is not None or bool(
+            self._initial_prompt and self._initial_prompt.strip()
+        )
+
+    def _schedule_initial_submission(self) -> bool:
+        """Schedule the startup prompt or skill after the next refresh.
+
+        Returns:
+            `True` when a startup submission was queued, `False` otherwise.
+        """
+        if not self._has_initial_submission():
+            return False
+        self.call_after_refresh(
+            lambda: asyncio.create_task(self._submit_initial_submission())
+        )
+        return True
+
+    async def _submit_initial_submission(self) -> None:
+        """Submit the startup prompt or skill after the UI is ready."""
+        try:
+            if self._initial_skill is not None:
+                await self._invoke_skill(
+                    self._initial_skill, self._initial_prompt or ""
+                )
+                return
+            if self._initial_prompt and self._initial_prompt.strip():
+                await self._handle_user_message(self._initial_prompt)
+        except Exception:
+            logger.exception("Unhandled error during initial submission")
+            with suppress(Exception):
+                await self._mount_message(
+                    ErrorMessage(
+                        "Failed to submit startup prompt. "
+                        "Try running the command manually in the session."
+                    )
+                )
+
     def _can_bypass_queue(self, value: str) -> bool:
         """Check if a slash command can skip the message queue.
 
@@ -2870,8 +2886,14 @@ class DeepAgentsApp(App):
         with suppress(NoMatches, ScreenStackError):
             self.query_one("#chat", VerticalScroll).anchor()
 
-    async def _handle_skill_command(self, command: str) -> None:
-        """Handle a `/skill:<name>` command by loading and invoking a skill.
+    async def _invoke_skill(
+        self,
+        skill_name: str,
+        args: str = "",
+        *,
+        command: str | None = None,
+    ) -> None:
+        """Load a skill, render its widget, and send its prompt to the agent.
 
         Looks up the skill from cached metadata (populated at startup), falling
         back to a fresh filesystem walk on cache miss. Reads the `SKILL.md`
@@ -2879,20 +2901,31 @@ class DeepAgentsApp(App):
         and sends the composed message to the agent.
 
         Args:
-            command: The full command string (e.g., `/skill:web-research find X`).
+            skill_name: Skill name to invoke.
+            args: Optional user request to append after the skill body.
+            command: Original slash command text for UI echo, if any.
         """
-        from deepagents_cli.command_registry import parse_skill_command
+        from deepagents_cli.skills.invocation import build_skill_invocation_envelope
         from deepagents_cli.skills.load import load_skill_content
 
-        skill_name, args = parse_skill_command(command)
-        if not skill_name:
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(AppMessage("Usage: /skill:<name> [args]"))
+        normalized_name = skill_name.strip().lower()
+
+        async def _mount_error(message: str) -> None:
+            if command is not None:
+                await self._mount_message(UserMessage(command))
+            await self._mount_message(AppMessage(message))
+
+        if not normalized_name:
+            if command is not None:
+                await self._mount_message(UserMessage(command))
+                await self._mount_message(AppMessage("Usage: /skill:<name> [args]"))
+            else:
+                await self._mount_message(AppMessage("Skill name is required."))
             return
 
         # Fast path: look up from the cached discovery results
         cached = next(
-            (s for s in self._discovered_skills if s["name"] == skill_name),
+            (s for s in self._discovered_skills if s["name"] == normalized_name),
             None,
         )
         allowed_roots = self._skill_allowed_roots
@@ -2906,34 +2939,28 @@ class DeepAgentsApp(App):
                 # Backfill cache so subsequent invocations are fast
                 self._discovered_skills = skills
                 self._skill_allowed_roots = allowed_roots
-                cached = next((s for s in skills if s["name"] == skill_name), None)
+                cached = next((s for s in skills if s["name"] == normalized_name), None)
             except OSError as exc:
                 logger.warning(
-                    "Filesystem error loading skill %r", skill_name, exc_info=True
+                    "Filesystem error loading skill %r", normalized_name, exc_info=True
                 )
-                await self._mount_message(UserMessage(command))
-                await self._mount_message(
-                    AppMessage(
-                        f"Could not load skill: {skill_name}. Filesystem error: {exc}"
-                    )
+                await _mount_error(
+                    f"Could not load skill: {normalized_name}. Filesystem error: {exc}"
                 )
                 return
             except Exception as exc:
                 logger.warning(
-                    "Error searching for skill %r", skill_name, exc_info=True
+                    "Error searching for skill %r", normalized_name, exc_info=True
                 )
-                await self._mount_message(UserMessage(command))
-                await self._mount_message(
-                    AppMessage(
-                        f"Error loading skill: {skill_name}. "
-                        f"Unexpected error: {type(exc).__name__}: {exc}"
-                    )
+                await _mount_error(
+                    f"Error loading skill: {normalized_name}. "
+                    f"Unexpected error: {type(exc).__name__}: {exc}"
                 )
                 return
 
         if cached is None:
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(AppMessage(f"Skill not found: {skill_name}"))
+            logger.warning("Skill not found: %r", normalized_name)
+            await _mount_error(f"Skill not found: {normalized_name}")
             return
 
         # Load SKILL.md content (filesystem I/O offloaded to thread)
@@ -2946,62 +2973,44 @@ class DeepAgentsApp(App):
             content = await asyncio.to_thread(_load)
         except PermissionError as exc:
             logger.warning(
-                "Containment check failed for skill %r", skill_name, exc_info=True
+                "Containment check failed for skill %r",
+                normalized_name,
+                exc_info=True,
             )
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(AppMessage(str(exc)))
+            await _mount_error(str(exc))
             return
         except OSError as exc:
             logger.warning(
-                "Filesystem error loading skill %r", skill_name, exc_info=True
+                "Filesystem error loading skill %r", normalized_name, exc_info=True
             )
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(
-                AppMessage(
-                    f"Could not load skill: {skill_name}. Filesystem error: {exc}"
-                )
+            await _mount_error(
+                f"Could not load skill: {normalized_name}. Filesystem error: {exc}"
             )
             return
         except Exception as exc:
-            logger.warning("Error reading skill %r", skill_name, exc_info=True)
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(
-                AppMessage(
-                    f"Error loading skill: {skill_name}. "
-                    f"Unexpected error: {type(exc).__name__}: {exc}"
-                )
+            logger.warning("Error reading skill %r", normalized_name, exc_info=True)
+            await _mount_error(
+                f"Error loading skill: {normalized_name}. "
+                f"Unexpected error: {type(exc).__name__}: {exc}"
             )
             return
 
         if content is None:
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(
-                AppMessage(
-                    f"Could not read content for skill: {skill_name}. "
-                    "Check that the SKILL.md file exists, is readable, "
-                    "and is saved as UTF-8."
-                )
+            await _mount_error(
+                f"Could not read content for skill: {normalized_name}. "
+                "Check that the SKILL.md file exists, is readable, "
+                "and is saved as UTF-8."
             )
             return
 
         if not content.strip():
-            await self._mount_message(UserMessage(command))
-            await self._mount_message(
-                AppMessage(
-                    f"Skill '{skill_name}' has an empty SKILL.md file. "
-                    "Add instructions to the file before invoking."
-                )
+            await _mount_error(
+                f"Skill '{normalized_name}' has an empty SKILL.md file. "
+                "Add instructions to the file before invoking."
             )
             return
 
-        prompt = (
-            f"I'm invoking the skill `{cached['name']}`. "
-            "Below are the full instructions from the skill's SKILL.md file. "
-            "Follow these instructions to complete the task.\n\n"
-            f"---\n{content}\n---"
-        )
-        if args:
-            prompt += f"\n\n**User request:** {args}"
+        envelope = build_skill_invocation_envelope(cached, content, args)
 
         await self._mount_message(
             SkillMessage(
@@ -3013,18 +3022,20 @@ class DeepAgentsApp(App):
             )
         )
         await self._send_to_agent(
-            prompt,
-            message_kwargs={
-                "additional_kwargs": {
-                    "__skill": {
-                        "name": cached["name"],
-                        "description": str(cached.get("description", "")),
-                        "source": str(cached.get("source", "")),
-                        "args": args,
-                    },
-                },
-            },
+            envelope.prompt,
+            message_kwargs=envelope.message_kwargs,
         )
+
+    async def _handle_skill_command(self, command: str) -> None:
+        """Handle a `/skill:<name>` command by loading and invoking a skill.
+
+        Args:
+            command: The full command string (e.g., `/skill:web-research find X`).
+        """
+        from deepagents_cli.command_registry import parse_skill_command
+
+        skill_name, args = parse_skill_command(command)
+        await self._invoke_skill(skill_name, args, command=command)
 
     async def _get_conversation_token_count(self) -> int | None:
         """Return the approximate conversation-only token count.
@@ -4940,6 +4951,7 @@ async def run_textual_app(
     thread_id: str | None = None,
     resume_thread: str | None = None,
     initial_prompt: str | None = None,
+    initial_skill: str | None = None,
     mcp_server_info: list[MCPServerInfo] | None = None,
     profile_override: dict[str, Any] | None = None,
     server_proc: ServerProcess | None = None,
@@ -4969,6 +4981,7 @@ async def run_textual_app(
 
             Resolved asynchronously during TUI startup.
         initial_prompt: Optional prompt to auto-submit when session starts.
+        initial_skill: Optional skill name to invoke when session starts.
         mcp_server_info: MCP server metadata for the `/mcp` viewer.
         profile_override: Extra profile fields from `--profile-override`,
             retained so later profile-aware behavior stays consistent with
@@ -4995,6 +5008,7 @@ async def run_textual_app(
         thread_id=thread_id,
         resume_thread=resume_thread,
         initial_prompt=initial_prompt,
+        initial_skill=initial_skill,
         mcp_server_info=mcp_server_info,
         profile_override=profile_override,
         server_proc=server_proc,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -505,6 +505,13 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--skill",
+        dest="initial_skill",
+        metavar="NAME",
+        help="Invoke a skill when the interactive session starts",
+    )
+
+    parser.add_argument(
         "-n",
         "--non-interactive",
         dest="non_interactive_message",
@@ -649,6 +656,7 @@ async def run_textual_cli_async(
     thread_id: str | None = None,
     resume_thread: str | None = None,
     initial_prompt: str | None = None,
+    initial_skill: str | None = None,
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
@@ -684,6 +692,7 @@ async def run_textual_cli_async(
 
             Resolved asynchronously inside the TUI.
         initial_prompt: Optional prompt to auto-submit when session starts
+        initial_skill: Optional skill name to invoke when the session starts.
         mcp_config_path: Optional path to MCP servers JSON configuration file.
 
             Merged on top of auto-discovered configs (highest precedence).
@@ -769,6 +778,7 @@ async def run_textual_cli_async(
             thread_id=thread_id,
             resume_thread=resume_thread,
             initial_prompt=initial_prompt,
+            initial_skill=initial_skill,
             profile_override=profile_override,
             server_kwargs=server_kwargs,
             mcp_preload_kwargs=mcp_preload_kwargs,
@@ -929,6 +939,15 @@ def apply_stdin_pipe(args: argparse.Namespace) -> None:
         # initial_prompt = "{contents of error.log}\n\nexplain this"
         ```
 
+    - If `initial_skill` is already set (`--skill`, but not `-n`), stores the
+        piped text in `initial_prompt` so the skill receives it as the
+        startup request:
+
+        ```bash
+        cat diff.txt | deepagents --skill code-review
+        # initial_prompt = "{contents of diff.txt}"
+        ```
+
     - Otherwise, sets `non_interactive_message` to the piped text, causing
         the CLI to run non-interactively with it as the prompt:
 
@@ -1004,10 +1023,21 @@ def apply_stdin_pipe(args: argparse.Namespace) -> None:
     if not stdin_text:
         return
 
+    # Priority: -n message > -m prompt > --skill (no -m) > fallback to -n.
+    # The initial_prompt branch uses `is not None` (not truthiness) so that
+    # `-m ""` is distinguished from "no -m at all", allowing stdin to land
+    # in initial_prompt even when the explicit value is empty.  The --skill
+    # branch only fires when -m was NOT provided; when both -m and --skill
+    # are set, stdin merges with the -m value (previous branch).
     if args.non_interactive_message:
         args.non_interactive_message = f"{stdin_text}\n\n{args.non_interactive_message}"
-    elif args.initial_prompt:
-        args.initial_prompt = f"{stdin_text}\n\n{args.initial_prompt}"
+    elif args.initial_prompt is not None:
+        if args.initial_prompt:
+            args.initial_prompt = f"{stdin_text}\n\n{args.initial_prompt}"
+        else:
+            args.initial_prompt = stdin_text
+    elif getattr(args, "initial_skill", None):
+        args.initial_prompt = stdin_text
     else:
         args.non_interactive_message = stdin_text
 
@@ -1278,6 +1308,22 @@ def cli_main() -> None:
             )
             sys.exit(2)
 
+        if (
+            getattr(args, "initial_skill", None)
+            and not args.non_interactive_message
+            and (args.quiet or args.no_stream)
+        ):
+            from rich.console import Console as _Console
+
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --skill requires "
+                "--non-interactive (-n) when combined with --quiet or "
+                "--no-stream.\n"
+                "  deepagents --skill code-review -m 'review this patch'\n"
+                "  deepagents --skill code-review -n 'review this patch'"
+            )
+            sys.exit(2)
+
         if (args.quiet or args.no_stream) and not args.non_interactive_message:
             # Print to stderr (not the module-level stdout console) and exit
             # with code 2 to match the POSIX convention for usage errors, as
@@ -1499,6 +1545,7 @@ def cli_main() -> None:
                     sandbox_type=args.sandbox,
                     sandbox_id=args.sandbox_id,
                     sandbox_setup=getattr(args, "sandbox_setup", None),
+                    initial_skill=getattr(args, "initial_skill", None),
                     quiet=args.quiet,
                     stream=not args.no_stream,
                     mcp_config_path=getattr(args, "mcp_config", None),
@@ -1561,6 +1608,7 @@ def cli_main() -> None:
                         thread_id=thread_id,
                         resume_thread=resume_thread,
                         initial_prompt=getattr(args, "initial_prompt", None),
+                        initial_skill=getattr(args, "initial_skill", None),
                         mcp_config_path=getattr(args, "mcp_config", None),
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -610,6 +610,7 @@ async def _run_agent_loop(
     *,
     quiet: bool = False,
     stream: bool = True,
+    message_kwargs: dict[str, Any] | None = None,
     thread_url_lookup: ThreadUrlLookupState | None = None,
 ) -> None:
     """Run the agent and handle HITL interrupts until the task completes.
@@ -628,6 +629,8 @@ async def _run_agent_loop(
 
             When `False`, the full response is buffered and flushed at
             the end.
+        message_kwargs: Extra fields merged into the initial HumanMessage
+            dict (e.g., `additional_kwargs` for persisted skill metadata).
         thread_url_lookup: Optional non-blocking lookup state for rendering
             a fast-follow LangSmith thread link.
 
@@ -636,9 +639,10 @@ async def _run_agent_loop(
     """
     spinner = None if quiet else _ConsoleSpinner(console)
     state = StreamState(quiet=quiet, stream=stream, spinner=spinner)
-    stream_input: dict[str, Any] | Command = {
-        "messages": [{"role": "user", "content": message}]
-    }
+    user_msg: dict[str, Any] = {"role": "user", "content": message}
+    if message_kwargs:
+        user_msg.update(message_kwargs)
+    stream_input: dict[str, Any] | Command = {"messages": [user_msg]}
 
     thread_id = config.get("configurable", {}).get("thread_id", "")
     await dispatch_hook("session.start", {"thread_id": thread_id})
@@ -748,6 +752,7 @@ async def run_non_interactive(
     sandbox_id: str | None = None,
     sandbox_setup: str | None = None,
     *,
+    initial_skill: str | None = None,
     profile_override: dict[str, Any] | None = None,
     quiet: bool = False,
     stream: bool = True,
@@ -784,6 +789,8 @@ async def run_non_interactive(
         sandbox_id: Optional existing sandbox ID to reuse.
         sandbox_setup: Optional path to setup script to run in the sandbox
             after creation.
+        initial_skill: Optional skill name whose `SKILL.md` instructions wrap
+            the user message before sending it to the agent.
         profile_override: Extra profile fields from `--profile-override`.
 
             Merged on top of config file profile overrides.
@@ -808,6 +815,85 @@ async def run_non_interactive(
     # stderr=True routes all console.print() to stderr; agent response text
     # uses _write_text() -> sys.stdout directly.
     console = Console(stderr=True) if quiet else Console()
+
+    message_kwargs: dict[str, Any] | None = None
+    if initial_skill and initial_skill.strip():
+        from deepagents_cli.skills.invocation import (
+            build_skill_invocation_envelope,
+            discover_skills_and_roots,
+        )
+        from deepagents_cli.skills.load import load_skill_content
+
+        normalized_skill = initial_skill.strip().lower()
+        try:
+            skills, allowed_roots = discover_skills_and_roots(assistant_id)
+            skill = next((s for s in skills if s["name"] == normalized_skill), None)
+        except OSError as e:
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Could not load skill: {escape_markup(normalized_skill)}. "
+                f"Filesystem error: {escape_markup(str(e))}"
+            )
+            return 1
+        except Exception as e:  # noqa: BLE001
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Error loading skill: {escape_markup(normalized_skill)}. "
+                f"Unexpected error: {type(e).__name__}: {escape_markup(str(e))}"
+            )
+            return 1
+
+        if skill is None:
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Skill not found: {escape_markup(normalized_skill)}"
+            )
+            return 1
+
+        try:
+            content = load_skill_content(
+                str(skill["path"]),
+                allowed_roots=allowed_roots,
+            )
+        except PermissionError as e:
+            console.print(f"[bold red]Error:[/bold red] {escape_markup(str(e))}")
+            return 1
+        except OSError as e:
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Could not load skill: {escape_markup(normalized_skill)}. "
+                f"Filesystem error: {escape_markup(str(e))}"
+            )
+            return 1
+        except Exception as e:  # noqa: BLE001
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Error loading skill: {escape_markup(normalized_skill)}. "
+                f"Unexpected error: {type(e).__name__}: {escape_markup(str(e))}"
+            )
+            return 1
+        if content is None:
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Could not read content for skill: {escape_markup(normalized_skill)}. "
+                "Check that the SKILL.md file exists, is readable, "
+                "and is saved as UTF-8."
+            )
+            return 1
+
+        if not content.strip():
+            console.print(
+                "[bold red]Error:[/bold red] "
+                f"Skill '{escape_markup(normalized_skill)}' has an empty "
+                "SKILL.md file. "
+                "Add instructions to the file before invoking."
+            )
+            return 1
+
+        envelope = build_skill_invocation_envelope(skill, content, message)
+        message = envelope.prompt
+        message_kwargs = envelope.message_kwargs
+
     try:
         result = create_model(
             model_name,
@@ -919,6 +1005,7 @@ async def run_non_interactive(
                 file_op_tracker,
                 quiet=quiet,
                 stream=stream,
+                message_kwargs=message_kwargs,
                 thread_url_lookup=thread_url_lookup,
             )
 

--- a/libs/cli/deepagents_cli/skills/invocation.py
+++ b/libs/cli/deepagents_cli/skills/invocation.py
@@ -1,0 +1,103 @@
+"""Helpers for loading and formatting skill invocations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deepagents_cli.skills.load import ExtendedSkillMetadata
+
+
+@dataclass(frozen=True)
+class SkillInvocationEnvelope:
+    """Structured prompt and checkpoint metadata for a skill invocation.
+
+    Attributes:
+        prompt: Composed prompt that wraps `SKILL.md` content with
+            invocation instructions.
+        message_kwargs: Extra fields merged into the initial HumanMessage.
+    """
+
+    prompt: str
+    message_kwargs: dict[str, Any]
+
+
+def discover_skills_and_roots(
+    assistant_id: str,
+) -> tuple[list[ExtendedSkillMetadata], list[Path]]:
+    """Discover skills and build pre-resolved containment roots.
+
+    Args:
+        assistant_id: Agent identifier used to resolve user skill directories.
+
+    Returns:
+        Tuple of `(skill metadata list, pre-resolved containment roots)`.
+    """
+    from deepagents_cli.config import settings
+    from deepagents_cli.skills.load import list_skills
+
+    skills = list_skills(
+        built_in_skills_dir=settings.get_built_in_skills_dir(),
+        user_skills_dir=settings.get_user_skills_dir(assistant_id),
+        project_skills_dir=settings.get_project_skills_dir(),
+        user_agent_skills_dir=settings.get_user_agent_skills_dir(),
+        project_agent_skills_dir=settings.get_project_agent_skills_dir(),
+        user_claude_skills_dir=settings.get_user_claude_skills_dir(),
+        project_claude_skills_dir=settings.get_project_claude_skills_dir(),
+    )
+    roots = [
+        path.resolve()
+        for path in (
+            settings.get_built_in_skills_dir(),
+            settings.get_user_skills_dir(assistant_id),
+            settings.get_project_skills_dir(),
+            settings.get_user_agent_skills_dir(),
+            settings.get_project_agent_skills_dir(),
+            settings.get_user_claude_skills_dir(),
+            settings.get_project_claude_skills_dir(),
+        )
+        if path is not None
+    ]
+    roots.extend(path.resolve() for path in settings.get_extra_skills_dirs())
+    return skills, roots
+
+
+def build_skill_invocation_envelope(
+    skill: ExtendedSkillMetadata,
+    content: str,
+    args: str = "",
+) -> SkillInvocationEnvelope:
+    """Build the wrapped prompt and persisted metadata for a skill.
+
+    Args:
+        skill: Loaded skill metadata.
+        content: Raw `SKILL.md` content.
+        args: Optional user request appended after the skill body.
+
+    Returns:
+        A `SkillInvocationEnvelope` with the composed prompt and
+            `message_kwargs` containing persisted skill metadata.
+    """
+    prompt = (
+        f"I'm invoking the skill `{skill['name']}`. "
+        "Below are the full instructions from the skill's SKILL.md file. "
+        "Follow these instructions to complete the task.\n\n"
+        f"---\n{content}\n---"
+    )
+    if args:
+        prompt += f"\n\n**User request:** {args}"
+
+    message_kwargs = {
+        "additional_kwargs": {
+            "__skill": {
+                "name": skill["name"],
+                "description": str(skill.get("description", "")),
+                "source": str(skill.get("source", "")),
+                "args": args,
+            },
+        },
+    }
+    return SkillInvocationEnvelope(prompt=prompt, message_kwargs=message_kwargs)

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -75,6 +75,7 @@ def show_help() -> None:
     )
     console.print("  --profile-override JSON    Override model profile fields as JSON")
     console.print("  -m, --message TEXT         Initial prompt to auto-submit on start")
+    console.print("  --skill NAME              Invoke a skill when the session starts")
     console.print(
         "  -y, --auto-approve         Auto-approve all tool calls (toggle: Shift+Tab)"
     )
@@ -139,6 +140,10 @@ def show_help() -> None:
     )
     console.print(
         "  cat prompt.txt | deepagents --stdin -q      # Explicit stdin",
+        style=theme.MUTED,
+    )
+    console.print(
+        "  deepagents --skill code-review -m 'review this patch'",
         style=theme.MUTED,
     )
     console.print()

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -69,6 +69,66 @@ class TestInitialPromptOnMount:
 
         assert submitted == ["hello world"]
 
+    async def test_initial_skill_triggers_invoke_skill(self) -> None:
+        """When `--skill` is set, startup should invoke that skill."""
+        mock_agent = MagicMock()
+        app = DeepAgentsApp(
+            agent=mock_agent,
+            thread_id="new-thread-123",
+            initial_prompt="  keep leading whitespace",
+            initial_skill="code-review",
+        )
+        submitted: list[tuple[str, str, str | None]] = []
+
+        async def capture(  # noqa: RUF029
+            skill_name: str,
+            args: str = "",
+            *,
+            command: str | None = None,
+        ) -> None:
+            submitted.append((skill_name, args, command))
+
+        app._invoke_skill = capture  # type: ignore[assignment]
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+        assert submitted == [("code-review", "  keep leading whitespace", None)]
+
+    async def test_initial_skill_runs_after_server_ready(self) -> None:
+        """Deferred startup should invoke the requested skill after connect."""
+        app = DeepAgentsApp(
+            thread_id="new-thread-123",
+            initial_prompt="review this diff",
+            initial_skill="code-review",
+        )
+        app._connecting = True
+        app.query_one = MagicMock(side_effect=NoMatches("welcome-banner"))  # type: ignore[assignment]
+        app.call_after_refresh = lambda cb: cb()  # type: ignore[assignment]
+        submitted: list[tuple[str, str, str | None]] = []
+
+        async def capture(  # noqa: RUF029
+            skill_name: str,
+            args: str = "",
+            *,
+            command: str | None = None,
+        ) -> None:
+            submitted.append((skill_name, args, command))
+
+        app._invoke_skill = capture  # type: ignore[assignment]
+
+        app.on_deep_agents_app_server_ready(
+            app.ServerReady(
+                agent=MagicMock(),
+                server_proc=None,
+                mcp_server_info=[],
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert submitted == [("code-review", "review this diff", None)]
+
 
 class TestAppCSSValidation:
     """Test that app CSS is valid and doesn't cause runtime errors."""

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -50,6 +50,27 @@ class TestInitialPromptArg:
         assert args.initial_prompt == ""
 
 
+class TestInitialSkillArg:
+    """Tests for `--skill` startup skill argument."""
+
+    def test_flag_sets_initial_skill(self) -> None:
+        """Verify `--skill` stores the requested skill name."""
+        with patch.object(sys, "argv", ["deepagents", "--skill", "code-review"]):
+            args = parse_args()
+        assert args.initial_skill == "code-review"
+
+    def test_with_message(self) -> None:
+        """Verify `--skill` works alongside `-m`."""
+        with patch.object(
+            sys,
+            "argv",
+            ["deepagents", "--skill", "code-review", "-m", "review this patch"],
+        ):
+            args = parse_args()
+        assert args.initial_skill == "code-review"
+        assert args.initial_prompt == "review this patch"
+
+
 class TestResumeArg:
     """Tests for -r/--resume thread resume argument."""
 

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -6,7 +6,7 @@ import os
 import sys
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -181,6 +181,71 @@ class TestQuietRequiresNonInteractive:
         assert exc_info.value.code == 2
 
 
+class TestSkillFlagValidation:
+    """Tests for `--skill` validation in `cli_main`."""
+
+    def test_skill_allowed_with_non_interactive(self) -> None:
+        """`--skill` should be accepted when `-n` selects headless mode."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["deepagents", "--skill", "code-review", "-n", "review this"],
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_cli.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 0
+        assert mock_run.await_args.kwargs["initial_skill"] == "code-review"  # type: ignore[union-attr]
+
+    def test_skill_with_quiet_without_non_interactive_exits_2(self) -> None:
+        """`--skill` + `--quiet` without `-n` should exit with code 2."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["deepagents", "--skill", "code-review", "-q"],
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 2
+
+    def test_skill_with_no_stream_without_non_interactive_exits_2(self) -> None:
+        """`--skill` + `--no-stream` without `-n` should exit with code 2."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["deepagents", "--skill", "code-review", "--no-stream"],
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 2
+
+
 class TestModelParamsArgument:
     """Tests for --model-params argument parsing."""
 
@@ -269,12 +334,14 @@ def _make_args(
     *,
     non_interactive_message: str | None = None,
     initial_prompt: str | None = None,
+    initial_skill: str | None = None,
     stdin: bool = False,
 ) -> argparse.Namespace:
     """Create a minimal argument namespace for stdin pipe tests."""
     return argparse.Namespace(
         non_interactive_message=non_interactive_message,
         initial_prompt=initial_prompt,
+        initial_skill=initial_skill,
         stdin=stdin,
     )
 
@@ -328,6 +395,26 @@ class TestApplyStdinPipe:
         with patch.object(sys, "stdin", fake_stdin):
             apply_stdin_pipe(args)
         assert args.initial_prompt == "error log contents\n\nexplain this"
+        assert args.non_interactive_message is None
+
+    def test_stdin_sets_initial_prompt_for_startup_skill(self) -> None:
+        """Piped stdin becomes the startup request when `--skill` is set."""
+        args = _make_args(initial_skill="code-review")
+        fake_stdin = io.StringIO("diff contents")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.initial_prompt == "diff contents"
+        assert args.non_interactive_message is None
+
+    def test_stdin_prepends_to_skill_prompt(self) -> None:
+        """Piped stdin is prepended when `--skill` and `-m` are combined."""
+        args = _make_args(initial_prompt="review this", initial_skill="code-review")
+        fake_stdin = io.StringIO("diff contents")
+        fake_stdin.isatty = lambda: False  # type: ignore[attr-defined]
+        with patch.object(sys, "stdin", fake_stdin):
+            apply_stdin_pipe(args)
+        assert args.initial_prompt == "diff contents\n\nreview this"
         assert args.non_interactive_message is None
 
     def test_non_interactive_takes_priority_over_initial_prompt(self) -> None:

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -923,6 +923,111 @@ class TestNonInteractivePrompt:
         _, kwargs = mock_start_server.call_args
         assert kwargs["interactive"] is False
 
+    async def test_initial_skill_wraps_prompt_and_metadata(self) -> None:
+        """Headless skill execution should send wrapped prompt + `__skill`."""
+        mock_agent = MagicMock()
+        mock_agent.astream = MagicMock(return_value=_async_iter([]))
+        mock_server_proc = MagicMock()
+        skill = {
+            "name": "code-review",
+            "description": "Review code changes",
+            "path": "/skills/code-review/SKILL.md",
+            "license": None,
+            "compatibility": None,
+            "metadata": {},
+            "allowed_tools": [],
+            "source": "user",
+        }
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.skills.invocation.discover_skills_and_roots",
+                return_value=([skill], []),
+            ),
+            patch(
+                "deepagents_cli.skills.load.load_skill_content",
+                return_value="# Instructions\nDo stuff",
+            ),
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+                return_value=(mock_agent, mock_server_proc, None),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            await run_non_interactive(
+                message="review this patch",
+                initial_skill="code-review",
+                quiet=True,
+            )
+
+        stream_input = mock_agent.astream.call_args.args[0]
+        user_msg = stream_input["messages"][0]
+        assert "I'm invoking the skill `code-review`." in user_msg["content"]
+        assert "**User request:** review this patch" in user_msg["content"]
+        assert user_msg["additional_kwargs"]["__skill"]["name"] == "code-review"
+        assert user_msg["additional_kwargs"]["__skill"]["args"] == "review this patch"
+
+    async def test_initial_skill_missing_returns_error_without_starting_server(
+        self,
+    ) -> None:
+        """Missing headless skill should fail before the server starts."""
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.settings",
+            ) as mock_settings,
+            patch(
+                "deepagents_cli.skills.invocation.discover_skills_and_roots",
+                return_value=([], []),
+            ),
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+            ) as mock_start_server,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            result = await run_non_interactive(
+                message="review this patch",
+                initial_skill="missing-skill",
+                quiet=True,
+            )
+
+        assert result == 1
+        mock_start_server.assert_not_awaited()
+
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029
     """Create an async iterator from a list for testing."""

--- a/libs/cli/tests/unit_tests/test_skill_invocation.py
+++ b/libs/cli/tests/unit_tests/test_skill_invocation.py
@@ -276,6 +276,7 @@ def _make_app() -> MagicMock:
     app._mount_message = AsyncMock(side_effect=capture_mount)
     app._handle_user_message = AsyncMock()
     app._send_to_agent = AsyncMock()
+    app._invoke_skill = DeepAgentsApp._invoke_skill.__get__(app)
     app._handle_skill_command = DeepAgentsApp._handle_skill_command.__get__(app)
     app._discover_skills_and_roots = DeepAgentsApp._discover_skills_and_roots.__get__(
         app
@@ -305,6 +306,60 @@ def _fake_skill(
         "allowed_tools": [],
         "source": "user",
     }
+
+
+class TestBuildSkillInvocationEnvelope:
+    """Direct unit tests for `build_skill_invocation_envelope`."""
+
+    def test_happy_path_with_args(self) -> None:
+        """Envelope should contain wrapped prompt and full metadata."""
+        from deepagents_cli.skills.invocation import build_skill_invocation_envelope
+
+        skill = {
+            "name": "code-review",
+            "description": "Review code changes",
+            "source": "user",
+            "path": "/skills/code-review/SKILL.md",
+        }
+        envelope = build_skill_invocation_envelope(
+            skill,  # type: ignore[arg-type]
+            "# Instructions\nDo stuff",
+            "review this patch",
+        )
+        assert "I'm invoking the skill `code-review`." in envelope.prompt
+        assert "---\n# Instructions\nDo stuff\n---" in envelope.prompt
+        assert "**User request:** review this patch" in envelope.prompt
+        meta = envelope.message_kwargs["additional_kwargs"]["__skill"]
+        assert meta["name"] == "code-review"
+        assert meta["description"] == "Review code changes"
+        assert meta["source"] == "user"
+        assert meta["args"] == "review this patch"
+
+    def test_empty_args_omits_user_request(self) -> None:
+        """No `**User request:**` line when args is empty."""
+        from deepagents_cli.skills.invocation import build_skill_invocation_envelope
+
+        skill = {"name": "test", "description": "", "source": "built-in", "path": "/x"}
+        envelope = build_skill_invocation_envelope(
+            skill,  # type: ignore[arg-type]
+            "body",
+            "",
+        )
+        assert "**User request:**" not in envelope.prompt
+        assert envelope.message_kwargs["additional_kwargs"]["__skill"]["args"] == ""
+
+    def test_missing_optional_fields_default_to_empty(self) -> None:
+        """Skill dicts without `description`/`source` should default to ''."""
+        from deepagents_cli.skills.invocation import build_skill_invocation_envelope
+
+        skill = {"name": "minimal", "path": "/x"}
+        envelope = build_skill_invocation_envelope(
+            skill,  # type: ignore[arg-type]
+            "body",
+        )
+        meta = envelope.message_kwargs["additional_kwargs"]["__skill"]
+        assert meta["description"] == ""
+        assert meta["source"] == ""
 
 
 class TestHandleSkillCommand:
@@ -428,6 +483,28 @@ class TestHandleSkillCommand:
         skill_msgs = [m for m in app._mounted_messages if isinstance(m, SkillMessage)]
         assert len(skill_msgs) == 1
         assert skill_msgs[0]._args == "find quantum"
+
+    async def test_direct_invoke_preserves_exact_args(self) -> None:
+        """Startup skill invocation should preserve the original prompt text."""
+        app = _make_app()
+        skill = _fake_skill()
+        with (
+            patch("deepagents_cli.skills.load.list_skills", return_value=[skill]),
+            patch(
+                "deepagents_cli.skills.load.load_skill_content",
+                return_value="# Instructions\nDo stuff",
+            ),
+            patch("deepagents_cli.config.settings"),
+        ):
+            await app._invoke_skill("test-skill", "  keep leading whitespace")
+
+        prompt = app._send_to_agent.call_args[0][0]
+        assert "**User request:**   keep leading whitespace" in prompt
+        metadata = app._send_to_agent.call_args.kwargs["message_kwargs"]
+        assert (
+            metadata["additional_kwargs"]["__skill"]["args"]
+            == "  keep leading whitespace"
+        )
 
     async def test_filesystem_error_shows_specific_message(self) -> None:
         app = _make_app()


### PR DESCRIPTION
Add `--skill NAME` flag to invoke a skill at CLI startup, in both interactive and non-interactive modes. Previously, skill invocation required an active session and the `/skill:<name>` slash command — this flag enables scripted and piped workflows like `git diff | deepagents --skill code-review -n 'review this'`.