### PR TITLE
fix(cli): normalize serialized message dicts in `/offload`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3656,7 +3656,9 @@ class DeepAgentsApp(App):
 
         # Server mode / direct checkpointer may return dicts; convert to
         # LangChain message objects so _convert_messages_to_data works.
-        if messages and isinstance(messages[0], dict):
+        # `any(...)` guards against heterogeneous lists where only some
+        # elements are serialized.
+        if any(isinstance(m, dict) for m in messages):
             from langchain_core.messages.utils import convert_to_messages
 
             messages = convert_to_messages(messages)

--- a/libs/cli/deepagents_cli/offload.py
+++ b/libs/cli/deepagents_cli/offload.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from langchain_core.messages import get_buffer_string
 from langchain_core.messages.utils import count_tokens_approximately
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         SummarizationEvent,
         SummarizationMiddleware,
     )
+    from langchain_core.messages import AnyMessage, HumanMessage
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +223,12 @@ async def perform_offload(
 
     Args:
         messages: Current conversation messages from agent state.
+
+            May be LangChain message objects or serialized dicts (the latter
+            when read from a remote HTTP state snapshot).
         prior_event: Existing `_summarization_event` if any.
+
+            In server mode `summary_message` may be a serialized message dict.
         thread_id: Thread identifier for backend storage.
         model_spec: Model specification string (e.g. "openai:gpt-4").
         profile_overrides: Optional profile overrides from CLI flags.
@@ -242,6 +248,31 @@ async def perform_offload(
         SummarizationMiddleware,
         compute_summarization_defaults,
     )
+
+    # Remote HTTP state snapshots may surface serialized message dicts instead
+    # of LangChain message objects. Normalize them before passing state into
+    # summarization middleware helpers. `any(...)` rather than checking index
+    # 0 guards against heterogeneous lists (e.g. a snapshot with a streamed
+    # append).
+    needs_message_conversion = any(isinstance(m, dict) for m in messages)
+    needs_summary_conversion = prior_event is not None and isinstance(
+        prior_event.get("summary_message"), dict
+    )
+    if needs_message_conversion or needs_summary_conversion:
+        from langchain_core.messages.utils import convert_to_messages
+
+        if needs_message_conversion:
+            messages = cast("list[AnyMessage]", convert_to_messages(messages))
+        if needs_summary_conversion and prior_event is not None:
+            converted_summary = cast(
+                "HumanMessage",
+                convert_to_messages([prior_event["summary_message"]])[0],
+            )
+            prior_event = {
+                "cutoff_index": prior_event["cutoff_index"],
+                "summary_message": converted_summary,
+                "file_path": prior_event["file_path"],
+            }
 
     try:
         result = create_model(model_spec, profile_overrides=profile_overrides)

--- a/libs/cli/deepagents_cli/remote_client.py
+++ b/libs/cli/deepagents_cli/remote_client.py
@@ -1,9 +1,9 @@
 """Remote agent client — thin wrapper around LangGraph's `RemoteGraph`.
 
 Delegates streaming, state management, and SSE handling to
-`langgraph.pregel.remote.RemoteGraph`. The only added logic is converting raw
-message dicts from the server into LangChain message objects that the CLI's
-Textual adapter expects.
+`langgraph.pregel.remote.RemoteGraph`. This wrapper converts streamed message
+dicts into LangChain message objects for the CLI's Textual adapter, but leaves
+state snapshots in the server's serialized form.
 """
 
 from __future__ import annotations
@@ -44,8 +44,9 @@ class RemoteAgent:
 
     Wraps `langgraph.pregel.remote.RemoteGraph` which handles SSE parsing,
     stream-mode negotiation (`messages-tuple`), namespace extraction, and
-    interrupt detection. This class adds only message-object conversion for the
-    Textual adapter and thread-ID normalization.
+    interrupt detection. This class adds streamed message-object conversion for
+    the Textual adapter and thread-ID normalization. State snapshots are
+    returned as provided by the server.
     """
 
     def __init__(
@@ -185,6 +186,10 @@ class RemoteAgent:
         Returns `None` when the thread does not exist on the server (404).
         All other errors (network, auth, 500) are logged at WARNING and
         re-raised so callers can handle them.
+
+        Unlike `astream`, message values are not deserialized; callers may
+        receive serialized message dicts in `values["messages"]` from the
+        server.
 
         Args:
             config: Config with `configurable.thread_id`.

--- a/libs/cli/tests/unit_tests/test_offload.py
+++ b/libs/cli/tests/unit_tests/test_offload.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.messages import BaseMessage
 
 from deepagents_cli.app import DeepAgentsApp
 from deepagents_cli.command_registry import SLASH_COMMANDS
@@ -37,6 +38,37 @@ def _make_messages(n: int) -> list[MagicMock]:
         msg.additional_kwargs = {}
         messages.append(msg)
     return messages
+
+
+def _make_dict_messages(n: int) -> list[dict[str, Any]]:
+    """Create serialized message payloads matching remote state snapshots."""
+    messages: list[dict[str, Any]] = []
+    for i in range(n):
+        message_type = "human" if i % 2 == 0 else "ai"
+        payload: dict[str, Any] = {
+            "content": f"Message {i}",
+            "additional_kwargs": {},
+            "response_metadata": {},
+            "type": message_type,
+            "name": None,
+            "id": f"msg-{i}",
+        }
+        if message_type == "ai":
+            payload["tool_calls"] = []
+        messages.append(payload)
+    return messages
+
+
+def _make_dict_summary_message() -> dict[str, Any]:
+    """Create a serialized summary message payload from remote state."""
+    return {
+        "content": "Old summary.",
+        "additional_kwargs": {"lc_source": "summarization"},
+        "response_metadata": {},
+        "type": "human",
+        "name": None,
+        "id": "summary-1",
+    }
 
 
 def _make_offload_result(
@@ -942,6 +974,104 @@ class TestOffloadRemoteFallback:
             update_values = app._agent.aupdate_state.call_args_list[0][0][1]
             event = update_values["_summarization_event"]
             assert event["cutoff_index"] == 7
+
+
+class TestOffloadRemoteStateNormalization:
+    """Verify `/offload` handles serialized remote state without crashing."""
+
+    async def test_remote_state_dict_messages_normalized_before_middleware(
+        self,
+    ) -> None:
+        """Serialized `messages` from remote state are normalized in the UI path."""
+        from deepagents_cli.remote_client import RemoteAgent
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            state = MagicMock()
+            state.values = {"messages": _make_dict_messages(6)}
+
+            app._agent = MagicMock(spec=RemoteAgent)
+            app._agent.aget_state = AsyncMock(return_value=state)
+            app._agent.aensure_thread = AsyncMock()
+            app._agent.aupdate_state = AsyncMock()
+            app._backend = MagicMock()
+            app._lc_thread_id = "test-thread"
+            app._agent_running = False
+
+            model_result, mock_mw = _mock_perform_deps(cutoff=3)
+
+            with (
+                patch(_CREATE_MODEL_PATH, return_value=model_result),
+                patch(
+                    _COMPUTE_DEFAULTS_PATH,
+                    return_value={"keep": ("fraction", 0.1)},
+                ),
+                patch(_MW_CLASS_PATH, return_value=mock_mw),
+                patch(_TOKEN_COUNT_PATH, return_value=100),
+                patch(
+                    _OFFLOAD_BACKEND_PATH,
+                    new_callable=AsyncMock,
+                    return_value="/p.md",
+                ),
+            ):
+                await app._handle_offload()
+                await pilot.pause()
+
+            passed_messages = mock_mw._apply_event_to_messages.call_args[0][0]
+            assert all(isinstance(message, BaseMessage) for message in passed_messages)
+            app._agent.aensure_thread.assert_awaited_once_with(
+                {"configurable": {"thread_id": "test-thread"}}
+            )
+            app._agent.aupdate_state.assert_awaited()
+
+    async def test_remote_state_dict_prior_event_normalized_before_middleware(
+        self,
+    ) -> None:
+        """Serialized `summary_message` is normalized in the UI path."""
+        from deepagents_cli.remote_client import RemoteAgent
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            state = MagicMock()
+            state.values = {
+                "messages": _make_dict_messages(6),
+                "_summarization_event": {
+                    "cutoff_index": 2,
+                    "summary_message": _make_dict_summary_message(),
+                    "file_path": None,
+                },
+            }
+
+            app._agent = MagicMock(spec=RemoteAgent)
+            app._agent.aget_state = AsyncMock(return_value=state)
+            app._agent.aensure_thread = AsyncMock()
+            app._agent.aupdate_state = AsyncMock()
+            app._backend = MagicMock()
+            app._lc_thread_id = "test-thread"
+            app._agent_running = False
+
+            model_result, mock_mw = _mock_perform_deps(cutoff=0)
+
+            with (
+                patch(_CREATE_MODEL_PATH, return_value=model_result),
+                patch(
+                    _COMPUTE_DEFAULTS_PATH,
+                    return_value={"keep": ("fraction", 0.1)},
+                ),
+                patch(_MW_CLASS_PATH, return_value=mock_mw),
+                patch(_TOKEN_COUNT_PATH, return_value=50),
+            ):
+                await app._handle_offload()
+                await pilot.pause()
+
+            passed_event = mock_mw._apply_event_to_messages.call_args[0][1]
+            assert isinstance(passed_event["summary_message"], BaseMessage)
+            app._agent.aensure_thread.assert_not_called()
+            app._agent.aupdate_state.assert_not_called()
 
 
 class TestFormatTokenCount:

--- a/libs/cli/tests/unit_tests/test_offload_dict_messages.py
+++ b/libs/cli/tests/unit_tests/test_offload_dict_messages.py
@@ -1,0 +1,336 @@
+"""Tests for #2741 fix: `perform_offload()` handles serialized state payloads.
+
+Remote HTTP state snapshots and checkpointer fallbacks may surface messages as
+raw dicts rather than `BaseMessage` objects. `perform_offload()` must
+normalize these before passing them to middleware helpers like
+`get_buffer_string()`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import BaseMessage
+
+from deepagents_cli.offload import OffloadResult, perform_offload
+
+if TYPE_CHECKING:
+    from deepagents.middleware.summarization import SummarizationEvent
+
+# Raw dict messages — what remote state snapshots and checkpoint fallbacks
+# may return before deserialization.
+_DICT_MESSAGES: list[dict[str, Any]] = [
+    {
+        "content": "Hi!",
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "human",
+        "name": None,
+        "id": "human-1",
+    },
+    {
+        "content": "Hello! How can I help?",
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "ai",
+        "name": None,
+        "id": "ai-1",
+    },
+    {
+        "content": "Tell me a joke",
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "human",
+        "name": None,
+        "id": "human-2",
+    },
+    {
+        "content": "Why did the chicken cross the road?",
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "ai",
+        "name": None,
+        "id": "ai-2",
+    },
+    {
+        "content": "Why?",
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "human",
+        "name": None,
+        "id": "human-3",
+    },
+    {
+        "content": "To get to the other side!",
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "ai",
+        "name": None,
+        "id": "ai-3",
+    },
+]
+
+# Patch targets
+_CREATE_MODEL_PATH = "deepagents_cli.offload.create_model"
+_COMPUTE_DEFAULTS_PATH = (
+    "deepagents.middleware.summarization.compute_summarization_defaults"
+)
+_MW_CLASS_PATH = "deepagents.middleware.summarization.SummarizationMiddleware"
+_TOKEN_COUNT_PATH = "deepagents_cli.offload.count_tokens_approximately"
+_OFFLOAD_BACKEND_PATH = "deepagents_cli.offload.offload_messages_to_backend"
+
+
+def _mock_perform_deps(*, cutoff: int = 3) -> tuple[MagicMock, MagicMock]:
+    """Return (mock_model_result, mock_middleware) for perform_offload tests."""
+    mock_model = MagicMock()
+    mock_model.profile = {"max_input_tokens": 200_000}
+    mock_result = MagicMock()
+    mock_result.model = mock_model
+
+    mock_mw = MagicMock()
+    mock_mw._apply_event_to_messages.side_effect = lambda msgs, _ev: list(msgs)
+    mock_mw._determine_cutoff_index.return_value = cutoff
+    mock_mw._partition_messages.side_effect = lambda msgs, idx: (
+        msgs[:idx],
+        msgs[idx:],
+    )
+    mock_mw._acreate_summary = AsyncMock(return_value="Summary of conversation.")
+
+    summary_msg = MagicMock()
+    summary_msg.content = "Summary of conversation."
+    summary_msg.additional_kwargs = {"lc_source": "summarization"}
+    mock_mw._build_new_messages_with_path.return_value = [summary_msg]
+    mock_mw._compute_state_cutoff.side_effect = lambda _ev, c: c
+    mock_mw._filter_summary_messages.side_effect = lambda msgs: msgs
+
+    return mock_result, mock_mw
+
+
+class TestDictMessageNormalization:
+    """Verify `perform_offload()` normalizes serialized state payloads."""
+
+    async def test_dict_messages_converted_before_middleware(self) -> None:
+        """Dict messages are converted to BaseMessage before reaching middleware."""
+        model_result, mock_mw = _mock_perform_deps(cutoff=3)
+
+        with (
+            patch(_CREATE_MODEL_PATH, return_value=model_result),
+            patch(_COMPUTE_DEFAULTS_PATH, return_value={"keep": ("fraction", 0.1)}),
+            patch(_MW_CLASS_PATH, return_value=mock_mw),
+            patch(_TOKEN_COUNT_PATH, return_value=100),
+            patch(_OFFLOAD_BACKEND_PATH, new_callable=AsyncMock, return_value="/p.md"),
+        ):
+            result = await perform_offload(
+                messages=list(_DICT_MESSAGES),
+                prior_event=None,
+                thread_id="test-thread",
+                model_spec="anthropic:claude-sonnet-4-20250514",
+                profile_overrides=None,
+                context_limit=None,
+                total_context_tokens=0,
+                backend=MagicMock(),
+            )
+
+        assert isinstance(result, OffloadResult)
+        assert result.messages_offloaded == 3
+        assert result.messages_kept == 3
+
+        passed_msgs = mock_mw._apply_event_to_messages.call_args[0][0]
+        assert all(isinstance(m, BaseMessage) for m in passed_msgs)
+
+    async def test_dict_prior_event_summary_message_converted(self) -> None:
+        """A prior_event with a dict summary_message is normalized."""
+        model_result, mock_mw = _mock_perform_deps(cutoff=0)
+
+        dict_summary = {
+            "content": "Previous summary.",
+            "additional_kwargs": {"lc_source": "summarization"},
+            "response_metadata": {},
+            "type": "human",
+            "name": None,
+            "id": "summary-1",
+        }
+        prior_event = cast(
+            "SummarizationEvent",
+            {
+                "cutoff_index": 2,
+                "summary_message": dict_summary,
+                "file_path": "/old.md",
+            },
+        )
+
+        with (
+            patch(_CREATE_MODEL_PATH, return_value=model_result),
+            patch(_COMPUTE_DEFAULTS_PATH, return_value={"keep": ("fraction", 0.1)}),
+            patch(_MW_CLASS_PATH, return_value=mock_mw),
+            patch(_TOKEN_COUNT_PATH, return_value=50),
+        ):
+            from deepagents_cli.offload import OffloadThresholdNotMet
+
+            result = await perform_offload(
+                messages=list(_DICT_MESSAGES),
+                prior_event=prior_event,
+                thread_id="test-thread",
+                model_spec="anthropic:claude-sonnet-4-20250514",
+                profile_overrides=None,
+                context_limit=None,
+                total_context_tokens=0,
+                backend=MagicMock(),
+            )
+
+        assert isinstance(result, OffloadThresholdNotMet)
+
+        passed_event = mock_mw._apply_event_to_messages.call_args[0][1]
+        assert isinstance(passed_event["summary_message"], BaseMessage)
+
+    async def test_base_message_inputs_unchanged(self) -> None:
+        """Already-proper BaseMessage objects pass through without issue."""
+        from langchain_core.messages.utils import convert_to_messages
+
+        model_result, mock_mw = _mock_perform_deps(cutoff=3)
+        proper_messages = convert_to_messages(_DICT_MESSAGES)
+
+        with (
+            patch(_CREATE_MODEL_PATH, return_value=model_result),
+            patch(_COMPUTE_DEFAULTS_PATH, return_value={"keep": ("fraction", 0.1)}),
+            patch(_MW_CLASS_PATH, return_value=mock_mw),
+            patch(_TOKEN_COUNT_PATH, return_value=100),
+            patch(_OFFLOAD_BACKEND_PATH, new_callable=AsyncMock, return_value="/p.md"),
+        ):
+            result = await perform_offload(
+                messages=proper_messages,
+                prior_event=None,
+                thread_id="test-thread",
+                model_spec="anthropic:claude-sonnet-4-20250514",
+                profile_overrides=None,
+                context_limit=None,
+                total_context_tokens=0,
+                backend=MagicMock(),
+            )
+
+        assert isinstance(result, OffloadResult)
+
+    async def test_dict_messages_and_dict_summary_normalized_together(self) -> None:
+        """Both flags at once: dicts in `messages` and in `prior_event`."""
+        model_result, mock_mw = _mock_perform_deps(cutoff=3)
+
+        dict_summary = {
+            "content": "Previous summary.",
+            "additional_kwargs": {"lc_source": "summarization"},
+            "response_metadata": {},
+            "type": "human",
+            "name": None,
+            "id": "summary-1",
+        }
+        prior_event = cast(
+            "SummarizationEvent",
+            {
+                "cutoff_index": 1,
+                "summary_message": dict_summary,
+                "file_path": "/old.md",
+            },
+        )
+
+        with (
+            patch(_CREATE_MODEL_PATH, return_value=model_result),
+            patch(_COMPUTE_DEFAULTS_PATH, return_value={"keep": ("fraction", 0.1)}),
+            patch(_MW_CLASS_PATH, return_value=mock_mw),
+            patch(_TOKEN_COUNT_PATH, return_value=100),
+            patch(_OFFLOAD_BACKEND_PATH, new_callable=AsyncMock, return_value="/p.md"),
+        ):
+            result = await perform_offload(
+                messages=list(_DICT_MESSAGES),
+                prior_event=prior_event,
+                thread_id="test-thread",
+                model_spec="anthropic:claude-sonnet-4-20250514",
+                profile_overrides=None,
+                context_limit=None,
+                total_context_tokens=0,
+                backend=MagicMock(),
+            )
+
+        assert isinstance(result, OffloadResult)
+
+        passed_msgs = mock_mw._apply_event_to_messages.call_args[0][0]
+        passed_event = mock_mw._apply_event_to_messages.call_args[0][1]
+        assert all(isinstance(m, BaseMessage) for m in passed_msgs)
+        assert isinstance(passed_event["summary_message"], BaseMessage)
+
+    async def test_heterogeneous_messages_fully_normalized(self) -> None:
+        """A list mixing BaseMessage and dict entries is normalized end-to-end."""
+        from langchain_core.messages.utils import convert_to_messages
+
+        model_result, mock_mw = _mock_perform_deps(cutoff=3)
+        # First element is a BaseMessage; rest are dicts. The [0]-only
+        # heuristic would have missed this; `any(...)` catches it.
+        head = convert_to_messages([_DICT_MESSAGES[0]])
+        tail: list[Any] = list(_DICT_MESSAGES[1:])
+        mixed: list[Any] = [*head, *tail]
+
+        with (
+            patch(_CREATE_MODEL_PATH, return_value=model_result),
+            patch(_COMPUTE_DEFAULTS_PATH, return_value={"keep": ("fraction", 0.1)}),
+            patch(_MW_CLASS_PATH, return_value=mock_mw),
+            patch(_TOKEN_COUNT_PATH, return_value=100),
+            patch(_OFFLOAD_BACKEND_PATH, new_callable=AsyncMock, return_value="/p.md"),
+        ):
+            result = await perform_offload(
+                messages=mixed,
+                prior_event=None,
+                thread_id="test-thread",
+                model_spec="anthropic:claude-sonnet-4-20250514",
+                profile_overrides=None,
+                context_limit=None,
+                total_context_tokens=0,
+                backend=MagicMock(),
+            )
+
+        assert isinstance(result, OffloadResult)
+
+        passed_msgs = mock_mw._apply_event_to_messages.call_args[0][0]
+        assert all(isinstance(m, BaseMessage) for m in passed_msgs)
+
+    async def test_empty_messages_with_dict_summary_still_normalizes(self) -> None:
+        """Empty `messages=[]` does not crash the guard; summary still normalized."""
+        model_result, mock_mw = _mock_perform_deps(cutoff=0)
+
+        dict_summary = {
+            "content": "Previous summary.",
+            "additional_kwargs": {"lc_source": "summarization"},
+            "response_metadata": {},
+            "type": "human",
+            "name": None,
+            "id": "summary-1",
+        }
+        prior_event = cast(
+            "SummarizationEvent",
+            {
+                "cutoff_index": 0,
+                "summary_message": dict_summary,
+                "file_path": "/old.md",
+            },
+        )
+
+        with (
+            patch(_CREATE_MODEL_PATH, return_value=model_result),
+            patch(_COMPUTE_DEFAULTS_PATH, return_value={"keep": ("fraction", 0.1)}),
+            patch(_MW_CLASS_PATH, return_value=mock_mw),
+            patch(_TOKEN_COUNT_PATH, return_value=0),
+        ):
+            from deepagents_cli.offload import OffloadThresholdNotMet
+
+            result = await perform_offload(
+                messages=[],
+                prior_event=prior_event,
+                thread_id="test-thread",
+                model_spec="anthropic:claude-sonnet-4-20250514",
+                profile_overrides=None,
+                context_limit=None,
+                total_context_tokens=0,
+                backend=MagicMock(),
+            )
+
+        assert isinstance(result, OffloadThresholdNotMet)
+        passed_event = mock_mw._apply_event_to_messages.call_args[0][1]
+        assert isinstance(passed_event["summary_message"], BaseMessage)


### PR DESCRIPTION
Fixes #2741

---

Normalize serialized message payloads in `perform_offload` so `/offload` works against remote HTTP state snapshots. `RemoteGraph.aget_state` returns `values["messages"]` as raw dicts rather than LangChain message objects, which was crashing middleware helpers like `get_buffer_string()` and `_apply_event_to_messages`.