### PR TITLE
chore(sdk): suppress pytest-benchmark warnings in integration tests

### DIFF
--- a/libs/deepagents/Makefile
+++ b/libs/deepagents/Makefile
@@ -35,7 +35,7 @@ coverage: ## Run unit tests with coverage
 
 integration_test: ## Run integration tests
 integration_test integration_tests:
-	uv run --group test pytest -n auto -vvv --timeout 30 $(TEST_FILE)
+	uv run --group test pytest -n auto -vvv --timeout 30 --benchmark-disable $(TEST_FILE)
 
 
 test_watch: ## Run tests in watch mode


### PR DESCRIPTION
Suppress `PytestBenchmarkWarning` noise in the SDK's integration test CI job. The unit test target already passes `--benchmark-disable` when running under xdist, but the integration test target was missing it — causing five identical warnings per run.