### PR TITLE
feat(ci): include version in workflow run name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || inputs.dangerous-nonmain-release
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: read
     env:
       WORKING_DIR: ${{ needs.setup.outputs.working-dir }}
@@ -160,6 +161,14 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"pkg-name={pkg_name}\n")
               f.write(f"version={version}\n")
+
+      - name: Update workflow run name with version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method PATCH \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f "name=Release ${{ steps.check-version.outputs.pkg-name }} ${{ steps.check-version.outputs.version }}"
 
   # Generate release notes from CHANGELOG.md (with git log fallback)
   # and collect contributor shoutouts from merged PRs

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1478,7 +1478,7 @@ class DeepAgentsApp(App):
                 cmd = upgrade_command()
                 self.notify(
                     f"Update available: v{latest} (current: v{cli_version}). "
-                    f"Run: {cmd}\n"
+                    f"Run: {cmd}\n\n"
                     f"Enable auto-updates: /auto-update",
                     severity="information",
                     timeout=15,


### PR DESCRIPTION
The workflow's `run-name` is evaluated at trigger time, before any jobs run — so it can only interpolate `inputs.package` (e.g., "Release deepagents-cli") and never the version. After the `build` job extracts the version from `pyproject.toml`, a new step patches the run name via the GitHub REST API to include it (e.g., "Release deepagents-cli 0.0.36").