### PR TITLE
ci(runloop): set up release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,6 @@
   "libs/deepagents": "0.5.0",
   "libs/acp": "0.0.5",
   "libs/partners/daytona": "0.0.5",
-  "libs/partners/modal": "0.0.3"
+  "libs/partners/modal": "0.0.3",
+  "libs/partners/runloop": "0.0.4"
 }

--- a/libs/partners/runloop/CHANGELOG.md
+++ b/libs/partners/runloop/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+---
+
+## Prior Releases
+
+Versions prior to 0.0.5 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=langchain-runloop) for details on previous versions.

--- a/libs/partners/runloop/langchain_runloop/_version.py
+++ b/libs/partners/runloop/langchain_runloop/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-runloop`."""
+
+__version__ = "0.0.4"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -114,6 +114,18 @@
         "langchain_modal/_version.py"
       ],
       "changelog-path": "CHANGELOG.md"
+    },
+    "libs/partners/runloop": {
+      "release-type": "python",
+      "package-name": "langchain-runloop",
+      "component": "langchain-runloop",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "pyproject.toml",
+        "langchain_runloop/_version.py"
+      ],
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
Onboard `langchain-runloop` to the release-please pipeline so it gets automated versioning, changelogs, and PyPI publishing alongside the SDK and CLI packages. The package was previously released manually; this brings it in line with the existing release infrastructure.