### PR TITLE
hotfix(sdk): relax xfail strictness on nondeterministic integration test

### DIFF
--- a/libs/deepagents/tests/integration_tests/test_deepagents.py
+++ b/libs/deepagents/tests/integration_tests/test_deepagents.py
@@ -100,7 +100,7 @@ class TestDeepAgents:
         assert any(tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "weather_agent" for tool_call in tool_calls)
         assert any(tool_call["name"] == "task" and tool_call["args"].get("subagent_type") == "soccer_agent" for tool_call in tool_calls)
 
-    @pytest.mark.xfail(strict=True, reason="Subagent middleware double-writes extended state keys in same step")
+    @pytest.mark.xfail(strict=False, reason="Subagent middleware double-writes extended state keys in same step")
     def test_deep_agent_with_extended_state_and_subagents(self):
         subagents = [
             {


### PR DESCRIPTION
Relax the `xfail` marker on `test_deep_agent_with_extended_state_and_subagents` from `strict=True` to `strict=False`. The underlying double-write bug in `_return_command_with_state_update` is real, but the test is nondeterministic — it calls a live LLM, so whether the model's tool-call pattern triggers the double-write varies between runs. `strict=True` causes XPASS failures when the model happens to take a path that avoids the bug.