### PR TITLE
ci(daytona): set up release-please

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -9,6 +9,7 @@ This document describes the release process for packages in the Deep Agents mono
 | `deepagents` (SDK) | `libs/deepagents` | `deepagents` | [deepagents](https://pypi.org/project/deepagents/) |
 | `deepagents-cli` | `libs/cli` | `deepagents-cli` | [deepagents-cli](https://pypi.org/project/deepagents-cli/) |
 | `deepagents-acp` | `libs/acp` | `deepagents-acp` | [deepagents-acp](https://pypi.org/project/deepagents-acp/) |
+| `langchain-daytona` | `libs/partners/daytona` | `langchain-daytona` | [langchain-daytona](https://pypi.org/project/langchain-daytona/) |
 
 ## Overview
 
@@ -97,7 +98,8 @@ Tracks the current version of each package:
 {
   "libs/cli": "0.0.35",
   "libs/deepagents": "0.5.0",
-  "libs/acp": "0.0.5"
+  "libs/acp": "0.0.5",
+  "libs/partners/daytona": "0.0.5"
 }
 ```
 
@@ -107,7 +109,7 @@ This file is automatically updated by release-please when releases are created.
 
 ### Detection Mechanism
 
-The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP). This file is always updated by release-please when merging a release PR.
+The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP, `libs/partners/daytona/CHANGELOG.md` for Daytona). This file is always updated by release-please when merging a release PR.
 
 ### Lockfile Updates
 
@@ -248,7 +250,7 @@ If a release PR shows `autorelease: pending` after the release workflow complete
 **To fix manually:**
 
 ```bash
-# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
+# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
 gh pr list --state merged --search "release(<PACKAGE>)" --limit 5
 
 # Update the label
@@ -268,7 +270,7 @@ Using the PyPI web interface or a CLI tool.
 #### 2. Delete GitHub Release/Tag (optional)
 
 ```bash
-# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
+# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
 gh release delete "<PACKAGE>==<VERSION>" --yes
 
 # Delete the git tag
@@ -336,7 +338,7 @@ This means a release PR was merged but its merge commit doesn't have the expecte
 **To diagnose**, compare the tag's commit with the release PR's merge commit:
 
 ```bash
-# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
+# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
 git ls-remote --tags origin | grep "<PACKAGE>==<VERSION>"
 
 # Find the release PR's merge commit
@@ -348,7 +350,7 @@ If these differ, release-please is confused.
 **To fix**, move the tag and update the GitHub release:
 
 ```bash
-# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, or deepagents-acp)
+# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
 git push origin :refs/tags/<PACKAGE>==<VERSION>
 
 # 2. Delete local tag if it exists

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,7 @@ jobs:
       cli-release: ${{ steps.check-releases.outputs.cli-release }}
       sdk-release: ${{ steps.check-releases.outputs.sdk-release }}
       acp-release: ${{ steps.check-releases.outputs.acp-release }}
+      daytona-release: ${{ steps.check-releases.outputs.daytona-release }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -39,7 +40,7 @@ jobs:
       # release-please always updates CHANGELOG.md when merging a release PR, and
       # the commit message matches pull-request-title-pattern in release-please-config.json:
       #   "release(${component}): ${version}"
-      # Components: deepagents-cli, deepagents, deepagents-acp
+      # Components: deepagents-cli, deepagents, deepagents-acp, langchain-daytona
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
@@ -87,6 +88,13 @@ jobs:
             echo "ACP release detected: $COMMIT_MSG"
           else
             echo "acp-release=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -q "^libs/partners/daytona/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-daytona\):"; then
+            echo "daytona-release=true" >> $GITHUB_OUTPUT
+            echo "Daytona release detected: $COMMIT_MSG"
+          else
+            echo "daytona-release=false" >> $GITHUB_OUTPUT
           fi
 
   # Update uv.lock files when release-please creates/updates a PR
@@ -163,6 +171,18 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: deepagents-acp
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+
+  # Trigger release workflow when Daytona release PR is merged
+  release-langchain-daytona:
+    needs: release-please
+    if: needs.release-please.outputs.daytona-release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      package: langchain-daytona
     permissions:
       contents: write
       id-token: write

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "libs/cli": "0.0.35",
   "libs/deepagents": "0.5.0",
-  "libs/acp": "0.0.5"
+  "libs/acp": "0.0.5",
+  "libs/partners/daytona": "0.0.5"
 }

--- a/libs/partners/daytona/CHANGELOG.md
+++ b/libs/partners/daytona/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+---
+
+## Prior Releases
+
+Versions prior to 0.0.5 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=langchain-daytona) for details on previous versions.

--- a/libs/partners/daytona/langchain_daytona/_version.py
+++ b/libs/partners/daytona/langchain_daytona/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-daytona`."""
+
+__version__ = "0.0.5"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -90,6 +90,18 @@
         "deepagents_acp/_version.py"
       ],
       "changelog-path": "CHANGELOG.md"
+    },
+    "libs/partners/daytona": {
+      "release-type": "python",
+      "package-name": "langchain-daytona",
+      "component": "langchain-daytona",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "pyproject.toml",
+        "langchain_daytona/_version.py"
+      ],
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
Onboard `langchain-daytona` to the release-please pipeline so it gets automated versioning, changelogs, and PyPI publishing alongside the SDK and CLI packages. The package was previously released manually; this brings it in line with the existing release infrastructure.