### PR TITLE
feat(sdk): Codex harness profile

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -394,6 +394,19 @@ REGISTRY: tuple[Model, ...] = (
         ),
     ),
     Model(
+        "openai:gpt-5.3-codex",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:openai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:openai",
+            }
+        ),
+    ),
+    Model(
         "openai:gpt-5.4",
         frozenset(
             {

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -94,6 +94,7 @@ on:
           - "openai:o4-mini"
           - "openai:gpt-5.1-codex"
           - "openai:gpt-5.2-codex"
+          - "openai:gpt-5.3-codex"
           - "openai:gpt-5.4"
           - "openai:gpt-5.4-mini"
           - "openrouter:minimax/minimax-m2.7"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -165,6 +165,11 @@ on:
         required: false
         default: ""
         type: string
+      disable_codex_compaction:
+        description: "TEMP (remove before merging codex profile): force codex profile onto default SummarizationMiddleware path. Use to A/B compare `/compact` vs. LLM summarization on the same codex model."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -284,7 +289,9 @@ jobs:
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
       LANGSMITH_TRACING: "true"
-      LANGSMITH_EXPERIMENT: ${{ matrix.model }}
+      LANGSMITH_EXPERIMENT: ${{ matrix.model }}${{ inputs.disable_codex_compaction && '-summary' || '' }}
+      # TEMP (remove with the `disable_codex_compaction` input):
+      DEEPAGENTS_DISABLE_CODEX_COMPACTION: ${{ inputs.disable_codex_compaction && '1' || '' }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       OLLAMA_HOST: "https://ollama.com"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -100,6 +100,7 @@ on:
           - "openai:o4-mini"
           - "openai:gpt-5.1-codex"
           - "openai:gpt-5.2-codex"
+          - "openai:gpt-5.3-codex"
           - "openai:gpt-5.4"
           - "openai:gpt-5.4-mini"
           - "openrouter:minimax/minimax-m2.7"

--- a/examples/async-subagent-server/uv.lock
+++ b/examples/async-subagent-server/uv.lock
@@ -367,14 +367,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/examples/async-subagent-server/uv.lock
+++ b/examples/async-subagent-server/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -677,9 +677,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/examples/content-builder-agent/uv.lock
+++ b/examples/content-builder-agent/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -436,9 +436,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/examples/nvidia_deep_agent/uv.lock
+++ b/examples/nvidia_deep_agent/uv.lock
@@ -1110,7 +1110,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1122,9 +1122,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/acp/uv.lock
+++ b/libs/acp/uv.lock
@@ -447,14 +447,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -984,14 +984,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -28,10 +28,11 @@ from langgraph.typing import ContextT
 from deepagents._models import get_model_identifier, get_model_provider, resolve_model
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
-from deepagents.backends.protocol import BackendFactory, BackendProtocol
+from deepagents.backends.protocol import BACKEND_TYPES, BackendFactory, BackendProtocol
 from deepagents.middleware._tool_aliasing import _ToolAliasingMiddleware
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.codex_compaction import CodexCompactionMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
@@ -129,6 +130,32 @@ def _resolve_extra_middleware(
     if callable(extra):
         return list(extra())  # ty: ignore[call-top-callable]
     return list(extra)
+
+
+def _build_compaction_layer(
+    profile: _HarnessProfile,
+    model: BaseChatModel,
+    backend: BACKEND_TYPES,
+) -> AgentMiddleware[Any, Any, Any]:
+    """Return the context-management middleware for the given profile.
+
+    Codex profiles opt into OpenAI's Responses `/compact` endpoint via
+    `CodexCompactionMiddleware`, which transparently falls back to LLM-based
+    summarization if the API call fails. Every other profile uses the default
+    `SummarizationMiddleware` directly.
+
+    Args:
+        profile: Merged harness profile for the target model.
+        model: Resolved chat model instance.
+        backend: Backend or factory for offloading history.
+
+    Returns:
+        A single middleware instance to slot into the agent stack in place of
+        the prior `create_summarization_middleware(model, backend)` call.
+    """
+    if profile.use_codex_compaction:
+        return CodexCompactionMiddleware(model, backend)
+    return create_summarization_middleware(model, backend)
 
 
 def _harness_profile_for_model(model: BaseChatModel, spec: str | None) -> _HarnessProfile:
@@ -456,7 +483,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             custom_tool_descriptions=_profile.tool_description_overrides,
             include_apply_patch=_profile.include_apply_patch,
         ),
-        create_summarization_middleware(model, backend),
+        _build_compaction_layer(_profile, model, backend),
         PatchToolCallsMiddleware(),
     ]
     if skills is not None:
@@ -517,7 +544,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                     custom_tool_descriptions=_subagent_profile.tool_description_overrides,
                     include_apply_patch=_subagent_profile.include_apply_patch,
                 ),
-                create_summarization_middleware(subagent_model, backend),
+                _build_compaction_layer(_subagent_profile, subagent_model, backend),
                 PatchToolCallsMiddleware(),
             ]
             subagent_skills = spec.get("skills")
@@ -586,7 +613,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 # template. Stale keys silently no-op if the tool is renamed.
                 task_description=_profile.tool_description_overrides.get("task"),
             ),
-            create_summarization_middleware(model, backend),
+            _build_compaction_layer(_profile, model, backend),
             PatchToolCallsMiddleware(),
         ]
     )

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -454,6 +454,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         FilesystemMiddleware(
             backend=backend,
             custom_tool_descriptions=_profile.tool_description_overrides,
+            include_apply_patch=_profile.include_apply_patch,
         ),
         create_summarization_middleware(model, backend),
         PatchToolCallsMiddleware(),
@@ -514,6 +515,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 FilesystemMiddleware(
                     backend=backend,
                     custom_tool_descriptions=_subagent_profile.tool_description_overrides,
+                    include_apply_patch=_subagent_profile.include_apply_patch,
                 ),
                 create_summarization_middleware(subagent_model, backend),
                 PatchToolCallsMiddleware(),
@@ -572,6 +574,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             FilesystemMiddleware(
                 backend=backend,
                 custom_tool_descriptions=_profile.tool_description_overrides,
+                include_apply_patch=_profile.include_apply_patch,
             ),
             SubAgentMiddleware(
                 backend=backend,

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -6,6 +6,7 @@ middleware.
 """
 
 import logging
+import os
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Any, cast
@@ -153,7 +154,11 @@ def _build_compaction_layer(
         A single middleware instance to slot into the agent stack in place of
         the prior `create_summarization_middleware(model, backend)` call.
     """
-    if profile.use_codex_compaction:
+    # TEMPORARY (revert before merging the codex profile): escape hatch used
+    # to A/B `/compact` vs. LLM summarization on the same codex model. When set,
+    # the codex profile is forced onto the default summarization path so the
+    # two arms differ only in compaction strategy.
+    if profile.use_codex_compaction and not os.environ.get("DEEPAGENTS_DISABLE_CODEX_COMPACTION"):
         return CodexCompactionMiddleware(model, backend)
     return create_summarization_middleware(model, backend)
 

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -29,6 +29,7 @@ from deepagents._models import get_model_identifier, get_model_provider, resolve
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
+from deepagents.middleware._tool_aliasing import _ToolAliasingMiddleware
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -458,6 +459,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # Strip excluded tools after all tool-injecting middleware has run
     if _profile.excluded_tools:
         gp_middleware.append(_ToolExclusionMiddleware(excluded=_profile.excluded_tools))
+    # Rename tools for models trained on different tool names (innermost wrap_model_call)
+    if _profile.tool_aliases:
+        gp_middleware.append(_ToolAliasingMiddleware(aliases=_profile.tool_aliases))
     # Prompt caching is unconditional: "ignore" silently skips non-Anthropic models
     gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
@@ -515,6 +519,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagent_middleware.extend(_resolve_extra_middleware(_subagent_profile))
             if _subagent_profile.excluded_tools:
                 subagent_middleware.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
+            if _subagent_profile.tool_aliases:
+                subagent_middleware.append(_ToolAliasingMiddleware(aliases=_subagent_profile.tool_aliases))
 
             # Prompt caching
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
@@ -587,6 +593,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     deepagent_middleware.extend(_resolve_extra_middleware(_profile))
     if _profile.excluded_tools:
         deepagent_middleware.append(_ToolExclusionMiddleware(excluded=_profile.excluded_tools))
+    if _profile.tool_aliases:
+        deepagent_middleware.append(_ToolAliasingMiddleware(aliases=_profile.tool_aliases))
     # Unconditional prompt caching (see general-purpose subagent comment).
     deepagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     if memory is not None:

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -156,6 +156,14 @@ def _harness_profile_for_model(model: BaseChatModel, spec: str | None) -> _Harne
     # Bare model name (no colon) — fall back to provider from the model class.
     provider = get_model_provider(model)
     if provider is not None:
+        # Reconstruct a qualified spec (e.g. "openai:gpt-5.3-codex") so that
+        # per-model profiles registered under the full spec are found even when
+        # the caller passed a pre-built model instance (bare identifier only).
+        if identifier is not None and ":" not in identifier:
+            qualified = f"{provider}:{identifier}"
+            profile = _get_harness_profile(qualified)
+            if profile != _HarnessProfile():
+                return profile
         return _get_harness_profile(provider)
     logger.debug("No harness profile found for pre-built model %s, using defaults", type(model).__name__)
     return _HarnessProfile()

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -48,6 +48,7 @@ Use a **plain tool** when:
 """
 
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.codex_compaction import CodexCompactionMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.permissions import FilesystemPermission
@@ -62,6 +63,7 @@ from deepagents.middleware.summarization import (
 __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
+    "CodexCompactionMiddleware",
     "CompiledSubAgent",
     "FilesystemMiddleware",
     "FilesystemPermission",

--- a/libs/deepagents/deepagents/middleware/_tool_aliasing.py
+++ b/libs/deepagents/deepagents/middleware/_tool_aliasing.py
@@ -75,8 +75,9 @@ def _rename_tool(
         copied = cast("dict[str, Any]", tool).copy()
         copied["name"] = new_name
         return copied
-    if hasattr(tool, "model_copy"):
-        return tool.model_copy(update={"name": new_name})
+    model_copy = getattr(tool, "model_copy", None)
+    if model_copy is not None:
+        return model_copy(update={"name": new_name})
     logger.warning(
         "Tool %r matched alias target %r but cannot be renamed (no "
         "`model_copy` support and not a dict). Model will see the original "
@@ -106,7 +107,7 @@ def _rewrite_ai_message_tool_calls(
             rewritten.append({**tc, "name": aliases[tc["name"]]})
             changed = True
         else:
-            rewritten.append(tc)
+            rewritten.append(cast("dict[str, Any]", tc))
 
     rewritten_invalid: list[dict[str, Any]] = []
     for tc in message.invalid_tool_calls:
@@ -114,7 +115,7 @@ def _rewrite_ai_message_tool_calls(
             rewritten_invalid.append({**tc, "name": aliases[tc["name"]]})
             changed = True
         else:
-            rewritten_invalid.append(tc)
+            rewritten_invalid.append(cast("dict[str, Any]", tc))
 
     if not changed:
         return message
@@ -191,7 +192,7 @@ def _rewrite_response_tool_names(
     if isinstance(result_msgs, list):
         new_msgs, changed = _rewrite_message_list(result_msgs, aliases)
         if changed:
-            return replace(response, result=new_msgs)
+            return replace(cast("Any", response), result=new_msgs)
         return response
 
     # ExtendedModelResponse: wraps a ModelResponse in .model_response
@@ -201,7 +202,10 @@ def _rewrite_response_tool_names(
         if isinstance(inner_msgs, list):
             new_msgs, changed = _rewrite_message_list(inner_msgs, aliases)
             if changed:
-                return replace(response, model_response=replace(inner, result=new_msgs))
+                return replace(
+                    cast("Any", response),
+                    model_response=replace(cast("Any", inner), result=new_msgs),
+                )
         return response
 
     return response

--- a/libs/deepagents/deepagents/middleware/_tool_aliasing.py
+++ b/libs/deepagents/deepagents/middleware/_tool_aliasing.py
@@ -1,20 +1,47 @@
 """Middleware for renaming tools at the model boundary.
 
-Renames tools in the outbound model request (canonical → alias) and reverts
-tool-call names in the inbound response (alias → canonical), keeping all other
-middleware and tool routing on canonical Deep Agents names.
+Translates tool names at the model boundary so the model sees its training
+vocabulary while the rest of the Deep Agents stack (state, routing, permissions,
+HITL, logging, tests) stays on canonical names.
 
-Positioning: should be placed late in the middleware stack (after
-``_ToolExclusionMiddleware``) so it is the innermost ``wrap_model_call``.
+## Outbound (canonical → alias)
+
+Rewrites, in order:
+
+1. ``request.tools`` — the current tool catalog (``execute`` → ``shell_command``).
+2. ``AIMessage.tool_calls`` and ``AIMessage.invalid_tool_calls`` in
+   ``request.messages`` — past tool calls in conversation history.
+3. ``ToolMessage.name`` in ``request.messages`` — tool result messages from
+   prior turns.
+
+Steps 2 and 3 are what give the model a consistent vocabulary across turns.
+If we only renamed the tool catalog and left history on canonical names, the
+model would see an unfamiliar name for the tool it supposedly called last turn
+— the very distribution mismatch this middleware exists to avoid.
+
+## Inbound (alias → canonical)
+
+Rewrites tool-call names in the response (``AIMessage`` directly,
+``ModelResponse.result``, or ``ExtendedModelResponse.model_response.result``)
+so downstream tool routing and state persistence see canonical names only.
+
+## Positioning
+
+Should be placed late in the middleware stack (after
+``_ToolExclusionMiddleware``) so it is the innermost *name-aware* transform.
+Any later middleware must be name-agnostic — e.g. ``AnthropicPromptCachingMiddleware``
+adds only positional cache markers and is not affected by rename order.
 """
 
 from __future__ import annotations
 
+import logging
+from collections import Counter
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain.agents.middleware.types import AgentMiddleware
-from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 
 from deepagents.middleware._tool_exclusion import _tool_name
 
@@ -29,16 +56,20 @@ if TYPE_CHECKING:
     )
     from langchain_core.tools import BaseTool
 
+logger = logging.getLogger(__name__)
+
 
 def _rename_tool(
     tool: BaseTool | dict[str, Any] | object,
     new_name: str,
 ) -> BaseTool | dict[str, Any] | object:
-    """Return a shallow copy of *tool* with its name replaced.
+    """Return a copy of *tool* with its name replaced.
 
     ``BaseTool`` instances are copied via ``model_copy``; dict tools get a
-    shallow ``dict.copy()``; other types (plain callables) are returned
-    unchanged.
+    shallow ``dict.copy()``; other shapes (plain callables, unusual custom
+    tool classes without ``model_copy``) cannot be renamed and are returned
+    unchanged with a warning — the model will see the tool under its
+    original name, which defeats the point of aliasing for that entry.
     """
     if isinstance(tool, dict):
         copied = cast("dict[str, Any]", tool).copy()
@@ -46,6 +77,13 @@ def _rename_tool(
         return copied
     if hasattr(tool, "model_copy"):
         return tool.model_copy(update={"name": new_name})
+    logger.warning(
+        "Tool %r matched alias target %r but cannot be renamed (no "
+        "`model_copy` support and not a dict). Model will see the original "
+        "name; this may degrade performance on models trained on the alias.",
+        getattr(tool, "name", tool),
+        new_name,
+    )
     return tool
 
 
@@ -86,24 +124,48 @@ def _rewrite_ai_message_tool_calls(
     )
 
 
+def _rewrite_tool_message_name(
+    message: ToolMessage,
+    aliases: dict[str, str],
+) -> ToolMessage:
+    """Rewrite ``ToolMessage.name`` per *aliases*, returning a copy.
+
+    If the name is absent or not in the alias map the original message is
+    returned unchanged (no copy).
+    """
+    name = message.name
+    if name is None or name not in aliases:
+        return message
+    return message.model_copy(update={"name": aliases[name]})
+
+
 def _rewrite_message_list(
     messages: list[BaseMessage],
     aliases: dict[str, str],
 ) -> tuple[list[BaseMessage], bool]:
-    """Rewrite tool-call names in a list of messages.
+    """Rewrite tool-related names in a list of messages.
 
-    Returns the (possibly new) list and whether any change was made.
+    Rewrites both ``AIMessage.tool_calls`` (plus ``invalid_tool_calls``) and
+    ``ToolMessage.name`` using *aliases*. Other message types pass through
+    unchanged.
+
+    Returns the (possibly new) list and whether any change was made. When
+    nothing changed the list is returned unchanged object-identity-wise,
+    allowing callers to skip ``request.override`` entirely.
     """
     changed = False
     result: list[BaseMessage] = []
     for msg in messages:
         if isinstance(msg, AIMessage):
-            rewritten = _rewrite_ai_message_tool_calls(msg, aliases)
-            if rewritten is not msg:
-                changed = True
-            result.append(rewritten)
+            rewritten: BaseMessage = _rewrite_ai_message_tool_calls(msg, aliases)
+        elif isinstance(msg, ToolMessage):
+            rewritten = _rewrite_tool_message_name(msg, aliases)
         else:
             result.append(msg)
+            continue
+        if rewritten is not msg:
+            changed = True
+        result.append(rewritten)
     return result, changed
 
 
@@ -145,56 +207,129 @@ def _rewrite_response_tool_names(
     return response
 
 
+def _validate_aliases(aliases: dict[str, str]) -> None:
+    """Validate that an alias map is safe to round-trip.
+
+    Two invariants are enforced:
+
+    1. **Injective values.** If two canonical names mapped to the same alias,
+       the reverse map would silently drop one entry and a round-tripped tool
+       call would resolve to the wrong canonical tool.
+    2. **Disjoint keys and values.** If a canonical name also appears as an
+       alias for a different canonical tool, the model's tool catalog would
+       contain a name that is simultaneously a canonical identifier elsewhere
+       in the system, and round-tripping becomes ambiguous.
+
+    Args:
+        aliases: The canonical → alias map.
+
+    Raises:
+        ValueError: If either invariant is violated. Empty maps pass.
+    """
+    if not aliases:
+        return
+
+    value_counts = Counter(aliases.values())
+    duplicates = sorted(v for v, count in value_counts.items() if count > 1)
+    if duplicates:
+        msg = f"Tool alias values must be unique so the reverse map is well-defined. Duplicate alias targets: {duplicates}. Aliases: {aliases}"
+        raise ValueError(msg)
+
+    collisions = sorted(set(aliases.keys()) & set(aliases.values()))
+    if collisions:
+        msg = (
+            "Tool alias keys and values must be disjoint — a name cannot be "
+            "both a canonical tool and an alias for a different tool. "
+            f"Collisions: {collisions}. Aliases: {aliases}"
+        )
+        raise ValueError(msg)
+
+
 class _ToolAliasingMiddleware(AgentMiddleware[Any, Any, Any]):
     """Rename tools at the model boundary for better model-distribution fit.
 
-    Placed as the innermost ``wrap_model_call`` so all other middleware
+    Placed late in the middleware stack so that all name-aware middleware
     (permissions, HITL, summarization, tool exclusion) continues to see
-    canonical Deep Agents tool names.
+    canonical Deep Agents tool names. The translation is symmetric: on the
+    way out, both the tool catalog and any past tool calls / tool messages
+    in ``request.messages`` are rewritten canonical → alias; on the way in,
+    tool-call names in the response are reverted alias → canonical.
 
     Args:
         aliases: Mapping of canonical tool name to model-facing alias
             (e.g. ``{"execute": "shell_command"}``).
+
+    Raises:
+        ValueError: If *aliases* has duplicate values or keys/values overlap.
+            See :func:`_validate_aliases`.
     """
 
     def __init__(self, *, aliases: dict[str, str]) -> None:
+        _validate_aliases(aliases)
         self._forward = aliases
         self._reverse = {v: k for k, v in aliases.items()}
+
+    def _apply_outbound(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        """Translate tool catalog and message history canonical → alias.
+
+        Returns the original request unchanged when the alias map is empty
+        or no tool/message actually needed renaming, so request identity is
+        preserved for downstream cache keys when aliasing is a no-op.
+        """
+        if not self._forward:
+            return request
+
+        renamed_tools: list[Any] = []
+        tools_changed = False
+        for tool in request.tools:
+            name = _tool_name(tool)
+            if name is not None and name in self._forward:
+                renamed_tools.append(_rename_tool(tool, self._forward[name]))
+                tools_changed = True
+            else:
+                renamed_tools.append(tool)
+
+        new_messages, messages_changed = _rewrite_message_list(list(request.messages), self._forward)
+
+        if not tools_changed and not messages_changed:
+            return request
+
+        overrides: dict[str, Any] = {}
+        if tools_changed:
+            overrides["tools"] = renamed_tools
+        if messages_changed:
+            overrides["messages"] = new_messages
+        return request.override(**overrides)
+
+    def _apply_inbound(
+        self,
+        response: ModelResponse[Any] | AIMessage | ExtendedModelResponse[Any],
+    ) -> ModelResponse[Any] | AIMessage | ExtendedModelResponse[Any]:
+        """Translate response tool-call names alias → canonical."""
+        if not self._reverse:
+            return response
+        return cast(
+            "ModelResponse[Any] | AIMessage | ExtendedModelResponse[Any]",
+            _rewrite_response_tool_names(response, self._reverse),
+        )
 
     def wrap_model_call(
         self,
         request: ModelRequest[Any],
         handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
     ) -> ModelResponse[Any]:
-        """Rename tools outbound, revert tool-call names inbound."""
-        if self._forward:
-            renamed = [
-                _rename_tool(t, self._forward[name])
-                if (name := _tool_name(t)) and name in self._forward
-                else t
-                for t in request.tools
-            ]
-            request = request.override(tools=renamed)
-        response = handler(request)
-        if self._reverse:
-            response = _rewrite_response_tool_names(response, self._reverse)
-        return response
+        """Rename tools and history outbound, revert tool-call names inbound."""
+        response = handler(self._apply_outbound(request))
+        return cast("ModelResponse[Any]", self._apply_inbound(response))
 
     async def awrap_model_call(
         self,
         request: ModelRequest[Any],
         handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[ResponseT]]],
     ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
-        """Async variant of ``wrap_model_call``."""
-        if self._forward:
-            renamed = [
-                _rename_tool(t, self._forward[name])
-                if (name := _tool_name(t)) and name in self._forward
-                else t
-                for t in request.tools
-            ]
-            request = request.override(tools=renamed)
-        response = await handler(request)
-        if self._reverse:
-            response = _rewrite_response_tool_names(response, self._reverse)
-        return response
+        """Async variant of :meth:`wrap_model_call`."""
+        response = await handler(self._apply_outbound(request))
+        return cast(
+            "ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]",
+            self._apply_inbound(response),
+        )

--- a/libs/deepagents/deepagents/middleware/_tool_aliasing.py
+++ b/libs/deepagents/deepagents/middleware/_tool_aliasing.py
@@ -1,0 +1,160 @@
+"""Middleware for renaming tools at the model boundary.
+
+Renames tools in the outbound model request (canonical → alias) and reverts
+tool-call names in the inbound response (alias → canonical), keeping all other
+middleware and tool routing on canonical Deep Agents names.
+
+Positioning: should be placed late in the middleware stack (after
+``_ToolExclusionMiddleware``) so it is the innermost ``wrap_model_call``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage
+
+from deepagents.middleware._tool_exclusion import _tool_name
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import (
+        ExtendedModelResponse,
+        ModelRequest,
+        ModelResponse,
+        ResponseT,
+    )
+    from langchain_core.tools import BaseTool
+
+
+def _rename_tool(
+    tool: BaseTool | dict[str, Any] | object,
+    new_name: str,
+) -> BaseTool | dict[str, Any] | object:
+    """Return a shallow copy of *tool* with its name replaced.
+
+    ``BaseTool`` instances are copied via ``model_copy``; dict tools get a
+    shallow ``dict.copy()``; other types (plain callables) are returned
+    unchanged.
+    """
+    if isinstance(tool, dict):
+        copied = cast("dict[str, Any]", tool).copy()
+        copied["name"] = new_name
+        return copied
+    if hasattr(tool, "model_copy"):
+        return tool.model_copy(update={"name": new_name})
+    return tool
+
+
+def _rewrite_ai_message_tool_calls(
+    message: AIMessage,
+    aliases: dict[str, str],
+) -> AIMessage:
+    """Rewrite tool-call names in *message* per *aliases*, returning a copy.
+
+    If no tool calls match the alias map the original message is returned
+    (no copy).
+    """
+    if not message.tool_calls and not message.invalid_tool_calls:
+        return message
+
+    changed = False
+    rewritten: list[dict[str, Any]] = []
+    for tc in message.tool_calls:
+        if tc["name"] in aliases:
+            rewritten.append({**tc, "name": aliases[tc["name"]]})
+            changed = True
+        else:
+            rewritten.append(tc)
+
+    rewritten_invalid: list[dict[str, Any]] = []
+    for tc in message.invalid_tool_calls:
+        if tc["name"] in aliases:
+            rewritten_invalid.append({**tc, "name": aliases[tc["name"]]})
+            changed = True
+        else:
+            rewritten_invalid.append(tc)
+
+    if not changed:
+        return message
+
+    return message.model_copy(
+        update={"tool_calls": rewritten, "invalid_tool_calls": rewritten_invalid},
+    )
+
+
+def _rewrite_response_tool_names(
+    response: object,  # ModelResponse | AIMessage | ExtendedModelResponse
+    aliases: dict[str, str],
+) -> object:
+    """Rewrite tool-call names in a model response using *aliases*.
+
+    Handles ``AIMessage`` directly and ``ExtendedModelResponse`` (which wraps
+    an ``AIMessage`` in its ``.message`` attribute).  Other response types are
+    returned unchanged.
+    """
+    if isinstance(response, AIMessage):
+        return _rewrite_ai_message_tool_calls(response, aliases)
+    msg = getattr(response, "message", None)
+    if isinstance(msg, AIMessage):
+        rewritten = _rewrite_ai_message_tool_calls(msg, aliases)
+        if rewritten is not msg:
+            return response.model_copy(update={"message": rewritten})
+    return response
+
+
+class _ToolAliasingMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Rename tools at the model boundary for better model-distribution fit.
+
+    Placed as the innermost ``wrap_model_call`` so all other middleware
+    (permissions, HITL, summarization, tool exclusion) continues to see
+    canonical Deep Agents tool names.
+
+    Args:
+        aliases: Mapping of canonical tool name to model-facing alias
+            (e.g. ``{"execute": "shell_command"}``).
+    """
+
+    def __init__(self, *, aliases: dict[str, str]) -> None:
+        self._forward = aliases
+        self._reverse = {v: k for k, v in aliases.items()}
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Rename tools outbound, revert tool-call names inbound."""
+        if self._forward:
+            renamed = [
+                _rename_tool(t, self._forward[name])
+                if (name := _tool_name(t)) and name in self._forward
+                else t
+                for t in request.tools
+            ]
+            request = request.override(tools=renamed)
+        response = handler(request)
+        if self._reverse:
+            response = _rewrite_response_tool_names(response, self._reverse)
+        return response
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
+        """Async variant of ``wrap_model_call``."""
+        if self._forward:
+            renamed = [
+                _rename_tool(t, self._forward[name])
+                if (name := _tool_name(t)) and name in self._forward
+                else t
+                for t in request.tools
+            ]
+            request = request.override(tools=renamed)
+        response = await handler(request)
+        if self._reverse:
+            response = _rewrite_response_tool_names(response, self._reverse)
+        return response

--- a/libs/deepagents/deepagents/middleware/_tool_aliasing.py
+++ b/libs/deepagents/deepagents/middleware/_tool_aliasing.py
@@ -10,10 +10,11 @@ Positioning: should be placed late in the middleware stack (after
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain.agents.middleware.types import AgentMiddleware
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, BaseMessage
 
 from deepagents.middleware._tool_exclusion import _tool_name
 
@@ -85,23 +86,62 @@ def _rewrite_ai_message_tool_calls(
     )
 
 
+def _rewrite_message_list(
+    messages: list[BaseMessage],
+    aliases: dict[str, str],
+) -> tuple[list[BaseMessage], bool]:
+    """Rewrite tool-call names in a list of messages.
+
+    Returns the (possibly new) list and whether any change was made.
+    """
+    changed = False
+    result: list[BaseMessage] = []
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            rewritten = _rewrite_ai_message_tool_calls(msg, aliases)
+            if rewritten is not msg:
+                changed = True
+            result.append(rewritten)
+        else:
+            result.append(msg)
+    return result, changed
+
+
 def _rewrite_response_tool_names(
     response: object,  # ModelResponse | AIMessage | ExtendedModelResponse
     aliases: dict[str, str],
 ) -> object:
     """Rewrite tool-call names in a model response using *aliases*.
 
-    Handles ``AIMessage`` directly and ``ExtendedModelResponse`` (which wraps
-    an ``AIMessage`` in its ``.message`` attribute).  Other response types are
-    returned unchanged.
+    Handles:
+    - ``AIMessage`` directly (bare message).
+    - ``ModelResponse`` (has ``.result: list[BaseMessage]``).
+    - ``ExtendedModelResponse`` (wraps a ``ModelResponse`` in
+      ``.model_response``).
+
+    Other response types are returned unchanged.
     """
     if isinstance(response, AIMessage):
         return _rewrite_ai_message_tool_calls(response, aliases)
-    msg = getattr(response, "message", None)
-    if isinstance(msg, AIMessage):
-        rewritten = _rewrite_ai_message_tool_calls(msg, aliases)
-        if rewritten is not msg:
-            return response.model_copy(update={"message": rewritten})
+
+    # ModelResponse: dataclass with .result list
+    result_msgs = getattr(response, "result", None)
+    if isinstance(result_msgs, list):
+        new_msgs, changed = _rewrite_message_list(result_msgs, aliases)
+        if changed:
+            return replace(response, result=new_msgs)
+        return response
+
+    # ExtendedModelResponse: wraps a ModelResponse in .model_response
+    inner = getattr(response, "model_response", None)
+    if inner is not None:
+        inner_msgs = getattr(inner, "result", None)
+        if isinstance(inner_msgs, list):
+            new_msgs, changed = _rewrite_message_list(inner_msgs, aliases)
+            if changed:
+                return replace(response, model_response=replace(inner, result=new_msgs))
+        return response
+
     return response
 
 

--- a/libs/deepagents/deepagents/middleware/codex_compaction.py
+++ b/libs/deepagents/deepagents/middleware/codex_compaction.py
@@ -36,13 +36,30 @@ via the standard LangGraph update mechanism:
 {
     "cutoff_index": int,  # absolute index in state messages
     "output": list[dict],  # /compact output items (model_dump'd)
-    "file_path": str | None,  # backend path for offloaded history
+    "file_path": str,  # backend path for offloaded history (non-null)
 }
 ```
 
-The ``_summarization_event`` key from the inner middleware is orthogonal. If a
-thread switches profiles mid-run, one of the two keys may become stale but
-neither is removed — both remain safe no-ops when inapplicable.
+### Mutual exclusion with ``_summarization_event``
+
+``codex_compaction_item`` and the inner middleware's ``_summarization_event``
+are **mutually exclusive**: at most one is live in state at a time. Whenever a
+successful compaction commits ``codex_compaction_item`` it also clears
+``_summarization_event``; whenever the fallback path commits
+``_summarization_event`` it also clears ``codex_compaction_item``. This
+prevents a subtle correctness bug where a mid-conversation switch between the
+two paths leaves both keys set and each path silently ignores the other's
+state, producing duplicated or dropped context on subsequent turns.
+
+## Recovery invariant
+
+A compaction event is only committed when BOTH the ``/compact`` call and the
+offload-to-backend step succeed. If the ``/compact`` call succeeds but offload
+fails, the event is **not** committed and the turn falls back to LLM
+summarization. This guarantees that every persisted ``codex_compaction_item``
+has a recoverable transcript file in the backend — without this invariant, a
+failed offload would leave users with an opaque blob and no way to retrieve
+the raw pre-compaction messages.
 
 ## Phase metadata
 
@@ -55,7 +72,6 @@ continues to lift ``block["phase"]`` onto the outbound input item.
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import TYPE_CHECKING, Annotated, Any, NotRequired
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
@@ -63,6 +79,7 @@ from langchain_core.messages import AIMessage, AnyMessage, BaseMessage
 from langgraph.types import Command
 from typing_extensions import TypedDict
 
+from deepagents._models import get_model_identifier
 from deepagents.middleware.summarization import (
     _DeepAgentsSummarizationMiddleware,
     create_summarization_middleware,
@@ -92,6 +109,11 @@ to trip the LLM-summarization fallback if the endpoint hangs.
 class _CodexCompactionEvent(TypedDict):
     """Event payload persisted in state after a successful `/compact` call.
 
+    A compaction event is only committed when both the ``/compact`` call and
+    the offload-to-backend step succeed, so every event carries a recoverable
+    backend path. ``file_path`` is typed permissively to tolerate legacy state
+    written by older versions of this middleware.
+
     Attributes:
         cutoff_index: Absolute index in state messages where compaction
             occurred. Messages before this index are superseded by the
@@ -101,7 +123,8 @@ class _CodexCompactionEvent(TypedDict):
             back to Responses input items via
             ``_construct_responses_api_input``.
         file_path: Backend path where the pre-compaction messages were
-            offloaded, or ``None`` if offload failed.
+            offloaded. Expected to be non-null for events committed by this
+            version; ``None`` may appear in legacy state from older versions.
     """
 
     cutoff_index: int
@@ -125,6 +148,31 @@ class CodexCompactionMiddleware(AgentMiddleware):
 
     Composes a ``_DeepAgentsSummarizationMiddleware`` for all non-compaction
     concerns (arg truncation, offload, partitioning, thread ID, fallback).
+
+    ### Inner-middleware contract
+
+    This class reaches into the composed ``_DeepAgentsSummarizationMiddleware``
+    for the following helpers; they must remain stable or this middleware
+    breaks silently:
+
+    - ``token_counter`` (public)
+    - ``_truncate_args``
+    - ``_should_summarize``
+    - ``_determine_cutoff_index``
+    - ``_partition_messages``
+    - ``_get_backend``
+    - ``_aoffload_to_backend``
+    - ``awrap_model_call`` (as the fallback entry point)
+
+    If you rename or change the signature of any of these, update this class
+    in lockstep.
+
+    ### Client configuration
+
+    For custom OpenAI configuration (``base_url``, proxy, custom API key,
+    etc.), construct the middleware manually and pass a pre-configured
+    ``AsyncOpenAI`` client. The standard wiring in ``graph.py`` does not
+    expose client configuration through the harness profile.
 
     Args:
         model: Resolved chat model instance. Must be an OpenAI model that
@@ -159,6 +207,7 @@ class CodexCompactionMiddleware(AgentMiddleware):
         self._model = model
         self._inner: _DeepAgentsSummarizationMiddleware = create_summarization_middleware(model, backend)
         self._client = client
+        self._sync_warned = False
 
     # ------------------------------------------------------------------
     # Helpers
@@ -175,18 +224,25 @@ class CodexCompactionMiddleware(AgentMiddleware):
     def _resolve_model_name(self) -> str:
         """Extract the OpenAI model identifier from the resolved chat model.
 
+        Delegates to `get_model_identifier`, which reads ``model_dump()`` and
+        therefore works for wrapped/bound models (e.g. ``RunnableBinding``
+        from ``.bind_tools()``) that ``getattr`` would miss. If the returned
+        identifier is qualified with a provider prefix (``"openai:gpt-X"``),
+        strip the prefix — the `/compact` endpoint expects the bare provider
+        identifier.
+
         Raises:
             RuntimeError: If no model name can be discovered. This is a
                 configuration error — compaction requires an OpenAI model.
         """
-        for attr in ("model_name", "model"):
-            value = getattr(self._model, attr, None)
-            if isinstance(value, str) and value:
-                return value
+        identifier = get_model_identifier(self._model)
+        if identifier:
+            return identifier.split(":", 1)[-1]
         msg = (
             "CodexCompactionMiddleware could not determine the OpenAI model "
             f"name from {type(self._model).__name__}. Configure the profile "
-            "with a ChatOpenAI instance."
+            "with a ChatOpenAI instance (or a compatible model that exposes "
+            "`model_name` or `model` via `model_dump()`)."
         )
         raise RuntimeError(msg)
 
@@ -314,6 +370,42 @@ class CodexCompactionMiddleware(AgentMiddleware):
         )
         return [item.model_dump(exclude_none=True, mode="json") for item in result.output]
 
+    async def _fall_back_to_summarization(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse | ExtendedModelResponse:
+        """Delegate to the inner summarization middleware and maintain mutual exclusion.
+
+        When the inner middleware commits a ``_summarization_event`` we must
+        clear any stale ``codex_compaction_item`` in the same state update, so
+        the two keys never coexist. If the inner returns a plain
+        ``ModelResponse`` (no summarization happened this turn), any existing
+        ``codex_compaction_item`` is still structurally valid — the raw
+        messages behind the old cutoff are unchanged — so we pass the
+        response through untouched.
+
+        Args:
+            request: Original request, forwarded unchanged.
+            handler: Downstream handler.
+
+        Returns:
+            The inner middleware's response, with a ``codex_compaction_item:
+            None`` clear merged into the command when the inner committed a
+            summarization event.
+        """
+        result = await self._inner.awrap_model_call(request, handler)
+        if not isinstance(result, ExtendedModelResponse):
+            return result
+        existing_update: dict[str, Any] = {}
+        if result.command is not None and result.command.update:
+            existing_update.update(result.command.update)
+        existing_update["codex_compaction_item"] = None
+        return ExtendedModelResponse(
+            model_response=result.model_response,
+            command=Command(update=existing_update),
+        )
+
     # ------------------------------------------------------------------
     # Main entry point
     # ------------------------------------------------------------------
@@ -329,10 +421,11 @@ class CodexCompactionMiddleware(AgentMiddleware):
         2. Delegate tool-call arg truncation to the inner middleware.
         3. If under the compaction trigger, forward unchanged.
         4. If over the trigger, call `/compact`:
-            - On success, rebuild state with a new compaction event and a
-                synthetic head message.
-            - On failure, delegate the full turn to the inner summarization
-                middleware (LLM-based fallback).
+            - On success AND successful offload, commit a new compaction event
+                (clearing any stale ``_summarization_event``).
+            - On `/compact` API failure OR offload failure, delegate the full
+                turn to the inner summarization middleware (LLM-based
+                fallback), clearing any stale ``codex_compaction_item``.
 
         Args:
             request: Incoming model request from LangGraph.
@@ -342,7 +435,8 @@ class CodexCompactionMiddleware(AgentMiddleware):
         Returns:
             A plain `ModelResponse` when no compaction happens this turn, or
                 an `ExtendedModelResponse` whose command updates
-                ``codex_compaction_item`` in state.
+                ``codex_compaction_item`` in state and clears
+                ``_summarization_event``.
         """
         inner = self._inner
 
@@ -369,24 +463,38 @@ class CodexCompactionMiddleware(AgentMiddleware):
         backend = inner._get_backend(request.state, request.runtime)
 
         # Sequence compact before offload: if ``/compact`` fails, we delegate
-        # the whole turn to ``inner.awrap_model_call`` which performs its own
-        # offload. Running the wrapper's offload in parallel (or before the
-        # fallback) would append the same pre-compaction window to the
-        # history file twice.
+        # the whole turn to the fallback helper, which invokes
+        # ``inner.awrap_model_call`` and performs its own offload. Running
+        # the wrapper's offload in parallel (or before the fallback) would
+        # append the same pre-compaction window to the history file twice.
         try:
             compact_output_items = await self._do_compact(to_compact)
-        except Exception:
+        except Exception as exc:
+            # Only absorb OpenAI SDK errors (rate limits, timeouts, 5xx, etc.)
+            # Programming errors (AttributeError, KeyError, ImportError) must
+            # surface loudly rather than hide behind the summarization
+            # fallback, which would silently mask real bugs.
+            from openai import APIError  # noqa: PLC0415
+
+            if not isinstance(exc, APIError):
+                raise
             logger.exception(
                 "Codex /compact call failed; falling back to LLM summarization",
             )
-            return await inner.awrap_model_call(request, handler)
+            return await self._fall_back_to_summarization(request, handler)
 
         file_path = await inner._aoffload_to_backend(backend, to_compact)
 
+        # Recovery invariant: only commit a compaction event if the transcript
+        # was also offloaded. A persisted compaction event without a backing
+        # file leaves users with an opaque blob and no recoverable history.
+        # Fall back to LLM summarization, which produces human-readable
+        # summary content and retries the offload on its own path.
         if file_path is None:
-            msg = "Offloading conversation history to backend failed during Codex compaction. Older messages will not be recoverable."
-            logger.error(msg)
-            warnings.warn(msg, stacklevel=2)
+            logger.error(
+                "Offload to backend failed after /compact succeeded; falling back to LLM summarization to preserve recoverable state.",
+            )
+            return await self._fall_back_to_summarization(request, handler)
 
         state_cutoff_index = self._compute_state_cutoff(prior_event, effective_cutoff)
         new_event: _CodexCompactionEvent = {
@@ -399,9 +507,17 @@ class CodexCompactionMiddleware(AgentMiddleware):
         modified_messages: list[BaseMessage] = [compaction_head, *preserved]
         response = await handler(request.override(messages=modified_messages))
 
+        # Mutual-exclusion: clearing ``_summarization_event`` ensures any
+        # stale state from a prior fallback turn does not coexist with the
+        # new compaction event. See module docstring for the invariant.
         return ExtendedModelResponse(
             model_response=response,
-            command=Command(update={"codex_compaction_item": new_event}),
+            command=Command(
+                update={
+                    "codex_compaction_item": new_event,
+                    "_summarization_event": None,
+                },
+            ),
         )
 
     def wrap_model_call(
@@ -412,8 +528,10 @@ class CodexCompactionMiddleware(AgentMiddleware):
         """Synchronous entry point — unsupported for compaction.
 
         The `/compact` endpoint is async-only via the OpenAI SDK. Sync callers
-        should not be common on the Codex path, but for safety we fall back
-        entirely to the inner summarization middleware's sync path.
+        on the Codex profile silently downgrade to LLM summarization via the
+        inner middleware's sync path. We emit a one-shot warning per
+        middleware instance so this downgrade is discoverable rather than
+        invisible.
 
         Args:
             request: Incoming model request.
@@ -422,4 +540,12 @@ class CodexCompactionMiddleware(AgentMiddleware):
         Returns:
             Whatever the inner summarization middleware returns.
         """
+        if not self._sync_warned:
+            logger.warning(
+                "CodexCompactionMiddleware was invoked synchronously; the "
+                "/compact endpoint is async-only. Falling back to LLM "
+                "summarization for all sync calls on this instance. Use the "
+                "async agent entry points to get true compaction behavior.",
+            )
+            self._sync_warned = True
         return self._inner.wrap_model_call(request, handler)

--- a/libs/deepagents/deepagents/middleware/codex_compaction.py
+++ b/libs/deepagents/deepagents/middleware/codex_compaction.py
@@ -1,0 +1,425 @@
+"""Codex-specific compaction middleware using the OpenAI Responses `/compact` endpoint.
+
+This middleware is a drop-in replacement for `SummarizationMiddleware` when the
+active harness profile sets ``use_codex_compaction=True`` (currently the Codex
+family — ``gpt-5.2-codex``, ``gpt-5.3-codex``).
+
+## What is compaction?
+
+Instead of generating an LLM-authored text summary of older turns (the default
+``SummarizationMiddleware`` behavior), compaction calls OpenAI's
+``/responses/compact`` endpoint, which returns an opaque ``encrypted_content``
+item. That item round-trips through the Responses API on subsequent turns and
+preserves procedural detail (tool-call sequencing, reasoning, phase metadata)
+that ad-hoc text summarization loses.
+
+Trade-off: the compaction item is opaque and only usable within OpenAI's
+Responses API. If the API call fails for any reason, this middleware falls
+back transparently to LLM-based summarization via an internal
+``_DeepAgentsSummarizationMiddleware`` instance.
+
+## Composition, not duplication
+
+Rather than re-implement trigger thresholds, arg truncation, offload,
+partitioning, and thread-ID resolution, this class **composes** a
+``_DeepAgentsSummarizationMiddleware`` (via ``create_summarization_middleware``)
+and delegates to it for everything except the ``/compact`` call itself. This
+preserves Deep Agents-level behaviors (especially tool-call arg truncation)
+that would otherwise be silently lost on Codex.
+
+## State contract
+
+Adds ``codex_compaction_item`` to agent state — a dict persisted across turns
+via the standard LangGraph update mechanism:
+
+```python
+{
+    "cutoff_index": int,  # absolute index in state messages
+    "output": list[dict],  # /compact output items (model_dump'd)
+    "file_path": str | None,  # backend path for offloaded history
+}
+```
+
+The ``_summarization_event`` key from the inner middleware is orthogonal. If a
+thread switches profiles mid-run, one of the two keys may become stale but
+neither is removed — both remain safe no-ops when inapplicable.
+
+## Phase metadata
+
+Phase round-tripping lives entirely in ``langchain-openai`` ``>=1.1.12``; this
+middleware does not touch the field. The drift-guard unit test in
+``test_codex_compaction.py`` confirms that ``_construct_responses_api_input``
+continues to lift ``block["phase"]`` onto the outbound input item.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired
+
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage
+from langgraph.types import Command
+from typing_extensions import TypedDict
+
+from deepagents.middleware.summarization import (
+    _DeepAgentsSummarizationMiddleware,
+    create_summarization_middleware,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+    from langchain_core.language_models import BaseChatModel
+    from openai import AsyncOpenAI
+
+    from deepagents.backends.protocol import BACKEND_TYPES
+
+logger = logging.getLogger(__name__)
+
+_COMPACT_TIMEOUT_SECONDS: float = 180.0
+"""Per-call timeout for ``/compact`` requests, in seconds.
+
+Compacting a large context window is a real model invocation and can take a
+while, but a runaway call must not stall a user turn. 180s is generous enough
+to cover large (~200k token) windows on Codex while still failing fast enough
+to trip the LLM-summarization fallback if the endpoint hangs.
+"""
+
+
+class _CodexCompactionEvent(TypedDict):
+    """Event payload persisted in state after a successful `/compact` call.
+
+    Attributes:
+        cutoff_index: Absolute index in state messages where compaction
+            occurred. Messages before this index are superseded by the
+            synthetic compaction head message on effective-list reconstruction.
+        output: The ``/compact`` endpoint's output items, serialized via
+            ``model_dump(exclude_none=True, mode="json")``. These round-trip
+            back to Responses input items via
+            ``_construct_responses_api_input``.
+        file_path: Backend path where the pre-compaction messages were
+            offloaded, or ``None`` if offload failed.
+    """
+
+    cutoff_index: int
+    output: list[dict[str, Any]]
+    file_path: str | None
+
+
+class _CodexCompactionState(AgentState):
+    """State extension adding the `/compact` output payload.
+
+    The value is the most recent compaction event; older events are superseded
+    rather than accumulated. Messages prior to ``cutoff_index`` are offloaded
+    to the backend and no longer part of the effective conversation.
+    """
+
+    codex_compaction_item: Annotated[NotRequired[_CodexCompactionEvent | None], PrivateStateAttr]
+
+
+class CodexCompactionMiddleware(AgentMiddleware):
+    """Compaction middleware using OpenAI Responses `/compact`.
+
+    Composes a ``_DeepAgentsSummarizationMiddleware`` for all non-compaction
+    concerns (arg truncation, offload, partitioning, thread ID, fallback).
+
+    Args:
+        model: Resolved chat model instance. Must be an OpenAI model that
+            supports the ``/compact`` endpoint (currently the Codex family).
+            The model is used both to extract the OpenAI model name for the
+            ``/compact`` request and as the summarization model for the
+            fallback path.
+        backend: Backend or factory for offloading conversation history
+            before compaction. Forwarded to the inner summarization middleware.
+        client: Optional pre-configured ``AsyncOpenAI`` client. If ``None``,
+            a default client is lazily created on first use, reading
+            credentials from the environment.
+    """
+
+    state_schema = _CodexCompactionState
+
+    def __init__(
+        self,
+        model: BaseChatModel,
+        backend: BACKEND_TYPES,
+        *,
+        client: AsyncOpenAI | None = None,
+    ) -> None:
+        """Initialize the compaction middleware.
+
+        Args:
+            model: Resolved OpenAI chat model instance (see class docstring).
+            backend: Backend or factory for offloading older turns.
+            client: Optional pre-configured `AsyncOpenAI` client; one is
+                lazily constructed if absent.
+        """
+        self._model = model
+        self._inner: _DeepAgentsSummarizationMiddleware = create_summarization_middleware(model, backend)
+        self._client = client
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> AsyncOpenAI:
+        """Return the cached `AsyncOpenAI` client, constructing one if needed."""
+        if self._client is None:
+            from openai import AsyncOpenAI  # noqa: PLC0415
+
+            self._client = AsyncOpenAI()
+        return self._client
+
+    def _resolve_model_name(self) -> str:
+        """Extract the OpenAI model identifier from the resolved chat model.
+
+        Raises:
+            RuntimeError: If no model name can be discovered. This is a
+                configuration error — compaction requires an OpenAI model.
+        """
+        for attr in ("model_name", "model"):
+            value = getattr(self._model, attr, None)
+            if isinstance(value, str) and value:
+                return value
+        msg = (
+            "CodexCompactionMiddleware could not determine the OpenAI model "
+            f"name from {type(self._model).__name__}. Configure the profile "
+            "with a ChatOpenAI instance."
+        )
+        raise RuntimeError(msg)
+
+    @staticmethod
+    def _build_compaction_message(output_items: list[dict[str, Any]]) -> AIMessage:
+        """Wrap raw `/compact` output items in an `AIMessage` for the message list.
+
+        The blocks round-trip unchanged through ``_construct_responses_api_input``
+        because the Responses layer in langchain-openai explicitly supports
+        ``compaction`` / ``reasoning`` / etc. content-block types.
+
+        Args:
+            output_items: List of ``ResponseOutputItem.model_dump()`` dicts
+                returned by the ``/compact`` call.
+
+        Returns:
+            A synthetic `AIMessage` that stands in for all compacted turns.
+        """
+        return AIMessage(
+            content=output_items,
+            additional_kwargs={"lc_source": "codex_compaction"},
+        )
+
+    def _effective_messages(
+        self,
+        messages: list[AnyMessage],
+        event: _CodexCompactionEvent | None,
+    ) -> list[AnyMessage]:
+        """Reconstruct the effective message list from state + compaction event.
+
+        When a prior compaction event exists, the effective conversation is
+        the synthetic compaction message followed by all state messages from
+        ``cutoff_index`` onward. Mirrors
+        ``_DeepAgentsSummarizationMiddleware._apply_event_to_messages``.
+
+        Args:
+            messages: Full message list from state.
+            event: The most recent `codex_compaction_item`, or ``None``.
+
+        Returns:
+            The effective conversation the model should see on this turn.
+        """
+        if event is None:
+            return list(messages)
+        try:
+            cutoff_idx = event["cutoff_index"]
+            output_items = event["output"]
+        except KeyError as exc:
+            logger.warning("Malformed codex_compaction_item (missing keys): %s", exc)
+            return list(messages)
+        compaction_msg = self._build_compaction_message(output_items)
+        if cutoff_idx > len(messages):
+            logger.warning(
+                "Compaction cutoff_index %d exceeds message count %d",
+                cutoff_idx,
+                len(messages),
+            )
+            return [compaction_msg]
+        return [compaction_msg, *messages[cutoff_idx:]]
+
+    @staticmethod
+    def _compute_state_cutoff(
+        event: _CodexCompactionEvent | None,
+        effective_cutoff: int,
+    ) -> int:
+        """Translate an effective-list cutoff to an absolute state index.
+
+        Same arithmetic as the summarization middleware: when a prior
+        compaction event exists, the effective list starts with one
+        synthesized message at index 0, so we subtract one to avoid
+        double-counting it.
+        """
+        if event is None:
+            return effective_cutoff
+        prior_cutoff = event.get("cutoff_index")
+        if not isinstance(prior_cutoff, int):
+            return effective_cutoff
+        return prior_cutoff + effective_cutoff - 1
+
+    async def _do_compact(
+        self,
+        to_compact: list[AnyMessage],
+    ) -> list[dict[str, Any]]:
+        """Invoke the Responses `/compact` endpoint and return serialized output.
+
+        When a prior compaction event exists, the synthetic compaction head is
+        already at ``to_compact[0]`` (see ``_effective_messages``). Its content
+        is the prior ``/compact`` output, and
+        ``_construct_responses_api_input`` passes each compaction / reasoning
+        content block through unchanged — so the prior items are emitted into
+        ``input_items`` exactly once via the normal round-trip. Do not also
+        prepend ``prior_event["output"]`` here; doing so duplicates the
+        compaction item in the outbound request.
+
+        We deliberately do not forward ``request.system_message`` as the
+        endpoint's ``instructions`` parameter. ``/compact`` summarizes prior
+        conversation state; it should not be handed a task-framing system
+        prompt that could steer the compaction away from a faithful transcript.
+        The system message is still sent on the subsequent ``/responses`` call
+        where it belongs.
+
+        Args:
+            to_compact: Messages to send to `/compact` (the "old" partition
+                of the current effective message list, including the
+                synthetic compaction head if one was present).
+
+        Returns:
+            The ``/compact`` response's ``output`` list, each item serialized
+                via ``model_dump(exclude_none=True, mode="json")``.
+
+        Raises:
+            Any exception from the OpenAI SDK is surfaced for the caller to
+            handle (typically triggers fallback to summarization).
+        """
+        from langchain_openai.chat_models.base import _construct_responses_api_input  # noqa: PLC0415
+
+        input_items = _construct_responses_api_input(to_compact)
+
+        client = self._get_client()
+        model_name = self._resolve_model_name()
+        result = await client.responses.compact(
+            model=model_name,
+            input=input_items,
+            timeout=_COMPACT_TIMEOUT_SECONDS,
+        )
+        return [item.model_dump(exclude_none=True, mode="json") for item in result.output]
+
+    # ------------------------------------------------------------------
+    # Main entry point
+    # ------------------------------------------------------------------
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse | ExtendedModelResponse:
+        """Apply compaction-aware message handling around the model call.
+
+        1. Reconstruct effective messages from any prior compaction event.
+        2. Delegate tool-call arg truncation to the inner middleware.
+        3. If under the compaction trigger, forward unchanged.
+        4. If over the trigger, call `/compact`:
+            - On success, rebuild state with a new compaction event and a
+                synthetic head message.
+            - On failure, delegate the full turn to the inner summarization
+                middleware (LLM-based fallback).
+
+        Args:
+            request: Incoming model request from LangGraph.
+            handler: Downstream handler to invoke with the (possibly modified)
+                request.
+
+        Returns:
+            A plain `ModelResponse` when no compaction happens this turn, or
+                an `ExtendedModelResponse` whose command updates
+                ``codex_compaction_item`` in state.
+        """
+        inner = self._inner
+
+        prior_event: _CodexCompactionEvent | None = request.state.get("codex_compaction_item")
+        effective = self._effective_messages(request.messages, prior_event)
+
+        truncated, _ = inner._truncate_args(effective, request.system_message, request.tools)
+
+        counted = [request.system_message, *truncated] if request.system_message is not None else truncated
+        try:
+            total_tokens = inner.token_counter(counted, tools=request.tools)  # ty: ignore[unknown-argument]
+        except TypeError:
+            total_tokens = inner.token_counter(counted)
+
+        if not inner._should_summarize(truncated, total_tokens):
+            return await handler(request.override(messages=truncated))
+
+        effective_cutoff = inner._determine_cutoff_index(truncated)
+        if effective_cutoff <= 0:
+            return await handler(request.override(messages=truncated))
+
+        to_compact, preserved = inner._partition_messages(truncated, effective_cutoff)
+
+        backend = inner._get_backend(request.state, request.runtime)
+
+        # Sequence compact before offload: if ``/compact`` fails, we delegate
+        # the whole turn to ``inner.awrap_model_call`` which performs its own
+        # offload. Running the wrapper's offload in parallel (or before the
+        # fallback) would append the same pre-compaction window to the
+        # history file twice.
+        try:
+            compact_output_items = await self._do_compact(to_compact)
+        except Exception:
+            logger.exception(
+                "Codex /compact call failed; falling back to LLM summarization",
+            )
+            return await inner.awrap_model_call(request, handler)
+
+        file_path = await inner._aoffload_to_backend(backend, to_compact)
+
+        if file_path is None:
+            msg = "Offloading conversation history to backend failed during Codex compaction. Older messages will not be recoverable."
+            logger.error(msg)
+            warnings.warn(msg, stacklevel=2)
+
+        state_cutoff_index = self._compute_state_cutoff(prior_event, effective_cutoff)
+        new_event: _CodexCompactionEvent = {
+            "cutoff_index": state_cutoff_index,
+            "output": compact_output_items,
+            "file_path": file_path,
+        }
+
+        compaction_head = self._build_compaction_message(compact_output_items)
+        modified_messages: list[BaseMessage] = [compaction_head, *preserved]
+        response = await handler(request.override(messages=modified_messages))
+
+        return ExtendedModelResponse(
+            model_response=response,
+            command=Command(update={"codex_compaction_item": new_event}),
+        )
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse | ExtendedModelResponse:
+        """Synchronous entry point — unsupported for compaction.
+
+        The `/compact` endpoint is async-only via the OpenAI SDK. Sync callers
+        should not be common on the Codex path, but for safety we fall back
+        entirely to the inner summarization middleware's sync path.
+
+        Args:
+            request: Incoming model request.
+            handler: Downstream handler.
+
+        Returns:
+            Whatever the inner summarization middleware returns.
+        """
+        return self._inner.wrap_model_call(request, handler)

--- a/libs/deepagents/deepagents/middleware/codex_compaction.py
+++ b/libs/deepagents/deepagents/middleware/codex_compaction.py
@@ -216,7 +216,15 @@ class CodexCompactionMiddleware(AgentMiddleware):
     def _get_client(self) -> AsyncOpenAI:
         """Return the cached `AsyncOpenAI` client, constructing one if needed."""
         if self._client is None:
-            from openai import AsyncOpenAI  # noqa: PLC0415
+            try:
+                from openai import AsyncOpenAI  # noqa: PLC0415
+            except ImportError as e:
+                msg = (
+                    "CodexCompactionMiddleware requires the `openai` package. "
+                    "Install it with `pip install 'deepagents[codex]'` or "
+                    "`pip install openai`."
+                )
+                raise ImportError(msg) from e
 
             self._client = AsyncOpenAI()
         return self._client
@@ -357,7 +365,16 @@ class CodexCompactionMiddleware(AgentMiddleware):
             Any exception from the OpenAI SDK is surfaced for the caller to
             handle (typically triggers fallback to summarization).
         """
-        from langchain_openai.chat_models.base import _construct_responses_api_input  # noqa: PLC0415
+        try:
+            from langchain_openai.chat_models.base import _construct_responses_api_input  # noqa: PLC0415
+        except ImportError as e:
+            msg = (
+                "CodexCompactionMiddleware requires `langchain-openai>=1.1.12` "
+                "(needed for `phase` field round-tripping on content blocks). "
+                "Install it with `pip install 'deepagents[codex]'` or "
+                "`pip install 'langchain-openai>=1.1.12,<2.0.0'`."
+            )
+            raise ImportError(msg) from e
 
         input_items = _construct_responses_api_input(to_compact)
 

--- a/libs/deepagents/deepagents/middleware/codex_compaction.py
+++ b/libs/deepagents/deepagents/middleware/codex_compaction.py
@@ -72,7 +72,7 @@ continues to lift ``block["phase"]`` onto the outbound input item.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated, Any, NotRequired
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired, cast
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
 from langchain_core.messages import AIMessage, AnyMessage, BaseMessage
@@ -270,7 +270,7 @@ class CodexCompactionMiddleware(AgentMiddleware):
             A synthetic `AIMessage` that stands in for all compacted turns.
         """
         return AIMessage(
-            content=output_items,
+            content=cast("list[str | dict[str, Any]]", output_items),
             additional_kwargs={"lc_source": "codex_compaction"},
         )
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -322,12 +322,92 @@ FILESYSTEM_SYSTEM_PROMPT = _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
     large_tool_results_prefix="/large_tool_results",
 )
 
+APPLY_PATCH_TOOL_DESCRIPTION = """Apply a patch to create, update, or delete files using V4A diff format.
+
+Use for single-file edits. For auto-generated changes or bulk search-and-replace, use edit_file or shell commands.
+
+The patch must follow V4A format:
+- *** Begin Patch / *** End Patch — wrap the entire patch
+- *** Add File: <path> — create a new file (lines prefixed with +)
+- *** Delete File: <path> — delete an existing file
+- *** Update File: <path> — modify a file using context lines and +/- changes
+- @@ — context anchor (optional text after @@ jumps to that line)
+- Lines prefixed with ' ' (space) are context, '+' are additions, '-' are deletions"""
+
 EXECUTION_SYSTEM_PROMPT = """## Execute Tool `execute`
 
 You have access to an `execute` tool for running shell commands in a sandboxed environment.
 Use this tool to run commands, scripts, tests, builds, and other shell operations.
 
 - execute: run a shell command in the sandbox (returns output and exit code)"""
+
+
+def _identify_files_needed(patch_text: str) -> list[str]:
+    """Extract file paths that need to be read before applying a patch."""
+    paths: list[str] = []
+    for line in patch_text.split("\n"):
+        for prefix in ("*** Update File: ", "*** Delete File: "):
+            if line.startswith(prefix):
+                paths.append(line[len(prefix):])
+    return paths
+
+
+def _apply_file_changes(
+    backend: BackendProtocol,
+    changes: dict[str, str | None],
+) -> str:
+    """Apply parsed patch results to the backend synchronously."""
+    msgs: list[str] = []
+    for path, content in changes.items():
+        if content is None:
+            msgs.append(f"Deleted '{path}' (manual removal may be needed)")
+            continue
+        existing = backend.read(path, offset=0, limit=1)
+        has_file = not (isinstance(existing, str) or existing.error)
+        if has_file:
+            raw = backend.read(path, offset=0, limit=999_999)
+            old = raw.file_data["content"] if not isinstance(raw, str) and raw.file_data else ""
+            result = backend.edit(path, old, content)
+            if result.error:
+                msgs.append(f"Error updating '{path}': {result.error}")
+            else:
+                msgs.append(f"Updated '{path}'")
+        else:
+            result = backend.write(path, content)
+            if result.error:
+                msgs.append(f"Error creating '{path}': {result.error}")
+            else:
+                msgs.append(f"Created '{path}'")
+    return "\n".join(msgs)
+
+
+async def _aapply_file_changes(
+    backend: BackendProtocol,
+    changes: dict[str, str | None],
+) -> str:
+    """Apply parsed patch results to the backend asynchronously."""
+    msgs: list[str] = []
+    for path, content in changes.items():
+        if content is None:
+            msgs.append(f"Deleted '{path}' (manual removal may be needed)")
+            continue
+        existing = await backend.aread(path, offset=0, limit=1)
+        has_file = not (isinstance(existing, str) or existing.error)
+        if has_file:
+            raw = await backend.aread(path, offset=0, limit=999_999)
+            old = raw.file_data["content"] if not isinstance(raw, str) and raw.file_data else ""
+            result = await backend.aedit(path, old, content)
+            if result.error:
+                msgs.append(f"Error updating '{path}': {result.error}")
+            else:
+                msgs.append(f"Updated '{path}'")
+        else:
+            result = await backend.awrite(path, content)
+            if result.error:
+                msgs.append(f"Error creating '{path}': {result.error}")
+            else:
+                msgs.append(f"Created '{path}'")
+    return "\n".join(msgs)
 
 
 def supports_execution(backend: BackendProtocol) -> bool:
@@ -581,6 +661,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_token_limit_before_evict: int | None = 20000,
         human_message_token_limit_before_evict: int | None = 50000,
         max_execute_timeout: int = 3600,
+        include_apply_patch: bool = False,
     ) -> None:
         """Initialize the filesystem middleware.
 
@@ -597,6 +678,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
                 Defaults to 3600 seconds (1 hour). Any per-command timeout
                 exceeding this value will be rejected with an error message.
+            include_apply_patch: If ``True``, add the ``apply_patch`` tool that
+                accepts V4A diffs. Intended for Codex models.
 
         Raises:
             ValueError: If `max_execute_timeout` is not positive.
@@ -628,6 +711,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_grep_tool(),
             self._create_execute_tool(),
         ]
+        if include_apply_patch:
+            self.tools.append(self._create_apply_patch_tool())
 
     def _get_backend(self, runtime: ToolRuntime[Any, Any]) -> BackendProtocol:
         """Get the resolved backend instance from backend or factory.
@@ -906,6 +991,80 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             coroutine=async_edit_file,
             infer_schema=False,
             args_schema=EditFileSchema,
+        )
+
+    def _create_apply_patch_tool(self) -> BaseTool:
+        """Create the apply_patch tool (V4A diff format)."""
+        from deepagents.utils._apply_patch import PatchError, apply_patch
+
+        tool_description = (
+            self._custom_tool_descriptions.get("apply_patch")
+            or APPLY_PATCH_TOOL_DESCRIPTION
+        )
+
+        def _read_raw(backend: BackendProtocol, path: str) -> str | None:
+            """Read raw file content from the backend (no line numbers)."""
+            result = backend.read(path, offset=0, limit=999_999)
+            if isinstance(result, str):
+                return result or None
+            if result.error or result.file_data is None:
+                return None
+            content = result.file_data["content"]
+            return content if content else None
+
+        async def _aread_raw(backend: BackendProtocol, path: str) -> str | None:
+            """Async variant of `_read_raw`."""
+            result = await backend.aread(path, offset=0, limit=999_999)
+            if isinstance(result, str):
+                return result or None
+            if result.error or result.file_data is None:
+                return None
+            content = result.file_data["content"]
+            return content if content else None
+
+        def sync_apply_patch(
+            patch: Annotated[str, "The V4A format patch string to apply."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> str:
+            """Apply a V4A patch synchronously."""
+            backend = self._get_backend(runtime)
+
+            try:
+                changes = apply_patch(
+                    patch, file_reader=lambda p: _read_raw(backend, p)
+                )
+            except PatchError as e:
+                return f"Error applying patch: {e}"
+
+            return _apply_file_changes(backend, changes)
+
+        async def async_apply_patch(
+            patch: Annotated[str, "The V4A format patch string to apply."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> str:
+            """Apply a V4A patch asynchronously."""
+            backend = self._get_backend(runtime)
+
+            # file_reader must be sync for the parser; read files upfront
+            needed = _identify_files_needed(patch)
+            file_cache: dict[str, str | None] = {}
+            for p in needed:
+                file_cache[p] = await _aread_raw(backend, p)
+
+            try:
+                changes = apply_patch(
+                    patch, file_reader=lambda p: file_cache.get(p, None)
+                )
+            except PatchError as e:
+                return f"Error applying patch: {e}"
+
+            return await _aapply_file_changes(backend, changes)
+
+        return StructuredTool.from_function(
+            name="apply_patch",
+            description=tool_description,
+            func=sync_apply_patch,
+            coroutine=async_apply_patch,
         )
 
     def _create_glob_tool(self) -> BaseTool:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -53,6 +53,11 @@ from deepagents.backends.utils import (
     validate_path,
 )
 from deepagents.middleware._utils import append_to_system_message
+from deepagents.utils._apply_patch import (
+    PatchError,
+    apply_patch,
+    list_referenced_files,
+)
 
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
 GLOB_TIMEOUT = 20.0  # seconds
@@ -367,11 +372,7 @@ def _format_fuzz_note(fuzz: int) -> str:
     if fuzz <= 0:
         return ""
     if fuzz >= _FUZZ_STRIP_FALLBACK_THRESHOLD:
-        return (
-            f"\nNote: applied with fuzz={fuzz}; at least one hunk "
-            "matched via whitespace-insensitive fallback. "
-            "Verify the patched file is correct."
-        )
+        return f"\nNote: applied with fuzz={fuzz}; at least one hunk matched via whitespace-insensitive fallback. Verify the patched file is correct."
     return f"\nNote: applied with fuzz={fuzz} (minor whitespace drift)."
 
 
@@ -1026,18 +1027,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _create_apply_patch_tool(self) -> BaseTool:
+    def _create_apply_patch_tool(self) -> BaseTool:  # noqa: C901  # single factory wiring sync+async variants of the apply_patch tool; splitting duplicates the closure over `self`/`backend`
         """Create the apply_patch tool (V4A diff format)."""
-        from deepagents.utils._apply_patch import (
-            PatchError,
-            apply_patch,
-            list_referenced_files,
-        )
-
-        tool_description = (
-            self._custom_tool_descriptions.get("apply_patch")
-            or APPLY_PATCH_TOOL_DESCRIPTION
-        )
+        tool_description = self._custom_tool_descriptions.get("apply_patch") or APPLY_PATCH_TOOL_DESCRIPTION
 
         def _read_raw(backend: BackendProtocol, path: str) -> str | None:
             """Read raw file content from the backend (no line numbers)."""
@@ -1048,7 +1040,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if result.error or result.file_data is None:
                 return None
             content = result.file_data["content"]
-            return content if content else None
+            return content or None
 
         async def _aread_raw(backend: BackendProtocol, path: str) -> str | None:
             """Async variant of `_read_raw`."""
@@ -1059,7 +1051,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if result.error or result.file_data is None:
                 return None
             content = result.file_data["content"]
-            return content if content else None
+            return content or None
 
         def sync_apply_patch(
             patch: Annotated[str, "The V4A format patch string to apply."],
@@ -1069,9 +1061,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             backend = self._get_backend(runtime)
 
             try:
-                result = apply_patch(
-                    patch, file_reader=lambda p: _read_raw(backend, p)
-                )
+                result = apply_patch(patch, file_reader=lambda p: _read_raw(backend, p))
             except (PatchError, ValueError) as e:
                 return f"Error applying patch: {e}"
 
@@ -1097,9 +1087,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 file_cache[p] = await _aread_raw(backend, validated)
 
             try:
-                result = apply_patch(
-                    patch, file_reader=lambda p: file_cache.get(p)
-                )
+                result = apply_patch(patch, file_reader=file_cache.get)
             except (PatchError, ValueError) as e:
                 return f"Error applying patch: {e}"
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -358,26 +358,31 @@ def _apply_file_changes(
 ) -> str:
     """Apply parsed patch results to the backend synchronously."""
     msgs: list[str] = []
-    for path, content in changes.items():
-        if content is None:
-            msgs.append(f"Deleted '{path}' (manual removal may be needed)")
+    for raw_path, content in changes.items():
+        try:
+            safe = validate_path(raw_path)
+        except ValueError as e:
+            msgs.append(f"Error: {e}")
             continue
-        existing = backend.read(path, offset=0, limit=1)
+        if content is None:
+            msgs.append(f"Deleted '{safe}' (manual removal may be needed)")
+            continue
+        existing = backend.read(safe, offset=0, limit=1)
         has_file = not (isinstance(existing, str) or existing.error)
         if has_file:
-            raw = backend.read(path, offset=0, limit=999_999)
+            raw = backend.read(safe, offset=0, limit=999_999)
             old = raw.file_data["content"] if not isinstance(raw, str) and raw.file_data else ""
-            result = backend.edit(path, old, content)
+            result = backend.edit(safe, old, content)
             if result.error:
-                msgs.append(f"Error updating '{path}': {result.error}")
+                msgs.append(f"Error updating '{safe}': {result.error}")
             else:
-                msgs.append(f"Updated '{path}'")
+                msgs.append(f"Updated '{safe}'")
         else:
-            result = backend.write(path, content)
+            result = backend.write(safe, content)
             if result.error:
-                msgs.append(f"Error creating '{path}': {result.error}")
+                msgs.append(f"Error creating '{safe}': {result.error}")
             else:
-                msgs.append(f"Created '{path}'")
+                msgs.append(f"Created '{safe}'")
     return "\n".join(msgs)
 
 
@@ -387,26 +392,31 @@ async def _aapply_file_changes(
 ) -> str:
     """Apply parsed patch results to the backend asynchronously."""
     msgs: list[str] = []
-    for path, content in changes.items():
-        if content is None:
-            msgs.append(f"Deleted '{path}' (manual removal may be needed)")
+    for raw_path, content in changes.items():
+        try:
+            safe = validate_path(raw_path)
+        except ValueError as e:
+            msgs.append(f"Error: {e}")
             continue
-        existing = await backend.aread(path, offset=0, limit=1)
+        if content is None:
+            msgs.append(f"Deleted '{safe}' (manual removal may be needed)")
+            continue
+        existing = await backend.aread(safe, offset=0, limit=1)
         has_file = not (isinstance(existing, str) or existing.error)
         if has_file:
-            raw = await backend.aread(path, offset=0, limit=999_999)
+            raw = await backend.aread(safe, offset=0, limit=999_999)
             old = raw.file_data["content"] if not isinstance(raw, str) and raw.file_data else ""
-            result = await backend.aedit(path, old, content)
+            result = await backend.aedit(safe, old, content)
             if result.error:
-                msgs.append(f"Error updating '{path}': {result.error}")
+                msgs.append(f"Error updating '{safe}': {result.error}")
             else:
-                msgs.append(f"Updated '{path}'")
+                msgs.append(f"Updated '{safe}'")
         else:
-            result = await backend.awrite(path, content)
+            result = await backend.awrite(safe, content)
             if result.error:
-                msgs.append(f"Error creating '{path}': {result.error}")
+                msgs.append(f"Error creating '{safe}': {result.error}")
             else:
-                msgs.append(f"Created '{path}'")
+                msgs.append(f"Created '{safe}'")
     return "\n".join(msgs)
 
 
@@ -1004,6 +1014,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         def _read_raw(backend: BackendProtocol, path: str) -> str | None:
             """Read raw file content from the backend (no line numbers)."""
+            path = validate_path(path)
             result = backend.read(path, offset=0, limit=999_999)
             if isinstance(result, str):
                 return result or None
@@ -1014,6 +1025,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         async def _aread_raw(backend: BackendProtocol, path: str) -> str | None:
             """Async variant of `_read_raw`."""
+            path = validate_path(path)
             result = await backend.aread(path, offset=0, limit=999_999)
             if isinstance(result, str):
                 return result or None
@@ -1033,7 +1045,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 changes = apply_patch(
                     patch, file_reader=lambda p: _read_raw(backend, p)
                 )
-            except PatchError as e:
+            except (PatchError, ValueError) as e:
                 return f"Error applying patch: {e}"
 
             return _apply_file_changes(backend, changes)
@@ -1049,13 +1061,17 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             needed = _identify_files_needed(patch)
             file_cache: dict[str, str | None] = {}
             for p in needed:
-                file_cache[p] = await _aread_raw(backend, p)
+                try:
+                    validated = validate_path(p)
+                except ValueError as e:
+                    return f"Error applying patch: {e}"
+                file_cache[p] = await _aread_raw(backend, validated)
 
             try:
                 changes = apply_patch(
                     patch, file_reader=lambda p: file_cache.get(p, None)
                 )
-            except PatchError as e:
+            except (PatchError, ValueError) as e:
                 return f"Error applying patch: {e}"
 
             return await _aapply_file_changes(backend, changes)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -342,14 +342,37 @@ Use this tool to run commands, scripts, tests, builds, and other shell operation
 - execute: run a shell command in the sandbox (returns output and exit code)"""
 
 
-def _identify_files_needed(patch_text: str) -> list[str]:
-    """Extract file paths that need to be read before applying a patch."""
-    paths: list[str] = []
-    for line in patch_text.split("\n"):
-        for prefix in ("*** Update File: ", "*** Delete File: "):
-            if line.startswith(prefix):
-                paths.append(line[len(prefix):])
-    return paths
+# Upper bound passed as ``limit=`` when the apply_patch helpers need the
+# entire file. Backends treat ``limit`` as a line-count cap; ~1M is large
+# enough that any realistic source file fits in a single request while
+# still guarding against pathological inputs.
+_APPLY_PATCH_READ_LIMIT = 999_999
+
+# Fuzz scoring thresholds (see `PatchResult.fuzz`). A single hunk matched
+# via the whitespace-insensitive ``strip()`` fallback contributes 100, so
+# anything at or above this level means at least one hunk required that
+# aggressive fallback and the result warrants a stronger verification hint
+# in the tool output.
+_FUZZ_STRIP_FALLBACK_THRESHOLD = 100
+
+
+def _format_fuzz_note(fuzz: int) -> str:
+    """Build a trailing note describing non-zero context-match fuzz.
+
+    Returns an empty string for exact matches so the happy path output
+    stays clean. For fuzz >= :data:`_FUZZ_STRIP_FALLBACK_THRESHOLD`, the
+    note flags that at least one hunk needed whitespace-insensitive
+    matching so the model can verify the result.
+    """
+    if fuzz <= 0:
+        return ""
+    if fuzz >= _FUZZ_STRIP_FALLBACK_THRESHOLD:
+        return (
+            f"\nNote: applied with fuzz={fuzz}; at least one hunk "
+            "matched via whitespace-insensitive fallback. "
+            "Verify the patched file is correct."
+        )
+    return f"\nNote: applied with fuzz={fuzz} (minor whitespace drift)."
 
 
 def _apply_file_changes(
@@ -370,7 +393,7 @@ def _apply_file_changes(
         existing = backend.read(safe, offset=0, limit=1)
         has_file = not (isinstance(existing, str) or existing.error)
         if has_file:
-            raw = backend.read(safe, offset=0, limit=999_999)
+            raw = backend.read(safe, offset=0, limit=_APPLY_PATCH_READ_LIMIT)
             old = raw.file_data["content"] if not isinstance(raw, str) and raw.file_data else ""
             result = backend.edit(safe, old, content)
             if result.error:
@@ -404,7 +427,7 @@ async def _aapply_file_changes(
         existing = await backend.aread(safe, offset=0, limit=1)
         has_file = not (isinstance(existing, str) or existing.error)
         if has_file:
-            raw = await backend.aread(safe, offset=0, limit=999_999)
+            raw = await backend.aread(safe, offset=0, limit=_APPLY_PATCH_READ_LIMIT)
             old = raw.file_data["content"] if not isinstance(raw, str) and raw.file_data else ""
             result = await backend.aedit(safe, old, content)
             if result.error:
@@ -1005,7 +1028,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
     def _create_apply_patch_tool(self) -> BaseTool:
         """Create the apply_patch tool (V4A diff format)."""
-        from deepagents.utils._apply_patch import PatchError, apply_patch
+        from deepagents.utils._apply_patch import (
+            PatchError,
+            apply_patch,
+            list_referenced_files,
+        )
 
         tool_description = (
             self._custom_tool_descriptions.get("apply_patch")
@@ -1015,7 +1042,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         def _read_raw(backend: BackendProtocol, path: str) -> str | None:
             """Read raw file content from the backend (no line numbers)."""
             path = validate_path(path)
-            result = backend.read(path, offset=0, limit=999_999)
+            result = backend.read(path, offset=0, limit=_APPLY_PATCH_READ_LIMIT)
             if isinstance(result, str):
                 return result or None
             if result.error or result.file_data is None:
@@ -1026,7 +1053,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         async def _aread_raw(backend: BackendProtocol, path: str) -> str | None:
             """Async variant of `_read_raw`."""
             path = validate_path(path)
-            result = await backend.aread(path, offset=0, limit=999_999)
+            result = await backend.aread(path, offset=0, limit=_APPLY_PATCH_READ_LIMIT)
             if isinstance(result, str):
                 return result or None
             if result.error or result.file_data is None:
@@ -1042,13 +1069,13 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             backend = self._get_backend(runtime)
 
             try:
-                changes = apply_patch(
+                result = apply_patch(
                     patch, file_reader=lambda p: _read_raw(backend, p)
                 )
             except (PatchError, ValueError) as e:
                 return f"Error applying patch: {e}"
 
-            return _apply_file_changes(backend, changes)
+            return _apply_file_changes(backend, result.changes) + _format_fuzz_note(result.fuzz)
 
         async def async_apply_patch(
             patch: Annotated[str, "The V4A format patch string to apply."],
@@ -1057,8 +1084,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             """Apply a V4A patch asynchronously."""
             backend = self._get_backend(runtime)
 
-            # file_reader must be sync for the parser; read files upfront
-            needed = _identify_files_needed(patch)
+            # The parser consumes a synchronous `file_reader` callback and
+            # cannot `await` mid-parse, so prefetch every referenced file
+            # concurrently and hand the parser a cache-backed reader.
+            needed = list_referenced_files(patch)
             file_cache: dict[str, str | None] = {}
             for p in needed:
                 try:
@@ -1068,13 +1097,14 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 file_cache[p] = await _aread_raw(backend, validated)
 
             try:
-                changes = apply_patch(
-                    patch, file_reader=lambda p: file_cache.get(p, None)
+                result = apply_patch(
+                    patch, file_reader=lambda p: file_cache.get(p)
                 )
             except (PatchError, ValueError) as e:
                 return f"Error applying patch: {e}"
 
-            return await _aapply_file_changes(backend, changes)
+            applied = await _aapply_file_changes(backend, result.changes)
+            return applied + _format_fuzz_note(result.fuzz)
 
         return StructuredTool.from_function(
             name="apply_patch",

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -208,7 +208,17 @@ def compute_summarization_defaults(model: BaseChatModel) -> SummarizationDefault
 
 
 class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
-    """Summarization middleware with backend for conversation history offloading."""
+    """Summarization middleware with backend for conversation history offloading.
+
+    !!! note
+
+        The Codex harness profile ships with ``use_codex_compaction=True`` and
+        wires [`CodexCompactionMiddleware`][deepagents.middleware.codex_compaction.CodexCompactionMiddleware]
+        in place of this class at the top level. The compaction middleware
+        composes a ``_DeepAgentsSummarizationMiddleware`` internally — so this
+        class is still the source of truth for arg truncation, offload,
+        partitioning, and the LLM-based fallback when ``/compact`` is unavailable.
+    """
 
     state_schema = SummarizationState
 

--- a/libs/deepagents/deepagents/profiles/__init__.py
+++ b/libs/deepagents/deepagents/profiles/__init__.py
@@ -9,9 +9,8 @@ Re-exports the profile dataclass, registry helpers, and provider modules so
 internal consumers can import from `deepagents.profiles` directly.
 """
 
-# Provider modules register their profiles as a side effect of import.
-# _openrouter registration fires via the `from` import below.
-from deepagents.profiles import _openai as _openai
+# Provider/model modules register their profiles as a side effect of import.
+from deepagents.profiles import _codex as _codex, _openai as _openai
 from deepagents.profiles._harness_profiles import (
     _HARNESS_PROFILES,
     _get_harness_profile,

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -1,13 +1,14 @@
-"""OpenAI Codex model harness profile.
+"""OpenAI Codex model harness profiles.
 
 !!! warning
 
     This is an internal API subject to change without deprecation. It is not
     intended for external use or consumption.
 
-Registers a per-model profile for ``gpt-5.3-codex`` that layers on top of
-the provider-wide OpenAI profile.  The merge gives us ``use_responses_api``
-from the provider level plus Codex-specific tuning here.
+Registers per-model profiles for Codex variants (``gpt-5.2-codex``,
+``gpt-5.3-codex``) that layer on top of the provider-wide OpenAI profile.
+The merge gives us ``use_responses_api`` from the provider level plus
+Codex-specific tuning here.
 
 Prompt additions are derived from the official Codex Prompting Guide
 (https://developers.openai.com/cookbook/examples/gpt-5/codex_prompting_guide)
@@ -28,9 +29,10 @@ through implementation, verification, and a clear explanation of outcomes.
 - Bias to action: default to implementing with reasonable assumptions. Do not \
 end your turn with clarifications unless truly blocked.
 - Do not communicate an upfront plan or status preamble before acting. Just act.
-- Avoid excessive looping or repetition. If you find yourself re-reading or \
-re-editing the same files without clear progress, stop and summarize what is \
-blocking you.
+- Avoid excessive looping or repetition. If you have already called a tool and \
+received a valid response, use that information — do not re-invoke the same \
+tool with identical arguments. If you find yourself re-reading, re-querying, \
+or re-editing without clear progress, stop and summarize what is blocking you.
 
 ## Parallel Tool Use
 
@@ -54,11 +56,11 @@ _CODEX_TOOL_DESCRIPTION_OVERRIDES: dict[str, str] = {
     ),
 }
 
-_register_harness_profile(
-    "openai:gpt-5.3-codex",
-    _HarnessProfile(
-        init_kwargs={"reasoning_effort": "medium"},
-        system_prompt_suffix=_CODEX_SYSTEM_PROMPT_SUFFIX,
-        tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
-    ),
+_CODEX_PROFILE = _HarnessProfile(
+    init_kwargs={"reasoning_effort": "medium"},
+    system_prompt_suffix=_CODEX_SYSTEM_PROMPT_SUFFIX,
+    tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
 )
+
+for _model in ("openai:gpt-5.2-codex", "openai:gpt-5.3-codex"):
+    _register_harness_profile(_model, _CODEX_PROFILE)

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -13,6 +13,14 @@ Codex-specific tuning here.
 Prompt additions are derived from the official Codex Prompting Guide
 (https://developers.openai.com/cookbook/examples/gpt-5/codex_prompting_guide)
 and optimized for the Deep Agents tool set.
+
+Context compaction on Codex uses the OpenAI Responses ``/compact`` endpoint
+rather than the default LLM-based summarization. Compaction returns an
+opaque ``encrypted_content`` item that preserves procedural fidelity better
+than an ad-hoc text summary, which matters for long multi-turn sessions
+with tool use. On ``/compact`` failure, the middleware transparently falls
+back to the standard ``SummarizationMiddleware`` pathway — no crash, no
+dropped context.
 """
 
 from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
@@ -74,6 +82,7 @@ _CODEX_PROFILE = _HarnessProfile(
     tool_aliases=_CODEX_TOOL_ALIASES,
     tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
     include_apply_patch=True,
+    use_codex_compaction=True,
     excluded_tools=frozenset({"edit_file"}),
 )
 

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -50,10 +50,9 @@ finish with pending items.
 
 ## File Editing
 
-- Prefer apply_patch for single-file edits — it uses the V4A diff format you \
-are trained on. Batch logical changes into one patch instead of many small ones.
-- For auto-generated changes (package.json, lock files, formatter output) or \
-bulk search-and-replace across many files, use edit_file or shell commands instead."""
+- Use apply_patch for file edits — it uses the V4A diff format you are trained \
+on. Batch logical changes into one patch instead of many small ones.
+- For bulk operations across many files, use shell commands (sed, awk, etc.)."""
 
 _CODEX_TOOL_ALIASES: dict[str, str] = {
     "execute": "shell_command",
@@ -75,6 +74,7 @@ _CODEX_PROFILE = _HarnessProfile(
     tool_aliases=_CODEX_TOOL_ALIASES,
     tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
     include_apply_patch=True,
+    excluded_tools=frozenset({"edit_file"}),
 )
 
 for _model in ("openai:gpt-5.2-codex", "openai:gpt-5.3-codex"):

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -56,7 +56,7 @@ on. Batch logical changes into one patch instead of many small ones.
 
 _CODEX_TOOL_ALIASES: dict[str, str] = {
     "execute": "shell_command",
-    "ls": "list_dir",
+    "list_dir": "ls",
 }
 
 _CODEX_TOOL_DESCRIPTION_OVERRIDES: dict[str, str] = {

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -48,17 +48,24 @@ without seeing a prior result.
 Mark each as done, blocked (with a one-sentence reason), or cancelled. Do not \
 finish with pending items."""
 
+_CODEX_TOOL_ALIASES: dict[str, str] = {
+    "execute": "shell_command",
+    "ls": "list_dir",
+}
+
 _CODEX_TOOL_DESCRIPTION_OVERRIDES: dict[str, str] = {
     "execute": (
         "Runs a shell command and returns its output. "
         "Use for git operations, build commands, tests, and other terminal tasks. "
-        "Prefer dedicated tools (read_file, grep, glob, ls) over shell equivalents."
+        "Prefer dedicated tools (read_file, grep, glob, list_dir) over "
+        "shell_command equivalents."
     ),
 }
 
 _CODEX_PROFILE = _HarnessProfile(
     init_kwargs={"reasoning_effort": "medium"},
     system_prompt_suffix=_CODEX_SYSTEM_PROMPT_SUFFIX,
+    tool_aliases=_CODEX_TOOL_ALIASES,
     tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
 )
 

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -1,0 +1,64 @@
+"""OpenAI Codex model harness profile.
+
+!!! warning
+
+    This is an internal API subject to change without deprecation. It is not
+    intended for external use or consumption.
+
+Registers a per-model profile for ``gpt-5.3-codex`` that layers on top of
+the provider-wide OpenAI profile.  The merge gives us ``use_responses_api``
+from the provider level plus Codex-specific tuning here.
+
+Prompt additions are derived from the official Codex Prompting Guide
+(https://developers.openai.com/cookbook/examples/gpt-5/codex_prompting_guide)
+and optimized for the Deep Agents tool set.
+"""
+
+from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
+
+_CODEX_SYSTEM_PROMPT_SUFFIX = """\
+## Codex-Specific Behavior
+
+- You are an autonomous senior engineer. Once given a direction, proactively \
+gather context, plan, implement, and verify without waiting for additional \
+prompts at each step.
+- Persist until the task is fully handled end-to-end within the current turn \
+whenever feasible. Do not stop at analysis or partial fixes; carry changes \
+through implementation, verification, and a clear explanation of outcomes.
+- Bias to action: default to implementing with reasonable assumptions. Do not \
+end your turn with clarifications unless truly blocked.
+- Do not communicate an upfront plan or status preamble before acting. Just act.
+- Avoid excessive looping or repetition. If you find yourself re-reading or \
+re-editing the same files without clear progress, stop and summarize what is \
+blocking you.
+
+## Parallel Tool Use
+
+- Before any tool call, decide ALL files and resources you will need.
+- Batch reads, searches, and other independent operations into parallel tool \
+calls instead of issuing them one at a time.
+- Only make sequential calls when you truly cannot determine the next step \
+without seeing a prior result.
+
+## Plan Hygiene
+
+- Before finishing, reconcile every TODO or plan item created via write_todos. \
+Mark each as done, blocked (with a one-sentence reason), or cancelled. Do not \
+finish with pending items."""
+
+_CODEX_TOOL_DESCRIPTION_OVERRIDES: dict[str, str] = {
+    "execute": (
+        "Runs a shell command and returns its output. "
+        "Use for git operations, build commands, tests, and other terminal tasks. "
+        "Prefer dedicated tools (read_file, grep, glob, ls) over shell equivalents."
+    ),
+}
+
+_register_harness_profile(
+    "openai:gpt-5.3-codex",
+    _HarnessProfile(
+        init_kwargs={"reasoning_effort": "medium"},
+        system_prompt_suffix=_CODEX_SYSTEM_PROMPT_SUFFIX,
+        tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
+    ),
+)

--- a/libs/deepagents/deepagents/profiles/_codex.py
+++ b/libs/deepagents/deepagents/profiles/_codex.py
@@ -46,7 +46,14 @@ without seeing a prior result.
 
 - Before finishing, reconcile every TODO or plan item created via write_todos. \
 Mark each as done, blocked (with a one-sentence reason), or cancelled. Do not \
-finish with pending items."""
+finish with pending items.
+
+## File Editing
+
+- Prefer apply_patch for single-file edits — it uses the V4A diff format you \
+are trained on. Batch logical changes into one patch instead of many small ones.
+- For auto-generated changes (package.json, lock files, formatter output) or \
+bulk search-and-replace across many files, use edit_file or shell commands instead."""
 
 _CODEX_TOOL_ALIASES: dict[str, str] = {
     "execute": "shell_command",
@@ -67,6 +74,7 @@ _CODEX_PROFILE = _HarnessProfile(
     system_prompt_suffix=_CODEX_SYSTEM_PROMPT_SUFFIX,
     tool_aliases=_CODEX_TOOL_ALIASES,
     tool_description_overrides=_CODEX_TOOL_DESCRIPTION_OVERRIDES,
+    include_apply_patch=True,
 )
 
 for _model in ("openai:gpt-5.2-codex", "openai:gpt-5.3-codex"):

--- a/libs/deepagents/deepagents/profiles/_harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_harness_profiles.py
@@ -105,6 +105,15 @@ class _HarnessProfile:
         become no-ops (same caveat as `tool_description_overrides`).
     """
 
+    include_apply_patch: bool = False
+    """When ``True``, ``FilesystemMiddleware`` adds an ``apply_patch`` tool
+    that accepts V4A diffs — the format Codex models are post-trained on.
+
+    The tool coexists with ``edit_file`` by default; use ``excluded_tools``
+    to remove ``edit_file`` if eval data shows ``apply_patch`` alone
+    performs better.
+    """
+
     excluded_tools: frozenset[str] = frozenset()
     """Tool names to remove from the tool set for this provider/model.
 
@@ -295,6 +304,7 @@ def _merge_profiles(base: _HarnessProfile, override: _HarnessProfile) -> _Harnes
             **override.tool_description_overrides,
         },
         tool_aliases={**base.tool_aliases, **override.tool_aliases},
+        include_apply_patch=override.include_apply_patch or base.include_apply_patch,
         excluded_tools=base.excluded_tools | override.excluded_tools,
         extra_middleware=_merge_middleware(base.extra_middleware, override.extra_middleware),
     )

--- a/libs/deepagents/deepagents/profiles/_harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_harness_profiles.py
@@ -89,6 +89,22 @@ class _HarnessProfile:
         overrides minimal and verify against the current tool names.
     """
 
+    tool_aliases: dict[str, str] = field(default_factory=dict)
+    """Per-tool name aliases, mapping canonical name to model-facing name.
+
+    Applied by `_ToolAliasingMiddleware` which renames tools in the model
+    request and reverts tool-call names in the response, keeping all other
+    middleware and tool routing on canonical names.
+
+    Only alias tools whose argument schemas are compatible — aliasing a name
+    without matching args will confuse the model.
+
+    !!! warning
+
+        Keys are matched by canonical tool name string. Stale keys silently
+        become no-ops (same caveat as `tool_description_overrides`).
+    """
+
     excluded_tools: frozenset[str] = frozenset()
     """Tool names to remove from the tool set for this provider/model.
 
@@ -278,6 +294,7 @@ def _merge_profiles(base: _HarnessProfile, override: _HarnessProfile) -> _Harnes
             **base.tool_description_overrides,
             **override.tool_description_overrides,
         },
+        tool_aliases={**base.tool_aliases, **override.tool_aliases},
         excluded_tools=base.excluded_tools | override.excluded_tools,
         extra_middleware=_merge_middleware(base.extra_middleware, override.extra_middleware),
     )

--- a/libs/deepagents/deepagents/profiles/_harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_harness_profiles.py
@@ -114,6 +114,24 @@ class _HarnessProfile:
     performs better.
     """
 
+    use_codex_compaction: bool = False
+    """When ``True``, swap the default ``SummarizationMiddleware`` for
+    ``CodexCompactionMiddleware``, which uses the OpenAI Responses
+    ``/compact`` endpoint to compress prior turns into an opaque
+    ``encrypted_content`` item.
+
+    The compaction middleware composes the standard summarization middleware
+    internally and delegates arg truncation, offload, and cutoff logic to
+    it — so behaviors like tool-call argument truncation still fire. On
+    ``/compact`` API failure it transparently falls back to LLM-based
+    summarization via the inner middleware.
+
+    Only meaningful for OpenAI models that support the ``/compact`` endpoint
+    (currently the Codex family). A profile with this flag set on a
+    non-compatible model will raise at compaction time, not at agent
+    construction.
+    """
+
     excluded_tools: frozenset[str] = frozenset()
     """Tool names to remove from the tool set for this provider/model.
 
@@ -305,6 +323,7 @@ def _merge_profiles(base: _HarnessProfile, override: _HarnessProfile) -> _Harnes
         },
         tool_aliases={**base.tool_aliases, **override.tool_aliases},
         include_apply_patch=override.include_apply_patch or base.include_apply_patch,
+        use_codex_compaction=override.use_codex_compaction or base.use_codex_compaction,
         excluded_tools=base.excluded_tools | override.excluded_tools,
         extra_middleware=_merge_middleware(base.extra_middleware, override.extra_middleware),
     )

--- a/libs/deepagents/deepagents/utils/__init__.py
+++ b/libs/deepagents/deepagents/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Internal utility modules shared across the Deep Agents SDK."""

--- a/libs/deepagents/deepagents/utils/_apply_patch.py
+++ b/libs/deepagents/deepagents/utils/_apply_patch.py
@@ -11,10 +11,13 @@ directly.
 
 from __future__ import annotations
 
-import re
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+MIN_PATCH_LINES = 2
 
 
 class PatchError(ValueError):
@@ -129,7 +132,7 @@ def _normalize_line_endings(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
-def apply_patch(
+def apply_patch(  # noqa: C901  # single-dispatch over 4 patch operations; splitting obscures the ported V4A state machine
     patch_text: str,
     *,
     file_reader: Callable[[str], str | None],
@@ -157,7 +160,7 @@ def apply_patch(
         PatchError: If the patch is malformed or context cannot be matched.
     """
     lines = _normalize_line_endings(patch_text).strip().split("\n")
-    if len(lines) < 2 or not lines[0].startswith(_BEGIN_PATCH):
+    if len(lines) < MIN_PATCH_LINES or not lines[0].startswith(_BEGIN_PATCH):
         msg = f"Invalid patch: missing '{_BEGIN_PATCH}' header"
         raise PatchError(msg)
     if lines[-1] != _END_PATCH:
@@ -239,7 +242,7 @@ def list_referenced_files(patch_text: str) -> list[str]:
     for line in _normalize_line_endings(patch_text).split("\n"):
         for prefix in _FILE_READ_PREFIXES:
             if line.startswith(prefix):
-                paths.append(line[len(prefix):])
+                paths.append(line[len(prefix) :])
                 break
     return paths
 
@@ -262,7 +265,7 @@ def _read_prefix(state: _ParserState, prefix: str) -> str:
     line = state.lines[state.index]
     if line.startswith(prefix):
         state.index += 1
-        return line[len(prefix):]
+        return line[len(prefix) :]
     return ""
 
 
@@ -313,14 +316,14 @@ def _parse_update_file(state: _ParserState, text: str) -> list[_Chunk]:
         state.index = section.end_index
         cursor = match.index + len(section.context)
 
-        for ch in section.chunks:
-            chunks.append(
-                _Chunk(
-                    orig_index=ch.orig_index + match.index,
-                    del_lines=list(ch.del_lines),
-                    ins_lines=list(ch.ins_lines),
-                )
+        chunks.extend(
+            _Chunk(
+                orig_index=ch.orig_index + match.index,
+                del_lines=list(ch.del_lines),
+                ins_lines=list(ch.ins_lines),
             )
+            for ch in section.chunks
+        )
 
     # Consume optional *** End of File
     if state.index < len(state.lines) and state.lines[state.index] == _END_FILE:
@@ -359,7 +362,7 @@ def _advance_cursor_to_anchor(
     return cursor
 
 
-def _read_section(lines: list[str], start: int) -> _SectionResult:
+def _read_section(lines: list[str], start: int) -> _SectionResult:  # noqa: C901, PLR0912  # linearly consumes the ported V4A section grammar; splitting by branch obscures the state transitions
     """Read one context+change section until the next terminator."""
     context: list[str] = []
     del_lines: list[str] = []
@@ -380,7 +383,7 @@ def _read_section(lines: list[str], start: int) -> _SectionResult:
 
         index += 1
         last_mode = mode
-        line = raw if raw else " "
+        line = raw or " "
         prefix = line[0]
 
         if prefix == "+":
@@ -396,11 +399,13 @@ def _read_section(lines: list[str], start: int) -> _SectionResult:
         content = line[1:]
 
         if mode == "keep" and last_mode != mode and (del_lines or ins_lines):
-            chunks.append(_Chunk(
-                orig_index=len(context) - len(del_lines),
-                del_lines=list(del_lines),
-                ins_lines=list(ins_lines),
-            ))
+            chunks.append(
+                _Chunk(
+                    orig_index=len(context) - len(del_lines),
+                    del_lines=list(del_lines),
+                    ins_lines=list(ins_lines),
+                )
+            )
             del_lines = []
             ins_lines = []
 
@@ -413,11 +418,13 @@ def _read_section(lines: list[str], start: int) -> _SectionResult:
             context.append(content)
 
     if del_lines or ins_lines:
-        chunks.append(_Chunk(
-            orig_index=len(context) - len(del_lines),
-            del_lines=list(del_lines),
-            ins_lines=list(ins_lines),
-        ))
+        chunks.append(
+            _Chunk(
+                orig_index=len(context) - len(del_lines),
+                del_lines=list(del_lines),
+                ins_lines=list(ins_lines),
+            )
+        )
 
     if index == start:
         next_line = lines[index] if index < len(lines) else ""
@@ -503,10 +510,7 @@ def _slice_matches(
     """Check if *source[start:start+len(target)]* matches *target* after *transform*."""
     if start + len(target) > len(source):
         return False
-    return all(
-        transform(source[start + i]) == transform(target[i])
-        for i in range(len(target))
-    )
+    return all(transform(source[start + i]) == transform(target[i]) for i in range(len(target)))
 
 
 # ---------------------------------------------------------------------------
@@ -528,7 +532,7 @@ def _apply_chunks(text: str, chunks: list[_Chunk]) -> str:
             msg = f"Overlapping chunk at {chunk.orig_index} (cursor at {cursor})"
             raise PatchError(msg)
 
-        dest.extend(orig_lines[cursor:chunk.orig_index])
+        dest.extend(orig_lines[cursor : chunk.orig_index])
         cursor = chunk.orig_index
 
         if chunk.ins_lines:

--- a/libs/deepagents/deepagents/utils/_apply_patch.py
+++ b/libs/deepagents/deepagents/utils/_apply_patch.py
@@ -1,0 +1,440 @@
+"""V4A diff parser and applier for the ``apply_patch`` tool.
+
+Ported from OpenAI's reference implementation
+(``openai-agents-python/src/agents/apply_diff.py``) and adapted for
+Deep Agents conventions.
+
+The module is intentionally backend-agnostic: callers pass a
+``file_reader`` callback so the parser never touches the filesystem
+directly.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+class PatchError(ValueError):
+    """Raised when a V4A patch cannot be parsed or applied."""
+
+
+# ---------------------------------------------------------------------------
+# Internal data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Chunk:
+    """A contiguous block of deletions and insertions at a known position."""
+
+    orig_index: int
+    del_lines: list[str] = field(default_factory=list)
+    ins_lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _ParserState:
+    """Mutable cursor over patch lines."""
+
+    lines: list[str]
+    index: int = 0
+    fuzz: int = 0
+
+
+@dataclass
+class _SectionResult:
+    """Output of `_read_section`: context lines, chunks, and continuation info."""
+
+    context: list[str]
+    chunks: list[_Chunk]
+    end_index: int
+    eof: bool
+
+
+@dataclass
+class _ContextMatch:
+    """Result of fuzzy context search."""
+
+    index: int
+    fuzz: int
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_END_PATCH = "*** End Patch"
+_END_FILE = "*** End of File"
+_SECTION_TERMINATORS = (
+    _END_PATCH,
+    "*** Update File:",
+    "*** Delete File:",
+    "*** Add File:",
+)
+_END_SECTION_MARKERS = (*_SECTION_TERMINATORS, _END_FILE)
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def apply_patch(
+    patch_text: str,
+    *,
+    file_reader: Callable[[str], str | None],
+) -> dict[str, str | None]:
+    """Parse and apply a V4A patch, returning the resulting file changes.
+
+    Args:
+        patch_text: Full V4A patch string (``*** Begin Patch`` ...
+            ``*** End Patch``).
+        file_reader: Callback that returns file content for a given
+            absolute path, or ``None`` if the file does not exist.
+            Called only for ``*** Update File`` and ``*** Delete File``
+            operations.
+
+    Returns:
+        Mapping of file path to new content. ``None`` values indicate
+        file deletion.
+
+    Raises:
+        PatchError: If the patch is malformed or context cannot be matched.
+    """
+    lines = patch_text.strip().split("\n")
+    if len(lines) < 2 or not lines[0].startswith("*** Begin Patch"):
+        msg = "Invalid patch: missing '*** Begin Patch' header"
+        raise PatchError(msg)
+    if lines[-1] != _END_PATCH:
+        msg = "Invalid patch: missing '*** End Patch' footer"
+        raise PatchError(msg)
+
+    state = _ParserState(lines=lines, index=1)
+    results: dict[str, str | None] = {}
+
+    while not _is_done(state, _SECTION_TERMINATORS[:1]):
+        # *** Add File
+        path = _read_prefix(state, "*** Add File: ")
+        if path:
+            if path in results:
+                msg = f"Add File Error: Duplicate Path: {path}"
+                raise PatchError(msg)
+            results[path] = _parse_add_file(state)
+            continue
+
+        # *** Delete File
+        path = _read_prefix(state, "*** Delete File: ")
+        if path:
+            if path in results:
+                msg = f"Delete File Error: Duplicate Path: {path}"
+                raise PatchError(msg)
+            content = file_reader(path)
+            if content is None:
+                msg = f"Delete File Error: Missing File: {path}"
+                raise PatchError(msg)
+            results[path] = None
+            continue
+
+        # *** Update File
+        path = _read_prefix(state, "*** Update File: ")
+        if path:
+            if path in results:
+                msg = f"Update File Error: Duplicate Path: {path}"
+                raise PatchError(msg)
+            content = file_reader(path)
+            if content is None:
+                msg = f"Update File Error: Missing File: {path}"
+                raise PatchError(msg)
+            # Consume optional *** Move to: (acknowledged but not used by this tool)
+            _read_prefix(state, "*** Move to: ")
+            normalized = content.replace("\r\n", "\n")
+            chunks = _parse_update_file(state, normalized)
+            results[path] = _apply_chunks(normalized, chunks)
+            continue
+
+        current = state.lines[state.index] if state.index < len(state.lines) else "<EOF>"
+        msg = f"Unknown Line: {current}"
+        raise PatchError(msg)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Parser helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_done(state: _ParserState, prefixes: Sequence[str]) -> bool:
+    if state.index >= len(state.lines):
+        return True
+    return any(state.lines[state.index].startswith(p) for p in prefixes)
+
+
+def _read_prefix(state: _ParserState, prefix: str) -> str:
+    """If the current line starts with *prefix*, consume it and return the remainder."""
+    if state.index >= len(state.lines):
+        return ""
+    line = state.lines[state.index]
+    if line.startswith(prefix):
+        state.index += 1
+        return line[len(prefix):]
+    return ""
+
+
+def _parse_add_file(state: _ParserState) -> str:
+    """Parse ``*** Add File`` content: all lines must start with ``+``."""
+    output: list[str] = []
+    while not _is_done(state, _SECTION_TERMINATORS):
+        line = state.lines[state.index]
+        state.index += 1
+        if not line.startswith("+"):
+            msg = f"Invalid Add File Line: {line}"
+            raise PatchError(msg)
+        output.append(line[1:])
+    return "\n".join(output)
+
+
+def _parse_update_file(state: _ParserState, text: str) -> list[_Chunk]:
+    """Parse ``*** Update File`` hunks and return positioned chunks."""
+    file_lines = text.split("\n")
+    chunks: list[_Chunk] = []
+    cursor = 0
+
+    while not _is_done(state, _END_SECTION_MARKERS):
+        # Handle @@ anchors
+        anchor = _read_prefix(state, "@@ ")
+        bare_anchor = False
+        if not anchor and state.index < len(state.lines) and state.lines[state.index] == "@@":
+            bare_anchor = True
+            state.index += 1
+
+        if not (anchor or bare_anchor or cursor == 0):
+            current = state.lines[state.index] if state.index < len(state.lines) else ""
+            msg = f"Invalid Line:\n{current}"
+            raise PatchError(msg)
+
+        if anchor.strip():
+            cursor = _advance_cursor_to_anchor(anchor, file_lines, cursor, state)
+
+        section = _read_section(state.lines, state.index)
+        match = _find_context(file_lines, section.context, cursor, eof=section.eof)
+        if match.index == -1:
+            ctx = "\n".join(section.context)
+            kind = "EOF Context" if section.eof else "Context"
+            msg = f"Invalid {kind} {cursor}:\n{ctx}"
+            raise PatchError(msg)
+
+        state.fuzz += match.fuzz
+        state.index = section.end_index
+        cursor = match.index + len(section.context)
+
+        for ch in section.chunks:
+            chunks.append(
+                _Chunk(
+                    orig_index=ch.orig_index + match.index,
+                    del_lines=list(ch.del_lines),
+                    ins_lines=list(ch.ins_lines),
+                )
+            )
+
+    # Consume optional *** End of File
+    if state.index < len(state.lines) and state.lines[state.index] == _END_FILE:
+        state.index += 1
+
+    return chunks
+
+
+def _advance_cursor_to_anchor(
+    anchor: str,
+    file_lines: list[str],
+    cursor: int,
+    state: _ParserState,
+) -> int:
+    """Jump the cursor forward to the region around *anchor*.
+
+    Positions the cursor so that the subsequent context search
+    can find the anchor line and its surroundings.  Returns the
+    index of the anchor line itself (not past it), since the
+    section's context typically includes the anchor as its first
+    context line.
+    """
+    # Exact match — skip ahead only if not already seen before cursor
+    if not any(line == anchor for line in file_lines[:cursor]):
+        for i in range(cursor, len(file_lines)):
+            if file_lines[i] == anchor:
+                return i
+
+    # Fuzzy: strip both sides
+    if not any(line.strip() == anchor.strip() for line in file_lines[:cursor]):
+        for i in range(cursor, len(file_lines)):
+            if file_lines[i].strip() == anchor.strip():
+                state.fuzz += 1
+                return i
+
+    return cursor
+
+
+def _read_section(lines: list[str], start: int) -> _SectionResult:
+    """Read one context+change section until the next terminator."""
+    context: list[str] = []
+    del_lines: list[str] = []
+    ins_lines: list[str] = []
+    chunks: list[_Chunk] = []
+    mode: Literal["keep", "add", "delete"] = "keep"
+    index = start
+
+    while index < len(lines):
+        raw = lines[index]
+        if raw.startswith(("@@", _END_PATCH, "*** Update File:", "*** Delete File:", "*** Add File:", _END_FILE)):
+            break
+        if raw == "***":
+            break
+        if raw.startswith("***"):
+            msg = f"Invalid Line: {raw}"
+            raise PatchError(msg)
+
+        index += 1
+        last_mode = mode
+        line = raw if raw else " "
+        prefix = line[0]
+
+        if prefix == "+":
+            mode = "add"
+        elif prefix == "-":
+            mode = "delete"
+        elif prefix == " ":
+            mode = "keep"
+        else:
+            msg = f"Invalid Line: {line}"
+            raise PatchError(msg)
+
+        content = line[1:]
+
+        if mode == "keep" and last_mode != mode and (del_lines or ins_lines):
+            chunks.append(_Chunk(
+                orig_index=len(context) - len(del_lines),
+                del_lines=list(del_lines),
+                ins_lines=list(ins_lines),
+            ))
+            del_lines = []
+            ins_lines = []
+
+        if mode == "delete":
+            del_lines.append(content)
+            context.append(content)
+        elif mode == "add":
+            ins_lines.append(content)
+        else:
+            context.append(content)
+
+    if del_lines or ins_lines:
+        chunks.append(_Chunk(
+            orig_index=len(context) - len(del_lines),
+            del_lines=list(del_lines),
+            ins_lines=list(ins_lines),
+        ))
+
+    if index == start:
+        next_line = lines[index] if index < len(lines) else ""
+        msg = f"Nothing in this section - index={index} {next_line}"
+        raise PatchError(msg)
+
+    if index < len(lines) and lines[index] == _END_FILE:
+        return _SectionResult(context, chunks, index + 1, eof=True)
+
+    return _SectionResult(context, chunks, index, eof=False)
+
+
+# ---------------------------------------------------------------------------
+# Context matching (fuzzy)
+# ---------------------------------------------------------------------------
+
+
+def _find_context(
+    lines: list[str],
+    context: list[str],
+    start: int,
+    *,
+    eof: bool,
+) -> _ContextMatch:
+    """Find where *context* lines appear in *lines*, starting at *start*."""
+    if eof:
+        end_start = max(0, len(lines) - len(context))
+        match = _find_context_core(lines, context, end_start)
+        if match.index != -1:
+            return match
+        fallback = _find_context_core(lines, context, start)
+        return _ContextMatch(index=fallback.index, fuzz=fallback.fuzz + 10000)
+    return _find_context_core(lines, context, start)
+
+
+def _find_context_core(
+    lines: list[str],
+    context: list[str],
+    start: int,
+) -> _ContextMatch:
+    """Core context search: exact -> rstrip -> strip."""
+    if not context:
+        return _ContextMatch(index=start, fuzz=0)
+
+    for i in range(start, len(lines)):
+        if _slice_matches(lines, context, i, lambda v: v):
+            return _ContextMatch(index=i, fuzz=0)
+
+    for i in range(start, len(lines)):
+        if _slice_matches(lines, context, i, lambda v: v.rstrip()):
+            return _ContextMatch(index=i, fuzz=1)
+
+    for i in range(start, len(lines)):
+        if _slice_matches(lines, context, i, lambda v: v.strip()):
+            return _ContextMatch(index=i, fuzz=100)
+
+    return _ContextMatch(index=-1, fuzz=0)
+
+
+def _slice_matches(
+    source: list[str],
+    target: list[str],
+    start: int,
+    transform: Callable[[str], str],
+) -> bool:
+    """Check if *source[start:start+len(target)]* matches *target* after *transform*."""
+    if start + len(target) > len(source):
+        return False
+    return all(
+        transform(source[start + i]) == transform(target[i])
+        for i in range(len(target))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chunk application
+# ---------------------------------------------------------------------------
+
+
+def _apply_chunks(text: str, chunks: list[_Chunk]) -> str:
+    """Apply positioned chunks to produce the updated file content."""
+    orig_lines = text.split("\n")
+    dest: list[str] = []
+    cursor = 0
+
+    for chunk in chunks:
+        if chunk.orig_index > len(orig_lines):
+            msg = f"Chunk index {chunk.orig_index} exceeds file length {len(orig_lines)}"
+            raise PatchError(msg)
+        if cursor > chunk.orig_index:
+            msg = f"Overlapping chunk at {chunk.orig_index} (cursor at {cursor})"
+            raise PatchError(msg)
+
+        dest.extend(orig_lines[cursor:chunk.orig_index])
+        cursor = chunk.orig_index
+
+        if chunk.ins_lines:
+            dest.extend(chunk.ins_lines)
+
+        cursor += len(chunk.del_lines)
+
+    dest.extend(orig_lines[cursor:])
+    return "\n".join(dest)

--- a/libs/deepagents/deepagents/utils/_apply_patch.py
+++ b/libs/deepagents/deepagents/utils/_apply_patch.py
@@ -62,61 +62,114 @@ class _ContextMatch:
     fuzz: int
 
 
+@dataclass(frozen=True)
+class PatchResult:
+    """Outcome of applying a V4A patch.
+
+    Attributes:
+        changes: File changes keyed by path. ``None`` values indicate
+            the file should be deleted.
+        fuzz: Total accumulated fuzz across every hunk. ``0`` means
+            every context line matched exactly. Higher values signal
+            progressively weaker matches (``1`` per hunk that required
+            trailing-whitespace tolerance, ``100`` per hunk that needed
+            full whitespace-insensitive matching, plus ``1`` per anchor
+            that required strip fallback). A high aggregate fuzz means
+            the patch context barely resembles the current file — a
+            useful signal that the patch may be stale.
+    """
+
+    changes: dict[str, str | None]
+    fuzz: int = 0
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
+_BEGIN_PATCH = "*** Begin Patch"
 _END_PATCH = "*** End Patch"
 _END_FILE = "*** End of File"
+
+# File-operation prefixes (with trailing space; path follows).
+_ADD_FILE_PREFIX = "*** Add File: "
+_DELETE_FILE_PREFIX = "*** Delete File: "
+_UPDATE_FILE_PREFIX = "*** Update File: "
+_MOVE_TO_PREFIX = "*** Move to: "
+
+# Section start markers: the file-op prefixes without their trailing space,
+# used to detect when a new section begins while scanning hunk bodies.
 _SECTION_TERMINATORS = (
     _END_PATCH,
-    "*** Update File:",
-    "*** Delete File:",
-    "*** Add File:",
+    _UPDATE_FILE_PREFIX.rstrip(),
+    _DELETE_FILE_PREFIX.rstrip(),
+    _ADD_FILE_PREFIX.rstrip(),
 )
 _END_SECTION_MARKERS = (*_SECTION_TERMINATORS, _END_FILE)
+
+# Prefixes whose path argument must be read from the backend before the
+# parser can process the corresponding section.
+_FILE_READ_PREFIXES = (_UPDATE_FILE_PREFIX, _DELETE_FILE_PREFIX)
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
+def _normalize_line_endings(text: str) -> str:
+    r"""Normalize CRLF and lone CR line endings to LF.
+
+    Models and clients often emit patch text (or file content) with
+    Windows-style CRLF or, rarely, classic-Mac-style CR terminators.
+    The parser splits on ``\n`` exclusively, so any stray ``\r``
+    would leak into extracted paths, section markers, and context
+    comparisons. Normalizing at the single entry point keeps the
+    internal invariants simple: every line is clean.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def apply_patch(
     patch_text: str,
     *,
     file_reader: Callable[[str], str | None],
-) -> dict[str, str | None]:
-    """Parse and apply a V4A patch, returning the resulting file changes.
+) -> PatchResult:
+    r"""Parse and apply a V4A patch, returning the resulting file changes.
 
     Args:
         patch_text: Full V4A patch string (``*** Begin Patch`` ...
-            ``*** End Patch``).
+            ``*** End Patch``). Any ``\r\n`` or lone ``\r`` line
+            endings are normalized to ``\n`` before parsing.
         file_reader: Callback that returns file content for a given
             absolute path, or ``None`` if the file does not exist.
             Called only for ``*** Update File`` and ``*** Delete File``
-            operations.
+            operations. The callback receives the path string exactly
+            as it appears in the patch; callers are responsible for
+            validating the path before touching real storage.
 
     Returns:
-        Mapping of file path to new content. ``None`` values indicate
-        file deletion.
+        A :class:`PatchResult` whose ``changes`` map file paths to new
+        content (``None`` values mean delete) and whose ``fuzz`` field
+        aggregates how far context matching drifted from exactness —
+        see :class:`PatchResult` for the scale.
 
     Raises:
         PatchError: If the patch is malformed or context cannot be matched.
     """
-    lines = patch_text.strip().split("\n")
-    if len(lines) < 2 or not lines[0].startswith("*** Begin Patch"):
-        msg = "Invalid patch: missing '*** Begin Patch' header"
+    lines = _normalize_line_endings(patch_text).strip().split("\n")
+    if len(lines) < 2 or not lines[0].startswith(_BEGIN_PATCH):
+        msg = f"Invalid patch: missing '{_BEGIN_PATCH}' header"
         raise PatchError(msg)
     if lines[-1] != _END_PATCH:
-        msg = "Invalid patch: missing '*** End Patch' footer"
+        msg = f"Invalid patch: missing '{_END_PATCH}' footer"
         raise PatchError(msg)
 
     state = _ParserState(lines=lines, index=1)
     results: dict[str, str | None] = {}
 
-    while not _is_done(state, _SECTION_TERMINATORS[:1]):
+    while not _is_done(state, (_END_PATCH,)):
         # *** Add File
-        path = _read_prefix(state, "*** Add File: ")
+        path = _read_prefix(state, _ADD_FILE_PREFIX)
         if path:
             if path in results:
                 msg = f"Add File Error: Duplicate Path: {path}"
@@ -125,7 +178,7 @@ def apply_patch(
             continue
 
         # *** Delete File
-        path = _read_prefix(state, "*** Delete File: ")
+        path = _read_prefix(state, _DELETE_FILE_PREFIX)
         if path:
             if path in results:
                 msg = f"Delete File Error: Duplicate Path: {path}"
@@ -138,7 +191,7 @@ def apply_patch(
             continue
 
         # *** Update File
-        path = _read_prefix(state, "*** Update File: ")
+        path = _read_prefix(state, _UPDATE_FILE_PREFIX)
         if path:
             if path in results:
                 msg = f"Update File Error: Duplicate Path: {path}"
@@ -148,8 +201,8 @@ def apply_patch(
                 msg = f"Update File Error: Missing File: {path}"
                 raise PatchError(msg)
             # Consume optional *** Move to: (acknowledged but not used by this tool)
-            _read_prefix(state, "*** Move to: ")
-            normalized = content.replace("\r\n", "\n")
+            _read_prefix(state, _MOVE_TO_PREFIX)
+            normalized = _normalize_line_endings(content)
             chunks = _parse_update_file(state, normalized)
             results[path] = _apply_chunks(normalized, chunks)
             continue
@@ -158,7 +211,37 @@ def apply_patch(
         msg = f"Unknown Line: {current}"
         raise PatchError(msg)
 
-    return results
+    return PatchResult(changes=results, fuzz=state.fuzz)
+
+
+def list_referenced_files(patch_text: str) -> list[str]:
+    """Return paths the patch must read from the backend before applying.
+
+    Performs a lightweight prescan identifying every ``*** Update File:``
+    and ``*** Delete File:`` operation so async callers can pre-fetch
+    file contents (the main ``apply_patch`` entry point consumes a
+    synchronous ``file_reader`` callback and cannot ``await`` mid-parse).
+
+    This intentionally shares the same prefix constants as the main
+    parser so the two stay in lock-step if the V4A format evolves. It
+    does **not** fully validate the patch structure; callers should
+    still invoke :func:`apply_patch` to surface parse errors.
+
+    Args:
+        patch_text: Full V4A patch string.
+
+    Returns:
+        Paths in the order they appear in the patch. Paths may repeat
+        if the patch is malformed; :func:`apply_patch` will reject such
+        duplicates when it runs.
+    """
+    paths: list[str] = []
+    for line in _normalize_line_endings(patch_text).split("\n"):
+        for prefix in _FILE_READ_PREFIXES:
+            if line.startswith(prefix):
+                paths.append(line[len(prefix):])
+                break
+    return paths
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +370,7 @@ def _read_section(lines: list[str], start: int) -> _SectionResult:
 
     while index < len(lines):
         raw = lines[index]
-        if raw.startswith(("@@", _END_PATCH, "*** Update File:", "*** Delete File:", "*** Add File:", _END_FILE)):
+        if raw.startswith(("@@", *_END_SECTION_MARKERS)):
             break
         if raw == "***":
             break
@@ -359,14 +442,31 @@ def _find_context(
     *,
     eof: bool,
 ) -> _ContextMatch:
-    """Find where *context* lines appear in *lines*, starting at *start*."""
+    """Find where *context* lines appear in *lines*, starting at *start*.
+
+    When *eof* is ``True`` the patch claimed ``*** End of File`` and we
+    first try to match against the tail of the file. If that fails but
+    the same context matches earlier in the file, the patch is almost
+    certainly stale — the model thought it was editing the last lines
+    but the file now has content after them. Rather than silently
+    accept that mismatch (the previous behavior, flagged by a dead
+    ``+10000`` fuzz sentinel), we raise so the caller sees it and can
+    re-read the file.
+    """
     if eof:
         end_start = max(0, len(lines) - len(context))
         match = _find_context_core(lines, context, end_start)
         if match.index != -1:
             return match
         fallback = _find_context_core(lines, context, start)
-        return _ContextMatch(index=fallback.index, fuzz=fallback.fuzz + 10000)
+        if fallback.index == -1:
+            return fallback
+        msg = (
+            "EOF context did not match at end of file, but matched earlier. "
+            "The '*** End of File' marker suggests the patch is stale; "
+            "re-read the file and regenerate the patch."
+        )
+        raise PatchError(msg)
     return _find_context_core(lines, context, start)
 
 

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -53,7 +53,7 @@ test = [
   "ty>=0.0.1,<1.0.0",
   "pytest-asyncio>=1.3.0",
   "langchain-tests>=1.1.6",
-  "langchain-openai",
+  "langchain-openai>=1.1.12,<2.0.0",
   "twine",
   "build",
 ]

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
     "wcmatch",
 ]
 
+[project.optional-dependencies]
+# Required by `CodexCompactionMiddleware` — specifically the `>=1.1.12` bound,
+# which is where `_construct_responses_api_input` started round-tripping the
+# `phase` field on content blocks that the middleware relies on.
+codex = ["langchain-openai>=1.1.12,<2.0.0"]
+
 
 [project.urls]
 Homepage = "https://docs.langchain.com/oss/python/deepagents/overview"

--- a/libs/deepagents/tests/unit_tests/middleware/test_apply_patch_path_validation.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_apply_patch_path_validation.py
@@ -1,0 +1,144 @@
+"""Tests for path traversal validation in apply_patch helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepagents.backends.protocol import BackendProtocol, EditResult, ReadResult, WriteResult
+from deepagents.middleware.filesystem import _aapply_file_changes, _apply_file_changes
+
+
+class _NeverCalledBackend(BackendProtocol):
+    """Backend that fails if any operation is called."""
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        msg = f"unexpected read: {file_path}"
+        raise AssertionError(msg)
+
+    async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        msg = f"unexpected aread: {file_path}"
+        raise AssertionError(msg)
+
+    def write(self, path: str, content: str) -> WriteResult:
+        msg = f"unexpected write: {path}"
+        raise AssertionError(msg)
+
+    async def awrite(self, path: str, content: str) -> WriteResult:
+        msg = f"unexpected awrite: {path}"
+        raise AssertionError(msg)
+
+    def edit(self, path: str, old: str, new: str) -> EditResult:
+        msg = f"unexpected edit: {path}"
+        raise AssertionError(msg)
+
+    async def aedit(self, path: str, old: str, new: str) -> EditResult:
+        msg = f"unexpected aedit: {path}"
+        raise AssertionError(msg)
+
+
+class _RecordingBackend(BackendProtocol):
+    """Backend that records which paths are accessed."""
+
+    def __init__(self) -> None:
+        self.accessed: list[str] = []
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        self.accessed.append(file_path)
+        return ReadResult(error="not found")
+
+    async def aread(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        self.accessed.append(file_path)
+        return ReadResult(error="not found")
+
+    def write(self, path: str, content: str) -> WriteResult:
+        self.accessed.append(path)
+        return WriteResult(path=path)
+
+    async def awrite(self, path: str, content: str) -> WriteResult:
+        self.accessed.append(path)
+        return WriteResult(path=path)
+
+
+class TestApplyFileChangesPathValidation:
+    """Path traversal attacks must be blocked before reaching the backend."""
+
+    @pytest.mark.parametrize(
+        "malicious_path",
+        [
+            "../etc/passwd",
+            "foo/../../etc/shadow",
+            "~/secret.txt",
+            "C:\\Windows\\system32\\config",
+        ],
+    )
+    def test_traversal_path_rejected_sync(self, malicious_path: str) -> None:
+        backend = _NeverCalledBackend()
+        result = _apply_file_changes(backend, {malicious_path: "pwned"})
+        assert "Error" in result
+
+    @pytest.mark.parametrize(
+        "malicious_path",
+        [
+            "../etc/passwd",
+            "foo/../../etc/shadow",
+            "~/secret.txt",
+            "C:\\Windows\\system32\\config",
+        ],
+    )
+    async def test_traversal_path_rejected_async(self, malicious_path: str) -> None:
+        backend = _NeverCalledBackend()
+        result = await _aapply_file_changes(backend, {malicious_path: "pwned"})
+        assert "Error" in result
+
+    def test_valid_path_passes_through_sync(self) -> None:
+        backend = _RecordingBackend()
+        result = _apply_file_changes(backend, {"/app/safe.py": "content"})
+        assert "Created '/app/safe.py'" in result
+        assert "/app/safe.py" in backend.accessed
+
+    async def test_valid_path_passes_through_async(self) -> None:
+        backend = _RecordingBackend()
+        result = await _aapply_file_changes(backend, {"/app/safe.py": "content"})
+        assert "Created '/app/safe.py'" in result
+        assert "/app/safe.py" in backend.accessed
+
+    def test_mixed_valid_and_malicious_sync(self) -> None:
+        """Valid paths succeed; traversal paths are rejected individually."""
+        backend = _RecordingBackend()
+        changes: dict[str, str | None] = {
+            "/app/ok.py": "good",
+            "../etc/passwd": "bad",
+            "/app/also_ok.py": "fine",
+        }
+        result = _apply_file_changes(backend, changes)
+        assert "Created '/app/ok.py'" in result
+        assert "Created '/app/also_ok.py'" in result
+        assert "Error" in result
+        assert "/app/ok.py" in backend.accessed
+        assert "/app/also_ok.py" in backend.accessed
+
+    async def test_mixed_valid_and_malicious_async(self) -> None:
+        """Valid paths succeed; traversal paths are rejected individually."""
+        backend = _RecordingBackend()
+        changes: dict[str, str | None] = {
+            "/app/ok.py": "good",
+            "../etc/passwd": "bad",
+            "/app/also_ok.py": "fine",
+        }
+        result = await _aapply_file_changes(backend, changes)
+        assert "Created '/app/ok.py'" in result
+        assert "Created '/app/also_ok.py'" in result
+        assert "Error" in result
+        assert "/app/ok.py" in backend.accessed
+        assert "/app/also_ok.py" in backend.accessed
+
+    def test_delete_with_traversal_path_rejected_sync(self) -> None:
+        """Deletion of a traversal path is also blocked."""
+        backend = _NeverCalledBackend()
+        result = _apply_file_changes(backend, {"../etc/passwd": None})
+        assert "Error" in result
+
+    async def test_delete_with_traversal_path_rejected_async(self) -> None:
+        backend = _NeverCalledBackend()
+        result = await _aapply_file_changes(backend, {"../etc/passwd": None})
+        assert "Error" in result

--- a/libs/deepagents/tests/unit_tests/middleware/test_codex_compaction.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_codex_compaction.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
+import pytest
 from langchain.agents.middleware.types import ExtendedModelResponse, ModelRequest
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langgraph.types import Command
+from openai import APITimeoutError
 
 from deepagents.middleware.codex_compaction import CodexCompactionMiddleware
 from deepagents.middleware.summarization import _DeepAgentsSummarizationMiddleware
@@ -21,6 +26,16 @@ from tests.unit_tests.middleware.test_summarization_middleware import (
 
 if TYPE_CHECKING:
     from langchain.agents.middleware.types import AgentState
+
+
+def _api_error() -> APITimeoutError:
+    """Construct an ``openai.APIError`` subclass suitable for tests.
+
+    ``APITimeoutError`` requires a real ``httpx.Request`` and is a recoverable
+    error category the middleware must fall back on (vs programming errors
+    like ``RuntimeError`` which must propagate).
+    """
+    return APITimeoutError(httpx.Request("POST", "https://api.openai.com/v1/responses/compact"))
 
 
 # -----------------------------------------------------------------------------
@@ -355,7 +370,7 @@ class TestFallback:
         middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
 
         fake_client = MagicMock()
-        fake_client.responses.compact = AsyncMock(side_effect=RuntimeError("boom"))
+        fake_client.responses.compact = AsyncMock(side_effect=_api_error())
         middleware._client = fake_client
 
         # Patch the inner middleware's awrap_model_call so we can assert it was
@@ -368,6 +383,31 @@ class TestFallback:
         await _run_awrap(middleware, _make_state(messages), runtime)
 
         fallback.assert_awaited_once()
+
+    async def test_non_api_error_propagates(self) -> None:
+        """Programming errors must surface, not silently trigger the fallback.
+
+        ``except Exception`` was swallowing real bugs (AttributeError,
+        ImportError, etc.) and hiding them behind the summarization fallback.
+        Only ``openai.APIError`` and its subclasses trigger the fallback now.
+        """
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(side_effect=RuntimeError("not a recoverable error"))
+        middleware._client = fake_client
+
+        fallback = AsyncMock(return_value=AIMessage(content="fallback"))
+        middleware._inner.awrap_model_call = fallback
+
+        runtime = make_mock_runtime()
+        with pytest.raises(RuntimeError, match="not a recoverable error"):
+            await _run_awrap(middleware, _make_state(messages), runtime)
+
+        fallback.assert_not_awaited()
 
     async def test_fallback_does_not_double_offload(self) -> None:
         """On `/compact` failure the wrapper must not offload before falling back.
@@ -384,7 +424,7 @@ class TestFallback:
         middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
 
         fake_client = MagicMock()
-        fake_client.responses.compact = AsyncMock(side_effect=RuntimeError("boom"))
+        fake_client.responses.compact = AsyncMock(side_effect=_api_error())
         middleware._client = fake_client
 
         # Stub the fallback so we can assert invocation without running the
@@ -496,3 +536,257 @@ class TestSubagentIndependence:
         assert isinstance(head_b, AIMessage)
         assert head_b.content == [{"type": "compaction", "encrypted_content": "b-blob"}]
         assert cap_a.messages[0] is not head_b
+
+
+# -----------------------------------------------------------------------------
+# State mutual exclusion between compaction and summarization events
+# -----------------------------------------------------------------------------
+
+
+class TestStateMutualExclusion:
+    """`codex_compaction_item` and `_summarization_event` must never coexist.
+
+    Two state keys with overlapping semantics is a known correctness hazard:
+    each path reads only its own key, so a path switch mid-conversation would
+    silently discard the other path's state. These tests enforce the
+    invariant by asserting every commit clears the sibling key.
+    """
+
+    async def test_compact_success_clears_summarization_event(self) -> None:
+        """A successful compact commits with ``_summarization_event: None``."""
+        messages = make_conversation_messages(num_old=6, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=4)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "new-blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        result, _ = await _run_awrap(middleware, _make_state(messages), runtime)
+
+        assert isinstance(result, ExtendedModelResponse)
+        update = result.command.update
+        assert update is not None
+        assert "codex_compaction_item" in update
+        assert update["_summarization_event"] is None, "compact success must clear _summarization_event to preserve the mutual-exclusion invariant"
+
+    async def test_fallback_clears_codex_compaction_item(self) -> None:
+        """When the fallback commits a summarization event, compaction item is cleared."""
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(side_effect=_api_error())
+        middleware._client = fake_client
+
+        # Simulate the inner middleware committing its own state update on the
+        # fallback path (what the real summarization path does on success).
+        fallback_response = ExtendedModelResponse(
+            model_response=AIMessage(content="fallback-summary"),
+            command=Command(update={"_summarization_event": {"cutoff_index": 3, "summary_message": AIMessage(content="sum"), "file_path": "/x.md"}}),
+        )
+        middleware._inner.awrap_model_call = AsyncMock(return_value=fallback_response)
+
+        runtime = make_mock_runtime()
+        prior_event = {
+            "cutoff_index": 1,
+            "output": [{"type": "compaction", "encrypted_content": "stale-blob"}],
+            "file_path": "/old.md",
+        }
+        result, _ = await _run_awrap(
+            middleware,
+            _make_state(messages, compaction_item=prior_event),
+            runtime,
+        )
+
+        assert isinstance(result, ExtendedModelResponse)
+        update = result.command.update
+        assert update is not None
+        assert update["codex_compaction_item"] is None, "fallback must clear stale codex_compaction_item to preserve mutual exclusion"
+        # Inner's own update must also be present in the merged command.
+        assert "_summarization_event" in update
+
+    async def test_fallback_passthrough_when_inner_returns_plain_response(self) -> None:
+        """If the inner returns a plain `ModelResponse`, pass through unchanged.
+
+        No new state is being committed, so there is no mutual-exclusion
+        violation to fix — the prior compaction item (if any) remains
+        structurally valid because its backing messages and offload file are
+        untouched.
+        """
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(side_effect=_api_error())
+        middleware._client = fake_client
+
+        # Inner returns a plain message (simulating "no summarization this
+        # turn"): no Command, no state update.
+        middleware._inner.awrap_model_call = AsyncMock(return_value=AIMessage(content="plain-reply"))
+
+        runtime = make_mock_runtime()
+        result, _ = await _run_awrap(middleware, _make_state(messages), runtime)
+
+        assert not isinstance(result, ExtendedModelResponse), "plain ModelResponse from fallback must not be wrapped in ExtendedModelResponse"
+
+
+# -----------------------------------------------------------------------------
+# Offload failure triggers fallback (recovery invariant)
+# -----------------------------------------------------------------------------
+
+
+class TestOffloadFailureFallback:
+    """If ``/compact`` succeeds but offload fails, fall back instead of committing.
+
+    A compaction event without a recoverable backend file is an opaque blob
+    the user cannot decode. The recovery invariant requires every committed
+    event to have a valid ``file_path``, so offload failure is promoted to a
+    hard fallback.
+    """
+
+    async def test_offload_failure_triggers_fallback(self) -> None:
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        # `should_fail=True` makes MockBackend.awrite/aedit return a WriteResult
+        # with error set, which makes _aoffload_to_backend return None.
+        backend = MockBackend(should_fail=True, error_message="disk full")
+        middleware = CodexCompactionMiddleware(_make_model(), backend)
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        compact_response = _make_compacted_response([{"type": "compaction", "encrypted_content": "compact-ok-blob"}])
+        fake_client.responses.compact = AsyncMock(return_value=compact_response)
+        middleware._client = fake_client
+
+        fallback = AsyncMock(return_value=AIMessage(content="fallback"))
+        middleware._inner.awrap_model_call = fallback
+
+        runtime = make_mock_runtime()
+        result, _ = await _run_awrap(middleware, _make_state(messages), runtime)
+
+        # Compact was called...
+        fake_client.responses.compact.assert_awaited_once()
+        # ...but because offload failed, the wrapper must fall back.
+        fallback.assert_awaited_once()
+        # And the event must NOT be committed: no ExtendedModelResponse
+        # originating from the compaction success path.
+        # (The inner's mocked fallback returns a plain AIMessage, so a plain
+        # return here confirms we never reached the commit branch.)
+        assert not isinstance(result, ExtendedModelResponse)
+
+    async def test_offload_failure_clears_stale_compaction_item(self) -> None:
+        """Offload-failure fallback must still honor mutual exclusion."""
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        backend = MockBackend(should_fail=True)
+        middleware = CodexCompactionMiddleware(_make_model(), backend)
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "blob"}]))
+        middleware._client = fake_client
+
+        fallback_response = ExtendedModelResponse(
+            model_response=AIMessage(content="fallback-summary"),
+            command=Command(update={"_summarization_event": {"cutoff_index": 3, "summary_message": AIMessage(content="sum"), "file_path": "/x.md"}}),
+        )
+        middleware._inner.awrap_model_call = AsyncMock(return_value=fallback_response)
+
+        runtime = make_mock_runtime()
+        prior_event = {
+            "cutoff_index": 1,
+            "output": [{"type": "compaction", "encrypted_content": "stale"}],
+            "file_path": "/old.md",
+        }
+        result, _ = await _run_awrap(
+            middleware,
+            _make_state(messages, compaction_item=prior_event),
+            runtime,
+        )
+
+        assert isinstance(result, ExtendedModelResponse)
+        update = result.command.update
+        assert update is not None
+        assert update["codex_compaction_item"] is None
+        assert "_summarization_event" in update
+
+
+# -----------------------------------------------------------------------------
+# Synchronous path downgrade warning
+# -----------------------------------------------------------------------------
+
+
+class TestSyncDowngrade:
+    """Sync callers silently get summarization; we must flag it audibly."""
+
+    def test_sync_call_warns_once_and_delegates(self, caplog: pytest.LogCaptureFixture) -> None:
+        messages = make_conversation_messages(num_old=1, num_recent=1)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+
+        sync_spy = MagicMock(return_value=AIMessage(content="sync-reply"))
+        middleware._inner.wrap_model_call = sync_spy
+
+        def handler(_req: ModelRequest) -> Any:  # noqa: ANN401
+            return AIMessage(content="inner-reply")
+
+        request = ModelRequest(
+            model=middleware._model,
+            messages=messages,
+            system_message=None,
+            tools=[],
+            runtime=make_mock_runtime(),
+            state=cast("AgentState[Any]", {"messages": messages}),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware.codex_compaction"):
+            middleware.wrap_model_call(request, handler)
+            middleware.wrap_model_call(request, handler)
+
+        assert sync_spy.call_count == 2, "both sync calls must delegate to the inner middleware"
+        sync_warnings = [
+            r
+            for r in caplog.records
+            if r.name == "deepagents.middleware.codex_compaction" and r.levelno == logging.WARNING and "synchronously" in r.getMessage()
+        ]
+        assert len(sync_warnings) == 1, f"sync downgrade warning must fire exactly once per instance, got {len(sync_warnings)}"
+
+
+# -----------------------------------------------------------------------------
+# Model name resolution via `get_model_identifier`
+# -----------------------------------------------------------------------------
+
+
+class TestResolveModelName:
+    """`_resolve_model_name` delegates to `get_model_identifier`."""
+
+    def test_strips_provider_prefix(self) -> None:
+        """Qualified identifiers like ``openai:gpt-5.3-codex`` have the prefix stripped."""
+
+        class _QualifiedModel(_FakeCodexModel):
+            model_name: str = "openai:gpt-5.3-codex"
+
+        middleware = CodexCompactionMiddleware(
+            _QualifiedModel(messages=iter([AIMessage(content="x")])),
+            MockBackend(),
+        )
+        assert middleware._resolve_model_name() == "gpt-5.3-codex"
+
+    def test_raises_when_identifier_missing(self) -> None:
+        """Models without a resolvable identifier produce a configuration error."""
+
+        class _UnnamedModel(_FakeCodexModel):
+            model_name: str = ""
+
+        middleware = CodexCompactionMiddleware(
+            _UnnamedModel(messages=iter([AIMessage(content="x")])),
+            MockBackend(),
+        )
+        with pytest.raises(RuntimeError, match="could not determine the OpenAI model name"):
+            middleware._resolve_model_name()

--- a/libs/deepagents/tests/unit_tests/middleware/test_codex_compaction.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_codex_compaction.py
@@ -1,0 +1,498 @@
+"""Unit tests for `CodexCompactionMiddleware`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from langchain.agents.middleware.types import ExtendedModelResponse, ModelRequest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+from deepagents.middleware.codex_compaction import CodexCompactionMiddleware
+from deepagents.middleware.summarization import _DeepAgentsSummarizationMiddleware
+from tests.unit_tests.chat_model import GenericFakeChatModel
+from tests.unit_tests.middleware.test_summarization_middleware import (
+    MockBackend,
+    make_conversation_messages,
+    make_mock_runtime,
+    mock_get_config,
+)
+
+if TYPE_CHECKING:
+    from langchain.agents.middleware.types import AgentState
+
+
+# -----------------------------------------------------------------------------
+# Fixtures and helpers
+# -----------------------------------------------------------------------------
+
+
+class _FakeCodexModel(GenericFakeChatModel):
+    """Chat model that looks enough like ChatOpenAI for compaction tests.
+
+    Exposes ``model_name`` so ``_resolve_model_name`` can pick it up, and a
+    profile with ``max_input_tokens`` so the inner summarization middleware
+    picks fraction-based trigger defaults.
+    """
+
+    model_name: str = "gpt-5.3-codex"
+
+    @property
+    def profile(self) -> dict[str, Any]:
+        return {"max_input_tokens": 1000}
+
+
+def _make_model() -> _FakeCodexModel:
+    """Build a fake Codex model with a spare reply in the iterator.
+
+    The summarization fallback path invokes the model once for its LLM
+    summary; supplying a response keeps the test from hanging if fallback
+    fires unexpectedly.
+    """
+    return _FakeCodexModel(messages=iter([AIMessage(content="fallback summary")]))
+
+
+def _make_state(messages: list[BaseMessage], compaction_item: dict[str, Any] | None = None) -> dict[str, Any]:
+    state: dict[str, Any] = {"messages": messages}
+    if compaction_item is not None:
+        state["codex_compaction_item"] = compaction_item
+    return state
+
+
+def _make_compacted_response(items: list[dict[str, Any]]) -> SimpleNamespace:
+    """Build a stand-in for ``CompactedResponse``.
+
+    The middleware only uses ``result.output`` and calls ``model_dump`` on
+    each item, so a lightweight namespace with pre-dumped items suffices.
+    """
+    dumped_items = [SimpleNamespace(model_dump=lambda i=item, **_kw: i) for item in items]
+    return SimpleNamespace(output=dumped_items)
+
+
+async def _run_awrap(
+    middleware: CodexCompactionMiddleware,
+    state: dict[str, Any],
+    runtime: Any,  # noqa: ANN401  # langgraph Runtime is mock-constructed in tests
+) -> tuple[Any, ModelRequest | None]:
+    """Invoke ``awrap_model_call`` and capture the request handed to the handler."""
+    request = ModelRequest(
+        model=middleware._model,
+        messages=state["messages"],
+        system_message=None,
+        tools=[],
+        runtime=runtime,
+        state=cast("AgentState[Any]", state),
+    )
+
+    captured: dict[str, ModelRequest] = {}
+
+    async def handler(req: ModelRequest) -> AIMessage:
+        captured["req"] = req
+        return AIMessage(content="model reply")
+
+    with mock_get_config("test-thread-codex"):
+        result = await middleware.awrap_model_call(request, handler)
+
+    return result, captured.get("req")
+
+
+# -----------------------------------------------------------------------------
+# Construction
+# -----------------------------------------------------------------------------
+
+
+class TestInit:
+    """Construction and composition."""
+
+    def test_composes_inner_summarization(self) -> None:
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        assert isinstance(middleware._inner, _DeepAgentsSummarizationMiddleware)
+
+    def test_resolve_model_name_reads_attribute(self) -> None:
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        assert middleware._resolve_model_name() == "gpt-5.3-codex"
+
+
+# -----------------------------------------------------------------------------
+# Trigger threshold
+# -----------------------------------------------------------------------------
+
+
+class TestTrigger:
+    """Below-trigger forwards; above-trigger calls `/compact`."""
+
+    async def test_below_trigger_forwards_untouched(self) -> None:
+        messages = make_conversation_messages(num_old=1, num_recent=1)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        # Force `_should_summarize` to be False so we bypass /compact entirely.
+        middleware._inner._should_summarize = MagicMock(return_value=False)
+
+        runtime = make_mock_runtime()
+        result, captured = await _run_awrap(middleware, _make_state(messages), runtime)
+
+        assert captured is not None
+        assert not isinstance(result, ExtendedModelResponse)
+        # No compaction happened, so the message list the handler saw matches the state.
+        assert len(captured.messages) == len(messages)
+
+    async def test_above_trigger_calls_compact(self) -> None:
+        messages = make_conversation_messages(num_old=6, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=4)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "opaque-blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        result, captured = await _run_awrap(middleware, _make_state(messages), runtime)
+
+        fake_client.responses.compact.assert_awaited_once()
+        kwargs = fake_client.responses.compact.await_args.kwargs
+        assert kwargs["model"] == "gpt-5.3-codex"
+        # Compaction happened — expect ExtendedModelResponse with a state update.
+        assert isinstance(result, ExtendedModelResponse)
+        event = result.command.update["codex_compaction_item"]
+        assert event["output"] == [{"type": "compaction", "encrypted_content": "opaque-blob"}]
+        # The handler saw the compact head + preserved messages, not the raw state list.
+        assert captured is not None
+        assert len(captured.messages) < len(messages)
+        head = captured.messages[0]
+        assert isinstance(head, AIMessage)
+        assert head.content == [{"type": "compaction", "encrypted_content": "opaque-blob"}]
+
+
+# -----------------------------------------------------------------------------
+# Prior item splice
+# -----------------------------------------------------------------------------
+
+
+class TestPriorItemSplice:
+    """Stored compaction output is reused on the next turn."""
+
+    async def test_prior_item_prepended_to_effective_messages(self) -> None:
+        messages = make_conversation_messages(num_old=2, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=False)
+
+        prior_output = [{"type": "compaction", "encrypted_content": "earlier-blob"}]
+        prior_event = {"cutoff_index": 2, "output": prior_output, "file_path": "/x.md"}
+        state = _make_state(messages, compaction_item=prior_event)
+
+        runtime = make_mock_runtime()
+        _result, captured = await _run_awrap(middleware, state, runtime)
+
+        assert captured is not None
+        # Effective list: [compaction_head, *messages[2:]] where messages has 4 items.
+        assert len(captured.messages) == 3
+        head = captured.messages[0]
+        assert isinstance(head, AIMessage)
+        assert head.content == prior_output
+
+    async def test_prior_item_prepended_to_compact_input(self) -> None:
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        prior_output = [{"type": "compaction", "encrypted_content": "earlier-blob"}]
+        prior_event = {"cutoff_index": 1, "output": prior_output, "file_path": "/x.md"}
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "new-blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        state = _make_state(messages, compaction_item=prior_event)
+        await _run_awrap(middleware, state, runtime)
+
+        # /compact was called with prior output items prefixed on the input.
+        kwargs = fake_client.responses.compact.await_args.kwargs
+        assert kwargs["input"][0] == prior_output[0]
+
+    async def test_prior_item_not_duplicated_in_compact_input(self) -> None:
+        """Regression guard for duplicate prior compaction items.
+
+        The synthetic head round-trips the prior compaction item through
+        ``_construct_responses_api_input``, so we must not also prepend
+        ``prior_event["output"]`` on top of it.
+        """
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        prior_output = [
+            {
+                "type": "compaction",
+                "encrypted_content": "earlier-blob",
+                "id": "compact_earlier",
+            }
+        ]
+        prior_event = {"cutoff_index": 1, "output": prior_output, "file_path": "/x.md"}
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "new-blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        state = _make_state(messages, compaction_item=prior_event)
+        await _run_awrap(middleware, state, runtime)
+
+        input_items = fake_client.responses.compact.await_args.kwargs["input"]
+        compaction_items = [item for item in input_items if item.get("type") == "compaction"]
+        assert len(compaction_items) == 1, f"prior compaction item sent twice: {compaction_items}"
+        assert compaction_items[0]["encrypted_content"] == "earlier-blob"
+        assert compaction_items[0]["id"] == "compact_earlier"
+
+
+# -----------------------------------------------------------------------------
+# Phase drift-guard on langchain-openai
+# -----------------------------------------------------------------------------
+
+
+class TestPhaseDriftGuard:
+    """`_construct_responses_api_input` must keep the `phase` field on blocks."""
+
+    def test_phase_lifted_to_item(self) -> None:
+        # Imported inside the test to keep it isolated from the middleware and
+        # act as a pure drift-guard on langchain-openai itself.
+        from langchain_openai.chat_models.base import _construct_responses_api_input  # noqa: PLC0415
+
+        msg = AIMessage(
+            id="ai-phase-1",
+            content=[
+                {
+                    "type": "output_text",
+                    "text": "let me think",
+                    "phase": "commentary",
+                    "id": "ai-phase-1",
+                }
+            ],
+        )
+        items = _construct_responses_api_input([msg])
+
+        assert any(item.get("phase") == "commentary" for item in items)
+
+
+# -----------------------------------------------------------------------------
+# Phase propagation end-to-end
+# -----------------------------------------------------------------------------
+
+
+class TestPhaseEndToEnd:
+    """Phase on a content block must survive the trip to `/compact`."""
+
+    async def test_phase_in_compact_input(self) -> None:
+        msg_with_phase = AIMessage(
+            id="ai-phase-2",
+            content=[
+                {
+                    "type": "output_text",
+                    "text": "commentary chunk",
+                    "phase": "commentary",
+                    "id": "ai-phase-2",
+                }
+            ],
+        )
+        messages: list[BaseMessage] = [
+            HumanMessage(content="hi", id="u-0"),
+            msg_with_phase,
+            HumanMessage(content="keep me", id="u-1"),
+            HumanMessage(content="keep me too", id="u-2"),
+        ]
+
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=2)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "phased-blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        await _run_awrap(middleware, _make_state(messages), runtime)
+
+        input_items = fake_client.responses.compact.await_args.kwargs["input"]
+        assert any(item.get("phase") == "commentary" for item in input_items), input_items
+
+
+# -----------------------------------------------------------------------------
+# Arg truncation still fires
+# -----------------------------------------------------------------------------
+
+
+class TestArgTruncation:
+    """Composition must preserve the inner middleware's arg-truncation pass."""
+
+    async def test_truncate_args_invoked(self) -> None:
+        messages = make_conversation_messages(num_old=1, num_recent=1)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=False)
+        spy = MagicMock(wraps=middleware._inner._truncate_args)
+        middleware._inner._truncate_args = spy
+
+        runtime = make_mock_runtime()
+        await _run_awrap(middleware, _make_state(messages), runtime)
+
+        spy.assert_called_once()
+
+
+# -----------------------------------------------------------------------------
+# Fallback on /compact failure
+# -----------------------------------------------------------------------------
+
+
+class TestFallback:
+    """Any `/compact` failure falls back to the inner summarization path."""
+
+    async def test_fallback_on_compact_error(self) -> None:
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(side_effect=RuntimeError("boom"))
+        middleware._client = fake_client
+
+        # Patch the inner middleware's awrap_model_call so we can assert it was
+        # called without running the real summarization (which would hit the
+        # fake model and potentially run out of responses).
+        fallback = AsyncMock(return_value=AIMessage(content="fallback"))
+        middleware._inner.awrap_model_call = fallback
+
+        runtime = make_mock_runtime()
+        await _run_awrap(middleware, _make_state(messages), runtime)
+
+        fallback.assert_awaited_once()
+
+    async def test_fallback_does_not_double_offload(self) -> None:
+        """On `/compact` failure the wrapper must not offload before falling back.
+
+        If the wrapper's own offload ran concurrently with the failed
+        ``/compact`` call, it would land in the backend; the summarization
+        fallback then performs its own offload, giving us two sections of the
+        same pre-compaction window in ``conversation_history/{thread_id}.md``.
+        """
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        backend = MockBackend()
+        middleware = CodexCompactionMiddleware(_make_model(), backend)
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(side_effect=RuntimeError("boom"))
+        middleware._client = fake_client
+
+        # Stub the fallback so we can assert invocation without running the
+        # real summarization (the stub replaces the inner middleware's own
+        # offload call too, so any write to the backend must have come from
+        # the wrapper).
+        fallback = AsyncMock(return_value=AIMessage(content="fallback"))
+        middleware._inner.awrap_model_call = fallback
+
+        runtime = make_mock_runtime()
+        await _run_awrap(middleware, _make_state(messages), runtime)
+
+        fallback.assert_awaited_once()
+        assert not backend.write_calls, f"wrapper offloaded before fallback: {backend.write_calls}"
+        assert not backend.edit_calls, f"wrapper offloaded before fallback: {backend.edit_calls}"
+
+
+# -----------------------------------------------------------------------------
+# Timeout on /compact
+# -----------------------------------------------------------------------------
+
+
+class TestCompactTimeout:
+    """`/compact` calls must have a bounded timeout so hangs do not stall a turn."""
+
+    async def test_compact_called_with_timeout(self) -> None:
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        await _run_awrap(middleware, _make_state(messages), runtime)
+
+        kwargs = fake_client.responses.compact.await_args.kwargs
+        assert "timeout" in kwargs, "compact call must supply a timeout"
+        assert isinstance(kwargs["timeout"], (int, float))
+        assert kwargs["timeout"] > 0
+
+
+# -----------------------------------------------------------------------------
+# History offload
+# -----------------------------------------------------------------------------
+
+
+class TestOffload:
+    """Pre-compaction messages land in the backend."""
+
+    async def test_offload_writes_to_backend(self) -> None:
+        messages = make_conversation_messages(num_old=4, num_recent=2)
+        backend = MockBackend()
+        middleware = CodexCompactionMiddleware(_make_model(), backend)
+        middleware._inner._should_summarize = MagicMock(return_value=True)
+        middleware._inner._determine_cutoff_index = MagicMock(return_value=3)
+
+        fake_client = MagicMock()
+        fake_client.responses.compact = AsyncMock(return_value=_make_compacted_response([{"type": "compaction", "encrypted_content": "blob"}]))
+        middleware._client = fake_client
+
+        runtime = make_mock_runtime()
+        await _run_awrap(middleware, _make_state(messages), runtime)
+
+        # MockBackend records writes on its `write_calls` / `edit_calls` lists.
+        assert backend.write_calls or backend.edit_calls
+
+
+# -----------------------------------------------------------------------------
+# Subagent independence
+# -----------------------------------------------------------------------------
+
+
+class TestSubagentIndependence:
+    """Each middleware instance owns its own client and composes a fresh inner."""
+
+    def test_independent_inner_instances(self) -> None:
+        m1 = CodexCompactionMiddleware(_make_model(), MockBackend())
+        m2 = CodexCompactionMiddleware(_make_model(), MockBackend())
+        assert m1._inner is not m2._inner
+        assert m1._model is not m2._model
+
+    async def test_state_is_per_request(self) -> None:
+        """Different requests with different states don't bleed compaction items."""
+        messages = make_conversation_messages(num_old=1, num_recent=1)
+        middleware = CodexCompactionMiddleware(_make_model(), MockBackend())
+        middleware._inner._should_summarize = MagicMock(return_value=False)
+
+        state_a = _make_state(messages)
+        state_b = _make_state(
+            messages,
+            compaction_item={
+                "cutoff_index": 1,
+                "output": [{"type": "compaction", "encrypted_content": "b-blob"}],
+                "file_path": None,
+            },
+        )
+        runtime = make_mock_runtime()
+
+        _res_a, cap_a = await _run_awrap(middleware, state_a, runtime)
+        _res_b, cap_b = await _run_awrap(middleware, state_b, runtime)
+
+        assert cap_a is not None
+        assert cap_b is not None
+        # Different heads: A is a normal first message, B is the synthesized compaction message.
+        head_b = cap_b.messages[0]
+        assert isinstance(head_b, AIMessage)
+        assert head_b.content == [{"type": "compaction", "encrypted_content": "b-blob"}]
+        assert cap_a.messages[0] is not head_b

--- a/libs/deepagents/tests/unit_tests/middleware/test_filesystem_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_filesystem_middleware_init.py
@@ -8,6 +8,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.middleware.filesystem import (
+    APPLY_PATCH_TOOL_DESCRIPTION,
     WRITE_FILE_TOOL_DESCRIPTION,
     FilesystemMiddleware,
 )
@@ -44,6 +45,30 @@ class TestFilesystemMiddlewareInit:
         assert tools["write_file"].description == WRITE_FILE_TOOL_DESCRIPTION.rstrip()
         assert "edit_file" in tools
         assert tools["edit_file"].description == "Squirtle"
+
+    def test_apply_patch_tool_absent_by_default(self) -> None:
+        mw = FilesystemMiddleware(backend=StateBackend())
+        names = {t.name for t in mw.tools}
+        assert "apply_patch" not in names
+
+    def test_apply_patch_tool_present_when_enabled(self) -> None:
+        mw = FilesystemMiddleware(backend=StateBackend(), include_apply_patch=True)
+        names = {t.name for t in mw.tools}
+        assert "apply_patch" in names
+
+    def test_apply_patch_custom_description(self) -> None:
+        mw = FilesystemMiddleware(
+            backend=StateBackend(),
+            include_apply_patch=True,
+            custom_tool_descriptions={"apply_patch": "Custom desc"},
+        )
+        tool = next(t for t in mw.tools if t.name == "apply_patch")
+        assert tool.description == "Custom desc"
+
+    def test_apply_patch_default_description(self) -> None:
+        mw = FilesystemMiddleware(backend=StateBackend(), include_apply_patch=True)
+        tool = next(t for t in mw.tools if t.name == "apply_patch")
+        assert tool.description == APPLY_PATCH_TOOL_DESCRIPTION.rstrip()
 
     def test_filesystem_tool_prompt_override_with_longterm_memory(self) -> None:
         """Test that custom tool descriptions work with composite backends and longterm memory."""

--- a/libs/deepagents/tests/unit_tests/test_apply_patch.py
+++ b/libs/deepagents/tests/unit_tests/test_apply_patch.py
@@ -1,0 +1,287 @@
+"""Unit tests for the V4A diff parser and applier."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepagents.utils._apply_patch import PatchError, apply_patch
+
+
+class TestAddFile:
+    """Tests for *** Add File operations."""
+
+    def test_single_line(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/hello.py\n"
+            "+print('hello')\n"
+            "*** End Patch"
+        )
+        result = apply_patch(patch, file_reader=lambda _p: None)
+        assert result == {"/app/hello.py": "print('hello')"}
+
+    def test_multiple_lines(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/main.py\n"
+            "+def main():\n"
+            "+    print('hello')\n"
+            "+\n"
+            "+main()\n"
+            "*** End Patch"
+        )
+        result = apply_patch(patch, file_reader=lambda _p: None)
+        assert result == {"/app/main.py": "def main():\n    print('hello')\n\nmain()"}
+
+    def test_duplicate_path_raises(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/x.py\n"
+            "+a\n"
+            "*** Add File: /app/x.py\n"
+            "+b\n"
+            "*** End Patch"
+        )
+        with pytest.raises(PatchError, match="Duplicate Path"):
+            apply_patch(patch, file_reader=lambda _p: None)
+
+
+class TestDeleteFile:
+    """Tests for *** Delete File operations."""
+
+    def test_delete(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Delete File: /app/old.py\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch,
+            file_reader=lambda p: "content" if p == "/app/old.py" else None,
+        )
+        assert result == {"/app/old.py": None}
+
+    def test_delete_missing_file_raises(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Delete File: /app/missing.py\n"
+            "*** End Patch"
+        )
+        with pytest.raises(PatchError, match="Missing File"):
+            apply_patch(patch, file_reader=lambda _p: None)
+
+
+class TestUpdateFile:
+    """Tests for *** Update File operations."""
+
+    def test_simple_insertion(self) -> None:
+        original = "line1\nline2\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            " line2\n"
+            "+inserted\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "line1\nline2\ninserted\nline3"}
+
+    def test_simple_deletion(self) -> None:
+        original = "line1\nline2\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            "-line2\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "line1\nline3"}
+
+    def test_replacement(self) -> None:
+        original = "line1\nline2\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            "-line2\n"
+            "+replaced\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "line1\nreplaced\nline3"}
+
+    def test_anchor_jump(self) -> None:
+        original = "a\nb\nc\nd\ne\nf"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@ d\n"
+            " d\n"
+            " e\n"
+            "+new\n"
+            " f\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "a\nb\nc\nd\ne\nnew\nf"}
+
+    def test_multiple_hunks(self) -> None:
+        original = "a\nb\nc\nd\ne"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " a\n"
+            "+x\n"
+            " b\n"
+            "@@ d\n"
+            " d\n"
+            "+y\n"
+            " e\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "a\nx\nb\nc\nd\ny\ne"}
+
+    def test_update_missing_file_raises(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/missing.py\n"
+            "@@\n"
+            " line1\n"
+            "*** End Patch"
+        )
+        with pytest.raises(PatchError, match="Missing File"):
+            apply_patch(patch, file_reader=lambda _p: None)
+
+
+class TestMultiFile:
+    """Tests for patches touching multiple files."""
+
+    def test_add_and_update(self) -> None:
+        original = "old content"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/new.py\n"
+            "+new content\n"
+            "*** Update File: /app/existing.py\n"
+            "@@\n"
+            "-old content\n"
+            "+updated content\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch,
+            file_reader=lambda p: original if p == "/app/existing.py" else None,
+        )
+        assert result == {
+            "/app/new.py": "new content",
+            "/app/existing.py": "updated content",
+        }
+
+    def test_add_delete_update(self) -> None:
+        files = {"/app/keep.py": "keep\nthis", "/app/remove.py": "bye"}
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/brand_new.py\n"
+            "+hello\n"
+            "*** Delete File: /app/remove.py\n"
+            "*** Update File: /app/keep.py\n"
+            "@@\n"
+            " keep\n"
+            "-this\n"
+            "+that\n"
+            "*** End Patch"
+        )
+        result = apply_patch(patch, file_reader=lambda p: files.get(p))
+        assert result == {
+            "/app/brand_new.py": "hello",
+            "/app/remove.py": None,
+            "/app/keep.py": "keep\nthat",
+        }
+
+
+class TestFuzzyMatching:
+    """Tests for whitespace-tolerant context matching."""
+
+    def test_trailing_whitespace_mismatch(self) -> None:
+        original = "line1  \nline2\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            " line2\n"
+            "+inserted\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "line1  \nline2\ninserted\nline3"}
+
+    def test_leading_whitespace_mismatch(self) -> None:
+        original = "  line1\nline2\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            " line2\n"
+            "+inserted\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result == {"/app/test.py": "  line1\nline2\ninserted\nline3"}
+
+
+class TestErrorHandling:
+    """Tests for invalid patch formats."""
+
+    def test_missing_begin_patch(self) -> None:
+        with pytest.raises(PatchError, match="Begin Patch"):
+            apply_patch("*** End Patch", file_reader=lambda _p: None)
+
+    def test_missing_end_patch(self) -> None:
+        with pytest.raises(PatchError, match="End Patch"):
+            apply_patch(
+                "*** Begin Patch\n*** Add File: /x\n+y\n",
+                file_reader=lambda _p: None,
+            )
+
+    def test_invalid_add_file_line(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/bad.py\n"
+            "not prefixed with plus\n"
+            "*** End Patch"
+        )
+        with pytest.raises(PatchError, match="Invalid Add File Line"):
+            apply_patch(patch, file_reader=lambda _p: None)
+
+    def test_empty_patch(self) -> None:
+        patch = "*** Begin Patch\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda _p: None)
+        assert result == {}

--- a/libs/deepagents/tests/unit_tests/test_apply_patch.py
+++ b/libs/deepagents/tests/unit_tests/test_apply_patch.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from deepagents.utils._apply_patch import PatchError, apply_patch
+from deepagents.utils._apply_patch import (
+    PatchError,
+    _apply_chunks,
+    _Chunk,
+    apply_patch,
+    list_referenced_files,
+)
 
 
 class TestAddFile:
@@ -18,7 +24,7 @@ class TestAddFile:
             "*** End Patch"
         )
         result = apply_patch(patch, file_reader=lambda _p: None)
-        assert result == {"/app/hello.py": "print('hello')"}
+        assert result.changes == {"/app/hello.py": "print('hello')"}
 
     def test_multiple_lines(self) -> None:
         patch = (
@@ -31,7 +37,7 @@ class TestAddFile:
             "*** End Patch"
         )
         result = apply_patch(patch, file_reader=lambda _p: None)
-        assert result == {"/app/main.py": "def main():\n    print('hello')\n\nmain()"}
+        assert result.changes == {"/app/main.py": "def main():\n    print('hello')\n\nmain()"}
 
     def test_duplicate_path_raises(self) -> None:
         patch = (
@@ -59,7 +65,7 @@ class TestDeleteFile:
             patch,
             file_reader=lambda p: "content" if p == "/app/old.py" else None,
         )
-        assert result == {"/app/old.py": None}
+        assert result.changes == {"/app/old.py": None}
 
     def test_delete_missing_file_raises(self) -> None:
         patch = (
@@ -89,7 +95,7 @@ class TestUpdateFile:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "line1\nline2\ninserted\nline3"}
+        assert result.changes == {"/app/test.py": "line1\nline2\ninserted\nline3"}
 
     def test_simple_deletion(self) -> None:
         original = "line1\nline2\nline3"
@@ -105,7 +111,7 @@ class TestUpdateFile:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "line1\nline3"}
+        assert result.changes == {"/app/test.py": "line1\nline3"}
 
     def test_replacement(self) -> None:
         original = "line1\nline2\nline3"
@@ -122,7 +128,7 @@ class TestUpdateFile:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "line1\nreplaced\nline3"}
+        assert result.changes == {"/app/test.py": "line1\nreplaced\nline3"}
 
     def test_anchor_jump(self) -> None:
         original = "a\nb\nc\nd\ne\nf"
@@ -139,7 +145,7 @@ class TestUpdateFile:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "a\nb\nc\nd\ne\nnew\nf"}
+        assert result.changes == {"/app/test.py": "a\nb\nc\nd\ne\nnew\nf"}
 
     def test_multiple_hunks(self) -> None:
         original = "a\nb\nc\nd\ne"
@@ -159,7 +165,7 @@ class TestUpdateFile:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "a\nx\nb\nc\nd\ny\ne"}
+        assert result.changes == {"/app/test.py": "a\nx\nb\nc\nd\ny\ne"}
 
     def test_update_missing_file_raises(self) -> None:
         patch = (
@@ -192,7 +198,7 @@ class TestMultiFile:
             patch,
             file_reader=lambda p: original if p == "/app/existing.py" else None,
         )
-        assert result == {
+        assert result.changes == {
             "/app/new.py": "new content",
             "/app/existing.py": "updated content",
         }
@@ -212,7 +218,7 @@ class TestMultiFile:
             "*** End Patch"
         )
         result = apply_patch(patch, file_reader=lambda p: files.get(p))
-        assert result == {
+        assert result.changes == {
             "/app/brand_new.py": "hello",
             "/app/remove.py": None,
             "/app/keep.py": "keep\nthat",
@@ -221,6 +227,23 @@ class TestMultiFile:
 
 class TestFuzzyMatching:
     """Tests for whitespace-tolerant context matching."""
+
+    def test_exact_match_has_zero_fuzz(self) -> None:
+        original = "line1\nline2\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            "+inserted\n"
+            " line2\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result.fuzz == 0
 
     def test_trailing_whitespace_mismatch(self) -> None:
         original = "line1  \nline2\nline3"
@@ -237,7 +260,8 @@ class TestFuzzyMatching:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "line1  \nline2\ninserted\nline3"}
+        assert result.changes == {"/app/test.py": "line1  \nline2\ninserted\nline3"}
+        assert result.fuzz == 1, "rstrip fallback should score fuzz=1 per hunk"
 
     def test_leading_whitespace_mismatch(self) -> None:
         original = "  line1\nline2\nline3"
@@ -254,7 +278,29 @@ class TestFuzzyMatching:
         result = apply_patch(
             patch, file_reader=lambda p: original if p == "/app/test.py" else None
         )
-        assert result == {"/app/test.py": "  line1\nline2\ninserted\nline3"}
+        assert result.changes == {"/app/test.py": "  line1\nline2\ninserted\nline3"}
+        assert result.fuzz == 100, "strip fallback should score fuzz=100 per hunk"
+
+    def test_multi_hunk_fuzz_accumulates(self) -> None:
+        """Fuzz from each hunk must sum into the aggregate score."""
+        original = "  a\nb\nc\n  d\ne"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " a\n"
+            "+x\n"
+            " b\n"
+            "@@ d\n"
+            " d\n"
+            "+y\n"
+            " e\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result.fuzz >= 100, "leading-space hunks must accumulate fuzz"
 
 
 class TestErrorHandling:
@@ -284,4 +330,252 @@ class TestErrorHandling:
     def test_empty_patch(self) -> None:
         patch = "*** Begin Patch\n*** End Patch"
         result = apply_patch(patch, file_reader=lambda _p: None)
-        assert result == {}
+        assert result.changes == {}
+
+
+class TestLineEndingNormalization:
+    """CRLF and lone-CR line endings must be normalized at the entry point."""
+
+    def test_crlf_patch_text_add_file(self) -> None:
+        patch = (
+            "*** Begin Patch\r\n"
+            "*** Add File: /app/hello.py\r\n"
+            "+print('hello')\r\n"
+            "*** End Patch\r\n"
+        )
+        result = apply_patch(patch, file_reader=lambda _p: None)
+        assert result.changes == {"/app/hello.py": "print('hello')"}
+
+    def test_crlf_patch_text_update_file(self) -> None:
+        """CRLF must not leak into extracted paths or section markers."""
+        original = "line1\nline2\nline3"
+        patch = (
+            "*** Begin Patch\r\n"
+            "*** Update File: /app/test.py\r\n"
+            "@@\r\n"
+            " line1\r\n"
+            " line2\r\n"
+            "+inserted\r\n"
+            " line3\r\n"
+            "*** End Patch\r\n"
+        )
+        seen: list[str] = []
+
+        def reader(path: str) -> str | None:
+            seen.append(path)
+            return original if path == "/app/test.py" else None
+
+        result = apply_patch(patch, file_reader=reader)
+        assert seen == ["/app/test.py"], "path must not carry a trailing \\r"
+        assert result.changes == {"/app/test.py": "line1\nline2\ninserted\nline3"}
+
+    def test_crlf_file_content_update(self) -> None:
+        """File content with CRLF must be matched by patches authored with LF."""
+        original_crlf = "line1\r\nline2\r\nline3"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " line1\n"
+            " line2\n"
+            "+inserted\n"
+            " line3\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch,
+            file_reader=lambda p: original_crlf if p == "/app/test.py" else None,
+        )
+        assert result.changes == {"/app/test.py": "line1\nline2\ninserted\nline3"}
+
+    def test_lone_cr_line_endings(self) -> None:
+        """Classic-Mac CR line endings must also normalize."""
+        patch = (
+            "*** Begin Patch\r"
+            "*** Add File: /app/hello.py\r"
+            "+print('hello')\r"
+            "*** End Patch"
+        )
+        result = apply_patch(patch, file_reader=lambda _p: None)
+        assert result.changes == {"/app/hello.py": "print('hello')"}
+
+
+class TestListReferencedFiles:
+    """list_referenced_files shares prefix constants with apply_patch."""
+
+    def test_extracts_update_and_delete(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/a.py\n"
+            "@@\n"
+            " line\n"
+            "*** Delete File: /app/b.py\n"
+            "*** Add File: /app/c.py\n"
+            "+new\n"
+            "*** End Patch"
+        )
+        assert list_referenced_files(patch) == ["/app/a.py", "/app/b.py"]
+
+    def test_ignores_add_file(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/only_add.py\n"
+            "+hello\n"
+            "*** End Patch"
+        )
+        assert list_referenced_files(patch) == []
+
+    def test_empty_patch(self) -> None:
+        assert list_referenced_files("*** Begin Patch\n*** End Patch") == []
+
+    def test_handles_crlf(self) -> None:
+        r"""Extraction must not return paths with trailing \r."""
+        patch = (
+            "*** Begin Patch\r\n"
+            "*** Update File: /app/a.py\r\n"
+            "*** Delete File: /app/b.py\r\n"
+            "*** End Patch\r\n"
+        )
+        assert list_referenced_files(patch) == ["/app/a.py", "/app/b.py"]
+
+    def test_matches_parser_for_update(self) -> None:
+        """Every path the parser reads must appear in list_referenced_files."""
+        files = {"/app/keep.py": "keep\nthis", "/app/remove.py": "bye"}
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: /app/brand_new.py\n"
+            "+hello\n"
+            "*** Delete File: /app/remove.py\n"
+            "*** Update File: /app/keep.py\n"
+            "@@\n"
+            " keep\n"
+            "-this\n"
+            "+that\n"
+            "*** End Patch"
+        )
+
+        prescan = set(list_referenced_files(patch))
+        observed: set[str] = set()
+
+        def reader(path: str) -> str | None:
+            observed.add(path)
+            return files.get(path)
+
+        apply_patch(patch, file_reader=reader)
+        assert observed.issubset(prescan), (
+            "parser requested a path the prescan did not surface"
+        )
+
+
+class TestEndOfFileMarker:
+    """The ``*** End of File`` marker anchors hunks to the tail of a file."""
+
+    def test_matches_at_end_of_file(self) -> None:
+        original = "alpha\nbeta\ngamma"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " beta\n"
+            " gamma\n"
+            "+delta\n"
+            "*** End of File\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result.changes == {"/app/test.py": "alpha\nbeta\ngamma\ndelta"}
+
+    def test_stale_eof_raises(self) -> None:
+        """If the EOF context matches earlier but not at EOF, the patch is stale."""
+        # Patch claims the context ``alpha\nbeta`` is at EOF, but the real
+        # file has ``gamma`` after beta — so the model was working from a
+        # stale view. The parser used to silently apply this with a
+        # ``+10000`` fuzz sentinel; now it should reject it outright.
+        original = "alpha\nbeta\ngamma"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " alpha\n"
+            " beta\n"
+            "+inserted\n"
+            "*** End of File\n"
+            "*** End Patch"
+        )
+        with pytest.raises(PatchError, match="stale"):
+            apply_patch(
+                patch,
+                file_reader=lambda p: original if p == "/app/test.py" else None,
+            )
+
+
+class TestBareAnchor:
+    """The bare ``@@`` separator (no anchor text) is a legal section start."""
+
+    def test_bare_anchor_between_hunks(self) -> None:
+        original = "a\nb\nc\nd\ne"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " a\n"
+            "+x\n"
+            " b\n"
+            "@@\n"
+            " d\n"
+            "+y\n"
+            " e\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result.changes == {"/app/test.py": "a\nx\nb\nc\nd\ny\ne"}
+
+
+class TestOverlappingChunks:
+    """Positioned chunks must not overlap; the applier guards against that."""
+
+    def test_overlap_raises(self) -> None:
+        """Two chunks whose spans collide must be rejected.
+
+        The first chunk deletes two lines starting at index 0, so the
+        applier's cursor advances to 2. The second chunk is positioned
+        at index 1 — already inside the first chunk's span — which must
+        trigger the overlap guard rather than silently corrupting the
+        output.
+        """
+        overlapping = [
+            _Chunk(orig_index=0, del_lines=["a", "b"], ins_lines=["x"]),
+            _Chunk(orig_index=1, del_lines=["b"], ins_lines=["y"]),
+        ]
+        with pytest.raises(PatchError, match="Overlapping"):
+            _apply_chunks("a\nb\nc", overlapping)
+
+    def test_chunk_past_eof_raises(self) -> None:
+        with pytest.raises(PatchError, match="exceeds file length"):
+            _apply_chunks("a\nb", [_Chunk(orig_index=99, del_lines=[], ins_lines=["x"])])
+
+
+class TestFuzzSignaling:
+    """EOF mismatch is a hard error; ordinary fuzz surfaces in the result."""
+
+    def test_no_silent_eof_fallback(self) -> None:
+        """The removed ``+10000`` sentinel must not reappear in ``result.fuzz``."""
+        original = "a\nb\nc"
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /app/test.py\n"
+            "@@\n"
+            " a\n"
+            "+x\n"
+            " b\n"
+            " c\n"
+            "*** End Patch"
+        )
+        result = apply_patch(
+            patch, file_reader=lambda p: original if p == "/app/test.py" else None
+        )
+        assert result.fuzz < 10000

--- a/libs/deepagents/tests/unit_tests/test_apply_patch.py
+++ b/libs/deepagents/tests/unit_tests/test_apply_patch.py
@@ -17,37 +17,17 @@ class TestAddFile:
     """Tests for *** Add File operations."""
 
     def test_single_line(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Add File: /app/hello.py\n"
-            "+print('hello')\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Add File: /app/hello.py\n+print('hello')\n*** End Patch"
         result = apply_patch(patch, file_reader=lambda _p: None)
         assert result.changes == {"/app/hello.py": "print('hello')"}
 
     def test_multiple_lines(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Add File: /app/main.py\n"
-            "+def main():\n"
-            "+    print('hello')\n"
-            "+\n"
-            "+main()\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Add File: /app/main.py\n+def main():\n+    print('hello')\n+\n+main()\n*** End Patch"
         result = apply_patch(patch, file_reader=lambda _p: None)
         assert result.changes == {"/app/main.py": "def main():\n    print('hello')\n\nmain()"}
 
     def test_duplicate_path_raises(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Add File: /app/x.py\n"
-            "+a\n"
-            "*** Add File: /app/x.py\n"
-            "+b\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Add File: /app/x.py\n+a\n*** Add File: /app/x.py\n+b\n*** End Patch"
         with pytest.raises(PatchError, match="Duplicate Path"):
             apply_patch(patch, file_reader=lambda _p: None)
 
@@ -56,11 +36,7 @@ class TestDeleteFile:
     """Tests for *** Delete File operations."""
 
     def test_delete(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Delete File: /app/old.py\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Delete File: /app/old.py\n*** End Patch"
         result = apply_patch(
             patch,
             file_reader=lambda p: "content" if p == "/app/old.py" else None,
@@ -68,11 +44,7 @@ class TestDeleteFile:
         assert result.changes == {"/app/old.py": None}
 
     def test_delete_missing_file_raises(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Delete File: /app/missing.py\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Delete File: /app/missing.py\n*** End Patch"
         with pytest.raises(PatchError, match="Missing File"):
             apply_patch(patch, file_reader=lambda _p: None)
 
@@ -82,99 +54,36 @@ class TestUpdateFile:
 
     def test_simple_insertion(self) -> None:
         original = "line1\nline2\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            " line2\n"
-            "+inserted\n"
-            " line3\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n line2\n+inserted\n line3\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "line1\nline2\ninserted\nline3"}
 
     def test_simple_deletion(self) -> None:
         original = "line1\nline2\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            "-line2\n"
-            " line3\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n-line2\n line3\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "line1\nline3"}
 
     def test_replacement(self) -> None:
         original = "line1\nline2\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            "-line2\n"
-            "+replaced\n"
-            " line3\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n-line2\n+replaced\n line3\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "line1\nreplaced\nline3"}
 
     def test_anchor_jump(self) -> None:
         original = "a\nb\nc\nd\ne\nf"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@ d\n"
-            " d\n"
-            " e\n"
-            "+new\n"
-            " f\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@ d\n d\n e\n+new\n f\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "a\nb\nc\nd\ne\nnew\nf"}
 
     def test_multiple_hunks(self) -> None:
         original = "a\nb\nc\nd\ne"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " a\n"
-            "+x\n"
-            " b\n"
-            "@@ d\n"
-            " d\n"
-            "+y\n"
-            " e\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n a\n+x\n b\n@@ d\n d\n+y\n e\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "a\nx\nb\nc\nd\ny\ne"}
 
     def test_update_missing_file_raises(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/missing.py\n"
-            "@@\n"
-            " line1\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/missing.py\n@@\n line1\n*** End Patch"
         with pytest.raises(PatchError, match="Missing File"):
             apply_patch(patch, file_reader=lambda _p: None)
 
@@ -217,7 +126,7 @@ class TestMultiFile:
             "+that\n"
             "*** End Patch"
         )
-        result = apply_patch(patch, file_reader=lambda p: files.get(p))
+        result = apply_patch(patch, file_reader=files.get)
         assert result.changes == {
             "/app/brand_new.py": "hello",
             "/app/remove.py": None,
@@ -230,76 +139,29 @@ class TestFuzzyMatching:
 
     def test_exact_match_has_zero_fuzz(self) -> None:
         original = "line1\nline2\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            "+inserted\n"
-            " line2\n"
-            " line3\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n+inserted\n line2\n line3\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.fuzz == 0
 
     def test_trailing_whitespace_mismatch(self) -> None:
         original = "line1  \nline2\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            " line2\n"
-            "+inserted\n"
-            " line3\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n line2\n+inserted\n line3\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "line1  \nline2\ninserted\nline3"}
         assert result.fuzz == 1, "rstrip fallback should score fuzz=1 per hunk"
 
     def test_leading_whitespace_mismatch(self) -> None:
         original = "  line1\nline2\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            " line2\n"
-            "+inserted\n"
-            " line3\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n line2\n+inserted\n line3\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "  line1\nline2\ninserted\nline3"}
         assert result.fuzz == 100, "strip fallback should score fuzz=100 per hunk"
 
     def test_multi_hunk_fuzz_accumulates(self) -> None:
         """Fuzz from each hunk must sum into the aggregate score."""
         original = "  a\nb\nc\n  d\ne"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " a\n"
-            "+x\n"
-            " b\n"
-            "@@ d\n"
-            " d\n"
-            "+y\n"
-            " e\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n a\n+x\n b\n@@ d\n d\n+y\n e\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.fuzz >= 100, "leading-space hunks must accumulate fuzz"
 
 
@@ -318,12 +180,7 @@ class TestErrorHandling:
             )
 
     def test_invalid_add_file_line(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Add File: /app/bad.py\n"
-            "not prefixed with plus\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Add File: /app/bad.py\nnot prefixed with plus\n*** End Patch"
         with pytest.raises(PatchError, match="Invalid Add File Line"):
             apply_patch(patch, file_reader=lambda _p: None)
 
@@ -337,28 +194,14 @@ class TestLineEndingNormalization:
     """CRLF and lone-CR line endings must be normalized at the entry point."""
 
     def test_crlf_patch_text_add_file(self) -> None:
-        patch = (
-            "*** Begin Patch\r\n"
-            "*** Add File: /app/hello.py\r\n"
-            "+print('hello')\r\n"
-            "*** End Patch\r\n"
-        )
+        patch = "*** Begin Patch\r\n*** Add File: /app/hello.py\r\n+print('hello')\r\n*** End Patch\r\n"
         result = apply_patch(patch, file_reader=lambda _p: None)
         assert result.changes == {"/app/hello.py": "print('hello')"}
 
     def test_crlf_patch_text_update_file(self) -> None:
         """CRLF must not leak into extracted paths or section markers."""
         original = "line1\nline2\nline3"
-        patch = (
-            "*** Begin Patch\r\n"
-            "*** Update File: /app/test.py\r\n"
-            "@@\r\n"
-            " line1\r\n"
-            " line2\r\n"
-            "+inserted\r\n"
-            " line3\r\n"
-            "*** End Patch\r\n"
-        )
+        patch = "*** Begin Patch\r\n*** Update File: /app/test.py\r\n@@\r\n line1\r\n line2\r\n+inserted\r\n line3\r\n*** End Patch\r\n"
         seen: list[str] = []
 
         def reader(path: str) -> str | None:
@@ -372,16 +215,7 @@ class TestLineEndingNormalization:
     def test_crlf_file_content_update(self) -> None:
         """File content with CRLF must be matched by patches authored with LF."""
         original_crlf = "line1\r\nline2\r\nline3"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " line1\n"
-            " line2\n"
-            "+inserted\n"
-            " line3\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n line1\n line2\n+inserted\n line3\n*** End Patch"
         result = apply_patch(
             patch,
             file_reader=lambda p: original_crlf if p == "/app/test.py" else None,
@@ -390,12 +224,7 @@ class TestLineEndingNormalization:
 
     def test_lone_cr_line_endings(self) -> None:
         """Classic-Mac CR line endings must also normalize."""
-        patch = (
-            "*** Begin Patch\r"
-            "*** Add File: /app/hello.py\r"
-            "+print('hello')\r"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\r*** Add File: /app/hello.py\r+print('hello')\r*** End Patch"
         result = apply_patch(patch, file_reader=lambda _p: None)
         assert result.changes == {"/app/hello.py": "print('hello')"}
 
@@ -404,25 +233,11 @@ class TestListReferencedFiles:
     """list_referenced_files shares prefix constants with apply_patch."""
 
     def test_extracts_update_and_delete(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/a.py\n"
-            "@@\n"
-            " line\n"
-            "*** Delete File: /app/b.py\n"
-            "*** Add File: /app/c.py\n"
-            "+new\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/a.py\n@@\n line\n*** Delete File: /app/b.py\n*** Add File: /app/c.py\n+new\n*** End Patch"
         assert list_referenced_files(patch) == ["/app/a.py", "/app/b.py"]
 
     def test_ignores_add_file(self) -> None:
-        patch = (
-            "*** Begin Patch\n"
-            "*** Add File: /app/only_add.py\n"
-            "+hello\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Add File: /app/only_add.py\n+hello\n*** End Patch"
         assert list_referenced_files(patch) == []
 
     def test_empty_patch(self) -> None:
@@ -430,12 +245,7 @@ class TestListReferencedFiles:
 
     def test_handles_crlf(self) -> None:
         r"""Extraction must not return paths with trailing \r."""
-        patch = (
-            "*** Begin Patch\r\n"
-            "*** Update File: /app/a.py\r\n"
-            "*** Delete File: /app/b.py\r\n"
-            "*** End Patch\r\n"
-        )
+        patch = "*** Begin Patch\r\n*** Update File: /app/a.py\r\n*** Delete File: /app/b.py\r\n*** End Patch\r\n"
         assert list_referenced_files(patch) == ["/app/a.py", "/app/b.py"]
 
     def test_matches_parser_for_update(self) -> None:
@@ -462,9 +272,7 @@ class TestListReferencedFiles:
             return files.get(path)
 
         apply_patch(patch, file_reader=reader)
-        assert observed.issubset(prescan), (
-            "parser requested a path the prescan did not surface"
-        )
+        assert observed.issubset(prescan), "parser requested a path the prescan did not surface"
 
 
 class TestEndOfFileMarker:
@@ -472,19 +280,8 @@ class TestEndOfFileMarker:
 
     def test_matches_at_end_of_file(self) -> None:
         original = "alpha\nbeta\ngamma"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " beta\n"
-            " gamma\n"
-            "+delta\n"
-            "*** End of File\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n beta\n gamma\n+delta\n*** End of File\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "alpha\nbeta\ngamma\ndelta"}
 
     def test_stale_eof_raises(self) -> None:
@@ -494,16 +291,7 @@ class TestEndOfFileMarker:
         # stale view. The parser used to silently apply this with a
         # ``+10000`` fuzz sentinel; now it should reject it outright.
         original = "alpha\nbeta\ngamma"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " alpha\n"
-            " beta\n"
-            "+inserted\n"
-            "*** End of File\n"
-            "*** End Patch"
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n alpha\n beta\n+inserted\n*** End of File\n*** End Patch"
         with pytest.raises(PatchError, match="stale"):
             apply_patch(
                 patch,
@@ -516,22 +304,8 @@ class TestBareAnchor:
 
     def test_bare_anchor_between_hunks(self) -> None:
         original = "a\nb\nc\nd\ne"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " a\n"
-            "+x\n"
-            " b\n"
-            "@@\n"
-            " d\n"
-            "+y\n"
-            " e\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n a\n+x\n b\n@@\n d\n+y\n e\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.changes == {"/app/test.py": "a\nx\nb\nc\nd\ny\ne"}
 
 
@@ -565,17 +339,6 @@ class TestFuzzSignaling:
     def test_no_silent_eof_fallback(self) -> None:
         """The removed ``+10000`` sentinel must not reappear in ``result.fuzz``."""
         original = "a\nb\nc"
-        patch = (
-            "*** Begin Patch\n"
-            "*** Update File: /app/test.py\n"
-            "@@\n"
-            " a\n"
-            "+x\n"
-            " b\n"
-            " c\n"
-            "*** End Patch"
-        )
-        result = apply_patch(
-            patch, file_reader=lambda p: original if p == "/app/test.py" else None
-        )
+        patch = "*** Begin Patch\n*** Update File: /app/test.py\n@@\n a\n+x\n b\n c\n*** End Patch"
+        result = apply_patch(patch, file_reader=lambda p: original if p == "/app/test.py" else None)
         assert result.fuzz < 10000

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -167,6 +167,7 @@ class TestProfileForModel:
         assert result.init_kwargs.get("reasoning_effort") == "medium"
         assert result.init_kwargs.get("use_responses_api") is True
         assert result.tool_aliases.get("execute") == "shell_command"
+        assert result.include_apply_patch is True
 
     def test_returns_empty_default_when_no_match(self) -> None:
         model = _make_model({"model_name": "unknown-model"})

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -20,6 +20,8 @@ from deepagents.graph import (
     create_deep_agent,
 )
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
+from deepagents.middleware.codex_compaction import CodexCompactionMiddleware
+from deepagents.middleware.summarization import _DeepAgentsSummarizationMiddleware
 from deepagents.profiles import _HARNESS_PROFILES, _get_harness_profile, _HarnessProfile, _register_harness_profile
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
@@ -631,3 +633,92 @@ class TestModelNoneDeprecationWarning:
 
         deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning) and "model=None" in str(w.message)]
         assert len(deprecations) == 0
+
+
+class TestCompactionLayerWiring:
+    """Profile flag flips the context-management middleware at every wiring site."""
+
+    @staticmethod
+    def _collect_stacks(
+        profile: _HarnessProfile,
+        subagent_profile: _HarnessProfile | None = None,
+    ) -> tuple[list, list[list], list]:
+        """Build an agent under the given profile and capture each middleware stack.
+
+        Returns:
+            ``(general_purpose_stack, per_subagent_stacks, main_stack)`` — the
+            three points where `_build_compaction_layer` is invoked in
+            ``graph.py``.
+        """
+        original = dict(_HARNESS_PROFILES)
+        sub_stacks: list[list] = []
+        try:
+            _register_harness_profile("compprov", profile)
+            if subagent_profile is not None:
+                _register_harness_profile("subcompprov", subagent_profile)
+
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+
+            def capture_subagent(*_args: Any, **kwargs: Any) -> MagicMock:
+                sub_stacks.extend(list(spec["middleware"]) for spec in (kwargs.get("subagents") or []) if "middleware" in spec)
+                return MagicMock()
+
+            subagents_kwarg: list[dict[str, Any]] = []
+            if subagent_profile is not None:
+                subagents_kwarg = [
+                    {
+                        "name": "sub",
+                        "description": "",
+                        "prompt": "",
+                        "model": "subcompprov:some-model",
+                    }
+                ]
+
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.FilesystemMiddleware", side_effect=lambda **_k: MagicMock()),
+                patch("deepagents.graph.SubAgentMiddleware", side_effect=capture_subagent),
+                patch("deepagents.graph.TodoListMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
+                patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+            ):
+                create_deep_agent(
+                    model="compprov:some-model",
+                    subagents=subagents_kwarg or None,
+                )
+
+            main_stack = list(mock_create.call_args.kwargs["middleware"])
+            # The general-purpose subagent is inserted as the first entry when no
+            # same-named override exists. Capture its middleware from the same
+            # SubAgentMiddleware kwargs we already collected.
+            gp_stack = sub_stacks[0] if sub_stacks else []
+            extra_sub_stacks = sub_stacks[1:] if len(sub_stacks) > 1 else []
+            return gp_stack, extra_sub_stacks, main_stack
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_codex_profile_swaps_summarization_for_compaction(self) -> None:
+        codex_like = _HarnessProfile(use_codex_compaction=True)
+        gp, subs, main = self._collect_stacks(codex_like, subagent_profile=codex_like)
+
+        for stack in (gp, *subs, main):
+            assert any(isinstance(m, CodexCompactionMiddleware) for m in stack), f"Expected CodexCompactionMiddleware in stack: {stack}"
+            assert not any(isinstance(m, _DeepAgentsSummarizationMiddleware) for m in stack), (
+                "Top-level _DeepAgentsSummarizationMiddleware should be absent when compaction is on; "
+                "the compaction middleware owns its own inner instance."
+            )
+
+    def test_non_codex_profile_keeps_summarization(self) -> None:
+        default_profile = _HarnessProfile()
+        gp, subs, main = self._collect_stacks(default_profile, subagent_profile=default_profile)
+
+        for stack in (gp, *subs, main):
+            assert any(isinstance(m, _DeepAgentsSummarizationMiddleware) for m in stack), (
+                f"Expected _DeepAgentsSummarizationMiddleware in stack: {stack}"
+            )
+            assert not any(isinstance(m, CodexCompactionMiddleware) for m in stack), (
+                f"CodexCompactionMiddleware should not appear for a non-codex profile: {stack}"
+            )

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -126,6 +126,48 @@ class TestProfileForModel:
             _HARNESS_PROFILES.clear()
             _HARNESS_PROFILES.update(original)
 
+    def test_reconstructs_qualified_spec_from_provider_and_identifier(self) -> None:
+        """Pre-built models with bare identifiers find per-model profiles via provider:id."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            provider_profile = _HarnessProfile(init_kwargs={"base": True})
+            model_profile = _HarnessProfile(init_kwargs={"model_specific": True})
+            _register_harness_profile("someprov", provider_profile)
+            _register_harness_profile("someprov:special-model", model_profile)
+            model = _make_model({"model_name": "special-model"})
+            model._get_ls_params = MagicMock(return_value={"ls_provider": "someprov"})
+            result = _harness_profile_for_model(model, None)
+            # Should get the merged profile, not just the provider-level one
+            assert result.init_kwargs["model_specific"] is True
+            assert result.init_kwargs["base"] is True
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_qualified_reconstruction_skipped_when_identifier_has_colon(self) -> None:
+        """Identifiers already containing a colon are not re-qualified."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            profile = _HarnessProfile(init_kwargs={"found": True})
+            _register_harness_profile("myprov", profile)
+            model = _make_model({"model_name": "myprov:already-qualified"})
+            model._get_ls_params = MagicMock(return_value={"ls_provider": "myprov"})
+            result = _harness_profile_for_model(model, None)
+            # The identifier itself matched via the first _get_harness_profile call
+            assert result is profile
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_codex_profile_found_for_prebuilt_model(self) -> None:
+        """Simulates Harbor/evals passing a pre-initialized Codex model."""
+        model = _make_model({"model_name": "gpt-5.3-codex"})
+        model._get_ls_params = MagicMock(return_value={"ls_provider": "openai"})
+        result = _harness_profile_for_model(model, None)
+        assert result.init_kwargs.get("reasoning_effort") == "medium"
+        assert result.init_kwargs.get("use_responses_api") is True
+        assert result.tool_aliases.get("execute") == "shell_command"
+
     def test_returns_empty_default_when_no_match(self) -> None:
         model = _make_model({"model_name": "unknown-model"})
         model._get_ls_params = MagicMock(return_value={})

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -646,6 +646,11 @@ class TestBuiltInProfiles:
         profile = _get_harness_profile(spec)
         assert profile.include_apply_patch is True
 
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_excludes_edit_file(self, spec: str) -> None:
+        profile = _get_harness_profile(spec)
+        assert "edit_file" in profile.excluded_tools
+
     def test_other_openai_models_unaffected_by_codex_profile(self) -> None:
         """Non-Codex OpenAI models get the provider profile, not the Codex one."""
         profile = _get_harness_profile("openai:gpt-5")

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -575,28 +575,33 @@ class TestBuiltInProfiles:
         profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
         assert profile == _HarnessProfile()
 
-    def test_codex_profile_registered(self) -> None:
-        assert "openai:gpt-5.3-codex" in _HARNESS_PROFILES
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_registered(self, spec: str) -> None:
+        assert spec in _HARNESS_PROFILES
 
-    def test_codex_profile_merges_with_openai_provider(self) -> None:
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_merges_with_openai_provider(self, spec: str) -> None:
         """Codex profile inherits use_responses_api from the OpenAI provider."""
-        profile = _get_harness_profile("openai:gpt-5.3-codex")
+        profile = _get_harness_profile(spec)
         assert profile.init_kwargs["use_responses_api"] is True
         assert profile.init_kwargs["reasoning_effort"] == "medium"
 
-    def test_codex_profile_has_system_prompt_suffix(self) -> None:
-        profile = _get_harness_profile("openai:gpt-5.3-codex")
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_has_system_prompt_suffix(self, spec: str) -> None:
+        profile = _get_harness_profile(spec)
         assert profile.system_prompt_suffix is not None
         assert "autonomous" in profile.system_prompt_suffix.lower()
         assert "parallel" in profile.system_prompt_suffix.lower()
         assert "bias to action" in profile.system_prompt_suffix.lower()
 
-    def test_codex_profile_has_execute_tool_override(self) -> None:
-        profile = _get_harness_profile("openai:gpt-5.3-codex")
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_has_execute_tool_override(self, spec: str) -> None:
+        profile = _get_harness_profile(spec)
         assert "execute" in profile.tool_description_overrides
 
-    def test_codex_profile_does_not_replace_base_system_prompt(self) -> None:
-        profile = _get_harness_profile("openai:gpt-5.3-codex")
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_does_not_replace_base_system_prompt(self, spec: str) -> None:
+        profile = _get_harness_profile(spec)
         assert profile.base_system_prompt is None
 
     def test_other_openai_models_unaffected_by_codex_profile(self) -> None:

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -638,8 +638,8 @@ class TestBuiltInProfiles:
         profile = _get_harness_profile(spec)
         assert "execute" in profile.tool_aliases
         assert profile.tool_aliases["execute"] == "shell_command"
-        assert "ls" in profile.tool_aliases
-        assert profile.tool_aliases["ls"] == "list_dir"
+        assert "list_dir" in profile.tool_aliases
+        assert profile.tool_aliases["list_dir"] == "ls"
 
     @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
     def test_codex_profile_includes_apply_patch(self, spec: str) -> None:

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -575,6 +575,36 @@ class TestBuiltInProfiles:
         profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
         assert profile == _HarnessProfile()
 
+    def test_codex_profile_registered(self) -> None:
+        assert "openai:gpt-5.3-codex" in _HARNESS_PROFILES
+
+    def test_codex_profile_merges_with_openai_provider(self) -> None:
+        """Codex profile inherits use_responses_api from the OpenAI provider."""
+        profile = _get_harness_profile("openai:gpt-5.3-codex")
+        assert profile.init_kwargs["use_responses_api"] is True
+        assert profile.init_kwargs["reasoning_effort"] == "medium"
+
+    def test_codex_profile_has_system_prompt_suffix(self) -> None:
+        profile = _get_harness_profile("openai:gpt-5.3-codex")
+        assert profile.system_prompt_suffix is not None
+        assert "autonomous" in profile.system_prompt_suffix.lower()
+        assert "parallel" in profile.system_prompt_suffix.lower()
+        assert "bias to action" in profile.system_prompt_suffix.lower()
+
+    def test_codex_profile_has_execute_tool_override(self) -> None:
+        profile = _get_harness_profile("openai:gpt-5.3-codex")
+        assert "execute" in profile.tool_description_overrides
+
+    def test_codex_profile_does_not_replace_base_system_prompt(self) -> None:
+        profile = _get_harness_profile("openai:gpt-5.3-codex")
+        assert profile.base_system_prompt is None
+
+    def test_other_openai_models_unaffected_by_codex_profile(self) -> None:
+        """Non-Codex OpenAI models get the provider profile, not the Codex one."""
+        profile = _get_harness_profile("openai:gpt-5")
+        assert profile.init_kwargs == {"use_responses_api": True}
+        assert profile.system_prompt_suffix is None
+
 
 class TestResolveModelWithProfiles:
     """Tests for resolve_model using the profile registry."""
@@ -585,6 +615,17 @@ class TestResolveModelWithProfiles:
             resolve_model("openai:gpt-5")
 
         mock.assert_called_once_with("openai:gpt-5", use_responses_api=True)
+
+    def test_codex_merges_provider_and_model_kwargs(self) -> None:
+        with patch("deepagents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            resolve_model("openai:gpt-5.3-codex")
+
+        mock.assert_called_once_with(
+            "openai:gpt-5.3-codex",
+            use_responses_api=True,
+            reasoning_effort="medium",
+        )
 
     def test_openrouter_runs_pre_init_and_factory(self) -> None:
         with (

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -304,6 +304,7 @@ class TestHarnessProfile:
         assert profile.system_prompt_suffix is None
         assert profile.tool_description_overrides == {}
         assert profile.tool_aliases == {}
+        assert profile.include_apply_patch is False
         assert profile.excluded_tools == frozenset()
         assert profile.extra_middleware == ()
 
@@ -467,6 +468,18 @@ class TestMergeProfiles:
         merged = _merge_profiles(base, override)
         assert merged.tool_aliases == {"execute": "shell_command"}
 
+    def test_include_apply_patch_override_wins(self) -> None:
+        base = _HarnessProfile(include_apply_patch=False)
+        override = _HarnessProfile(include_apply_patch=True)
+        merged = _merge_profiles(base, override)
+        assert merged.include_apply_patch is True
+
+    def test_include_apply_patch_inherits_from_base(self) -> None:
+        base = _HarnessProfile(include_apply_patch=True)
+        override = _HarnessProfile()
+        merged = _merge_profiles(base, override)
+        assert merged.include_apply_patch is True
+
     def test_excluded_tools_union(self) -> None:
         base = _HarnessProfile(excluded_tools=frozenset({"execute", "write_file"}))
         override = _HarnessProfile(excluded_tools=frozenset({"execute", "task"}))
@@ -627,6 +640,11 @@ class TestBuiltInProfiles:
         assert profile.tool_aliases["execute"] == "shell_command"
         assert "ls" in profile.tool_aliases
         assert profile.tool_aliases["ls"] == "list_dir"
+
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_includes_apply_patch(self, spec: str) -> None:
+        profile = _get_harness_profile(spec)
+        assert profile.include_apply_patch is True
 
     def test_other_openai_models_unaffected_by_codex_profile(self) -> None:
         """Non-Codex OpenAI models get the provider profile, not the Codex one."""

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -303,6 +303,7 @@ class TestHarnessProfile:
         assert profile.base_system_prompt is None
         assert profile.system_prompt_suffix is None
         assert profile.tool_description_overrides == {}
+        assert profile.tool_aliases == {}
         assert profile.excluded_tools == frozenset()
         assert profile.extra_middleware == ()
 
@@ -450,6 +451,21 @@ class TestMergeProfiles:
             "t1": "base",
             "t2": "override",
         }
+
+    def test_tool_aliases_merged(self) -> None:
+        base = _HarnessProfile(tool_aliases={"execute": "run", "ls": "list_dir"})
+        override = _HarnessProfile(tool_aliases={"execute": "shell_command"})
+        merged = _merge_profiles(base, override)
+        assert merged.tool_aliases == {
+            "execute": "shell_command",
+            "ls": "list_dir",
+        }
+
+    def test_tool_aliases_inherits_from_base(self) -> None:
+        base = _HarnessProfile(tool_aliases={"execute": "shell_command"})
+        override = _HarnessProfile()
+        merged = _merge_profiles(base, override)
+        assert merged.tool_aliases == {"execute": "shell_command"}
 
     def test_excluded_tools_union(self) -> None:
         base = _HarnessProfile(excluded_tools=frozenset({"execute", "write_file"}))
@@ -603,6 +619,14 @@ class TestBuiltInProfiles:
     def test_codex_profile_does_not_replace_base_system_prompt(self, spec: str) -> None:
         profile = _get_harness_profile(spec)
         assert profile.base_system_prompt is None
+
+    @pytest.mark.parametrize("spec", ["openai:gpt-5.2-codex", "openai:gpt-5.3-codex"])
+    def test_codex_profile_has_tool_aliases(self, spec: str) -> None:
+        profile = _get_harness_profile(spec)
+        assert "execute" in profile.tool_aliases
+        assert profile.tool_aliases["execute"] == "shell_command"
+        assert "ls" in profile.tool_aliases
+        assert profile.tool_aliases["ls"] == "list_dir"
 
     def test_other_openai_models_unaffected_by_codex_profile(self) -> None:
         """Non-Codex OpenAI models get the provider profile, not the Codex one."""

--- a/libs/deepagents/tests/unit_tests/test_tool_aliasing.py
+++ b/libs/deepagents/tests/unit_tests/test_tool_aliasing.py
@@ -1,0 +1,204 @@
+"""Unit tests for _ToolAliasingMiddleware."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from langchain_core.messages import AIMessage
+from langchain_core.tools import StructuredTool
+
+from deepagents.middleware._tool_aliasing import (
+    _rename_tool,
+    _rewrite_ai_message_tool_calls,
+    _rewrite_response_tool_names,
+    _ToolAliasingMiddleware,
+)
+
+
+class TestRenameTool:
+    """Tests for _rename_tool helper."""
+
+    def test_rename_dict_tool(self) -> None:
+        tool: dict[str, Any] = {"name": "execute", "description": "Run a command"}
+        result = _rename_tool(tool, "shell_command")
+        assert result["name"] == "shell_command"
+        assert result["description"] == "Run a command"
+        assert tool["name"] == "execute"
+
+    def test_rename_basetool(self) -> None:
+        def sample(text: str) -> str:
+            return text
+
+        tool = StructuredTool.from_function(
+            func=sample, name="execute", description="Run a command"
+        )
+        result = _rename_tool(tool, "shell_command")
+        assert result.name == "shell_command"
+        assert result.description == "Run a command"
+        assert tool.name == "execute"
+
+    def test_rename_plain_callable_is_noop(self) -> None:
+        def my_func() -> None:
+            pass
+
+        result = _rename_tool(my_func, "new_name")
+        assert result is my_func
+
+
+class TestRewriteAIMessageToolCalls:
+    """Tests for _rewrite_ai_message_tool_calls."""
+
+    def test_rewrites_matching_tool_calls(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "ls"}, "id": "1", "type": "tool_call"},
+                {"name": "read_file", "args": {"path": "/a"}, "id": "2", "type": "tool_call"},
+            ],
+        )
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result.tool_calls[0]["name"] == "execute"
+        assert result.tool_calls[1]["name"] == "read_file"
+        assert msg.tool_calls[0]["name"] == "shell_command"
+
+    def test_no_match_returns_original(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "read_file", "args": {"path": "/a"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result is msg
+
+    def test_empty_tool_calls_returns_original(self) -> None:
+        msg = AIMessage(content="hello")
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result is msg
+
+    def test_rewrites_invalid_tool_calls(self) -> None:
+        msg = AIMessage(
+            content="",
+            invalid_tool_calls=[
+                {"name": "shell_command", "args": "bad", "id": "1", "error": "parse error"},
+            ],
+        )
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result.invalid_tool_calls[0]["name"] == "execute"
+
+
+class TestRewriteResponseToolNames:
+    """Tests for _rewrite_response_tool_names with various response types."""
+
+    def test_ai_message(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        result = _rewrite_response_tool_names(msg, {"list_dir": "ls"})
+        assert isinstance(result, AIMessage)
+        assert result.tool_calls[0]["name"] == "ls"
+
+    def test_unknown_type_returned_unchanged(self) -> None:
+        obj = {"not": "a message"}
+        result = _rewrite_response_tool_names(obj, {"x": "y"})
+        assert result is obj
+
+
+class TestToolAliasingMiddleware:
+    """Tests for the full middleware round-trip."""
+
+    def test_roundtrip_sync(self) -> None:
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command", "ls": "list_dir"})
+
+        tool_dict: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        ls_tool: dict[str, Any] = {"name": "ls", "description": "List files"}
+        other: dict[str, Any] = {"name": "read_file", "description": "Read a file"}
+
+        model_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "git status"}, "id": "1", "type": "tool_call"},
+                {"name": "list_dir", "args": {"path": "/"}, "id": "2", "type": "tool_call"},
+                {"name": "read_file", "args": {"path": "/a.py"}, "id": "3", "type": "tool_call"},
+            ],
+        )
+
+        captured_request: dict[str, Any] = {}
+
+        def handler(request: object) -> AIMessage:
+            captured_request["tools"] = request.tools  # type: ignore[attr-defined]
+            return model_response
+
+        class FakeRequest:
+            tools: ClassVar[list[dict[str, Any]]] = [tool_dict, ls_tool, other]
+
+            def override(self, **kwargs: Any) -> FakeRequest:
+                new = FakeRequest()
+                new.tools = kwargs.get("tools", self.tools)
+                return new
+
+        response = mw.wrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+
+        tool_names_sent = [t["name"] for t in captured_request["tools"]]
+        assert tool_names_sent == ["shell_command", "list_dir", "read_file"]
+
+        assert isinstance(response, AIMessage)
+        assert response.tool_calls[0]["name"] == "execute"
+        assert response.tool_calls[1]["name"] == "ls"
+        assert response.tool_calls[2]["name"] == "read_file"
+
+    def test_empty_aliases_is_noop(self) -> None:
+        mw = _ToolAliasingMiddleware(aliases={})
+
+        tool: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        model_response = AIMessage(content="ok")
+
+        class FakeRequest:
+            tools: ClassVar[list[dict[str, Any]]] = [tool]
+
+            def override(self, **kwargs: Any) -> FakeRequest:
+                new = FakeRequest()
+                new.tools = kwargs.get("tools", self.tools)
+                return new
+
+        response = mw.wrap_model_call(FakeRequest(), lambda _r: model_response)  # type: ignore[arg-type]
+
+        assert response is model_response
+
+    async def test_roundtrip_async(self) -> None:
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        tool: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        model_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "ls"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def handler(request: object) -> AIMessage:
+            captured["tools"] = request.tools  # type: ignore[attr-defined]
+            return model_response
+
+        class FakeRequest:
+            tools: ClassVar[list[dict[str, Any]]] = [tool]
+
+            def override(self, **kwargs: Any) -> FakeRequest:
+                new = FakeRequest()
+                new.tools = kwargs.get("tools", self.tools)
+                return new
+
+        response = await mw.awrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+
+        assert captured["tools"][0]["name"] == "shell_command"
+        assert isinstance(response, AIMessage)
+        assert response.tool_calls[0]["name"] == "execute"

--- a/libs/deepagents/tests/unit_tests/test_tool_aliasing.py
+++ b/libs/deepagents/tests/unit_tests/test_tool_aliasing.py
@@ -2,18 +2,41 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+import logging
+from dataclasses import dataclass, field
+from typing import Any
 
+import pytest
 from langchain.agents.middleware.types import ExtendedModelResponse, ModelResponse
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 
 from deepagents.middleware._tool_aliasing import (
     _rename_tool,
     _rewrite_ai_message_tool_calls,
     _rewrite_response_tool_names,
+    _rewrite_tool_message_name,
     _ToolAliasingMiddleware,
+    _validate_aliases,
 )
+
+
+@dataclass
+class FakeRequest:
+    """Minimal stand-in for ``ModelRequest`` in middleware tests.
+
+    Matches just enough of the real interface (``tools``, ``messages``,
+    ``override``) for the aliasing middleware to exercise its full code path.
+    """
+
+    tools: list[Any] = field(default_factory=list)
+    messages: list[BaseMessage] = field(default_factory=list)
+
+    def override(self, **kwargs: Any) -> FakeRequest:
+        return FakeRequest(
+            tools=kwargs.get("tools", self.tools),
+            messages=kwargs.get("messages", self.messages),
+        )
 
 
 class TestRenameTool:
@@ -30,9 +53,7 @@ class TestRenameTool:
         def sample(text: str) -> str:
             return text
 
-        tool = StructuredTool.from_function(
-            func=sample, name="execute", description="Run a command"
-        )
+        tool = StructuredTool.from_function(func=sample, name="execute", description="Run a command")
         result = _rename_tool(tool, "shell_command")
         assert result.name == "shell_command"
         assert result.description == "Run a command"
@@ -171,19 +192,12 @@ class TestToolAliasingMiddleware:
 
         captured_request: dict[str, Any] = {}
 
-        def handler(request: object) -> AIMessage:
-            captured_request["tools"] = request.tools  # type: ignore[attr-defined]
+        def handler(request: FakeRequest) -> AIMessage:
+            captured_request["tools"] = request.tools
             return model_response
 
-        class FakeRequest:
-            tools: ClassVar[list[dict[str, Any]]] = [tool_dict, ls_tool, other]
-
-            def override(self, **kwargs: Any) -> FakeRequest:
-                new = FakeRequest()
-                new.tools = kwargs.get("tools", self.tools)
-                return new
-
-        response = mw.wrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+        request = FakeRequest(tools=[tool_dict, ls_tool, other])
+        response = mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
 
         tool_names_sent = [t["name"] for t in captured_request["tools"]]
         assert tool_names_sent == ["shell_command", "list_dir", "read_file"]
@@ -210,19 +224,12 @@ class TestToolAliasingMiddleware:
 
         captured_request: dict[str, Any] = {}
 
-        def handler(request: object) -> ModelResponse[Any]:
-            captured_request["tools"] = request.tools  # type: ignore[attr-defined]
+        def handler(request: FakeRequest) -> ModelResponse[Any]:
+            captured_request["tools"] = request.tools
             return ModelResponse(result=[ai_msg])
 
-        class FakeRequest:
-            tools: ClassVar[list[dict[str, Any]]] = [tool_dict, ls_tool]
-
-            def override(self, **kwargs: Any) -> FakeRequest:
-                new = FakeRequest()
-                new.tools = kwargs.get("tools", self.tools)
-                return new
-
-        response = mw.wrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+        request = FakeRequest(tools=[tool_dict, ls_tool])
+        response = mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
 
         tool_names_sent = [t["name"] for t in captured_request["tools"]]
         assert tool_names_sent == ["shell_command", "list_dir"]
@@ -239,17 +246,32 @@ class TestToolAliasingMiddleware:
         tool: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
         model_response = AIMessage(content="ok")
 
-        class FakeRequest:
-            tools: ClassVar[list[dict[str, Any]]] = [tool]
-
-            def override(self, **kwargs: Any) -> FakeRequest:
-                new = FakeRequest()
-                new.tools = kwargs.get("tools", self.tools)
-                return new
-
-        response = mw.wrap_model_call(FakeRequest(), lambda _r: model_response)  # type: ignore[arg-type]
+        request = FakeRequest(tools=[tool])
+        response = mw.wrap_model_call(request, lambda _r: model_response)  # type: ignore[arg-type]
 
         assert response is model_response
+
+    def test_no_rename_preserves_request_identity(self) -> None:
+        """If nothing matches the alias map, pass the original request through.
+
+        This lets downstream middleware / cache keys that hold onto request
+        object identity continue to observe the same reference.
+        """
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        request = FakeRequest(
+            tools=[{"name": "read_file", "description": "Read"}],
+            messages=[HumanMessage(content="hi")],
+        )
+
+        captured: dict[str, Any] = {}
+
+        def handler(received: FakeRequest) -> AIMessage:
+            captured["request"] = received
+            return AIMessage(content="ok")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+        assert captured["request"] is request
 
     async def test_roundtrip_async_bare_ai_message(self) -> None:
         mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
@@ -264,19 +286,12 @@ class TestToolAliasingMiddleware:
 
         captured: dict[str, Any] = {}
 
-        async def handler(request: object) -> AIMessage:
-            captured["tools"] = request.tools  # type: ignore[attr-defined]
+        async def handler(request: FakeRequest) -> AIMessage:
+            captured["tools"] = request.tools
             return model_response
 
-        class FakeRequest:
-            tools: ClassVar[list[dict[str, Any]]] = [tool]
-
-            def override(self, **kwargs: Any) -> FakeRequest:
-                new = FakeRequest()
-                new.tools = kwargs.get("tools", self.tools)
-                return new
-
-        response = await mw.awrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+        request = FakeRequest(tools=[tool])
+        response = await mw.awrap_model_call(request, handler)  # type: ignore[arg-type]
 
         assert captured["tools"][0]["name"] == "shell_command"
         assert isinstance(response, AIMessage)
@@ -296,22 +311,211 @@ class TestToolAliasingMiddleware:
 
         captured: dict[str, Any] = {}
 
-        async def handler(request: object) -> ModelResponse[Any]:
-            captured["tools"] = request.tools  # type: ignore[attr-defined]
+        async def handler(request: FakeRequest) -> ModelResponse[Any]:
+            captured["tools"] = request.tools
             return ModelResponse(result=[ai_msg])
 
-        class FakeRequest:
-            tools: ClassVar[list[dict[str, Any]]] = [tool]
-
-            def override(self, **kwargs: Any) -> FakeRequest:
-                new = FakeRequest()
-                new.tools = kwargs.get("tools", self.tools)
-                return new
-
-        response = await mw.awrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+        request = FakeRequest(tools=[tool])
+        response = await mw.awrap_model_call(request, handler)  # type: ignore[arg-type]
 
         assert captured["tools"][0]["name"] == "list_dir"
         assert isinstance(response, ModelResponse)
         rewritten = response.result[0]
         assert isinstance(rewritten, AIMessage)
         assert rewritten.tool_calls[0]["name"] == "ls"
+
+
+class TestValidateAliases:
+    """Tests for alias-map validation."""
+
+    def test_empty_passes(self) -> None:
+        _validate_aliases({})
+
+    def test_simple_valid_mapping_passes(self) -> None:
+        _validate_aliases({"execute": "shell_command", "list_dir": "ls"})
+
+    def test_duplicate_values_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            _validate_aliases({"a": "x", "b": "x"})
+
+    def test_key_value_collision_rejected(self) -> None:
+        """`b` appears as both a canonical name and as an alias for `a`."""
+        with pytest.raises(ValueError, match="must be disjoint"):
+            _validate_aliases({"a": "b", "b": "c"})
+
+    def test_constructor_rejects_invalid_aliases(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            _ToolAliasingMiddleware(aliases={"a": "x", "b": "x"})
+
+
+class TestRewriteToolMessageName:
+    """Tests for _rewrite_tool_message_name."""
+
+    def test_rewrites_matching_name(self) -> None:
+        msg = ToolMessage(content="ok", tool_call_id="1", name="execute")
+        result = _rewrite_tool_message_name(msg, {"execute": "shell_command"})
+        assert result.name == "shell_command"
+        assert result.tool_call_id == "1"
+        assert result.content == "ok"
+        assert msg.name == "execute"  # original untouched
+
+    def test_no_match_returns_original(self) -> None:
+        msg = ToolMessage(content="ok", tool_call_id="1", name="read_file")
+        result = _rewrite_tool_message_name(msg, {"execute": "shell_command"})
+        assert result is msg
+
+    def test_missing_name_returns_original(self) -> None:
+        msg = ToolMessage(content="ok", tool_call_id="1")
+        result = _rewrite_tool_message_name(msg, {"execute": "shell_command"})
+        assert result is msg
+
+
+class TestHistoryRewriteOutbound:
+    """Outbound canonical→alias rewriting of request.messages.
+
+    This is the main-bug fix: without this, turn N+1 ships aliased tools
+    to the model but canonical names in the past-turn tool calls, so the
+    model sees two names for the same tool.
+    """
+
+    def test_history_tool_calls_rewritten_on_outbound(self) -> None:
+        """Canonical names in AIMessage.tool_calls become aliases for the model."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        past_ai = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "execute", "args": {"command": "ls"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        past_tool = ToolMessage(content="file.py", tool_call_id="1", name="execute")
+
+        request = FakeRequest(
+            tools=[{"name": "execute", "description": "Run cmd"}],
+            messages=[HumanMessage(content="run ls"), past_ai, past_tool],
+        )
+
+        captured: dict[str, Any] = {}
+
+        def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            captured["tools"] = req.tools
+            return AIMessage(content="done")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        # Model saw aliased tool catalog
+        assert captured["tools"][0]["name"] == "shell_command"
+        # Model saw aliased past tool calls
+        sent_ai = captured["messages"][1]
+        assert isinstance(sent_ai, AIMessage)
+        assert sent_ai.tool_calls[0]["name"] == "shell_command"
+        # Model saw aliased ToolMessage.name
+        sent_tool = captured["messages"][2]
+        assert isinstance(sent_tool, ToolMessage)
+        assert sent_tool.name == "shell_command"
+
+        # Caller's original messages are untouched (defensive copy)
+        assert past_ai.tool_calls[0]["name"] == "execute"
+        assert past_tool.name == "execute"
+
+    def test_history_with_invalid_tool_calls(self) -> None:
+        """Invalid (malformed-args) past tool calls are also renamed."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        past_ai = AIMessage(
+            content="",
+            invalid_tool_calls=[
+                {"name": "execute", "args": "bad-json", "id": "1", "error": "parse"},
+            ],
+        )
+        request = FakeRequest(tools=[], messages=[past_ai])
+
+        captured: dict[str, Any] = {}
+
+        def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            return AIMessage(content="ok")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        sent = captured["messages"][0]
+        assert isinstance(sent, AIMessage)
+        assert sent.invalid_tool_calls[0]["name"] == "shell_command"
+
+    def test_no_history_rename_preserves_other_messages(self) -> None:
+        """HumanMessages and unrelated AIMessages pass through untouched."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        human = HumanMessage(content="hi")
+        bare_ai = AIMessage(content="hello")
+        request = FakeRequest(tools=[], messages=[human, bare_ai])
+
+        captured: dict[str, Any] = {}
+
+        def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            return AIMessage(content="ok")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        # Object identity preserved for unchanged messages
+        assert captured["messages"][0] is human
+        assert captured["messages"][1] is bare_ai
+
+    async def test_history_rewrite_async(self) -> None:
+        """Async path rewrites history identically."""
+        mw = _ToolAliasingMiddleware(aliases={"list_dir": "ls"})
+
+        past_ai = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        request = FakeRequest(tools=[], messages=[past_ai])
+
+        captured: dict[str, Any] = {}
+
+        async def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            return AIMessage(content="ok")
+
+        await mw.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        sent = captured["messages"][0]
+        assert isinstance(sent, AIMessage)
+        assert sent.tool_calls[0]["name"] == "ls"
+
+
+class TestRenameToolWarning:
+    """_rename_tool warns when a tool cannot be renamed."""
+
+    def test_warns_on_unrenameable_tool(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Plain object with no model_copy and not a dict triggers the warning."""
+
+        class WeirdTool:
+            name = "execute"
+
+        weird = WeirdTool()
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware._tool_aliasing"):
+            result = _rename_tool(weird, "shell_command")
+
+        assert result is weird  # unchanged
+        assert any("cannot be renamed" in record.message for record in caplog.records), (
+            f"Expected warning not logged. Got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_no_warning_on_dict_tool(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware._tool_aliasing"):
+            _rename_tool({"name": "execute"}, "shell_command")
+        assert not any("cannot be renamed" in r.message for r in caplog.records)
+
+    def test_no_warning_on_basetool(self, caplog: pytest.LogCaptureFixture) -> None:
+        def sample(text: str) -> str:
+            return text
+
+        tool = StructuredTool.from_function(func=sample, name="execute", description="Run cmd")
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware._tool_aliasing"):
+            _rename_tool(tool, "shell_command")
+        assert not any("cannot be renamed" in r.message for r in caplog.records)

--- a/libs/deepagents/tests/unit_tests/test_tool_aliasing.py
+++ b/libs/deepagents/tests/unit_tests/test_tool_aliasing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+from langchain.agents.middleware.types import ExtendedModelResponse, ModelResponse
 from langchain_core.messages import AIMessage
 from langchain_core.tools import StructuredTool
 
@@ -105,6 +106,43 @@ class TestRewriteResponseToolNames:
         assert isinstance(result, AIMessage)
         assert result.tool_calls[0]["name"] == "ls"
 
+    def test_model_response(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+                {"name": "read_file", "args": {"path": "/a"}, "id": "2", "type": "tool_call"},
+            ],
+        )
+        resp = ModelResponse(result=[msg])
+        result = _rewrite_response_tool_names(resp, {"list_dir": "ls"})
+        assert isinstance(result, ModelResponse)
+        rewritten_msg = result.result[0]
+        assert isinstance(rewritten_msg, AIMessage)
+        assert rewritten_msg.tool_calls[0]["name"] == "ls"
+        assert rewritten_msg.tool_calls[1]["name"] == "read_file"
+
+    def test_model_response_no_match(self) -> None:
+        msg = AIMessage(content="hello")
+        resp = ModelResponse(result=[msg])
+        result = _rewrite_response_tool_names(resp, {"x": "y"})
+        assert result is resp
+
+    def test_extended_model_response(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"cmd": "ls"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        inner = ModelResponse(result=[msg])
+        resp = ExtendedModelResponse(model_response=inner)
+        result = _rewrite_response_tool_names(resp, {"shell_command": "execute"})
+        assert isinstance(result, ExtendedModelResponse)
+        rewritten_msg = result.model_response.result[0]
+        assert isinstance(rewritten_msg, AIMessage)
+        assert rewritten_msg.tool_calls[0]["name"] == "execute"
+
     def test_unknown_type_returned_unchanged(self) -> None:
         obj = {"not": "a message"}
         result = _rewrite_response_tool_names(obj, {"x": "y"})
@@ -114,7 +152,8 @@ class TestRewriteResponseToolNames:
 class TestToolAliasingMiddleware:
     """Tests for the full middleware round-trip."""
 
-    def test_roundtrip_sync(self) -> None:
+    def test_roundtrip_sync_bare_ai_message(self) -> None:
+        """Handler returns a bare AIMessage (legacy path)."""
         mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command", "ls": "list_dir"})
 
         tool_dict: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
@@ -154,6 +193,46 @@ class TestToolAliasingMiddleware:
         assert response.tool_calls[1]["name"] == "ls"
         assert response.tool_calls[2]["name"] == "read_file"
 
+    def test_roundtrip_sync_model_response(self) -> None:
+        """Handler returns a ModelResponse (realistic path)."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command", "ls": "list_dir"})
+
+        tool_dict: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        ls_tool: dict[str, Any] = {"name": "ls", "description": "List files"}
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "git status"}, "id": "1", "type": "tool_call"},
+                {"name": "list_dir", "args": {"path": "/"}, "id": "2", "type": "tool_call"},
+            ],
+        )
+
+        captured_request: dict[str, Any] = {}
+
+        def handler(request: object) -> ModelResponse[Any]:
+            captured_request["tools"] = request.tools  # type: ignore[attr-defined]
+            return ModelResponse(result=[ai_msg])
+
+        class FakeRequest:
+            tools: ClassVar[list[dict[str, Any]]] = [tool_dict, ls_tool]
+
+            def override(self, **kwargs: Any) -> FakeRequest:
+                new = FakeRequest()
+                new.tools = kwargs.get("tools", self.tools)
+                return new
+
+        response = mw.wrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+
+        tool_names_sent = [t["name"] for t in captured_request["tools"]]
+        assert tool_names_sent == ["shell_command", "list_dir"]
+
+        assert isinstance(response, ModelResponse)
+        rewritten = response.result[0]
+        assert isinstance(rewritten, AIMessage)
+        assert rewritten.tool_calls[0]["name"] == "execute"
+        assert rewritten.tool_calls[1]["name"] == "ls"
+
     def test_empty_aliases_is_noop(self) -> None:
         mw = _ToolAliasingMiddleware(aliases={})
 
@@ -172,7 +251,7 @@ class TestToolAliasingMiddleware:
 
         assert response is model_response
 
-    async def test_roundtrip_async(self) -> None:
+    async def test_roundtrip_async_bare_ai_message(self) -> None:
         mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
 
         tool: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
@@ -202,3 +281,37 @@ class TestToolAliasingMiddleware:
         assert captured["tools"][0]["name"] == "shell_command"
         assert isinstance(response, AIMessage)
         assert response.tool_calls[0]["name"] == "execute"
+
+    async def test_roundtrip_async_model_response(self) -> None:
+        """Async handler returns ModelResponse (realistic path)."""
+        mw = _ToolAliasingMiddleware(aliases={"ls": "list_dir"})
+
+        tool: dict[str, Any] = {"name": "ls", "description": "List files"}
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def handler(request: object) -> ModelResponse[Any]:
+            captured["tools"] = request.tools  # type: ignore[attr-defined]
+            return ModelResponse(result=[ai_msg])
+
+        class FakeRequest:
+            tools: ClassVar[list[dict[str, Any]]] = [tool]
+
+            def override(self, **kwargs: Any) -> FakeRequest:
+                new = FakeRequest()
+                new.tools = kwargs.get("tools", self.tools)
+                return new
+
+        response = await mw.awrap_model_call(FakeRequest(), handler)  # type: ignore[arg-type]
+
+        assert captured["tools"][0]["name"] == "list_dir"
+        assert isinstance(response, ModelResponse)
+        rewritten = response.result[0]
+        assert isinstance(rewritten, AIMessage)
+        assert rewritten.tool_calls[0]["name"] == "ls"

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -455,7 +455,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.2.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -845,9 +845,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
 ]
 
 [[package]]
@@ -867,16 +867,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.14"
+version = "1.1.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/f5/b1a56f703fb90952b07ff9fb5507123a39df1267d62a7f2bb821c5dbb628/langchain_openai-1.1.14.tar.gz", hash = "sha256:71b4262932fabe506ce79c175dbc956cc48f24d81e20b27662df493147750643", size = 1115195, upload-time = "2026-04-16T14:55:24.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/fa/8c33befbc0cf81b21371cc1dab4e7bf94a80b8116194f263a5021ec02529/langchain_openai-1.1.14-py3-none-any.whl", hash = "sha256:cb525d2011f9813fc15a7dcfd4bca5b87badcbcb2c113a7fbe45d1b8a1bbb69c", size = 88705, upload-time = "2026-04-16T14:55:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
 ]
 
 [[package]]
@@ -903,7 +903,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.8"
+version = "1.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -913,9 +913,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/02/196eff4f673fd461f8780930c3bfa7f27d6533a48e4f1104d544e843b093/langgraph-1.1.8.tar.gz", hash = "sha256:a97b8248129f2e007b81eef8277009ad1e1280b75fa2175889ab5aff5dcc4578", size = 560389, upload-time = "2026-04-17T19:45:50.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/8a/47b983e33d3afc8c2c2385d2d8f3731ddfb5cb08e88f307f75105252a94c/langgraph-1.1.5.tar.gz", hash = "sha256:24b85d2d40cd002766d489e76f18027f947e4151366ac7ed97bab030ce50e494", size = 548492, upload-time = "2026-04-03T14:12:33.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/38/c72e795f6f8fd05a8e7c3be32c04ea8534294decc6785f3b04e0ce932e8a/langgraph-1.1.8-py3-none-any.whl", hash = "sha256:3278c7e335da25eac3327bb474c502d4cab94ae6dcc685fbf93be2bbf7664cd5", size = 173678, upload-time = "2026-04-17T19:45:48.991Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6a/542bb56c8270d3df858285be138aec5e292b4e43dadb6b0b6fe051f535c1/langgraph-1.1.5-py3-none-any.whl", hash = "sha256:cb25c20d135167837951906c0feeb26c91c733bd5001a920c4cb1ffb92a1097c", size = 169354, upload-time = "2026-04-03T14:12:31.879Z" },
 ]
 
 [[package]]

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -423,6 +423,11 @@ dependencies = [
     { name = "wcmatch" },
 ]
 
+[package.optional-dependencies]
+codex = [
+    { name = "langchain-openai" },
+]
+
 [package.dev-dependencies]
 test = [
     { name = "build" },
@@ -448,9 +453,11 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -852,9 +852,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -455,7 +455,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -867,16 +867,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.11"
+version = "1.1.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/cd/439be2b8deb8bd0d4c470c7c7f66698a84d823e583c3d36a322483cb7cab/langchain_openai-1.1.11.tar.gz", hash = "sha256:44b003a2960d1f6699f23721196b3b97d0c420d2e04444950869213214b7a06a", size = 1088560, upload-time = "2026-03-09T23:02:36.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/e4cb42848c25f65969adfb500a06dea1a541831604250fd0d8aa6e54fef5/langchain_openai-1.1.11-py3-none-any.whl", hash = "sha256:a03596221405d38d6852fb865467cb0d9ff9e79f335905eb6a576e8c4874ac71", size = 87694, upload-time = "2026-03-09T23:02:35.651Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
 ]
 
 [[package]]

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -16,20 +16,20 @@ Source of truth: [`tests/evals/`](tests/evals/).
 - [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L178) — `tests/evals/test_file_operations.py:178`
 - [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L202) — `tests/evals/test_file_operations.py:202`
 - [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L225) — `tests/evals/test_file_operations.py:225`
-- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L248) — `tests/evals/test_file_operations.py:248`
-- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L273) — `tests/evals/test_file_operations.py:273`
-- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L291) — `tests/evals/test_file_operations.py:291`
-- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L561) — `tests/evals/test_file_operations.py:561`
-- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L599) — `tests/evals/test_file_operations.py:599`
+- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L250) — `tests/evals/test_file_operations.py:250`
+- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L275) — `tests/evals/test_file_operations.py:275`
+- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L293) — `tests/evals/test_file_operations.py:293`
+- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L563) — `tests/evals/test_file_operations.py:563`
+- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L601) — `tests/evals/test_file_operations.py:601`
 
 ## Retrieval (`retrieval`) (6 evals)
 
 - [`test_frames`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_external_benchmarks.py#L67) — `tests/evals/test_external_benchmarks.py:67`
-- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L321) — `tests/evals/test_file_operations.py:321`
-- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L349) — `tests/evals/test_file_operations.py:349`
-- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L377) — `tests/evals/test_file_operations.py:377`
-- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L413) — `tests/evals/test_file_operations.py:413`
-- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L488) — `tests/evals/test_file_operations.py:488`
+- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L323) — `tests/evals/test_file_operations.py:323`
+- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L351) — `tests/evals/test_file_operations.py:351`
+- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L379) — `tests/evals/test_file_operations.py:379`
+- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L415) — `tests/evals/test_file_operations.py:415`
+- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L490) — `tests/evals/test_file_operations.py:490`
 
 ## Tool Use (`tool_use`) (53 evals)
 

--- a/libs/evals/MODEL_GROUPS.md
+++ b/libs/evals/MODEL_GROUPS.md
@@ -7,7 +7,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 
 ## Model groups
 
-### `set0` (32 models)
+### `set0` (33 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-5-20250929`
@@ -39,10 +39,11 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:o4-mini`
 - `openai:gpt-5.1-codex`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 
-### `set1` (12 models)
+### `set1` (13 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-6`
@@ -55,6 +56,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `ollama:qwen3.5:397b-cloud`
 - `openai:gpt-4.1`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 
 ### `set2` (17 models)
@@ -158,7 +160,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `ollama:qwen3-coder:480b-cloud`
 - `ollama:deepseek-v3.2:cloud`
 
-### `openai` (9 models)
+### `openai` (10 models)
 
 - `openai:gpt-4o`
 - `openai:gpt-4o-mini`
@@ -167,6 +169,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:o4-mini`
 - `openai:gpt-5.1-codex`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 
@@ -181,7 +184,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`
 
-## `all` (53 models)
+## `all` (54 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-5-20250929`
@@ -229,6 +232,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:o4-mini`
 - `openai:gpt-5.1-codex`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 - `openrouter:minimax/minimax-m2.7`

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -24,7 +24,6 @@ from harbor.models.trajectories import (
     ToolCall,
     Trajectory,
 )
-from langchain.chat_models import init_chat_model
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langsmith import trace
 from langsmith.client import Client
@@ -112,14 +111,21 @@ class DeepAgentsWrapper(BaseAgent):
             self._model = model
             self._model_name = model.model
         else:
+            from deepagents._models import resolve_model
+
             self._model_name = model_name
-            model_kwargs: dict[str, Any] = {}
-            if openrouter_provider:
-                model_kwargs["openrouter_provider"] = {
+            model = resolve_model(model_name)
+            overrides: dict[str, Any] = {}
+            if hasattr(model, "temperature"):
+                overrides["temperature"] = temperature
+            if openrouter_provider and hasattr(model, "openrouter_provider"):
+                overrides["openrouter_provider"] = {
                     "only": [openrouter_provider],
                     "allow_fallbacks": False,
                 }
-            self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
+            if overrides:
+                model = model.model_copy(update=overrides)
+            self._model = model
 
         self._temperature = temperature
         self._verbose = verbose

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -95,7 +95,13 @@ required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 override-dependencies = [
-    "openai>=1.109.1,<2.0.0",
+    # TEMP (revert before merging codex profile): bumped to openai 2.x so
+    # `client.responses.compact` is available for the codex `/compact` vs
+    # LLM-summarization A/B. The stale pin (inherited from the initial
+    # harbor port) fought with langchain-openai>=1.1.14's own openai>=2.26.0
+    # requirement and was the direct cause of `AsyncResponses has no
+    # attribute 'compact'` when CodexCompactionMiddleware hit the async path.
+    "openai>=2.26.0,<3.0.0",
     "e2b==2.4.3",
     # CVE-2026-24486: path traversal vulnerability in < 0.0.22
     "python-multipart>=0.0.22",

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
 from deepagents import __version__ as deepagents_version
+from deepagents._models import resolve_model
 from deepagents.graph import get_default_model
 
 pytest_plugins = ["tests.evals.pytest_reporter"]
@@ -187,19 +188,24 @@ def langsmith_experiment_metadata(request: pytest.FixtureRequest) -> dict[str, A
 
 @pytest.fixture
 def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
-    kwargs: dict[str, Any] = {}
     provider = request.config.getoption("--openrouter-provider")
-    if provider:
-        if not model_name.startswith("openrouter:"):
-            msg = "--openrouter-provider requires an openrouter: model prefix"
-            raise ValueError(msg)
-        kwargs["openrouter_provider"] = {
-            "only": [provider],
-            "allow_fallbacks": False,
-        }
+    if provider and not model_name.startswith("openrouter:"):
+        msg = "--openrouter-provider requires an openrouter: model prefix"
+        raise ValueError(msg)
+
     if model_name.startswith("openrouter:"):
-        # OpenRouter SDK passes timeout=None to httpx, disabling its default
-        # 5s read timeout. This causes indefinite hangs on TCP stalls.
-        # See: https://github.com/OpenRouterTeam/python-sdk/issues/72
-        kwargs["timeout"] = 120_000  # ms
-    return init_chat_model(model_name, **kwargs)
+        # OpenRouter needs extra kwargs (timeout, provider pinning) that
+        # resolve_model doesn't accept, so use init_chat_model directly.
+        # The OpenRouter harness profile (pre_init, init_kwargs_factory)
+        # is still applied via create_deep_agent's _harness_profile_for_model.
+        kwargs: dict[str, Any] = {"timeout": 120_000}  # ms — prevents TCP stall hangs
+        if provider:
+            kwargs["openrouter_provider"] = {
+                "only": [provider],
+                "allow_fallbacks": False,
+            }
+        return init_chat_model(model_name, **kwargs)
+
+    # resolve_model applies harness profile init_kwargs (e.g. reasoning_effort
+    # for Codex, use_responses_api for OpenAI) during model construction.
+    return resolve_model(model_name)

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
 from deepagents import __version__ as deepagents_version
+from deepagents._models import resolve_model
 from deepagents.graph import get_default_model
 
 pytest_plugins = ["tests.evals.pytest_reporter"]
@@ -157,19 +158,24 @@ def langsmith_experiment_metadata(request: pytest.FixtureRequest) -> dict[str, A
 
 @pytest.fixture
 def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
-    kwargs: dict[str, Any] = {}
     provider = request.config.getoption("--openrouter-provider")
-    if provider:
-        if not model_name.startswith("openrouter:"):
-            msg = "--openrouter-provider requires an openrouter: model prefix"
-            raise ValueError(msg)
-        kwargs["openrouter_provider"] = {
-            "only": [provider],
-            "allow_fallbacks": False,
-        }
+    if provider and not model_name.startswith("openrouter:"):
+        msg = "--openrouter-provider requires an openrouter: model prefix"
+        raise ValueError(msg)
+
     if model_name.startswith("openrouter:"):
-        # OpenRouter SDK passes timeout=None to httpx, disabling its default
-        # 5s read timeout. This causes indefinite hangs on TCP stalls.
-        # See: https://github.com/OpenRouterTeam/python-sdk/issues/72
-        kwargs["timeout"] = 120_000  # ms
-    return init_chat_model(model_name, **kwargs)
+        # OpenRouter needs extra kwargs (timeout, provider pinning) that
+        # resolve_model doesn't accept, so use init_chat_model directly.
+        # The OpenRouter harness profile (pre_init, init_kwargs_factory)
+        # is still applied via create_deep_agent's _harness_profile_for_model.
+        kwargs: dict[str, Any] = {"timeout": 120_000}  # ms — prevents TCP stall hangs
+        if provider:
+            kwargs["openrouter_provider"] = {
+                "only": [provider],
+                "allow_fallbacks": False,
+            }
+        return init_chat_model(model_name, **kwargs)
+
+    # resolve_model applies harness profile init_kwargs (e.g. reasoning_effort
+    # for Codex, use_responses_api for OpenAI) during model construction.
+    return resolve_model(model_name)

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -223,7 +223,12 @@ def test_ls_directory_missing_file_yes_no(model: BaseChatModel) -> None:
 @pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
 def test_edit_file_replace_text(model: BaseChatModel) -> None:
-    """Edits a file by replacing text, then validates the edit."""
+    """Edits a file by replacing text, then validates the edit.
+
+    Models with ``edit_file`` can do a blind search-and-replace (1 tool call).
+    Models with only ``apply_patch`` need to read first to build context (2 tool calls).
+    The scorer is intentionally relaxed on step/call counts to support both paths.
+    """
     agent = create_deep_agent(model=model)
     run_agent(
         agent,
@@ -231,13 +236,10 @@ def test_edit_file_replace_text(model: BaseChatModel) -> None:
         model=model,
         query=(
             "Replace all instances of 'cat' with 'dog' in /note.md, then tell me "
-            "how many replacements you made. Do not read the file before editing it."
+            "how many replacements you made."
         ),
-        # 1st step: request a tool call to edit /note.md.
-        # 2nd step: report completion.
-        # 1 tool call request: edit_file.
         scorer=TrajectoryScorer()
-        .expect(agent_steps=2, tool_call_requests=1)
+        .expect(agent_steps=3)
         .success(file_equals("/note.md", "dog dog dog\n")),
     )
 

--- a/libs/evals/tests/evals/test_summarization.py
+++ b/libs/evals/tests/evals/test_summarization.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 import requests
 from deepagents import create_deep_agent
+from deepagents._models import get_model_identifier
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.summarization import create_summarization_tool_middleware
 from langchain.agents.middleware import ModelCallLimitMiddleware
@@ -28,7 +29,7 @@ from langchain_core.load import load
 from langchain_core.messages import AnyMessage, HumanMessage
 from langgraph.checkpoint.memory import InMemorySaver
 
-from tests.evals.utils import AgentTrajectory, run_agent
+from tests.evals.utils import AgentTrajectory, run_agent, run_agent_async
 
 pytestmark = [pytest.mark.eval_category("summarization")]
 """Apply summarization category to all tests in this module. Tier is set per-test."""
@@ -127,17 +128,22 @@ def _setup_summarization_test(
 
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.langsmith
-def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel) -> None:
+async def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel) -> None:
     """Test that summarization triggers and the agent can continue reading a large file."""
     # Lowered from 15_000 so the (fraction=0.85) trigger fires reliably on
     # token-efficient / cache-heavy OpenAI Codex runs, where final-turn input
     # counts previously landed just under the threshold and compaction never
     # fired. 5_000 keeps the 0.85 fraction (~4.25K tokens) well inside one
     # 500-line chunk of the test file for both Anthropic and OpenAI models.
+    #
+    # TEMP (revert before merging the codex profile): uses the async invoke
+    # path so `CodexCompactionMiddleware.awrap_model_call` (the only path
+    # that calls `/compact`) runs. The sync entry point deliberately falls
+    # back to LLM summarization, which defeats the A/B comparison.
     agent, _, _ = _setup_summarization_test(tmp_path, model, 5_000)
     thread_id = uuid.uuid4().hex[:8]
 
-    trajectory = run_agent(
+    trajectory = await run_agent_async(
         agent,
         model=model,
         query="Can you read the entirety of summarization.py, 500 lines at a time, and summarize it?",
@@ -172,17 +178,20 @@ def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel) -> None:
 
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.langsmith
-def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatModel) -> None:
+async def test_summarization_offloads_to_filesystem(
+    tmp_path: Path, model: BaseChatModel
+) -> None:
     """Test that conversation history is offloaded to filesystem during summarization.
 
     This verifies the summarization middleware correctly writes conversation history
     as markdown to the backend at /conversation_history/{thread_id}.md.
     """
-    # See `test_summarize_continues_task` for rationale on the 5_000 cap.
+    # See `test_summarize_continues_task` for rationale on the 5_000 cap and
+    # the TEMP async-invoke switch required to actually exercise `/compact`.
     agent, _, root = _setup_summarization_test(tmp_path, model, 5_000)
     thread_id = uuid.uuid4().hex[:8]
 
-    _ = run_agent(
+    _ = await run_agent_async(
         agent,
         model=model,
         query="Can you read the entirety of summarization.py, 500 lines at a time, and summarize it?",
@@ -228,7 +237,7 @@ def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatMod
     # Ask about a specific detail from the beginning of the file that was read
     # before summarization. The agent should read the conversation history to find it.
     # The first standard library import in summarization.py (after `from __future__`) is `import base64`.
-    followup_trajectory = run_agent(
+    followup_trajectory = await run_agent_async(
         agent,
         model=model,
         query=(
@@ -303,6 +312,15 @@ def test_compact_tool_not_overly_sensitive(tmp_path: Path, model: BaseChatModel)
 @pytest.mark.langsmith
 def test_compact_tool_large_reads(tmp_path: Path, model: BaseChatModel) -> None:
     """Agent calls compact_conversation when asked to read another large file after a long conversation."""
+    # TEMP (revert before merging the codex profile): this test exercises the
+    # `compact_conversation` TOOL under a tight `run_limit=3` budget, which is
+    # orthogonal to the `/compact` vs. LLM-summarization A/B we're running.
+    # Codex's proactive tool-use behavior here produces noise that muddies the
+    # signal on the two tests that actually do compare compaction mechanisms.
+    model_id = get_model_identifier(model) or ""
+    if "codex" in model_id.lower():
+        pytest.skip("TEMP: skipped during codex /compact vs. summary A/B experiment")
+
     another_large_file = "https://raw.githubusercontent.com/langchain-ai/deepagents/5c90376c02754c67d448908e55d1e953f54b8acd/libs/deepagents/deepagents/middleware/filesystem.py"
 
     response = requests.get(another_large_file, timeout=30)

--- a/libs/evals/tests/evals/test_summarization.py
+++ b/libs/evals/tests/evals/test_summarization.py
@@ -68,6 +68,20 @@ def _write_file(p: Path, content: str) -> None:
     p.write_text(content)
 
 
+def _compaction_committed(state_values: dict[str, Any]) -> bool:
+    """Return True if either compaction path committed an event to state.
+
+    The default `SummarizationMiddleware` commits `_summarization_event`; the
+    codex profile's `CodexCompactionMiddleware` commits `codex_compaction_item`
+    on `/compact` success and falls back to `_summarization_event` otherwise.
+    Either key signals that compaction ran.
+    """
+    return bool(
+        state_values.get("_summarization_event")
+        or state_values.get("codex_compaction_item")
+    )
+
+
 def _setup_summarization_test(
     tmp_path: Path,
     model: BaseChatModel,
@@ -125,10 +139,10 @@ def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel) -> None:
         thread_id=thread_id,
     )
 
-    # Check we summarized
+    # Check we summarized (either default summary path or codex `/compact` path).
     config = {"configurable": {"thread_id": thread_id}}
     state = agent.get_state(config)
-    assert state.values["_summarization_event"]
+    assert _compaction_committed(state.values)
 
     # Verify the agent made substantial progress reading the file after summarization.
     # We check the highest line number seen across all tool observations to confirm
@@ -169,12 +183,13 @@ def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatMod
         thread_id=thread_id,
     )
 
-    # Check we summarized
+    # Check we summarized (either default summary path or codex `/compact` path).
     config = {"configurable": {"thread_id": thread_id}}
     state = agent.get_state(config)
-    assert state.values["_summarization_event"]
+    assert _compaction_committed(state.values)
 
-    # Verify conversation history was offloaded to filesystem
+    # Verify conversation history was offloaded to filesystem. Both paths call
+    # `_aoffload_to_backend`, so the markdown transcript is written either way.
     conversation_history_root = root / "conversation_history"
     assert conversation_history_root.exists(), (
         f"Conversation history root directory not found at {conversation_history_root}"
@@ -193,10 +208,15 @@ def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatMod
     # Should contain human-readable message content (from get_buffer_string)
     assert "Human:" in content or "AI:" in content, "Missing message content in markdown file"
 
-    # Verify the summary message references the conversation_history path
-    summary_message = state.values["_summarization_event"]["summary_message"]
-    assert "conversation_history" in summary_message.content
-    assert f"{thread_id}.md" in summary_message.content
+    # The LLM-summary path injects a text pointer to the offloaded file into
+    # the summary message; the codex `/compact` path produces an opaque
+    # encrypted_content block with no prose reference. Only assert the pointer
+    # when the summary event is the one that fired.
+    summary_event = state.values.get("_summarization_event")
+    if summary_event:
+        summary_message = summary_event["summary_message"]
+        assert "conversation_history" in summary_message.content
+        assert f"{thread_id}.md" in summary_message.content
 
     # --- Needle in the haystack follow-up ---
     # Ask about a specific detail from the beginning of the file that was read

--- a/libs/evals/tests/evals/test_summarization.py
+++ b/libs/evals/tests/evals/test_summarization.py
@@ -129,7 +129,12 @@ def _setup_summarization_test(
 @pytest.mark.langsmith
 def test_summarize_continues_task(tmp_path: Path, model: BaseChatModel) -> None:
     """Test that summarization triggers and the agent can continue reading a large file."""
-    agent, _, _ = _setup_summarization_test(tmp_path, model, 15_000)
+    # Lowered from 15_000 so the (fraction=0.85) trigger fires reliably on
+    # token-efficient / cache-heavy OpenAI Codex runs, where final-turn input
+    # counts previously landed just under the threshold and compaction never
+    # fired. 5_000 keeps the 0.85 fraction (~4.25K tokens) well inside one
+    # 500-line chunk of the test file for both Anthropic and OpenAI models.
+    agent, _, _ = _setup_summarization_test(tmp_path, model, 5_000)
     thread_id = uuid.uuid4().hex[:8]
 
     trajectory = run_agent(
@@ -173,7 +178,8 @@ def test_summarization_offloads_to_filesystem(tmp_path: Path, model: BaseChatMod
     This verifies the summarization middleware correctly writes conversation history
     as markdown to the backend at /conversation_history/{thread_id}.md.
     """
-    agent, _, root = _setup_summarization_test(tmp_path, model, 15_000)
+    # See `test_summarize_continues_task` for rationale on the 5_000 cap.
+    agent, _, root = _setup_summarization_test(tmp_path, model, 5_000)
     thread_id = uuid.uuid4().hex[:8]
 
     _ = run_agent(

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -2409,7 +2409,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0a3"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2421,9 +2421,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/3b/c4f9466f2ca7d56bde381ee26e78272b3eff65255ddc3954e3c4f99ca6d5/langchain_core-1.3.0a3.tar.gz", hash = "sha256:d27d9e43060850159a84c3913ba71bfcdd5807d52a4794c6ee719116510a5f04", size = 860836, upload-time = "2026-04-16T19:40:36.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/ed/e58ff8229b18a9c5cfbeb531d463b5193bb643ddfa97cf42f2c11c06d4db/langchain_core-1.3.0a3-py3-none-any.whl", hash = "sha256:f819afed6c2c48fc70dadf7f968f03f224307820e6965a885a357412090c9241", size = 515161, upload-time = "2026-04-16T19:40:35.493Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -23,7 +23,7 @@ required-markers = [
 [manifest]
 overrides = [
     { name = "e2b", specifier = "==2.4.3" },
-    { name = "openai", specifier = ">=1.109.1,<2.0.0" },
+    { name = "openai", specifier = ">=2.26.0,<3.0.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "python-multipart", specifier = ">=0.0.22" },
 ]
@@ -3426,7 +3426,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.109.1"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3438,9 +3438,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1083,9 +1083,11 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1090,7 +1090,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1106,9 +1106,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -648,14 +648,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -594,14 +594,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -1035,7 +1035,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1047,9 +1047,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -421,14 +421,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -820,9 +820,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -694,7 +694,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -706,9 +706,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -402,14 +402,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/repl/uv.lock
+++ b/libs/repl/uv.lock
@@ -421,14 +421,16 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
+    { name = "langchain-openai", marker = "extra == 'codex'", specifier = ">=1.1.12,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
 ]
+provides-extras = ["codex"]
 
 [package.metadata.requires-dev]
 test = [
     { name = "build" },
-    { name = "langchain-openai" },
+    { name = "langchain-openai", specifier = ">=1.1.12,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.1.6" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },

--- a/libs/repl/uv.lock
+++ b/libs/repl/uv.lock
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -820,9 +820,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a harness profile for OpenAI's Codex models (`gpt-5.2-codex`, `gpt-5.3-codex`) so Deep Agents speaks the dialect these models were trained on, without changing behavior for any other model.

## changes

- **New `_CODEX_PROFILE`** registered for `openai:gpt-5.2-codex` and `openai:gpt-5.3-codex`. Layered on top of the existing OpenAI provider profile (inherits `use_responses_api`).
- **Tool aliasing middleware** (`_ToolAliasingMiddleware`): renames `execute` → `shell_command` and `list_dir` → `ls` on the outbound request and reverts tool-call names on the inbound response. Internal routing and middleware stay on canonical names.
- **`apply_patch` tool**: V4A-diff parser/applier ported from OpenAI's reference implementation, gated on `include_apply_patch=True`. `edit_file` is excluded for Codex via `excluded_tools`.
- **`CodexCompactionMiddleware`**: composes the existing `SummarizationMiddleware` and substitutes a `/compact` call for the summary-generation step. Falls back to LLM summarization on API failure so no turn is ever lost. Phase metadata is preserved by `langchain-openai >= 1.1.12`, with a drift-guard unit test.
- **Codex-tuned system prompt suffix**: bias-to-action, parallel tool use, plan hygiene, `apply_patch` preference — derived from OpenAI's Codex Prompting Guide.
- **Evals + models registry**: `gpt-5.2-codex` / `gpt-5.3-codex` added to the models matrix; `deepagents_wrapper` routes Codex init through `resolve_model` so profile `init_kwargs` are applied in Harbor.
