### PR TITLE
feat(cli): warn on missing tavily key, add `/notifications`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2626,9 +2626,9 @@ class DeepAgentsApp(App):
             await self._mount_message(UserMessage(command))
             help_body = (
                 "Commands: /quit, /clear, /offload, /editor, /mcp, "
-                "/model [--model-params JSON] [--default], /reload, "
-                "/skill:<name>, /remember, /skill-creator, /theme, /tokens, "
-                "/threads, /trace, "
+                "/model [--model-params JSON] [--default], /notifications, "
+                "/reload, /skill:<name>, /remember, /skill-creator, /theme, "
+                "/tokens, /threads, /trace, "
                 "/update, /auto-update, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
@@ -2774,6 +2774,8 @@ class DeepAgentsApp(App):
             await self._show_mcp_viewer()
         elif cmd == "/theme":
             await self._show_theme_selector()
+        elif cmd == "/notifications":
+            await self._show_notification_settings()
         elif cmd == "/model" or cmd.startswith("/model "):
             model_arg = None
             set_default = False
@@ -4550,6 +4552,36 @@ class DeepAgentsApp(App):
                 self._chat_input.focus_input()
 
         screen = ThemeSelectorScreen(current_theme=self.theme)
+        self.push_screen(screen, handle_result)
+
+    async def _show_notification_settings(self) -> None:
+        """Show notification settings modal."""
+        from deepagents_cli.model_config import is_warning_suppressed
+        from deepagents_cli.widgets.notification_settings import (
+            WARNING_TOGGLES,
+            NotificationSettingsScreen,
+        )
+
+        suppressed: set[str] = set()
+        try:
+            for key, _ in WARNING_TOGGLES:
+                if await asyncio.to_thread(is_warning_suppressed, key):
+                    suppressed.add(key)
+        except Exception:
+            logger.warning("Failed to read notification settings", exc_info=True)
+            suppressed = set()
+            self.notify(
+                "Could not read notification preferences. Showing defaults.",
+                severity="warning",
+                timeout=6,
+                markup=False,
+            )
+
+        def handle_result(_result: None) -> None:
+            if self._chat_input:
+                self._chat_input.focus_input()
+
+        screen = NotificationSettingsScreen(suppressed=suppressed)
         self.push_screen(screen, handle_result)
 
     async def _show_mcp_viewer(self) -> None:

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -78,6 +78,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         bypass_tier=BypassTier.IMMEDIATE_UI,
     ),
     SlashCommand(
+        name="/notifications",
+        description="Configure startup warning preferences",
+        bypass_tier=BypassTier.IMMEDIATE_UI,
+        hidden_keywords="warnings alerts suppress",
+    ),
+    SlashCommand(
         name="/offload",
         description="Free up context window space by offloading older messages",
         bypass_tier=BypassTier.QUEUED,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -67,18 +67,19 @@ def check_cli_dependencies() -> None:
 
 
 _RIPGREP_URL = "https://github.com/BurntSushi/ripgrep#installation"
+"""Fallback installation URL when no platform package manager is detected."""
 
-_RIPGREP_SUPPRESS_HINT = (
-    "To suppress, add to ~/.deepagents/config.toml:\n"
-    "\\[warnings]\n"
-    'suppress = \\["ripgrep"]'
-)
+_SUPPRESS_HINT_TUI = "Use /notifications to manage warnings."
+"""Suppression hint for TUI toasts, referencing the in-app settings screen."""
 
-_TAVILY_SUPPRESS_HINT = (
-    "To suppress, add to ~/.deepagents/config.toml:\n"
-    "\\[warnings]\n"
-    'suppress = \\["tavily"]'
+_SUPPRESS_HINT_CLI = (
+    'To suppress, edit ~/.deepagents/config.toml:\n\\[warnings]\nsuppress = \\["<key>"]'
 )
+"""Suppression hint for non-interactive CLI output.
+
+Contains a `<key>` placeholder that callers replace with the warning key
+(e.g. `"ripgrep"`, `"tavily"`).
+"""
 
 
 def _ripgrep_install_hint() -> str:
@@ -162,13 +163,13 @@ def format_tool_warning_tui(tool: str) -> str:
         return (
             "ripgrep is not installed; the grep tool will use a slower fallback.\n"
             f"\nInstall: {hint}\n\n"
-            f"{_RIPGREP_SUPPRESS_HINT}"
+            f"{_SUPPRESS_HINT_TUI}"
         )
     if tool == "tavily":
         return (
             "Web search is disabled \u2014 TAVILY_API_KEY is not set.\n"
             "\nGet a key at https://tavily.com\n\n"
-            f"{_TAVILY_SUPPRESS_HINT}"
+            f"{_SUPPRESS_HINT_TUI}"
         )
     return f"{tool} is not installed."
 
@@ -186,17 +187,19 @@ def format_tool_warning_cli(tool: str) -> str:
         hint = _ripgrep_install_hint()
         if hint.startswith("http"):
             hint = f"[link={hint}]{hint}[/link]"
+        suppress = _SUPPRESS_HINT_CLI.replace("<key>", "ripgrep")
         return (
             "ripgrep is not installed; the grep tool will use a slower fallback.\n"
             f"Install: {hint}\n\n"
-            f"{_RIPGREP_SUPPRESS_HINT}\n"
+            f"{suppress}\n"
         )
     if tool == "tavily":
         url = "https://tavily.com"
+        suppress = _SUPPRESS_HINT_CLI.replace("<key>", "tavily")
         return (
             "Web search is disabled \u2014 TAVILY_API_KEY is not set.\n"
             f"Get a key at [link={url}]{url}[/link]\n\n"
-            f"{_TAVILY_SUPPRESS_HINT}\n"
+            f"{suppress}\n"
         )
     return f"{tool} is not installed."
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -74,6 +74,12 @@ _RIPGREP_SUPPRESS_HINT = (
     'suppress = \\["ripgrep"]'
 )
 
+_TAVILY_SUPPRESS_HINT = (
+    "To suppress, add to ~/.deepagents/config.toml:\n"
+    "\\[warnings]\n"
+    'suppress = \\["tavily"]'
+)
+
 
 def _ripgrep_install_hint() -> str:
     """Return a platform-specific install command for ripgrep.
@@ -133,6 +139,12 @@ def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
     missing: list[str] = []
     if shutil.which("rg") is None and not is_warning_suppressed("ripgrep", config_path):
         missing.append("ripgrep")
+
+    from deepagents_cli.config import settings
+
+    if not settings.has_tavily and not is_warning_suppressed("tavily", config_path):
+        missing.append("tavily")
+
     return missing
 
 
@@ -151,6 +163,12 @@ def format_tool_warning_tui(tool: str) -> str:
             "ripgrep is not installed; the grep tool will use a slower fallback.\n"
             f"\nInstall: {hint}\n\n"
             f"{_RIPGREP_SUPPRESS_HINT}"
+        )
+    if tool == "tavily":
+        return (
+            "Web search is disabled \u2014 TAVILY_API_KEY is not set.\n"
+            "\nGet a key at https://tavily.com\n\n"
+            f"{_TAVILY_SUPPRESS_HINT}"
         )
     return f"{tool} is not installed."
 
@@ -172,6 +190,13 @@ def format_tool_warning_cli(tool: str) -> str:
             "ripgrep is not installed; the grep tool will use a slower fallback.\n"
             f"Install: {hint}\n\n"
             f"{_RIPGREP_SUPPRESS_HINT}\n"
+        )
+    if tool == "tavily":
+        url = "https://tavily.com"
+        return (
+            "Web search is disabled \u2014 TAVILY_API_KEY is not set.\n"
+            f"Get a key at [link={url}]{url}[/link]\n\n"
+            f"{_TAVILY_SUPPRESS_HINT}\n"
         )
     return f"{tool} is not installed."
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -1277,7 +1277,14 @@ def suppress_warning(key: str, config_path: Path | None = None) -> bool:
 
         if "warnings" not in data:
             data["warnings"] = {}
-        suppress_list: list[str] = data["warnings"].get("suppress", [])
+        suppress_list = data["warnings"].get("suppress", [])
+        if not isinstance(suppress_list, list):
+            logger.debug(
+                "[warnings].suppress in %s should be a list, got %s",
+                config_path,
+                type(suppress_list).__name__,
+            )
+            suppress_list = []
         if key not in suppress_list:
             suppress_list.append(key)
         data["warnings"]["suppress"] = suppress_list
@@ -1293,6 +1300,61 @@ def suppress_warning(key: str, config_path: Path | None = None) -> bool:
             raise
     except (OSError, tomllib.TOMLDecodeError):
         logger.exception("Could not save warning suppression for '%s'", key)
+        return False
+    return True
+
+
+def unsuppress_warning(key: str, config_path: Path | None = None) -> bool:
+    """Remove a warning key from the suppression list in the config file.
+
+    Reads existing config (if any), removes `key` from `[warnings].suppress`,
+    and writes back using atomic temp-file rename. No-op if the key is not
+    present or the file does not exist.
+
+    Args:
+        key: Warning identifier to unsuppress (e.g., `'ripgrep'`).
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        `True` if save succeeded, `False` if it failed due to I/O errors.
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+
+    try:
+        if not config_path.exists():
+            return True  # nothing to remove
+
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+
+        suppress_list = data.get("warnings", {}).get("suppress", [])
+        if not isinstance(suppress_list, list):
+            logger.debug(
+                "[warnings].suppress in %s should be a list, got %s",
+                config_path,
+                type(suppress_list).__name__,
+            )
+            return True  # treat as nothing to remove
+        if key not in suppress_list:
+            return True  # already unsuppressed
+
+        suppress_list.remove(key)
+        data.setdefault("warnings", {})["suppress"] = suppress_list
+
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.exception("Could not remove warning suppression for '%s'", key)
         return False
     return True
 

--- a/libs/cli/deepagents_cli/widgets/notification_settings.py
+++ b/libs/cli/deepagents_cli/widgets/notification_settings.py
@@ -1,0 +1,156 @@
+"""Notification settings screen for /notifications command."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from textual.binding import Binding, BindingType
+from textual.containers import VerticalGroup
+from textual.screen import ModalScreen
+from textual.widgets import Checkbox, Static
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+from deepagents_cli import theme
+from deepagents_cli.config import get_glyphs, is_ascii_mode
+
+logger = logging.getLogger(__name__)
+
+# Warning keys and their user-facing labels.
+# Checked = warning is shown at startup (not suppressed). Unchecked = suppressed.
+WARNING_TOGGLES: list[tuple[str, str]] = [
+    ("ripgrep", "Warn when ripgrep is not installed"),
+    ("tavily", "Warn when TAVILY_API_KEY is not set (web search)"),
+]
+
+
+class NotificationSettingsScreen(ModalScreen[None]):
+    """Modal dialog for managing startup warning preferences.
+
+    Each checkbox maps to a key in `[warnings].suppress` in
+    `~/.deepagents/config.toml`. Toggling a checkbox immediately
+    persists the change.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "Close", show=False),
+    ]
+
+    CSS = """
+    NotificationSettingsScreen {
+        align: center middle;
+        background: transparent;
+    }
+
+    NotificationSettingsScreen > VerticalGroup {
+        width: 65;
+        max-width: 90%;
+        height: auto;
+        max-height: 80%;
+        background: $surface;
+        border: solid $primary;
+        padding: 1 2;
+    }
+
+    NotificationSettingsScreen .ns-title {
+        text-style: bold;
+        color: $primary;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    NotificationSettingsScreen .ns-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        margin-top: 1;
+        text-align: center;
+    }
+
+    NotificationSettingsScreen Checkbox {
+        margin: 0;
+        border: none;
+        &:focus {
+            border: none;
+        }
+    }
+    """
+
+    def __init__(self, suppressed: set[str]) -> None:
+        """Initialize the notification settings screen.
+
+        Args:
+            suppressed: Set of currently suppressed warning keys.
+        """
+        super().__init__()
+        self._suppressed = suppressed
+
+    def compose(self) -> ComposeResult:
+        """Compose the screen layout.
+
+        Yields:
+            Widgets for the notification settings UI.
+        """
+        glyphs = get_glyphs()
+        with VerticalGroup():
+            yield Static("Notification Settings", classes="ns-title")
+            for key, label in WARNING_TOGGLES:
+                yield Checkbox(
+                    label,
+                    value=key not in self._suppressed,
+                    id=f"ns-{key}",
+                )
+            help_text = f"Tab navigate {glyphs.bullet} Esc close"
+            yield Static(help_text, classes="ns-help")
+
+    def on_mount(self) -> None:
+        """Apply ASCII border if needed."""
+        if is_ascii_mode():
+            container = self.query_one(VerticalGroup)
+            colors = theme.get_theme_colors(self)
+            container.styles.border = ("ascii", colors.success)
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        """Persist warning suppression toggle to config.toml on change."""
+        event.stop()
+        checkbox_id = event.checkbox.id
+        if not checkbox_id or not checkbox_id.startswith("ns-"):
+            return
+        key = checkbox_id.removeprefix("ns-")
+        enabled = event.value
+
+        async def _persist() -> None:
+            from deepagents_cli.model_config import (
+                suppress_warning,
+                unsuppress_warning,
+            )
+
+            try:
+                if enabled:
+                    ok = await asyncio.to_thread(unsuppress_warning, key)
+                else:
+                    ok = await asyncio.to_thread(suppress_warning, key)
+            except Exception:
+                logger.warning(
+                    "Failed to persist notification setting for %r",
+                    key,
+                    exc_info=True,
+                )
+                ok = False
+            if not ok:
+                self.app.notify(
+                    "Could not save notification preference. "
+                    "Check file permissions for ~/.deepagents/config.toml.",
+                    severity="warning",
+                    timeout=6,
+                    markup=False,
+                )
+
+        self.call_later(_persist)
+
+    def action_cancel(self) -> None:
+        """Close the screen."""
+        self.dismiss(None)

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -635,13 +635,16 @@ class TestFormatToolWarnings:
         assert f"[link={url}]" in msg
         assert "[/link]" in msg
 
-    def test_both_formats_contain_suppress_hint(self) -> None:
-        """Both formats include the config suppression hint."""
-        formatters = (format_tool_warning_tui, format_tool_warning_cli)
-        for fmt in formatters:
-            msg = fmt("ripgrep")
-            assert "\\[warnings]" in msg
-            assert 'suppress = \\["ripgrep"]' in msg
+    def test_tui_format_contains_notifications_hint(self) -> None:
+        """TUI format references /notifications command."""
+        msg = format_tool_warning_tui("ripgrep")
+        assert "/notifications" in msg
+
+    def test_cli_format_contains_config_hint(self) -> None:
+        """CLI format references config.toml for suppression."""
+        msg = format_tool_warning_cli("ripgrep")
+        assert "config.toml" in msg
+        assert 'suppress = \\["ripgrep"]' in msg
 
     def test_unknown_tool_fallback(self) -> None:
         """Unknown tools get a generic message."""
@@ -661,12 +664,16 @@ class TestFormatToolWarnings:
         assert "TAVILY_API_KEY" in msg
         assert "[link=https://tavily.com]" in msg
 
-    def test_both_formats_tavily_contain_suppress_hint(self) -> None:
-        """Both tavily formats include the config suppression hint."""
-        for fmt in (format_tool_warning_tui, format_tool_warning_cli):
-            msg = fmt("tavily")
-            assert "\\[warnings]" in msg
-            assert 'suppress = \\["tavily"]' in msg
+    def test_tui_format_tavily_contains_notifications_hint(self) -> None:
+        """TUI tavily format references /notifications command."""
+        msg = format_tool_warning_tui("tavily")
+        assert "/notifications" in msg
+
+    def test_cli_format_tavily_contains_config_hint(self) -> None:
+        """CLI tavily format references config.toml for suppression."""
+        msg = format_tool_warning_cli("tavily")
+        assert "config.toml" in msg
+        assert 'suppress = \\["tavily"]' in msg
 
 
 class TestRunTextualCliAsyncModelConfigError:

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import inspect
+from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -286,6 +287,15 @@ class TestServerCleanupLifecycle:
 class TestCheckOptionalTools:
     """Tests for check_optional_tools() function."""
 
+    @pytest.fixture(autouse=True)
+    def _tavily_available(self) -> Iterator[None]:
+        """Patch settings.has_tavily to True so ripgrep-only tests stay isolated."""
+        with patch(
+            "deepagents_cli.config.settings",
+            SimpleNamespace(has_tavily=True),
+        ):
+            yield
+
     def test_returns_tool_name_when_rg_not_found(self) -> None:
         """Returns `['ripgrep']` when `rg` is not on PATH."""
         with patch("deepagents_cli.main.shutil.which", return_value=None):
@@ -339,6 +349,42 @@ class TestCheckOptionalTools:
             missing = check_optional_tools(config_path=config_path)
 
         assert missing == ["ripgrep"]
+
+    def test_returns_tavily_when_key_missing(self) -> None:
+        """Returns `'tavily'` when TAVILY_API_KEY is not set."""
+        with (
+            patch("deepagents_cli.main.shutil.which", return_value="/usr/bin/rg"),
+            patch(
+                "deepagents_cli.config.settings",
+                SimpleNamespace(has_tavily=False),
+            ),
+        ):
+            missing = check_optional_tools()
+
+        assert missing == ["tavily"]
+
+    def test_omits_tavily_when_key_present(self) -> None:
+        """Does not include `'tavily'` when TAVILY_API_KEY is set."""
+        with patch("deepagents_cli.main.shutil.which", return_value="/usr/bin/rg"):
+            missing = check_optional_tools()
+
+        assert "tavily" not in missing
+
+    def test_tavily_warning_suppressed_via_config(self, tmp_path: Path) -> None:
+        """Returns empty list when tavily warning is suppressed in config."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["tavily"]\n')
+
+        with (
+            patch("deepagents_cli.main.shutil.which", return_value="/usr/bin/rg"),
+            patch(
+                "deepagents_cli.config.settings",
+                SimpleNamespace(has_tavily=False),
+            ),
+        ):
+            missing = check_optional_tools(config_path=config_path)
+
+        assert missing == []
 
 
 class TestRipgrepInstallHint:
@@ -601,6 +647,26 @@ class TestFormatToolWarnings:
         """Unknown tools get a generic message."""
         assert format_tool_warning_tui("foo") == "foo is not installed."
         assert format_tool_warning_cli("foo") == "foo is not installed."
+
+    def test_tui_format_tavily_contains_env_hint(self) -> None:
+        """TUI format for tavily mentions the env var."""
+        msg = format_tool_warning_tui("tavily")
+        assert "TAVILY_API_KEY" in msg
+        assert "tavily.com" in msg
+        assert "[link=" not in msg
+
+    def test_cli_format_tavily_contains_env_hint(self) -> None:
+        """CLI format for tavily mentions the env var with Rich link."""
+        msg = format_tool_warning_cli("tavily")
+        assert "TAVILY_API_KEY" in msg
+        assert "[link=https://tavily.com]" in msg
+
+    def test_both_formats_tavily_contain_suppress_hint(self) -> None:
+        """Both tavily formats include the config suppression hint."""
+        for fmt in (format_tool_warning_tui, format_tool_warning_cli):
+            msg = fmt("tavily")
+            assert "\\[warnings]" in msg
+            assert 'suppress = \\["tavily"]' in msg
 
 
 class TestRunTextualCliAsyncModelConfigError:

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -30,6 +30,7 @@ from deepagents_cli.model_config import (
     save_recent_model,
     save_thread_columns,
     suppress_warning,
+    unsuppress_warning,
 )
 
 
@@ -2664,6 +2665,92 @@ class TestSuppressWarning:
             data = tomllib.load(f)
         assert data["models"]["default"] == "some:model"
         assert "ripgrep" in data["warnings"]["suppress"]
+
+
+class TestUnsuppressWarning:
+    """Tests for unsuppress_warning() function."""
+
+    def test_removes_key_from_suppress_list(self, tmp_path: Path) -> None:
+        """Removes the specified key from the suppression list."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["ripgrep", "tavily"]\n')
+
+        result = unsuppress_warning("tavily", config_path)
+
+        assert result is True
+        assert not is_warning_suppressed("tavily", config_path)
+        assert is_warning_suppressed("ripgrep", config_path)
+
+    def test_noop_when_key_not_present(self, tmp_path: Path) -> None:
+        """Returns True without error when key is not in the list."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = ["ripgrep"]\n')
+
+        result = unsuppress_warning("tavily", config_path)
+
+        assert result is True
+        assert is_warning_suppressed("ripgrep", config_path)
+
+    def test_noop_when_file_missing(self, tmp_path: Path) -> None:
+        """Returns True when config file does not exist."""
+        config_path = tmp_path / "config.toml"
+
+        result = unsuppress_warning("ripgrep", config_path)
+
+        assert result is True
+
+    def test_noop_when_no_warnings_section(self, tmp_path: Path) -> None:
+        """Returns True when config has no [warnings] section."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models]\ndefault = "some:model"\n')
+
+        result = unsuppress_warning("ripgrep", config_path)
+
+        assert result is True
+
+    def test_preserves_other_config(self, tmp_path: Path) -> None:
+        """Other config sections are preserved after unsuppressing."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            '[models]\ndefault = "some:model"\n\n[warnings]\nsuppress = ["tavily"]\n'
+        )
+
+        unsuppress_warning("tavily", config_path)
+
+        assert not is_warning_suppressed("tavily", config_path)
+        import tomllib
+
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["models"]["default"] == "some:model"
+
+    def test_returns_false_on_corrupt_toml(self, tmp_path: Path) -> None:
+        """Returns False when config file contains malformed TOML."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("this is not valid toml [[[")
+
+        result = unsuppress_warning("tavily", config_path)
+
+        assert result is False
+
+    def test_noop_when_suppress_is_not_a_list(self, tmp_path: Path) -> None:
+        """Returns True when suppress value is not a list."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[warnings]\nsuppress = "ripgrep"\n')
+
+        result = unsuppress_warning("ripgrep", config_path)
+
+        assert result is True
+
+    def test_roundtrip_suppress_unsuppress(self, tmp_path: Path) -> None:
+        """Suppress then unsuppress returns to original state."""
+        config_path = tmp_path / "config.toml"
+
+        suppress_warning("tavily", config_path)
+        assert is_warning_suppressed("tavily", config_path)
+
+        unsuppress_warning("tavily", config_path)
+        assert not is_warning_suppressed("tavily", config_path)
 
 
 class TestGetModelProfiles:


### PR DESCRIPTION
Add a startup warning when `TAVILY_API_KEY` is not set, alerting users that web search is unavailable. Also introduce a `/notifications` slash command with a modal settings screen so users can toggle individual startup warnings on or off without hand-editing `config.toml`.

## Changes
- Add `tavily` to `check_optional_tools` — checks `settings.has_tavily` and the `[warnings].suppress` config, matching the existing `ripgrep` pattern
- Add `NotificationSettingsScreen` modal with per-warning checkboxes that persist immediately to `~/.deepagents/config.toml` via `suppress_warning`/`unsuppress_warning`
- Add `unsuppress_warning()` in `model_config.py` as the inverse of `suppress_warning`, with the same atomic temp-file write strategy
- Split the old `_RIPGREP_SUPPRESS_HINT` into `_SUPPRESS_HINT_TUI` (points to `/notifications`) and `_SUPPRESS_HINT_CLI` (shows `config.toml` snippet with a `<key>` placeholder), and add Tavily-specific formatting for both output modes
- Harden `suppress_warning` and `unsuppress_warning` against `[warnings].suppress` not being a list