### PR TITLE
fix(sdk): reload skills on every agent turn to enable dynamic skill creation

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -727,9 +727,8 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
     def before_agent(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> SkillsStateUpdate | None:  # ty: ignore[invalid-method-override]
         """Load skills metadata before agent execution (synchronous).
 
-        Loads skills once per session from all configured sources. If
-        `skills_metadata` is already present in state (from a prior turn or
-        checkpointed session), the load is skipped and `None` is returned.
+        Loads skills from all configured sources on every agent turn, so that
+        skills created or updated during a session are picked up immediately.
 
         Skills are loaded in source order with later sources overriding
         earlier ones if they contain skills with the same name (last one wins).
@@ -740,12 +739,8 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
             config: Runnable config.
 
         Returns:
-            State update with `skills_metadata` populated, or `None` if already present.
+            State update with `skills_metadata` populated.
         """
-        # Skip if skills_metadata is already present in state (even if empty)
-        if "skills_metadata" in state:
-            return None
-
         # Resolve backend (supports both direct instances and factory functions)
         backend = self._get_backend(state, runtime, config)
         all_skills: dict[str, SkillMetadata] = {}
@@ -763,9 +758,8 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
     async def abefore_agent(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> SkillsStateUpdate | None:  # ty: ignore[invalid-method-override]
         """Load skills metadata before agent execution (async).
 
-        Loads skills once per session from all configured sources. If
-        `skills_metadata` is already present in state (from a prior turn or
-        checkpointed session), the load is skipped and `None` is returned.
+        Loads skills from all configured sources on every agent turn, so that
+        skills created or updated during a session are picked up immediately.
 
         Skills are loaded in source order with later sources overriding
         earlier ones if they contain skills with the same name (last one wins).
@@ -776,12 +770,8 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
             config: Runnable config.
 
         Returns:
-            State update with `skills_metadata` populated, or `None` if already present.
+            State update with `skills_metadata` populated.
         """
-        # Skip if skills_metadata is already present in state (even if empty)
-        if "skills_metadata" in state:
-            return None
-
         # Resolve backend (supports both direct instances and factory functions)
         backend = self._get_backend(state, runtime, config)
         all_skills: dict[str, SkillMetadata] = {}

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -1263,8 +1263,12 @@ def test_agent_with_skills_middleware_multiple_registries_override(tmp_path: Pat
     assert "Base registry description" not in content, "Should not contain base source description"
 
 
-def test_before_agent_skips_loading_if_metadata_present(tmp_path: Path) -> None:
-    """Test that before_agent skips loading if skills_metadata is already in state."""
+def test_before_agent_always_reloads_skills(tmp_path: Path) -> None:
+    """Test that before_agent always reloads skills regardless of existing state.
+
+    Skills are reloaded on every turn so that skills created during a session
+    are picked up immediately without restarting.
+    """
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create a skill in the backend
@@ -1280,7 +1284,7 @@ def test_before_agent_skips_loading_if_metadata_present(tmp_path: Path) -> None:
         sources=sources,
     )
 
-    # Case 1: State has skills_metadata with some skills
+    # Case 1: State has skills_metadata with stale skills from a prior turn
     existing_metadata: list[SkillMetadata] = [
         {
             "name": "existing-skill",
@@ -1295,15 +1299,21 @@ def test_before_agent_skips_loading_if_metadata_present(tmp_path: Path) -> None:
     state_with_metadata = {"skills_metadata": existing_metadata}
     result = middleware.before_agent(state_with_metadata, None, {})  # type: ignore[arg-type]
 
-    # Should return None, not load new skills
-    assert result is None
+    # Should reload from backend, replacing stale metadata
+    assert result is not None
+    assert "skills_metadata" in result
+    assert len(result["skills_metadata"]) == 1
+    assert result["skills_metadata"][0]["name"] == "test-skill"
 
     # Case 2: State has empty list for skills_metadata
     state_with_empty_list = {"skills_metadata": []}
     result = middleware.before_agent(state_with_empty_list, None, {})  # type: ignore[arg-type]
 
-    # Should still return None and not reload
-    assert result is None
+    # Should reload and return the current skills
+    assert result is not None
+    assert "skills_metadata" in result
+    assert len(result["skills_metadata"]) == 1
+    assert result["skills_metadata"][0]["name"] == "test-skill"
 
     # Case 3: State does NOT have skills_metadata key
     state_without_metadata = {}

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
@@ -296,8 +296,12 @@ async def test_abefore_agent_empty_sources(tmp_path: Path) -> None:
     assert result["skills_metadata"] == []
 
 
-async def test_abefore_agent_skips_loading_if_metadata_present(tmp_path: Path) -> None:
-    """Test that abefore_agent skips loading if skills_metadata is already in state."""
+async def test_abefore_agent_always_reloads_skills(tmp_path: Path) -> None:
+    """Test that abefore_agent always reloads skills regardless of existing state.
+
+    Skills are reloaded on every turn so that skills created during a session
+    are picked up immediately without restarting.
+    """
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
     # Create a skill in the backend
@@ -313,12 +317,15 @@ async def test_abefore_agent_skips_loading_if_metadata_present(tmp_path: Path) -
         sources=sources,
     )
 
-    # State has skills_metadata already
+    # State has skills_metadata already (simulating a subsequent turn)
     state_with_metadata = {"skills_metadata": []}
     result = await middleware.abefore_agent(state_with_metadata, None, {})  # type: ignore[arg-type]
 
-    # Should return None, not load new skills
-    assert result is None
+    # Should reload from backend, not return None
+    assert result is not None
+    assert "skills_metadata" in result
+    assert len(result["skills_metadata"]) == 1
+    assert result["skills_metadata"][0]["name"] == "test-skill"
 
 
 async def test_agent_with_skills_middleware_multiple_sources_async(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #2613

## Problem

`SkillsMiddleware` cached `skills_metadata` in agent state after the first turn and skipped reloading on subsequent turns:

```python
# Skip if skills_metadata is already present in state (even if empty)
if "skills_metadata" in state:
    return None
```

This meant that skills created during a session (e.g., via `write_file`) were never discovered in the same session — users had to restart entirely.

## Solution

Remove the early-return cache check so skills are reloaded from backend sources on every agent turn. This ensures dynamically created or updated skills are available in the next turn without a session restart.

## Testing

- Updated `test_before_agent_skips_loading_if_metadata_present` → `test_before_agent_always_reloads_skills` to verify that skills are reloaded even when `skills_metadata` is already present in state.
- Updated the async counterpart `test_abefore_agent_skips_loading_if_metadata_present` → `test_abefore_agent_always_reloads_skills` with the same logic.
- All existing tests continue to pass.