### PR TITLE
fix(cli): guard against textual cursor/document desync crash

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -434,7 +434,9 @@ class ChatTextArea(TextArea):
         """
         try:
             return super().scroll_cursor_visible(center=center, animate=animate)
-        except ValueError:  # Textual <=8.0.2: get_offsets raises on off-by-one in clamp
+        except (
+            ValueError
+        ):  # WrappedDocument.get_offsets off-by-one clamp in location_to_offset
             logger.warning(
                 "Cursor/document desync in scroll_cursor_visible "
                 "(cursor=%s, doc_lines=%d); skipping scroll",

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -13,6 +13,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content
 from textual.css.query import NoMatches
+from textual.geometry import Offset
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static, TextArea
@@ -411,6 +412,36 @@ class ChatTextArea(TextArea):
         self._paste_burst_timer: Timer | None = None
         # See _BACKSLASH_ENTER_GAP_SECONDS for context.
         self._backslash_pending_time: float | None = None
+
+    def scroll_cursor_visible(
+        self, center: bool = False, animate: bool = False
+    ) -> Offset:
+        """Scroll to make the cursor visible, guarding against cursor/document desync.
+
+        Textual's `WrappedDocument.location_to_offset` has an off-by-one in its
+        line-index clamp (`len(...)` instead of `len(...) - 1`). When a reactive
+        watcher (e.g. `_watch_show_vertical_scrollbar`) fires between a document
+        replacement and cursor update, the stale cursor location triggers a
+        `ValueError`. Guard here since `scroll_cursor_visible` is the sole
+        caller of `_recompute_cursor_offset`.
+
+        Args:
+            center: Whether the cursor should be scrolled to the center.
+            animate: Whether to animate while scrolling.
+
+        Returns:
+            The scroll offset applied, or `Offset(0, 0)` on desync.
+        """
+        try:
+            return super().scroll_cursor_visible(center=center, animate=animate)
+        except ValueError:  # Textual <=8.0.2: get_offsets raises on off-by-one in clamp
+            logger.warning(
+                "Cursor/document desync in scroll_cursor_visible "
+                "(cursor=%s, doc_lines=%d); skipping scroll",
+                self.cursor_location,
+                self.document.line_count,
+            )
+            return Offset(0, 0)
 
     def set_app_focus(self, *, has_focus: bool) -> None:
         """Set whether the app should show the cursor as active.

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -2263,3 +2263,29 @@ class TestChatInputTypingBubble:
             await pilot.pause()
 
             assert app.chat_input_typing_count == 2
+
+
+class TestScrollCursorVisibleDesync:
+    """scroll_cursor_visible should not crash on cursor/document desync."""
+
+    async def test_returns_zero_offset_on_value_error(self) -> None:
+        """When super() raises ValueError, return Offset(0, 0)."""
+        from unittest.mock import patch
+
+        from textual.geometry import Offset
+        from textual.widgets import TextArea
+
+        app = _TextAreaTypingApp()
+        async with app.run_test() as pilot:
+            text_area = app.query_one(ChatTextArea)
+            text_area.focus()
+            await pilot.pause()
+
+            with patch.object(
+                TextArea,
+                "scroll_cursor_visible",
+                side_effect=ValueError("line index out of bounds"),
+            ):
+                result = text_area.scroll_cursor_visible()
+
+            assert result == Offset(0, 0)


### PR DESCRIPTION
Guard against a Textual crash in `ChatTextArea` where `WrappedDocument.location_to_offset` has an off-by-one in its line-index clamp. When a reactive watcher like `_watch_show_vertical_scrollbar` fires between a document replacement and cursor update, the stale cursor location causes a `ValueError` that kills the widget. The fix overrides `scroll_cursor_visible` — the sole caller of the crashing code path — to catch the transient desync and return `Offset(0, 0)`, matching the parent class's own early-exit contract.