### PR TITLE
fix(filesystem): detect URL characters in paths and improve file-not-found errors

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -317,7 +317,7 @@ class FilesystemBackend(BackendProtocol):
         resolved_path = self._resolve_path(file_path)
 
         if not resolved_path.exists() or not resolved_path.is_file():
-            return ReadResult(error=f"File '{file_path}' not found")
+            return ReadResult(error=f"File '{file_path}' not found. Use the ls or glob tool to list available files and verify the correct path.")
 
         try:
             fd = os.open(resolved_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
@@ -405,7 +405,7 @@ class FilesystemBackend(BackendProtocol):
         resolved_path = self._resolve_path(file_path)
 
         if not resolved_path.exists() or not resolved_path.is_file():
-            return EditResult(error=f"Error: File '{file_path}' not found")
+            return EditResult(error=f"Error: File '{file_path}' not found. Use the ls or glob tool to list available files and verify the correct path.")
 
         try:
             # Read securely

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -427,6 +427,16 @@ def validate_path(path: str, *, allowed_prefixes: Sequence[str] | None = None) -
         msg = f"Path traversal not allowed: {path}"
         raise ValueError(msg)
 
+    # Detect URL query/fragment characters that indicate a URL was mistakenly
+    # used as a file path (e.g. '/some/file?query=1' or '/path#anchor').
+    if "?" in path or "#" in path:
+        msg = (
+            f"Path contains URL characters ('?' or '#') which are not valid in file paths: {path}. "
+            "Ensure you are providing a filesystem path, not a URL. "
+            "Use the ls or glob tool to find the correct file path."
+        )
+        raise ValueError(msg)
+
     # Reject Windows absolute paths (e.g., C:\..., D:/...)
     if re.match(r"^[a-zA-Z]:", path):
         msg = f"Windows absolute paths are not supported: {path}. Please use virtual paths starting with / (e.g., /workspace/file.txt)"

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -681,3 +681,23 @@ class TestEditCrlfNormalization:
         final = (tmp_path / "history.md").read_text()
         assert "## Summary 2" in final
         assert "Human: next" in final
+
+
+class TestInvalidPathErrors:
+    """Tests for actionable error messages when paths are invalid. See #2463."""
+
+    def test_edit_file_not_found_suggests_ls(self, tmp_path: Path):
+        """edit() should suggest using ls/glob when the file is not found."""
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        result = be.edit("/nonexistent.txt", "old", "new")
+        assert result.error is not None
+        assert "not found" in result.error
+        assert "ls" in result.error or "glob" in result.error
+
+    def test_read_file_not_found_suggests_ls(self, tmp_path: Path):
+        """read() should suggest using ls/glob when the file is not found."""
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        result = be.read("/nonexistent.txt")
+        assert result.error is not None
+        assert "not found" in result.error
+        assert "ls" in result.error or "glob" in result.error

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -89,6 +89,24 @@ class TestValidatePath:
         with pytest.raises(ValueError, match="Path traversal not allowed"):
             validate_path("/workspace/../../../etc/shadow")
 
+    @pytest.mark.parametrize(
+        ("invalid_path", "error_match"),
+        [
+            ("/email_request_05-04-2021?", "URL characters"),
+            ("/some/file?query=1", "URL characters"),
+            ("/path/to/file#anchor", "URL characters"),
+            ("/data?format=json#section", "URL characters"),
+        ],
+    )
+    def test_url_characters_rejected(self, invalid_path: str, error_match: str) -> None:
+        """Test that paths containing URL query/fragment characters are rejected.
+
+        Agents sometimes mistakenly pass URLs or URL-like strings as file paths.
+        These should be caught early with a helpful error message. See #2463.
+        """
+        with pytest.raises(ValueError, match=error_match):
+            validate_path(invalid_path)
+
     def test_dot_and_empty_string_normalize_to_slash_dot(self) -> None:
         """Document that `'.'` and `''` normalize to `'/.'` via `os.path.normpath`."""
         assert validate_path(".") == "/."


### PR DESCRIPTION
Fixes #2463

## Problem

When an agent passes a path with URL characters (e.g. /email_request_05-04-2021?), validate_path() accepts it silently and the downstream error message provides no recovery guidance.

## Solution

1. Detect ? and # in validate_path() with a helpful error message pointing to ls/glob
2. Add recovery hints to file-not-found errors in read() and edit()

## Testing

New tests in test_utils.py and test_filesystem_backend.py