### PR TITLE
test(sdk): xfail langsmith sandbox integration tests

### DIFF
--- a/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
@@ -42,3 +42,19 @@ class TestLangSmithSandboxStandard(SandboxIntegrationTests):
     @pytest.mark.xfail(strict=True, reason="Upstream langchain_tests uses `in` on ReadResult dataclass")
     def test_edit_single_occurrence(self, sandbox_backend: SandboxBackendProtocol) -> None:
         super().test_edit_single_occurrence(sandbox_backend)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="LangSmithSandbox.write() bypasses existence check; fix stashed",
+    )
+    def test_write_existing_file_fails(self, sandbox_backend: SandboxBackendProtocol, sandbox_test_root: str) -> None:
+        super().test_write_existing_file_fails(sandbox_backend, sandbox_test_root)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BaseSandbox.read() via execute() hangs on large content over websocket; fix stashed",
+    )
+    async def test_awrite_aread_adownload_large_text_with_escaped_content(
+        self, sandbox_backend: SandboxBackendProtocol, sandbox_test_root: str
+    ) -> None:
+        await super().test_awrite_aread_adownload_large_text_with_escaped_content(sandbox_backend, sandbox_test_root)


### PR DESCRIPTION
Mark two known `LangSmithSandbox` integration test failures as `xfail(strict=True)` while fixes are pending. `test_write_existing_file_fails` fails because `LangSmithSandbox.write()` delegates directly to the LangSmith SDK without the existence preflight check that `BaseSandbox.write()` performs. `test_awrite_aread_adownload_large_text_with_escaped_content` times out because `BaseSandbox.read()` pipes large file content through `execute()` over websocket, which hangs for 2500+ lines of unicode text.