### PR TITLE
feat: add tool-call hooks and Faramesh policy integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,28 +146,28 @@ from deepagents.middleware import AgentMiddleware
 
 @tool
 def rm(path: str) -> str:
-  """Delete a file path."""
-  return f"deleted {path}"
+    """Delete a file path."""
+    return f"deleted {path}"
 
 
 class PolicyMiddleware(AgentMiddleware):
-  """Example policy check at tool boundary."""
+    """Example policy check at tool boundary."""
 
-  def wrap_tool_call(self, request, handler):
-    if request.tool_call["name"] == "rm":
-      path = str(request.tool_call.get("args", {}).get("path", ""))
-      if path.startswith("/etc"):
-        return ToolMessage(
-          content="Policy denied: destructive operations on /etc are blocked.",
-          tool_call_id=request.tool_call["id"],
-        )
-    return handler(request)
+    def wrap_tool_call(self, request, handler):
+        if request.tool_call["name"] == "rm":
+            path = str(request.tool_call.get("args", {}).get("path", ""))
+            if path.startswith("/etc"):
+                return ToolMessage(
+                    content="Policy denied: destructive operations on /etc are blocked.",
+                    tool_call_id=request.tool_call["id"],
+                )
+        return handler(request)
 
 
 agent = create_deep_agent(
-  model=init_chat_model("openai:gpt-4.1"),
-  tools=[rm],
-  middleware=[PolicyMiddleware()],
+    model=init_chat_model("openai:gpt-4.1"),
+    tools=[rm],
+    middleware=[PolicyMiddleware()],
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,42 +133,43 @@ This project was primarily inspired by Claude Code, and initially was largely an
 
 Deep Agents follows a "trust the LLM" model. The agent can do anything its tools allow. Enforce boundaries at the tool/sandbox level, not by expecting the model to self-police. See the [security policy](https://github.com/langchain-ai/deepagents?tab=security-ov-file) for more information.
 
-You can enforce policy decisions at tool-call boundaries using middleware:
+For explicit policy enforcement at tool boundaries, Deep Agents supports hook-based integration via `before_tool_call_hooks` and `after_tool_call_hooks` on `create_deep_agent(...)`.
+
+If you want a concrete governance integration reference, see [examples/faramesh_policy_hooks](examples/faramesh_policy_hooks/), which demonstrates a Faramesh policy check before tool execution.
+
+Example:
 
 ```python
+from deepagents import create_deep_agent
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 
-from deepagents import create_deep_agent
-from deepagents.middleware import AgentMiddleware
+
+def deny_sensitive_rm(tool_request):
+  if tool_request.tool_call["name"] != "rm":
+    return None
+
+  path = str(tool_request.tool_call.get("args", {}).get("path", ""))
+  if path.startswith("/etc"):
+    return ToolMessage(
+      content="Policy denied: destructive operations on /etc are blocked.",
+      tool_call_id=tool_request.tool_call["id"],
+    )
+  return None
 
 
 @tool
 def rm(path: str) -> str:
-    """Delete a file path."""
-    return f"deleted {path}"
-
-
-class PolicyMiddleware(AgentMiddleware):
-    """Example policy check at tool boundary."""
-
-    def wrap_tool_call(self, request, handler):
-        if request.tool_call["name"] == "rm":
-            path = str(request.tool_call.get("args", {}).get("path", ""))
-            if path.startswith("/etc"):
-                return ToolMessage(
-                    content="Policy denied: destructive operations on /etc are blocked.",
-                    tool_call_id=request.tool_call["id"],
-                )
-        return handler(request)
+  """Delete a file path."""
+  return f"deleted {path}"
 
 
 agent = create_deep_agent(
     model=init_chat_model("openai:gpt-4.1"),
     tools=[rm],
-    middleware=[PolicyMiddleware()],
+  before_tool_call_hooks=[deny_sensitive_rm],
 )
 ```
 
-This pattern keeps policy and governance logic outside model prompts and close to executable actions.
+This keeps policy logic close to executable actions and avoids relying on prompt-only constraints.

--- a/README.md
+++ b/README.md
@@ -132,3 +132,43 @@ This project was primarily inspired by Claude Code, and initially was largely an
 ## Security
 
 Deep Agents follows a "trust the LLM" model. The agent can do anything its tools allow. Enforce boundaries at the tool/sandbox level, not by expecting the model to self-police. See the [security policy](https://github.com/langchain-ai/deepagents?tab=security-ov-file) for more information.
+
+You can enforce policy decisions at tool-call boundaries using middleware:
+
+```python
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+
+from deepagents import create_deep_agent
+from deepagents.middleware import AgentMiddleware
+
+
+@tool
+def rm(path: str) -> str:
+  """Delete a file path."""
+  return f"deleted {path}"
+
+
+class PolicyMiddleware(AgentMiddleware):
+  """Example policy check at tool boundary."""
+
+  def wrap_tool_call(self, request, handler):
+    if request.tool_call["name"] == "rm":
+      path = str(request.tool_call.get("args", {}).get("path", ""))
+      if path.startswith("/etc"):
+        return ToolMessage(
+          content="Policy denied: destructive operations on /etc are blocked.",
+          tool_call_id=request.tool_call["id"],
+        )
+    return handler(request)
+
+
+agent = create_deep_agent(
+  model=init_chat_model("openai:gpt-4.1"),
+  tools=[rm],
+  middleware=[PolicyMiddleware()],
+)
+```
+
+This pattern keeps policy and governance logic outside model prompts and close to executable actions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@
 | [deploy-mcp-docs-agent](deploy-mcp-docs-agent/) | `deepagents deploy` example: docs research agent that uses MCP tools to search LangChain documentation |
 | [async-subagent-server](async-subagent-server/) | Self-hosted Agent Protocol server exposing a Deep Agents researcher as an async subagent, with a supervisor REPL |
 | [nvidia_deep_agent](nvidia_deep_agent/) | Multi-model agent with NVIDIA Nemotron Super for research and GPU-accelerated code execution via RAPIDS |
+| [faramesh_policy_hooks](faramesh_policy_hooks/) | Deep Agents integration example using tool-call hooks to enforce Faramesh policy decisions before tool execution |
 | [ralph_mode](ralph_mode/) | Autonomous looping pattern that runs with fresh context each iteration, using the filesystem for persistence |
 | [downloading_agents](downloading_agents/) | Shows how agents are just folders—download a zip, unzip, and run |
 | [better-harness](better-harness/) | Eval-driven outer-loop optimization of a Deep Agents harness using the `better-harness` research artifact |

--- a/examples/faramesh_policy_hooks/README.md
+++ b/examples/faramesh_policy_hooks/README.md
@@ -1,0 +1,45 @@
+# Faramesh Policy Hooks Example
+
+This example shows Deep Agents integration with Faramesh policy decisions using the built-in tool-call hook API.
+
+## What it demonstrates
+
+- `before_tool_call_hooks` in `create_deep_agent(...)`
+- External policy decision call before tool execution
+- Returning a `ToolMessage` to block disallowed tool calls
+
+## Setup
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install deepagents langchain-openai
+export OPENAI_API_KEY=...
+export FARAMESH_POLICY_URL=http://localhost:8080/policy/check
+python agent.py
+```
+
+## Policy endpoint contract used by this example
+
+Request JSON:
+
+```json
+{
+  "tool": "read_secret",
+  "args": {
+    "path": "/etc/shadow"
+  }
+}
+```
+
+Response JSON:
+
+```json
+{"allow": true}
+```
+
+or
+
+```json
+{"allow": false, "reason": "sensitive path is blocked"}
+```

--- a/examples/faramesh_policy_hooks/agent.py
+++ b/examples/faramesh_policy_hooks/agent.py
@@ -1,0 +1,84 @@
+"""Deep Agents + Faramesh policy integration via tool-call hooks.
+
+This example demonstrates using Deep Agents hook APIs to call an external
+Faramesh policy endpoint before each tool execution.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib import request
+
+from deepagents import create_deep_agent
+from langchain_core.messages import ToolMessage
+from langchain_openai import ChatOpenAI
+from langchain.tools import tool
+
+
+@tool
+def read_secret(path: str) -> str:
+    """Read a sensitive path for demonstration purposes."""
+    return f"Simulated read from {path}"
+
+
+def faramesh_policy_hook(tool_request):
+    """Ask a Faramesh policy endpoint whether this tool call is allowed.
+
+    Expected response JSON from the endpoint:
+      {"allow": true}
+      {"allow": false, "reason": "..."}
+    """
+    policy_url = os.getenv("FARAMESH_POLICY_URL")
+    if not policy_url:
+        return None
+
+    payload = {
+        "tool": tool_request.tool_call.get("name"),
+        "args": tool_request.tool_call.get("args", {}),
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        policy_url,
+        data=body,
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with request.urlopen(req, timeout=5) as response:  # noqa: S310
+            decision = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return ToolMessage(
+            content=f"Faramesh policy check failed: {exc}",
+            tool_call_id=tool_request.tool_call["id"],
+        )
+
+    if decision.get("allow", True):
+        return None
+
+    reason = decision.get("reason", "Blocked by Faramesh policy.")
+    return ToolMessage(
+        content=f"Policy denied: {reason}",
+        tool_call_id=tool_request.tool_call["id"],
+    )
+
+
+agent = create_deep_agent(
+    model=ChatOpenAI(model="gpt-4.1-mini"),
+    tools=[read_secret],
+    before_tool_call_hooks=[faramesh_policy_hook],
+)
+
+if __name__ == "__main__":
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Try to use read_secret on /etc/shadow and explain what happened.",
+                }
+            ]
+        }
+    )
+    print(result)

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -7,6 +7,7 @@ from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.permissions import FilesystemPermission
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
+from deepagents.middleware.tool_hooks import ToolHooksMiddleware
 
 __all__ = [
     "AsyncSubAgent",
@@ -17,6 +18,7 @@ __all__ = [
     "MemoryMiddleware",
     "SubAgent",
     "SubAgentMiddleware",
+    "ToolHooksMiddleware",
     "__version__",
     "create_deep_agent",
 ]

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -43,6 +43,13 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
+from deepagents.middleware.tool_hooks import (
+    AfterToolCallHook,
+    AsyncAfterToolCallHook,
+    AsyncBeforeToolCallHook,
+    BeforeToolCallHook,
+    ToolHooksMiddleware,
+)
 from deepagents.profiles import _get_harness_profile, _HarnessProfile
 
 logger = logging.getLogger(__name__)
@@ -220,6 +227,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
     *,
     system_prompt: str | SystemMessage | None = None,
+    before_tool_call_hooks: Sequence[BeforeToolCallHook] = (),
+    after_tool_call_hooks: Sequence[AfterToolCallHook] = (),
+    async_before_tool_call_hooks: Sequence[AsyncBeforeToolCallHook] = (),
+    async_after_tool_call_hooks: Sequence[AsyncAfterToolCallHook] = (),
     middleware: Sequence[AgentMiddleware] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
@@ -290,8 +301,22 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             - `SummarizationMiddleware`
             - `PatchToolCallsMiddleware`
             - `AsyncSubAgentMiddleware` (if async `subagents` are provided)
+            - `ToolHooksMiddleware` (if any explicit tool-call hooks are provided)
 
             *User middleware is inserted here.*
+
+        before_tool_call_hooks: Sync callbacks evaluated before each tool call.
+
+            If a hook returns a `ToolMessage` or `Command`, the tool call is
+            short-circuited and the returned value is used directly.
+        after_tool_call_hooks: Sync callbacks evaluated after each tool call.
+
+            Hooks can return a replacement `ToolMessage` or `Command` to
+            override the original result.
+        async_before_tool_call_hooks: Async callbacks evaluated before each
+            tool call in async execution paths.
+        async_after_tool_call_hooks: Async callbacks evaluated after each tool
+            call in async execution paths.
 
             Tail stack:
 
@@ -578,6 +603,16 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # Async here means that we run these subagents in a non-blocking manner.
         # Currently this supports agents deployed via LangSmith deployments.
         deepagent_middleware.append(AsyncSubAgentMiddleware(async_subagents=async_subagents))
+
+    if before_tool_call_hooks or after_tool_call_hooks or async_before_tool_call_hooks or async_after_tool_call_hooks:
+        deepagent_middleware.append(
+            ToolHooksMiddleware(
+                before_call_hooks=before_tool_call_hooks,
+                after_call_hooks=after_tool_call_hooks,
+                async_before_call_hooks=async_before_tool_call_hooks,
+                async_after_call_hooks=async_after_tool_call_hooks,
+            )
+        )
 
     if middleware:
         deepagent_middleware.extend(middleware)

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -58,6 +58,13 @@ from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
     create_summarization_tool_middleware,
 )
+from deepagents.middleware.tool_hooks import (
+  AfterToolCallHook,
+  AsyncAfterToolCallHook,
+  AsyncBeforeToolCallHook,
+  BeforeToolCallHook,
+  ToolHooksMiddleware,
+)
 
 __all__ = [
     "AsyncSubAgent",
@@ -71,5 +78,10 @@ __all__ = [
     "SubAgentMiddleware",
     "SummarizationMiddleware",
     "SummarizationToolMiddleware",
+    "AfterToolCallHook",
+    "AsyncAfterToolCallHook",
+    "AsyncBeforeToolCallHook",
+    "BeforeToolCallHook",
+    "ToolHooksMiddleware",
     "create_summarization_tool_middleware",
 ]

--- a/libs/deepagents/deepagents/middleware/tool_hooks.py
+++ b/libs/deepagents/deepagents/middleware/tool_hooks.py
@@ -1,0 +1,105 @@
+"""Middleware for explicit before/after tool-call hooks.
+
+This middleware makes tool-governance integration straightforward for external
+systems by exposing callback hooks around every tool invocation.
+"""
+
+from collections.abc import Awaitable, Callable, Sequence
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain.tools.tool_node import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+ToolCallResult = ToolMessage | Command
+"""Result type returned by wrapped tool calls."""
+
+BeforeToolCallHook = Callable[[ToolCallRequest], ToolCallResult | None]
+"""Sync hook called before executing a tool.
+
+Return a `ToolCallResult` to short-circuit execution, or `None` to continue.
+"""
+
+AfterToolCallHook = Callable[[ToolCallRequest, ToolCallResult], ToolCallResult | None]
+"""Sync hook called after executing a tool.
+
+Return a replacement `ToolCallResult` to override, or `None` to keep original.
+"""
+
+AsyncBeforeToolCallHook = Callable[[ToolCallRequest], Awaitable[ToolCallResult | None]]
+"""Async hook called before executing a tool."""
+
+AsyncAfterToolCallHook = Callable[[ToolCallRequest, ToolCallResult], Awaitable[ToolCallResult | None]]
+"""Async hook called after executing a tool."""
+
+
+class ToolHooksMiddleware(AgentMiddleware):
+    """Run explicit callbacks before and after every tool call.
+
+    This is useful for plugging in policy engines, audit sinks, and
+    request/response validators without requiring each integration to define a
+    custom middleware class.
+    """
+
+    def __init__(
+        self,
+        *,
+        before_call_hooks: Sequence[BeforeToolCallHook] = (),
+        after_call_hooks: Sequence[AfterToolCallHook] = (),
+        async_before_call_hooks: Sequence[AsyncBeforeToolCallHook] = (),
+        async_after_call_hooks: Sequence[AsyncAfterToolCallHook] = (),
+    ) -> None:
+        self._before_call_hooks = list(before_call_hooks)
+        self._after_call_hooks = list(after_call_hooks)
+        self._async_before_call_hooks = list(async_before_call_hooks)
+        self._async_after_call_hooks = list(async_after_call_hooks)
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolCallResult],
+    ) -> ToolCallResult:
+        """Apply sync hooks around a tool call."""
+        for hook in self._before_call_hooks:
+            maybe_result = hook(request)
+            if maybe_result is not None:
+                return maybe_result
+
+        tool_result = handler(request)
+
+        for hook in self._after_call_hooks:
+            maybe_result = hook(request, tool_result)
+            if maybe_result is not None:
+                tool_result = maybe_result
+
+        return tool_result
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolCallResult]],
+    ) -> ToolCallResult:
+        """Apply sync and async hooks around a tool call in async contexts."""
+        for hook in self._before_call_hooks:
+            maybe_result = hook(request)
+            if maybe_result is not None:
+                return maybe_result
+
+        for hook in self._async_before_call_hooks:
+            maybe_result = await hook(request)
+            if maybe_result is not None:
+                return maybe_result
+
+        tool_result = await handler(request)
+
+        for hook in self._after_call_hooks:
+            maybe_result = hook(request, tool_result)
+            if maybe_result is not None:
+                tool_result = maybe_result
+
+        for hook in self._async_after_call_hooks:
+            maybe_result = await hook(request, tool_result)
+            if maybe_result is not None:
+                tool_result = maybe_result
+
+        return tool_result


### PR DESCRIPTION
Resolves #2779

## Summary
This is not docs-only.

Adds first-class tool-call hook support to Deep Agents and a concrete Faramesh integration example.

## What changed
- Added ToolHooksMiddleware in libs/deepagents/deepagents/middleware/tool_hooks.py
- Added new create_deep_agent hook parameters:
  - before_tool_call_hooks
  - after_tool_call_hooks
  - async_before_tool_call_hooks
  - async_after_tool_call_hooks
- Wired hook middleware into the main middleware stack in libs/deepagents/deepagents/graph.py
- Exported hook middleware and hook types via package __init__ modules
- Added Faramesh integration code example:
  - examples/faramesh_policy_hooks/agent.py
  - examples/faramesh_policy_hooks/README.md
- Updated README.md security section and examples/README.md

## Why
- Enables explicit policy/governance integration at tool boundaries
- Supports vendor integrations (including Faramesh) without requiring custom middleware per user
- Provides runnable integration code, not only documentation

## Scope
- Runtime/API changes in Deep Agents middleware layer
- New example code
- Documentation updates
