### PR TITLE
style(evals): make radar charts sexier

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -443,11 +443,17 @@ jobs:
             git add README.md
           fi
 
-          # Copy charts into run-specific directory.
+          # Copy charts into run-specific directory (light + dark variants).
           mkdir -p "${asset_dir}"
           cp "$GITHUB_WORKSPACE/charts/radar.png" "${asset_dir}/radar.png"
+          if [ -f "$GITHUB_WORKSPACE/charts/radar-dark.png" ]; then
+            cp "$GITHUB_WORKSPACE/charts/radar-dark.png" "${asset_dir}/radar-dark.png"
+          fi
           if [ -d "$GITHUB_WORKSPACE/charts/individual" ]; then
             cp -r "$GITHUB_WORKSPACE/charts/individual" "${asset_dir}/individual"
+          fi
+          if [ -d "$GITHUB_WORKSPACE/charts/individual-dark" ]; then
+            cp -r "$GITHUB_WORKSPACE/charts/individual-dark" "${asset_dir}/individual-dark"
           fi
 
           git add "${asset_dir}"
@@ -465,13 +471,30 @@ jobs:
         env:
           BASE_URL: ${{ steps.publish-charts.outputs.base_url }}
         run: |
+          # Use <picture> with prefers-color-scheme so GitHub automatically
+          # shows the right variant based on the reader's theme setting.
+          # Direct download links are included for each variant.
+          has_dark=false
+          [ -f charts/radar-dark.png ] && has_dark=true
+
           {
             echo ""
             echo "## Radar charts"
             echo ""
             echo "### Combined"
             echo ""
-            echo "![Combined radar chart](${BASE_URL}/radar.png)"
+            if $has_dark; then
+              echo '<picture>'
+              echo "  <source media=\"(prefers-color-scheme: dark)\" srcset=\"${BASE_URL}/radar-dark.png\">"
+              echo "  <img alt=\"Combined radar chart\" src=\"${BASE_URL}/radar.png\">"
+              echo '</picture>'
+              echo ""
+              echo "Download: [light](${BASE_URL}/radar.png) · [dark](${BASE_URL}/radar-dark.png)"
+            else
+              echo "![Combined radar chart](${BASE_URL}/radar.png)"
+              echo ""
+              echo "Download: [light](${BASE_URL}/radar.png)"
+            fi
             echo ""
 
             if [ -d charts/individual ]; then
@@ -479,7 +502,18 @@ jobs:
               echo ""
               for img in charts/individual/*.png; do
                 name="$(basename "$img" .png)"
-                echo "![${name}](${BASE_URL}/individual/${name}.png)"
+                if [ -d charts/individual-dark ] && [ -f "charts/individual-dark/${name}.png" ]; then
+                  echo '<picture>'
+                  echo "  <source media=\"(prefers-color-scheme: dark)\" srcset=\"${BASE_URL}/individual-dark/${name}.png\">"
+                  echo "  <img alt=\"${name}\" src=\"${BASE_URL}/individual/${name}.png\">"
+                  echo '</picture>'
+                  echo ""
+                  echo "Download: [light](${BASE_URL}/individual/${name}.png) · [dark](${BASE_URL}/individual-dark/${name}.png)"
+                else
+                  echo "![${name}](${BASE_URL}/individual/${name}.png)"
+                  echo ""
+                  echo "Download: [light](${BASE_URL}/individual/${name}.png)"
+                fi
                 echo ""
               done
             fi

--- a/libs/evals/deepagents_evals/radar.py
+++ b/libs/evals/deepagents_evals/radar.py
@@ -13,6 +13,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None  # type: ignore[assignment]
+
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from matplotlib.projections.polar import PolarAxes
@@ -47,17 +52,65 @@ CATEGORY_LABELS: dict[str, str] = _categories_raw["labels"]
 
 del _categories_raw
 
-_COLORS: list[str] = [
-    "#2563eb",  # blue
-    "#dc2626",  # red
-    "#16a34a",  # green
-    "#9333ea",  # purple
-    "#ea580c",  # orange
-    "#0891b2",  # cyan
-    "#be185d",  # pink
-    "#854d0e",  # brown
-]
-"""Eight visually distinct hex colors, cycled across models on the radar chart."""
+
+@dataclass(frozen=True)
+class _Theme:
+    """Color scheme for a radar chart."""
+
+    bg: str
+    grid: str
+    label: str
+    tick: str
+    watermark_alpha: float
+    fill_alpha: float
+    pill_alpha: float
+    colors: tuple[str, ...]
+
+
+_LIGHT = _Theme(
+    bg="#f8f9fa",
+    grid="#d5d8dc",
+    label="#2c3e50",
+    tick="#7f8c8d",
+    watermark_alpha=0.6,
+    fill_alpha=0.08,
+    pill_alpha=0.85,
+    colors=(
+        "#1b4f72",  # navy
+        "#b03a2e",  # burgundy
+        "#1e8449",  # forest
+        "#6c3483",  # plum
+        "#ca6f1e",  # amber
+        "#148f77",  # teal
+        "#a04000",  # rust
+        "#2e4053",  # slate
+    ),
+)
+
+_DARK = _Theme(
+    bg="#0d1117",
+    grid="#30363d",
+    label="#c9d1d9",
+    tick="#8b949e",
+    watermark_alpha=0.45,
+    fill_alpha=0.12,
+    pill_alpha=0.92,
+    colors=(
+        "#58a6ff",  # blue
+        "#f97583",  # coral
+        "#56d364",  # green
+        "#d2a8ff",  # lavender
+        "#f0883e",  # orange
+        "#39d2c0",  # teal
+        "#ff7eb6",  # pink
+        "#e3b341",  # gold
+    ),
+)
+
+_THEMES: dict[str, _Theme] = {"light": _LIGHT, "dark": _DARK}
+
+THEMES: list[str] = list(_THEMES.keys())
+"""Supported chart themes, derived from the internal theme registry."""
 
 
 @dataclass(frozen=True)
@@ -80,6 +133,7 @@ def generate_radar(
     title: str = "Eval Results",
     output: str | Path | None = None,
     figsize: tuple[float, float] = (10, 10),
+    theme: str = "light",
     _color_offset: int = 0,
 ) -> Figure:
     """Generate a radar chart comparing models across eval categories.
@@ -90,11 +144,22 @@ def generate_radar(
         title: Chart title.
         output: If provided, save the figure to this path (PNG/SVG/PDF).
         figsize: Figure size in inches.
+        theme: Color scheme — `"light"` or `"dark"`.
+
+            Unrecognized values fall back to `"light"`.
 
     Returns:
         The matplotlib `Figure` object.
     """
-    import matplotlib.pyplot as plt
+    if plt is None:
+        msg = "matplotlib is required for chart generation. Install: pip install deepagents-evals[charts]"
+        raise ImportError(msg)
+
+    try:
+        t = _THEMES[theme]
+    except KeyError:
+        msg = f"Unknown theme {theme!r}; expected one of {sorted(_THEMES)}"
+        raise ValueError(msg) from None
 
     cats = categories or EVAL_CATEGORIES
     n = len(cats)
@@ -106,57 +171,165 @@ def generate_radar(
 
     fig, ax_raw = plt.subplots(figsize=figsize, subplot_kw={"polar": True})
     ax = cast("PolarAxes", ax_raw)
+    fig.patch.set_facecolor(t.bg)
+    ax.set_facecolor(t.bg)
 
     # Start from top (90 degrees) and go clockwise.
     ax.set_theta_offset(math.pi / 2)
     ax.set_theta_direction(-1)
 
-    # Draw grid and axis labels.
+    # --- Grid & spine styling ---
+    ax.grid(color=t.grid, linewidth=0.6, linestyle="-", alpha=0.7)
+    ax.spines["polar"].set_color(t.grid)
+    ax.spines["polar"].set_linewidth(0.8)
+
+    # Axis labels — placed manually so they always render above the data.
+    # Default tick labels sit inside the axes z-order stack and get covered
+    # by polar fills regardless of zorder settings.
     ax.set_xticks(angles[:-1])
-    ax.set_xticklabels(labels, fontsize=11, fontweight="bold")
+    ax.set_xticklabels([])  # hide default labels
+
+    label_radius = 1.22
+    # The top label (angle ≈ 0) sits directly below the title — pull it in
+    # slightly so the two don't collide.
+    top_radius = 1.12
+    for angle, text in zip(angles[:-1], labels, strict=True):
+        ha = "center"
+        if 0 < angle < math.pi:
+            ha = "left"
+        elif math.pi < angle < 2 * math.pi:
+            ha = "right"
+
+        is_top = abs(angle) < 0.01 or abs(angle - 2 * math.pi) < 0.01  # noqa: PLR2004
+        r = top_radius if is_top else label_radius
+
+        ax.text(
+            angle,
+            r,
+            text,
+            ha=ha,
+            va="center",
+            fontsize=11,
+            fontweight="semibold",
+            color=t.label,
+            zorder=15,
+            bbox={
+                "facecolor": t.bg,
+                "edgecolor": "none",
+                "pad": 3,
+                "alpha": 0.95,
+            },
+        )
 
     # Radial ticks at 0.2 intervals.
     ax.set_yticks([0.2, 0.4, 0.6, 0.8, 1.0])
-    ax.set_yticklabels(["0.2", "0.4", "0.6", "0.8", "1.0"], fontsize=8, color="grey")
+    ax.set_yticklabels(
+        ["20%", "40%", "60%", "80%", "100%"],
+        fontsize=7,
+        color=t.tick,
+    )
     ax.set_ylim(0, 1.05)
 
     # Plot each model as a filled polygon.
     for idx, result in enumerate(results):
-        color = _COLORS[(idx + _color_offset) % len(_COLORS)]
+        color = t.colors[(idx + _color_offset) % len(t.colors)]
         values = [result.scores.get(c, 0.0) for c in cats]
         values.append(values[0])  # close polygon
 
+        # Filled area.
+        ax.fill(angles, values, alpha=t.fill_alpha, color=color, zorder=2)
+
+        # Primary line.
         ax.plot(
             angles,
             values,
-            "o-",
-            linewidth=2,
+            "-",
+            linewidth=2.2,
             color=color,
             label=_short_model_name(result.model),
-            markersize=5,
+            solid_capstyle="round",
+            solid_joinstyle="round",
+            zorder=3,
         )
-        ax.fill(angles, values, alpha=0.1, color=color)
 
-        # Annotate each point with its score.
+        # Data points.
+        ax.plot(
+            angles,
+            values,
+            "o",
+            color=color,
+            markersize=5,
+            markeredgecolor=t.bg,
+            markeredgewidth=1.2,
+            zorder=4,
+        )
+
+        # Score annotations with background pill.  When multiple models are
+        # plotted, stagger radially outward along each spoke so pills don't
+        # pile up at the same point.
+        multi = len(results) > 1
+        radial_bump = 0.05 + idx * 0.06 if multi else 0.04
+
         for angle, val in zip(angles[:-1], values[:-1], strict=True):
-            ax.annotate(
+            ax.text(
+                angle,
+                val + radial_bump,
                 f"{val:.0%}",
-                xy=(angle, val),
-                xytext=(0, 8),
-                textcoords="offset points",
                 ha="center",
-                fontsize=7,
+                va="center",
+                fontsize=6.5 if multi else 7,
+                fontweight="medium",
                 color=color,
+                zorder=6,
+                bbox={
+                    "boxstyle": "round,pad=0.2",
+                    "facecolor": t.bg,
+                    "edgecolor": color,
+                    "linewidth": 0.5,
+                    "alpha": t.pill_alpha,
+                },
             )
 
-    ax.legend(loc="upper right", bbox_to_anchor=(1.3, 1.1), fontsize=10)
-    ax.set_title(title, fontsize=14, fontweight="bold", pad=20)
-    fig.tight_layout()
+    # Legend — anchored to the figure's upper-right to avoid wasting space.
+    legend = fig.legend(
+        loc="upper right",
+        fontsize=9,
+        frameon=True,
+        fancybox=True,
+        shadow=False,
+        framealpha=0.95,
+        edgecolor=t.grid,
+        labelcolor=t.label,
+    )
+    legend.get_frame().set_linewidth(0.8)
+    legend.get_frame().set_facecolor(t.bg)
+
+    # Title.
+    ax.set_title(
+        title,
+        fontsize=15,
+        fontweight="bold",
+        color=t.label,
+        pad=60,
+    )
+    # Watermark.
+    fig.text(
+        0.98,
+        0.02,
+        "langchain-ai/deep-agents",
+        ha="right",
+        va="bottom",
+        fontsize=7,
+        color=t.tick,
+        alpha=t.watermark_alpha,
+        style="italic",
+    )
+    fig.tight_layout(pad=2.0)
 
     if output is not None:
         path = Path(output)
         path.parent.mkdir(parents=True, exist_ok=True)
-        fig.savefig(path, dpi=150, bbox_inches="tight")
+        fig.savefig(path, dpi=150, bbox_inches="tight", facecolor=t.bg)
         plt.close(fig)
 
     return fig
@@ -169,6 +342,7 @@ def generate_individual_radars(
     output_dir: str | Path = "charts/individual",
     title_prefix: str = "Eval Results",
     figsize: tuple[float, float] = (10, 10),
+    theme: str = "light",
 ) -> list[Path]:
     """Generate one radar chart per model.
 
@@ -180,6 +354,9 @@ def generate_individual_radars(
         output_dir: Directory to write per-model PNGs.
         title_prefix: Prefix for each chart title (model name is appended).
         figsize: Figure size in inches.
+        theme: Color scheme — `"light"` or `"dark"`.
+
+            Unrecognized values fall back to `"light"`.
 
     Returns:
         List of paths to the saved PNG files.
@@ -198,6 +375,7 @@ def generate_individual_radars(
             title=f"{title_prefix} — {name}",
             output=dest,
             figsize=figsize,
+            theme=theme,
             _color_offset=idx,
         )
         paths.append(dest)

--- a/libs/evals/scripts/generate_radar.py
+++ b/libs/evals/scripts/generate_radar.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from deepagents_evals.radar import (
     ALL_CATEGORIES,
     EVAL_CATEGORIES,
+    THEMES,
     ModelResult,
     generate_individual_radars,
     generate_radar,
@@ -88,22 +89,31 @@ def _no_results_hint(outcome: str) -> str:
 def _clear_stale_outputs(output: Path, individual_dir: Path | None) -> None:
     """Remove stale radar artifacts from a previous run.
 
-    This only removes files created by this script: the aggregate chart output
-    and top-level PNG files inside `individual_dir`.
+    This only removes files created by this script: the aggregate chart outputs
+    (light and dark variants) and top-level PNG files inside `individual_dir`
+    and its dark variant.
 
     Args:
-        output: Aggregate chart output path.
+        output: Base aggregate chart output path.
+
+            Dark variant is derived by appending `-dark` to the stem.
         individual_dir: Directory containing per-model PNGs, if configured.
     """
-    if output.is_file() or output.is_symlink():
-        output.unlink()
+    for suffix in ("", "-dark"):
+        variant = output.with_stem(output.stem + suffix)
+        if variant.is_file() or variant.is_symlink():
+            variant.unlink()
 
-    if individual_dir is None or not individual_dir.is_dir():
+    if individual_dir is None:
         return
 
-    for path in individual_dir.glob("*.png"):
-        if path.is_file() or path.is_symlink():
-            path.unlink()
+    for suffix in ("", "-dark"):
+        d = individual_dir.with_name(individual_dir.name + suffix)
+        if not d.is_dir():
+            continue
+        for path in d.glob("*.png"):
+            if path.is_file() or path.is_symlink():
+                path.unlink()
 
 
 def main() -> None:
@@ -213,37 +223,47 @@ def main() -> None:
     excluded = set(ALL_CATEGORIES) - set(EVAL_CATEGORIES)
     ordered.extend(sorted(all_cats - set(ordered) - excluded))
 
-    try:
-        generate_radar(
-            results,
-            categories=ordered,
-            title=args.title,
-            output=args.output,
-        )
-    except OSError as exc:
-        print(f"error: could not save chart to {args.output}: {exc}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as exc:  # noqa: BLE001  # top-level script should surface chart backend failures cleanly
-        print(f"error: chart generation failed: {exc}", file=sys.stderr)
-        sys.exit(1)
-    print(f"saved: {args.output}")
+    # Generate charts for each theme (light + dark).
+    for theme in THEMES:
+        suffix = f"-{theme}" if theme != "light" else ""
+        out = args.output.with_stem(args.output.stem + suffix)
 
-    if args.individual_dir and len(results) > 1:
         try:
-            paths = generate_individual_radars(
+            generate_radar(
                 results,
                 categories=ordered,
-                output_dir=args.individual_dir,
-                title_prefix=args.title,
+                title=args.title,
+                output=out,
+                theme=theme,
             )
         except OSError as exc:
-            print(f"error: could not save individual charts: {exc}", file=sys.stderr)
+            print(f"error: could not save chart to {out}: {exc}", file=sys.stderr)
             sys.exit(1)
         except Exception as exc:  # noqa: BLE001  # top-level script should surface chart backend failures cleanly
-            print(f"error: individual chart generation failed: {exc}", file=sys.stderr)
+            print(f"error: chart generation failed ({theme}): {exc}", file=sys.stderr)
             sys.exit(1)
-        for p in paths:
-            print(f"saved: {p}")
+        print(f"saved: {out}")
+
+        if args.individual_dir and len(results) > 1:
+            ind_dir = args.individual_dir.with_name(args.individual_dir.name + suffix)
+            try:
+                paths = generate_individual_radars(
+                    results,
+                    categories=ordered,
+                    output_dir=ind_dir,
+                    title_prefix=args.title,
+                    theme=theme,
+                )
+            except OSError as exc:
+                print(f"error: could not save individual charts: {exc}", file=sys.stderr)
+                sys.exit(1)
+            except Exception as exc:  # noqa: BLE001  # top-level script should surface chart backend failures cleanly
+                print(
+                    f"error: individual chart generation failed ({theme}): {exc}", file=sys.stderr
+                )
+                sys.exit(1)
+            for p in paths:
+                print(f"saved: {p}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add light and dark theme support to the eval radar charts. The renderer gets a full visual redesign — themed backgrounds, styled grid/spines, score annotation pills with background boxes, a staggered radial layout for multi-model overlap, and a `langchain-ai/deep-agents` watermark. Both variants are generated on every CI run and served via `<picture>` + `prefers-color-scheme` so GitHub auto-selects the right one for the reader's theme.