### PR TITLE
fix(sdk): raise `ValueError` for permission paths without leading slash

### DIFF
--- a/libs/deepagents/deepagents/middleware/permissions.py
+++ b/libs/deepagents/deepagents/middleware/permissions.py
@@ -6,6 +6,7 @@ Defines ``FilesystemPermission`` rules and enforces them via
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Any, Literal
 
 import wcmatch.glob as wcglob
@@ -74,11 +75,18 @@ class FilesystemPermission:
     mode: Literal["allow", "deny"] = "allow"
 
     def __post_init__(self) -> None:
-        """Validate that all paths start with '/'."""
+        """Validate that all paths start with '/', contain no '..' traversal, and no '~'."""
         for path in self.paths:
             if not path.startswith("/"):
                 msg = f"Permission path must start with '/': {path!r}"
                 raise ValueError(msg)
+            parts = PurePosixPath(path.replace("\\", "/")).parts
+            if ".." in parts:
+                msg = f"Permission path must not contain '..': {path!r}"
+                raise ValueError(msg)
+            if "~" in parts:
+                msg = f"Permission path must not contain '~': {path!r}"
+                raise NotImplementedError(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/deepagents/deepagents/middleware/permissions.py
+++ b/libs/deepagents/deepagents/middleware/permissions.py
@@ -73,6 +73,12 @@ class FilesystemPermission:
     paths: list[str]
     mode: Literal["allow", "deny"] = "allow"
 
+    def __post_init__(self) -> None:
+        for path in self.paths:
+            if not path.startswith("/"):
+                msg = f"Permission path must start with '/': {path!r}"
+                raise ValueError(msg)
+
 
 # ---------------------------------------------------------------------------
 # Glob flags

--- a/libs/deepagents/deepagents/middleware/permissions.py
+++ b/libs/deepagents/deepagents/middleware/permissions.py
@@ -74,6 +74,7 @@ class FilesystemPermission:
     mode: Literal["allow", "deny"] = "allow"
 
     def __post_init__(self) -> None:
+        """Validate that all paths start with '/'."""
         for path in self.paths:
             if not path.startswith("/"):
                 msg = f"Permission path must start with '/': {path!r}"

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -97,6 +97,14 @@ class TestFilesystemPermission:
         with pytest.raises(ValueError, match="Permission path must start with '/'"):
             FilesystemPermission(operations=["read"], paths=["/valid/**", "invalid/**"])
 
+    def test_path_with_dotdot_raises(self):
+        with pytest.raises(ValueError, match=r"must not contain '\.\.'"):
+            FilesystemPermission(operations=["read"], paths=["/workspace/../secrets/**"])
+
+    def test_path_with_tilde_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="must not contain '~'"):
+            FilesystemPermission(operations=["read"], paths=["/~/data/**"])
+
 
 class TestPermissionMiddleware:
     def _backend(self):

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -89,6 +89,14 @@ class TestFilesystemPermission:
         assert "read" in rule.operations
         assert "write" in rule.operations
 
+    def test_path_without_leading_slash_raises(self):
+        with pytest.raises(ValueError, match="Permission path must start with '/'"):
+            FilesystemPermission(operations=["read"], paths=["workspace/**"])
+
+    def test_mixed_paths_with_missing_slash_raises(self):
+        with pytest.raises(ValueError, match="Permission path must start with '/'"):
+            FilesystemPermission(operations=["read"], paths=["/valid/**", "invalid/**"])
+
 
 class TestPermissionMiddleware:
     def _backend(self):


### PR DESCRIPTION
Relative paths in FilesystemPermission silently never match because input paths are canonicalized to start with '/'.  Also prevent path traversal (..) and home directory expansion (~). Validate at construction time to catch misconfiguration early.