### PR TITLE
fix(sdk): preserve goto and graph when intercepting Command in FilesystemMiddleware

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1610,7 +1610,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     resolved_backend,
                 )
                 processed_messages.append(processed_message)
-            return Command(update={**update, "messages": processed_messages})
+            return Command(goto=tool_result.goto, graph=tool_result.graph, update={**update, "messages": processed_messages})
         msg = f"Unreachable code reached in _intercept_large_tool_result: for tool_result of type {type(tool_result)}"
         raise AssertionError(msg)
 
@@ -1645,7 +1645,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     resolved_backend,
                 )
                 processed_messages.append(processed_message)
-            return Command(update={**update, "messages": processed_messages})
+            return Command(goto=tool_result.goto, graph=tool_result.graph, update={**update, "messages": processed_messages})
         msg = f"Unreachable code reached in _aintercept_large_tool_result: for tool_result of type {type(tool_result)}"
         raise AssertionError(msg)
 

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1011,6 +1011,24 @@ class TestFilesystemMiddleware:
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
         assert result.update["custom_key"] == "custom_value"
 
+    def test_intercept_command_preserves_goto_and_graph(self):
+        """Test that goto and graph are preserved when intercepting a Command (fixes #2500)."""
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
+        runtime = _runtime("test_123")
+
+        tool_message = ToolMessage(content="small content", tool_call_id="test_123")
+        command = Command(
+            goto="agent_b",
+            graph=Command.PARENT,
+            update={"messages": [tool_message]},
+        )
+        result = middleware._intercept_large_tool_result(command, runtime)
+
+        assert isinstance(result, Command)
+        assert result.goto == "agent_b"
+        assert result.graph == Command.PARENT
+
     def test_sanitize_tool_call_id(self):
         """Test that tool_call_id is sanitized to prevent path traversal."""
         assert sanitize_tool_call_id("call_123") == "call_123"


### PR DESCRIPTION
Fixes #2500

## Problem

`FilesystemMiddleware._intercept_large_tool_result` (and its async counterpart `_aintercept_large_tool_result`) reconstructs a `Command` object after processing large tool messages, but drops the `goto` and `graph` fields from the original `Command`.

This causes multi-agent handoffs using `Command(goto=..., graph=Command.PARENT)` to silently fail when `create_deep_agent` is used — the target agent node is never executed, even though the same setup works correctly with `create_agent`.

Bisecting middleware confirms `FilesystemMiddleware` is the sole cause.

## Solution

Pass `goto=tool_result.goto` and `graph=tool_result.graph` when reconstructing the `Command` in both the sync and async intercept methods:

```python
# Before
return Command(update={**update, "messages": processed_messages})

# After
return Command(goto=tool_result.goto, graph=tool_result.graph, update={**update, "messages": processed_messages})
```

This is similar to PR #1482 which fixed the same method dropping `ToolMessage` metadata during reconstruction.

## Testing

Added a unit test `test_intercept_command_preserves_goto_and_graph` to `TestFilesystemMiddlewareIntercept` that verifies `goto` and `graph` are preserved after interception.