### PR TITLE
ci(acp): set up release-please

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -8,6 +8,7 @@ This document describes the release process for packages in the Deep Agents mono
 | ------- | ---- | --------- | ---- |
 | `deepagents` (SDK) | `libs/deepagents` | `deepagents` | [deepagents](https://pypi.org/project/deepagents/) |
 | `deepagents-cli` | `libs/cli` | `deepagents-cli` | [deepagents-cli](https://pypi.org/project/deepagents-cli/) |
+| `deepagents-acp` | `libs/acp` | `deepagents-acp` | [deepagents-acp](https://pypi.org/project/deepagents-acp/) |
 
 ## Overview
 
@@ -94,8 +95,9 @@ Tracks the current version of each package:
 
 ```json
 {
-  "libs/cli": "0.0.34",
-  "libs/deepagents": "0.5.0"
+  "libs/cli": "0.0.35",
+  "libs/deepagents": "0.5.0",
+  "libs/acp": "0.0.5"
 }
 ```
 
@@ -105,7 +107,7 @@ This file is automatically updated by release-please when releases are created.
 
 ### Detection Mechanism
 
-The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK). This file is always updated by release-please when merging a release PR.
+The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP). This file is always updated by release-please when merging a release PR.
 
 ### Lockfile Updates
 
@@ -246,7 +248,7 @@ If a release PR shows `autorelease: pending` after the release workflow complete
 **To fix manually:**
 
 ```bash
-# Find the PR number for the release commit (replace <PACKAGE> with deepagents or deepagents-cli)
+# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
 gh pr list --state merged --search "release(<PACKAGE>)" --limit 5
 
 # Update the label
@@ -266,7 +268,7 @@ Using the PyPI web interface or a CLI tool.
 #### 2. Delete GitHub Release/Tag (optional)
 
 ```bash
-# Delete the GitHub release (replace <PACKAGE> with deepagents or deepagents-cli)
+# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
 gh release delete "<PACKAGE>==<VERSION>" --yes
 
 # Delete the git tag
@@ -334,7 +336,7 @@ This means a release PR was merged but its merge commit doesn't have the expecte
 **To diagnose**, compare the tag's commit with the release PR's merge commit:
 
 ```bash
-# Find what commit the tag points to (replace <PACKAGE> with deepagents or deepagents-cli)
+# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
 git ls-remote --tags origin | grep "<PACKAGE>==<VERSION>"
 
 # Find the release PR's merge commit
@@ -346,7 +348,7 @@ If these differ, release-please is confused.
 **To fix**, move the tag and update the GitHub release:
 
 ```bash
-# 1. Delete the remote tag (replace <PACKAGE> with deepagents or deepagents-cli)
+# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
 git push origin :refs/tags/<PACKAGE>==<VERSION>
 
 # 2. Delete local tag if it exists

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       cli-release: ${{ steps.check-releases.outputs.cli-release }}
       sdk-release: ${{ steps.check-releases.outputs.sdk-release }}
+      acp-release: ${{ steps.check-releases.outputs.acp-release }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -38,7 +39,7 @@ jobs:
       # release-please always updates CHANGELOG.md when merging a release PR, and
       # the commit message matches pull-request-title-pattern in release-please-config.json:
       #   "release(${component}): ${version}"
-      # Components: deepagents-cli, deepagents
+      # Components: deepagents-cli, deepagents, deepagents-acp
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
@@ -79,6 +80,13 @@ jobs:
             echo "SDK release detected: $COMMIT_MSG"
           else
             echo "sdk-release=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -q "^libs/acp/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-acp\):"; then
+            echo "acp-release=true" >> $GITHUB_OUTPUT
+            echo "ACP release detected: $COMMIT_MSG"
+          else
+            echo "acp-release=false" >> $GITHUB_OUTPUT
           fi
 
   # Update uv.lock files when release-please creates/updates a PR
@@ -143,6 +151,18 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: deepagents
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+
+  # Trigger release workflow when ACP release PR is merged
+  release-deepagents-acp:
+    needs: release-please
+    if: needs.release-please.outputs.acp-release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      package: deepagents-acp
     permissions:
       contents: write
       id-token: write

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "libs/cli": "0.0.35",
-  "libs/deepagents": "0.5.0"
+  "libs/deepagents": "0.5.0",
+  "libs/acp": "0.0.5"
 }

--- a/libs/acp/CHANGELOG.md
+++ b/libs/acp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+---
+
+## Prior Releases
+
+Versions prior to 0.0.5 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=deepagents-acp) for details on previous versions.

--- a/libs/acp/deepagents_acp/_version.py
+++ b/libs/acp/deepagents_acp/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `deepagents-acp`."""
+
+__version__ = "0.0.5"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -78,6 +78,18 @@
         "deepagents/_version.py"
       ],
       "changelog-path": "CHANGELOG.md"
+    },
+    "libs/acp": {
+      "release-type": "python",
+      "package-name": "deepagents-acp",
+      "component": "deepagents-acp",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "pyproject.toml",
+        "deepagents_acp/_version.py"
+      ],
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
Onboard `deepagents-acp` to the release-please pipeline so it gets automated versioning, changelogs, and PyPI publishing alongside the SDK and CLI packages. The package was previously released manually; this brings it in line with the existing release infrastructure.