### PR TITLE
fix(backends): ripgrep glob fails with directory components when search path is absolute

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -495,7 +495,7 @@ class FilesystemBackend(BackendProtocol):
         cmd = ["rg", "--json", "-F"]  # -F enables fixed-string (literal) mode
         if include_glob:
             cmd.extend(["--glob", include_glob])
-        cmd.extend(["--", pattern, str(base_full)])
+        cmd.extend(["--", pattern, "."])
 
         try:
             proc = subprocess.run(  # noqa: S603
@@ -504,6 +504,7 @@ class FilesystemBackend(BackendProtocol):
                 text=True,
                 timeout=30,
                 check=False,
+                cwd=str(base_full),
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
             return None
@@ -520,7 +521,7 @@ class FilesystemBackend(BackendProtocol):
             ftext = pdata.get("path", {}).get("text")
             if not ftext:
                 continue
-            p = Path(ftext)
+            p = (base_full / ftext).resolve()
             if self.virtual_mode:
                 try:
                     virt = self._to_virtual_path(p)

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -550,6 +550,31 @@ def test_grep_literal_search_with_special_chars(tmp_path: Path, pattern: str, ex
     assert any(expected_file in m["path"] for m in matches), f"Pattern '{pattern}' not found in {expected_file}"
 
 
+@pytest.mark.skipif(
+    not any((Path(d) / "rg").exists() for d in ("/usr/bin", "/usr/local/bin", "/opt/homebrew/bin")),
+    reason="ripgrep not installed",
+)
+def test_grep_glob_with_directory_component(tmp_path: Path) -> None:
+    """Test that --glob patterns with directory components match correctly.
+
+    ripgrep's --glob matches against paths relative to the process cwd, not
+    the search root. When the search root is an absolute path and cwd differs,
+    globs like ``subdir/*.md`` silently match nothing. This test ensures the
+    fix (searching ``.`` with ``cwd=base_full``) works.
+    """
+    sub = tmp_path / "docs"
+    sub.mkdir()
+    (sub / "guide.md").write_text("hello world")
+    (sub / "notes.txt").write_text("hello world")
+    (tmp_path / "root.md").write_text("hello world")
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    result = be.grep("hello", path="/", glob="docs/*.md")
+    assert result.matches is not None
+    assert len(result.matches) == 1
+    assert result.matches[0]["path"] == "/docs/guide.md"
+
+
 class TestToVirtualPath:
     """Tests for FilesystemBackend._to_virtual_path."""
 


### PR DESCRIPTION
Fixes #2732

## Problem

`FilesystemBackend._ripgrep_search` passes the resolved absolute path directly to ripgrep:

```python
cmd.extend(["--", pattern, str(base_full)])
```

ripgrep's `--glob` flag matches against paths **relative to the process cwd**, not the search root. When `base_full` is an absolute path and the process cwd differs from it, glob patterns containing directory components (e.g. `subdir/*.md`) silently match nothing.

### Reproduction

```bash
# cwd != search root → glob with directory component fails
cd /tmp
rg --glob "docs/*.md" -l -F "hello" /path/to/project
# exit 1 (no matches)

# cwd == search root → same glob works
cd /path/to/project
rg --glob "docs/*.md" -l -F "hello" /path/to/project
# docs/guide.md
```

Simple globs without directory components (e.g. `*.md`) are unaffected because ripgrep treats them as `**/*.md`.

Tested with ripgrep 15.1.0 on macOS.

## Fix

Pass `.` as the search path with `cwd=base_full`, so ripgrep always resolves glob patterns against the intended search directory:

```diff
- cmd.extend(["--", pattern, str(base_full)])
+ cmd.extend(["--", pattern, "."])

  proc = subprocess.run(
      cmd,
      capture_output=True,
      text=True,
      timeout=30,
      check=False,
+     cwd=str(base_full),
  )

- p = Path(ftext)
+ p = (base_full / ftext).resolve()
```

## Test

Added `test_grep_glob_with_directory_component` — creates a subdirectory, searches with a `subdir/*.md` glob, and asserts only the expected file is returned.

All 37 existing filesystem backend tests continue to pass.