### PR TITLE
docs(cli): sync deploy guide with docs site refinements

### DIFF
--- a/deepagents-deploy.md
+++ b/deepagents-deploy.md
@@ -17,58 +17,119 @@ Deep Agents Deploy is built on [Deep Agents](https://github.com/langchain-ai/dee
 - **Self-hostable** — LangSmith Deployments can be self-hosted so memory stays in your infrastructure
 
 > [!WARNING] Warning: Beta
-> `deepagents deploy` is currently in beta. APIs, configuration format, and behavior may change between releases. Keep an eye on the [releases page](https://github.com/langchain-ai/deepagents/releases) for detailed changelogs.
+> `deepagents deploy` is currently in beta. APIs, configuration format, and behavior may change between releases. See the [releases page](https://github.com/langchain-ai/deepagents/releases) for detailed changelogs.
 
-## Comparing to Claude Managed Agents
+## Compare to Claude Managed Agents
 
 |  | Deep Agents Deploy | Claude Managed Agents |
 | --- | --- | --- |
-| Model Support | OpenAI, Anthropic, Google, Bedrock, Azure, Fireworks, Baseten, OpenRouter, [many more](https://docs.langchain.com/oss/python/integrations/providers/overview) | Anthropic only |
+| Model support | OpenAI, Anthropic, Google, Bedrock, Azure, Fireworks, Baseten, OpenRouter, [many more](https://docs.langchain.com/oss/integrations/providers/overview) | Anthropic only |
 | Harness | Open source (MIT) | Proprietary, closed source |
-| Sandbox | LangSmith, Daytona, Modal, Runloop, or [custom](https://docs.langchain.com/oss/python/contributing/implement-langchain#sandboxes) | Built in |
-| MCP Support | ✅ | ✅ |
-| Skill Support | ✅ | ✅ |
-| AGENTS.md Support | ✅ | ❌ |
-| Agent Endpoints | MCP, A2A, Agent Protocol | Proprietary |
-| Self Hosting | ✅ | ❌ |
+| Sandbox | LangSmith, Daytona, Modal, Runloop, or [custom](https://docs.langchain.com/oss/contributing/implement-langchain#sandboxes) | Built in |
+| MCP support | ✅ | ✅ |
+| Skill support | ✅ | ✅ |
+| AGENTS.md support | ✅ | ❌ |
+| Agent endpoints | MCP, A2A, Agent Protocol | Proprietary |
+| Self hosting | ✅ | ❌ |
 
 ## What you're deploying
 
-`deepagents deploy` takes your agent configuration and deploys it as a [LangSmith Deployment](https://docs.langchain.com/langsmith/deployment) — a horizontally scalable server with 30+ endpoints including MCP, A2A, Agent Protocol, human-in-the-loop, and memory APIs.
-
-You configure your agent with a few parameters:
+`deepagents deploy` packages your agent configuration and deploys it as a [LangSmith Deployment](https://docs.langchain.com/langsmith/deployment). You configure your agent with a few parameters:
 
 | Parameter | Description |
 | --- | --- |
 | **`model`** | The LLM to use. Any provider works — see [Supported Models](#supported-models). |
 | **`AGENTS.md`** | The system prompt, loaded at the start of each session. |
 | **`skills`** | [Agent Skills](https://agentskills.io/) for specialized knowledge and actions. Skills are synced into the sandbox so the agent can execute them at runtime. See [Skills docs](https://docs.langchain.com/oss/python/deepagents/skills). |
-| **`mcp.json`** | MCP tools (HTTPS/SSE). See [MCP docs](https://docs.langchain.com/oss/python/langchain/mcp). |
-| **`sandbox`** | Optional execution environment. See [Sandboxes](#sandboxes). |
+| **`mcp.json`** | MCP tools (HTTP/SSE). See [MCP docs](https://docs.langchain.com/oss/python/langchain/mcp). |
+| **`sandbox`** | Optional execution environment. See [Sandbox providers](#sandbox-providers). |
+
+## Usage
+
+```bash
+deepagents init [name] [--force]                                             # scaffold a new project
+deepagents dev  [--config deepagents.toml] [--port 2024] [--allow-blocking]  # bundle and run locally
+deepagents deploy [--config deepagents.toml] [--dry-run]                     # bundle and deploy
+```
+
+By default, `deepagents deploy` looks for `deepagents.toml` in the current directory. Pass `--config` to use a different path:
+
+```bash
+deepagents deploy --config path/to/deepagents.toml
+```
+
+### `deepagents init`
+
+Scaffold a new agent project:
+
+```bash
+deepagents init my-agent
+```
+
+This creates the following files:
+
+| File | Purpose |
+| --- | --- |
+| `deepagents.toml` | Agent config — name, model, optional sandbox |
+| `AGENTS.md` | System prompt loaded at session start |
+| `.env` | API key template (`ANTHROPIC_API_KEY`, `LANGSMITH_API_KEY`, etc.) |
+| `mcp.json` | MCP server configuration (empty by default) |
+| `skills/` | Directory for [Agent Skills](https://agentskills.io/), with an example `review` skill |
+
+After init, edit `AGENTS.md` with your agent's instructions and run `deepagents deploy`.
 
 ## Project layout
 
+The deploy command uses a convention-based project layout. Place the following files alongside your `deepagents.toml` and they are automatically discovered:
+
 ```txt
 my-agent/
-    .env             # API keys and secrets
-    AGENTS.md        # required — system prompt
-    skills/          # optional — agent skills
-    mcp.json         # optional — HTTP/SSE MCP servers
-    deepagents.toml  # agent configuration
+├── deepagents.toml
+├── AGENTS.md
+├── .env
+├── mcp.json
+└── skills/
+    ├── code-review/
+    │   └── SKILL.md
+    └── data-analysis/
+        └── SKILL.md
 ```
 
-### `deepagents.toml`
+| File/directory | Purpose | Required |
+| --- | --- | --- |
+| `AGENTS.md` | [Memory](https://docs.langchain.com/oss/python/deepagents/memory) for the agent. Provides persistent context (project conventions, instructions, preferences) that is always loaded at startup. | Yes |
+| `skills/` | Directory of [skill](https://docs.langchain.com/oss/python/deepagents/skills) definitions. Each subdirectory should contain a `SKILL.md` file. | No |
+| `mcp.json` | [MCP](https://modelcontextprotocol.io/) server configuration. Only `http` and `sse` transports are supported in deployed contexts. | No |
+| `.env` | Environment variables (API keys, secrets). Placed alongside `deepagents.toml` at the project root. | No |
+
+> [!WARNING]
+> `mcp.json` must only contain servers using `http` or `sse` transports. Servers using `stdio` transport are not supported in deployed environments because there is no local process to spawn.
+>
+> Convert stdio servers to HTTP or SSE before deploying.
+
+## Configuration file
+
+`deepagents.toml` configures the agent's identity and sandbox environment. Only the `[agent]` section is required. The `[sandbox]` section is optional and defaults to no sandbox.
+
+### `[agent]`
+
+(Required)
+
+Core agent identity. For more on model selection and provider configuration, see [Supported Models](#supported-models).
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | *(required)* | Name for the deployed agent. Used as the assistant identifier in LangSmith. |
+| `model` | string | `anthropic:claude-sonnet-4-6` | Model identifier in `provider:model` format. See [Supported Models](#supported-models). |
 
 ```toml
 [agent]
-name = "my-agent"
+name = "research-assistant"
 model = "anthropic:claude-sonnet-4-6"
-
-# optional, but strongly encouraged when using skills or code execution
-[sandbox]
-provider = "langsmith"   # langsmith | daytona | modal | runloop
-scope    = "thread"      # thread | assistant
 ```
+
+> [!NOTE]
+> The `name` field is the only required value in the entire configuration file. Everything else has defaults.
 
 Skills, MCP servers, and model dependencies are auto-detected from the project layout — you don't declare them in `deepagents.toml`:
 
@@ -77,13 +138,29 @@ Skills, MCP servers, and model dependencies are auto-detected from the project l
 - **Model dependencies** — the `provider:` prefix in the `model` field determines the required `langchain-*` package (e.g., `anthropic` -> `langchain-anthropic`).
 - **Sandbox dependencies** — the `[sandbox].provider` value maps to its partner package (e.g., `daytona` -> `langchain-daytona`).
 
+### `[sandbox]`
+
+(Optional)
+
+Configure the isolated execution environment where the agent runs code. Sandboxes provide a container with a filesystem and shell access, so untrusted code cannot affect the host.
+
+When omitted or set to `provider = "none"`, the sandbox is disabled. Sandboxes are for if you need code execution or skill script execution.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `provider` | string | `none` | Sandbox provider. Supported values: `"none"`, `"daytona"`, `"modal"`, `"runloop"`, `"langsmith"` (private beta). See [Sandbox providers](#sandbox-providers). |
+| `template` | string | `deepagents-deploy` | Provider-specific template name for the sandbox environment. |
+| `image` | string | `python:3` | Base Docker image for the sandbox container. |
+| `scope` | string | `thread` | Sandbox lifecycle scope. `"thread"` creates one sandbox per conversation. `"assistant"` shares a single sandbox across all conversations for the same assistant. |
+
+**Scope behavior:**
+
+- `"thread"` (default): Each conversation gets its own sandbox. Different threads get different sandboxes, but the same thread reuses its sandbox across turns. Use this when each conversation should start with a clean environment.
+- `"assistant"`: All conversations share one sandbox. Files, installed packages, and other state persist across conversations. Use this when the agent maintains a long-lived workspace like a cloned repo.
+
 ### `.env`
 
 Place a `.env` file alongside `deepagents.toml` with your API keys:
-
-```bash
-cp .env.example .env
-```
 
 ```bash
 # Required — model provider keys
@@ -101,34 +178,6 @@ MODAL_TOKEN_SECRET=...
 RUNLOOP_API_KEY=...
 ```
 
-## Usage
-
-```bash
-deepagents init [name] [--force]               # scaffold a new project (name prompted if omitted)
-deepagents dev  [--config deepagents.toml] [--port 2024] [--allow-blocking]   # bundle and run locally
-deepagents deploy [--config deepagents.toml] [--dry-run]                      # bundle and deploy
-```
-
-### `deepagents init`
-
-Scaffolds a new agent project with the full layout:
-
-```bash
-deepagents init my-agent
-```
-
-This creates:
-
-| File | Purpose |
-| --- | --- |
-| `deepagents.toml` | Agent config — name, model, optional sandbox |
-| `AGENTS.md` | System prompt loaded at session start |
-| `.env` | API key template (`ANTHROPIC_API_KEY`, `LANGSMITH_API_KEY`), etc. |
-| `mcp.json` | MCP server configuration (empty by default) |
-| `skills/` | Directory for [Agent Skills](https://agentskills.io/), with an example `review` skill |
-
-After init, edit `AGENTS.md` with your agent's instructions and run `deepagents deploy`.
-
 ## Supported models
 
 Any provider supported by LangChain's [`init_chat_model()`](https://docs.langchain.com/oss/python/integrations/providers/overview) works. Use the `provider:model-name` format in `deepagents.toml`:
@@ -140,13 +189,11 @@ model = "google_genai:gemini-3.1-pro-preview"
 # ...and so on
 ```
 
-## Sandboxes
+## Sandbox providers
 
-Sandboxes provide isolated execution environments for your agent to run code and scripts. Using a sandbox is optional, but strongly recommended for any operations that use Agent Skills or for code execution.
+Each sandbox provider requires specific configuration in `deepagents.toml` and environment variables in `.env`.
 
-### Providers
-
-#### Daytona
+### Daytona
 
 Cloud development environments with full workspace isolation. [Learn more.](https://www.daytona.io/)
 
@@ -160,7 +207,7 @@ provider = "daytona"
 DAYTONA_API_KEY=...
 ```
 
-#### Modal
+### Modal
 
 Serverless compute — sandboxes spin up on demand. [Learn more.](https://modal.com/docs/guide/sandboxes)
 
@@ -175,7 +222,7 @@ MODAL_TOKEN_ID=...
 MODAL_TOKEN_SECRET=...
 ```
 
-#### Runloop
+### Runloop
 
 Isolated DevBox environments for agent execution. [Learn more.](https://runloop.ai/)
 
@@ -189,13 +236,12 @@ provider = "runloop"
 RUNLOOP_API_KEY=...
 ```
 
-#### LangSmith Sandbox (Private preview)
+### LangSmith Sandbox
 
-[(Documentation)](https://docs.langchain.com/langsmith/sandboxes)
+> [!NOTE]
+> LangSmith Sandbox is currently in private beta. [Sign up for the waitlist.](https://docs.langchain.com/langsmith/sandboxes#sandboxes-overview)
 
 No additional setup beyond your LangSmith API key.
-
-Add the following to your `deepagents.toml`:
 
 ```toml
 [sandbox]
@@ -209,29 +255,42 @@ image = "python:3"
 LANGSMITH_API_KEY=lsv2_...
 ```
 
-#### Custom sandbox
+### Custom sandbox
 
-You can implement your own sandbox provider. See the [custom sandbox guide](https://docs.langchain.com/oss/python/contributing/implement-langchain#sandboxes).
-
-### Sandbox scope
-
-By default, each thread gets its own sandbox (`scope = "thread"`). Set `scope = "assistant"` to share one sandbox across all threads for the same assistant.
-
-```toml
-[sandbox]
-provider = "langsmith"
-scope = "assistant"   # shared across threads
-```
+Implement your own sandbox provider. See the [custom sandbox guide](https://docs.langchain.com/oss/contributing/implement-langchain#sandboxes).
 
 ## Deployment endpoints
 
 The deployed server exposes:
 
 - [**MCP**](https://modelcontextprotocol.io/docs/getting-started/intro) — call your agent as a tool from other agents
-- [**A2A**](https://a2a-protocol.org/latest/) — multi-agent orchestration via [A2A protocol](https://a2a-protocol.org/latest/)
-- **[Agent Protocol](https://github.com/langchain-ai/agent-protocol)** — standard API for building UIs
-- **[Human-in-the-loop](https://docs.langchain.com/oss/python/deepagents/human-in-the-loop)** — approval gates for sensitive actions
-- **[Memory](https://docs.langchain.com/oss/python/deepagents/memory)** — short-term and long-term memory access
+- [**A2A**](https://a2a-protocol.org/latest/) — multi-agent orchestration via A2A protocol
+- [**Agent Protocol**](https://github.com/langchain-ai/agent-protocol) — standard API for building UIs
+- [**Human-in-the-loop**](https://docs.langchain.com/oss/python/deepagents/human-in-the-loop) — approval gates for sensitive actions
+- [**Memory**](https://docs.langchain.com/oss/python/deepagents/memory) — short-term and long-term memory access
+
+## Examples
+
+A content writing agent that only needs a model and system prompt, with no code execution:
+
+```toml
+[agent]
+name = "deepagents-deploy-content-writer"
+model = "anthropic:claude-sonnet-4-6"
+```
+
+A coding agent with a LangSmith sandbox for running code:
+
+```toml
+[agent]
+name = "deepagents-deploy-coding-agent"
+model = "anthropic:claude-sonnet-4-5"
+
+[sandbox]
+provider = "langsmith"
+template = "coding-agent"
+image = "python:3.12"
+```
 
 ## Gotchas
 


### PR DESCRIPTION
Sync `deepagents-deploy.md` with refinements from the published docs site (`deploy.mdx`). The standalone markdown in the repo had drifted — inconsistent casing in table headers, an `HTTPS/SSE` typo, a flat project layout diagram, and no detailed config field reference. The docs version had been restructured with a richer project layout, a full `[agent]`/`[sandbox]` configuration reference, scope behavior docs, and example configs.