### PR TITLE
fix(evals): skip empty radar runs without stale chart artifacts

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -324,6 +324,8 @@ jobs:
       - name: "📊 Generate radar chart"
         if: hashFiles('evals_summary.json') != '' && steps.install-evals.outcome == 'success'
         working-directory: libs/evals
+        env:
+          EVAL_OUTCOME: ${{ needs.eval.result }}
         run: uv run --extra charts python scripts/generate_radar.py --summary ../../evals_summary.json -o ../../charts/radar.png --individual-dir ../../charts/individual --title "Deep Agents Eval Results"
 
       - name: "📤 Upload JSON summary"

--- a/libs/evals/scripts/generate_radar.py
+++ b/libs/evals/scripts/generate_radar.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -56,6 +57,55 @@ def _load_category_results(path: Path) -> list[ModelResult]:
     return [ModelResult(model=entry["model"], scores=entry["scores"]) for entry in data]
 
 
+def _no_results_hint(outcome: str) -> str:
+    """Return a human-readable hint explaining why there are no results.
+
+    Args:
+        outcome: Upstream eval job result string (e.g. "cancelled", "failure").
+
+    Returns:
+        Diagnostic message tailored to the outcome.
+    """
+    outcome = outcome.strip().lower()
+    if outcome == "cancelled":
+        return (
+            "the upstream eval job was cancelled — most likely it hit the "
+            "workflow timeout-minutes limit. Check the eval job annotations "
+            "for 'exceeded the maximum execution time'."
+        )
+    if outcome == "failure":
+        return (
+            "the upstream eval job failed before producing a report. "
+            "Check the 'Run Evals' step logs for errors."
+        )
+    return (
+        "the summary file is an empty JSON array — all eval jobs may have "
+        "been cancelled (e.g. timeout) or failed before producing a report. "
+        "Check the upstream eval job logs for details."
+    )
+
+
+def _clear_stale_outputs(output: Path, individual_dir: Path | None) -> None:
+    """Remove stale radar artifacts from a previous run.
+
+    This only removes files created by this script: the aggregate chart output
+    and top-level PNG files inside `individual_dir`.
+
+    Args:
+        output: Aggregate chart output path.
+        individual_dir: Directory containing per-model PNGs, if configured.
+    """
+    if output.is_file() or output.is_symlink():
+        output.unlink()
+
+    if individual_dir is None or not individual_dir.is_dir():
+        return
+
+    for path in individual_dir.glob("*.png"):
+        if path.is_file() or path.is_symlink():
+            path.unlink()
+
+
 def main() -> None:
     """Entry point for radar chart generation."""
     parser = argparse.ArgumentParser(description="Generate eval radar charts")
@@ -73,6 +123,13 @@ def main() -> None:
         type=Path,
         default=None,
         help="Directory for per-model radar charts (one PNG each)",
+    )
+    parser.add_argument(
+        "--eval-outcome",
+        default=None,
+        help="Upstream eval job result (e.g. 'cancelled', 'failure'). "
+        "Falls back to EVAL_OUTCOME env var. Used to produce a targeted "
+        "diagnostic message when there are no results to chart.",
     )
 
     args = parser.parse_args()
@@ -103,13 +160,13 @@ def main() -> None:
 
     if not results:
         source = args.summary or args.results or "toy"
-        msg = (
-            f"error: no results to plot from {source}\n"
-            "hint: the summary file may be an empty JSON array (all evals "
-            "cancelled or failed). Check the eval runner logs for details."
-        )
+        outcome = args.eval_outcome or os.environ.get("EVAL_OUTCOME", "")
+        hint = _no_results_hint(outcome)
+        msg = f"skipped: no results to plot from {source}\nhint: {hint}"
+        _clear_stale_outputs(args.output, args.individual_dir)
+        print(msg)
         print(msg, file=sys.stderr)
-        sys.exit(1)
+        sys.exit(0)
 
     # Detect categories from results (use all categories present across models).
     all_cats = set()
@@ -119,6 +176,7 @@ def main() -> None:
     min_axes = 3
     if len(all_cats) < min_axes:
         msg = f"skipped: radar chart needs >= {min_axes} categories, got {len(all_cats)}"
+        _clear_stale_outputs(args.output, args.individual_dir)
         print(msg)
         print(msg, file=sys.stderr)
         sys.exit(0)
@@ -140,7 +198,7 @@ def main() -> None:
     except OSError as exc:
         print(f"error: could not save chart to {args.output}: {exc}", file=sys.stderr)
         sys.exit(1)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # top-level script should surface chart backend failures cleanly
         print(f"error: chart generation failed: {exc}", file=sys.stderr)
         sys.exit(1)
     print(f"saved: {args.output}")
@@ -156,7 +214,7 @@ def main() -> None:
         except OSError as exc:
             print(f"error: could not save individual charts: {exc}", file=sys.stderr)
             sys.exit(1)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # top-level script should surface chart backend failures cleanly
             print(f"error: individual chart generation failed: {exc}", file=sys.stderr)
             sys.exit(1)
         for p in paths:

--- a/libs/evals/tests/unit_tests/test_generate_radar_script.py
+++ b/libs/evals/tests/unit_tests/test_generate_radar_script.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_EVALS_DIR = Path(__file__).resolve().parents[2]
+_SCRIPT = _EVALS_DIR / "scripts" / "generate_radar.py"
+
+
+def _run_generate_radar(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_EVALS_DIR,
+        timeout=30,
+    )
+
+
+def test_empty_summary_clears_stale_outputs(tmp_path: Path) -> None:
+    summary = tmp_path / "summary.json"
+    summary.write_text("[]", encoding="utf-8")
+
+    output = tmp_path / "charts" / "radar.png"
+    output.parent.mkdir(parents=True)
+    output.write_text("stale aggregate", encoding="utf-8")
+
+    individual_dir = tmp_path / "individual"
+    individual_dir.mkdir()
+    stale_png = individual_dir / "stale-model.png"
+    stale_png.write_text("stale png", encoding="utf-8")
+    keep_txt = individual_dir / "notes.txt"
+    keep_txt.write_text("keep me", encoding="utf-8")
+
+    result = _run_generate_radar(
+        "--summary",
+        str(summary),
+        "--output",
+        str(output),
+        "--individual-dir",
+        str(individual_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "skipped: no results to plot" in result.stdout
+    assert not output.exists()
+    assert not stale_png.exists()
+    assert keep_txt.exists()
+
+
+def test_too_few_categories_clears_stale_outputs(tmp_path: Path) -> None:
+    results = tmp_path / "results.json"
+    results.write_text(
+        json.dumps(
+            [
+                {
+                    "model": "openai:gpt-5.4",
+                    "scores": {"file_operations": 0.8, "memory": 0.9},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "charts" / "radar.png"
+    output.parent.mkdir(parents=True)
+    output.write_text("stale aggregate", encoding="utf-8")
+
+    individual_dir = tmp_path / "individual"
+    individual_dir.mkdir()
+    stale_png = individual_dir / "stale-model.png"
+    stale_png.write_text("stale png", encoding="utf-8")
+
+    result = _run_generate_radar(
+        "--results",
+        str(results),
+        "--output",
+        str(output),
+        "--individual-dir",
+        str(individual_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "skipped: radar chart needs >= 3 categories, got 2" in result.stdout
+    assert not output.exists()
+    assert not stale_png.exists()


### PR DESCRIPTION
Radar generation should not fail the workflow when upstream eval jobs produce no summary data because they were cancelled or failed. But a successful skip also must not leave yesterday's radar images in place, or downstream artifact checks can publish stale charts as if they were current.