### PR TITLE
style(cli): neutral "what's new" heading for editable installs

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1505,11 +1505,15 @@ class DeepAgentsApp(App):
 
         try:
             from deepagents_cli._version import __version__ as cli_version
+            from deepagents_cli.config import _is_editable_install
+
+            if await asyncio.to_thread(_is_editable_install):
+                heading = f"Now running v{cli_version}"
+            else:
+                heading = f"Updated to v{cli_version}"
 
             await self._mount_message(
-                AppMessage(
-                    f"Updated to v{cli_version}\nSee what's new: {CHANGELOG_URL}"
-                )
+                AppMessage(f"{heading}\nSee what's new: {CHANGELOG_URL}")
             )
         except Exception:
             logger.debug("What's new banner display failed", exc_info=True)


### PR DESCRIPTION
The "what's new" banner in `_show_whats_new` unconditionally said "Updated to vX.Y.Z" — misleading for editable installs where nothing was auto-updated; the version just changed because the developer pulled new code.
