### PR TITLE
hotfix(infra): fix integration test workflow failures

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,10 +19,8 @@ on:
           - all
           - libs/deepagents
           - libs/cli
-          - libs/repl
           - libs/partners/daytona
           - libs/partners/modal
-          - libs/partners/quickjs
           - libs/partners/runloop
       working-directory-override:
         type: string
@@ -41,10 +39,8 @@ env:
   DEFAULT_LIBS: >-
     ["libs/deepagents",
     "libs/cli",
-    "libs/repl",
     "libs/partners/daytona",
     "libs/partners/modal",
-    "libs/partners/quickjs",
     "libs/partners/runloop"]
 
 jobs:
@@ -108,6 +104,11 @@ jobs:
       - name: "📦 Install Dependencies"
         working-directory: ${{ matrix.working-directory }}
         run: uv sync --group test
+
+      - name: "📦 Install Sandbox Extras (CLI only)"
+        if: matrix.working-directory == 'libs/cli'
+        working-directory: ${{ matrix.working-directory }}
+        run: uv sync --group test --extra all-sandboxes
 
       - name: "🚀 Run Integration Tests"
         working-directory: ${{ matrix.working-directory }}

--- a/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
@@ -1,3 +1,4 @@
+import unicodedata
 import uuid
 
 import pytest
@@ -19,6 +20,11 @@ from deepagents.middleware.filesystem import (
 from tests.utils import ResearchMiddleware, get_la_liga_standings, get_nba_standings, get_nfl_standings, get_premier_league_standings
 
 
+def _to_ascii(text: str) -> str:
+    """Normalize unicode to ASCII (e.g. 'pokémon' → 'pokemon')."""
+    return unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+
+
 def build_composite_state_backend(*, routes):
     return CompositeBackend(default=StateBackend(), routes=routes)
 
@@ -36,7 +42,7 @@ class TestFilesystem:
             ],
         )
         response = agent.invoke({"messages": [HumanMessage(content="What do you like?")]})
-        assert "pokemon" in response["messages"][1].text.lower()
+        assert "pokemon" in _to_ascii(response["messages"][1].text.lower())
 
     def test_filesystem_system_prompt_override_with_composite_backend(self):
         def backend(_rt):
@@ -53,7 +59,7 @@ class TestFilesystem:
             store=InMemoryStore(),
         )
         response = agent.invoke({"messages": [HumanMessage(content="What do you like?")]})
-        assert "pizza" in response["messages"][1].text.lower()
+        assert "pizza" in _to_ascii(response["messages"][1].text.lower())
 
     def test_ls_longterm_without_path(self):
         checkpointer = MemorySaver()


### PR DESCRIPTION
Fix two integration test workflow issues: CLI sandbox provider packages weren't installed (causing 94 `ImportError`s for daytona/runloop/modal), and `libs/repl` + `libs/partners/quickjs` were in the test matrix despite having no `integration_tests/` directory (pytest exit code 5). Also fix a flaky SDK assertion where Claude returns `"pokémon"` (accented é) instead of ASCII `"pokemon"`.
