### PR TITLE
fix(cli): fix mktemp template in debug script for macOS

### DIFF
--- a/libs/cli/scripts/debug_server.sh
+++ b/libs/cli/scripts/debug_server.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-OUT=$(mktemp "${TMPDIR:-/tmp}/deepagents_debug_XXXXXX.txt")
+OUT=$(mktemp "${TMPDIR:-/tmp}deepagents_debug_XXXXXX")
 
 {
     echo "=== deepagents debug dump ==="


### PR DESCRIPTION
Fix BSD `mktemp` compatibility on macOS: the template must end with the `X` characters for randomization to work, and `$TMPDIR` already includes a trailing slash. Without this, the output file is literally named `deepagents_debug_XXXXXX.txt`.