### PR TITLE
feat(backends): add overwrite parameter to write methods

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -461,18 +461,22 @@ class CompositeBackend(BackendProtocol):
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
         """Create a new file, routing to appropriate backend.
 
         Args:
             file_path: Absolute file path.
             content: File content as a string.
+            overwrite: If ``True``, overwrite the file when it already exists.
+
+                Defaults to ``False``.
 
         Returns:
             Success message or Command object, or error if file already exists.
         """
         backend, stripped_key = self._get_backend_and_key(file_path)
-        res = backend.write(stripped_key, content)
+        res = backend.write(stripped_key, content, overwrite=overwrite)
         if res.path is not None:
             res = replace(res, path=file_path)
         return res
@@ -481,10 +485,11 @@ class CompositeBackend(BackendProtocol):
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
         """Async version of write."""
         backend, stripped_key = self._get_backend_and_key(file_path)
-        res = await backend.awrite(stripped_key, content)
+        res = await backend.awrite(stripped_key, content, overwrite=overwrite)
         if res.path is not None:
             res = replace(res, path=file_path)
         return res

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -350,20 +350,24 @@ class FilesystemBackend(BackendProtocol):
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
-        """Create a new file with content.
+        """Create a new file with content, optionally overwriting.
 
         Args:
-            file_path: Path where the new file will be created.
+            file_path: Path where the file will be created.
             content: Text content to write to the file.
+            overwrite: If ``True``, overwrite the file when it already exists.
+
+                Defaults to ``False``.
 
         Returns:
             `WriteResult` with path on success, or error message if the file
-                already exists or write fails.
+                already exists (and ``overwrite`` is ``False``) or write fails.
         """
         resolved_path = self._resolve_path(file_path)
 
-        if resolved_path.exists():
+        if not overwrite and resolved_path.exists():
             return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
 
         try:

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -67,7 +67,12 @@ class LangSmithSandbox(BaseSandbox):
             truncated=False,
         )
 
-    def write(self, file_path: str, content: str) -> WriteResult:
+    def write(
+        self,
+        file_path: str,
+        content: str,
+        overwrite: bool = False,  # noqa: ARG002, FBT001, FBT002
+    ) -> WriteResult:
         """Write content using the LangSmith SDK to avoid ARG_MAX.
 
         `BaseSandbox.write()` sends the full content in a shell command, which
@@ -77,6 +82,10 @@ class LangSmithSandbox(BaseSandbox):
         Args:
             file_path: Destination path inside the sandbox.
             content: Text content to write.
+            overwrite: If ``True``, overwrite the file when it already exists.
+
+                Defaults to ``False``. The LangSmith SDK always overwrites,
+                so this parameter only controls the preflight check.
 
         Returns:
             `WriteResult` with the written path on success, or an error message.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -475,14 +475,21 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
-        """Write content to a new file in the filesystem, error if file exists.
+        """Write content to a file in the filesystem.
+
+        By default, errors if the file already exists. Set ``overwrite=True``
+        to replace an existing file.
 
         Args:
             file_path: Absolute path where the file should be created.
 
                 Must start with '/'.
             content: String content to write to the file.
+            overwrite: If ``True``, overwrite the file when it already exists.
+
+                Defaults to ``False``.
 
         Returns:
             WriteResult
@@ -493,9 +500,10 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
         """Async version of write."""
-        return await asyncio.to_thread(self.write, file_path, content)
+        return await asyncio.to_thread(self.write, file_path, content, overwrite)
 
     def edit(
         self,

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -442,25 +442,31 @@ except PermissionError:
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
-        """Create a new file, failing if it already exists.
+        """Create a new file, optionally overwriting if it already exists.
 
         Args:
             file_path: Absolute path for the new file.
             content: UTF-8 text content to write.
+            overwrite: If ``True``, overwrite the file when it already exists.
+
+                Defaults to ``False``.
 
         Returns:
             `WriteResult` with `path` on success or `error` on failure.
         """
-        # Existence check + mkdir. There is a TOCTOU window between this check
-        # and the upload below - a concurrent process could create the file in
-        # between. This is an inherent limitation of splitting the operation;
-        path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
-        check_cmd = _WRITE_CHECK_TEMPLATE.format(path_b64=path_b64)
-        result = self.execute(check_cmd)
-        if result.exit_code != 0 or "Error:" in result.output:
-            error_msg = result.output.strip() or f"Failed to write file '{file_path}'"
-            return WriteResult(error=error_msg)
+        if not overwrite:
+            # Existence check + mkdir. There is a TOCTOU window between this
+            # check and the upload below - a concurrent process could create
+            # the file in between. This is an inherent limitation of splitting
+            # the operation;
+            path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
+            check_cmd = _WRITE_CHECK_TEMPLATE.format(path_b64=path_b64)
+            result = self.execute(check_cmd)
+            if result.exit_code != 0 or "Error:" in result.output:
+                error_msg = result.output.strip() or f"Failed to write file '{file_path}'"
+                return WriteResult(error=error_msg)
 
         responses = self.upload_files([(file_path, content.encode("utf-8"))])
         if not responses:

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -243,14 +243,15 @@ class StateBackend(BackendProtocol):
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
-        """Create a new file with content.
+        """Create a new file with content, optionally overwriting.
 
         The update is queued directly via `CONFIG_KEY_SEND`.
         """
         files = self._read_files()
 
-        if file_path in files:
+        if not overwrite and file_path in files:
             return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
 
         new_file_data = create_file_data(content)

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -480,8 +480,9 @@ class StoreBackend(BackendProtocol):
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
-        """Create a new file with content.
+        """Create a new file with content, optionally overwriting.
 
         Returns WriteResult on success or error.
         """
@@ -489,9 +490,12 @@ class StoreBackend(BackendProtocol):
         namespace = self._get_namespace()
 
         # Check if file exists
-        existing = store.get(namespace, file_path)
-        if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
+        if not overwrite:
+            existing = store.get(namespace, file_path)
+            if existing is not None:
+                return WriteResult(
+                    error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
+                )
 
         # Create new file
         file_data = create_file_data(content)
@@ -503,6 +507,7 @@ class StoreBackend(BackendProtocol):
         self,
         file_path: str,
         content: str,
+        overwrite: bool = False,  # noqa: FBT001, FBT002
     ) -> WriteResult:
         """Async version of write using native store async methods.
 
@@ -512,9 +517,12 @@ class StoreBackend(BackendProtocol):
         namespace = self._get_namespace()
 
         # Check if file exists using async method
-        existing = await store.aget(namespace, file_path)
-        if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
+        if not overwrite:
+            existing = await store.aget(namespace, file_path)
+            if existing is not None:
+                return WriteResult(
+                    error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
+                )
 
         # Create new file using async method
         file_data = create_file_data(content)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -144,6 +144,7 @@ class WriteFileSchema(BaseModel):
 
     file_path: str = Field(description="Absolute path where the file should be created. Must be absolute, not relative.")
     content: str = Field(description="The text content to write to the file. This parameter is required.")
+    overwrite: bool = Field(default=False, description="If True, overwrite the file if it already exists. Defaults to False.")
 
 
 class EditFileSchema(BaseModel):
@@ -225,10 +226,11 @@ Usage:
 - Only use emojis if the user explicitly requests it."""
 
 
-WRITE_FILE_TOOL_DESCRIPTION = """Writes to a new file in the filesystem.
+WRITE_FILE_TOOL_DESCRIPTION = """Writes a file to the filesystem.
 
 Usage:
-- The write_file tool will create the a new file.
+- By default, creates a new file and errors if the file already exists.
+- Set overwrite=True to replace an existing file's content.
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
@@ -802,6 +804,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
+            overwrite: Annotated[bool, "If True, overwrite the file if it already exists. Defaults to False."] = False,  # noqa: FBT002
         ) -> str:
             """Synchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
@@ -809,7 +812,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
-            res: WriteResult = resolved_backend.write(validated_path, content)
+            res: WriteResult = resolved_backend.write(validated_path, content, overwrite=overwrite)
             if res.error:
                 return res.error
             return f"Updated file {res.path}"
@@ -818,6 +821,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
+            overwrite: Annotated[bool, "If True, overwrite the file if it already exists. Defaults to False."] = False,  # noqa: FBT002
         ) -> str:
             """Asynchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
@@ -825,7 +829,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return f"Error: {e}"
-            res: WriteResult = await resolved_backend.awrite(validated_path, content)
+            res: WriteResult = await resolved_backend.awrite(validated_path, content, overwrite=overwrite)
             if res.error:
                 return res.error
             return f"Updated file {res.path}"

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -59,6 +59,10 @@ class TestBackendProtocolRaisesNotImplemented:
         with pytest.raises(NotImplementedError):
             backend.write("/file.txt", "content")
 
+    def test_write_with_overwrite(self, backend: BareBackend) -> None:
+        with pytest.raises(NotImplementedError):
+            backend.write("/file.txt", "content", overwrite=True)
+
     def test_edit(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             backend.edit("/file.txt", "old", "new")
@@ -102,6 +106,10 @@ class TestAsyncMethodsPropagateNotImplemented:
     async def test_awrite(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.awrite("/file.txt", "content")
+
+    async def test_awrite_with_overwrite(self, backend: BareBackend) -> None:
+        with pytest.raises(NotImplementedError):
+            await backend.awrite("/file.txt", "content", overwrite=True)
 
     async def test_aedit(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -814,3 +814,44 @@ def test_sandbox_edit_upload_malformed_output_cleans_up() -> None:
     assert "unexpected server response" in result.error
     assert len(cleanup_commands) == 1
     assert ".deepagents_edit_" in cleanup_commands[0]
+
+
+# -- overwrite tests -----------------------------------------------------------
+
+
+def test_sandbox_write_overwrite_skips_check() -> None:
+    """Test that write(overwrite=True) skips the existence check command."""
+    sandbox = MockSandbox()
+    commands: list[str] = []
+    original_execute = sandbox.execute
+
+    def tracking_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        commands.append(command)
+        return original_execute(command, timeout=timeout)
+
+    sandbox.execute = tracking_execute  # type: ignore[assignment]
+
+    result = sandbox.write("/test/file.txt", "content", overwrite=True)
+
+    assert result.error is None
+    assert result.path == "/test/file.txt"
+    # No check command should have been issued
+    assert len(commands) == 0
+    # upload_files should still be called
+    assert len(sandbox._uploaded) == 1
+
+
+def test_sandbox_write_overwrite_false_still_checks() -> None:
+    """Test that write(overwrite=False) still runs the existence check."""
+    sandbox = MockSandbox()
+
+    def fail_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
+        sandbox.last_command = command
+        return ExecuteResponse(output="Error: File already exists", exit_code=1)
+
+    sandbox.execute = fail_execute  # type: ignore[assignment]
+
+    result = sandbox.write("/test/existing.txt", "content", overwrite=False)
+    assert result.error is not None
+    assert "Error:" in result.error
+    assert len(sandbox._uploaded) == 0

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes a file to the filesystem.\n\nUsage:\n- By default, creates a new file and errors if the file already exists.\n- Set overwrite=True to replace an existing file's content.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -99,6 +99,11 @@
           "file_path": {
             "description": "Absolute path where the file should be created. Must be absolute, not relative.",
             "type": "string"
+          },
+          "overwrite": {
+            "default": false,
+            "description": "If True, overwrite the file if it already exists. Defaults to False.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes a file to the filesystem.\n\nUsage:\n- By default, creates a new file and errors if the file already exists.\n- Set overwrite=True to replace an existing file's content.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -99,6 +99,11 @@
           "file_path": {
             "description": "Absolute path where the file should be created. Must be absolute, not relative.",
             "type": "string"
+          },
+          "overwrite": {
+            "default": false,
+            "description": "If True, overwrite the file if it already exists. Defaults to False.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes a file to the filesystem.\n\nUsage:\n- By default, creates a new file and errors if the file already exists.\n- Set overwrite=True to replace an existing file's content.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -99,6 +99,11 @@
           "file_path": {
             "description": "Absolute path where the file should be created. Must be absolute, not relative.",
             "type": "string"
+          },
+          "overwrite": {
+            "default": false,
+            "description": "If True, overwrite the file if it already exists. Defaults to False.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes a file to the filesystem.\n\nUsage:\n- By default, creates a new file and errors if the file already exists.\n- Set overwrite=True to replace an existing file's content.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -99,6 +99,11 @@
           "file_path": {
             "description": "Absolute path where the file should be created. Must be absolute, not relative.",
             "type": "string"
+          },
+          "overwrite": {
+            "default": false,
+            "description": "If True, overwrite the file if it already exists. Defaults to False.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes a file to the filesystem.\n\nUsage:\n- By default, creates a new file and errors if the file already exists.\n- Set overwrite=True to replace an existing file's content.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -99,6 +99,11 @@
           "file_path": {
             "description": "Absolute path where the file should be created. Must be absolute, not relative.",
             "type": "string"
+          },
+          "overwrite": {
+            "default": false,
+            "description": "If True, overwrite the file if it already exists. Defaults to False.",
+            "type": "boolean"
           }
         },
         "required": [


### PR DESCRIPTION
Add `overwrite: bool = False` parameter to `write()`/`awrite()` on `BackendProtocol` and all implementations, allowing callers to replace an existing file instead of erroring. 

Adds an `overwrite` parameter (default `False`) to `BackendProtocol.write()` and `awrite()`. When `True`, the existence check is skipped and the file content is replaced. All backend implementations (`FilesystemBackend`, `BaseSandbox`/`LangSmithSandbox`, `StateBackend`, `StoreBackend`, `CompositeBackend`) and the `FilesystemMiddleware` tool wrappers are updated to accept and propagate this parameter.

No breaking changes. The new parameter defaults to `False`, preserving the existing create-only behavior.

How I verified this works:

- Added unit tests for `BackendProtocol` (`test_write_with_overwrite`, `test_awrite_with_overwrite`) verifying the parameter propagates through the base class.
- Added sandbox-specific tests (`test_sandbox_write_overwrite_skips_check`, `test_sandbox_write_overwrite_false_still_checks`) verifying the existence check is skipped/performed based on the flag.
- Updated all smoke test snapshots to reflect the new `overwrite` field in the `write_file` tool schema.

Note: the same issue exists in [deepagentsjs](https://github.com/langchain-ai/deepagentsjs) - the `write` method there also lacks an `overwrite` option. A corresponding change should be made in that repo for parity.
