### PR TITLE
fix(sdk): patch invalid tool calls without tool messages (#2703)

### DIFF
--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -21,23 +21,32 @@ class PatchToolCallsMiddleware(AgentMiddleware):
         # Iterate over the messages and add any dangling tool calls
         for i, msg in enumerate(messages):
             patched_messages.append(msg)
-            if isinstance(msg, AIMessage) and msg.tool_calls:
-                for tool_call in msg.tool_calls:
+            if isinstance(msg, AIMessage) and (msg.tool_calls or msg.invalid_tool_calls):
+                # Both lists always default to [] on AIMessage, so unpacking is safe.
+                for tool_call in [*msg.tool_calls, *msg.invalid_tool_calls]:
+                    call_id = tool_call["id"]
+                    if call_id is None:
+                        # No id means no ToolMessage can be correlated; skip.
+                        continue
                     corresponding_tool_msg = next(
-                        (msg for msg in messages[i:] if msg.type == "tool" and msg.tool_call_id == tool_call["id"]),  # ty: ignore[unresolved-attribute]
+                        (m for m in messages[i:] if m.type == "tool" and m.tool_call_id == call_id),  # ty: ignore[unresolved-attribute]
                         None,
                     )
                     if corresponding_tool_msg is None:
                         # We have a dangling tool call which needs a ToolMessage
-                        tool_msg = (
-                            f"Tool call {tool_call['name']} with id {tool_call['id']} was "
-                            "cancelled - another message came in before it could be completed."
-                        )
+                        call_name = tool_call["name"] or "unknown"
+                        is_invalid = tool_call.get("type") == "invalid_tool_call"
+                        if is_invalid:
+                            tool_msg = f"Tool call {call_name} with id {call_id} could not be executed - arguments were malformed or truncated."
+                        else:
+                            tool_msg = (
+                                f"Tool call {call_name} with id {call_id} was cancelled - another message came in before it could be completed."
+                            )
                         patched_messages.append(
                             ToolMessage(
                                 content=tool_msg,
-                                name=tool_call["name"],
-                                tool_call_id=tool_call["id"],
+                                name=call_name,
+                                tool_call_id=call_id,
                             )
                         )
 

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1816,6 +1816,100 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[7].type == "human"
         assert patched_messages[7].content == "What is the weather in Tokyo?"
 
+    def test_invalid_tool_call_without_tool_message(self) -> None:
+        input_messages = [
+            SystemMessage(content="You are a helpful assistant.", id="1"),
+            AIMessage(
+                content="I tried to call a tool but made a mistake",
+                invalid_tool_calls=[
+                    {"id": "inv_123", "name": "bad_tool", "args": "bad json", "error": "Malformed args", "type": "invalid_tool_call"}
+                ],
+                id="2",
+            ),
+            HumanMessage(content="What happened?", id="3"),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+        assert isinstance(state_update["messages"], Overwrite)
+        patched_messages = state_update["messages"].value
+
+        assert len(patched_messages) == 4
+        assert patched_messages[1].type == "ai"
+        assert patched_messages[2].type == "tool"
+        assert patched_messages[2].tool_call_id == "inv_123"
+        assert patched_messages[2].name == "bad_tool"
+        assert "could not be executed" in patched_messages[2].content
+        assert "malformed or truncated" in patched_messages[2].content
+
+    def test_invalid_tool_call_with_tool_message_present(self) -> None:
+        input_messages = [
+            SystemMessage(content="You are a helpful assistant.", id="1"),
+            AIMessage(
+                content="I tried to call a tool but made a mistake",
+                invalid_tool_calls=[
+                    {"id": "inv_123", "name": "bad_tool", "args": "bad json", "error": "Malformed args", "type": "invalid_tool_call"}
+                ],
+                id="2",
+            ),
+            ToolMessage(content="You provided bad args", tool_call_id="inv_123", name="bad_tool", id="3"),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+        assert isinstance(state_update["messages"], Overwrite)
+        patched_messages = state_update["messages"].value
+
+        assert len(patched_messages) == 3
+        assert patched_messages[2].type == "tool"
+        assert patched_messages[2].tool_call_id == "inv_123"
+
+    def test_invalid_tool_call_with_none_id_skipped(self) -> None:
+        input_messages = [
+            SystemMessage(content="You are a helpful assistant.", id="1"),
+            AIMessage(
+                content="I tried to call a tool but made a mistake",
+                invalid_tool_calls=[{"id": None, "name": "bad_tool", "args": "bad json", "error": "Malformed args", "type": "invalid_tool_call"}],
+                id="2",
+            ),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+        assert isinstance(state_update["messages"], Overwrite)
+        patched_messages = state_update["messages"].value
+
+        # No ToolMessage added because id is None
+        assert len(patched_messages) == 2
+        assert patched_messages[1].type == "ai"
+
+    def test_mixed_valid_and_invalid_tool_calls_both_patched(self) -> None:
+        input_messages = [
+            AIMessage(
+                content="Multiple tools",
+                tool_calls=[{"id": "valid_1", "name": "good_tool", "args": {}}],
+                invalid_tool_calls=[{"id": "inv_1", "name": "bad_tool", "args": "bad json", "error": "Malformed args", "type": "invalid_tool_call"}],
+                id="1",
+            ),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+        assert isinstance(state_update["messages"], Overwrite)
+        patched_messages = state_update["messages"].value
+
+        assert len(patched_messages) == 3
+        assert patched_messages[0].type == "ai"
+
+        # Order of appending is tool_calls then invalid_tool_calls
+        assert patched_messages[1].type == "tool"
+        assert patched_messages[1].tool_call_id == "valid_1"
+        assert "cancelled - another message came in" in patched_messages[1].content
+
+        assert patched_messages[2].type == "tool"
+        assert patched_messages[2].tool_call_id == "inv_1"
+        assert "could not be executed - arguments were malformed" in patched_messages[2].content
+
 
 class TestTruncation:
     def test_truncate_list_result_no_truncation(self):


### PR DESCRIPTION
updates `PatchToolCallsMiddleware` to handle missing tool messages for malformed or truncated tool calls preventing API errors caused by dangling tool call IDs.

fixes #2703

### how did you verify your code works?

added 4 new unit tests covering edge cases for `invalid_tool_calls` in `tests/unit_tests/test_middleware.py`: single invalid calls, mixed valid and invalid calls, and handling of calls without IDs.

> partial assistance from claude was utilized in forming this PR

### social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
LinkedIn: https://www.linkedin.com/in/aarushi-s-52623b207/