### PR TITLE
fix(cli): deduplicate MCP servers in approval prompt across config files

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1093,12 +1093,15 @@ def _check_mcp_project_trust(*, trust_flag: bool = False) -> bool | None:
     if not project_configs:
         return None
 
-    # Collect all stdio servers across project configs
-    all_stdio: list[tuple[str, str, list[str]]] = []
+    # Collect all stdio servers across project configs, deduplicating by name.
+    # Later configs take precedence, consistent with merge_mcp_configs semantics.
+    seen: dict[str, tuple[str, str, list[str]]] = {}
     for path in project_configs:
         cfg = load_mcp_config_lenient(path)
         if cfg is not None:
-            all_stdio.extend(extract_stdio_server_commands(cfg))
+            for entry in extract_stdio_server_commands(cfg):
+                seen[entry[0]] = entry
+    all_stdio = list(seen.values())
 
     if not all_stdio:
         return None


### PR DESCRIPTION
Fixes #2374

## Problem

When a project has both a root `.mcp.json` and a `.deepagents/.mcp.json` containing the same MCP servers (common with tools like [rulesync](https://github.com/dyoshikawa/rulesync) that mirror configs across tools), `_check_mcp_project_trust` iterates over every project config path and extends `all_stdio` without deduplication. Each server appears once per config file it appears in, causing duplicate entries in the startup approval prompt.

## Solution

Replace the naive `list.extend` accumulation with a name-keyed dict, so each server name appears at most once. Later configs take precedence, consistent with the existing `merge_mcp_configs` semantics used elsewhere in the codebase.

```python
# Before
all_stdio: list[tuple[str, str, list[str]]] = []
for path in project_configs:
    cfg = load_mcp_config_lenient(path)
    if cfg is not None:
        all_stdio.extend(extract_stdio_server_commands(cfg))

# After
seen: dict[str, tuple[str, str, list[str]]] = {}
for path in project_configs:
    cfg = load_mcp_config_lenient(path)
    if cfg is not None:
        for entry in extract_stdio_server_commands(cfg):
            seen[entry[0]] = entry
all_stdio = list(seen.values())
```

## Testing

Manually verified with a project containing both `.mcp.json` and `.deepagents/.mcp.json` defining the same server — the approval prompt now shows each server exactly once. The fix is a single-function, in-place change with no impact on other code paths.