### PR TITLE
fix(cli): throttle update notification to once per day and fix teardown banner

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1447,7 +1447,7 @@ class DeepAgentsApp(App):
             logger.debug("Background update check failed", exc_info=True)
             return
 
-        # Phase 2: auto-update or notify (failures surfaced to user)
+        # Phase 2: auto-update or notify
         try:
             from deepagents_cli._version import __version__ as cli_version
 
@@ -1495,6 +1495,12 @@ class DeepAgentsApp(App):
                 await asyncio.to_thread(mark_update_notified, latest)
         except Exception:
             logger.warning("Update check/notify failed unexpectedly", exc_info=True)
+            if is_auto_update_enabled():
+                self.notify(
+                    "Auto-update failed unexpectedly.",
+                    severity="warning",
+                    timeout=10,
+                )
 
     async def _show_whats_new(self) -> None:
         """Show a 'what's new' banner on the first launch after an upgrade."""

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1475,6 +1475,16 @@ class DeepAgentsApp(App):
                         markup=False,
                     )
             else:
+                from deepagents_cli.update_check import (
+                    mark_update_notified,
+                    should_notify_update,
+                )
+
+                if latest is None or not await asyncio.to_thread(
+                    should_notify_update, latest
+                ):
+                    return
+
                 cmd = upgrade_command()
                 self.notify(
                     f"Update available: v{latest} (current: v{cli_version}). "
@@ -1484,6 +1494,7 @@ class DeepAgentsApp(App):
                     timeout=15,
                     markup=False,
                 )
+                await asyncio.to_thread(mark_update_notified, latest)
         except Exception:
             logger.warning("Auto-update failed unexpectedly", exc_info=True)
             self.notify(

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1439,7 +1439,7 @@ class DeepAgentsApp(App):
             )
 
             available, latest = await asyncio.to_thread(is_update_available)
-            if not available:
+            if not available or latest is None:
                 return
 
             self._update_available = (True, latest)
@@ -1480,9 +1480,7 @@ class DeepAgentsApp(App):
                     should_notify_update,
                 )
 
-                if latest is None or not await asyncio.to_thread(
-                    should_notify_update, latest
-                ):
+                if not await asyncio.to_thread(should_notify_update, latest):
                     return
 
                 cmd = upgrade_command()
@@ -1496,12 +1494,7 @@ class DeepAgentsApp(App):
                 )
                 await asyncio.to_thread(mark_update_notified, latest)
         except Exception:
-            logger.warning("Auto-update failed unexpectedly", exc_info=True)
-            self.notify(
-                "Update failed unexpectedly.",
-                severity="warning",
-                timeout=10,
-            )
+            logger.warning("Update check/notify failed unexpectedly", exc_info=True)
 
     async def _show_whats_new(self) -> None:
         """Show a 'what's new' banner on the first launch after an upgrade."""

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -657,6 +657,11 @@ def parse_args() -> argparse.Namespace:
         help="Check for and install updates, then exit",
     )
     parser.add_argument(
+        "--auto-update",
+        action="store_true",
+        help="Toggle automatic updates on or off, then exit",
+    )
+    parser.add_argument(
         "--acp",
         action="store_true",
         help="Run as an ACP server over stdio instead of launching the Textual UI",
@@ -1426,6 +1431,35 @@ def cli_main() -> None:
                 )
                 sys.exit(1)
 
+        # Handle --auto-update flag (headless toggle, no session)
+        if args.auto_update:
+            try:
+                from deepagents_cli.config import _is_editable_install
+                from deepagents_cli.update_check import (
+                    is_auto_update_enabled,
+                    set_auto_update,
+                )
+
+                if _is_editable_install():
+                    console.print(
+                        "[bold yellow]Warning:[/bold yellow] "
+                        "Auto-updates are not available for editable installs."
+                    )
+                    sys.exit(1)
+
+                currently_enabled = is_auto_update_enabled()
+                new_state = not currently_enabled
+                set_auto_update(new_state)
+                label = "enabled" if new_state else "disabled"
+                console.print(f"Auto-updates {label}.")
+            except Exception:
+                logger.warning("--auto-update failed", exc_info=True)
+                console.print(
+                    "[bold red]Error:[/bold red] Failed to toggle auto-updates."
+                )
+                sys.exit(1)
+            sys.exit(0)
+
         # Handle --default-model / --clear-default-model (headless, no session)
         if args.clear_default_model:
             from deepagents_cli.model_config import clear_default_model
@@ -1721,12 +1755,8 @@ def cli_main() -> None:
                         cmd_hint.append(upgrade_command(), style="cyan")
                         console.print(cmd_hint)
                         if not is_auto_update_enabled():
-                            auto_hint = Text("Tip: use ", style="dim")
-                            auto_hint.append("/auto-update", style="cyan")
-                            auto_hint.append(
-                                " in the CLI to enable auto-updates",
-                                style="dim",
-                            )
+                            auto_hint = Text("Enable auto-updates: ", style="dim")
+                            auto_hint.append("deepagents --auto-update", style="cyan")
                             console.print(auto_hint)
                         mark_update_notified(latest)
             except Exception:

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1760,7 +1760,7 @@ def cli_main() -> None:
                             console.print(auto_hint)
                         mark_update_notified(latest)
             except Exception:
-                logger.debug("Failed to display exit update banner", exc_info=True)
+                logger.warning("Failed to display exit update banner", exc_info=True)
     except KeyboardInterrupt:
         # Clean exit on Ctrl+C — suppress ugly traceback.
         # `console` may not be bound if Ctrl+C arrives during config import.

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1431,7 +1431,8 @@ def cli_main() -> None:
                 )
                 sys.exit(1)
 
-        # Handle --auto-update flag (headless toggle, no session)
+        # Handle --auto-update flag (headless toggle: reads current state
+        # and inverts it, no session)
         if args.auto_update:
             try:
                 from deepagents_cli.config import _is_editable_install
@@ -1452,6 +1453,13 @@ def cli_main() -> None:
                 set_auto_update(new_state)
                 label = "enabled" if new_state else "disabled"
                 console.print(f"Auto-updates {label}.")
+            except OSError:
+                logger.warning("--auto-update failed: filesystem error", exc_info=True)
+                console.print(
+                    "[bold red]Error:[/bold red] Failed to toggle auto-updates. "
+                    "Check permissions for ~/.deepagents/"
+                )
+                sys.exit(1)
             except Exception:
                 logger.warning("--auto-update failed", exc_info=True)
                 console.print(

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1702,23 +1702,33 @@ def cli_main() -> None:
             # Warn about available update on exit
             try:
                 if result.update_available[0]:
+                    from deepagents_cli._version import __version__ as cli_version
                     from deepagents_cli.update_check import (
                         is_auto_update_enabled,
+                        mark_update_notified,
+                        should_notify_update,
                         upgrade_command,
                     )
 
                     latest = result.update_available[1]
-                    console.print()
-                    update_msg = Text("Update available: ", style="yellow bold")
-                    update_msg.append(f"v{latest}", style="yellow")
-                    console.print(update_msg)
-                    cmd_hint = Text("Run: ", style="dim")
-                    cmd_hint.append(upgrade_command(), style="cyan")
-                    console.print(cmd_hint)
-                    if not is_auto_update_enabled():
-                        auto_hint = Text("Enable auto-updates: ", style="dim")
-                        auto_hint.append("/auto-update", style="cyan")
-                        console.print(auto_hint)
+                    if latest and should_notify_update(latest):
+                        console.print()
+                        update_msg = Text("Update available: ", style="yellow bold")
+                        update_msg.append(f"v{latest}", style="yellow")
+                        update_msg.append(f" (current: v{cli_version})", style="dim")
+                        console.print(update_msg)
+                        cmd_hint = Text("Run: ", style="dim")
+                        cmd_hint.append(upgrade_command(), style="cyan")
+                        console.print(cmd_hint)
+                        if not is_auto_update_enabled():
+                            auto_hint = Text("Tip: use ", style="dim")
+                            auto_hint.append("/auto-update", style="cyan")
+                            auto_hint.append(
+                                " in the CLI to enable auto-updates",
+                                style="dim",
+                            )
+                            console.print(auto_hint)
+                        mark_update_notified(latest)
             except Exception:
                 logger.debug("Failed to display exit update banner", exc_info=True)
     except KeyboardInterrupt:

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -125,6 +125,9 @@ def show_help() -> None:
     console.print(
         "  --update                   Check for and install updates, then exit"
     )
+    console.print(
+        "  --auto-update              Toggle automatic updates on or off, then exit"
+    )
     console.print("  --acp                      Run as an ACP server over stdio")
     console.print("  -v, --version              Show deepagents CLI and SDK versions")
     console.print("  -h, --help                 Show this help message and exit")

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -1,7 +1,8 @@
 """Update lifecycle for `deepagents-cli`.
 
 Handles version checking against PyPI (with caching), install-method detection,
-auto-upgrade execution, config-driven opt-in/out, and "what's new" tracking.
+auto-upgrade execution, config-driven opt-in/out, notification throttling, and
+"what's new" tracking.
 
 Most public entry points absorb errors and return sentinel values.
 `set_auto_update` raises on write failures so callers can surface
@@ -191,7 +192,7 @@ def _read_update_state() -> dict[str, object]:
 
 
 def _write_update_state(patch: dict[str, object]) -> None:
-    """Merge *patch* into the shared update state file.
+    """Merge *patch* into the shared update state file (shallow, top-level only).
 
     Args:
         patch: Keys to merge into the existing state.
@@ -489,7 +490,8 @@ def _read_update_config() -> dict[str, bool]:
 
 def get_seen_version() -> str | None:
     """Return the last version the user saw the "what's new" banner for."""
-    return _read_update_state().get("seen_version")  # type: ignore[return-value]
+    value = _read_update_state().get("seen_version")
+    return value if isinstance(value, str) else None
 
 
 def mark_version_seen(version: str) -> None:

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -174,6 +174,48 @@ def get_latest_version(
     return prerelease if include_prereleases else stable
 
 
+def should_notify_update(latest: str) -> bool:
+    """Return whether the user should be notified about version *latest*.
+
+    Throttles notifications to at most once per `CACHE_TTL` period for a
+    given version, preventing repeated banners every session.
+
+    Args:
+        latest: The version string to check against.
+    """
+    try:
+        if CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            notified_at = data.get("notified_at", 0)
+            notified_version = data.get("notified_version")
+            if notified_version == latest and time.time() - notified_at < CACHE_TTL:
+                return False
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug("Failed to read notification state", exc_info=True)
+    return True
+
+
+def mark_update_notified(latest: str) -> None:
+    """Record that the user was notified about version *latest*.
+
+    Writes into the existing cache file so a subsequent
+    `should_notify_update` call can suppress duplicate banners.
+
+    Args:
+        latest: The version string that was shown.
+    """
+    try:
+        data: dict[str, object] = {}
+        if CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        data["notified_at"] = time.time()
+        data["notified_version"] = latest
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(json.dumps(data), encoding="utf-8")
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug("Failed to write notification marker", exc_info=True)
+
+
 def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None]:
     """Check whether a newer version of deepagents-cli is available.
 

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -32,7 +32,7 @@ from deepagents_cli.model_config import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_PATH
 logger = logging.getLogger(__name__)
 
 CACHE_FILE: Path = DEFAULT_CONFIG_DIR / "latest_version.json"
-SEEN_VERSION_FILE: Path = DEFAULT_CONFIG_DIR / "seen_version.json"
+UPDATE_STATE_FILE: Path = DEFAULT_CONFIG_DIR / "update_state.json"
 CACHE_TTL = 86_400  # 24 hours
 
 InstallMethod = Literal["uv", "pip", "brew", "unknown"]
@@ -174,6 +174,41 @@ def get_latest_version(
     return prerelease if include_prereleases else stable
 
 
+def _read_update_state() -> dict[str, object]:
+    """Read the shared update state file.
+
+    Returns:
+        Parsed dict, or empty dict on missing/corrupt file.
+    """
+    try:
+        if UPDATE_STATE_FILE.exists():
+            raw = json.loads(UPDATE_STATE_FILE.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                return raw
+    except (OSError, json.JSONDecodeError):
+        logger.debug("Failed to read update state file", exc_info=True)
+    return {}
+
+
+def _write_update_state(patch: dict[str, object]) -> None:
+    """Merge *patch* into the shared update state file.
+
+    Args:
+        patch: Keys to merge into the existing state.
+    """
+    data = _read_update_state()
+    data.update(patch)
+    try:
+        UPDATE_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        UPDATE_STATE_FILE.write_text(json.dumps(data), encoding="utf-8")
+    except OSError:
+        logger.warning(
+            "Failed to write update state to %s",
+            UPDATE_STATE_FILE,
+            exc_info=True,
+        )
+
+
 def should_notify_update(latest: str) -> bool:
     """Return whether the user should be notified about version *latest*.
 
@@ -182,38 +217,31 @@ def should_notify_update(latest: str) -> bool:
 
     Args:
         latest: The version string to check against.
+
+    Returns:
+        `True` if the user should see the update banner, `False` if the
+            notification was already shown within the `CACHE_TTL` window.
     """
-    try:
-        if CACHE_FILE.exists():
-            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
-            notified_at = data.get("notified_at", 0)
-            notified_version = data.get("notified_version")
-            if notified_version == latest and time.time() - notified_at < CACHE_TTL:
-                return False
-    except (OSError, json.JSONDecodeError, TypeError):
-        logger.debug("Failed to read notification state", exc_info=True)
-    return True
+    data = _read_update_state()
+    notified_at = data.get("notified_at", 0)
+    notified_version = data.get("notified_version")
+    return not (
+        isinstance(notified_at, (int, float))
+        and notified_version == latest
+        and time.time() - notified_at < CACHE_TTL
+    )
 
 
 def mark_update_notified(latest: str) -> None:
     """Record that the user was notified about version *latest*.
 
-    Writes into the existing cache file so a subsequent
+    Writes into the shared update state file so a subsequent
     `should_notify_update` call can suppress duplicate banners.
 
     Args:
         latest: The version string that was shown.
     """
-    try:
-        data: dict[str, object] = {}
-        if CACHE_FILE.exists():
-            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
-        data["notified_at"] = time.time()
-        data["notified_version"] = latest
-        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CACHE_FILE.write_text(json.dumps(data), encoding="utf-8")
-    except (OSError, json.JSONDecodeError, TypeError):
-        logger.debug("Failed to write notification marker", exc_info=True)
+    _write_update_state({"notified_at": time.time(), "notified_version": latest})
 
 
 def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None]:
@@ -461,25 +489,12 @@ def _read_update_config() -> dict[str, bool]:
 
 def get_seen_version() -> str | None:
     """Return the last version the user saw the "what's new" banner for."""
-    try:
-        if SEEN_VERSION_FILE.exists():
-            data = json.loads(SEEN_VERSION_FILE.read_text(encoding="utf-8"))
-            return data.get("version")
-    except (OSError, json.JSONDecodeError, KeyError, TypeError):
-        logger.debug("Failed to read seen-version file", exc_info=True)
-    return None
+    return _read_update_state().get("seen_version")  # type: ignore[return-value]
 
 
 def mark_version_seen(version: str) -> None:
     """Record that the user has seen the "what's new" banner for *version*."""
-    try:
-        SEEN_VERSION_FILE.parent.mkdir(parents=True, exist_ok=True)
-        SEEN_VERSION_FILE.write_text(
-            json.dumps({"version": version, "seen_at": time.time()}),
-            encoding="utf-8",
-        )
-    except OSError:
-        logger.debug("Failed to write seen-version file", exc_info=True)
+    _write_update_state({"seen_version": version, "seen_at": time.time()})
 
 
 def should_show_whats_new() -> bool:

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -332,6 +332,22 @@ class TestNoMcpArg:
         assert exc_info.value.code == 2
 
 
+class TestAutoUpdateArg:
+    """Tests for --auto-update argument parsing."""
+
+    def test_flag_parsed(self) -> None:
+        """Verify --auto-update sets auto_update=True."""
+        with patch.object(sys, "argv", ["deepagents", "--auto-update"]):
+            args = parse_args()
+        assert args.auto_update is True
+
+    def test_default_false(self) -> None:
+        """Verify auto_update defaults to False."""
+        with patch.object(sys, "argv", ["deepagents"]):
+            args = parse_args()
+        assert args.auto_update is False
+
+
 def test_default_agent_name_matches_canonical() -> None:
     """Ensure the duplicated constant in main.py stays in sync with agent.py."""
     assert _DEFAULT_AGENT_NAME == DEFAULT_AGENT_NAME

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -17,7 +17,9 @@ from deepagents_cli.update_check import (
     get_latest_version,
     is_auto_update_enabled,
     is_update_available,
+    mark_update_notified,
     set_auto_update,
+    should_notify_update,
 )
 
 
@@ -480,3 +482,148 @@ class TestIsAutoUpdateEnabled:
         assert config_path.exists()
         with patch("deepagents_cli.config._is_editable_install", return_value=True):
             assert is_auto_update_enabled() is False
+
+
+class TestShouldNotifyUpdate:
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Override UPDATE_STATE_FILE to use a temporary directory."""
+        path = tmp_path / "update_state.json"
+        with patch("deepagents_cli.update_check.UPDATE_STATE_FILE", path):
+            yield path
+
+    def test_no_file_returns_true(self, state_file) -> None:  # noqa: ARG002
+        """First-run case: no state file exists."""
+        assert should_notify_update("2.0.0") is True
+
+    def test_same_version_within_ttl(self, state_file) -> None:
+        """Same version notified recently — suppress."""
+        state_file.write_text(
+            json.dumps({"notified_at": time.time(), "notified_version": "2.0.0"})
+        )
+        assert should_notify_update("2.0.0") is False
+
+    def test_different_version_within_ttl(self, state_file) -> None:
+        """New version available — notify even within TTL window."""
+        state_file.write_text(
+            json.dumps({"notified_at": time.time(), "notified_version": "1.9.0"})
+        )
+        assert should_notify_update("2.0.0") is True
+
+    def test_same_version_ttl_expired(self, state_file) -> None:
+        """TTL expired — re-notify for same version."""
+        state_file.write_text(
+            json.dumps(
+                {
+                    "notified_at": time.time() - CACHE_TTL - 1,
+                    "notified_version": "2.0.0",
+                }
+            )
+        )
+        assert should_notify_update("2.0.0") is True
+
+    def test_corrupt_json(self, state_file) -> None:
+        """Malformed JSON — fail-open (show banner)."""
+        state_file.write_text("not valid json")
+        assert should_notify_update("2.0.0") is True
+
+    def test_non_dict_json(self, state_file) -> None:
+        """JSON array instead of object — fail-open."""
+        state_file.write_text(json.dumps([1, 2, 3]))
+        assert should_notify_update("2.0.0") is True
+
+    def test_non_numeric_notified_at(self, state_file) -> None:
+        """notified_at is a string — treated as invalid, show banner."""
+        state_file.write_text(
+            json.dumps({"notified_at": "not-a-number", "notified_version": "2.0.0"})
+        )
+        assert should_notify_update("2.0.0") is True
+
+    def test_missing_notified_at_key(self, state_file) -> None:
+        """File exists but missing notified_at — defaults to 0, TTL expired."""
+        state_file.write_text(json.dumps({"notified_version": "2.0.0"}))
+        assert should_notify_update("2.0.0") is True
+
+
+class TestMarkUpdateNotified:
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Override UPDATE_STATE_FILE to use a temporary directory."""
+        path = tmp_path / "update_state.json"
+        with patch("deepagents_cli.update_check.UPDATE_STATE_FILE", path):
+            yield path
+
+    def test_creates_file(self, state_file) -> None:
+        """Creates state file when none exists."""
+        mark_update_notified("2.0.0")
+        assert state_file.exists()
+        data = json.loads(state_file.read_text())
+        assert data["notified_version"] == "2.0.0"
+        assert isinstance(data["notified_at"], float)
+
+    def test_overwrites_previous(self, state_file) -> None:
+        """Overwrites previous notification marker."""
+        mark_update_notified("1.0.0")
+        mark_update_notified("2.0.0")
+        data = json.loads(state_file.read_text())
+        assert data["notified_version"] == "2.0.0"
+
+    def test_round_trip(self, state_file) -> None:  # noqa: ARG002
+        """Mark then should_notify returns False for same version."""
+        mark_update_notified("2.0.0")
+        assert should_notify_update("2.0.0") is False
+
+    def test_round_trip_different_version(self, state_file) -> None:  # noqa: ARG002
+        """Mark then should_notify returns True for different version."""
+        mark_update_notified("1.9.0")
+        assert should_notify_update("2.0.0") is True
+
+    def test_write_failure_does_not_raise(self, state_file) -> None:
+        """Write failure is absorbed gracefully."""
+        with patch(
+            "deepagents_cli.update_check.UPDATE_STATE_FILE",
+            type(state_file)("/nonexistent/readonly/path/state.json"),
+        ):
+            mark_update_notified("2.0.0")  # should not raise
+
+    def test_does_not_touch_cache_file(self, state_file, cache_file) -> None:
+        """Notification state is independent of version cache."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "version": "2.0.0",
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        mark_update_notified("2.0.0")
+        # Cache file should be untouched
+        cache_data = json.loads(cache_file.read_text())
+        assert "notified_at" not in cache_data
+        assert "notified_version" not in cache_data
+        # State file should have the marker
+        assert state_file.exists()
+        state_data = json.loads(state_file.read_text())
+        assert state_data["notified_version"] == "2.0.0"
+
+    def test_get_latest_version_does_not_clobber_notify(
+        self,
+        state_file,  # noqa: ARG002
+        cache_file,  # noqa: ARG002
+    ) -> None:
+        """get_latest_version writing cache doesn't destroy notification state."""
+        mark_update_notified("2.0.0")
+        with patch("requests.get", return_value=_mock_pypi_response("3.0.0")):
+            get_latest_version(bypass_cache=True)
+        # Notification marker should survive
+        assert should_notify_update("2.0.0") is False
+
+    def test_preserves_seen_version(self, state_file) -> None:
+        """Marking notification preserves existing seen_version data."""
+        from deepagents_cli.update_check import mark_version_seen
+
+        mark_version_seen("1.0.0")
+        mark_update_notified("2.0.0")
+        data = json.loads(state_file.read_text())
+        assert data["seen_version"] == "1.0.0"
+        assert data["notified_version"] == "2.0.0"

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -15,9 +15,11 @@ from deepagents_cli.update_check import (
     _latest_from_releases,
     _parse_version,
     get_latest_version,
+    get_seen_version,
     is_auto_update_enabled,
     is_update_available,
     mark_update_notified,
+    mark_version_seen,
     set_auto_update,
     should_notify_update,
 )
@@ -620,10 +622,89 @@ class TestMarkUpdateNotified:
 
     def test_preserves_seen_version(self, state_file) -> None:
         """Marking notification preserves existing seen_version data."""
-        from deepagents_cli.update_check import mark_version_seen
-
         mark_version_seen("1.0.0")
         mark_update_notified("2.0.0")
         data = json.loads(state_file.read_text())
         assert data["seen_version"] == "1.0.0"
         assert data["notified_version"] == "2.0.0"
+
+
+class TestGetSeenVersion:
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Override UPDATE_STATE_FILE to use a temporary directory."""
+        path = tmp_path / "update_state.json"
+        with patch("deepagents_cli.update_check.UPDATE_STATE_FILE", path):
+            yield path
+
+    def test_no_file_returns_none(self, state_file) -> None:  # noqa: ARG002
+        """No state file -> None."""
+        assert get_seen_version() is None
+
+    def test_round_trip(self, state_file) -> None:  # noqa: ARG002
+        """Mark then get returns the same version."""
+        mark_version_seen("1.0.0")
+        assert get_seen_version() == "1.0.0"
+
+    def test_corrupt_json_returns_none(self, state_file) -> None:
+        """Corrupt state file -> None."""
+        state_file.write_text("not json")
+        assert get_seen_version() is None
+
+    def test_non_string_value_returns_none(self, state_file) -> None:
+        """Non-string seen_version -> None (type guard)."""
+        state_file.write_text(json.dumps({"seen_version": 123}))
+        assert get_seen_version() is None
+
+    def test_preserves_notification_keys(self, state_file) -> None:  # noqa: ARG002
+        """Marking seen preserves existing notification data."""
+        mark_update_notified("2.0.0")
+        mark_version_seen("1.0.0")
+        assert get_seen_version() == "1.0.0"
+        assert should_notify_update("2.0.0") is False
+
+
+class TestShouldShowWhatsNew:
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Override UPDATE_STATE_FILE to use a temporary directory."""
+        path = tmp_path / "update_state.json"
+        with patch("deepagents_cli.update_check.UPDATE_STATE_FILE", path):
+            yield path
+
+    def test_first_run_returns_false_and_marks(self, state_file) -> None:
+        """First run: returns False and writes current version as seen."""
+        from deepagents_cli.update_check import should_show_whats_new
+
+        with patch("deepagents_cli.update_check.__version__", "1.0.0"):
+            assert should_show_whats_new() is False
+        assert state_file.exists()
+        data = json.loads(state_file.read_text())
+        assert data["seen_version"] == "1.0.0"
+
+    def test_same_version_returns_false(self, state_file) -> None:  # noqa: ARG002
+        """Current version == seen version -> False."""
+        from deepagents_cli.update_check import should_show_whats_new
+
+        mark_version_seen("1.0.0")
+        with patch("deepagents_cli.update_check.__version__", "1.0.0"):
+            assert should_show_whats_new() is False
+
+    def test_newer_version_returns_true(self, state_file) -> None:  # noqa: ARG002
+        """Current version > seen version -> True."""
+        from deepagents_cli.update_check import should_show_whats_new
+
+        mark_version_seen("1.0.0")
+        with patch("deepagents_cli.update_check.__version__", "2.0.0"):
+            assert should_show_whats_new() is True
+
+    def test_coexists_with_notification_state(self, state_file) -> None:  # noqa: ARG002
+        """What's-new and notification state don't interfere."""
+        from deepagents_cli.update_check import should_show_whats_new
+
+        mark_update_notified("2.0.0")
+        mark_version_seen("1.0.0")
+        with patch("deepagents_cli.update_check.__version__", "2.0.0"):
+            assert should_show_whats_new() is True
+        # Notification throttle still works
+        assert should_notify_update("2.0.0") is False


### PR DESCRIPTION
The update notification had three issues: it fired every session instead of once a day, the teardown banner omitted the current version (unlike the in-app toast), and the teardown's `/auto-update` hint was unusable outside the TUI (no slash commands!).

This adds a notification throttle (once per 24h per version, shared across both surfaces) and aligns the teardown banner format with the in-app toast.
