### PR TITLE
docs(sdk,cli): fill missing docstrings in model-specific code

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1867,9 +1867,10 @@ _OPENROUTER_APP_CATEGORIES: list[str] = ["cli-agent"]
 def _apply_openrouter_defaults(kwargs: dict[str, Any]) -> None:
     """Inject default OpenRouter attribution kwargs.
 
-    Sets `app_url` and `app_title` via `setdefault` so that user-supplied
-    values in config take precedence. These map to the `HTTP-Referer` and
-    `X-Title` headers that `ChatOpenRouter` sends for app attribution
+    Sets `app_url`, `app_title`, and `app_categories` via `setdefault` so
+    that user-supplied values in config take precedence. These map to the
+    `HTTP-Referer`, `X-Title`, and `X-OpenRouter-Categories` headers that
+    `ChatOpenRouter` sends for app attribution
     (see https://openrouter.ai/docs/app-attribution).
 
     Users can override either value provider-wide or per-model in
@@ -2305,8 +2306,8 @@ def validate_model_capabilities(model: BaseChatModel, model_name: str) -> None:
 
     Note:
         This validation is best-effort. Models without profiles will pass with
-        a warning. Exits via sys.exit(1) if model profile explicitly indicates
-        tool_calling=False.
+        a warning. Calls `sys.exit(1)` if the model's profile explicitly
+        indicates `tool_calling=False`.
     """
     console = _get_console()
     profile = getattr(model, "profile", None)

--- a/libs/cli/deepagents_cli/configurable_model.py
+++ b/libs/cli/deepagents_cli/configurable_model.py
@@ -29,6 +29,13 @@ def _is_anthropic_model(model: object) -> bool:
 
     Uses `_get_ls_params` from `BaseChatModel` to read the provider name.
 
+    Args:
+        model: A model instance to inspect.
+
+            Typed as `object` (rather than `BaseChatModel`) so the caller can
+            pass any model without an import-time dependency on a specific
+            provider package.
+
     Returns:
         `True` if the model's `ls_provider` is `'anthropic'`.
     """
@@ -52,9 +59,19 @@ must be stripped on cross-provider swap."""
 def _apply_overrides(request: ModelRequest) -> ModelRequest:
     """Apply model/param overrides from `CLIContext` on the runtime.
 
+    Reads `'model'` and `'model_params'` from `runtime.context` and, when
+    present, swaps the model and/or merges extra settings into the request.
+    On a cross-provider swap away from Anthropic, Anthropic-only settings
+    (e.g. `cache_control`) are stripped. The `### Model Identity` section
+    in the system prompt is also patched to reflect the new model.
+
+    Args:
+        request: The incoming model request from the middleware chain.
+
     Returns:
         The original request unchanged when no `CLIContext` is present or it
-            contains no overrides, otherwise a new request with overrides.
+            contains no overrides, otherwise a new request with overrides
+            applied via `request.override()`.
     """
     runtime = request.runtime
     if runtime is None:
@@ -143,14 +160,32 @@ def _apply_overrides(request: ModelRequest) -> ModelRequest:
 
 
 class ConfigurableModelMiddleware(AgentMiddleware):
-    """Swap the model or per-call settings from `runtime.context`."""
+    """Swap the model or per-call settings from `runtime.context`.
+
+    Reads two optional keys from the runtime context dict:
+
+    - `'model'` — a `provider:model` spec (e.g. `"openai:gpt-5"`).
+        When present and different from the current model, the request is
+        re-routed to the new model.
+    - `'model_params'` — a dict of extra model settings (e.g.
+        `{"temperature": 0}`) that are shallow-merged into the
+        request's `model_settings`.
+
+    This middleware is typically the outermost layer so it intercepts every
+    model call before provider-specific middleware (like
+    `AnthropicPromptCachingMiddleware`) runs.
+    """
 
     def wrap_model_call(  # noqa: PLR6301
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
-        """Apply runtime overrides and delegate to the next handler."""  # noqa: DOC201
+        """Apply runtime overrides and delegate to the next handler.
+
+        Returns:
+            The `ModelResponse` produced by the downstream handler.
+        """
         return handler(_apply_overrides(request))
 
     async def awrap_model_call(  # noqa: PLR6301
@@ -158,5 +193,9 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        """Apply runtime overrides and delegate to the next async handler."""  # noqa: DOC201
+        """Apply runtime overrides and delegate to the next async handler.
+
+        Returns:
+            The `ModelResponse` produced by the downstream handler.
+        """
         return await handler(_apply_overrides(request))

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -1,4 +1,9 @@
-"""Deep Agents come with planning, filesystem, and subagents."""
+"""Primary graph assembly module for Deep Agents.
+
+Provides `create_deep_agent`, the main entry point for constructing a fully
+configured Deep Agent with planning, filesystem, subagent, and summarization
+middleware.
+"""
 
 from collections.abc import Callable, Sequence
 from typing import Any, cast

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -68,13 +68,23 @@ Keep working until the task is fully complete. Don't stop partway and explain wh
 ## Progress Updates
 
 For longer tasks, provide brief progress updates at reasonable intervals — a concise sentence recapping what you've done and what's next."""  # noqa: E501
+"""Default system prompt appended to every Deep Agent.
+
+When a caller passes `system_prompt` to `create_deep_agent`, the custom prompt
+is prepended and this base prompt is appended. When `system_prompt` is `None`,
+this is used as the sole system prompt.
+"""
 
 
 def get_default_model() -> ChatAnthropic:
-    """Get default model.
+    """Get the default model for Deep Agents.
+
+    Used as a fallback when `model=None` is passed to `create_deep_agent`.
+
+    Requires `ANTHROPIC_API_KEY` to be set in the environment.
 
     Returns:
-        `ChatAnthropic` instance configured with Claude Sonnet 4.6.
+        `ChatAnthropic` instance configured with `claude-sonnet-4-6`.
     """
     return ChatAnthropic(
         model_name="claude-sonnet-4-6",
@@ -258,6 +268,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
     Returns:
         A configured Deep Agent.
+
+    Raises:
+        ImportError: If a required provider package is missing or below the
+            minimum supported version (e.g., `langchain-openrouter`).
     """
     model = get_default_model() if model is None else resolve_model(model)
     backend = backend if backend is not None else StateBackend()
@@ -271,6 +285,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     ]
     if skills is not None:
         gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+    # "ignore" makes this a no-op for non-Anthropic models so we can add it
+    # unconditionally to every middleware stack.
     gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     general_purpose_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]
         **GENERAL_PURPOSE_SUBAGENT,
@@ -308,6 +324,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             if subagent_skills:
                 subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
             subagent_middleware.extend(spec.get("middleware", []))
+            # "ignore" is a no-op for non-Anthropic models (see comment above).
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
             subagent_interrupt_on = spec.get("interrupt_on", interrupt_on)
@@ -355,6 +372,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         deepagent_middleware.extend(middleware)
     # Caching + memory after all other middleware so memory updates don't
     # invalidate the Anthropic prompt cache prefix.
+    # "ignore" is a no-op for non-Anthropic models (see general-purpose subagent
+    # comment above).
     deepagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     if memory is not None:
         deepagent_middleware.append(MemoryMiddleware(backend=backend, sources=memory))

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -285,8 +285,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     ]
     if skills is not None:
         gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
-    # "ignore" makes this a no-op for non-Anthropic models so we can add it
-    # unconditionally to every middleware stack.
+    # "ignore" silently skips cache-control header injection for non-Anthropic
+    # models, so this middleware can be added unconditionally.
     gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     general_purpose_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]
         **GENERAL_PURPOSE_SUBAGENT,
@@ -324,7 +324,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             if subagent_skills:
                 subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
             subagent_middleware.extend(spec.get("middleware", []))
-            # "ignore" is a no-op for non-Anthropic models (see comment above).
+            # "ignore" skips caching for non-Anthropic models (see comment above).
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
             subagent_interrupt_on = spec.get("interrupt_on", interrupt_on)
@@ -372,8 +372,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         deepagent_middleware.extend(middleware)
     # Caching + memory after all other middleware so memory updates don't
     # invalidate the Anthropic prompt cache prefix.
-    # "ignore" is a no-op for non-Anthropic models (see general-purpose subagent
-    # comment above).
+    # "ignore" skips caching for non-Anthropic models (see general-purpose
+    # subagent comment above).
     deepagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     if memory is not None:
         deepagent_middleware.append(MemoryMiddleware(backend=backend, sources=memory))

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1076,8 +1076,11 @@ A condensed summary follows:
         )
 
 
-# Public alias
 SummarizationMiddleware = _DeepAgentsSummarizationMiddleware
+"""Public alias for `_DeepAgentsSummarizationMiddleware`.
+
+This is the name external callers should import and reference.
+"""
 
 
 def create_summarization_middleware(
@@ -1090,11 +1093,16 @@ def create_summarization_middleware(
     (or uses fixed-token fallbacks) and returns a configured middleware.
 
     Args:
-        model: Resolved chat model instance.
+        model: Resolved `BaseChatModel` instance.
+
+            Use `resolve_model()` first if needed for model strings.
         backend: Backend instance or factory for persisting conversation history.
 
     Returns:
         Configured `SummarizationMiddleware` instance.
+
+    Raises:
+        TypeError: If `model` is not a `BaseChatModel` instance.
     """
     from langchain.chat_models import BaseChatModel as RuntimeBaseChatModel  # noqa: PLC0415
 


### PR DESCRIPTION
Fill in missing and incomplete docstrings across the SDK and CLI model-specific code paths. Several public functions, middleware classes, and module-level constants lacked `Args`, `Returns`, or `Raises` sections, and a few docstrings were inaccurate relative to their implementations.