### PR TITLE
refactor(ci): collapse per-version test matrix into reusable workflow

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -93,7 +93,7 @@ jobs:
           - ${{ inputs.os }}
         include: ${{ fromJSON(inputs.extra-configurations) }}
       fail-fast: false
-    name: "Python ${{ matrix.python-version }} / ${{ matrix.os }}"
+    name: "Python ${{ matrix.python-version }} (${{ matrix.os }})"
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -9,20 +9,30 @@ on:
         required: true
         type: string
         description: "From which folder this pipeline executes"
-      python-version:
+      python-versions:
         required: true
         type: string
-        description: "Python version to use"
+        description: "JSON array of Python versions (must be quoted strings; e.g. '[\"3.11\",\"3.12\"]' — NOT '[3.11, 3.12]') to test on the primary OS"
       os:
         required: false
         type: string
         default: "ubuntu-latest"
-        description: "Runner OS (e.g. ubuntu-latest or windows-latest)"
-      coverage:
+        description: "Primary runner OS (e.g. ubuntu-latest); paired with every python-versions entry"
+      extra-configurations:
         required: false
-        type: boolean
-        default: true
-        description: "Collect coverage (disable to speed up non-primary matrix legs)"
+        type: string
+        default: "[]"
+        description: "JSON array of additional {python-version, os} legs (e.g. '[{\"python-version\":\"3.13\",\"os\":\"windows-latest\"}]')"
+      coverage-python-version:
+        required: false
+        type: string
+        default: ""
+        description: "Python version of the leg on which to collect coverage; empty disables coverage for all legs"
+      coverage-os:
+        required: false
+        type: string
+        default: ""
+        description: "Runner OS of the coverage leg; empty defaults to the primary 'os' input"
 
 permissions:
   contents: read
@@ -32,22 +42,67 @@ env:
   UV_FROZEN: "true"
 
 jobs:
+  validate-inputs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: "🔍 Validate matrix inputs and coverage leg"
+        shell: bash
+        env:
+          VERSIONS: ${{ inputs.python-versions }}
+          EXTRAS: ${{ inputs.extra-configurations }}
+          PRIMARY_OS: ${{ inputs.os }}
+          COV_PY: ${{ inputs.coverage-python-version }}
+          COV_OS: ${{ inputs.coverage-os || inputs.os }}
+        run: |
+          if ! echo "$VERSIONS" | jq -e 'type == "array" and all(.[]; type == "string")' > /dev/null; then
+            echo "::error::python-versions must be a JSON array of quoted strings (got: $VERSIONS)"
+            exit 1
+          fi
+          if ! echo "$EXTRAS" | jq -e 'type == "array" and all(.[]; has("python-version") and has("os") and (.["python-version"] | type == "string") and (.os | type == "string"))' > /dev/null; then
+            echo "::error::extra-configurations must be a JSON array of objects each with string 'python-version' and 'os' keys (got: $EXTRAS)"
+            exit 1
+          fi
+          if [ -z "$COV_PY" ]; then
+            echo "coverage-python-version is empty; coverage disabled for all legs"
+            exit 0
+          fi
+          LEGS=$(jq -nc \
+            --argjson versions "$VERSIONS" \
+            --arg primary_os "$PRIMARY_OS" \
+            --argjson extras "$EXTRAS" \
+            '($versions | map({"python-version": ., "os": $primary_os})) + $extras')
+          if ! echo "$LEGS" | jq -e --arg py "$COV_PY" --arg os "$COV_OS" \
+            'any(.[]; .["python-version"] == $py and .os == $os)' > /dev/null; then
+            echo "::error::coverage leg (python=$COV_PY, os=$COV_OS) is not among configured legs: $LEGS"
+            exit 1
+          fi
+          echo "Coverage will be collected on Python $COV_PY / $COV_OS"
+
   build:
+    needs: validate-inputs
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    name: "Python ${{ inputs.python-version }}"
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-versions) }}
+        os:
+          - ${{ inputs.os }}
+        include: ${{ fromJSON(inputs.extra-configurations) }}
+      fail-fast: false
+    name: "Python ${{ matrix.python-version }} / ${{ matrix.os }}"
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: "🐍 Set up Python ${{ inputs.python-version }} + UV"
+      - name: "🐍 Set up Python ${{ matrix.python-version }} + UV"
         uses: "./.github/actions/uv_setup"
         id: setup-python
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache-suffix: test-${{ inputs.working-directory }}
           working-directory: ${{ inputs.working-directory }}
 
@@ -60,11 +115,16 @@ jobs:
         shell: bash
         env:
           RUN_SANDBOX_TESTS: "true"
+          PY: ${{ matrix.python-version }}
+          PY_OS: ${{ matrix.os }}
+          COV_PY: ${{ inputs.coverage-python-version }}
+          COV_OS: ${{ inputs.coverage-os || inputs.os }}
         run: |
-          if [ "${{ inputs.coverage }}" = "false" ]; then
-            make test COV_ARGS= PYTEST_EXTRA=-q
-          else
+          if [ -n "$COV_PY" ] && [ "$PY" = "$COV_PY" ] && [ "$PY_OS" = "$COV_OS" ]; then
             make test PYTEST_EXTRA=-q
+          else
+            echo "Coverage disabled for Python $PY / $PY_OS (target=$COV_PY / $COV_OS)"
+            make test COV_ARGS= PYTEST_EXTRA=-q
           fi
 
       # Windows cannot run `make test` because `LocalShellBackend` requires POSIX
@@ -76,11 +136,17 @@ jobs:
       - name: "🧪 Run Unit Tests (Windows)"
         if: runner.os == 'Windows'
         shell: bash
+        env:
+          PY: ${{ matrix.python-version }}
+          PY_OS: ${{ matrix.os }}
+          COV_PY: ${{ inputs.coverage-python-version }}
+          COV_OS: ${{ inputs.coverage-os || inputs.os }}
         run: |
-          if [ "${{ inputs.coverage }}" = "false" ]; then
-            uv run --group test pytest -n auto -vvv tests/unit_tests/
-          else
+          if [ -n "$COV_PY" ] && [ "$PY" = "$COV_PY" ] && [ "$PY_OS" = "$COV_OS" ]; then
             uv run --group test pytest -n auto -vvv tests/unit_tests/ --cov=deepagents --cov-report=term-missing
+          else
+            echo "Coverage disabled for Python $PY / $PY_OS (target=$COV_PY / $COV_OS)"
+            uv run --group test pytest -n auto -vvv tests/unit_tests/
           fi
 
       - name: "🧹 Verify Clean Working Directory"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,110 +191,72 @@ jobs:
     name: "🧪 Test deepagents"
     needs: changes
     if: needs.changes.outputs.deepagents == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/deepagents"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
+      extra-configurations: '[{"python-version": "3.13", "os": "windows-latest"}]'
+      coverage-python-version: "3.12"
 
   test-cli:
     name: "🧪 Test cli"
     needs: changes
     if: needs.changes.outputs.cli == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/cli"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
+      coverage-python-version: "3.12"
 
   test-evals:
     name: "🧪 Test evals"
     needs: changes
     if: needs.changes.outputs.evals == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/evals"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
+      python-versions: '["3.12", "3.13", "3.14"]'
+      coverage-python-version: "3.12"
 
   test-daytona:
     name: "🧪 Test daytona"
     needs: changes
     if: needs.changes.outputs.daytona == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/partners/daytona"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
+      coverage-python-version: "3.12"
 
   test-modal:
     name: "🧪 Test modal"
     needs: changes
     if: needs.changes.outputs.modal == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/partners/modal"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
+      coverage-python-version: "3.12"
 
   test-runloop:
     name: "🧪 Test runloop"
     needs: changes
     if: needs.changes.outputs.runloop == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/partners/runloop"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
-
-  test-deepagents-windows:
-    name: "🧪 Test deepagents (Windows)"
-    needs: changes
-    if: needs.changes.outputs.deepagents == 'true' || github.event_name == 'push'
-    uses: ./.github/workflows/_test.yml
-    with:
-      working-directory: "libs/deepagents"
-      python-version: "3.13"
-      os: "windows-latest"
-      coverage: false
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
+      coverage-python-version: "3.12"
 
   test-repl:
     name: "🧪 Test repl"
     needs: changes
     if: needs.changes.outputs.repl == 'true' || github.event_name == 'push'
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-      fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:
       working-directory: "libs/repl"
-      python-version: ${{ matrix.python-version }}
-      coverage: ${{ matrix.python-version == '3.12' }}
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
+      coverage-python-version: "3.12"
 
   # Run CodSpeed benchmarks on SDK changes
   benchmark-deepagents:
@@ -345,7 +307,6 @@ jobs:
       - lint-repl
       - lint-quickjs
       - test-deepagents
-      - test-deepagents-windows
       - test-cli
       - test-evals
       - test-daytona

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -218,7 +218,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "uv.lock" "**/uv.lock"
+          git add "**/uv.lock"
           if git diff --staged --quiet; then
             echo "No lockfile changes to commit"
           else


### PR DESCRIPTION
Collapse the per-Python test matrix into the reusable `_test.yml` workflow so each package renders as a single parent row in the Actions UI with child rows per leg, instead of one top-level row per version. Unify the Windows deepagents leg under the same parent, and tighten input validation and shell handling along the way.

## Changes
- Move `strategy.matrix.python-version` out of each caller in `ci.yml` and into `_test.yml`; callers now pass `python-versions` as a JSON-array string parsed via `fromJSON()`
- Replace the boolean `coverage` input with `coverage-python-version` + `coverage-os` — coverage runs only on the leg matching **both** Python version and OS, avoiding collisions when a version appears on multiple OSes
- Add `extra-configurations` input (JSON array of `{python-version, os}` objects) merged via `matrix.include`; delete the standalone `test-deepagents-windows` job and fold Windows 3.13 into `test-deepagents` as an extra configuration
- Job name is now `Python <ver> / <os>` so the merged rows stay self-describing in the UI
- Add a `validate-inputs` job using `jq` to enforce schema (`python-versions` are quoted strings; each `extra-configurations` entry has string `python-version` and `os`) and to fail loudly if the configured coverage leg isn't among the real matrix legs
- Move all caller-controlled values (`matrix.python-version`, `inputs.coverage-*`) out of inline `${{ }}` in `run:` bodies into `env:` with `$PY` / `$COV_PY` / `$PY_OS` / `$COV_OS` references, closing a template-injection sink on a reusable workflow
- Drop `test-deepagents-windows` from the `ci_success` aggregate's `needs:` list
- Narrow the lockfile pathspec in `release-please.yml` to `git add "**/uv.lock"` (the prior `"uv.lock"` entry was redundant — `**` already matches top-level)
