### PR TITLE
fix(ci): fan out `update-lockfiles` across prs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,7 @@ jobs:
       repl-release: ${{ steps.check-releases.outputs.repl-release }}
       release-version: ${{ steps.check-releases.outputs.release-version }}
       pr: ${{ steps.release.outputs.pr }}
+      prs: ${{ steps.release.outputs.prs }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
@@ -106,7 +107,7 @@ jobs:
           # NOTE: separate-pull-requests=true ensures one release commit per workflow run,
           # so a single version output is correct — each package triggers its own run.
           RELEASE_VERSION=$(echo "$COMMIT_MSG" | sed -nE 's/^release\([^)]+\): +([^ ]+).*/\1/p')
-          echo "release-version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
           if [ -n "$RELEASE_VERSION" ]; then
             echo "Extracted release version: $RELEASE_VERSION"
@@ -118,59 +119,59 @@ jobs:
           # bash suppresses errexit inside `if` compound commands.
 
           if echo "$CHANGED" | grep -q "^libs/cli/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-cli\):"; then
-            echo "cli-release=true" >> $GITHUB_OUTPUT
+            echo "cli-release=true" >> "$GITHUB_OUTPUT"
             echo "CLI release detected: $COMMIT_MSG"
           else
-            echo "cli-release=false" >> $GITHUB_OUTPUT
+            echo "cli-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/deepagents/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents\):"; then
-            echo "sdk-release=true" >> $GITHUB_OUTPUT
+            echo "sdk-release=true" >> "$GITHUB_OUTPUT"
             echo "SDK release detected: $COMMIT_MSG"
           else
-            echo "sdk-release=false" >> $GITHUB_OUTPUT
+            echo "sdk-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/acp/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-acp\):"; then
-            echo "acp-release=true" >> $GITHUB_OUTPUT
+            echo "acp-release=true" >> "$GITHUB_OUTPUT"
             echo "ACP release detected: $COMMIT_MSG"
           else
-            echo "acp-release=false" >> $GITHUB_OUTPUT
+            echo "acp-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/partners/daytona/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-daytona\):"; then
-            echo "daytona-release=true" >> $GITHUB_OUTPUT
+            echo "daytona-release=true" >> "$GITHUB_OUTPUT"
             echo "Daytona release detected: $COMMIT_MSG"
           else
-            echo "daytona-release=false" >> $GITHUB_OUTPUT
+            echo "daytona-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/partners/modal/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-modal\):"; then
-            echo "modal-release=true" >> $GITHUB_OUTPUT
+            echo "modal-release=true" >> "$GITHUB_OUTPUT"
             echo "Modal release detected: $COMMIT_MSG"
           else
-            echo "modal-release=false" >> $GITHUB_OUTPUT
+            echo "modal-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/partners/runloop/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-runloop\):"; then
-            echo "runloop-release=true" >> $GITHUB_OUTPUT
+            echo "runloop-release=true" >> "$GITHUB_OUTPUT"
             echo "Runloop release detected: $COMMIT_MSG"
           else
-            echo "runloop-release=false" >> $GITHUB_OUTPUT
+            echo "runloop-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/partners/quickjs/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-quickjs\):"; then
-            echo "quickjs-release=true" >> $GITHUB_OUTPUT
+            echo "quickjs-release=true" >> "$GITHUB_OUTPUT"
             echo "QuickJS release detected: $COMMIT_MSG"
           else
-            echo "quickjs-release=false" >> $GITHUB_OUTPUT
+            echo "quickjs-release=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED" | grep -q "^libs/repl/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-repl\):"; then
-            echo "repl-release=true" >> $GITHUB_OUTPUT
+            echo "repl-release=true" >> "$GITHUB_OUTPUT"
             echo "REPL release detected: $COMMIT_MSG"
           else
-            echo "repl-release=false" >> $GITHUB_OUTPUT
+            echo "repl-release=false" >> "$GITHUB_OUTPUT"
           fi
 
   # Update uv.lock files when release-please creates/updates a PR
@@ -178,24 +179,33 @@ jobs:
   # https://github.com/googleapis/release-please/issues/2561
   update-lockfiles:
     needs: release-please
-    if: needs.release-please.outputs.pr != ''
+    if: needs.release-please.outputs.prs != '[]' && needs.release-please.outputs.prs != ''
+    name: Update lockfiles (${{ matrix.pr.headBranchName }})
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: update-lockfiles-${{ matrix.pr.headBranchName }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJson(needs.release-please.outputs.prs) }}
     steps:
       - name: Checkout release branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
+          ref: ${{ matrix.pr.headBranchName }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Update lockfiles
         run: |
-          for dir in $(find . -name "uv.lock" -type f -exec dirname {} \;); do
+          git ls-files "uv.lock" "**/uv.lock" | sort | while IFS= read -r lockfile; do
+            dir=$(dirname "$lockfile")
             echo "Updating $dir"
-            if [ "$dir" = "./libs/acp" ]; then
+            if [ "$dir" = "libs/acp" ]; then
               uv lock --directory "$dir" --python 3.14
             else
               uv lock --directory "$dir" --python 3.12
@@ -203,15 +213,18 @@ jobs:
           done
 
       - name: Commit and push
+        env:
+          RELEASE_BRANCH: ${{ matrix.pr.headBranchName }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "*/uv.lock"
+          git add "uv.lock" "**/uv.lock"
           if git diff --staged --quiet; then
             echo "No lockfile changes to commit"
           else
+            git diff --staged --stat
             git commit -m "chore: update lockfiles"
-            git push
+            git push origin "HEAD:${RELEASE_BRANCH}"
           fi
 
   # Trigger release workflow when CLI release PR is merged


### PR DESCRIPTION
Switch the `update-lockfiles` job to a matrix over release-please's new `prs` output so lockfile regeneration works under `separate-pull-requests: true`. The previous single-PR code path would only check out one branch and silently skip the others when multiple release PRs were created in the same run.
