### PR TITLE
fix(cli): sort MCP tools deterministically for prompt-cache stability

### DIFF
--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -530,6 +530,11 @@ async def _load_tools_from_config(
                     ],
                 )
             )
+        # Sort tools deterministically by name so the tools block in API
+        # requests is stable across turns. MCP's list_tools() does not guarantee
+        # order, and any change in the tools array busts the prompt cache at the
+        # tools block.
+        all_tools.sort(key=lambda t: t.name)
     except Exception as e:
         await manager.cleanup()
         error_msg = (

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -662,9 +662,17 @@ class TestGetMCPTools:
             }
         )
 
-        # Create mock tools from different servers
-        mock_tools_fs = [MagicMock(name="read_file"), MagicMock(name="write_file")]
-        mock_tools_search = [MagicMock(name="web_search")]
+        # Create mock tools from different servers.
+        # Note: MagicMock(name=...) sets the internal _mock_name, not a .name
+        # attribute. Set .name explicitly so tools can be sorted by name.
+        tool_read = MagicMock()
+        tool_read.name = "read_file"
+        tool_write = MagicMock()
+        tool_write.name = "write_file"
+        tool_search = MagicMock()
+        tool_search.name = "web_search"
+        mock_tools_fs = [tool_read, tool_write]
+        mock_tools_search = [tool_search]
 
         # Setup mock client with session support
         mock_session_fs = AsyncMock()
@@ -1683,3 +1691,114 @@ class TestHealthCheckIntegration:
         error_msg = str(exc_info.value)
         assert "missing-cmd" in error_msg
         assert "down:9999" in error_msg
+
+
+class TestToolOrdering:
+    """Tools returned by get_mcp_tools are sorted deterministically."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_health_checks(self) -> Generator[None]:
+        """Bypass pre-flight health checks for all tests in this class."""
+        with (
+            patch("deepagents_cli.mcp_tools._check_stdio_server"),
+            patch(
+                "deepagents_cli.mcp_tools._check_remote_server",
+                new_callable=AsyncMock,
+            ),
+        ):
+            yield
+
+    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
+    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
+    async def test_tools_sorted_alphabetically_by_name(
+        self,
+        mock_client_class: MagicMock,
+        mock_load_tools: AsyncMock,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Tools from MCP servers are sorted by name for stable prompt caches."""
+        path = write_config(
+            {
+                "mcpServers": {
+                    "srv": {"command": "node", "args": ["server.js"]},
+                }
+            }
+        )
+
+        # Return tools in non-alphabetical order
+        zeta = MagicMock()
+        zeta.name = "srv_zeta"
+        zeta.description = "z"
+        alpha = MagicMock()
+        alpha.name = "srv_alpha"
+        alpha.description = "a"
+        mu = MagicMock()
+        mu.name = "srv_mu"
+        mu.description = "m"
+        mock_load_tools.return_value = [zeta, alpha, mu]
+
+        mock_session = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client = MagicMock()
+        mock_client.session.return_value = cm
+        mock_client_class.return_value = mock_client
+
+        tools, manager, _ = await get_mcp_tools(path)
+
+        assert [t.name for t in tools] == ["srv_alpha", "srv_mu", "srv_zeta"]
+        await manager.cleanup()
+
+    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
+    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
+    async def test_tools_sorted_across_multiple_servers(
+        self,
+        mock_client_class: MagicMock,
+        mock_load_tools: AsyncMock,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Tools from multiple servers are interleaved alphabetically."""
+        path = write_config(
+            {
+                "mcpServers": {
+                    "beta": {"command": "node", "args": ["b.js"]},
+                    "alpha": {"command": "node", "args": ["a.js"]},
+                }
+            }
+        )
+
+        tool_b = MagicMock()
+        tool_b.name = "beta_write"
+        tool_b.description = "w"
+        tool_a = MagicMock()
+        tool_a.name = "alpha_read"
+        tool_a.description = "r"
+
+        mock_session_a = AsyncMock()
+        mock_session_b = AsyncMock()
+
+        def mock_load_side_effect(
+            session: AsyncMock, **_kwargs: object
+        ) -> list[MagicMock]:
+            if session == mock_session_b:
+                return [tool_b]
+            return [tool_a]
+
+        mock_load_tools.side_effect = mock_load_side_effect
+
+        def mock_session_cm(server_name: str) -> MagicMock:
+            session = mock_session_b if server_name == "beta" else mock_session_a
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(return_value=session)
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        mock_client = MagicMock()
+        mock_client.session.side_effect = mock_session_cm
+        mock_client_class.return_value = mock_client
+
+        tools, manager, _ = await get_mcp_tools(path)
+
+        assert [t.name for t in tools] == ["alpha_read", "beta_write"]
+        await manager.cleanup()

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -5475,7 +5475,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "8.0.2"
+version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -5485,9 +5485,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/08/c6bcb1e3c4c9528ec9049f4ac685afdafc72866664270f0deb416ccbba2a/textual-8.0.2.tar.gz", hash = "sha256:7b342f3ee9a5f2f1bd42d7b598cae00ff1275da68536769510db4b7fe8cabf5d", size = 6099270, upload-time = "2026-03-03T20:23:46.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/bc/0cd17f96f00b6e8bfbca64c574088c85f3c614912b3030f313752e30a099/textual-8.0.2-py3-none-any.whl", hash = "sha256:4ceadbe0e8a30eb80f9995000f4d031f711420a31b02da38f3482957b7c50ce4", size = 719174, upload-time = "2026-03-03T20:23:50.46Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
MCP's `list_tools()` does not guarantee tool ordering. If tool order differs between turns — from paginated responses, server restarts, or SDK changes — the tools array in the API request changes, busting the prompt cache at the tools block. Sort the collected tools by name in `_load_tools_from_config` to make the tools block deterministic. Inspired by [openclaw/openclaw#58037](https://github.com/openclaw/openclaw/pull/58037).