### PR TITLE
ci(infra): add `deps-dev` commit scope to pr linter

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -94,6 +94,7 @@ jobs:
             deepagents
             deepagents-cli
             deps
+            deps-dev
             evals
             examples
             harbor


### PR DESCRIPTION
Add `deps-dev` as an allowed PR title scope in the conventional commits linter. This enables PRs that bump dev-only dependencies such as dependabot PRs.