### PR TITLE
fix(evals): create artifacts directory in langsmith sandbox startup

### DIFF
--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -296,7 +296,8 @@ class LangSmithEnvironment(BaseEnvironment):
         logger.info("Created LangSmith sandbox '%s'", sandbox.name)
 
         await sandbox.run(
-            f"mkdir -p {EnvironmentPaths.agent_dir} {EnvironmentPaths.verifier_dir}",
+            f"mkdir -p {EnvironmentPaths.agent_dir} {EnvironmentPaths.verifier_dir}"
+            f" {EnvironmentPaths.artifacts_dir}",
             timeout=30,
         )
 


### PR DESCRIPTION
- Create `/logs/artifacts` alongside `/logs/agent` and `/logs/verifier` during LangSmith sandbox `start()`, fixing `find: '/logs/artifacts': No such file or directory` warnings emitted after every trial
