### PR TITLE
feat(evals): add glm-5.1 via ollama and openrouter

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -264,6 +264,17 @@ REGISTRY: tuple[Model, ...] = (
         ),
     ),
     Model(
+        "ollama:glm-5.1",
+        frozenset(
+            {
+                "eval:set2",
+                "eval:ollama",
+                "harbor:set2",
+                "harbor:ollama",
+            }
+        ),
+    ),
+    Model(
         "ollama:minimax-m2.5",
         frozenset(
             {
@@ -425,12 +436,21 @@ REGISTRY: tuple[Model, ...] = (
         ),
     ),
     Model(
-        "openrouter:nvidia/nemotron-3-super-120b-a12b",
+        "openrouter:z-ai/glm-5.1",
         frozenset(
             {
                 "eval:open",
                 "eval:openrouter",
                 "harbor:open",
+                "harbor:openrouter",
+            }
+        ),
+    ),
+    Model(
+        "openrouter:nvidia/nemotron-3-super-120b-a12b",
+        frozenset(
+            {
+                "eval:openrouter",
                 "harbor:openrouter",
             }
         ),

--- a/libs/evals/MODEL_GROUPS.md
+++ b/libs/evals/MODEL_GROUPS.md
@@ -58,12 +58,13 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:gpt-5.2-codex`
 - `openai:gpt-5.4`
 
-### `set2` (16 models)
+### `set2` (17 models)
 
 - `groq:openai/gpt-oss-120b`
 - `groq:qwen/qwen3-32b`
 - `groq:moonshotai/kimi-k2-instruct`
 - `ollama:glm-5`
+- `ollama:glm-5.1`
 - `ollama:minimax-m2.5`
 - `ollama:qwen3.5:397b-cloud`
 - `ollama:nemotron-3-nano:30b`
@@ -93,7 +94,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 
 - `baseten:zai-org/GLM-5`
 - `ollama:minimax-m2.7:cloud`
-- `openrouter:nvidia/nemotron-3-super-120b-a12b`
+- `openrouter:z-ai/glm-5.1`
 
 ## Provider groups
 
@@ -142,9 +143,10 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 
 - `nvidia:nvidia/nemotron-3-super-120b-a12b`
 
-### `ollama` (12 models)
+### `ollama` (13 models)
 
 - `ollama:glm-5`
+- `ollama:glm-5.1`
 - `ollama:minimax-m2.5`
 - `ollama:minimax-m2.7:cloud`
 - `ollama:qwen3.5:397b-cloud`
@@ -169,9 +171,10 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 
-### `openrouter` (2 models)
+### `openrouter` (3 models)
 
 - `openrouter:minimax/minimax-m2.7`
+- `openrouter:z-ai/glm-5.1`
 - `openrouter:nvidia/nemotron-3-super-120b-a12b`
 
 ### `xai` (2 models)
@@ -179,7 +182,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`
 
-## `all` (52 models)
+## `all` (54 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-20250514`
@@ -209,6 +212,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `groq:moonshotai/kimi-k2-instruct`
 - `nvidia:nvidia/nemotron-3-super-120b-a12b`
 - `ollama:glm-5`
+- `ollama:glm-5.1`
 - `ollama:minimax-m2.5`
 - `ollama:minimax-m2.7:cloud`
 - `ollama:qwen3.5:397b-cloud`
@@ -230,6 +234,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 - `openrouter:minimax/minimax-m2.7`
+- `openrouter:z-ai/glm-5.1`
 - `openrouter:nvidia/nemotron-3-super-120b-a12b`
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`


### PR DESCRIPTION
Add GLM-5.1 to the eval model registry via Ollama and OpenRouter, and swap `openrouter:nvidia/nemotron-3-super-120b-a12b` out of the `open` preset in favor of the new GLM entry.