### PR TITLE
feat(ci): convert working-directory to validated dropdown

### DIFF
--- a/.github/scripts/test_release_options.py
+++ b/.github/scripts/test_release_options.py
@@ -1,0 +1,50 @@
+"""Verify release.yml dropdown options match actual package names on disk."""
+
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _get_release_options() -> list[str]:
+    workflow = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    with open(workflow) as f:
+        data = yaml.safe_load(f)
+    try:
+        # PyYAML (YAML 1.1) parses the bare key `on` as boolean True
+        return data[True]["workflow_dispatch"]["inputs"]["package"]["options"]
+    except (KeyError, TypeError) as e:
+        msg = f"Could not find workflow_dispatch package options in {workflow}: {e}"
+        raise AssertionError(msg) from e
+
+
+def _get_package_names() -> set[str]:
+    """Read project.name from every pyproject.toml under libs/."""
+    libs = REPO_ROOT / "libs"
+    names: set[str] = set()
+    for pyproject in libs.rglob("pyproject.toml"):
+        # Only consider direct children of libs/ and libs/partners/
+        rel = pyproject.parent.relative_to(libs)
+        parts = rel.parts
+        if len(parts) == 1 or (len(parts) == 2 and parts[0] == "partners"):
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            name = data.get("project", {}).get("name")
+            if name:
+                names.add(name)
+    return names
+
+
+def test_release_options_match_packages() -> None:
+    options = set(_get_release_options())
+    packages = _get_package_names()
+    missing_from_dropdown = packages - options
+    extra_in_dropdown = options - packages
+    assert not missing_from_dropdown, (
+        f"Packages on disk missing from release.yml dropdown: {missing_from_dropdown}"
+    )
+    assert not extra_in_dropdown, (
+        f"Dropdown options with no matching package: {extra_in_dropdown}"
+    )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,21 @@ jobs:
       working-directory: "libs/cli"
     secrets: inherit
 
+  # Verify release.yml dropdown options stay in sync with package directories
+  check-release-options:
+    name: "Validate Release Options"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "🐍 Setup Python 3.11"
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: "📦 Install Dependencies"
+        run: python -m pip install pyyaml pytest
+      - name: "🔍 Check release dropdown matches packages"
+        run: python -m pytest .github/scripts/test_release_options.py -v
+
   # Final status check - ensures all jobs passed
   ci_success:
     name: "✅ CI Success"
@@ -327,6 +342,7 @@ jobs:
       - test-repl
       - benchmark-deepagents
       - benchmark-cli
+      - check-release-options
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
       # We want to keep this build stage *separate* from the release stage,
       # so that there's no sharing of permissions between them.
       # (Release stage has trusted publishing and GitHub repo contents write access,
+      # which the build stage must not have access to.)
       #
       # Otherwise, a malicious `build` step (e.g. via a compromised dependency)
       # could get access to our GitHub or PyPI credentials.
@@ -514,15 +515,7 @@ jobs:
         env:
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
           VERSION: ${{ needs.build.outputs.version }}
-        # Here we use:
-        # - The default regular PyPI index as the *primary* index, meaning
-        #   that it takes priority (https://pypi.org/simple)
-        # - The test PyPI index as an extra index, so that any dependencies that
-        #   are not found on test PyPI can be resolved and installed anyway.
-        #   (https://test.pypi.org/simple). This will include the PKG_NAME==VERSION
-        #   package because VERSION will not have been uploaded to regular PyPI yet.
-        # - attempt install again after 5 seconds if it fails because there is
-        #   sometimes a delay in availability on test pypi
+        # Install directly from the locally-built wheel (no index resolution needed)
         run: |
           uv venv
           VIRTUAL_ENV=.venv uv pip install dist/*.whl


### PR DESCRIPTION
Convert the `working-directory` input in the release workflow from a free-text string to a dropdown of known package paths. This prevents typo-driven release failures and makes the dispatch UI self-documenting. A CI job keeps the dropdown in sync with what's actually on disk.

## Changes
- Change `working-directory` from `type: string` to `type: choice` in `_release.yml`, enumerating all 21 releasable packages under `libs/` and `libs/partners/`
- Add `check-release-options` CI job in `check_diffs.yml` that runs a pytest script to assert the dropdown options match directories containing a `pyproject.toml`