### PR TITLE
fix(sdk): add sandbox blob read thresholds

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -144,6 +144,13 @@ Payloads above this use _edit_via_upload (temp file upload + server-side replace
 to avoid size limits on the execute() request body imposed by some sandbox providers.
 """
 
+_MAX_TEXT_READ_BYTES: Final = 500 * 1024
+_MAX_BLOB_INLINE_BYTES: Final = 500 * 1024
+_MAX_BLOB_DOWNLOAD_BYTES: Final = 10 * 1024 * 1024
+_BLOB_PREVIEW_TOO_LARGE_ERROR: Final = (
+    f"Binary file exceeds maximum preview size of {_MAX_BLOB_INLINE_BYTES} bytes"
+)
+
 _EDIT_TMPFILE_TEMPLATE = """python3 -c "
 import os, sys, json, base64
 
@@ -208,6 +215,7 @@ import os, sys, base64, json
 
 MAX_OUTPUT_BYTES = 500 * 1024
 MAX_BINARY_BYTES = 500 * 1024
+BLOB_PREVIEW_TOO_LARGE_ERROR = 'Binary file exceeds maximum preview size of 512000 bytes'
 TRUNCATION_MSG = '\\n\\n' + (
     '[Output was truncated due to size limits. '
     'This paginated read result exceeded the sandbox stdout limit. '
@@ -228,7 +236,7 @@ file_type = '{file_type}'
 if file_type != 'text':
     file_size = os.path.getsize(path)
     if file_size > MAX_BINARY_BYTES:
-        print(json.dumps({{'error': 'Binary file exceeds maximum preview size of ' + str(MAX_BINARY_BYTES) + ' bytes'}}))
+        print(json.dumps({{'error': BLOB_PREVIEW_TOO_LARGE_ERROR}}))
         sys.exit(0)
     with open(path, 'rb') as f:
         raw = f.read()
@@ -390,8 +398,10 @@ except PermissionError:
         with guidance to continue pagination using a different `offset` or
         smaller `limit`.
 
-        Binary files (non-UTF-8) are returned base64-encoded without
-        pagination.
+        Blob files under 500 KiB are returned inline as base64. Blob files over
+        500 KiB and up to 10 MiB are fetched via `download_files()` and then
+        returned as base64. Larger blobs return an error explaining that the
+        current size threshold is exceeded.
 
         Args:
             file_path: Absolute path to the file to read.
@@ -406,6 +416,9 @@ except PermissionError:
             `ReadResult` with `file_data` on success or `error` on failure.
         """
         file_type = _get_file_type(file_path)
+        if file_type != "text":
+            return self._read_blob(file_path)
+
         path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
 
         # Defensive int coercion in case callers bypass type checking.
@@ -435,6 +448,64 @@ except PermissionError:
             file_data=FileData(
                 content=data["content"],
                 encoding=data.get("encoding", "utf-8"),
+            )
+        )
+
+    def _read_blob(self, file_path: str) -> ReadResult:
+        """Read non-text file content using inline or download thresholds."""
+        path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
+        cmd = _READ_COMMAND_TEMPLATE.format(
+            path_b64=path_b64,
+            file_type="blob",
+            offset=0,
+            limit=0,
+        )
+        result = self.execute(cmd)
+        output = result.output.rstrip()
+
+        try:
+            data = json.loads(output)
+        except (json.JSONDecodeError, ValueError):
+            detail = output[:200] if output else "(empty)"
+            return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
+
+        if not isinstance(data, dict):
+            detail = output[:200] if output else "(empty)"
+            return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
+
+        if "error" in data:
+            if data["error"] != _BLOB_PREVIEW_TOO_LARGE_ERROR:
+                return ReadResult(error=f"File '{file_path}': {data['error']}")
+        else:
+            return ReadResult(
+                file_data=FileData(
+                    content=data["content"],
+                    encoding=data.get("encoding", "utf-8"),
+                )
+            )
+
+        responses = self.download_files([file_path])
+        if not responses:
+            return ReadResult(error=f"File '{file_path}': download_files returned no response")
+        response = responses[0]
+        if response.error is not None:
+            return ReadResult(error=f"File '{file_path}': {response.error}")
+        if response.content is None:
+            return ReadResult(error=f"File '{file_path}': download_files returned no content")
+
+        size = len(response.content)
+        if size > _MAX_BLOB_DOWNLOAD_BYTES:
+            return ReadResult(
+                error=(
+                    f"File '{file_path}': blob size {size} bytes exceeds the current "
+                    f"threshold of {_MAX_BLOB_DOWNLOAD_BYTES} bytes"
+                )
+            )
+
+        return ReadResult(
+            file_data=FileData(
+                content=base64.b64encode(response.content).decode("ascii"),
+                encoding="base64",
             )
         )
 

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -204,6 +204,56 @@ def test_read_binary_file() -> None:
     assert result.file_data["encoding"] == "base64"
 
 
+def test_read_binary_file_uses_download_for_medium_blob() -> None:
+    """Test that blobs over the inline limit use download_files up to 10 MiB."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 512000 bytes"})
+    download_called = False
+    payload = b"\x80\x81\x82\xff" * 200_000
+
+    def tracking_download(paths: list[str]) -> list[FileDownloadResponse]:
+        nonlocal download_called
+        download_called = True
+        assert paths == ["/test/medium.jpg"]
+        return [FileDownloadResponse(path=paths[0], content=payload, error=None)]
+
+    sandbox.download_files = tracking_download  # type: ignore[assignment]
+
+    result = sandbox.read("/test/medium.jpg")
+
+    assert download_called
+    assert result.error is None
+    assert result.file_data == {
+        "encoding": "base64",
+        "content": base64.b64encode(payload).decode("ascii"),
+    }
+
+
+def test_read_binary_file_returns_threshold_error_for_large_blob() -> None:
+    """Test that blobs over 10 MiB return a threshold error."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 512000 bytes"})
+    payload = b"x" * (10 * 1024 * 1024 + 1)
+
+    sandbox.download_files = lambda paths: [FileDownloadResponse(path=paths[0], content=payload, error=None)]  # type: ignore[assignment]
+
+    result = sandbox.read("/test/large.jpg")
+
+    assert result.error is not None
+    assert "exceeds the current threshold" in result.error
+    assert str(10 * 1024 * 1024) in result.error
+
+
+def test_read_binary_file_preserves_non_threshold_errors() -> None:
+    """Test that non-threshold blob errors are returned directly."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "permission_denied"})
+
+    result = sandbox.read("/test/blocked.jpg")
+
+    assert result.error == "File '/test/blocked.jpg': permission_denied"
+
+
 def test_read_file_not_found() -> None:
     """Test that read() returns error for missing files."""
     sandbox = MockSandbox()


### PR DESCRIPTION
Adjusts `BaseSandbox` read behavior to keep text reads capped at 500 KiB while handling blobs in three tiers: inline base64 up to 500 KiB, download_files up to 10 MiB, and a clear threshold error above that. This also adds unit coverage for the download fallback, oversize blobs, and preserving non-threshold blob errors.