### PR TITLE
fix(ci): separate release PRs per package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "skip-github-release": true,
   "draft-pull-request": true,
+  "separate-pull-requests": true,
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
When #2515 added the SDK as a second package in `release-please-config.json`, release-please switched to its grouped-PR mode. Grouped PRs use the default title `chore: release main` instead of the configured `pull-request-title-pattern`, and wrap each component's changelog in a `<details>` block. This breaks the commit-message regex in `release-please.yml` that gates publish jobs — `release(deepagents):` never matches `chore: release main`, so merging the current SDK release PR (#2518) would silently skip the PyPI publish.