### PR TITLE
docs(cli): remove broken local links from skill-creator guidance

### DIFF
--- a/libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md
+++ b/libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md
@@ -150,12 +150,12 @@ Extract text with pdfplumber:
 
 ## Advanced features
 
-- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
-- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
-- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+- **Form filling**: See `references/FORMS.md` for complete guide
+- **API reference**: See `references/REFERENCE.md` for all methods
+- **Examples**: See `references/EXAMPLES.md` for common patterns
 ```
 
-The agent loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+The agent loads `references/FORMS.md`, `references/REFERENCE.md`, or `references/EXAMPLES.md` only when needed.
 
 **Pattern 2: Domain-specific organization**
 
@@ -195,17 +195,17 @@ Show basic content, link to advanced content:
 
 ## Creating documents
 
-Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+Use docx-js for new documents. See `references/DOCX-JS.md`.
 
 ## Editing documents
 
 For simple edits, modify the XML directly.
 
-**For tracked changes**: See [REDLINING.md](REDLINING.md)
-**For OOXML details**: See [OOXML.md](OOXML.md)
+**For tracked changes**: See `references/REDLINING.md`
+**For OOXML details**: See `references/OOXML.md`
 ```
 
-The agent reads REDLINING.md or OOXML.md only when the user needs those features.
+The agent reads `references/REDLINING.md` or `references/OOXML.md` only when the user needs those features.
 
 **Important guidelines:**
 

--- a/libs/cli/examples/skills/skill-creator/SKILL.md
+++ b/libs/cli/examples/skills/skill-creator/SKILL.md
@@ -147,12 +147,12 @@ Extract text with pdfplumber:
 
 ## Advanced features
 
-- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
-- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
-- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+- **Form filling**: See `references/FORMS.md` for complete guide
+- **API reference**: See `references/REFERENCE.md` for all methods
+- **Examples**: See `references/EXAMPLES.md` for common patterns
 ```
 
-The agent loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+The agent loads `references/FORMS.md`, `references/REFERENCE.md`, or `references/EXAMPLES.md` only when needed.
 
 **Pattern 2: Domain-specific organization**
 
@@ -192,17 +192,17 @@ Show basic content, link to advanced content:
 
 ## Creating documents
 
-Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+Use docx-js for new documents. See `references/DOCX-JS.md`.
 
 ## Editing documents
 
 For simple edits, modify the XML directly.
 
-**For tracked changes**: See [REDLINING.md](REDLINING.md)
-**For OOXML details**: See [OOXML.md](OOXML.md)
+**For tracked changes**: See `references/REDLINING.md`
+**For OOXML details**: See `references/OOXML.md`
 ```
 
-The agent reads REDLINING.md or OOXML.md only when the user needs those features.
+The agent reads `references/REDLINING.md` or `references/OOXML.md` only when the user needs those features.
 
 **Important guidelines:**
 


### PR DESCRIPTION
## summary
- replace stale markdown links in both skill-creator SKILL.md files with non-link reference paths
- avoid pointing to files that are not present in those skill directories
- keep the guidance examples while preventing dead local links

## validation
- python link check over:
  - libs/cli/examples/skills/skill-creator/SKILL.md
  - libs/cli/deepagents_cli/built_in_skills/skill-creator/SKILL.md