### PR TITLE
docs(examples): fix typos in nvidia README and add missing examples to index     

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,8 @@
 | [deep_research](deep_research/) | Multi-step web research agent using Tavily for URL discovery, parallel sub-agents, and strategic reflection |
 | [content-builder-agent](content-builder-agent/) | Content writing agent that demonstrates memory (`AGENTS.md`), skills, and subagents for blog posts, LinkedIn posts, and tweets with generated images |
 | [text-to-sql-agent](text-to-sql-agent/) | Natural language to SQL agent with planning, skill-based workflows, and the Chinook demo database |
+| [nvidia_deep_agent](nvidia_deep_agent/) | Multi-model agent with NVIDIA Nemotron for research and GPU-accelerated data processing via Modal sandbox |
+| [async-subagent-server](async-subagent-server/) | Self-hosted Agent Protocol server exposing a DeepAgents researcher as an async subagent with a supervisor REPL |
 | [ralph_mode](ralph_mode/) | Autonomous looping pattern that runs with fresh context each iteration, using the filesystem for persistence |
 | [downloading_agents](downloading_agents/) | Shows how agents are just folders—download a zip, unzip, and run |
 

--- a/examples/deep_research/agent.py
+++ b/examples/deep_research/agent.py
@@ -7,7 +7,6 @@ for conducting web research with strategic thinking and context management.
 from datetime import datetime
 
 from langchain.chat_models import init_chat_model
-from langchain_google_genai import ChatGoogleGenerativeAI
 from deepagents import create_deep_agent
 
 from research_agent.prompts import (
@@ -43,9 +42,6 @@ research_sub_agent = {
     "system_prompt": RESEARCHER_INSTRUCTIONS.format(date=current_date),
     "tools": [tavily_search, think_tool],
 }
-
-# Model Gemini 3 
-# model = ChatGoogleGenerativeAI(model="gemini-3-pro-preview", temperature=0.0)
 
 # Model Claude 4.5
 model = init_chat_model(model="anthropic:claude-sonnet-4-5-20250929", temperature=0.0)

--- a/examples/nvidia_deep_agent/README.md
+++ b/examples/nvidia_deep_agent/README.md
@@ -43,7 +43,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Install dependencies:
 
 ```bash
-cd nemotron-deep-agent
+cd examples/nvidia_deep_agent
 uv sync
 ```
 
@@ -58,7 +58,7 @@ export LANGSMITH_PROJECT="nemotron-deep-agent"
 export LANGSMITH_TRACING="true"
 ```
 
-Add your Modal keys to your `.env`(`MODAL_TOKEN_ID` & `MODEL_TOKEN_SECRET)`
+Add your Modal keys to your `.env` (`MODAL_TOKEN_ID` & `MODAL_TOKEN_SECRET`)
 
 OR
 


### PR DESCRIPTION
  - Fix wrong directory name in nvidia_deep_agent quickstart (`nemotron-deep-agent` → `examples/nvidia_deep_agent`)                    
  - Fix `MODEL_TOKEN_SECRET` typo → `MODAL_TOKEN_SECRET` and fix mismatched backtick/parenthesis                                                      
  - Add nvidia_deep_agent and async-subagent-server to examples/README.md 
table                                                                     
  - Remove unused `langchain_google_genai` import and commented-out Gemini code in deep_research/agent.py                                            
Generated with the assistance of generative AI.