### PR TITLE
chore(ci): add `langchain-*` partner scopes to pr title lint

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -27,9 +27,10 @@
 #   * hotfix     — urgent fix that won't trigger a release
 #
 # Allowed Scope(s) (required):
-#   acp, ci, cli, cli-gha, daytona, deepagents, deepagents-cli, deepagents-acp, deps,
-#   evals, examples, harbor, infra, langsmith-sandbox, modal, quickjs, repl,
-#   runloop, sdk
+#   acp, ci, cli, cli-gha, daytona, deepagents, deepagents-acp, deepagents-cli, deps,
+#   deps-dev, evals, examples, harbor, infra, langchain-daytona, langchain-modal,
+#   langchain-quickjs, langchain-repl, langchain-runloop, langsmith-sandbox, modal,
+#   quickjs, repl, runloop, sdk
 #
 # Multiple scopes can be used by separating them with a comma.
 #
@@ -93,14 +94,19 @@ jobs:
             cli-gha
             daytona
             deepagents
-            deepagents-cli
             deepagents-acp
+            deepagents-cli
             deps
             deps-dev
             evals
             examples
             harbor
             infra
+            langchain-daytona
+            langchain-modal
+            langchain-quickjs
+            langchain-repl
+            langchain-runloop
             langsmith-sandbox
             modal
             quickjs


### PR DESCRIPTION
Add `langchain-daytona`, `langchain-modal`, `langchain-quickjs`, `langchain-repl`, and `langchain-runloop` to the PR-title allowed-scopes list in `pr_lint.yml`. These scopes are already referenced in `release.yml`, `release-please.yml`, `RELEASING.md`, and `pr-labeler-config.json` but were missing from the lint workflow, which would reject PRs using them.