### PR TITLE
fix(ci): grant actions:write to release callers for run rename

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -209,6 +209,7 @@ jobs:
     with:
       package: deepagents-cli
     permissions:
+      actions: write
       contents: write
       id-token: write
       # write needed to update PR label from "autorelease: pending" to "autorelease: tagged"
@@ -222,6 +223,7 @@ jobs:
     with:
       package: deepagents
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -234,6 +236,7 @@ jobs:
     with:
       package: deepagents-acp
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -246,6 +249,7 @@ jobs:
     with:
       package: langchain-daytona
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -258,6 +262,7 @@ jobs:
     with:
       package: langchain-modal
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -270,6 +275,7 @@ jobs:
     with:
       package: langchain-runloop
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -282,6 +288,7 @@ jobs:
     with:
       package: langchain-quickjs
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -294,6 +301,7 @@ jobs:
     with:
       package: langchain-repl
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
               f.write(f"version={version}\n")
 
       - name: Update workflow run name with version
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
The "Update workflow run name with version" step (#2627) was failing with a 404 during release-please-triggered releases. Reusable workflows inherit the *caller's* permissions as a ceiling — `release-please.yml` never granted `actions: write`, so the `build` job's `GITHUB_TOKEN` couldn't reach the runs API (GitHub masks 403 as 404). The step is also now non-fatal so a cosmetic rename can't block a real release.