### PR TITLE
feat(sdk): anthropic profile

### DIFF
--- a/libs/deepagents/deepagents/profiles/__init__.py
+++ b/libs/deepagents/deepagents/profiles/__init__.py
@@ -11,7 +11,10 @@ internal consumers can import from `deepagents.profiles` directly.
 
 # Provider modules register their profiles as a side effect of import.
 # _openrouter registration fires via the `from` import below.
-from deepagents.profiles import _openai as _openai
+from deepagents.profiles import _anthropic as _anthropic, _openai as _openai
+from deepagents.profiles._anthropic import (
+    _ANTHROPIC_SYSTEM_PROMPT_SUFFIX,
+)
 from deepagents.profiles._harness_profiles import (
     _HARNESS_PROFILES,
     _get_harness_profile,
@@ -29,6 +32,7 @@ from deepagents.profiles._openrouter import (
 
 __all__ = [
     "OPENROUTER_MIN_VERSION",
+    "_ANTHROPIC_SYSTEM_PROMPT_SUFFIX",
     "_HARNESS_PROFILES",
     "_OPENROUTER_APP_TITLE",
     "_OPENROUTER_APP_URL",

--- a/libs/deepagents/deepagents/profiles/__init__.py
+++ b/libs/deepagents/deepagents/profiles/__init__.py
@@ -11,9 +11,24 @@ internal consumers can import from `deepagents.profiles` directly.
 
 # Provider modules register their profiles as a side effect of import.
 # _openrouter registration fires via the `from` import below.
-from deepagents.profiles import _anthropic as _anthropic, _openai as _openai
+# _anthropic_opus registers the model-level Opus 4.6 overlay.
+# _anthropic_opus47 registers the model-level Opus 4.7 overlay.
+from deepagents.profiles import (
+    _anthropic as _anthropic,
+    _anthropic_opus as _anthropic_opus,
+    _anthropic_opus47 as _anthropic_opus47,
+    _openai as _openai,
+)
 from deepagents.profiles._anthropic import (
     _ANTHROPIC_SYSTEM_PROMPT_SUFFIX,
+)
+from deepagents.profiles._anthropic_opus import (
+    _ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX,
+    _OPUS_SYSTEM_PROMPT_SUFFIX,
+)
+from deepagents.profiles._anthropic_opus47 import (
+    _ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX,
+    _OPUS_47_SYSTEM_PROMPT_SUFFIX,
 )
 from deepagents.profiles._harness_profiles import (
     _HARNESS_PROFILES,
@@ -32,10 +47,14 @@ from deepagents.profiles._openrouter import (
 
 __all__ = [
     "OPENROUTER_MIN_VERSION",
+    "_ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX",
+    "_ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX",
     "_ANTHROPIC_SYSTEM_PROMPT_SUFFIX",
     "_HARNESS_PROFILES",
     "_OPENROUTER_APP_TITLE",
     "_OPENROUTER_APP_URL",
+    "_OPUS_47_SYSTEM_PROMPT_SUFFIX",
+    "_OPUS_SYSTEM_PROMPT_SUFFIX",
     "_HarnessProfile",
     "_get_harness_profile",
     "_merge_profiles",

--- a/libs/deepagents/deepagents/profiles/__init__.py
+++ b/libs/deepagents/deepagents/profiles/__init__.py
@@ -13,10 +13,15 @@ internal consumers can import from `deepagents.profiles` directly.
 # _openrouter registration fires via the `from` import below.
 # _anthropic_opus registers the model-level Opus 4.6 overlay.
 # _anthropic_opus47 registers the model-level Opus 4.7 overlay.
+# _anthropic_sonnet registers an intentionally empty Sonnet 4.6 profile
+# (audit anchor; see module docstring for rationale).
+# _anthropic_haiku does the same for Haiku 4.5.
 from deepagents.profiles import (
     _anthropic as _anthropic,
+    _anthropic_haiku as _anthropic_haiku,
     _anthropic_opus as _anthropic_opus,
     _anthropic_opus47 as _anthropic_opus47,
+    _anthropic_sonnet as _anthropic_sonnet,
     _openai as _openai,
 )
 from deepagents.profiles._anthropic import (

--- a/libs/deepagents/deepagents/profiles/_anthropic.py
+++ b/libs/deepagents/deepagents/profiles/_anthropic.py
@@ -1,0 +1,52 @@
+"""Anthropic provider harness profile.
+
+!!! warning
+
+    This is an internal API subject to change without deprecation. It is not
+    intended for external use or consumption.
+
+Registers a provider-level profile for Anthropic models with a system prompt
+suffix that improves agentic performance. Based on Anthropic's prompting best
+practices for Claude's latest models.
+"""
+# ruff: noqa: E501
+
+from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
+
+_ANTHROPIC_SYSTEM_PROMPT_SUFFIX = """\
+<parallel_tool_calls>
+If you intend to call multiple tools and there are no dependencies between the calls, make all of the independent calls in the same message. Read multiple files simultaneously, run independent searches in parallel, or check multiple resources at once. Only sequence calls when one depends on the output of another. Never use placeholders for values you don't have yet — if a call depends on a prior result, wait for it.
+</parallel_tool_calls>
+
+<grounded_responses>
+Never speculate about code, files, or system state you have not directly observed. If a task involves a specific file or function, read it before making claims about its contents or behavior. When uncertain about current state, investigate first — do not guess.
+</grounded_responses>
+
+<tool_result_reflection>
+After receiving tool results, reflect on their quality and relevance before taking the next action. Use this reflection to determine whether your current approach is still the best path, rather than mechanically continuing a plan that new information may have invalidated.
+</tool_result_reflection>
+
+<decisive_execution>
+When approaching a problem, choose a strategy and commit to it. Avoid revisiting decisions unless you encounter evidence that directly contradicts your reasoning. If weighing multiple approaches, pick the most promising one and execute — course-correct only if it fails.
+</decisive_execution>"""
+"""System prompt suffix appended for all Anthropic models.
+
+Covers four areas that complement the base ``BASE_AGENT_PROMPT`` without
+duplicating it:
+
+* **Parallel tool calls** — explicit guidance to batch independent calls,
+  the single largest latency improvement for Claude in agentic loops.
+* **Grounded responses** — hard constraint against speculating about
+  unobserved code/files (upgrades the softer "read relevant files" in the
+  base prompt).
+* **Tool-result reflection** — leverages Claude's interleaved thinking to
+  re-evaluate the plan after each tool round.
+* **Decisive execution** — prevents waffling between strategies, reducing
+  wasted tokens without conflicting with the base prompt's "analyze *why*
+  on failure" guidance.
+"""
+
+_register_harness_profile(
+    "anthropic",
+    _HarnessProfile(system_prompt_suffix=_ANTHROPIC_SYSTEM_PROMPT_SUFFIX),
+)

--- a/libs/deepagents/deepagents/profiles/_anthropic_haiku.py
+++ b/libs/deepagents/deepagents/profiles/_anthropic_haiku.py
@@ -1,0 +1,61 @@
+"""Anthropic Haiku 4.5 model harness profile.
+
+!!! warning
+
+    This is an internal API subject to change without deprecation. It is not
+    intended for external use or consumption.
+
+Registers an intentionally empty model-level profile for
+``anthropic:claude-haiku-4-5``.  Same audit conclusion as the Sonnet 4.6
+profile (see :mod:`deepagents.profiles._anthropic_sonnet`): the
+provider-level Anthropic profile already covers every prompt-suffix
+recommendation that Anthropic's `prompting best practices
+<https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>`_
+attributes to "Claude's latest models" (the scope sentence explicitly
+includes Haiku 4.5 in that set), and no Haiku-specific behavioral
+tendencies are documented anywhere in the article or the `Haiku 4.5
+migration guide
+<https://platform.claude.com/docs/en/about-claude/models/migration-guide#migrating-to-claude-haiku-4-5>`_:
+
+* The best-practices article contains only two incidental Haiku mentions
+  (scope sentence + context-awareness note).  It contains zero Haiku
+  behavioral-prompt recommendations.  The overengineering, overthinking,
+  and subagent-overuse sections are all explicitly tagged Opus-only and
+  do not apply here — the same reasoning that excluded them from Sonnet.
+* The migration guide's Haiku 4.5 section is entirely API/config changes
+  (model ID, rate limits, tool versions, sampling parameters, ``refusal``
+  stop reason, extended-thinking configuration) — none of which are
+  prompt concerns.  There is no behavior-change list comparable to the
+  Opus 4.7 migration notes.
+
+One wrinkle worth documenting in case it is revisited: Haiku 4.5 predates
+the 4.6 generation and uses extended thinking with ``budget_tokens``, not
+adaptive thinking (the article notes "Extended thinking is deprecated in
+Claude 4.6 or newer models").  The provider-level
+``<tool_result_reflection>`` section was originally motivated by
+adaptive-/interleaved-thinking behavior, but its text is plain
+behavioral guidance that does not depend on a specific thinking mode, so
+inheriting it on Haiku is appropriate.  If future evals show the
+section misfires on Haiku specifically, the fix belongs here as a
+model-level override rather than a provider-level change.
+
+Haiku 4.5 is frequently selected as a fast / low-cost subagent model in
+Deep Agent setups.  The audit anchor is particularly valuable here:
+"make Haiku prompts shorter / more efficient" is a plausible future
+edit, but nothing in the source documentation supports it, and any such
+steering should require new evidence (evals, documented behavior
+changes) before landing.
+
+The empty override composes with the Anthropic provider profile via
+``_merge_profiles``: a ``None`` ``system_prompt_suffix`` on the override
+falls back to the provider suffix, so Haiku 4.5 resolves to
+``_ANTHROPIC_SYSTEM_PROMPT_SUFFIX`` verbatim.  The registration is
+behaviorally a no-op; its value is the anchored audit and the tests.
+"""
+
+from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
+
+_register_harness_profile(
+    "anthropic:claude-haiku-4-5",
+    _HarnessProfile(),
+)

--- a/libs/deepagents/deepagents/profiles/_anthropic_opus.py
+++ b/libs/deepagents/deepagents/profiles/_anthropic_opus.py
@@ -1,0 +1,60 @@
+"""Anthropic Opus 4.6 model harness profile.
+
+!!! warning
+
+    This is an internal API subject to change without deprecation. It is not
+    intended for external use or consumption.
+
+Registers a model-level profile for ``anthropic:claude-opus-4-6`` that layers
+Opus-specific agentic guidance on top of the Anthropic provider profile.  The
+three additional sections address behavioral tendencies documented in Anthropic's
+`prompting best practices for Claude 4.6
+<https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>`_
+that are specific to Opus 4.6 (and do not apply to Sonnet / Haiku):
+
+* **Minimal changes** — curbs overengineering and scope creep.
+* **Subagent discipline** — prevents excessive delegation for simple tasks.
+* **Focused exploration** — constrains broad upfront codebase scanning.
+
+Because ``_merge_profiles`` replaces ``system_prompt_suffix`` (scalar override),
+this module composes its suffix from ``_ANTHROPIC_SYSTEM_PROMPT_SUFFIX`` (the
+provider-level sections) plus the Opus-specific additions so nothing is lost.
+"""
+# ruff: noqa: E501
+
+from deepagents.profiles._anthropic import _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
+
+_OPUS_SYSTEM_PROMPT_SUFFIX = """\
+<minimal_changes>
+Only make changes that are directly requested or clearly necessary to fulfill the request. Do not add features, refactor surrounding code, or introduce abstractions beyond what the task requires. A bug fix does not need nearby code cleaned up. A simple feature does not need extra configurability. Do not add documentation, type annotations, or error handling to code you did not change. The right amount of complexity is the minimum needed for the current task.
+</minimal_changes>
+
+<subagent_discipline>
+Prefer working directly over delegating to subagents when the task is simple — single-file edits, quick lookups, sequential operations, or anything that takes only a few tool calls. Reserve subagents for work that genuinely benefits from parallelism, isolated context, or independent workstreams. When in doubt, do the work yourself.
+</subagent_discipline>
+
+<focused_exploration>
+When starting a task, read the specific files relevant to the problem rather than broadly scanning the codebase. Form a plan from what you find and begin executing. Expand your investigation only when you encounter something that requires additional context — do not front-load extensive exploration.
+</focused_exploration>"""
+"""Opus-specific prompt sections appended after the provider-level Anthropic sections.
+
+* **Minimal changes** — sourced from "Overeagerness" (article section on Opus 4.5
+  and Opus 4.6 overengineering).  Language is moderate to avoid undertriggering on
+  legitimate refactoring tasks.
+* **Subagent discipline** — sourced from "Subagent orchestration" (article notes
+  Opus 4.6 has a strong predilection for subagents).  Complements the existing
+  ``TASK_SYSTEM_PROMPT`` "when NOT to use" guidance by framing it as a model-level
+  behavioral preference rather than a tool-level rule.
+* **Focused exploration** — sourced from "Overthinking and excessive thoroughness"
+  (article notes Opus 4.6 does significantly more upfront exploration).  Strengthens
+  the provider-level ``<decisive_execution>`` which gives mild general coverage.
+"""
+
+_ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX = _ANTHROPIC_SYSTEM_PROMPT_SUFFIX + "\n\n" + _OPUS_SYSTEM_PROMPT_SUFFIX
+"""Full system prompt suffix for Opus 4.6: Anthropic provider sections + Opus overlay."""
+
+_register_harness_profile(
+    "anthropic:claude-opus-4-6",
+    _HarnessProfile(system_prompt_suffix=_ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX),
+)

--- a/libs/deepagents/deepagents/profiles/_anthropic_opus47.py
+++ b/libs/deepagents/deepagents/profiles/_anthropic_opus47.py
@@ -1,0 +1,64 @@
+"""Anthropic Opus 4.7 model harness profile.
+
+!!! warning
+
+    This is an internal API subject to change without deprecation. It is not
+    intended for external use or consumption.
+
+Registers a model-level profile for ``anthropic:claude-opus-4-7`` that layers
+Opus 4.7-specific agentic guidance on top of the Anthropic provider profile.
+
+Opus 4.7's native tendencies are inverted from Opus 4.6 on several axes: the
+`migration guide
+<https://platform.claude.com/docs/en/about-claude/models/migration-guide#migrating-to-claude-opus-4-7>`_
+documents that Opus 4.7 spawns fewer subagents by default, uses tools less
+often (preferring reasoning), and scopes its work more strictly to what was
+asked. As a result, the Opus 4.6 overlay sections (``<minimal_changes>``,
+``<subagent_discipline>``, ``<focused_exploration>``) would compound these
+tendencies in the wrong direction for a Deep Agent and are deliberately *not*
+included here.
+
+The two sections below are sourced from explicit Anthropic recommendations in
+the 4.7 migration guide:
+
+* **Tool usage** — counteracts the reduced tool-calling default (#7).
+* **Subagent usage** — counteracts the reduced subagent-spawning default (#5).
+
+Because ``_merge_profiles`` replaces ``system_prompt_suffix`` (scalar override),
+this module composes its suffix from ``_ANTHROPIC_SYSTEM_PROMPT_SUFFIX`` (the
+provider-level sections) plus the Opus 4.7 additions so the provider guidance
+is preserved.
+"""
+# ruff: noqa: E501
+
+from deepagents.profiles._anthropic import _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
+
+_OPUS_47_SYSTEM_PROMPT_SUFFIX = """\
+<tool_usage>
+When a task depends on the state of files, tests, or system output, use tools to observe that state directly rather than reasoning from memory about what it probably contains. Read files before describing them. Run tests before claiming they pass. Search the codebase before asserting a symbol does or does not exist. Active investigation with tools is the default mode of working, not a fallback.
+</tool_usage>
+
+<subagent_usage>
+Consider spawning subagents when a task has genuinely independent workstreams that can run in parallel, when a subtask needs isolated context to avoid polluting the main thread, or when delegating a large well-scoped unit of work would reduce orchestration overhead. Subagents are especially useful for independent research, parallel code exploration across unrelated areas, and large self-contained implementations. Use them when the parallelism or isolation pays for the coordination cost.
+</subagent_usage>"""
+"""Opus 4.7-specific prompt sections appended after the provider-level Anthropic sections.
+
+* **Tool usage** — sourced from migration guide behavior change #7
+  ("Fewer tool calls by default").  Reinforces active investigation via tools
+  rather than reasoning from memory.  Complements the provider-level
+  ``<grounded_responses>`` which targets hallucinated *claims*; this section
+  targets the *working loop*.
+* **Subagent usage** — sourced from migration guide behavior change #5
+  ("Fewer subagents spawned by default").  Mild, specific encouragement for
+  the cases where subagents genuinely help.  Moderate tone per the "more
+  literal instruction following" caveat in the migration guide (#2).
+"""
+
+_ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX = _ANTHROPIC_SYSTEM_PROMPT_SUFFIX + "\n\n" + _OPUS_47_SYSTEM_PROMPT_SUFFIX
+"""Full system prompt suffix for Opus 4.7: Anthropic provider sections + Opus 4.7 overlay."""
+
+_register_harness_profile(
+    "anthropic:claude-opus-4-7",
+    _HarnessProfile(system_prompt_suffix=_ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX),
+)

--- a/libs/deepagents/deepagents/profiles/_anthropic_sonnet.py
+++ b/libs/deepagents/deepagents/profiles/_anthropic_sonnet.py
@@ -1,0 +1,64 @@
+"""Anthropic Sonnet 4.6 model harness profile.
+
+!!! warning
+
+    This is an internal API subject to change without deprecation. It is not
+    intended for external use or consumption.
+
+Registers an intentionally empty model-level profile for
+``anthropic:claude-sonnet-4-6``.  The provider-level Anthropic profile
+(:data:`~deepagents.profiles._anthropic._ANTHROPIC_SYSTEM_PROMPT_SUFFIX`)
+already covers every prompt-suffix recommendation that Anthropic's
+`prompting best practices
+<https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>`_
+attributes to "Claude's latest models" as a class (parallel tool calling,
+grounded responses, post-tool reflection, decisive execution).  Nothing in
+that article — or in the `Sonnet 4.6 migration guide
+<https://platform.claude.com/docs/en/about-claude/models/migration-guide#migrating-to-claude-sonnet-4-6>`_
+— documents Sonnet-specific behavioral tendencies that warrant additional
+prompt steering:
+
+* The article's overeagerness, overthinking, and subagent-overuse warnings
+  are all explicitly tagged "Opus 4.5 / 4.6" (not Sonnet).  The Opus 4.6
+  overlay in :mod:`deepagents.profiles._anthropic_opus` already carries
+  those and notes they "do not apply to Sonnet / Haiku".
+* Opus 4.7's migration guide lists seven concrete behavior changes (fewer
+  tool calls, fewer subagents, more literal instruction following, etc.)
+  that justify its overlay in
+  :mod:`deepagents.profiles._anthropic_opus47`.  Sonnet 4.6's migration
+  section contains no comparable behavior-change list — only API/config
+  changes (prefill deprecation, adaptive thinking, effort parameter) that
+  are handled at the SDK/API layer, not the prompt.
+* Sonnet 4.6-specific callouts in the article (default ``high`` effort,
+  computer-use best-in-class with adaptive thinking, positioning for
+  fast-turnaround workloads) are API kwargs or use-case guidance, not
+  prompt content.  Forcing defaults like ``effort=medium`` at the harness
+  level would hurt users who legitimately want ``high`` effort for
+  autonomous coding; those choices belong at the call site via
+  ``init_kwargs``.
+
+Registering an empty profile (rather than omitting this module) serves
+three purposes:
+
+1. Makes the audit discoverable — anyone grepping for ``sonnet`` in the
+   profiles package lands here and finds the documented rationale.
+2. Provides a drop-in template if a future Sonnet release documents
+   behavior changes the way Opus 4.7 did.
+3. Gives the test suite (``TestBuiltInProfiles``) a stable anchor to
+   assert "Sonnet 4.6 uses the provider suffix unchanged", preventing
+   silent divergence.
+
+The empty override is composed with the Anthropic provider profile by
+``_merge_profiles``: a ``None`` ``system_prompt_suffix`` on the override
+falls back to the provider suffix, so Sonnet 4.6 resolves to
+``_ANTHROPIC_SYSTEM_PROMPT_SUFFIX`` verbatim — identical to what a bare
+provider-prefix lookup would return.  The extra registration is
+behaviorally a no-op; its value is the anchored audit and the tests.
+"""
+
+from deepagents.profiles._harness_profiles import _HarnessProfile, _register_harness_profile
+
+_register_harness_profile(
+    "anthropic:claude-sonnet-4-6",
+    _HarnessProfile(),
+)

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -211,12 +211,13 @@ class TestToolDescriptionOverrides:
 
 
 class TestDefaultModelProfile:
-    """Tests for default model=None getting the default profile."""
+    """Tests for default model=None getting the Anthropic provider profile."""
 
-    def test_default_model_gets_default_profile(self) -> None:
-        """model=None resolves to default profile (no Anthropic-specific registration)."""
+    def test_default_model_gets_anthropic_profile(self) -> None:
+        """model=None resolves to Anthropic; profile carries the provider suffix."""
         profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
-        assert profile == _HarnessProfile()
+        assert profile.system_prompt_suffix is not None
+        assert "<parallel_tool_calls>" in profile.system_prompt_suffix
 
 
 class TestToolDescriptionOverrideWiring:

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -15,10 +15,14 @@ from deepagents._models import (
     resolve_model,
 )
 from deepagents.profiles import (
+    _ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX,
+    _ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX,
     _ANTHROPIC_SYSTEM_PROMPT_SUFFIX,
     _HARNESS_PROFILES,
     _OPENROUTER_APP_TITLE,
     _OPENROUTER_APP_URL,
+    _OPUS_47_SYSTEM_PROMPT_SUFFIX,
+    _OPUS_SYSTEM_PROMPT_SUFFIX,
     OPENROUTER_MIN_VERSION,
     _get_harness_profile,
     _HarnessProfile,
@@ -593,6 +597,112 @@ class TestBuiltInProfiles:
         assert profile.pre_init is None
         assert profile.init_kwargs_factory is None
         assert profile.extra_middleware == ()
+
+    def test_opus_profile_registered(self) -> None:
+        """Opus 4.6 model profile is registered at import time."""
+        assert "anthropic:claude-opus-4-6" in _HARNESS_PROFILES
+
+    def test_opus_suffix_includes_provider_sections(self) -> None:
+        """Opus suffix includes all four Anthropic provider prompt sections."""
+        profile = _get_harness_profile("anthropic:claude-opus-4-6")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<parallel_tool_calls>",
+            "<grounded_responses>",
+            "<tool_result_reflection>",
+            "<decisive_execution>",
+        ):
+            assert tag in suffix
+
+    def test_opus_suffix_includes_opus_sections(self) -> None:
+        """Opus suffix includes the three Opus-specific prompt sections."""
+        profile = _get_harness_profile("anthropic:claude-opus-4-6")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<minimal_changes>",
+            "<subagent_discipline>",
+            "<focused_exploration>",
+        ):
+            assert tag in suffix
+
+    def test_opus_profile_merges_with_provider(self) -> None:
+        """Opus model profile merges with the Anthropic provider profile."""
+        profile = _get_harness_profile("anthropic:claude-opus-4-6")
+        assert profile.system_prompt_suffix == _ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX
+        assert profile.init_kwargs == {}
+        assert profile.extra_middleware == ()
+
+    def test_opus_suffix_is_provider_plus_overlay(self) -> None:
+        """Opus suffix equals the Anthropic suffix concatenated with the overlay."""
+        assert _ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX == (_ANTHROPIC_SYSTEM_PROMPT_SUFFIX + "\n\n" + _OPUS_SYSTEM_PROMPT_SUFFIX)
+
+    def test_non_opus_anthropic_unaffected(self) -> None:
+        """Non-Opus Anthropic models still get the plain provider suffix."""
+        profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
+        assert profile.system_prompt_suffix == _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+
+    def test_opus_47_profile_registered(self) -> None:
+        """Opus 4.7 model profile is registered at import time."""
+        assert "anthropic:claude-opus-4-7" in _HARNESS_PROFILES
+
+    def test_opus_47_suffix_includes_provider_sections(self) -> None:
+        """Opus 4.7 suffix includes all four Anthropic provider prompt sections."""
+        profile = _get_harness_profile("anthropic:claude-opus-4-7")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<parallel_tool_calls>",
+            "<grounded_responses>",
+            "<tool_result_reflection>",
+            "<decisive_execution>",
+        ):
+            assert tag in suffix
+
+    def test_opus_47_suffix_includes_opus_47_sections(self) -> None:
+        """Opus 4.7 suffix includes the two Opus 4.7-specific prompt sections."""
+        profile = _get_harness_profile("anthropic:claude-opus-4-7")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<tool_usage>",
+            "<subagent_usage>",
+        ):
+            assert tag in suffix
+
+    def test_opus_47_suffix_excludes_opus_46_sections(self) -> None:
+        """Opus 4.7 must not inherit the Opus 4.6 overlay sections.
+
+        The 4.6 sections (`<minimal_changes>`, `<subagent_discipline>`,
+        `<focused_exploration>`) would reinforce 4.7's native tendencies in the
+        wrong direction per the migration guide.
+        """
+        profile = _get_harness_profile("anthropic:claude-opus-4-7")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<minimal_changes>",
+            "<subagent_discipline>",
+            "<focused_exploration>",
+        ):
+            assert tag not in suffix
+
+    def test_opus_47_profile_merges_with_provider(self) -> None:
+        """Opus 4.7 model profile merges with the Anthropic provider profile."""
+        profile = _get_harness_profile("anthropic:claude-opus-4-7")
+        assert profile.system_prompt_suffix == _ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX
+        assert profile.init_kwargs == {}
+        assert profile.extra_middleware == ()
+
+    def test_opus_47_suffix_is_provider_plus_overlay(self) -> None:
+        """Opus 4.7 suffix equals the Anthropic suffix concatenated with the 4.7 overlay."""
+        assert _ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX == (_ANTHROPIC_SYSTEM_PROMPT_SUFFIX + "\n\n" + _OPUS_47_SYSTEM_PROMPT_SUFFIX)
+
+    def test_opus_46_and_47_have_distinct_suffixes(self) -> None:
+        """Opus 4.6 and 4.7 profiles diverge on the overlay content."""
+        assert _OPUS_SYSTEM_PROMPT_SUFFIX != _OPUS_47_SYSTEM_PROMPT_SUFFIX
+        assert _ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX != _ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX
 
 
 class TestResolveModelWithProfiles:

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -15,6 +15,7 @@ from deepagents._models import (
     resolve_model,
 )
 from deepagents.profiles import (
+    _ANTHROPIC_SYSTEM_PROMPT_SUFFIX,
     _HARNESS_PROFILES,
     _OPENROUTER_APP_TITLE,
     _OPENROUTER_APP_URL,
@@ -102,7 +103,8 @@ class TestResolveModel:
 
         mock.assert_called_once_with("openrouter:anthropic/claude-sonnet-4-6")
 
-    def test_non_openai_string(self) -> None:
+    def test_anthropic_string_passes_no_init_kwargs(self) -> None:
+        """Anthropic profile has no init_kwargs so resolve_model passes none."""
         with patch("deepagents._models.init_chat_model") as mock:
             mock.return_value = MagicMock(spec=BaseChatModel)
             result = resolve_model("anthropic:claude-sonnet-4-6")
@@ -517,8 +519,8 @@ class TestProfileMergingEndToEnd:
             _HARNESS_PROFILES.clear()
             _HARNESS_PROFILES.update(original)
 
-    def test_anthropic_exact_model_inherits_provider_profile(self) -> None:
-        """Per-model Anthropic profile merges with the provider-level profile."""
+    def test_anthropic_exact_model_overrides_provider_suffix(self) -> None:
+        """Per-model Anthropic suffix wins over the provider-level suffix."""
         original = dict(_HARNESS_PROFILES)
         try:
             _register_harness_profile(
@@ -527,9 +529,22 @@ class TestProfileMergingEndToEnd:
             )
             profile = _get_harness_profile("anthropic:claude-sonnet-4-6-20250514")
             assert profile.system_prompt_suffix == "be concise"
-            # AnthropicPromptCachingMiddleware is applied unconditionally in
-            # graph.py, not via the profile, so extra_middleware should be empty.
             assert profile.extra_middleware == ()
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_anthropic_exact_model_inherits_provider_suffix(self) -> None:
+        """Per-model Anthropic profile without a suffix inherits the provider suffix."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            _register_harness_profile(
+                "anthropic:claude-opus-4-6",
+                _HarnessProfile(init_kwargs={"temperature": 0}),
+            )
+            profile = _get_harness_profile("anthropic:claude-opus-4-6")
+            assert profile.system_prompt_suffix == _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+            assert profile.init_kwargs == {"temperature": 0}
         finally:
             _HARNESS_PROFILES.clear()
             _HARNESS_PROFILES.update(original)
@@ -570,10 +585,14 @@ class TestBuiltInProfiles:
         assert profile.pre_init is not None
         assert profile.init_kwargs_factory is not None
 
-    def test_anthropic_returns_default_profile(self) -> None:
-        """Anthropic has no registered profile; caching is unconditional in graph.py."""
+    def test_anthropic_profile_has_system_prompt_suffix(self) -> None:
+        """Anthropic registers a provider-level prompt suffix for agentic quality."""
         profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
-        assert profile == _HarnessProfile()
+        assert profile.system_prompt_suffix == _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+        assert profile.init_kwargs == {}
+        assert profile.pre_init is None
+        assert profile.init_kwargs_factory is None
+        assert profile.extra_middleware == ()
 
 
 class TestResolveModelWithProfiles:

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -704,6 +704,83 @@ class TestBuiltInProfiles:
         assert _OPUS_SYSTEM_PROMPT_SUFFIX != _OPUS_47_SYSTEM_PROMPT_SUFFIX
         assert _ANTHROPIC_OPUS_SYSTEM_PROMPT_SUFFIX != _ANTHROPIC_OPUS_47_SYSTEM_PROMPT_SUFFIX
 
+    def test_sonnet_46_profile_registered(self) -> None:
+        """Sonnet 4.6 model profile is registered at import time as an audit anchor."""
+        assert "anthropic:claude-sonnet-4-6" in _HARNESS_PROFILES
+
+    def test_sonnet_46_uses_provider_suffix_unchanged(self) -> None:
+        """Sonnet 4.6 resolves to the Anthropic provider suffix verbatim.
+
+        The Sonnet 4.6 profile is intentionally empty; no documented
+        Sonnet-specific behavioral tendencies justify an overlay.  The empty
+        override composes with the provider profile and inherits the
+        suffix unchanged.
+        """
+        profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
+        assert profile.system_prompt_suffix == _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+        assert profile.init_kwargs == {}
+        assert profile.pre_init is None
+        assert profile.init_kwargs_factory is None
+        assert profile.extra_middleware == ()
+
+    def test_sonnet_46_excludes_opus_overlay_sections(self) -> None:
+        """Sonnet 4.6 must not carry Opus 4.6 or 4.7 overlay sections.
+
+        Locks in the audit finding that Opus-specific prompt steering
+        (overengineering, subagent overuse, reduced tool usage) does not
+        apply to Sonnet and should not leak in via future edits.
+        """
+        profile = _get_harness_profile("anthropic:claude-sonnet-4-6")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<minimal_changes>",
+            "<subagent_discipline>",
+            "<focused_exploration>",
+            "<tool_usage>",
+            "<subagent_usage>",
+        ):
+            assert tag not in suffix
+
+    def test_haiku_45_profile_registered(self) -> None:
+        """Haiku 4.5 model profile is registered at import time as an audit anchor."""
+        assert "anthropic:claude-haiku-4-5" in _HARNESS_PROFILES
+
+    def test_haiku_45_uses_provider_suffix_unchanged(self) -> None:
+        """Haiku 4.5 resolves to the Anthropic provider suffix verbatim.
+
+        The Haiku 4.5 profile is intentionally empty; the source material
+        documents no Haiku-specific behavioral tendencies that warrant an
+        overlay.  The empty override composes with the provider profile
+        and inherits the suffix unchanged.
+        """
+        profile = _get_harness_profile("anthropic:claude-haiku-4-5")
+        assert profile.system_prompt_suffix == _ANTHROPIC_SYSTEM_PROMPT_SUFFIX
+        assert profile.init_kwargs == {}
+        assert profile.pre_init is None
+        assert profile.init_kwargs_factory is None
+        assert profile.extra_middleware == ()
+
+    def test_haiku_45_excludes_opus_overlay_sections(self) -> None:
+        """Haiku 4.5 must not carry Opus 4.6 or 4.7 overlay sections.
+
+        Haiku is often chosen as a fast subagent model; this test guards
+        against a future contributor grafting Opus-only steering
+        (overengineering, subagent overuse, reduced tool usage) onto
+        Haiku without new evidence.
+        """
+        profile = _get_harness_profile("anthropic:claude-haiku-4-5")
+        suffix = profile.system_prompt_suffix
+        assert suffix is not None
+        for tag in (
+            "<minimal_changes>",
+            "<subagent_discipline>",
+            "<focused_exploration>",
+            "<tool_usage>",
+            "<subagent_usage>",
+        ):
+            assert tag not in suffix
+
 
 class TestResolveModelWithProfiles:
     """Tests for resolve_model using the profile registry."""

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -412,7 +412,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "langchain" },


### PR DESCRIPTION
Adds harness profiles for Anthropic Claude models, grounded in Anthropic's published prompting best practices and per-model migration guides.

## What

- **`_anthropic.py`** — provider-level suffix applied to every Claude model. Covers parallel tool calls, grounded responses, post-tool reflection, and decisive execution (from Anthropic's "latest Claude models" guidance).
- **`_anthropic_opus.py`** — Opus 4.6 overlay. Adds minimal-changes, subagent discipline, and focused-exploration sections to curb Opus 4.6's documented overeagerness / overthinking / subagent-overuse tendencies.
- **`_anthropic_opus47.py`** — Opus 4.7 overlay. Inverts the 4.6 approach because the 4.7 migration guide documents *reduced* tool and subagent use by default; encourages active tool use and appropriate subagent spawning.
- **`_anthropic_sonnet.py` / `_anthropic_haiku.py`** — intentionally empty registrations. Anthropic docs contain no Sonnet/Haiku-specific behavioral prompt recommendations, so these inherit the provider suffix unchanged. The modules exist as audit anchors with the rationale inline, plus a stable hook for future tests and migrations.

Every overlay cites the exact Anthropic doc section it derives from, so future edits require new evidence rather than vibes.