### PR TITLE
feat(ci): label release-please PRs with package scope

### DIFF
--- a/.github/scripts/pr-labeler-config.json
+++ b/.github/scripts/pr-labeler-config.json
@@ -52,6 +52,7 @@
     "cli-gha": "github_actions",
     "daytona": "daytona",
     "deepagents": "deepagents",
+    "deepagents-acp": "acp",
     "deepagents-cli": "cli",
     "deps": "dependencies",
     "docs": "documentation",
@@ -59,6 +60,11 @@
     "examples": "examples",
     "harbor": "evals",
     "infra": "infra",
+    "langchain-daytona": "daytona",
+    "langchain-modal": "modal",
+    "langchain-quickjs": "quickjs",
+    "langchain-repl": "repl",
+    "langchain-runloop": "runloop",
     "modal": "modal",
     "quickjs": "quickjs",
     "repl": "repl",
@@ -94,6 +100,16 @@
     {
       "label": "modal",
       "prefix": "libs/partners/modal/",
+      "skipExcludedFiles": true
+    },
+    {
+      "label": "quickjs",
+      "prefix": "libs/partners/quickjs/",
+      "skipExcludedFiles": true
+    },
+    {
+      "label": "repl",
+      "prefix": "libs/repl/",
       "skipExcludedFiles": true
     },
     {

--- a/.github/scripts/pr-labeler.js
+++ b/.github/scripts/pr-labeler.js
@@ -252,6 +252,38 @@ function init(github, owner, repo, config, core) {
     return tierLabel;
   }
 
+  // ── Full PR labeling (title + file + size) ───────────────────────
+
+  async function labelPR(prNumber, { title } = {}) {
+    if (!prNumber) {
+      throw new Error('labelPR() requires a valid prNumber');
+    }
+    const toAdd = new Set();
+
+    const prTitle = title ?? (await github.rest.pulls.get({
+      owner, repo, pull_number: prNumber,
+    })).data.title;
+
+    // Title-based labels
+    for (const l of matchTitleLabels(prTitle).labels) toAdd.add(l);
+
+    // File-based labels + size
+    const files = await github.paginate(github.rest.pulls.listFiles, {
+      owner, repo, pull_number: prNumber, per_page: 100,
+    });
+    toAdd.add(computeSize(files).sizeLabel);
+    for (const l of matchFileLabels(files)) toAdd.add(l);
+
+    for (const name of toAdd) await ensureLabel(name);
+    const labels = [...toAdd];
+    if (labels.length) {
+      await github.rest.issues.addLabels({
+        owner, repo, issue_number: prNumber, labels,
+      });
+    }
+    return labels;
+  }
+
   return {
     ensureLabel,
     getSizeLabel,
@@ -259,6 +291,7 @@ function init(github, owner, repo, config, core) {
     buildFileRules,
     matchFileLabels,
     matchTitleLabels,
+    labelPR,
     allTypeLabels,
     checkMembership,
     getContributorInfo,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,6 +49,36 @@ jobs:
         with:
           fetch-depth: 2
 
+      # release-please uses GITHUB_TOKEN, so its PR events don't trigger
+      # pull_request_target (GitHub's infinite-loop prevention). Reuse the
+      # shared labelPR() helper so labeling logic stays in one place.
+      - name: Label release PRs
+        if: steps.release.outputs.prs != '[]' && steps.release.outputs.prs != ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
+        with:
+          script: |
+            let prs;
+            try {
+              prs = JSON.parse(process.env.RELEASE_PRS || '[]');
+            } catch (e) {
+              core.warning(`Failed to parse RELEASE_PRS: ${e.message}`);
+              return;
+            }
+            if (!prs.length) return;
+            const { owner, repo } = context.repo;
+            const { h } = require('./.github/scripts/pr-labeler.js').loadAndInit(github, owner, repo, core);
+            for (const pr of prs) {
+              try {
+                const labels = await h.labelPR(pr.number, { title: pr.title });
+                console.log(`PR #${pr.number} ("${pr.title}"): +[${labels.join(', ')}]`);
+              } catch (e) {
+                core.warning(`Failed to label PR #${pr.number}: ${e.message}`);
+              }
+            }
+
       - name: Check if release PRs were merged
         id: check-releases
         run: |


### PR DESCRIPTION
Release PRs created by release-please were never getting package labels (e.g., `repl`, `quickjs`, `deepagents`) because release-please uses `GITHUB_TOKEN`, and GitHub doesn't fire `pull_request_target` events for PRs created by that token. This also affected all other packages whose release-please component names (like `langchain-repl`, `deepagents-acp`) had no `scopeToLabel` mapping.

## Changes
- Add `labelPR()` to `pr-labeler.js` — a reusable function that applies title-based, file-based, and size labels to a given PR number, composing the existing `matchTitleLabels`, `matchFileLabels`, and `computeSize` helpers
- Call `labelPR()` from a new step in `release-please.yml` after checkout, with `continue-on-error: true` so labeling failures never block release detection or downstream publish jobs
- Add missing `scopeToLabel` entries for all release-please component names: `deepagents-acp`, `langchain-daytona`, `langchain-modal`, `langchain-quickjs`, `langchain-repl`, `langchain-runloop`
- Add missing `fileRules` for `libs/partners/quickjs/` and `libs/repl/` so file-based labeling works for those packages
