### PR TITLE
fix(evals): various eval fixes

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -394,6 +394,19 @@ REGISTRY: tuple[Model, ...] = (
         ),
     ),
     Model(
+        "openai:gpt-5.3-codex",
+        frozenset(
+            {
+                "eval:set0",
+                "eval:set1",
+                "eval:openai",
+                "harbor:set0",
+                "harbor:set1",
+                "harbor:openai",
+            }
+        ),
+    ),
+    Model(
         "openai:gpt-5.4",
         frozenset(
             {

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -94,6 +94,7 @@ on:
           - "openai:o4-mini"
           - "openai:gpt-5.1-codex"
           - "openai:gpt-5.2-codex"
+          - "openai:gpt-5.3-codex"
           - "openai:gpt-5.4"
           - "openai:gpt-5.4-mini"
           - "openrouter:minimax/minimax-m2.7"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -100,6 +100,7 @@ on:
           - "openai:o4-mini"
           - "openai:gpt-5.1-codex"
           - "openai:gpt-5.2-codex"
+          - "openai:gpt-5.3-codex"
           - "openai:gpt-5.4"
           - "openai:gpt-5.4-mini"
           - "openrouter:minimax/minimax-m2.7"

--- a/libs/evals/MODEL_GROUPS.md
+++ b/libs/evals/MODEL_GROUPS.md
@@ -7,7 +7,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 
 ## Model groups
 
-### `set0` (32 models)
+### `set0` (33 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-5-20250929`
@@ -39,10 +39,11 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:o4-mini`
 - `openai:gpt-5.1-codex`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 
-### `set1` (12 models)
+### `set1` (13 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-6`
@@ -55,6 +56,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `ollama:qwen3.5:397b-cloud`
 - `openai:gpt-4.1`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 
 ### `set2` (17 models)
@@ -158,7 +160,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `ollama:qwen3-coder:480b-cloud`
 - `ollama:deepseek-v3.2:cloud`
 
-### `openai` (9 models)
+### `openai` (10 models)
 
 - `openai:gpt-4o`
 - `openai:gpt-4o-mini`
@@ -167,6 +169,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:o4-mini`
 - `openai:gpt-5.1-codex`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 
@@ -181,7 +184,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`
 
-## `all` (53 models)
+## `all` (54 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-sonnet-4-5-20250929`
@@ -229,6 +232,7 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:o4-mini`
 - `openai:gpt-5.1-codex`
 - `openai:gpt-5.2-codex`
+- `openai:gpt-5.3-codex`
 - `openai:gpt-5.4`
 - `openai:gpt-5.4-mini`
 - `openrouter:minimax/minimax-m2.7`

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -382,7 +382,7 @@ class LangSmithEnvironment(BaseEnvironment):
 
         When `cwd` is not provided, defaults to the container's
         `WORKDIR` (resolved at `start()`) rather than LangSmith's
-        dataplane default of ``/``. This preserves the semantics that
+        dataplane default of `/`. This preserves the semantics that
         terminal-bench verifier scripts assume when they probe ``$PWD``.
 
         Args:

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -71,6 +71,7 @@ class LangSmithEnvironment(BaseEnvironment):
         self._sandbox: AsyncSandbox | None = None
         self._client: AsyncSandboxClient | None = None
         self._template_name: str | None = None
+        self._default_cwd: str | None = None
         super().__init__(
             environment_dir,
             environment_name,
@@ -274,6 +275,54 @@ class LangSmithEnvironment(BaseEnvironment):
             timeout=30,
         )
 
+        self._default_cwd = await self._detect_workdir(sandbox)
+        logger.info(
+            "LangSmith sandbox '%s' default cwd resolved to '%s'",
+            sandbox.name,
+            self._default_cwd,
+        )
+
+    @staticmethod
+    async def _detect_workdir(sandbox: AsyncSandbox) -> str:
+        """Resolve the container's Dockerfile ``WORKDIR`` at runtime.
+
+        LangSmith's ``sandbox.run(cwd=None)`` spawns each command from the
+        dataplane daemon's cwd, not the image's ``WORKDIR``. Terminal-bench
+        verifier scripts rely on ``WORKDIR`` (e.g. ``/app``) — many include
+        ``if [ "$PWD" = "/" ]; then exit 1; fi`` as a guard and abort without
+        writing ``/logs/verifier/reward.txt`` when this assumption is violated.
+
+        PID 1 (the container entrypoint) inherits the image's ``WORKDIR`` as
+        its cwd, so ``readlink /proc/1/cwd`` yields the correct directory
+        without requiring access to the image metadata. Falls back to ``/app``
+        (terminal-bench convention) when the probe is inconclusive.
+
+        Args:
+            sandbox: The active LangSmith sandbox.
+
+        Returns:
+            Absolute path to use as the default working directory for
+            subsequent command execution.
+        """
+        try:
+            result = await sandbox.run("readlink /proc/1/cwd", timeout=15)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to probe /proc/1/cwd; falling back to '/app'", exc_info=True
+            )
+            return "/app"
+
+        candidate = (result.stdout or "").strip()
+        if result.exit_code == 0 and candidate and candidate != "/":
+            return candidate
+
+        probe = await sandbox.run(
+            "[ -d /app ] && echo /app || echo /",
+            timeout=15,
+        )
+        fallback = (probe.stdout or "").strip() or "/"
+        return fallback if fallback != "/" else "/app"
+
     async def stop(self, delete: bool) -> None:
         """Tear down the LangSmith sandbox and its dedicated template.
 
@@ -309,6 +358,7 @@ class LangSmithEnvironment(BaseEnvironment):
         self._sandbox = None
         self._client = None
         self._template_name = None
+        self._default_cwd = None
 
     # -- Command execution -----------------------------------------------------
 
@@ -332,9 +382,15 @@ class LangSmithEnvironment(BaseEnvironment):
     ) -> ExecResult:
         """Execute a command inside the LangSmith sandbox.
 
+        When ``cwd`` is not provided, defaults to the container's
+        ``WORKDIR`` (resolved at ``start()``) rather than LangSmith's
+        dataplane default of ``/``. This preserves the semantics that
+        terminal-bench verifier scripts assume when they probe ``$PWD``.
+
         Args:
             command: Shell command string to execute.
-            cwd: Working directory for command execution.
+            cwd: Working directory for command execution. Overrides the
+                detected default when provided.
             env: Environment variables to set.
             timeout_sec: Timeout in seconds.
 
@@ -343,11 +399,12 @@ class LangSmithEnvironment(BaseEnvironment):
         """
         sandbox = self._require_sandbox()
         effective_timeout = timeout_sec if timeout_sec is not None else _DEFAULT_EXEC_TIMEOUT_SEC
+        effective_cwd = cwd if cwd is not None else self._default_cwd
 
         result = await sandbox.run(
             command,
             timeout=effective_timeout,
-            cwd=cwd,
+            cwd=effective_cwd,
             env=env,
         )
         return ExecResult(

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -287,7 +287,7 @@ class LangSmithEnvironment(BaseEnvironment):
         """Resolve the container's Dockerfile ``WORKDIR`` at runtime.
 
         LangSmith's `sandbox.run(cwd=None)` spawns each command from the
-        dataplane daemon's cwd, not the image's ``WORKDIR``. Terminal-bench
+        dataplane daemon's cwd, not the image's `WORKDIR`. Terminal-bench
         verifier scripts rely on ``WORKDIR`` (e.g. ``/app``) — many include
         ``if [ "$PWD" = "/" ]; then exit 1; fi`` as a guard and abort without
         writing ``/logs/verifier/reward.txt`` when this assumption is violated.

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -383,7 +383,7 @@ class LangSmithEnvironment(BaseEnvironment):
         When `cwd` is not provided, defaults to the container's
         `WORKDIR` (resolved at `start()`) rather than LangSmith's
         dataplane default of `/`. This preserves the semantics that
-        terminal-bench verifier scripts assume when they probe ``$PWD``.
+        terminal-bench verifier scripts assume when they probe `$PWD`.
 
         Args:
             command: Shell command string to execute.

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -286,7 +286,7 @@ class LangSmithEnvironment(BaseEnvironment):
     async def _detect_workdir(sandbox: AsyncSandbox) -> str:
         """Resolve the container's Dockerfile ``WORKDIR`` at runtime.
 
-        LangSmith's ``sandbox.run(cwd=None)`` spawns each command from the
+        LangSmith's `sandbox.run(cwd=None)` spawns each command from the
         dataplane daemon's cwd, not the image's ``WORKDIR``. Terminal-bench
         verifier scripts rely on ``WORKDIR`` (e.g. ``/app``) — many include
         ``if [ "$PWD" = "/" ]; then exit 1; fi`` as a guard and abort without

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -381,7 +381,7 @@ class LangSmithEnvironment(BaseEnvironment):
         """Execute a command inside the LangSmith sandbox.
 
         When `cwd` is not provided, defaults to the container's
-        ``WORKDIR`` (resolved at ``start()``) rather than LangSmith's
+        `WORKDIR` (resolved at `start()`) rather than LangSmith's
         dataplane default of ``/``. This preserves the semantics that
         terminal-bench verifier scripts assume when they probe ``$PWD``.
 

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -380,7 +380,7 @@ class LangSmithEnvironment(BaseEnvironment):
     ) -> ExecResult:
         """Execute a command inside the LangSmith sandbox.
 
-        When ``cwd`` is not provided, defaults to the container's
+        When `cwd` is not provided, defaults to the container's
         ``WORKDIR`` (resolved at ``start()``) rather than LangSmith's
         dataplane default of ``/``. This preserves the semantics that
         terminal-bench verifier scripts assume when they probe ``$PWD``.

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -288,7 +288,7 @@ class LangSmithEnvironment(BaseEnvironment):
 
         LangSmith's `sandbox.run(cwd=None)` spawns each command from the
         dataplane daemon's cwd, not the image's `WORKDIR`. Terminal-bench
-        verifier scripts rely on ``WORKDIR`` (e.g. ``/app``) — many include
+        verifier scripts rely on `WORKDIR` (e.g. `/app`) — many include
         ``if [ "$PWD" = "/" ]; then exit 1; fi`` as a guard and abort without
         writing ``/logs/verifier/reward.txt`` when this assumption is violated.
 

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -290,7 +290,7 @@ class LangSmithEnvironment(BaseEnvironment):
         dataplane daemon's cwd, not the image's `WORKDIR`. Terminal-bench
         verifier scripts rely on `WORKDIR` (e.g. `/app`) — many include
         `if [ "$PWD" = "/" ]; then exit 1; fi` as a guard and abort without
-        writing ``/logs/verifier/reward.txt`` when this assumption is violated.
+        writing `/logs/verifier/reward.txt` when this assumption is violated.
 
         PID 1 (the container entrypoint) inherits the image's ``WORKDIR`` as
         its cwd, so ``readlink /proc/1/cwd`` yields the correct directory

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -289,7 +289,7 @@ class LangSmithEnvironment(BaseEnvironment):
         LangSmith's `sandbox.run(cwd=None)` spawns each command from the
         dataplane daemon's cwd, not the image's `WORKDIR`. Terminal-bench
         verifier scripts rely on `WORKDIR` (e.g. `/app`) — many include
-        ``if [ "$PWD" = "/" ]; then exit 1; fi`` as a guard and abort without
+        `if [ "$PWD" = "/" ]; then exit 1; fi` as a guard and abort without
         writing ``/logs/verifier/reward.txt`` when this assumption is violated.
 
         PID 1 (the container entrypoint) inherits the image's ``WORKDIR`` as

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -294,7 +294,7 @@ class LangSmithEnvironment(BaseEnvironment):
 
         PID 1 (the container entrypoint) inherits the image's `WORKDIR` as
         its cwd, so `readlink /proc/1/cwd` yields the correct directory
-        without requiring access to the image metadata. Falls back to ``/app``
+        without requiring access to the image metadata. Falls back to `/app`
         (terminal-bench convention) when the probe is inconclusive.
 
         Args:

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -292,7 +292,7 @@ class LangSmithEnvironment(BaseEnvironment):
         `if [ "$PWD" = "/" ]; then exit 1; fi` as a guard and abort without
         writing `/logs/verifier/reward.txt` when this assumption is violated.
 
-        PID 1 (the container entrypoint) inherits the image's ``WORKDIR`` as
+        PID 1 (the container entrypoint) inherits the image's `WORKDIR` as
         its cwd, so ``readlink /proc/1/cwd`` yields the correct directory
         without requiring access to the image metadata. Falls back to ``/app``
         (terminal-bench convention) when the probe is inconclusive.

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -293,7 +293,7 @@ class LangSmithEnvironment(BaseEnvironment):
         writing `/logs/verifier/reward.txt` when this assumption is violated.
 
         PID 1 (the container entrypoint) inherits the image's `WORKDIR` as
-        its cwd, so ``readlink /proc/1/cwd`` yields the correct directory
+        its cwd, so `readlink /proc/1/cwd` yields the correct directory
         without requiring access to the image metadata. Falls back to ``/app``
         (terminal-bench convention) when the probe is inconclusive.
 

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -307,9 +307,7 @@ class LangSmithEnvironment(BaseEnvironment):
         try:
             result = await sandbox.run("readlink /proc/1/cwd", timeout=15)
         except Exception:  # noqa: BLE001
-            logger.warning(
-                "Failed to probe /proc/1/cwd; falling back to '/app'", exc_info=True
-            )
+            logger.warning("Failed to probe /proc/1/cwd; falling back to '/app'", exc_info=True)
             return "/app"
 
         candidate = (result.stdout or "").strip()

--- a/libs/evals/tests/unit_tests/test_langsmith_environment.py
+++ b/libs/evals/tests/unit_tests/test_langsmith_environment.py
@@ -577,9 +577,7 @@ class TestWorkdirDetection:
         ) -> _FakeExecResult:
             sandbox._run_calls.append((command, timeout, cwd, env))
             if "readlink /proc/1/cwd" in command:
-                return _FakeExecResult(
-                    stdout=readlink_stdout, exit_code=readlink_exit_code
-                )
+                return _FakeExecResult(stdout=readlink_stdout, exit_code=readlink_exit_code)
             if "-d /app" in command:
                 return _FakeExecResult(stdout=dir_probe_stdout)
             return _FakeExecResult()

--- a/libs/evals/tests/unit_tests/test_langsmith_environment.py
+++ b/libs/evals/tests/unit_tests/test_langsmith_environment.py
@@ -500,6 +500,32 @@ class TestExec:
         assert cwd == "/app"
         assert cmd_env == {"FOO": "bar"}
 
+    async def test_exec_uses_default_cwd_when_none_provided(self, tmp_path: Path) -> None:
+        """Regression: without this, LangSmith's dataplane defaults to "/",
+        which causes terminal-bench verifier scripts to abort early without
+        writing /logs/verifier/reward.txt.
+        """
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # type: ignore[assignment]
+        env._default_cwd = "/app"
+
+        await env.exec("ls")
+
+        _, _, cwd, _ = sandbox._run_calls[0]
+        assert cwd == "/app"
+
+    async def test_exec_explicit_cwd_overrides_default(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # type: ignore[assignment]
+        env._default_cwd = "/app"
+
+        await env.exec("ls", cwd="/tmp")
+
+        _, _, cwd, _ = sandbox._run_calls[0]
+        assert cwd == "/tmp"
+
     async def test_exec_uses_default_timeout(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
@@ -522,6 +548,145 @@ class TestExec:
         env = _make_env(tmp_path)
         with pytest.raises(RuntimeError, match="start"):
             await env.exec("echo fail")
+
+
+class TestWorkdirDetection:
+    """Tests for container WORKDIR detection at start()."""
+
+    @staticmethod
+    def _install_probe_sandbox(
+        mock_client: MagicMock,
+        *,
+        readlink_stdout: str = "",
+        readlink_exit_code: int = 0,
+        dir_probe_stdout: str = "",
+    ) -> _FakeSandbox:
+        """Install a sandbox whose `run()` answers the workdir probes.
+
+        Both probes (`readlink /proc/1/cwd` and the `/app`-existence fallback)
+        are dispatched from the same method so assertions stay simple.
+        """
+        sandbox = _FakeSandbox()
+
+        async def _run(
+            command: str,
+            *,
+            timeout: int = 60,  # noqa: ASYNC109
+            cwd: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> _FakeExecResult:
+            sandbox._run_calls.append((command, timeout, cwd, env))
+            if "readlink /proc/1/cwd" in command:
+                return _FakeExecResult(
+                    stdout=readlink_stdout, exit_code=readlink_exit_code
+                )
+            if "-d /app" in command:
+                return _FakeExecResult(stdout=dir_probe_stdout)
+            return _FakeExecResult()
+
+        sandbox.run = _run  # type: ignore[assignment]
+        mock_client.create_sandbox.return_value = sandbox
+        return sandbox
+
+    async def test_detects_workdir_from_pid1(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(mock_client, readlink_stdout="/app\n")
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_detects_non_app_workdir(self, tmp_path: Path) -> None:
+        """Images with non-standard WORKDIRs (e.g. /workspace) must be honored."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(mock_client, readlink_stdout="/workspace\n")
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/workspace"
+
+    async def test_falls_back_to_app_when_root(self, tmp_path: Path) -> None:
+        """When the container has no WORKDIR, prefer /app if it exists."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(
+                mock_client,
+                readlink_stdout="/\n",
+                dir_probe_stdout="/app\n",
+            )
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_falls_back_to_app_on_probe_failure(self, tmp_path: Path) -> None:
+        """A broken readlink probe must not prevent start()."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            sandbox = _FakeSandbox()
+
+            async def _run(
+                command: str,
+                *,
+                timeout: int = 60,  # noqa: ASYNC109
+                cwd: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> _FakeExecResult:
+                sandbox._run_calls.append((command, timeout, cwd, env))
+                if "readlink /proc/1/cwd" in command:
+                    msg = "connection reset"
+                    raise RuntimeError(msg)
+                return _FakeExecResult()
+
+            sandbox.run = _run  # type: ignore[assignment]
+            mock_client.create_sandbox.return_value = sandbox
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_falls_back_to_app_when_nothing_resolves(self, tmp_path: Path) -> None:
+        """When /app doesn't exist either, still default to /app rather
+        than "/" to preserve terminal-bench verifier PWD semantics."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(
+                mock_client,
+                readlink_stdout="/\n",
+                dir_probe_stdout="/\n",
+            )
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_stop_clears_default_cwd(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        env._sandbox = _FakeSandbox()  # type: ignore[assignment]
+        env._client = AsyncMock()
+        env._template_name = "tmpl"
+        env._default_cwd = "/app"
+
+        await env.stop(delete=False)
+
+        assert env._default_cwd is None
 
 
 class TestFileOps:


### PR DESCRIPTION
## Summary

- Add `openai:gpt-5.3-codex` to the model registry (`set0`, `set1`, `openai` groups) and wire it into the `evals` + `harbor` workflow dropdowns.
- Fix missing `verifier_result` in terminal-bench runs on LangSmith/Daytona sandboxes.

## Context — verifier fix

Harbor's `Verifier.verify()` calls `environment.exec(...)` without a cwd. LangSmith's `sandbox.run(cwd=None)` spawns commands from `/` (not the image's `WORKDIR`), so terminal-bench `test.sh` scripts hit their `if [ "$PWD" = "/" ]; then exit 1; fi` guard and abort before writing `/logs/verifier/reward.txt`. The reward file never materializes, verifier raises `RewardFileNotFoundError`, harbor's outer `except Exception` swallows it, and `result.json` ends up with `verifier_result: null` → `add-feedback` logs "no verifier_result" and falls back to 0.0.

`LangSmithEnvironment` now probes `readlink /proc/1/cwd` at `start()` to resolve the container's runtime `WORKDIR` (PID 1 inherits it from the image) and uses that as the default cwd for subsequent `exec()` calls. Falls back to `/app` (terminal-bench convention) if the probe is inconclusive. Explicit `cwd=...` arguments from callers still win.
