### PR TITLE
feat(examples): add trace summaries to better-harness proposer workspace

### DIFF
--- a/examples/better-harness/better_harness/__init__.py
+++ b/examples/better-harness/better_harness/__init__.py
@@ -8,10 +8,13 @@ from better_harness.core import (
     RunReport,
     SplitResult,
     Surface,
+    TraceStep,
+    TraceSummary,
     Variant,
     load_experiment,
     main,
     run_experiment,
+    summarize_langsmith_trace,
     validate_experiment,
 )
 from better_harness.patching import (
@@ -31,6 +34,8 @@ __all__ = [
     "RunReport",
     "SplitResult",
     "Surface",
+    "TraceStep",
+    "TraceSummary",
     "Variant",
     "build_baseline_variant",
     "build_variant",
@@ -41,6 +46,7 @@ __all__ = [
     "patch_from_env",
     "patch_module_attrs",
     "run_experiment",
+    "summarize_langsmith_trace",
     "validate_experiment",
     "workspace_override_context",
 ]

--- a/examples/better-harness/better_harness/agent.py
+++ b/examples/better-harness/better_harness/agent.py
@@ -11,11 +11,19 @@ import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from better_harness.core import Experiment, Proposal, RunLayout, SplitResult, Variant
+from better_harness.core import (
+    CaseOutcome,
+    Experiment,
+    Proposal,
+    RunLayout,
+    SplitResult,
+    Variant,
+    summarize_langsmith_trace,
+)
 from better_harness.patching import build_variant, prepend_pythonpath
 
 DEFAULT_SYSTEM_PROMPT = """You are Better Agent, an outer-loop Deep Agent that improves another agent harness.
@@ -80,6 +88,10 @@ def build_proposer_workspace(
     _write_train_artifacts(
         experiment=experiment,
         train_result=train_result,
+        root=root,
+    )
+    _write_train_traces(
+        outcomes=list(train_result.failing_outcomes()),
         root=root,
     )
     _write_visible_history(layout=layout, root=root)
@@ -282,6 +294,51 @@ def _write_train_artifacts(
             task_dir = tasks_root / rendered
             if task_dir.exists():
                 shutil.copytree(task_dir, train_cases_dir / rendered, dirs_exist_ok=True)
+
+
+def _write_train_traces(
+    *,
+    outcomes: list[CaseOutcome],
+    root: Path,
+) -> int:
+    """Write trace summaries for failing cases to the proposer workspace.
+
+    Reads already-fetched LangSmith trace JSON files from each outcome's
+    `artifacts_dir` and writes a single `train_traces.json` containing
+    compact summaries.
+
+    Args:
+        outcomes: Failing case outcomes to summarize.
+        root: Proposer workspace root directory.
+
+    Returns:
+        Number of traces written.
+
+    """
+    traces: list[dict[str, Any]] = []
+    for outcome in outcomes:
+        if not outcome.artifacts_dir:
+            continue
+        traces_dir = Path(outcome.artifacts_dir) / "traces" / "langsmith"
+        if not traces_dir.is_dir():
+            continue
+        for trace_path in sorted(traces_dir.glob("*.json")):
+            try:
+                trace_data = json.loads(trace_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            summary = summarize_langsmith_trace(
+                trace_data,
+                trace_ref=outcome.trace_ref,
+            )
+            traces.append({"case_id": outcome.case_id, **asdict(summary)})
+            break  # one trace per case
+    if not traces:
+        return 0
+    (root / "train_traces.json").write_text(
+        json.dumps(traces, indent=2) + "\n"
+    )
+    return len(traces)
 
 
 def _write_visible_history(*, layout: RunLayout, root: Path) -> None:

--- a/examples/better-harness/better_harness/core.py
+++ b/examples/better-harness/better_harness/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
@@ -844,6 +845,118 @@ def fetch_langsmith_trace(*, endpoint: str, api_key: str, trace_id: str) -> dict
         raise RuntimeError(f"LangSmith fetch failed for {trace_id}: HTTP {exc.code}: {detail}") from exc
     except urllib.error.URLError as exc:
         raise RuntimeError(f"LangSmith fetch failed for {trace_id}: {exc}") from exc
+
+
+_MAX_TRACE_CONTENT_LEN = 2000
+
+
+@dataclass(frozen=True)
+class TraceStep:
+    """One step in a summarized agent trace."""
+
+    type: str
+    content: str
+    name: str | None = None
+    status: str | None = None
+    tool_calls: tuple[dict[str, Any], ...] | None = None
+
+
+@dataclass(frozen=True)
+class TraceSummary:
+    """Summarized LangSmith trace for the proposer workspace."""
+
+    status: str | None
+    error: str | None
+    trace_ref: str | None
+    steps: tuple[TraceStep, ...]
+
+
+def summarize_langsmith_trace(
+    trace_data: dict[str, Any],
+    *,
+    trace_ref: str | None = None,
+) -> TraceSummary:
+    """Summarize a LangSmith trace into a compact structure.
+
+    Supports both LangChain constructor format (`kwargs.type`) and
+    OpenAI chat format (`role`/`content`) as returned by the LangSmith
+    `include_messages=true` API.
+
+    Args:
+        trace_data: Raw JSON dict from `fetch_langsmith_trace`.
+        trace_ref: Optional LangSmith URL for linking back.
+
+    Returns:
+        A `TraceSummary` with extracted steps. Returns a summary with
+        empty steps if the trace cannot be parsed.
+
+    """
+    messages = trace_data.get("messages") or []
+    steps: list[TraceStep] = []
+    for msg in messages:
+        if "kwargs" in msg:
+            kwargs = msg["kwargs"]
+            msg_type = kwargs.get("type", "unknown")
+            content = kwargs.get("content")
+            raw_tool_calls = kwargs.get("tool_calls")
+            name = kwargs.get("name")
+            status = kwargs.get("status")
+        else:
+            role = msg.get("role", "unknown")
+            # user/assistant/tool/system all pass through; normalize
+            # the two that differ from LC naming.
+            msg_type = {"user": "human", "assistant": "ai"}.get(role, role)
+            content = msg.get("content")
+            raw_tool_calls = msg.get("tool_calls")
+            name = msg.get("name")
+            status = msg.get("status")
+
+        if content is None:
+            content = ""
+        elif isinstance(content, list):
+            text_parts = [
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            content = "\n".join(text_parts)
+        elif not isinstance(content, str):
+            content = str(content)
+
+        if len(content) > _MAX_TRACE_CONTENT_LEN:
+            content = content[:_MAX_TRACE_CONTENT_LEN] + "... [truncated]"
+
+        tool_calls = None
+        if raw_tool_calls:
+            parsed: list[dict[str, Any]] = []
+            for tc in raw_tool_calls:
+                if "function" in tc:
+                    fn = tc["function"]
+                    args = fn.get("arguments", {})
+                    if isinstance(args, str):
+                        with contextlib.suppress(json.JSONDecodeError, ValueError):
+                            args = json.loads(args)
+                    parsed.append({"name": fn.get("name"), "args": args})
+                else:
+                    parsed.append({"name": tc.get("name"), "args": tc.get("args")})
+            tool_calls = tuple(parsed)
+
+        steps.append(
+            TraceStep(
+                type=msg_type,
+                content=content,
+                name=name,
+                status=status,
+                tool_calls=tool_calls,
+            )
+        )
+
+    return TraceSummary(
+        status=trace_data.get("status"),
+        error=trace_data.get("error"),
+        trace_ref=trace_ref,
+        steps=tuple(steps),
+    )
 
 
 def collect_trace_refs(run_dir: Path) -> list[dict[str, Any]]:

--- a/examples/better-harness/tests/test_better_harness.py
+++ b/examples/better-harness/tests/test_better_harness.py
@@ -17,8 +17,13 @@ from better_harness import (
     main,
     run_experiment,
 )
-from better_harness.agent import build_proposer_workspace
-from better_harness.core import RunLayout, extract_langsmith_trace_id, write_trace_payloads
+from better_harness.agent import _write_train_traces, build_proposer_workspace
+from better_harness.core import (
+    RunLayout,
+    extract_langsmith_trace_id,
+    summarize_langsmith_trace,
+    write_trace_payloads,
+)
 from better_harness.patching import (
     build_baseline_variant,
     build_variant,
@@ -756,3 +761,243 @@ def test_cli_inventory_and_split_commands(tmp_path: Path, capsys: pytest.Capture
 
     captured = capsys.readouterr()
     assert str(inventory_path) in captured.out
+
+
+def test_summarize_langsmith_trace_extracts_steps():
+    trace_data = {
+        "status": "success",
+        "error": None,
+        "messages": [
+            {
+                "lc": 1,
+                "type": "constructor",
+                "id": ["langchain", "schema", "messages", "HumanMessage"],
+                "kwargs": {"type": "human", "content": "Fix the auth bug"},
+            },
+            {
+                "lc": 1,
+                "type": "constructor",
+                "id": ["langchain", "schema", "messages", "AIMessage"],
+                "kwargs": {
+                    "type": "ai",
+                    "content": "I'll investigate the auth module.",
+                    "tool_calls": [
+                        {"name": "read_file", "args": {"path": "auth.py"}},
+                    ],
+                },
+            },
+            {
+                "lc": 1,
+                "type": "constructor",
+                "id": ["langchain", "schema", "messages", "ToolMessage"],
+                "kwargs": {
+                    "type": "tool",
+                    "content": "def login(): pass",
+                    "name": "read_file",
+                    "status": "success",
+                },
+            },
+        ],
+    }
+    summary = summarize_langsmith_trace(trace_data)
+    assert summary.status == "success"
+    assert summary.error is None
+    assert len(summary.steps) == 3
+    assert summary.steps[0].type == "human"
+    assert summary.steps[0].content == "Fix the auth bug"
+    assert summary.steps[1].type == "ai"
+    assert summary.steps[1].tool_calls == ({"name": "read_file", "args": {"path": "auth.py"}},)
+    assert summary.steps[2].type == "tool"
+    assert summary.steps[2].name == "read_file"
+    assert summary.steps[2].status == "success"
+
+
+def test_summarize_langsmith_trace_handles_list_content():
+    trace_data = {
+        "status": "success",
+        "error": None,
+        "messages": [
+            {
+                "lc": 1,
+                "type": "constructor",
+                "id": ["langchain", "schema", "messages", "AIMessage"],
+                "kwargs": {
+                    "type": "ai",
+                    "content": [
+                        {"type": "text", "text": "I'll read the file."},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_01",
+                            "name": "read_file",
+                            "input": {"path": "auth.py"},
+                        },
+                    ],
+                    "tool_calls": [
+                        {"name": "read_file", "args": {"path": "auth.py"}},
+                    ],
+                },
+            },
+        ],
+    }
+    summary = summarize_langsmith_trace(trace_data)
+    assert len(summary.steps) == 1
+    assert summary.steps[0].content == "I'll read the file."
+    assert summary.steps[0].tool_calls is not None
+
+
+def test_summarize_langsmith_trace_truncates_long_content():
+    long_content = "x" * 5000
+    trace_data = {
+        "status": "success",
+        "error": None,
+        "messages": [
+            {
+                "lc": 1,
+                "type": "constructor",
+                "id": ["langchain", "schema", "messages", "ToolMessage"],
+                "kwargs": {
+                    "type": "tool",
+                    "content": long_content,
+                    "name": "read_file",
+                    "status": "success",
+                },
+            },
+        ],
+    }
+    summary = summarize_langsmith_trace(trace_data)
+    assert len(summary.steps[0].content) < 5000
+    assert summary.steps[0].content.endswith("... [truncated]")
+
+
+def test_summarize_langsmith_trace_handles_empty():
+    assert summarize_langsmith_trace({}).steps == ()
+    assert summarize_langsmith_trace({"messages": None}).steps == ()
+    assert summarize_langsmith_trace({"messages": []}).steps == ()
+
+
+def test_summarize_langsmith_trace_openai_format():
+    trace_data = {
+        "status": "success",
+        "error": None,
+        "messages": [
+            {"role": "user", "content": "Find error logs"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "tc1",
+                        "function": {
+                            "name": "search_docs",
+                            "arguments": '{"query": "errors"}',
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "Error: permission denied",
+                "tool_call_id": "tc1",
+            },
+            {"role": "assistant", "content": "The search failed due to permissions."},
+        ],
+    }
+    summary = summarize_langsmith_trace(trace_data)
+    assert summary.status == "success"
+    assert len(summary.steps) == 4
+    assert summary.steps[0].type == "human"
+    assert summary.steps[0].content == "Find error logs"
+    assert summary.steps[1].type == "ai"
+    assert summary.steps[1].tool_calls == ({"name": "search_docs", "args": {"query": "errors"}},)
+    assert summary.steps[2].type == "tool"
+    assert summary.steps[2].content == "Error: permission denied"
+    assert summary.steps[3].type == "ai"
+    assert summary.steps[3].content == "The search failed due to permissions."
+
+
+def test_write_train_traces_writes_json(tmp_path: Path):
+    artifacts_dir = tmp_path / "case_artifacts"
+    traces_dir = artifacts_dir / "traces" / "langsmith"
+    traces_dir.mkdir(parents=True)
+    # Real LangSmith API format (OpenAI chat messages with function tool calls).
+    trace_payload = {
+        "status": "success",
+        "error": None,
+        "messages": [
+            {"role": "user", "content": "Send a Slack DM to user U12345"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "toolu_01",
+                        "function": {
+                            "name": "slack_send_dm",
+                            "arguments": '{"user_id": "U12345", "message": "Hello"}',
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "Sent DM to U12345: Hello",
+                "tool_call_id": "toolu_01",
+            },
+            {"role": "assistant", "content": "Done! I sent the DM."},
+        ],
+    }
+    (traces_dir / "019c2754-dcf0-7971-ad86-ee82ed690b8a.json").write_text(
+        json.dumps(trace_payload) + "\n"
+    )
+
+    outcomes = [
+        CaseOutcome(
+            case_id="tests/test_foo.py::test_bar[model]",
+            split="train",
+            stratum="tool_use",
+            status="failed",
+            score=0.0,
+            duration_s=1.0,
+            failure_message="assertion failed",
+            artifacts_dir=str(artifacts_dir),
+            trace_ref="https://smith.langchain.com/r/abc123",
+        ),
+    ]
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    count = _write_train_traces(outcomes=outcomes, root=workspace)
+
+    assert count == 1
+    result_path = workspace / "train_traces.json"
+    assert result_path.exists()
+    traces = json.loads(result_path.read_text())
+    assert len(traces) == 1
+    assert traces[0]["case_id"] == "tests/test_foo.py::test_bar[model]"
+    assert traces[0]["trace_ref"] == "https://smith.langchain.com/r/abc123"
+    assert len(traces[0]["steps"]) == 4
+    assert traces[0]["steps"][0]["type"] == "human"
+    assert traces[0]["steps"][1]["tool_calls"][0]["name"] == "slack_send_dm"
+    assert traces[0]["steps"][2]["type"] == "tool"
+    assert traces[0]["steps"][3]["content"] == "Done! I sent the DM."
+
+
+def test_write_train_traces_skips_missing_artifacts(tmp_path: Path):
+    outcomes = [
+        CaseOutcome(
+            case_id="tests/test_foo.py::test_bar[model]",
+            split="train",
+            stratum="tool_use",
+            status="failed",
+            score=0.0,
+            duration_s=1.0,
+        ),
+    ]
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    count = _write_train_traces(outcomes=outcomes, root=workspace)
+
+    assert count == 0
+    assert not (workspace / "train_traces.json").exists()


### PR DESCRIPTION
## What this does

The Better Agent currently sees failure messages like:

> "Expected slack_send_dm but agent called github_create_issue"

It knows what went wrong but not why. This change adds the full agent
trajectory to the proposer workspace so it can see the reasoning and
tool calls that led to the failure.

## How it works

Trace data is already fetched by `write_trace_payloads` and saved to
disk. This reads those files and writes compact summaries to
`train_traces.json` in the proposer workspace.

- `core.py`: `summarize_langsmith_trace()` — extracts messages from
  LangSmith traces, supports both LC constructor and OpenAI chat
  formats, truncates tool output at 2000 chars
- `agent.py`: `_write_train_traces()` — called from
  `build_proposer_workspace`, skips cases without trace artifacts
- 7 new tests, both message formats

Tested against real evals (`test_tool_selection`, `test_followup_quality`)
with traces from gpt-4.1-mini.