### PR TITLE
ci(modal): set up release-please

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -10,6 +10,7 @@ This document describes the release process for packages in the Deep Agents mono
 | `deepagents-cli` | `libs/cli` | `deepagents-cli` | [deepagents-cli](https://pypi.org/project/deepagents-cli/) |
 | `deepagents-acp` | `libs/acp` | `deepagents-acp` | [deepagents-acp](https://pypi.org/project/deepagents-acp/) |
 | `langchain-daytona` | `libs/partners/daytona` | `langchain-daytona` | [langchain-daytona](https://pypi.org/project/langchain-daytona/) |
+| `langchain-modal` | `libs/partners/modal` | `langchain-modal` | [langchain-modal](https://pypi.org/project/langchain-modal/) |
 
 ## Overview
 
@@ -99,7 +100,8 @@ Tracks the current version of each package:
   "libs/cli": "0.0.35",
   "libs/deepagents": "0.5.0",
   "libs/acp": "0.0.5",
-  "libs/partners/daytona": "0.0.5"
+  "libs/partners/daytona": "0.0.5",
+  "libs/partners/modal": "0.0.3"
 }
 ```
 
@@ -109,7 +111,7 @@ This file is automatically updated by release-please when releases are created.
 
 ### Detection Mechanism
 
-The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP, `libs/partners/daytona/CHANGELOG.md` for Daytona). This file is always updated by release-please when merging a release PR.
+The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP, `libs/partners/daytona/CHANGELOG.md` for Daytona, `libs/partners/modal/CHANGELOG.md` for Modal). This file is always updated by release-please when merging a release PR.
 
 ### Lockfile Updates
 
@@ -250,7 +252,7 @@ If a release PR shows `autorelease: pending` after the release workflow complete
 **To fix manually:**
 
 ```bash
-# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
+# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, or langchain-modal)
 gh pr list --state merged --search "release(<PACKAGE>)" --limit 5
 
 # Update the label
@@ -270,7 +272,7 @@ Using the PyPI web interface or a CLI tool.
 #### 2. Delete GitHub Release/Tag (optional)
 
 ```bash
-# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
+# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, or langchain-modal)
 gh release delete "<PACKAGE>==<VERSION>" --yes
 
 # Delete the git tag
@@ -338,7 +340,7 @@ This means a release PR was merged but its merge commit doesn't have the expecte
 **To diagnose**, compare the tag's commit with the release PR's merge commit:
 
 ```bash
-# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
+# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, or langchain-modal)
 git ls-remote --tags origin | grep "<PACKAGE>==<VERSION>"
 
 # Find the release PR's merge commit
@@ -350,7 +352,7 @@ If these differ, release-please is confused.
 **To fix**, move the tag and update the GitHub release:
 
 ```bash
-# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, or langchain-daytona)
+# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, or langchain-modal)
 git push origin :refs/tags/<PACKAGE>==<VERSION>
 
 # 2. Delete local tag if it exists

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ jobs:
       sdk-release: ${{ steps.check-releases.outputs.sdk-release }}
       acp-release: ${{ steps.check-releases.outputs.acp-release }}
       daytona-release: ${{ steps.check-releases.outputs.daytona-release }}
+      modal-release: ${{ steps.check-releases.outputs.modal-release }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -40,7 +41,7 @@ jobs:
       # release-please always updates CHANGELOG.md when merging a release PR, and
       # the commit message matches pull-request-title-pattern in release-please-config.json:
       #   "release(${component}): ${version}"
-      # Components: deepagents-cli, deepagents, deepagents-acp, langchain-daytona
+      # Components: deepagents-cli, deepagents, deepagents-acp, langchain-daytona, langchain-modal
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
@@ -95,6 +96,13 @@ jobs:
             echo "Daytona release detected: $COMMIT_MSG"
           else
             echo "daytona-release=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -q "^libs/partners/modal/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-modal\):"; then
+            echo "modal-release=true" >> $GITHUB_OUTPUT
+            echo "Modal release detected: $COMMIT_MSG"
+          else
+            echo "modal-release=false" >> $GITHUB_OUTPUT
           fi
 
   # Update uv.lock files when release-please creates/updates a PR
@@ -183,6 +191,18 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-daytona
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+
+  # Trigger release workflow when Modal release PR is merged
+  release-langchain-modal:
+    needs: release-please
+    if: needs.release-please.outputs.modal-release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      package: langchain-modal
     permissions:
       contents: write
       id-token: write

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "libs/cli": "0.0.35",
   "libs/deepagents": "0.5.0",
   "libs/acp": "0.0.5",
-  "libs/partners/daytona": "0.0.5"
+  "libs/partners/daytona": "0.0.5",
+  "libs/partners/modal": "0.0.3"
 }

--- a/libs/acp/CHANGELOG.md
+++ b/libs/acp/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ## Prior Releases
 
-Versions prior to 0.0.5 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=deepagents-acp) for details on previous versions.
+Versions prior to 0.0.6 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=deepagents-acp) for details on previous versions.

--- a/libs/deepagents/CHANGELOG.md
+++ b/libs/deepagents/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ## Prior Releases
 
-Versions prior to 0.5.0 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=deepagents) for details on previous versions.
+Versions prior to 0.5.1 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=deepagents) for details on previous versions.

--- a/libs/partners/daytona/CHANGELOG.md
+++ b/libs/partners/daytona/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ## Prior Releases
 
-Versions prior to 0.0.5 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=langchain-daytona) for details on previous versions.
+Versions prior to 0.0.6 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=langchain-daytona) for details on previous versions.

--- a/libs/partners/modal/CHANGELOG.md
+++ b/libs/partners/modal/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+---
+
+## Prior Releases
+
+Versions prior to 0.0.4 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=langchain-modal) for details on previous versions.

--- a/libs/partners/modal/langchain_modal/_version.py
+++ b/libs/partners/modal/langchain_modal/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-modal`."""
+
+__version__ = "0.0.3"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -102,6 +102,18 @@
         "langchain_daytona/_version.py"
       ],
       "changelog-path": "CHANGELOG.md"
+    },
+    "libs/partners/modal": {
+      "release-type": "python",
+      "package-name": "langchain-modal",
+      "component": "langchain-modal",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "pyproject.toml",
+        "langchain_modal/_version.py"
+      ],
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
Onboard `langchain-modal` to the release-please pipeline so it gets automated versioning, changelogs, and PyPI publishing alongside the SDK and CLI packages. The package was previously released manually; this brings it in line with the existing release infrastructure.