### PR TITLE
fix(ci): pass secrets to reusable release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -223,6 +223,7 @@ jobs:
     with:
       package: deepagents-cli
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -237,6 +238,7 @@ jobs:
     with:
       package: deepagents
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -250,6 +252,7 @@ jobs:
     with:
       package: deepagents-acp
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -263,6 +266,7 @@ jobs:
     with:
       package: langchain-daytona
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -276,6 +280,7 @@ jobs:
     with:
       package: langchain-modal
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -289,6 +294,7 @@ jobs:
     with:
       package: langchain-runloop
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -302,6 +308,7 @@ jobs:
     with:
       package: langchain-quickjs
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -315,6 +322,7 @@ jobs:
     with:
       package: langchain-repl
       version: ${{ needs.release-please.outputs.release-version }}
+    secrets: inherit
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@
 # Flow: build -> pre-release-checks -> test-pypi -> publish -> release
 
 name: "⚠️ Manual Package Release"
-run-name: "Release ${{ inputs.package }}${{ inputs.version && format(' {0}', inputs.version) || '' }}"
+run-name: "release(${{ inputs.package }}):${{ inputs.version && format(' {0}', inputs.version) || '' }}"
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
The release-please workflow calls `release.yml` as a reusable workflow but wasn't passing `secrets: inherit`, which would cause every automated release triggered by release-please to fail at the publish step. Also cleans up the `release.yml` run-name to use conventional commit style.
