### PR TITLE
fix(cli): dismiss slash command autocomplete on space

### DIFF
--- a/libs/cli/deepagents_cli/widgets/autocomplete.py
+++ b/libs/cli/deepagents_cli/widgets/autocomplete.py
@@ -208,6 +208,11 @@ class SlashCommandController:
         # Get the search string (text after /)
         search = text[1:cursor_index].lower()
 
+        # Space means the user finished picking a command — dismiss popup
+        if " " in search:
+            self.reset()
+            return
+
         if not search:
             # No search text — show all commands (display only cmd + desc)
             suggestions = [(cmd, desc) for cmd, desc, _ in self._commands][

--- a/libs/cli/tests/unit_tests/test_autocomplete.py
+++ b/libs/cli/tests/unit_tests/test_autocomplete.py
@@ -294,6 +294,45 @@ class TestSlashCommandController:
         controller.on_text_changed("/zzzzzzzzz", 10)
         mock_view.clear_completion_suggestions.assert_called()
 
+    def test_space_dismisses_suggestions(self, controller, mock_view):
+        """Typing a space after a command name dismisses the popup."""
+        controller.on_text_changed("/model", 6)
+        mock_view.render_completion_suggestions.assert_called()
+
+        controller.on_text_changed("/model ", 7)
+        mock_view.clear_completion_suggestions.assert_called()
+
+    def test_space_with_args_stays_dismissed(self, controller, mock_view):
+        """Suggestions stay dismissed while typing arguments after a space."""
+        # First show suggestions, then dismiss with space
+        controller.on_text_changed("/model", 6)
+        mock_view.render_completion_suggestions.assert_called()
+        mock_view.reset_mock()
+
+        controller.on_text_changed("/model gpt-4o", 13)
+        mock_view.render_completion_suggestions.assert_not_called()
+
+    def test_bare_slash_space_dismisses(self, controller, mock_view):
+        """Typing '/ ' (slash then space, no command) dismisses the popup."""
+        controller.on_text_changed("/", 1)
+        mock_view.render_completion_suggestions.assert_called()
+
+        controller.on_text_changed("/ ", 2)
+        mock_view.clear_completion_suggestions.assert_called()
+
+    def test_backspace_from_space_restores_suggestions(self, controller, mock_view):
+        """Deleting the space after '/model ' re-shows suggestions."""
+        controller.on_text_changed("/model", 6)
+        mock_view.render_completion_suggestions.assert_called()
+
+        controller.on_text_changed("/model ", 7)
+        mock_view.clear_completion_suggestions.assert_called()
+        mock_view.reset_mock()
+
+        # Simulate backspace back to "/model"
+        controller.on_text_changed("/model", 6)
+        mock_view.render_completion_suggestions.assert_called()
+
     @pytest.mark.usefixtures("mock_view")
     def test_double_reset_is_safe(self, controller):
         """Calling reset twice does not raise or double-clear."""


### PR DESCRIPTION
Dismiss the slash command autocomplete popup when the user types a space. Previously, the popup stayed open while typing arguments (e.g., `/model gpt-5.4`), which is unnecessary — once a space appears after the command name, the user is done selecting.