### PR TITLE
fix(cli): fail fast on missing provider credentials

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -2195,7 +2195,14 @@ def create_model(
         >>> model = create_model("gpt-4o")  # Auto-detects openai
         >>> model = create_model()  # Uses environment defaults
     """
-    from deepagents_cli.model_config import ModelConfig, ModelConfigError, ModelSpec
+    from deepagents_cli.model_config import (
+        IMPLICIT_AUTH_PROVIDERS,
+        ModelConfig,
+        ModelConfigError,
+        ModelSpec,
+        get_credential_env_var,
+        has_provider_credentials,
+    )
 
     if not model_spec:
         model_spec = _get_default_model_spec()
@@ -2224,6 +2231,20 @@ def create_model(
         # Bare model name — auto-detect provider or let init_chat_model infer
         model_name = model_spec
         provider = detect_provider(model_spec) or ""
+
+    # Early credential check — fail fast with an actionable message instead of
+    # letting the provider SDK raise an opaque auth error on first invocation.
+    # Providers that support implicit auth (e.g., Vertex AI ADC) are excluded
+    # because their env-var mapping is not a reliable indicator.
+    if provider and provider not in IMPLICIT_AUTH_PROVIDERS:
+        cred_status = has_provider_credentials(provider)
+        if cred_status is False:
+            env_var = get_credential_env_var(provider) or f"<{provider} API key>"
+            msg = (
+                f"No credentials found for provider '{provider}'. "
+                f"Please set the {env_var} environment variable."
+            )
+            raise ModelConfigError(msg)
 
     # Provider-specific kwargs (with per-model overrides)
     kwargs = _get_provider_kwargs(provider, model_name=model_name)

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -255,6 +255,14 @@ Providers not listed here fall through to the config-file check or the langchain
 registry fallback.
 """
 
+IMPLICIT_AUTH_PROVIDERS: frozenset[str] = frozenset({"google_vertexai"})
+"""Providers that support implicit auth (e.g., ADC, local servers).
+
+These providers can authenticate without the env var listed in
+`PROVIDER_API_KEY_ENV`, so a missing env var should not be treated as a hard
+credential failure. Used by `create_model` to skip the early credential check.
+"""
+
 
 # Module-level caches — cleared by `clear_caches()`.
 _available_models_cache: dict[str, list[str]] | None = None
@@ -707,25 +715,36 @@ def get_model_profiles(
 def has_provider_credentials(provider: str) -> bool | None:
     """Check if credentials are available for a provider.
 
-    Resolution order:
+    Combines two credential sources to decide whether a provider's API key
+    is present *before* attempting model creation:
 
-    1. Config-file providers (`config.toml`) with `api_key_env` — takes
-        priority so user overrides are respected.
-    2. Config-file providers with `class_path` but no `api_key_env` —
-        assumed to manage their own auth (e.g., custom headers, JWT, mTLS).
-    3. Hardcoded `PROVIDER_API_KEY_ENV` mapping (anthropic, openai, etc.).
-    4. For any other provider (e.g., third-party langchain provider
-        packages), credential status is unknown — the provider itself will
-        report auth failures at model-creation time.
+    1. **Config-file providers** (`config.toml` `[providers.<name>]`):
+        - If the section declares `api_key_env`, that env var is checked
+            via `resolve_env_var()` (which honors `DEEPAGENTS_CLI_` prefixes).
+
+            Returns `True`/`False` accordingly.
+        - If the section has `class_path` but no `api_key_env`, the provider is
+            assumed to manage its own auth (e.g., custom headers, JWT, mTLS) and
+            `True` is returned.
+        - If neither `api_key_env` nor `class_path` is set, falls through
+            to step 2.
+    2. **Hardcoded registry** (`PROVIDER_API_KEY_ENV`): a module-level dict
+        mapping 18 well-known provider names to their canonical env var
+        (e.g., `"anthropic"` → `"ANTHROPIC_API_KEY"`). The env var is checked
+        via `resolve_env_var()`.
+    3. **Unknown providers** not present in either source: returns `None` so
+        callers can decide whether to block or defer to the provider SDK's own
+        auth handling.
 
     Args:
-        provider: Provider name.
+        provider: Provider name (e.g., `"anthropic"`, `"openai"`).
 
     Returns:
-        True if credentials are confirmed available or the provider is
-            expected to manage its own auth (e.g., `class_path` providers),
-            False if confirmed missing, or None if credential status cannot
-            be determined.
+        `True` if credentials are confirmed available or the provider is
+            expected to manage its own auth (e.g., `class_path` providers).
+        `False` if the required env var is known but not set.
+        `None` if credential status cannot be determined (provider not in
+            config or `PROVIDER_API_KEY_ENV`).
     """
     # Config-file providers take priority when api_key_env is specified.
     config = ModelConfig.load()

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -438,6 +438,12 @@ class TestCreateModelProfileExtraction:
     now uses it internally.
     """
 
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
+
     @patch("langchain.chat_models.init_chat_model")
     def test_extracts_context_limit_from_profile(
         self, mock_init_chat_model: Mock
@@ -603,6 +609,12 @@ class TestModelResultApplyToSettings:
 class TestCreateModelProfileOverrides:
     """Tests for profile overrides from config.toml in create_model."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
+
     @patch("langchain.chat_models.init_chat_model")
     def test_profile_override_sets_context_limit(
         self, mock_init_chat_model: Mock, tmp_path: Path
@@ -758,6 +770,12 @@ max_input_tokens = 4096
 
 class TestCreateModelCLIProfileOverrides:
     """Tests for CLI --profile-override in create_model."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
 
     @patch("langchain.chat_models.init_chat_model")
     def test_cli_profile_override_sets_context_limit(
@@ -1719,6 +1737,12 @@ api_key_env = "FIREWORKS_API_KEY"
 class TestCreateModelExtraKwargs:
     """Tests for create_model() with extra_kwargs from --model-params."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
+
     @patch("langchain.chat_models.init_chat_model")
     def test_extra_kwargs_passed_to_model(self, mock_init_chat_model: Mock) -> None:
         """extra_kwargs are forwarded to init_chat_model."""
@@ -1785,6 +1809,12 @@ max_tokens = 1024
 
 class TestCreateModelEdgeCaseParsing:
     """Tests for create_model() edge-case spec parsing."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
 
     @patch("langchain.chat_models.init_chat_model")
     def test_leading_colon_treated_as_bare_model(


### PR DESCRIPTION
Add an early credential check in `create_model()` so users get an actionable error at startup — naming the exact env var to set — instead of an opaque auth failure on the first LLM call. Providers that support implicit auth (e.g., Vertex AI's ADC) are excluded via the new `IMPLICIT_AUTH_PROVIDERS` set.