### PR TITLE
ci(repl): set up release-please

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -13,6 +13,7 @@ This document describes the release process for packages in the Deep Agents mono
 | `langchain-modal` | `libs/partners/modal` | `langchain-modal` | [langchain-modal](https://pypi.org/project/langchain-modal/) |
 | `langchain-runloop` | `libs/partners/runloop` | `langchain-runloop` | [langchain-runloop](https://pypi.org/project/langchain-runloop/) |
 | `langchain-quickjs` | `libs/partners/quickjs` | `langchain-quickjs` | [langchain-quickjs](https://pypi.org/project/langchain-quickjs/) |
+| `langchain-repl` | `libs/repl` | `langchain-repl` | [langchain-repl](https://pypi.org/project/langchain-repl/) |
 
 ## Overview
 
@@ -105,7 +106,8 @@ Tracks the current version of each package:
   "libs/partners/daytona": "0.0.5",
   "libs/partners/modal": "0.0.3",
   "libs/partners/runloop": "0.0.4",
-  "libs/partners/quickjs": "0.0.1"
+  "libs/partners/quickjs": "0.0.1",
+  "libs/repl": "0.0.1"
 }
 ```
 
@@ -115,7 +117,7 @@ This file is automatically updated by release-please when releases are created.
 
 ### Detection Mechanism
 
-The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP, `libs/partners/daytona/CHANGELOG.md` for Daytona, `libs/partners/modal/CHANGELOG.md` for Modal, `libs/partners/runloop/CHANGELOG.md` for Runloop, `libs/partners/quickjs/CHANGELOG.md` for QuickJS). This file is always updated by release-please when merging a release PR.
+The release-please workflow (`.github/workflows/release-please.yml`) detects releases by checking if a package's `CHANGELOG.md` was modified in the commit (e.g., `libs/cli/CHANGELOG.md` for the CLI, `libs/deepagents/CHANGELOG.md` for the SDK, `libs/acp/CHANGELOG.md` for ACP, `libs/partners/daytona/CHANGELOG.md` for Daytona, `libs/partners/modal/CHANGELOG.md` for Modal, `libs/partners/runloop/CHANGELOG.md` for Runloop, `libs/partners/quickjs/CHANGELOG.md` for QuickJS, `libs/repl/CHANGELOG.md` for REPL). This file is always updated by release-please when merging a release PR.
 
 ### Lockfile Updates
 
@@ -256,7 +258,7 @@ If a release PR shows `autorelease: pending` after the release workflow complete
 **To fix manually:**
 
 ```bash
-# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, or langchain-quickjs)
+# Find the PR number for the release commit (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, langchain-quickjs, or langchain-repl)
 gh pr list --state merged --search "release(<PACKAGE>)" --limit 5
 
 # Update the label
@@ -276,7 +278,7 @@ Using the PyPI web interface or a CLI tool.
 #### 2. Delete GitHub Release/Tag (optional)
 
 ```bash
-# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, or langchain-quickjs)
+# Delete the GitHub release (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, langchain-quickjs, or langchain-repl)
 gh release delete "<PACKAGE>==<VERSION>" --yes
 
 # Delete the git tag
@@ -344,7 +346,7 @@ This means a release PR was merged but its merge commit doesn't have the expecte
 **To diagnose**, compare the tag's commit with the release PR's merge commit:
 
 ```bash
-# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, or langchain-quickjs)
+# Find what commit the tag points to (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, langchain-quickjs, or langchain-repl)
 git ls-remote --tags origin | grep "<PACKAGE>==<VERSION>"
 
 # Find the release PR's merge commit
@@ -356,7 +358,7 @@ If these differ, release-please is confused.
 **To fix**, move the tag and update the GitHub release:
 
 ```bash
-# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, or langchain-quickjs)
+# 1. Delete the remote tag (replace <PACKAGE> with deepagents, deepagents-cli, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, langchain-quickjs, or langchain-repl)
 git push origin :refs/tags/<PACKAGE>==<VERSION>
 
 # 2. Delete local tag if it exists

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,7 @@ jobs:
       modal-release: ${{ steps.check-releases.outputs.modal-release }}
       runloop-release: ${{ steps.check-releases.outputs.runloop-release }}
       quickjs-release: ${{ steps.check-releases.outputs.quickjs-release }}
+      repl-release: ${{ steps.check-releases.outputs.repl-release }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -43,7 +44,7 @@ jobs:
       # release-please always updates CHANGELOG.md when merging a release PR, and
       # the commit message matches pull-request-title-pattern in release-please-config.json:
       #   "release(${component}): ${version}"
-      # Components: deepagents-cli, deepagents, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, langchain-quickjs
+      # Components: deepagents-cli, deepagents, deepagents-acp, langchain-daytona, langchain-modal, langchain-runloop, langchain-quickjs, langchain-repl
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
@@ -119,6 +120,13 @@ jobs:
             echo "QuickJS release detected: $COMMIT_MSG"
           else
             echo "quickjs-release=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -q "^libs/repl/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-repl\):"; then
+            echo "repl-release=true" >> $GITHUB_OUTPUT
+            echo "REPL release detected: $COMMIT_MSG"
+          else
+            echo "repl-release=false" >> $GITHUB_OUTPUT
           fi
 
   # Update uv.lock files when release-please creates/updates a PR
@@ -243,6 +251,18 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-quickjs
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+
+  # Trigger release workflow when REPL release PR is merged
+  release-langchain-repl:
+    needs: release-please
+    if: needs.release-please.outputs.repl-release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      package: langchain-repl
     permissions:
       contents: write
       id-token: write

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
   "libs/partners/daytona": "0.0.5",
   "libs/partners/modal": "0.0.3",
   "libs/partners/runloop": "0.0.4",
-  "libs/partners/quickjs": "0.0.1"
+  "libs/partners/quickjs": "0.0.1",
+  "libs/repl": "0.0.1"
 }

--- a/libs/repl/CHANGELOG.md
+++ b/libs/repl/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+---
+
+## Prior Releases
+
+Versions prior to 0.0.2 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=langchain-repl) for details on previous versions.

--- a/libs/repl/langchain_repl/_version.py
+++ b/libs/repl/langchain_repl/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-repl`."""
+
+__version__ = "0.0.1"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -138,6 +138,18 @@
         "langchain_quickjs/_version.py"
       ],
       "changelog-path": "CHANGELOG.md"
+    },
+    "libs/repl": {
+      "release-type": "python",
+      "package-name": "langchain-repl",
+      "component": "langchain-repl",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "pyproject.toml",
+        "langchain_repl/_version.py"
+      ],
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
Onboard `langchain-repl` to the release-please pipeline so it gets automated versioning, changelogs, and PyPI publishing alongside the SDK and CLI packages. The package was previously released manually; this brings it in line with the existing release infrastructure.