### PR TITLE
chore(cli): log non-default api key source resolution

### DIFF
--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -232,9 +232,12 @@ class _LangSmithProvider(SandboxProvider):
 
         from deepagents_cli.model_config import resolve_env_var
 
-        self._api_key = (
+        sandbox_key = resolve_env_var("LANGSMITH_SANDBOX_API_KEY")
+        if sandbox_key:
+            logger.debug("Using LangSmith API key from LANGSMITH_SANDBOX_API_KEY")
+        self._api_key: str | None = (
             api_key
-            or resolve_env_var("LANGSMITH_SANDBOX_API_KEY")
+            or sandbox_key
             or resolve_env_var("LANGSMITH_API_KEY")
             or resolve_env_var("LANGCHAIN_API_KEY")
         )

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -62,6 +62,8 @@ def resolve_env_var(name: str) -> str | None:
                     name,
                     prefixed,
                 )
+            if val:
+                logger.debug("Resolved %s from %s", name, prefixed)
             return val or None
     return os.environ.get(name) or None
 

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -255,7 +255,8 @@ class LangSmithEnvironment(BaseEnvironment):
             raise ValueError(msg)
 
         api_key, key_source = resolved
-        logger.info("Using LangSmith API key from %s", key_source)
+        if key_source == "LANGSMITH_SANDBOX_API_KEY":
+            logger.info("Using LangSmith API key from %s", key_source)
 
         client = AsyncSandboxClient(api_key=api_key)
         self._client = client


### PR DESCRIPTION
Add debug logging when a non-default API key source is used. Without this, there's no way to tell whether `LANGSMITH_SANDBOX_API_KEY` or a `DEEPAGENTS_CLI_*` prefixed override is silently winning over the canonical env var.