### PR TITLE
chore(ci): require pr scope, replace runtime run-name rename with static

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -6,14 +6,14 @@ This document describes the release process for packages in the Deep Agents mono
 
 | Package | Path | Component | PyPI |
 | ------- | ---- | --------- | ---- |
-| `deepagents` (SDK) | `libs/deepagents` | `deepagents` | [deepagents](https://pypi.org/project/deepagents/) |
-| `deepagents-cli` | `libs/cli` | `deepagents-cli` | [deepagents-cli](https://pypi.org/project/deepagents-cli/) |
-| `deepagents-acp` | `libs/acp` | `deepagents-acp` | [deepagents-acp](https://pypi.org/project/deepagents-acp/) |
-| `langchain-daytona` | `libs/partners/daytona` | `langchain-daytona` | [langchain-daytona](https://pypi.org/project/langchain-daytona/) |
-| `langchain-modal` | `libs/partners/modal` | `langchain-modal` | [langchain-modal](https://pypi.org/project/langchain-modal/) |
-| `langchain-runloop` | `libs/partners/runloop` | `langchain-runloop` | [langchain-runloop](https://pypi.org/project/langchain-runloop/) |
-| `langchain-quickjs` | `libs/partners/quickjs` | `langchain-quickjs` | [langchain-quickjs](https://pypi.org/project/langchain-quickjs/) |
-| `langchain-repl` | `libs/repl` | `langchain-repl` | [langchain-repl](https://pypi.org/project/langchain-repl/) |
+| `deepagents` (SDK) | `libs/deepagents` | `deepagents` | [`deepagents`](https://pypi.org/project/deepagents/) |
+| `deepagents-cli` | `libs/cli` | `deepagents-cli` | [`deepagents-cli`](https://pypi.org/project/deepagents-cli/) |
+| `deepagents-acp` | `libs/acp` | `deepagents-acp` | [`deepagents-acp`](https://pypi.org/project/deepagents-acp/) |
+| `langchain-daytona` | `libs/partners/daytona` | `langchain-daytona` | [`langchain-daytona`](https://pypi.org/project/langchain-daytona/) |
+| `langchain-modal` | `libs/partners/modal` | `langchain-modal` | [`langchain-modal`](https://pypi.org/project/langchain-modal/) |
+| `langchain-runloop` | `libs/partners/runloop` | `langchain-runloop` | [`langchain-runloop`](https://pypi.org/project/langchain-runloop/) |
+| `langchain-quickjs` | `libs/partners/quickjs` | `langchain-quickjs` | [`langchain-quickjs`](https://pypi.org/project/langchain-quickjs/) |
+| `langchain-repl` | `libs/repl` | `langchain-repl` | [`langchain-repl`](https://pypi.org/project/langchain-repl/) |
 
 ## Overview
 
@@ -61,7 +61,7 @@ Version bumps are determined by commit types. All packages are currently pre-1.0
 
 ## Commit Format
 
-All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format with types and scopes defined in [`.github/workflows/pr_lint.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml):
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format with types and scopes defined in [`.github/workflows/pr_lint.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml). **Scope is required** — PRs without a scope will fail the title lint check.
 
 ```text
 <type>(<scope>): <description>
@@ -125,7 +125,7 @@ The [release workflow (`.github/workflows/release.yml`)](https://github.com/lang
 2. **Build** - Creates distribution package
 3. **Release Notes** + **Pre-release Checks** - Run in parallel; release notes extracts changelog and collects contributor shoutouts; pre-release checks run tests against the built package
 4. **Test PyPI** - Publishes to test.pypi.org for validation (after pre-release checks pass)
-5. **Publish** - Publishes to PyPI
+5. **Publish** - Publishes to PyPI (requires Test PyPI to succeed)
 6. **Mark Release** - Creates a published GitHub release with the built artifacts; updates PR labels. For the SDK (`libs/deepagents`), we set it as the repository's `latest` (unless it's a pre-release).
 
 ### Release PR Labels
@@ -288,6 +288,9 @@ PyPI does not allow re-uploading the same version. If a release failed partway:
 1. If already on PyPI: bump the version and release again
 2. If only on test PyPI: the workflow uses `skip-existing: true`, so re-running should work
 3. If the GitHub release exists but PyPI publish failed (e.g., from a manual re-run): delete the release/tag and re-run the workflow
+
+> [!NOTE]
+> The Test PyPI step uses `skip-existing: true` so that **workflow re-runs** don't fail when the version was already uploaded on a previous attempt. The tradeoff: on re-runs the Test PyPI step is silently skipped rather than re-validated, so it no longer acts as an upload gate.
 
 ### Unexpected Commit Authors in Release PRs
 

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -2,14 +2,14 @@
 #
 # FORMAT (Conventional Commits 1.0.0):
 #
-#   <type>[optional scope]: <description>
+#   <type>(<scope>): <description>
 #   [optional body]
 #   [optional footer(s)]
 #
 # Examples:
 #     feat(sdk): add multi‐agent support
 #     fix(cli): resolve flag parsing error
-#     docs: update API usage examples
+#     docs(sdk): update API usage examples
 #
 # Allowed Types:
 #   * feat       — a new feature (MINOR)
@@ -26,7 +26,7 @@
 #   * release    — prepare a new release
 #   * hotfix     — urgent fix that won't trigger a release
 #
-# Allowed Scope(s) (optional):
+# Allowed Scope(s) (required):
 #   acp, ci, cli, cli-gha, daytona, deepagents, deepagents-cli, deps, evals,
 #   examples, harbor, infra, langsmith-sandbox, modal, quickjs, repl, runloop, sdk
 #
@@ -34,10 +34,10 @@
 #
 # Rules:
 #   1. The 'Type' must start with a lowercase letter.
-#   2. Breaking changes: append "!" after type/scope (e.g., feat!: drop x support)
+#   2. Breaking changes: append "!" after type/scope (e.g., feat(sdk)!: drop x support)
 #   3. When releasing (updating the pyproject.toml and uv.lock), the commit message
 #      should be: `release(scope): x.y.z` (e.g., `release(deepagents): 1.2.0` with no
-#      body, footer, or preceeding/proceeding text).
+#      body, footer, or preceding/following text).
 #
 # Enforces Conventional Commits format for pull request titles to maintain a clear and
 # machine-readable change history.
@@ -104,7 +104,7 @@ jobs:
             repl
             runloop
             sdk
-          requireScope: false
+          requireScope: true
           disallowScopes: |
             release
             [A-Z]+

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,7 @@ jobs:
       runloop-release: ${{ steps.check-releases.outputs.runloop-release }}
       quickjs-release: ${{ steps.check-releases.outputs.quickjs-release }}
       repl-release: ${{ steps.check-releases.outputs.repl-release }}
+      release-version: ${{ steps.check-releases.outputs.release-version }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -98,6 +99,19 @@ jobs:
 
           if [ -z "$COMMIT_MSG" ]; then
             echo "::warning::Commit message is empty — no release will be triggered."
+          fi
+
+          # Extract version from release commit message: "release(component): X.Y.Z"
+          # [^ ]+ stops at the first space to avoid capturing trailing PR refs like "(#1234)"
+          # NOTE: separate-pull-requests=true ensures one release commit per workflow run,
+          # so a single version output is correct — each package triggers its own run.
+          RELEASE_VERSION=$(echo "$COMMIT_MSG" | sed -nE 's/^release\([^)]+\): +([^ ]+).*/\1/p')
+          echo "release-version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+          if [ -n "$RELEASE_VERSION" ]; then
+            echo "Extracted release version: $RELEASE_VERSION"
+          elif echo "$COMMIT_MSG" | grep -qE "^release\("; then
+            echo "::warning::Commit looks like a release but version extraction failed: $COMMIT_MSG"
           fi
 
           # grep -q in an `if` conditional is safe under set -eo pipefail;
@@ -208,8 +222,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: deepagents-cli
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       # write needed to update PR label from "autorelease: pending" to "autorelease: tagged"
@@ -222,8 +236,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: deepagents
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -235,8 +249,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: deepagents-acp
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -248,8 +262,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-daytona
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -261,8 +275,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-modal
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -274,8 +288,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-runloop
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -287,8 +301,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-quickjs
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -300,8 +314,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: langchain-repl
+      version: ${{ needs.release-please.outputs.release-version }}
     permissions:
-      actions: write
       contents: write
       id-token: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@
 # Flow: build -> pre-release-checks -> test-pypi -> publish -> release
 
 name: "⚠️ Manual Package Release"
-run-name: "Release ${{ inputs.package }}"
+run-name: "Release ${{ inputs.package }}${{ inputs.version && format(' {0}', inputs.version) || '' }}"
 on:
   workflow_call:
     inputs:
@@ -15,6 +15,11 @@ on:
         required: true
         type: string
         description: "Package to release"
+      version:
+        required: false
+        type: string
+        default: ""
+        description: "Version being released (used in run name)"
   workflow_dispatch:
     inputs:
       package:
@@ -32,6 +37,11 @@ on:
           - langchain-repl
           - langchain-runloop
         default: deepagents
+      version:
+        required: false
+        type: string
+        default: ""
+        description: "Version string — does NOT control the released version"
       dangerous-nonmain-release:
         required: false
         type: boolean
@@ -108,7 +118,6 @@ jobs:
     if: github.ref == 'refs/heads/main' || inputs.dangerous-nonmain-release
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: read
     env:
       WORKING_DIR: ${{ needs.setup.outputs.working-dir }}
@@ -167,14 +176,14 @@ jobs:
               f.write(f"version={version}\n")
               f.write(f"is-prerelease={'true' if is_pre else 'false'}\n")
 
-      - name: Update workflow run name with version
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Validate version consistency
+        if: inputs.version != ''
         run: |
-          gh api --method PATCH \
-            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f "name=Release ${{ steps.check-version.outputs.pkg-name }} ${{ steps.check-version.outputs.version }}"
+          BUILD_VERSION="${{ steps.check-version.outputs.version }}"
+          INPUT_VERSION="${{ inputs.version }}"
+          if [ "$BUILD_VERSION" != "$INPUT_VERSION" ]; then
+            echo "::warning::Version mismatch — run name says '$INPUT_VERSION' but pyproject.toml says '$BUILD_VERSION'"
+          fi
 
   # Generate release notes from CHANGELOG.md (with git log fallback)
   # and collect contributor shoutouts from merged PRs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ See `.github/RELEASING.md` for the full workflow (version bumping, pre-releases,
 
 ### PR labeling and linting
 
-**Title linting** (`.github/workflows/pr_lint.yml`) – Enforces Conventional Commits format and allowed scopes on PR titles
+**Title linting** (`.github/workflows/pr_lint.yml`) – Enforces Conventional Commits format with required scope on PR titles
 
 **Auto-labeling:**
 


### PR DESCRIPTION
Require PR scope in the title lint check and replace the runtime `gh api` workflow-run rename with a static `run-name` template. The old rename needed `actions:write` on every release caller and failed silently under `continue-on-error`; the new approach extracts the version from the release-please commit message in `release-please.yml` and passes it as an input to `release.yml`, eliminating the API call and the permission entirely.

## Changes

- Set `requireScope: true` in `pr_lint.yml` and update header comments/examples to reflect required scope — breaking-change example now reads `feat(sdk)!: drop x support`, scopeless `docs:` example replaced with `docs(sdk):`
- Extract release version via `sed -nE 's/^release\([^)]+\): +([^ ]+).*/\1/p'` in the `check-releases` step and forward it as a `version` input to all 8 `release.yml` caller jobs; regex uses `[^ ]+` to avoid capturing trailing PR refs like `(#1234)`
- Replace the `gh api --method PATCH` run-rename step with a `run-name` template using `format()` to conditionally append the version (no trailing space when empty)
- Drop `actions: write` from the `build` job and all 8 caller permissions blocks — no remaining consumers
- Add a `Validate version consistency` step in `build` that emits a `::warning::` if the input version (from the commit message) diverges from the authoritative version in `pyproject.toml`
- Add a `::warning::` in `release-please.yml` when a commit matches `^release\(` but the version extraction returns empty, catching regex/title-pattern drift early
- Document the `skip-existing: true` tradeoff in `RELEASING.md`: re-runs won't fail on duplicate Test PyPI uploads, but the step is silently skipped rather than re-validated
