### PR TITLE
Fix: Add explicit UTF-8 encoding for Windows compatibility

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -365,7 +365,7 @@ def reset_agent(
             )
             raise SystemExit(1)
 
-        source_content = source_md.read_text()
+        source_content = source_md.read_text(encoding="utf-8")
         action_desc = f"contents of agent '{source_agent}'"
     else:
         source_content = get_default_coding_instructions()
@@ -505,7 +505,7 @@ def get_system_prompt(
         ... {CONDITIONAL SECTIONS} ...
         ```
     """
-    template = (Path(__file__).parent / "system_prompt.md").read_text()
+    template = (Path(__file__).parent / "system_prompt.md").read_text(encoding="utf-8")
 
     skills_path = f"~/.deepagents/{assistant_id}/skills"
 

--- a/libs/cli/deepagents_cli/built_in_skills/skill-creator/scripts/quick_validate.py
+++ b/libs/cli/deepagents_cli/built_in_skills/skill-creator/scripts/quick_validate.py
@@ -32,7 +32,7 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1762,7 +1762,7 @@ def get_default_coding_instructions() -> str:
         The default agent instructions as a string.
     """
     default_prompt_path = Path(__file__).parent / "default_agent_prompt.md"
-    return default_prompt_path.read_text()
+    return default_prompt_path.read_text(encoding="utf-8")
 
 
 def detect_provider(model_name: str) -> str | None:


### PR DESCRIPTION
On Windows, Python's open() defaults to GBK encoding which causes UnicodeDecodeError when reading files with UTF-8 characters. This fix adds encoding='utf-8' to read_text() calls in core CLI files.

Affected files:
- deepagents_cli/agent.py (system_prompt.md, source_md)
- deepagents_cli/config.py (default_agent_prompt.md)
- quick_validate.py (SKILL.md)

Fixes #2356