### PR TITLE
feat(cli): MCP OAuth auth for http/sse servers

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -348,7 +348,9 @@ class QueuedMessage:
     """The input mode that determines message routing."""
 
 
-DeferredActionKind = Literal["model_switch", "thread_switch", "chat_output"]
+DeferredActionKind = Literal[
+    "model_switch", "thread_switch", "chat_output", "mcp_login"
+]
 """Valid `DeferredAction.kind` values for type-checked deduplication."""
 
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -4757,7 +4757,7 @@ class DeepAgentsApp(App):
             await self._mount_message(
                 AppMessage(
                     f"Logged in to MCP server '{server}'. "
-                    f"Run /clear to pick up its tools.{refresh_warning}"
+                    f"Restart the agent to pick up its tools.{refresh_warning}"
                 )
             )
         elif exit_code == exit_no_config:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -346,10 +346,7 @@ def _parse_mcp_login_argv(command: str) -> str:
         raise ValueError(msg)
     server = parts[0]
     if not _SERVER_NAME_RE.fullmatch(server):
-        msg = (
-            f"Invalid server name {server!r}. "
-            "Must match [A-Za-z0-9_-]+."
-        )
+        msg = f"Invalid server name {server!r}. Must match [A-Za-z0-9_-]+."
         raise ValueError(msg)
     return server
 
@@ -4682,7 +4679,7 @@ class DeepAgentsApp(App):
 
         # `_handle_command` routes anything matching `/mcp ...` here. Anything
         # that isn't `/mcp login` is an unknown subcommand.
-        subcommand = command[len("/mcp "):].split(maxsplit=1)
+        subcommand = command[len("/mcp ") :].split(maxsplit=1)
         if not subcommand or subcommand[0] != "login":
             await self._mount_message(
                 AppMessage("Unknown /mcp subcommand. Usage: /mcp login <server>")
@@ -4702,9 +4699,7 @@ class DeepAgentsApp(App):
                     execute=partial(self._run_mcp_login_interactive, server),
                 )
             )
-            self.notify(
-                "MCP login will run after current task completes.", timeout=3
-            )
+            self.notify("MCP login will run after current task completes.", timeout=3)
             return
 
         self.call_later(self._run_mcp_login_interactive, server)
@@ -4736,9 +4731,7 @@ class DeepAgentsApp(App):
         exit_code: int | None = None
         try:
             with self.suspend():
-                exit_code = await run_mcp_login(
-                    server=server, config_path=config_path
-                )
+                exit_code = await run_mcp_login(server=server, config_path=config_path)
         except KeyboardInterrupt:
             await self._mount_message(AppMessage("MCP login cancelled."))
             return
@@ -4772,9 +4765,7 @@ class DeepAgentsApp(App):
                 AppMessage("No MCP config found. Add one and retry.")
             )
         else:
-            await self._mount_message(
-                AppMessage("Login failed. See output above.")
-            )
+            await self._mount_message(AppMessage("Login failed. See output above."))
 
     async def _refresh_mcp_server_info(self) -> None:
         """Re-probe MCP servers and refresh the cached `MCPServerInfo` list.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -4523,8 +4523,6 @@ class DeepAgentsApp(App):
         Args:
             extra_kwargs: Extra constructor kwargs from `--model-params`.
         """
-        from functools import partial
-
         from deepagents_cli.config import settings
         from deepagents_cli.widgets.model_selector import ModelSelectorScreen
 
@@ -4807,8 +4805,6 @@ class DeepAgentsApp(App):
 
     async def _show_thread_selector(self) -> None:
         """Show interactive thread selector as a modal screen."""
-        from functools import partial
-
         from deepagents_cli.sessions import get_cached_threads, get_thread_limit
         from deepagents_cli.widgets.thread_selector import ThreadSelectorScreen
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -4671,6 +4671,73 @@ class DeepAgentsApp(App):
         screen = NotificationSettingsScreen(suppressed=suppressed)
         self.push_screen(screen, handle_result)
 
+    async def _run_mcp_login_interactive(self, server: str) -> None:
+        """Run `deepagents mcp login <server>` with Textual suspended.
+
+        Reuses the existing `run_mcp_login` CLI handler. The Textual event
+        loop's input/output is paused while the OAuth paste-back flow runs
+        on the real TTY (same pattern as `/editor`). Outcomes are translated
+        into chat messages; exceptions never propagate out.
+
+        Args:
+            server: The MCP server name from the user's config.
+        """
+        if self._mcp_preload_kwargs is None:
+            await self._mount_message(
+                AppMessage(
+                    "MCP is disabled — run without --no-mcp and with a valid "
+                    "MCP config to use /mcp login."
+                )
+            )
+            return
+
+        config_path = self._mcp_preload_kwargs.get("mcp_config_path")
+
+        from deepagents_cli.mcp_commands import run_mcp_login
+
+        exit_code: int | None = None
+        try:
+            with self.suspend():
+                exit_code = await run_mcp_login(
+                    server=server, config_path=config_path
+                )
+        except KeyboardInterrupt:
+            await self._mount_message(AppMessage("MCP login cancelled."))
+            return
+        except Exception as exc:  # any failure becomes a chat message
+            logger.exception("MCP login raised unexpectedly")
+            await self._mount_message(
+                AppMessage(f"MCP login failed: {type(exc).__name__}: {exc}")
+            )
+            return
+
+        exit_no_config = 2
+        if exit_code == 0:
+            refresh_warning = ""
+            try:
+                await self._refresh_mcp_server_info()
+            except Exception:  # cache refresh is best-effort
+                logger.warning(
+                    "Failed to refresh /mcp viewer after login", exc_info=True
+                )
+                refresh_warning = (
+                    " (couldn't refresh /mcp viewer — run /reload to retry)"
+                )
+            await self._mount_message(
+                AppMessage(
+                    f"Logged in to MCP server '{server}'. "
+                    f"Run /clear to pick up its tools.{refresh_warning}"
+                )
+            )
+        elif exit_code == exit_no_config:
+            await self._mount_message(
+                AppMessage("No MCP config found. Add one and retry.")
+            )
+        else:
+            await self._mount_message(
+                AppMessage("Login failed. See output above.")
+            )
+
     async def _refresh_mcp_server_info(self) -> None:
         """Re-probe MCP servers and refresh the cached `MCPServerInfo` list.
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -322,6 +322,37 @@ def _extract_model_params_flag(raw_arg: str) -> tuple[str, dict[str, Any] | None
     return remaining, params
 
 
+def _parse_mcp_login_argv(command: str) -> str:
+    """Parse `/mcp login <server>` and return the server name.
+
+    Args:
+        command: The command string starting with `/mcp login`.
+
+    Returns:
+        The server name string extracted from the command.
+
+    Raises:
+        ValueError: If the command is malformed or the server name fails
+            validation. The message is suitable for direct display in chat.
+    """
+    from deepagents_cli.mcp_tools import _SERVER_NAME_RE
+
+    # Strip the "/mcp login" prefix; expect exactly one additional token.
+    rest = command.strip()[len("/mcp login") :].strip()
+    parts = rest.split()
+    if len(parts) != 1:
+        msg = "Usage: /mcp login <server>"
+        raise ValueError(msg)
+    server = parts[0]
+    if not _SERVER_NAME_RE.fullmatch(server):
+        msg = (
+            f"Invalid server name {server!r}. "
+            "Must match [A-Za-z0-9_-]+."
+        )
+        raise ValueError(msg)
+    return server
+
+
 InputMode = Literal["normal", "shell", "command"]
 
 _TYPING_IDLE_THRESHOLD_SECONDS: float = 2.0

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2830,14 +2830,7 @@ class DeepAgentsApp(App):
         elif cmd == "/mcp":
             await self._show_mcp_viewer()
         elif cmd.startswith("/mcp "):
-            stripped = command.strip()
-            if stripped.startswith("/mcp login"):
-                await self._dispatch_mcp_login(stripped)
-            else:
-                await self._mount_message(UserMessage(command))
-                await self._mount_message(
-                    AppMessage("Unknown /mcp subcommand. Usage: /mcp login <server>")
-                )
+            await self._dispatch_mcp_login(command.strip())
         elif cmd == "/theme":
             await self._show_theme_selector()
         elif cmd == "/notifications":
@@ -4686,6 +4679,15 @@ class DeepAgentsApp(App):
             command: The full command string (e.g. `"/mcp login notion"`).
         """
         await self._mount_message(UserMessage(command))
+
+        # `_handle_command` routes anything matching `/mcp ...` here. Anything
+        # that isn't `/mcp login` is an unknown subcommand.
+        subcommand = command[len("/mcp "):].split(maxsplit=1)
+        if not subcommand or subcommand[0] != "login":
+            await self._mount_message(
+                AppMessage("Unknown /mcp subcommand. Usage: /mcp login <server>")
+            )
+            return
 
         try:
             server = _parse_mcp_login_argv(command)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -4671,6 +4671,23 @@ class DeepAgentsApp(App):
         screen = NotificationSettingsScreen(suppressed=suppressed)
         self.push_screen(screen, handle_result)
 
+    async def _refresh_mcp_server_info(self) -> None:
+        """Re-probe MCP servers and refresh the cached `MCPServerInfo` list.
+
+        Called after a successful `/mcp login` so the `/mcp` viewer reflects
+        the new authenticated state. No-op when MCP is disabled (no preload
+        kwargs were stored at startup). Exceptions propagate so the caller
+        can surface a warning to the user.
+        """
+        if self._mcp_preload_kwargs is None:
+            return
+
+        from deepagents_cli.main import _preload_session_mcp_server_info
+
+        info = await _preload_session_mcp_server_info(**self._mcp_preload_kwargs)
+        self._mcp_server_info = info
+        self._mcp_tool_count = sum(len(s.tools) for s in (info or []))
+
     async def _show_mcp_viewer(self) -> None:
         """Show read-only MCP server/tool viewer as a modal screen."""
         from deepagents_cli.widgets.mcp_viewer import MCPViewerScreen

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -15,6 +15,7 @@ import webbrowser
 from collections import deque
 from contextlib import suppress
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -2828,6 +2829,15 @@ class DeepAgentsApp(App):
             await self._handle_skill_command(rewritten)
         elif cmd == "/mcp":
             await self._show_mcp_viewer()
+        elif cmd.startswith("/mcp "):
+            stripped = command.strip()
+            if stripped.startswith("/mcp login"):
+                await self._dispatch_mcp_login(stripped)
+            else:
+                await self._mount_message(UserMessage(command))
+                await self._mount_message(
+                    AppMessage("Unknown /mcp subcommand. Usage: /mcp login <server>")
+                )
         elif cmd == "/theme":
             await self._show_theme_selector()
         elif cmd == "/notifications":
@@ -4670,6 +4680,34 @@ class DeepAgentsApp(App):
 
         screen = NotificationSettingsScreen(suppressed=suppressed)
         self.push_screen(screen, handle_result)
+
+    async def _dispatch_mcp_login(self, command: str) -> None:
+        """Route `/mcp login <server>`: validate, defer when busy, run when idle.
+
+        Args:
+            command: The full command string (e.g. `"/mcp login notion"`).
+        """
+        await self._mount_message(UserMessage(command))
+
+        try:
+            server = _parse_mcp_login_argv(command)
+        except ValueError as exc:
+            await self._mount_message(AppMessage(str(exc)))
+            return
+
+        if self._agent_running or self._shell_running:
+            self._defer_action(
+                DeferredAction(
+                    kind="mcp_login",
+                    execute=partial(self._run_mcp_login_interactive, server),
+                )
+            )
+            self.notify(
+                "MCP login will run after current task completes.", timeout=3
+            )
+            return
+
+        self.call_later(self._run_mcp_login_interactive, server)
 
     async def _run_mcp_login_interactive(self, server: str) -> None:
         """Run `deepagents mcp login <server>` with Textual suspended.

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -86,8 +86,9 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         name="/mcp",
         description="Show active MCP servers and tools",
-        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
-        hidden_keywords="servers",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="servers login",
+        argument_hint="[login <server>]",
     ),
     SlashCommand(
         name="/model",

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -265,6 +265,7 @@ def parse_args() -> argparse.Namespace:
     from deepagents_cli.deploy import setup_deploy_parsers
     from deepagents_cli.output import add_json_output_arg
     from deepagents_cli.skills import setup_skills_parser
+    from deepagents_cli.mcp_commands import setup_mcp_parsers
 
     # Factory that builds an argparse Action whose __call__ invokes the
     # supplied *help_fn* instead of argparse's default help text.  Each
@@ -391,6 +392,8 @@ def parse_args() -> argparse.Namespace:
         subparsers,
         make_help_action=_make_help_action,
     )
+
+    setup_mcp_parsers(subparsers, make_help_action=_make_help_action)
 
     threads_parser = subparsers.add_parser(
         "threads",
@@ -1587,6 +1590,25 @@ def cli_main() -> None:
             else:
                 # No subcommand provided, show threads help screen
                 show_threads_help()
+        elif args.command == "mcp":
+            if args.mcp_command == "login":
+                import asyncio
+
+                from deepagents_cli.mcp_commands import run_mcp_login
+
+                exit_code = asyncio.run(
+                    run_mcp_login(
+                        server=args.server,
+                        config_path=args.config_path,
+                    )
+                )
+                sys.exit(exit_code)
+            else:
+                console.print(
+                    "[bold red]Error:[/bold red] "
+                    "Unknown mcp subcommand. Try: deepagents mcp login <server>"
+                )
+                sys.exit(2)
         elif args.non_interactive_message:
             # Check for optional tools before running agent (stderr so
             # --quiet piped output stays clean)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1594,10 +1594,13 @@ def cli_main() -> None:
             if args.mcp_command == "login":
                 from deepagents_cli.mcp_commands import run_mcp_login
 
+                # Subcommand-scoped `--config` wins over the global
+                # `--mcp-config` if both are set.
+                config_path = args.config_path or getattr(args, "mcp_config", None)
                 exit_code = asyncio.run(
                     run_mcp_login(
                         server=args.server,
-                        config_path=args.config_path,
+                        config_path=config_path,
                     )
                 )
                 sys.exit(exit_code)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -263,9 +263,9 @@ def parse_args() -> argparse.Namespace:
         Parsed arguments namespace.
     """
     from deepagents_cli.deploy import setup_deploy_parsers
+    from deepagents_cli.mcp_commands import setup_mcp_parsers
     from deepagents_cli.output import add_json_output_arg
     from deepagents_cli.skills import setup_skills_parser
-    from deepagents_cli.mcp_commands import setup_mcp_parsers
 
     # Factory that builds an argparse Action whose __call__ invokes the
     # supplied *help_fn* instead of argparse's default help text.  Each

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1605,11 +1605,9 @@ def cli_main() -> None:
                 )
                 sys.exit(exit_code)
             else:
-                console.print(
-                    "[bold red]Error:[/bold red] "
-                    "Unknown mcp subcommand. Try: deepagents mcp login <server>"
-                )
-                sys.exit(2)
+                from deepagents_cli.ui import show_mcp_help
+
+                show_mcp_help()
         elif args.non_interactive_message:
             # Check for optional tools before running agent (stderr so
             # --quiet piped output stays clean)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1592,8 +1592,6 @@ def cli_main() -> None:
                 show_threads_help()
         elif args.command == "mcp":
             if args.mcp_command == "login":
-                import asyncio
-
                 from deepagents_cli.mcp_commands import run_mcp_login
 
                 exit_code = asyncio.run(

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -19,6 +19,54 @@ _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _STORAGE_VERSION = 1
 
 
+# Slack's MCP server rejects Dynamic Client Registration — every client must
+# use a pre-registered Slack app ID. See Slack's MCP "App Identity" docs.
+# https://localhost is the redirect URI registered on the Slack app; the CLI's
+# paste-back flow lets the user copy the final URL after OAuth approval.
+_SLACK_MCP_CLIENT_ID = "4518649543379.10944517634130"
+_SLACK_REDIRECT_URI = "https://localhost"
+
+
+def _is_slack_mcp_url(url: str) -> bool:
+    """Return True when *url* points at a Slack-hosted MCP endpoint.
+
+    Matches any `*.slack.com` or `slack.com` host so the special-case stays
+    robust across subdomain changes (e.g., `mcp.slack.com` → `api.slack.com`).
+    """
+    host = urlparse(url).hostname or ""
+    return host == "slack.com" or host.endswith(".slack.com")
+
+
+_SLACK_TEAM_ID_RE = re.compile(r"^T[A-Z0-9]{2,}$")
+
+
+def _prompt_slack_team() -> str | None:
+    """Interactively ask the user which Slack workspace to install into.
+
+    Slack's `/oauth/v2/authorize` accepts an optional `team=<team_id>`
+    parameter that pre-selects the workspace. When the user leaves the prompt
+    blank, Slack shows its own workspace picker on the authorization page,
+    which is the right default for first-time or single-workspace users.
+
+    Returns:
+        The entered team ID (e.g., ``T01234567``), or ``None`` if the user
+        left the prompt blank.
+    """
+    raw = input(
+        "Slack team ID to install the app into "
+        "(e.g. T01234567 — leave blank to pick on Slack's page): "
+    ).strip()
+    if not raw:
+        return None
+    if not _SLACK_TEAM_ID_RE.fullmatch(raw):
+        msg = (
+            f"Invalid Slack team ID {raw!r}. Team IDs start with 'T' and "
+            "contain only uppercase letters and digits (e.g. 'T01234567')."
+        )
+        raise RuntimeError(msg)
+    return raw
+
+
 def resolve_headers(
     headers: dict[str, str],
     *,
@@ -204,19 +252,29 @@ RedirectHandler = Callable[[str], Awaitable[None]]
 CallbackHandler = Callable[[], Awaitable[tuple[str, str | None]]]
 
 
-def _make_paste_back_handlers() -> tuple[RedirectHandler, CallbackHandler]:
+def _make_paste_back_handlers(
+    *, extra_auth_params: dict[str, str] | None = None
+) -> tuple[RedirectHandler, CallbackHandler]:
     """Create paste-back redirect and callback handlers for OAuth.
+
+    Args:
+        extra_auth_params: Extra query-string parameters to merge into the
+            authorization URL before showing it to the user. Used to thread
+            vendor-specific hints (e.g., Slack's ``team=<id>``) without
+            changing the MCP SDK's URL-builder.
 
     Returns:
         A tuple of (redirect_handler, callback_handler) functions that implement
         the paste-back OAuth flow for interactive CLI use.
     """
+    extras = dict(extra_auth_params or {})
 
     async def redirect(auth_url: str) -> None:
+        final_url = _append_query_params(auth_url, extras) if extras else auth_url
         print(  # noqa: T201 - intentional user-facing prompt
             "\nOpen this URL in a browser, approve access, then paste the full "
             "callback URL back here:\n"
-            f"\n  {auth_url}\n"
+            f"\n  {final_url}\n"
         )
 
     async def callback() -> tuple[str, str | None]:
@@ -230,33 +288,64 @@ def _make_paste_back_handlers() -> tuple[RedirectHandler, CallbackHandler]:
     return redirect, callback
 
 
+def _append_query_params(url: str, params: dict[str, str]) -> str:
+    """Return *url* with *params* merged into its query string.
+
+    New keys override any existing value for the same key. Preserves the
+    original scheme, netloc, path, and fragment.
+    """
+    from urllib.parse import urlencode, urlunparse
+
+    parsed = urlparse(url)
+    existing = dict(parse_qs(parsed.query, keep_blank_values=True))
+    for key, value in params.items():
+        existing[key] = [value]
+    new_query = urlencode(existing, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+
+
 def build_oauth_provider(
     *,
     server_name: str,  # noqa: ARG001 - reserved for future error-message use
     server_url: str,
     storage: TokenStorage,
+    extra_auth_params: dict[str, str] | None = None,
 ) -> OAuthClientProvider:
     """Construct a paste-back `OAuthClientProvider` for an MCP server.
 
     The metadata defaults match what most public MCP servers accept under
     Dynamic Client Registration; servers are expected to advertise scopes
-    via their OAuth metadata document.
+    via their OAuth metadata document. Slack is special-cased — it rejects
+    DCR and requires a pre-registered app ID (see `_SLACK_MCP_CLIENT_ID`),
+    so the metadata uses Slack's registered `https://localhost` redirect URI.
 
     Args:
         server_name: The name of the MCP server (for future error messages).
         server_url: The MCP server's URL (e.g., "https://mcp.notion.com/mcp").
         storage: A TokenStorage instance for persisting OAuth credentials.
+        extra_auth_params: Extra query params appended to the authorization
+            URL before the user is prompted to open it. Used for Slack's
+            ``team=<id>`` workspace selector.
 
     Returns:
         An OAuthClientProvider configured for paste-back OAuth flow.
     """
-    redirect, callback = _make_paste_back_handlers()
-    metadata = OAuthClientMetadata(
-        client_name="deepagents-cli",
-        redirect_uris=[AnyUrl("http://localhost/callback")],
-        grant_types=["authorization_code", "refresh_token"],
-        response_types=["code"],
-    )
+    redirect, callback = _make_paste_back_handlers(extra_auth_params=extra_auth_params)
+    if _is_slack_mcp_url(server_url):
+        metadata = OAuthClientMetadata(
+            client_name="deepagents-cli",
+            redirect_uris=[AnyUrl(_SLACK_REDIRECT_URI)],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    else:
+        metadata = OAuthClientMetadata(
+            client_name="deepagents-cli",
+            redirect_uris=[AnyUrl("http://localhost/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+        )
     return OAuthClientProvider(
         server_url=server_url,
         client_metadata=metadata,
@@ -264,6 +353,53 @@ def build_oauth_provider(
         redirect_handler=redirect,
         callback_handler=callback,
     )
+
+
+async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:
+    """Write the hardcoded Slack `client_info` to *storage* if not already set.
+
+    The MCP SDK's `OAuthClientProvider` calls `storage.get_client_info()` at
+    the start of the flow and, when it returns non-None, skips Dynamic Client
+    Registration entirely (see `mcp/client/auth/oauth2.py:561`). Pre-seeding
+    storage is therefore how we opt out of DCR for Slack.
+    """
+    existing = await storage.get_client_info()
+    if existing is not None and existing.client_id == _SLACK_MCP_CLIENT_ID:
+        return
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id=_SLACK_MCP_CLIENT_ID,
+            redirect_uris=[AnyUrl(_SLACK_REDIRECT_URI)],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+
+def _find_http_status_error(exc: BaseException) -> Any:
+    """Recursively search *exc* (and any ExceptionGroup it wraps) for an
+    `httpx.HTTPStatusError`.
+
+    The MCP streamable-HTTP client runs inside an anyio `TaskGroup`, so HTTP
+    errors from `raise_for_status` arrive wrapped in one or more
+    `BaseExceptionGroup` layers. Returns the innermost `HTTPStatusError` or
+    `None` if the exception tree doesn't contain one.
+    """
+    import httpx
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc
+    sub_exceptions = getattr(exc, "exceptions", None)
+    if sub_exceptions:
+        for sub in sub_exceptions:
+            found = _find_http_status_error(sub)
+            if found is not None:
+                return found
+    cause = exc.__cause__ or exc.__context__
+    if cause is not None and cause is not exc:
+        return _find_http_status_error(cause)
+    return None
 
 
 async def _drive_handshake(
@@ -274,14 +410,116 @@ async def _drive_handshake(
     The MCP SDK's `OAuthClientProvider` hooks into session startup and runs
     discovery → DCR → paste-back handlers → token exchange. Tokens land in
     `storage` via `set_tokens` before this returns.
+
+    When the post-OAuth MCP init request fails with an HTTP error, the
+    response body almost always carries the real reason (invalid_scope,
+    missing_team, etc.). We unwrap the ExceptionGroup-wrapped error so that
+    body gets surfaced to the user instead of being swallowed.
     """
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
     client = MultiServerMCPClient(connections=connections)
     server_name = next(iter(connections))
-    async with client.session(server_name):
-        # Entering the session drives the full flow.
-        pass
+    try:
+        async with client.session(server_name):
+            # Entering the session drives the full flow.
+            pass
+    except BaseException as exc:
+        status_error = _find_http_status_error(exc)
+        if status_error is None:
+            raise
+        response = status_error.response
+        request = status_error.request
+
+        # Streamed responses have already been consumed by `raise_for_status`;
+        # try several paths to recover the body for the user.
+        body = ""
+        for reader in (
+            lambda: response.text,
+            lambda: response.content.decode(errors="replace"),
+        ):
+            try:
+                body = reader()
+                if body:
+                    break
+            except Exception:  # noqa: BLE001 — best-effort diagnostic
+                continue
+        if not body:
+            try:
+                await response.aread()
+                body = response.text
+            except Exception:  # noqa: BLE001
+                pass
+
+        lines = [
+            f"MCP server '{server_name}' rejected the initialize request:",
+            f"  HTTP {response.status_code} {response.reason_phrase} "
+            f"from {request.method} {request.url}",
+        ]
+        content_type = response.headers.get("content-type")
+        if content_type:
+            lines.append(f"  Content-Type: {content_type}")
+        slack_err = response.headers.get("x-slack-error")
+        if slack_err:
+            lines.append(f"  X-Slack-Error: {slack_err}")
+        www_auth = response.headers.get("www-authenticate")
+        if www_auth:
+            lines.append(f"  WWW-Authenticate: {www_auth}")
+
+        if body:
+            truncated = body if len(body) <= 2000 else body[:2000] + "…[truncated]"
+            lines.append("\nResponse body:")
+            lines.append(truncated)
+        else:
+            # Streamed responses in the MCP SDK are consumed by raise_for_status
+            # before we can read the body. Replay the request manually as a
+            # non-streaming POST so we can see what the server actually said.
+            replay = await _replay_request_for_body(request)
+            if replay is not None:
+                lines.append("\n[Replayed request to capture response body]")
+                lines.append(replay)
+            else:
+                lines.append(
+                    "\n(Response body was empty on both the original request "
+                    "and a replay. Check the Slack app's OAuth scopes and the "
+                    "MCP-Protocol-Version the server expects.)"
+                )
+
+        raise RuntimeError("\n".join(lines)) from status_error
+
+
+async def _replay_request_for_body(request: Any) -> str | None:
+    """Resend *request* as a non-streaming POST so we can read the body.
+
+    The MCP SDK streams responses, which makes failed 4xx/5xx bodies
+    unavailable after `raise_for_status` closes the stream. Replaying the
+    same request outside of streaming mode is the simplest way to recover
+    the body for diagnostics.
+
+    Returns a human-readable summary (status line + body, truncated) or
+    ``None`` if the replay itself failed.
+    """
+    import httpx
+
+    try:
+        body_bytes = request.content
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.request(
+                request.method,
+                str(request.url),
+                content=body_bytes,
+                headers=dict(request.headers),
+            )
+        preview = resp.text
+        if len(preview) > 2000:  # noqa: PLR2004 — inline truncation threshold
+            preview = preview[:2000] + "…[truncated]"
+        return (
+            f"HTTP {resp.status_code} {resp.reason_phrase}\n"
+            f"Content-Type: {resp.headers.get('content-type', '(none)')}\n\n"
+            f"{preview}"
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort diagnostic
+        return f"(replay failed: {type(exc).__name__}: {exc})"
 
 
 async def login(
@@ -314,10 +552,25 @@ async def login(
         raise ValueError(msg)
 
     storage = FileTokenStorage(server_name)
+
+    extra_auth_params: dict[str, str] = {}
+
+    # Slack forbids Dynamic Client Registration; pre-seed storage with the
+    # hardcoded app's client_info so the MCP SDK skips its DCR branch. Also
+    # prompt for a team ID so users on multiple workspaces can pick which one
+    # the app gets installed into; Slack's `/oauth/v2/authorize` accepts
+    # `team=<team_id>` to pre-select, or shows a workspace picker when absent.
+    if _is_slack_mcp_url(server_config["url"]):
+        await _preseed_slack_client_info(storage)
+        team_id = _prompt_slack_team()
+        if team_id:
+            extra_auth_params["team"] = team_id
+
     provider = build_oauth_provider(
         server_name=server_name,
         server_url=server_config["url"],
         storage=storage,
+        extra_auth_params=extra_auth_params or None,
     )
     conn: dict
     if transport == "http":

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -480,6 +480,11 @@ async def _run_device_flow(
     param is provider-dependent: GitHub Apps ignore it (permissions come from
     app config), OAuth Apps and most other IdPs require it.
 
+    Returns:
+        The issued `OAuthToken` (bearer access token, refresh token when
+        supported, and expiry). Refresh tokens are not guaranteed by the
+        Device Flow; callers must handle `refresh_token is None`.
+
     Raises:
         RuntimeError: If the provider returns a terminal error, or the user
             doesn't complete authorization before the device code expires.
@@ -529,10 +534,7 @@ async def _run_device_flow(
                 interval += 5
                 continue
             if err:
-                msg = (
-                    f"Device flow failed: {err}: "
-                    f"{body.get('error_description', '')}"
-                )
+                msg = f"Device flow failed: {err}: {body.get('error_description', '')}"
                 raise RuntimeError(msg)
             return OAuthToken.model_validate(body)
 
@@ -790,8 +792,7 @@ async def login(
     if _is_github_mcp_url(server_config["url"]):
         await _preseed_github_auth(storage)
         print(  # noqa: T201 — user-facing confirmation
-            f"Logged in to MCP server '{server_name}'. "
-            f"Tokens saved to {storage._path}."
+            f"Logged in to MCP server '{server_name}'. Tokens saved to {storage._path}."
         )
         return
 

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -50,6 +50,21 @@ def _is_slack_mcp_url(url: str) -> bool:
     return host == "slack.com" or host.endswith(".slack.com")
 
 
+# GitHub's Remote MCP Server rejects DCR and its token endpoint requires a
+# client_secret — unsafe to distribute in a public CLI. RFC 8628 Device Flow
+# works with client_id only, so the CLI obtains a GitHub access token that
+# way and pre-seeds it into storage; the MCP SDK then treats auth as already
+# complete and attaches `Authorization: Bearer <token>` to every request.
+_GITHUB_MCP_CLIENT_ID = "Ov23lirWr31UGKF4GEo3"
+_GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+_GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"  # noqa: S105 — OAuth endpoint URL, not a secret
+
+
+def _is_github_mcp_url(url: str) -> bool:
+    """Return True when *url* points at GitHub's remote MCP endpoint."""
+    return (urlparse(url).hostname or "") == "api.githubcopilot.com"
+
+
 _SLACK_TEAM_ID_RE = re.compile(r"^T[A-Z0-9]{2,}$")
 
 
@@ -397,6 +412,108 @@ async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:
     )
 
 
+async def _run_device_flow(
+    *,
+    device_code_url: str,
+    token_url: str,
+    client_id: str,
+    scope: str | None = None,
+) -> OAuthToken:
+    """Run OAuth 2.0 Device Authorization Grant (RFC 8628) and return the token.
+
+    Generic across providers that implement RFC 8628. Omits `client_secret` —
+    only use for public clients (CLIs, desktop apps). Callers pass provider-
+    specific endpoints and the registered public `client_id`. The `scope`
+    param is provider-dependent: GitHub Apps ignore it (permissions come from
+    app config), OAuth Apps and most other IdPs require it.
+
+    Raises:
+        RuntimeError: If the provider returns a terminal error, or the user
+            doesn't complete authorization before the device code expires.
+    """
+    import asyncio
+
+    import httpx
+
+    init_data = {"client_id": client_id}
+    if scope is not None:
+        init_data["scope"] = scope
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            device_code_url,
+            data=init_data,
+            headers={"Accept": "application/json"},
+        )
+        resp.raise_for_status()
+        dev = resp.json()
+
+        print(  # noqa: T201 — user-facing prompt
+            f"\nVisit {dev['verification_uri']} and enter code: "
+            f"{dev['user_code']}\n(code expires in {dev['expires_in']}s)\n"
+        )
+
+        interval = max(int(dev.get("interval", 5)), 1)
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + int(dev["expires_in"])
+        while loop.time() < deadline:
+            await asyncio.sleep(interval)
+            tok = await client.post(
+                token_url,
+                data={
+                    "client_id": client_id,
+                    "device_code": dev["device_code"],
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                },
+                headers={"Accept": "application/json"},
+            )
+            tok.raise_for_status()
+            body = tok.json()
+            err = body.get("error")
+            if err == "authorization_pending":
+                continue
+            if err == "slow_down":
+                interval += 5
+                continue
+            if err:
+                msg = (
+                    f"Device flow failed: {err}: "
+                    f"{body.get('error_description', '')}"
+                )
+                raise RuntimeError(msg)
+            return OAuthToken.model_validate(body)
+
+    msg = "Device flow timed out; re-run `deepagents mcp login <server>`."
+    raise RuntimeError(msg)
+
+
+async def _preseed_github_auth(storage: FileTokenStorage) -> None:
+    """Run GitHub Device Flow and persist the token + stub client_info.
+
+    GitHub Apps ignore the ``scope`` param — permissions come from the app's
+    configured permissions, so we don't send one. The client_info stub exists
+    purely so the MCP SDK skips its DCR branch on subsequent sessions; token
+    refresh against GitHub requires a client_secret and isn't supported in
+    this flow, so callers must re-run ``mcp login <server>`` when tokens
+    expire.
+    """
+    token = await _run_device_flow(
+        device_code_url=_GITHUB_DEVICE_CODE_URL,
+        token_url=_GITHUB_TOKEN_URL,
+        client_id=_GITHUB_MCP_CLIENT_ID,
+    )
+    await storage.set_tokens(token)
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id=_GITHUB_MCP_CLIENT_ID,
+            redirect_uris=[AnyUrl("http://localhost/callback")],
+            grant_types=["urn:ietf:params:oauth:grant-type:device_code"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",  # noqa: S106 — OAuth method literal, not a password
+        )
+    )
+
+
 def _find_http_status_error(exc: BaseException) -> httpx.HTTPStatusError | None:
     """Find the first `httpx.HTTPStatusError` wrapped inside *exc*.
 
@@ -586,6 +703,18 @@ async def login(
         raise ValueError(msg)
 
     storage = FileTokenStorage(server_name)
+
+    # GitHub's MCP server doesn't implement DCR, and its token endpoint
+    # requires a client_secret that a public CLI can't safely distribute.
+    # Route through Device Flow (no secret) and persist the bearer token so
+    # regular MCP sessions pick it up via FileTokenStorage.get_tokens().
+    if _is_github_mcp_url(server_config["url"]):
+        await _preseed_github_auth(storage)
+        print(  # noqa: T201 — user-facing confirmation
+            f"Logged in to MCP server '{server_name}'. "
+            f"Tokens saved to {storage._path}."
+        )
+        return
 
     extra_auth_params: dict[str, str] = {}
 

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
+import stat
+from pathlib import Path
+
+from mcp.client.auth import TokenStorage
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
 
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+_STORAGE_VERSION = 1
 
 
 def resolve_headers(
@@ -76,3 +84,115 @@ def _interpolate(s: str, *, header: str, server_name: str | None) -> str:
         out.append(ch)
         i += 1
     return "".join(out)
+
+
+def _tokens_dir() -> Path:
+    """Resolve the mcp-tokens directory.
+
+    Re-reads `$HOME` on every call so tests that override it via
+    `monkeypatch.setenv("HOME", ...)` transparently redirect token files.
+    Falls back to the module-level `DEFAULT_CONFIG_DIR` when `$HOME` is unset.
+    """
+    home_override = os.environ.get("HOME")
+    if home_override:
+        return Path(home_override) / ".deepagents" / "mcp-tokens"
+    from deepagents_cli.model_config import DEFAULT_CONFIG_DIR
+
+    return DEFAULT_CONFIG_DIR / "mcp-tokens"
+
+
+class FileTokenStorage(TokenStorage):
+    """File-backed `TokenStorage` under `~/.deepagents/mcp-tokens/<server>.json`.
+
+    Atomic-write via tmp-file + `os.replace` + chmod(0o600). Directory is
+    created with mode 0o700. Permission bits are POSIX-only.
+    """
+
+    def __init__(self, server_name: str) -> None:
+        self._server_name = server_name
+
+    @property
+    def _path(self) -> Path:
+        return _tokens_dir() / f"{self._server_name}.json"
+
+    async def get_tokens(self) -> OAuthToken | None:
+        data = self._read()
+        if data is None:
+            return None
+        raw = data.get("tokens")
+        if raw is None:
+            return None
+        return OAuthToken.model_validate(raw)
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        data = self._read() or {}
+        data["version"] = _STORAGE_VERSION
+        data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
+        self._write(data)
+
+    async def get_client_info(self) -> OAuthClientInformationFull | None:
+        data = self._read()
+        if data is None:
+            return None
+        raw = data.get("client_info")
+        if raw is None:
+            return None
+        return OAuthClientInformationFull.model_validate(raw)
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        data = self._read() or {}
+        data["version"] = _STORAGE_VERSION
+        data["client_info"] = json.loads(
+            client_info.model_dump_json(exclude_none=True)
+        )
+        self._write(data)
+
+    def _read(self) -> dict | None:
+        path = self._path
+        if not path.exists():
+            return None
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            msg = (
+                f"Failed to read MCP token file {path}: {exc}. "
+                "Delete the file and re-run `deepagents mcp login "
+                f"{self._server_name}` if it is corrupt."
+            )
+            raise RuntimeError(msg) from exc
+        if data.get("version") != _STORAGE_VERSION:
+            msg = (
+                f"MCP token file {path} has unsupported version "
+                f"{data.get('version')!r} (expected {_STORAGE_VERSION}). "
+                "Delete it and re-run `deepagents mcp login "
+                f"{self._server_name}`."
+            )
+            raise RuntimeError(msg)
+        return data
+
+    def _write(self, data: dict) -> None:
+        path = self._path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Tighten directory perms on POSIX (best effort on Windows).
+        if hasattr(os, "chmod"):
+            try:
+                os.chmod(path.parent, stat.S_IRWXU)  # 0o700
+            except OSError:
+                pass
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
+        try:
+            os.replace(tmp, path)
+        except Exception:
+            # Clean up the tmp file so no partial state leaks at the final path.
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise
+        if hasattr(os, "chmod"):
+            try:
+                os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+            except OSError:
+                pass

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -2,21 +2,34 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
 import stat
 from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 from mcp.client.auth import OAuthClientProvider, TokenStorage
-from mcp.shared.auth import AnyUrl, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from mcp.shared.auth import (
+    AnyUrl,
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthToken,
+)
 
+if TYPE_CHECKING:
+    import httpx
 
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 _STORAGE_VERSION = 1
+
+# Cap HTTP response bodies (and replays) shown in error messages so a
+# misconfigured server can't flood the user's terminal with MBs of HTML.
+_BODY_TRUNCATE_AT = 2000
 
 
 # Slack's MCP server rejects Dynamic Client Registration — every client must
@@ -51,6 +64,9 @@ def _prompt_slack_team() -> str | None:
     Returns:
         The entered team ID (e.g., ``T01234567``), or ``None`` if the user
         left the prompt blank.
+
+    Raises:
+        RuntimeError: If the entered ID isn't a valid Slack team ID format.
     """
     raw = input(
         "Slack team ID to install the app into "
@@ -77,10 +93,14 @@ def resolve_headers(
     `$${VAR}` is the escape form and collapses to the literal `${VAR}` with no
     lookup. A dollar sign not followed by `{` or `$` is left untouched.
 
+    Returns:
+        A new dict with all env-var references resolved to their current values.
+
     Raises:
         TypeError: If a header value is not a string.
-        RuntimeError: If a `${VAR}` references an unset environment variable.
-    """
+        RuntimeError: If a `${VAR}` references an unset environment variable
+            (propagated from the inner `_interpolate` helper).
+    """  # noqa: DOC502 — RuntimeError is raised via `_interpolate`
     resolved: dict[str, str] = {}
     for name, value in headers.items():
         if not isinstance(value, str):
@@ -142,6 +162,9 @@ def _tokens_dir() -> Path:
     Re-reads `$HOME` on every call so tests that override it via
     `monkeypatch.setenv("HOME", ...)` transparently redirect token files.
     Falls back to the module-level `DEFAULT_CONFIG_DIR` when `$HOME` is unset.
+
+    Returns:
+        Absolute path to the per-user mcp-tokens directory.
     """
     home_override = os.environ.get("HOME")
     if home_override:
@@ -159,6 +182,7 @@ class FileTokenStorage(TokenStorage):
     """
 
     def __init__(self, server_name: str) -> None:
+        """Bind this storage to *server_name* under `~/.deepagents/mcp-tokens/`."""
         self._server_name = server_name
 
     @property
@@ -166,6 +190,7 @@ class FileTokenStorage(TokenStorage):
         return _tokens_dir() / f"{self._server_name}.json"
 
     async def get_tokens(self) -> OAuthToken | None:
+        """Return the stored `OAuthToken`, or `None` if none is persisted."""
         data = self._read()
         if data is None:
             return None
@@ -175,12 +200,14 @@ class FileTokenStorage(TokenStorage):
         return OAuthToken.model_validate(raw)
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
+        """Persist *tokens* to disk, merging with any existing client_info."""
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
         self._write(data)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
+        """Return the stored client registration, or `None` if none is persisted."""
         data = self._read()
         if data is None:
             return None
@@ -190,11 +217,10 @@ class FileTokenStorage(TokenStorage):
         return OAuthClientInformationFull.model_validate(raw)
 
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        """Persist *client_info* to disk, merging with any existing tokens."""
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
-        data["client_info"] = json.loads(
-            client_info.model_dump_json(exclude_none=True)
-        )
+        data["client_info"] = json.loads(client_info.model_dump_json(exclude_none=True))
         self._write(data)
 
     def _read(self) -> dict | None:
@@ -226,26 +252,20 @@ class FileTokenStorage(TokenStorage):
         path.parent.mkdir(parents=True, exist_ok=True)
         # Tighten directory perms on POSIX (best effort on Windows).
         if hasattr(os, "chmod"):
-            try:
-                os.chmod(path.parent, stat.S_IRWXU)  # 0o700
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                Path(path.parent).chmod(stat.S_IRWXU)  # 0o700
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
         try:
-            os.replace(tmp, path)
+            Path(tmp).replace(path)
         except Exception:
             # Clean up the tmp file so no partial state leaks at the final path.
-            try:
+            with contextlib.suppress(OSError):
                 tmp.unlink()
-            except OSError:
-                pass
             raise
         if hasattr(os, "chmod"):
-            try:
-                os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                Path(path).chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
 
 
 RedirectHandler = Callable[[str], Awaitable[None]]
@@ -269,7 +289,7 @@ def _make_paste_back_handlers(
     """
     extras = dict(extra_auth_params or {})
 
-    async def redirect(auth_url: str) -> None:
+    async def redirect(auth_url: str) -> None:  # noqa: RUF029 — MCP SDK requires async handler
         final_url = _append_query_params(auth_url, extras) if extras else auth_url
         print(  # noqa: T201 - intentional user-facing prompt
             "\nOpen this URL in a browser, approve access, then paste the full "
@@ -277,8 +297,8 @@ def _make_paste_back_handlers(
             f"\n  {final_url}\n"
         )
 
-    async def callback() -> tuple[str, str | None]:
-        url = input("Callback URL: ").strip()
+    async def callback() -> tuple[str, str | None]:  # noqa: RUF029 — MCP SDK requires async handler
+        url = input("Callback URL: ").strip()  # noqa: ASYNC250 — interactive paste-back is intentional
         params = parse_qs(urlparse(url).query)
         if "code" not in params or not params["code"]:
             msg = "Callback URL is missing the 'code' parameter."
@@ -337,7 +357,7 @@ def build_oauth_provider(
             redirect_uris=[AnyUrl(_SLACK_REDIRECT_URI)],
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
-            token_endpoint_auth_method="none",
+            token_endpoint_auth_method="none",  # noqa: S106 — OAuth method literal, not a password
         )
     else:
         metadata = OAuthClientMetadata(
@@ -372,19 +392,22 @@ async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:
             redirect_uris=[AnyUrl(_SLACK_REDIRECT_URI)],
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
-            token_endpoint_auth_method="none",
+            token_endpoint_auth_method="none",  # noqa: S106 — OAuth method literal, not a password
         )
     )
 
 
-def _find_http_status_error(exc: BaseException) -> Any:
-    """Recursively search *exc* (and any ExceptionGroup it wraps) for an
-    `httpx.HTTPStatusError`.
+def _find_http_status_error(exc: BaseException) -> httpx.HTTPStatusError | None:
+    """Find the first `httpx.HTTPStatusError` wrapped inside *exc*.
 
-    The MCP streamable-HTTP client runs inside an anyio `TaskGroup`, so HTTP
-    errors from `raise_for_status` arrive wrapped in one or more
-    `BaseExceptionGroup` layers. Returns the innermost `HTTPStatusError` or
-    `None` if the exception tree doesn't contain one.
+    Recursively searches *exc* and any `BaseExceptionGroup` / chained
+    `__cause__` / `__context__` it wraps. The MCP streamable-HTTP client runs
+    inside an anyio `TaskGroup`, so HTTP errors from `raise_for_status` arrive
+    wrapped in one or more `BaseExceptionGroup` layers.
+
+    Returns:
+        The innermost `httpx.HTTPStatusError` found, or `None` if the
+        exception tree doesn't contain one.
     """
     import httpx
 
@@ -403,7 +426,8 @@ def _find_http_status_error(exc: BaseException) -> Any:
 
 
 async def _drive_handshake(
-    connections: dict, storage: FileTokenStorage
+    connections: dict,
+    storage: FileTokenStorage,  # noqa: ARG001 — documents caller contract; SDK writes via the provider
 ) -> None:
     """Open a one-shot MCP session to trigger the OAuth handshake.
 
@@ -415,6 +439,11 @@ async def _drive_handshake(
     response body almost always carries the real reason (invalid_scope,
     missing_team, etc.). We unwrap the ExceptionGroup-wrapped error so that
     body gets surfaced to the user instead of being swallowed.
+
+    Raises:
+        RuntimeError: If the MCP server rejects the initialize request with
+            an HTTP error; the message includes status line, headers, and the
+            response body when recoverable.
     """
     from langchain_mcp_adapters.client import MultiServerMCPClient
 
@@ -442,19 +471,21 @@ async def _drive_handshake(
                 body = reader()
                 if body:
                     break
-            except Exception:  # noqa: BLE001 — best-effort diagnostic
+            except Exception:  # noqa: BLE001, S112 — best-effort diagnostic, swallow and try next
                 continue
         if not body:
             try:
                 await response.aread()
                 body = response.text
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001, S110 — best-effort diagnostic, body stays empty
                 pass
 
         lines = [
             f"MCP server '{server_name}' rejected the initialize request:",
-            f"  HTTP {response.status_code} {response.reason_phrase} "
-            f"from {request.method} {request.url}",
+            (
+                f"  HTTP {response.status_code} {response.reason_phrase} "
+                f"from {request.method} {request.url}"
+            ),
         ]
         content_type = response.headers.get("content-type")
         if content_type:
@@ -467,17 +498,19 @@ async def _drive_handshake(
             lines.append(f"  WWW-Authenticate: {www_auth}")
 
         if body:
-            truncated = body if len(body) <= 2000 else body[:2000] + "…[truncated]"
-            lines.append("\nResponse body:")
-            lines.append(truncated)
+            truncated = (
+                body
+                if len(body) <= _BODY_TRUNCATE_AT
+                else body[:_BODY_TRUNCATE_AT] + "…[truncated]"
+            )
+            lines.extend(("\nResponse body:", truncated))
         else:
             # Streamed responses in the MCP SDK are consumed by raise_for_status
             # before we can read the body. Replay the request manually as a
             # non-streaming POST so we can see what the server actually said.
             replay = await _replay_request_for_body(request)
             if replay is not None:
-                lines.append("\n[Replayed request to capture response body]")
-                lines.append(replay)
+                lines.extend(("\n[Replayed request to capture response body]", replay))
             else:
                 lines.append(
                     "\n(Response body was empty on both the original request "
@@ -488,7 +521,7 @@ async def _drive_handshake(
         raise RuntimeError("\n".join(lines)) from status_error
 
 
-async def _replay_request_for_body(request: Any) -> str | None:
+async def _replay_request_for_body(request: httpx.Request) -> str | None:
     """Resend *request* as a non-streaming POST so we can read the body.
 
     The MCP SDK streams responses, which makes failed 4xx/5xx bodies
@@ -496,8 +529,9 @@ async def _replay_request_for_body(request: Any) -> str | None:
     same request outside of streaming mode is the simplest way to recover
     the body for diagnostics.
 
-    Returns a human-readable summary (status line + body, truncated) or
-    ``None`` if the replay itself failed.
+    Returns:
+        A human-readable summary (status line + body, truncated) or ``None``
+        if the replay itself failed.
     """
     import httpx
 
@@ -511,8 +545,8 @@ async def _replay_request_for_body(request: Any) -> str | None:
                 headers=dict(request.headers),
             )
         preview = resp.text
-        if len(preview) > 2000:  # noqa: PLR2004 — inline truncation threshold
-            preview = preview[:2000] + "…[truncated]"
+        if len(preview) > _BODY_TRUNCATE_AT:
+            preview = preview[:_BODY_TRUNCATE_AT] + "…[truncated]"
         return (
             f"HTTP {resp.status_code} {resp.reason_phrase}\n"
             f"Content-Type: {resp.headers.get('content-type', '(none)')}\n\n"
@@ -540,7 +574,7 @@ async def login(
     if server_config.get("auth") != "oauth":
         msg = (
             f"Server '{server_name}' does not use OAuth "
-            "(set \"auth\": \"oauth\" in mcpServers)."
+            '(set "auth": "oauth" in mcpServers).'
         )
         raise ValueError(msg)
     transport = server_config.get("type") or server_config.get("transport", "stdio")
@@ -572,7 +606,7 @@ async def login(
         storage=storage,
         extra_auth_params=extra_auth_params or None,
     )
-    conn: dict
+    conn: StreamableHttpConnection | SSEConnection
     if transport == "http":
         conn = StreamableHttpConnection(
             transport="streamable_http", url=server_config["url"], auth=provider
@@ -582,6 +616,5 @@ async def login(
 
     await _drive_handshake({server_name: conn}, storage)
     print(  # noqa: T201 - user-facing confirmation
-        f"Logged in to MCP server '{server_name}'. "
-        f"Tokens saved to {storage._path}."
+        f"Logged in to MCP server '{server_name}'. Tokens saved to {storage._path}."
     )

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -55,7 +55,7 @@ def _is_slack_mcp_url(url: str) -> bool:
 # works with client_id only, so the CLI obtains a GitHub access token that
 # way and pre-seeds it into storage; the MCP SDK then treats auth as already
 # complete and attaches `Authorization: Bearer <token>` to every request.
-_GITHUB_MCP_CLIENT_ID = "Ov23lirWr31UGKF4GEo3"
+_GITHUB_MCP_CLIENT_ID = "Iv23libxz8qOApH0WQL3"
 _GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
 _GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"  # noqa: S105 — OAuth endpoint URL, not a secret
 
@@ -287,6 +287,45 @@ RedirectHandler = Callable[[str], Awaitable[None]]
 CallbackHandler = Callable[[], Awaitable[tuple[str, str | None]]]
 
 
+class MCPReauthRequiredError(RuntimeError):
+    """Raised when an MCP server needs interactive re-authentication.
+
+    The runtime OAuth provider (used during agent tool calls) raises this
+    instead of driving the paste-back authorization-code flow — that flow
+    calls `input()`, which blocks the event loop in Textual and trips
+    blockbuster in LangGraph dev. Callers catch this, invalidate the cached
+    session, and surface a `ToolException` instructing the user to run
+    `deepagents mcp login <server>`.
+    """
+
+    def __init__(self, server_name: str) -> None:
+        """Build with *server_name* so the message tells the user what to fix."""
+        self.server_name = server_name
+        super().__init__(
+            f"MCP server {server_name!r} needs re-authentication. "
+            f"Run: deepagents mcp login {server_name}"
+        )
+
+
+def _make_reauth_required_handlers(
+    server_name: str,
+) -> tuple[RedirectHandler, CallbackHandler]:
+    """Return OAuth handlers that refuse to prompt and raise instead.
+
+    Attached by `build_oauth_provider(..., interactive=False)` on the runtime
+    path so a mid-session 401 → SDK auth-flow fallback surfaces as a clean
+    `MCPReauthRequiredError` rather than blocking on `input()`.
+    """
+
+    async def redirect(_auth_url: str) -> None:  # noqa: RUF029 — MCP SDK requires async handler
+        raise MCPReauthRequiredError(server_name)
+
+    async def callback() -> tuple[str, str | None]:  # noqa: RUF029 — MCP SDK requires async handler
+        raise MCPReauthRequiredError(server_name)
+
+    return redirect, callback
+
+
 def _make_paste_back_handlers(
     *, extra_auth_params: dict[str, str] | None = None
 ) -> tuple[RedirectHandler, CallbackHandler]:
@@ -341,12 +380,13 @@ def _append_query_params(url: str, params: dict[str, str]) -> str:
 
 def build_oauth_provider(
     *,
-    server_name: str,  # noqa: ARG001 - reserved for future error-message use
+    server_name: str,
     server_url: str,
     storage: TokenStorage,
     extra_auth_params: dict[str, str] | None = None,
+    interactive: bool = True,
 ) -> OAuthClientProvider:
-    """Construct a paste-back `OAuthClientProvider` for an MCP server.
+    """Construct an `OAuthClientProvider` for an MCP server.
 
     The metadata defaults match what most public MCP servers accept under
     Dynamic Client Registration; servers are expected to advertise scopes
@@ -355,17 +395,30 @@ def build_oauth_provider(
     so the metadata uses Slack's registered `https://localhost` redirect URI.
 
     Args:
-        server_name: The name of the MCP server (for future error messages).
+        server_name: The name of the MCP server — used in re-auth error
+            messages when ``interactive`` is false.
         server_url: The MCP server's URL (e.g., "https://mcp.notion.com/mcp").
         storage: A TokenStorage instance for persisting OAuth credentials.
         extra_auth_params: Extra query params appended to the authorization
             URL before the user is prompted to open it. Used for Slack's
-            ``team=<id>`` workspace selector.
+            ``team=<id>`` workspace selector. Ignored when
+            ``interactive=False``.
+        interactive: When true (the `deepagents mcp login` path), attach
+            paste-back handlers that prompt on stdin. When false (the
+            runtime tool-loading path), attach handlers that raise
+            `MCPReauthRequiredError` instead of prompting — prompting from a
+            tool call blocks the Textual event loop and trips blockbuster
+            in LangGraph dev.
 
     Returns:
-        An OAuthClientProvider configured for paste-back OAuth flow.
+        An OAuthClientProvider configured for the chosen flow.
     """
-    redirect, callback = _make_paste_back_handlers(extra_auth_params=extra_auth_params)
+    if interactive:
+        redirect, callback = _make_paste_back_handlers(
+            extra_auth_params=extra_auth_params
+        )
+    else:
+        redirect, callback = _make_reauth_required_handlers(server_name=server_name)
     if _is_slack_mcp_url(server_url):
         metadata = OAuthClientMetadata(
             client_name="deepagents-cli",
@@ -512,6 +565,32 @@ async def _preseed_github_auth(storage: FileTokenStorage) -> None:
             token_endpoint_auth_method="none",  # noqa: S106 — OAuth method literal, not a password
         )
     )
+
+
+def find_reauth_required(exc: BaseException) -> MCPReauthRequiredError | None:
+    """Find an `MCPReauthRequiredError` anywhere inside *exc*'s exception tree.
+
+    The MCP SDK's auth flow runs inside anyio `TaskGroup`s, so an exception
+    raised by a `callback_handler` arrives wrapped in one or more
+    `BaseExceptionGroup` layers by the time it reaches a tool-call site.
+    Shape mirrors `_find_http_status_error`.
+
+    Returns:
+        The innermost `MCPReauthRequiredError` found, or `None` if the
+        exception tree doesn't contain one.
+    """
+    if isinstance(exc, MCPReauthRequiredError):
+        return exc
+    sub_exceptions = getattr(exc, "exceptions", None)
+    if sub_exceptions:
+        for sub in sub_exceptions:
+            found = find_reauth_required(sub)
+            if found is not None:
+                return found
+    cause = exc.__cause__ or exc.__context__
+    if cause is not None and cause is not exc:
+        return find_reauth_required(cause)
+    return None
 
 
 def _find_http_status_error(exc: BaseException) -> httpx.HTTPStatusError | None:

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -1,0 +1,78 @@
+"""OAuth + bearer-token auth helpers for MCP servers."""
+
+from __future__ import annotations
+
+import os
+import re
+
+
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def resolve_headers(
+    headers: dict[str, str],
+    *,
+    server_name: str | None = None,
+) -> dict[str, str]:
+    """Resolve `${VAR}` env-var references in header values.
+
+    `$${VAR}` is the escape form and collapses to the literal `${VAR}` with no
+    lookup. A dollar sign not followed by `{` or `$` is left untouched.
+
+    Raises:
+        TypeError: If a header value is not a string.
+        RuntimeError: If a `${VAR}` references an unset environment variable.
+    """
+    resolved: dict[str, str] = {}
+    for name, value in headers.items():
+        if not isinstance(value, str):
+            where = f"mcpServers.{server_name}.headers.{name}" if server_name else name
+            msg = f"{where} must be a string, got {type(value).__name__}"
+            raise TypeError(msg)
+        resolved[name] = _interpolate(value, header=name, server_name=server_name)
+    return resolved
+
+
+def _interpolate(s: str, *, header: str, server_name: str | None) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == "$" and i + 1 < len(s):
+            nxt = s[i + 1]
+            if nxt == "$":
+                # `$${...}` → literal `${...}` if a brace group follows;
+                # otherwise literal `$$`.
+                if i + 2 < len(s) and s[i + 2] == "{":
+                    end = s.find("}", i + 3)
+                    if end != -1:
+                        out.append("$" + s[i + 2 : end + 1])
+                        i = end + 1
+                        continue
+                out.append("$$")
+                i += 2
+                continue
+            if nxt == "{":
+                end = s.find("}", i + 2)
+                if end != -1:
+                    var_name = s[i + 2 : end]
+                    if _IDENT_RE.fullmatch(var_name):
+                        val = os.environ.get(var_name)
+                        if val is None:
+                            where = (
+                                f"mcpServers.{server_name}.headers.{header}"
+                                if server_name
+                                else header
+                            )
+                            msg = (
+                                f"{where} references unset env var {var_name}. "
+                                f"Set {var_name} in the environment or remove "
+                                "the reference."
+                            )
+                            raise RuntimeError(msg)
+                        out.append(val)
+                        i = end + 1
+                        continue
+        out.append(ch)
+        i += 1
+    return "".join(out)

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -264,3 +264,71 @@ def build_oauth_provider(
         redirect_handler=redirect,
         callback_handler=callback,
     )
+
+
+async def _drive_handshake(
+    connections: dict, storage: FileTokenStorage
+) -> None:
+    """Open a one-shot MCP session to trigger the OAuth handshake.
+
+    The MCP SDK's `OAuthClientProvider` hooks into session startup and runs
+    discovery → DCR → paste-back handlers → token exchange. Tokens land in
+    `storage` via `set_tokens` before this returns.
+    """
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    client = MultiServerMCPClient(connections=connections)
+    server_name = next(iter(connections))
+    async with client.session(server_name):
+        # Entering the session drives the full flow.
+        pass
+
+
+async def login(
+    *,
+    server_name: str,
+    server_config: dict,
+) -> None:
+    """Drive OAuth login for `server_name`, persisting tokens on success.
+
+    Raises:
+        ValueError: If `server_config` isn't an OAuth http/sse server.
+    """
+    from langchain_mcp_adapters.sessions import (
+        SSEConnection,
+        StreamableHttpConnection,
+    )
+
+    if server_config.get("auth") != "oauth":
+        msg = (
+            f"Server '{server_name}' does not use OAuth "
+            "(set \"auth\": \"oauth\" in mcpServers)."
+        )
+        raise ValueError(msg)
+    transport = server_config.get("type") or server_config.get("transport", "stdio")
+    if transport not in {"http", "sse"}:
+        msg = (
+            f"Server '{server_name}' uses {transport!r} transport; "
+            "OAuth login is only valid for http/sse."
+        )
+        raise ValueError(msg)
+
+    storage = FileTokenStorage(server_name)
+    provider = build_oauth_provider(
+        server_name=server_name,
+        server_url=server_config["url"],
+        storage=storage,
+    )
+    conn: dict
+    if transport == "http":
+        conn = StreamableHttpConnection(
+            transport="streamable_http", url=server_config["url"], auth=provider
+        )
+    else:
+        conn = SSEConnection(transport="sse", url=server_config["url"], auth=provider)
+
+    await _drive_handshake({server_name: conn}, storage)
+    print(  # noqa: T201 - user-facing confirmation
+        f"Logged in to MCP server '{server_name}'. "
+        f"Tokens saved to {storage._path}."
+    )

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -6,10 +6,12 @@ import json
 import os
 import re
 import stat
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
-from mcp.client.auth import TokenStorage
-from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.shared.auth import AnyUrl, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 
 
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
@@ -196,3 +198,69 @@ class FileTokenStorage(TokenStorage):
                 os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
             except OSError:
                 pass
+
+
+RedirectHandler = Callable[[str], Awaitable[None]]
+CallbackHandler = Callable[[], Awaitable[tuple[str, str | None]]]
+
+
+def _make_paste_back_handlers() -> tuple[RedirectHandler, CallbackHandler]:
+    """Create paste-back redirect and callback handlers for OAuth.
+
+    Returns:
+        A tuple of (redirect_handler, callback_handler) functions that implement
+        the paste-back OAuth flow for interactive CLI use.
+    """
+
+    async def redirect(auth_url: str) -> None:
+        print(  # noqa: T201 - intentional user-facing prompt
+            "\nOpen this URL in a browser, approve access, then paste the full "
+            "callback URL back here:\n"
+            f"\n  {auth_url}\n"
+        )
+
+    async def callback() -> tuple[str, str | None]:
+        url = input("Callback URL: ").strip()
+        params = parse_qs(urlparse(url).query)
+        if "code" not in params or not params["code"]:
+            msg = "Callback URL is missing the 'code' parameter."
+            raise RuntimeError(msg)
+        return params["code"][0], (params.get("state") or [None])[0]
+
+    return redirect, callback
+
+
+def build_oauth_provider(
+    *,
+    server_name: str,  # noqa: ARG001 - reserved for future error-message use
+    server_url: str,
+    storage: TokenStorage,
+) -> OAuthClientProvider:
+    """Construct a paste-back `OAuthClientProvider` for an MCP server.
+
+    The metadata defaults match what most public MCP servers accept under
+    Dynamic Client Registration; servers are expected to advertise scopes
+    via their OAuth metadata document.
+
+    Args:
+        server_name: The name of the MCP server (for future error messages).
+        server_url: The MCP server's URL (e.g., "https://mcp.notion.com/mcp").
+        storage: A TokenStorage instance for persisting OAuth credentials.
+
+    Returns:
+        An OAuthClientProvider configured for paste-back OAuth flow.
+    """
+    redirect, callback = _make_paste_back_handlers()
+    metadata = OAuthClientMetadata(
+        client_name="deepagents-cli",
+        redirect_uris=[AnyUrl("http://localhost/callback")],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+    )
+    return OAuthClientProvider(
+        server_url=server_url,
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=redirect,
+        callback_handler=callback,
+    )

--- a/libs/cli/deepagents_cli/mcp_commands.py
+++ b/libs/cli/deepagents_cli/mcp_commands.py
@@ -1,0 +1,83 @@
+"""CLI commands for `deepagents mcp`.
+
+Registered via `setup_mcp_parsers` in `main.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TYPE_CHECKING, Any
+
+from deepagents_cli.mcp_auth import login
+from deepagents_cli.mcp_tools import discover_mcp_configs, load_mcp_config
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def setup_mcp_parsers(
+    subparsers: Any,  # noqa: ANN401
+    *,
+    make_help_action: Callable[[Callable[[], None]], type[argparse.Action]],
+) -> None:
+    """Register the `deepagents mcp` command group."""
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help="Manage MCP servers",
+        add_help=False,
+    )
+    mcp_parser.add_argument(
+        "-h",
+        "--help",
+        action=make_help_action(lambda: mcp_parser.print_help()),
+    )
+    mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
+
+    login_parser = mcp_sub.add_parser(
+        "login",
+        help="Run the OAuth login flow for an MCP server",
+        add_help=False,
+    )
+    login_parser.add_argument("server", help="Server name from mcpServers config")
+    login_parser.add_argument(
+        "--config",
+        dest="config_path",
+        default=None,
+        help="Path to an MCP config JSON file (default: auto-discovered)",
+    )
+    login_parser.add_argument(
+        "-h",
+        "--help",
+        action=make_help_action(lambda: login_parser.print_help()),
+    )
+
+
+async def run_mcp_login(*, server: str, config_path: str | None) -> int:
+    """Handler for `deepagents mcp login <server>`. Returns an exit code."""
+    if config_path is None:
+        found = discover_mcp_configs()
+        if not found:
+            print(  # noqa: T201
+                "No MCP config file found. Pass --config <path>.",
+                file=sys.stderr,
+            )
+            return 2
+        config_path = str(found[-1])  # highest-precedence file
+
+    config = load_mcp_config(config_path)
+    servers = config.get("mcpServers", {})
+    if server not in servers:
+        print(  # noqa: T201
+            f"Server {server!r} not found in {config_path}. "
+            f"Known servers: {sorted(servers)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        await login(server_name=server, server_config=servers[server])
+    except (ValueError, RuntimeError) as exc:
+        print(f"Login failed: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+    return 0

--- a/libs/cli/deepagents_cli/mcp_commands.py
+++ b/libs/cli/deepagents_cli/mcp_commands.py
@@ -9,11 +9,23 @@ import argparse
 import sys
 from typing import TYPE_CHECKING, Any
 
-from deepagents_cli.mcp_auth import login
-from deepagents_cli.mcp_tools import discover_mcp_configs, load_mcp_config
-
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+def _lazy_ui_help(fn_name: str) -> Callable[[], None]:
+    """Return a callable that lazily imports and invokes a `ui` help function.
+
+    Defers the `ui` import (which pulls in Rich + config) until the user
+    actually triggers the help action, keeping parse-time imports cheap.
+    """
+
+    def _show() -> None:
+        from deepagents_cli import ui
+
+        getattr(ui, fn_name)()
+
+    return _show
 
 
 def setup_mcp_parsers(
@@ -30,7 +42,7 @@ def setup_mcp_parsers(
     mcp_parser.add_argument(
         "-h",
         "--help",
-        action=make_help_action(lambda: mcp_parser.print_help()),
+        action=make_help_action(_lazy_ui_help("show_mcp_help")),
     )
     mcp_sub = mcp_parser.add_subparsers(dest="mcp_command")
 
@@ -49,12 +61,15 @@ def setup_mcp_parsers(
     login_parser.add_argument(
         "-h",
         "--help",
-        action=make_help_action(lambda: login_parser.print_help()),
+        action=make_help_action(_lazy_ui_help("show_mcp_login_help")),
     )
 
 
 async def run_mcp_login(*, server: str, config_path: str | None) -> int:
     """Handler for `deepagents mcp login <server>`. Returns an exit code."""
+    from deepagents_cli.mcp_auth import login
+    from deepagents_cli.mcp_tools import discover_mcp_configs, load_mcp_config
+
     if config_path is None:
         found = discover_mcp_configs()
         if not found:

--- a/libs/cli/deepagents_cli/mcp_commands.py
+++ b/libs/cli/deepagents_cli/mcp_commands.py
@@ -65,7 +65,14 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
             return 2
         config_path = str(found[-1])  # highest-precedence file
 
-    config = load_mcp_config(config_path)
+    try:
+        config = load_mcp_config(config_path)
+    except (FileNotFoundError, TypeError, ValueError, RuntimeError) as exc:
+        print(  # noqa: T201
+            f"Failed to load MCP config {config_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
     servers = config.get("mcpServers", {})
     if server not in servers:
         print(  # noqa: T201

--- a/libs/cli/deepagents_cli/mcp_commands.py
+++ b/libs/cli/deepagents_cli/mcp_commands.py
@@ -5,11 +5,11 @@ Registered via `setup_mcp_parsers` in `main.py`.
 
 from __future__ import annotations
 
-import argparse
 import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import argparse
     from collections.abc import Callable
 
 
@@ -66,7 +66,12 @@ def setup_mcp_parsers(
 
 
 async def run_mcp_login(*, server: str, config_path: str | None) -> int:
-    """Handler for `deepagents mcp login <server>`. Returns an exit code."""
+    """Handler for `deepagents mcp login <server>`.
+
+    Returns:
+        Process exit code: 0 on success, 1 on config or login failure,
+        2 if no config file could be found.
+    """
     from deepagents_cli.mcp_auth import login
     from deepagents_cli.mcp_tools import discover_mcp_configs, load_mcp_config
 

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -12,6 +12,7 @@ import asyncio
 import atexit
 import json
 import logging
+import re
 import shutil
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
@@ -57,6 +58,11 @@ _SUPPORTED_REMOTE_TYPES = {"sse", "http"}
 """Supported transport types for remote MCP servers (SSE and HTTP)."""
 
 
+_SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+"""Server names become token-file basenames under ~/.deepagents/mcp-tokens/;
+restricting to alphanumerics, hyphens, and underscores keeps them path-safe."""
+
+
 def _resolve_server_type(server_config: dict[str, Any]) -> str:
     """Determine the transport type for a server config.
 
@@ -85,6 +91,13 @@ def _validate_server_config(server_name: str, server_config: dict[str, Any]) -> 
         TypeError: If config fields have wrong types.
         ValueError: If required fields are missing or server type is unsupported.
     """
+    if not _SERVER_NAME_RE.fullmatch(server_name):
+        error_msg = (
+            f"Invalid server name {server_name!r}: server names must contain "
+            "only alphanumerics, hyphens, and underscores."
+        )
+        raise ValueError(error_msg)
+
     if not isinstance(server_config, dict):
         error_msg = f"Server '{server_name}' config must be a dictionary"
         raise TypeError(error_msg)

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -8,6 +8,8 @@ and project-level locations.
 
 from __future__ import annotations
 
+import asyncio
+import atexit
 import json
 import logging
 import shutil
@@ -18,7 +20,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
-    from langchain_mcp_adapters.client import Connection, MultiServerMCPClient
+    from langchain_mcp_adapters.client import Connection
+    from mcp import ClientSession
 
     from deepagents_cli.project_utils import ProjectContext
 
@@ -384,22 +387,200 @@ def load_mcp_config_lenient(config_path: Path) -> dict[str, Any] | None:
         return None
 
 
-class MCPSessionManager:
-    """Manages persistent MCP sessions for stateful stdio servers.
+# Exception-type names that indicate the MCP session's transport is dead and
+# should be torn down + reopened. We match by class name to avoid importing
+# anyio at module top level and to keep the check loop-agnostic.
+_TRANSIENT_EXC_NAMES = frozenset(
+    {
+        "ClosedResourceError",
+        "BrokenResourceError",
+        "EndOfStream",
+        "WouldBlock",
+    }
+)
 
-    This manager creates and maintains persistent sessions for stdio MCP
-    servers, preventing server restarts on every tool call. Sessions are kept
-    alive until explicitly cleaned up.
+
+def _is_transient_session_error(exc: BaseException) -> bool:
+    """Return True when *exc* signals the MCP session is no longer usable.
+
+    Triggers invalidate-and-retry. Narrow on purpose — we don't want to retry
+    logical tool errors (`ToolException`), only transport/connection failures
+    and auth-layer errors where a fresh session will pick up refreshed tokens.
+    """
+    name = type(exc).__name__
+    if name in _TRANSIENT_EXC_NAMES:
+        return True
+    # OSError covers BrokenPipeError, ConnectionResetError, ConnectionError, etc.
+    # ToolException is NOT an OSError subclass, so tool-logic errors still fall
+    # through the retry gate.
+    return isinstance(exc, (OSError, asyncio.IncompleteReadError))
+
+
+class MCPSessionManager:
+    """Process-wide cache for persistent MCP client sessions.
+
+    Sessions are created lazily on first use in whatever asyncio event loop
+    calls `get_or_create_session`. This is critical for the CLI's server-
+    subprocess path: module import does metadata discovery in a throwaway
+    `asyncio.run()` loop, then the LangGraph server's uvicorn loop calls tools
+    — and a session created in the throwaway loop would have dead anyio memory
+    streams by the time the uvicorn loop uses it.
+
+    Each cached server gets its own `AsyncExitStack` so a single bad session
+    can be invalidated (and its subprocess reaped) without disturbing peers.
+
+    This class is the singleton returned by
+    :func:`get_default_session_manager`. Directly instantiating
+    :class:`MCPSessionManager` produces an isolated instance, which is useful
+    in tests but does not participate in the process-wide session cache.
     """
 
     def __init__(self) -> None:
-        """Initialize the session manager."""
-        self.client: MultiServerMCPClient | None = None
-        self.exit_stack = AsyncExitStack()
+        """Initialize an empty session cache."""
+        self._lock = asyncio.Lock()
+        self._stacks: dict[str, AsyncExitStack] = {}
+        self._sessions: dict[str, ClientSession] = {}
+
+    async def get_or_create_session(
+        self,
+        server_name: str,
+        connection: Connection,
+    ) -> ClientSession:
+        """Return a live `ClientSession` for *server_name*, opening one if needed.
+
+        Uses double-checked locking so concurrent first-callers do not spawn
+        duplicate subprocesses. Session + subprocess lifecycle is tied to a
+        per-server `AsyncExitStack` so individual entries can be invalidated
+        without closing unrelated sessions.
+
+        Args:
+            server_name: Identifier used as the cache key.
+            connection: Adapter connection config (stdio / http / sse).
+
+        Returns:
+            An initialized `ClientSession` bound to the current event loop.
+
+        Raises:
+            Exception: Propagates any error from `create_session` /
+                `initialize`; the partial stack is rolled back so the cache is
+                left in a clean state on failure.
+        """
+        existing = self._sessions.get(server_name)
+        if existing is not None:
+            return existing
+
+        async with self._lock:
+            existing = self._sessions.get(server_name)
+            if existing is not None:
+                return existing
+
+            from langchain_mcp_adapters.sessions import create_session
+
+            stack = AsyncExitStack()
+            await stack.__aenter__()  # noqa: PLC2801 — manual enter: we hold stack lifetime across method boundaries
+            try:
+                session = await stack.enter_async_context(create_session(connection))
+                await session.initialize()
+            except BaseException:
+                # Roll back so a subsequent call can retry cleanly.
+                try:
+                    await stack.aclose()
+                except Exception:
+                    logger.debug(
+                        "Error closing partially-opened MCP session for %s",
+                        server_name,
+                        exc_info=True,
+                    )
+                raise
+
+            self._stacks[server_name] = stack
+            self._sessions[server_name] = session
+            return session
+
+    async def invalidate(self, server_name: str) -> None:
+        """Close and forget a single server's cached session.
+
+        Safe to call when no entry exists (no-op). After invalidation the next
+        `get_or_create_session` call will open a fresh session, which re-reads
+        OAuth tokens from storage and re-establishes the transport.
+        """
+        async with self._lock:
+            self._sessions.pop(server_name, None)
+            stack = self._stacks.pop(server_name, None)
+        if stack is not None:
+            try:
+                await stack.aclose()
+            except Exception:
+                logger.debug(
+                    "Error closing MCP session for %s during invalidate",
+                    server_name,
+                    exc_info=True,
+                )
+
+    async def aclose_all(self) -> None:
+        """Close every cached session. Idempotent — safe to call repeatedly."""
+        async with self._lock:
+            names = list(self._stacks.keys())
+            stacks = [self._stacks.pop(name) for name in names]
+            for name in names:
+                self._sessions.pop(name, None)
+        for stack in stacks:
+            try:
+                await stack.aclose()
+            except Exception:
+                logger.debug("Error closing MCP session on shutdown", exc_info=True)
 
     async def cleanup(self) -> None:
-        """Clean up all managed sessions and close connections."""
-        await self.exit_stack.aclose()
+        """Back-compat alias for `aclose_all`."""
+        await self.aclose_all()
+
+
+_DEFAULT_MANAGER: MCPSessionManager | None = None
+
+
+def get_default_session_manager() -> MCPSessionManager:
+    """Return the process-wide `MCPSessionManager` singleton.
+
+    The singleton is created lazily on first access. Proxy tools built by
+    `_load_tools_from_config` resolve the manager at call time (not
+    construction time) via this accessor so tests can swap the manager via
+    `reset_default_session_manager_for_testing`.
+    """
+    global _DEFAULT_MANAGER  # noqa: PLW0603 — module-level singleton cache
+    if _DEFAULT_MANAGER is None:
+        _DEFAULT_MANAGER = MCPSessionManager()
+    return _DEFAULT_MANAGER
+
+
+def reset_default_session_manager_for_testing() -> None:
+    """Drop the cached singleton. Call from test fixtures only."""
+    global _DEFAULT_MANAGER  # noqa: PLW0603 — test-only reset
+    _DEFAULT_MANAGER = None
+
+
+def _best_effort_shutdown() -> None:
+    """Close cached MCP sessions on interpreter exit, best-effort.
+
+    Runs at `atexit` time. We try to close sessions in a fresh event loop, but
+    stdio subprocess cleanup depends on anyio streams being closed in their
+    original loop — so this is a best-effort hook, not a correctness guarantee.
+    Child subprocesses are reaped when the parent process exits regardless.
+    """
+    if _DEFAULT_MANAGER is None or not _DEFAULT_MANAGER._stacks:  # noqa: SLF001
+        return
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                asyncio.wait_for(_DEFAULT_MANAGER.aclose_all(), timeout=2.0)
+            )
+        finally:
+            loop.close()
+    except Exception:
+        logger.debug("Best-effort MCP shutdown failed", exc_info=True)
+
+
+atexit.register(_best_effort_shutdown)
 
 
 def _check_stdio_server(server_name: str, server_config: dict[str, Any]) -> None:
@@ -457,30 +638,155 @@ async def _check_remote_server(server_name: str, server_config: dict[str, Any]) 
         raise RuntimeError(msg) from exc
 
 
+async def _discover_tools(session: ClientSession) -> list[Any]:
+    """Enumerate MCP tools from *session*, paginating until exhausted.
+
+    Mirrors `langchain_mcp_adapters.tools._list_all_tools` but avoids importing
+    that private helper so this module does not silently break on an adapter
+    refactor. Caps pagination at 1000 pages to match the adapter's guard
+    against a misbehaving server returning infinite cursors.
+    """
+    cursor: str | None = None
+    tools: list[Any] = []
+    for _ in range(1000):
+        page = await session.list_tools(cursor=cursor)
+        if page.tools:
+            tools.extend(page.tools)
+        if not page.nextCursor:
+            return tools
+        cursor = page.nextCursor
+    msg = "Reached max of 1000 iterations while listing MCP tools."
+    raise RuntimeError(msg)
+
+
+def _build_cached_mcp_tool(
+    *,
+    mcp_tool: Any,  # noqa: ANN401 — mcp.types.Tool; avoid importing at module top
+    server_name: str,
+    connection: Connection,
+    tool_name_prefix: bool,
+) -> BaseTool:
+    """Build a StructuredTool that routes through the cached session manager.
+
+    The returned tool looks up the `MCPSessionManager` singleton at call time
+    (not closure time) so tests can swap the manager. On transient session
+    errors (transport dead, OAuth token expired mid-stream) the tool
+    invalidates the cache entry and retries once; a second transient failure
+    surfaces as a `ToolException` rather than crashing the agent loop.
+
+    Args:
+        mcp_tool: MCP `Tool` object as returned by `session.list_tools()`.
+        server_name: Server identifier used as the session-cache key and, if
+            *tool_name_prefix* is true, as a prefix on the LangChain tool name.
+        connection: Adapter connection config passed to `create_session`.
+        tool_name_prefix: When true, prefix the LangChain tool name with
+            ``<server_name>_`` to avoid name collisions across servers.
+
+    Returns:
+        A `StructuredTool` wrapping the remote MCP tool.
+    """
+    from langchain_core.tools import StructuredTool, ToolException
+    from langchain_mcp_adapters.tools import _convert_call_tool_result
+
+    original_tool_name = mcp_tool.name
+    lc_tool_name = (
+        f"{server_name}_{original_tool_name}"
+        if tool_name_prefix and server_name
+        else original_tool_name
+    )
+
+    meta = getattr(mcp_tool, "meta", None)
+    base_meta = (
+        mcp_tool.annotations.model_dump() if mcp_tool.annotations is not None else {}
+    )
+    wrapped_meta = {"_meta": meta} if meta is not None else {}
+    metadata = {**base_meta, **wrapped_meta} or None
+
+    async def coroutine(
+        runtime: Any = None,  # noqa: ANN401, ARG001 — LangGraph may pass runtime; unused here
+        **arguments: Any,
+    ) -> Any:  # noqa: ANN401 — StructuredTool response_format="content_and_artifact" returns a tuple
+        async def _call_once() -> Any:  # noqa: ANN401 — MCP CallToolResult; dynamic to avoid top-level import
+            manager = get_default_session_manager()
+            session = await manager.get_or_create_session(server_name, connection)
+            return await session.call_tool(original_tool_name, arguments)
+
+        try:
+            result = await _call_once()
+        except ToolException:
+            # Logical error from the MCP server — not transient. Let it bubble.
+            raise
+        except BaseException as exc:
+            if not _is_transient_session_error(exc):
+                raise
+            logger.info(
+                "MCP session for %r appears dead (%s: %s); "
+                "invalidating and retrying once",
+                server_name,
+                type(exc).__name__,
+                exc,
+            )
+            await get_default_session_manager().invalidate(server_name)
+            try:
+                result = await _call_once()
+            except ToolException:
+                raise
+            except BaseException as retry_exc:
+                # Second failure: clear the cache again so the next turn can
+                # try once more from scratch, but surface this call as a
+                # ToolException rather than crashing the agent loop.
+                await get_default_session_manager().invalidate(server_name)
+                msg = (
+                    f"MCP tool {lc_tool_name!r} failed after one retry on "
+                    f"server {server_name!r}: {type(retry_exc).__name__}: "
+                    f"{retry_exc}"
+                )
+                raise ToolException(msg) from retry_exc
+
+        return _convert_call_tool_result(result)
+
+    return StructuredTool(
+        name=lc_tool_name,
+        description=mcp_tool.description or "",
+        args_schema=mcp_tool.inputSchema,
+        coroutine=coroutine,
+        response_format="content_and_artifact",
+        metadata=metadata,
+    )
+
+
 async def _load_tools_from_config(
     config: dict[str, Any],
 ) -> tuple[list[BaseTool], MCPSessionManager, list[MCPServerInfo]]:
     """Build MCP connections from a validated config and load tools.
 
-    This is the shared implementation used by both `get_mcp_tools` (explicit
-    path) and `resolve_and_load_mcp_tools` (auto-discovery).
+    Discovery opens a throwaway session per server (torn down before this
+    function returns) purely to capture tool metadata — names, descriptions,
+    input schemas. The returned tools are proxies that lazily bind real
+    sessions through the `MCPSessionManager` singleton on first invocation,
+    inside whatever event loop the agent runs on. This avoids the cross-loop
+    `ClosedResourceError` that would occur if we cached sessions created in
+    a temporary loop (e.g., `asyncio.run` at module import).
+
+    Shared implementation used by both `get_mcp_tools` (explicit path) and
+    `resolve_and_load_mcp_tools` (auto-discovery).
 
     Args:
         config: Validated MCP configuration dict with `mcpServers` key.
 
     Returns:
-        Tuple of `(tools_list, session_manager, server_infos)`.
+        Tuple of `(tools_list, session_manager, server_infos)` — the manager
+        is the process-wide singleton; callers need not manage its lifetime.
 
     Raises:
         RuntimeError: If MCP server fails to spawn or connect.
     """
-    from langchain_mcp_adapters.client import MultiServerMCPClient
     from langchain_mcp_adapters.sessions import (
         SSEConnection,
         StdioConnection,
         StreamableHttpConnection,
+        create_session,
     )
-    from langchain_mcp_adapters.tools import load_mcp_tools
 
     # Pre-flight health checks (best-effort early detection; the session setup
     # below has its own error handling for TOCTOU races).
@@ -552,56 +858,56 @@ async def _load_tools_from_config(
                 transport="stdio",
             )
 
-    # Create session manager to track persistent sessions
-    manager = MCPSessionManager()
+    # Discovery: open one throwaway session per server just to enumerate
+    # tools, then close it. No session state survives this loop — the proxy
+    # tools built below bind fresh, cached sessions lazily in the event loop
+    # that actually invokes them (see _build_cached_mcp_tool).
+    all_tools: list[BaseTool] = []
+    server_infos: list[MCPServerInfo] = []
 
-    try:
-        client = MultiServerMCPClient(connections=connections)
-        manager.client = client
-    except Exception as e:
-        await manager.cleanup()
-        error_msg = f"Failed to initialize MCP client: {e}"
-        raise RuntimeError(error_msg) from e
+    for server_name, server_config in config["mcpServers"].items():
+        try:
+            async with create_session(connections[server_name]) as session:
+                await session.initialize()
+                mcp_tools = await _discover_tools(session)
+        except Exception as e:
+            error_msg = (
+                f"Failed to load tools from MCP server '{server_name}': {e}\n"
+                "For stdio servers: Check that the command and args are correct,"
+                " and that the MCP server is installed"
+                " (e.g., run 'npx -y <package>' manually to test).\n"
+                "For sse/http servers: Check that the URL is correct"
+                " and the server is running."
+            )
+            raise RuntimeError(error_msg) from e
 
-    try:
-        all_tools: list[BaseTool] = []
-        server_infos: list[MCPServerInfo] = []
-        for server_name, server_config in config["mcpServers"].items():
-            session = await manager.exit_stack.enter_async_context(
-                client.session(server_name)
+        server_tools: list[BaseTool] = [
+            _build_cached_mcp_tool(
+                mcp_tool=mcp_tool,
+                server_name=server_name,
+                connection=connections[server_name],
+                tool_name_prefix=True,
             )
-            tools = await load_mcp_tools(
-                session, server_name=server_name, tool_name_prefix=True
+            for mcp_tool in mcp_tools
+        ]
+        all_tools.extend(server_tools)
+        server_infos.append(
+            MCPServerInfo(
+                name=server_name,
+                transport=_resolve_server_type(server_config),
+                tools=[
+                    MCPToolInfo(name=t.name, description=t.description or "")
+                    for t in server_tools
+                ],
             )
-            all_tools.extend(tools)
-            server_infos.append(
-                MCPServerInfo(
-                    name=server_name,
-                    transport=_resolve_server_type(server_config),
-                    tools=[
-                        MCPToolInfo(name=t.name, description=t.description or "")
-                        for t in tools
-                    ],
-                )
-            )
-        # Sort tools deterministically by name so the tools block in API
-        # requests is stable across turns. MCP's list_tools() does not guarantee
-        # order, and any change in the tools array busts the prompt cache at the
-        # tools block.
-        all_tools.sort(key=lambda t: t.name)
-    except Exception as e:
-        await manager.cleanup()
-        error_msg = (
-            f"Failed to load tools from MCP server '{server_name}': {e}\n"
-            "For stdio servers: Check that the command and args are correct,"
-            " and that the MCP server is installed"
-            " (e.g., run 'npx -y <package>' manually to test).\n"
-            "For sse/http servers: Check that the URL is correct"
-            " and the server is running."
         )
-        raise RuntimeError(error_msg) from e
 
-    return all_tools, manager, server_infos
+    # Sort tools deterministically by name so the tools block in API requests
+    # is stable across turns. MCP's list_tools() does not guarantee order, and
+    # any change in the tools array busts the prompt cache at the tools block.
+    all_tools.sort(key=lambda t: t.name)
+
+    return all_tools, get_default_session_manager(), server_infos
 
 
 async def get_mcp_tools(

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -495,7 +495,11 @@ async def _load_tools_from_config(
                     url=server_config["url"],
                 )
             if "headers" in server_config:
-                conn["headers"] = server_config["headers"]
+                from deepagents_cli.mcp_auth import resolve_headers
+
+                conn["headers"] = resolve_headers(
+                    server_config["headers"], server_name=server_name
+                )
             connections[server_name] = conn
         else:
             # stdio server connection (default)

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -395,7 +395,7 @@ def load_mcp_config_lenient(config_path: Path) -> dict[str, Any] | None:
     except OSError as e:
         logger.warning("Skipping unreadable MCP config %s: %s", config_path, e)
         return None
-    except (json.JSONDecodeError, ValueError, TypeError) as e:
+    except (json.JSONDecodeError, ValueError, TypeError, RuntimeError) as e:
         logger.warning("Skipping invalid MCP config %s: %s", config_path, e)
         return None
 

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -131,6 +131,30 @@ def _validate_server_config(server_name: str, server_config: dict[str, Any]) -> 
         )
         raise ValueError(error_msg)
 
+    # Validate the optional `auth` field.
+    auth = server_config.get("auth")
+    if auth is not None:
+        if auth != "oauth":
+            msg = (
+                f"Server '{server_name}' has unsupported auth value "
+                f"{auth!r}. Only 'oauth' is supported."
+            )
+            raise ValueError(msg)
+        if server_type == "stdio":
+            msg = (
+                f"Server '{server_name}' uses stdio transport; "
+                "'auth: oauth' is only valid for http/sse transports."
+            )
+            raise ValueError(msg)
+        # Can't drive both OAuth and a static Authorization header.
+        header_names = {k.lower() for k in (server_config.get("headers") or {})}
+        if "authorization" in header_names:
+            msg = (
+                f"Server '{server_name}' cannot combine 'auth: oauth' "
+                "with an 'Authorization' header."
+            )
+            raise ValueError(msg)
+
 
 def load_mcp_config(config_path: str) -> dict[str, Any]:
     """Load and validate MCP configuration from JSON file.

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -42,7 +42,7 @@ class MCPToolInfo:
 
 @dataclass
 class MCPServerInfo:
-    """Metadata for a connected MCP server and its tools."""
+    """Metadata for a configured MCP server and its tools."""
 
     name: str
     """Server name from the MCP configuration."""
@@ -51,7 +51,16 @@ class MCPServerInfo:
     """Transport type (`stdio`, `sse`, or `http`)."""
 
     tools: list[MCPToolInfo] = field(default_factory=list)
-    """Tools exposed by this server."""
+    """Tools exposed by this server (empty when `status != "ok"`)."""
+
+    status: str = "ok"
+    """Load status — `"ok"`, `"unauthenticated"`, or `"error"`. A non-`"ok"`
+    server is reported in the viewer but its tools are not mounted on the
+    agent, so a single failing server never blocks startup."""
+
+    error: str | None = None
+    """Human-readable reason when `status != "ok"`, suitable for display in
+    the TUI (e.g. `"Run: deepagents mcp login gh"`)."""
 
 
 _SUPPORTED_REMOTE_TYPES = {"sse", "http"}
@@ -799,9 +808,9 @@ async def _load_tools_from_config(
     Returns:
         Tuple of `(tools_list, session_manager, server_infos)` — the manager
         is the process-wide singleton; callers need not manage its lifetime.
-
-    Raises:
-        RuntimeError: If MCP server fails to spawn or connect.
+        Servers that fail pre-flight, lack OAuth tokens, or can't complete
+        a discovery session are skipped (tools omitted) and reported in
+        `server_infos` with `status != "ok"`.
     """
     from langchain_mcp_adapters.sessions import (
         SSEConnection,
@@ -810,9 +819,16 @@ async def _load_tools_from_config(
         create_session,
     )
 
+    # Per-server status tracking. A failure at any stage (pre-flight,
+    # OAuth-token lookup, session init) marks the server with a non-"ok"
+    # status and skips it instead of aborting the whole startup — so a
+    # single dark server never blocks the agent. The TUI's MCP viewer and
+    # the welcome surface read `status` / `error` from the returned
+    # `MCPServerInfo`s to signal which servers need attention.
+    skipped: dict[str, tuple[str, str]] = {}  # server_name -> (status, error)
+
     # Pre-flight health checks (best-effort early detection; the session setup
     # below has its own error handling for TOCTOU races).
-    errors: list[str] = []
     for server_name, server_config in config["mcpServers"].items():
         server_type = _resolve_server_type(server_config)
         try:
@@ -821,17 +837,19 @@ async def _load_tools_from_config(
             elif server_type == "stdio":
                 _check_stdio_server(server_name, server_config)
         except RuntimeError as exc:
-            errors.append(str(exc))
-    if errors:
-        msg = "Pre-flight health check(s) failed:\n" + "\n".join(
-            f"  - {e}" for e in errors
-        )
-        raise RuntimeError(msg)
+            logger.warning(
+                "MCP server '%s' skipped: pre-flight failed: %s",
+                server_name,
+                exc,
+            )
+            skipped[server_name] = ("error", str(exc))
 
     # Create connections dict for MultiServerMCPClient
     # Convert Claude Desktop format to langchain-mcp-adapters format
     connections: dict[str, Connection] = {}
     for server_name, server_config in config["mcpServers"].items():
+        if server_name in skipped:
+            continue
         server_type = _resolve_server_type(server_config)
 
         if server_type in _SUPPORTED_REMOTE_TYPES:
@@ -860,11 +878,14 @@ async def _load_tools_from_config(
 
                 storage = FileTokenStorage(server_name)
                 if await storage.get_tokens() is None:
-                    msg = (
-                        f"MCP server '{server_name}' requires OAuth login. "
-                        f"Run: deepagents mcp login {server_name}"
+                    auth_msg = f"Run: deepagents mcp login {server_name}"
+                    logger.warning(
+                        "MCP server '%s' skipped: not authenticated. %s",
+                        server_name,
+                        auth_msg,
                     )
-                    raise RuntimeError(msg)
+                    skipped[server_name] = ("unauthenticated", auth_msg)
+                    continue
                 conn["auth"] = build_oauth_provider(
                     server_name=server_name,
                     server_url=server_config["url"],
@@ -888,20 +909,37 @@ async def _load_tools_from_config(
     server_infos: list[MCPServerInfo] = []
 
     for server_name, server_config in config["mcpServers"].items():
+        transport = _resolve_server_type(server_config)
+        if server_name in skipped:
+            status, error = skipped[server_name]
+            server_infos.append(
+                MCPServerInfo(
+                    name=server_name,
+                    transport=transport,
+                    status=status,
+                    error=error,
+                )
+            )
+            continue
         try:
             async with create_session(connections[server_name]) as session:
                 await session.initialize()
                 mcp_tools = await _discover_tools(session)
-        except Exception as e:
-            error_msg = (
-                f"Failed to load tools from MCP server '{server_name}': {e}\n"
-                "For stdio servers: Check that the command and args are correct,"
-                " and that the MCP server is installed"
-                " (e.g., run 'npx -y <package>' manually to test).\n"
-                "For sse/http servers: Check that the URL is correct"
-                " and the server is running."
+        except Exception as e:  # noqa: BLE001 — per-server skip
+            logger.warning(
+                "MCP server '%s' skipped: tool discovery failed: %s",
+                server_name,
+                e,
             )
-            raise RuntimeError(error_msg) from e
+            server_infos.append(
+                MCPServerInfo(
+                    name=server_name,
+                    transport=transport,
+                    status="error",
+                    error=str(e),
+                )
+            )
+            continue
 
         server_tools: list[BaseTool] = [
             _build_cached_mcp_tool(
@@ -916,7 +954,7 @@ async def _load_tools_from_config(
         server_infos.append(
             MCPServerInfo(
                 name=server_name,
-                transport=_resolve_server_type(server_config),
+                transport=transport,
                 tools=[
                     MCPToolInfo(name=t.name, description=t.description or "")
                     for t in server_tools
@@ -993,8 +1031,9 @@ async def resolve_and_load_mcp_tools(
             When no tools are loaded, returns `([], None, [])`.
 
     Raises:
-        RuntimeError: If an MCP server config is invalid or fails to
-            spawn/connect.
+        RuntimeError: If the MCP config itself is malformed. Per-server
+            spawn/connect failures are reported via `server_infos` rather
+            than raising.
     """
     if no_mcp:
         return [], None, []

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -742,12 +742,22 @@ def _build_cached_mcp_tool(
             session = await manager.get_or_create_session(server_name, connection)
             return await session.call_tool(original_tool_name, arguments)
 
+        from deepagents_cli.mcp_auth import find_reauth_required
+
         try:
             result = await _call_once()
         except ToolException:
             # Logical error from the MCP server — not transient. Let it bubble.
             raise
         except BaseException as exc:
+            # If the SDK's OAuth refresh path tripped our non-interactive
+            # re-auth signal, surface it as a ToolException so the LLM sees
+            # the "run deepagents mcp login" hint instead of the agent
+            # crashing or (worse) blocking on input().
+            reauth = find_reauth_required(exc)
+            if reauth is not None:
+                await get_default_session_manager().invalidate(server_name)
+                raise ToolException(str(reauth)) from exc
             if not _is_transient_session_error(exc):
                 raise
             logger.info(
@@ -767,6 +777,9 @@ def _build_cached_mcp_tool(
                 # try once more from scratch, but surface this call as a
                 # ToolException rather than crashing the agent loop.
                 await get_default_session_manager().invalidate(server_name)
+                retry_reauth = find_reauth_required(retry_exc)
+                if retry_reauth is not None:
+                    raise ToolException(str(retry_reauth)) from retry_exc
                 msg = (
                     f"MCP tool {lc_tool_name!r} failed after one retry on "
                     f"server {server_name!r}: {type(retry_exc).__name__}: "
@@ -890,6 +903,7 @@ async def _load_tools_from_config(
                     server_name=server_name,
                     server_url=server_config["url"],
                     storage=storage,
+                    interactive=False,
                 )
             connections[server_name] = conn
         else:

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -102,6 +102,14 @@ def _validate_server_config(server_name: str, server_config: dict[str, Any]) -> 
         if headers is not None and not isinstance(headers, dict):
             error_msg = f"Server '{server_name}' 'headers' must be a dictionary"
             raise TypeError(error_msg)
+
+        # Fail fast on unset env-var references in header values.
+        # We discard the resolved result; real resolution happens at
+        # connection time (see _load_tools_from_config).
+        if headers is not None:
+            from deepagents_cli.mcp_auth import resolve_headers
+
+            resolve_headers(headers, server_name=server_name)
     elif server_type == "stdio":
         # stdio server validation
         if "command" not in server_config:

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -466,17 +466,16 @@ class MCPSessionManager:
         per-server `AsyncExitStack` so individual entries can be invalidated
         without closing unrelated sessions.
 
+        Any error from `create_session` / `initialize` (including
+        `CancelledError`) propagates after the partial stack is rolled back,
+        so the cache is left in a clean state on failure.
+
         Args:
             server_name: Identifier used as the cache key.
             connection: Adapter connection config (stdio / http / sse).
 
         Returns:
             An initialized `ClientSession` bound to the current event loop.
-
-        Raises:
-            Exception: Propagates any error from `create_session` /
-                `initialize`; the partial stack is rolled back so the cache is
-                left in a clean state on failure.
         """
         existing = self._sessions.get(server_name)
         if existing is not None:
@@ -579,7 +578,7 @@ def _best_effort_shutdown() -> None:
     original loop — so this is a best-effort hook, not a correctness guarantee.
     Child subprocesses are reaped when the parent process exits regardless.
     """
-    if _DEFAULT_MANAGER is None or not _DEFAULT_MANAGER._stacks:  # noqa: SLF001
+    if _DEFAULT_MANAGER is None or not _DEFAULT_MANAGER._stacks:
         return
     try:
         loop = asyncio.new_event_loop()
@@ -658,6 +657,14 @@ async def _discover_tools(session: ClientSession) -> list[Any]:
     that private helper so this module does not silently break on an adapter
     refactor. Caps pagination at 1000 pages to match the adapter's guard
     against a misbehaving server returning infinite cursors.
+
+    Returns:
+        The full flat list of `mcp.types.Tool` objects returned across all
+        pages.
+
+    Raises:
+        RuntimeError: If pagination does not terminate within 1000 pages,
+            indicating a misbehaving server that keeps returning cursors.
     """
     cursor: str | None = None
     tools: list[Any] = []
@@ -699,7 +706,9 @@ def _build_cached_mcp_tool(
         A `StructuredTool` wrapping the remote MCP tool.
     """
     from langchain_core.tools import StructuredTool, ToolException
-    from langchain_mcp_adapters.tools import _convert_call_tool_result
+    from langchain_mcp_adapters.tools import (
+        _convert_call_tool_result,  # noqa: PLC2701 — adapter's private helper is the only path to materialize a CallToolResult as a LangChain ToolMessage
+    )
 
     original_tool_name = mcp_tool.name
     lc_tool_name = (

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -524,6 +524,24 @@ async def _load_tools_from_config(
                 conn["headers"] = resolve_headers(
                     server_config["headers"], server_name=server_name
                 )
+            if server_config.get("auth") == "oauth":
+                from deepagents_cli.mcp_auth import (
+                    FileTokenStorage,
+                    build_oauth_provider,
+                )
+
+                storage = FileTokenStorage(server_name)
+                if await storage.get_tokens() is None:
+                    msg = (
+                        f"MCP server '{server_name}' requires OAuth login. "
+                        f"Run: deepagents mcp login {server_name}"
+                    )
+                    raise RuntimeError(msg)
+                conn["auth"] = build_oauth_provider(
+                    server_name=server_name,
+                    server_url=server_config["url"],
+                    storage=storage,
+                )
             connections[server_name] = conn
         else:
             # stdio server connection (default)

--- a/libs/cli/deepagents_cli/server.py
+++ b/libs/cli/deepagents_cli/server.py
@@ -446,11 +446,24 @@ class ServerProcess:
         self._process = None
 
         if self._log_file is not None:
+            log_path = Path(self._log_file.name)
             try:
                 self._log_file.close()
-                Path(self._log_file.name).unlink()
             except OSError:
-                logger.debug("Failed to clean up log file", exc_info=True)
+                logger.debug("Failed to close log file", exc_info=True)
+
+            from deepagents_cli._env_vars import DEBUG
+
+            if os.environ.get(DEBUG):
+                print(  # noqa: T201
+                    f"Server log preserved at: {log_path}",
+                    file=sys.stderr,
+                )
+            else:
+                try:
+                    log_path.unlink()
+                except OSError:
+                    logger.debug("Failed to clean up log file", exc_info=True)
             self._log_file = None
 
     def stop(self) -> None:

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -371,6 +371,44 @@ def show_update_help() -> None:
     console.print()
 
 
+def show_mcp_help() -> None:
+    """Show help information for the `mcp` subcommand.
+
+    Invoked via the `-h` argparse action or directly from `cli_main`
+    when no mcp subcommand is given.
+    """
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents mcp <command> [options]")
+    console.print()
+    console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
+    console.print("  login <server>    Run the OAuth login flow for an MCP server")
+    console.print()
+    _print_option_section()
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents mcp login notion")
+    console.print("  deepagents mcp login linear --config ./mcp-config.json")
+    console.print()
+
+
+def show_mcp_login_help() -> None:
+    """Show help information for the `mcp login` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents mcp login <server> [--config PATH]")
+    console.print()
+    _print_option_section(
+        "  --config PATH           Path to an MCP config JSON file"
+        " (default: auto-discovered)",
+    )
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  deepagents mcp login notion")
+    console.print("  deepagents mcp login linear --config ./mcp-config.json")
+    console.print()
+
+
 def show_threads_help() -> None:
     """Show help information for the `threads` subcommand.
 

--- a/libs/cli/deepagents_cli/widgets/mcp_viewer.py
+++ b/libs/cli/deepagents_cli/widgets/mcp_viewer.py
@@ -268,13 +268,30 @@ class MCPViewerScreen(ModalScreen[None]):
                     for server in self._server_info:
                         tool_count = len(server.tools)
                         t_label = "tool" if tool_count == 1 else "tools"
-                        yield Static(
-                            Content.from_markup(
+                        if server.status == "ok":
+                            header_markup = (
                                 "[bold]$name[/bold]"
                                 f" [dim]$transport {glyphs.bullet}"
-                                f" {tool_count} {t_label}[/dim]",
+                                f" {tool_count} {t_label}[/dim]"
+                            )
+                        else:
+                            # Surface unauth / error servers inline so users
+                            # know the server is configured but unavailable,
+                            # and (for "unauthenticated") what to run to fix
+                            # it. The tools list is empty for these entries.
+                            header_markup = (
+                                "[bold]$name[/bold]"
+                                f" [dim]$transport[/dim]"
+                                f" [yellow]{glyphs.bullet} $status[/yellow]"
+                                f" [dim]— $error[/dim]"
+                            )
+                        yield Static(
+                            Content.from_markup(
+                                header_markup,
                                 name=server.name,
                                 transport=server.transport,
+                                status=server.status,
+                                error=server.error or "",
                             ),
                             classes="mcp-server-header",
                         )

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -217,6 +217,9 @@ ignore-var-parameters = true
 "tests/**" = [
     "ANN001",   # Missing type annotation for function argument — not needed in tests
     "ANN201",   # Missing return type annotation — not needed in tests
+    "ANN202",   # Missing return type on private helper — not needed in tests
+    "ARG001",   # Unused function argument — common for pytest fixtures / mock stand-ins
+    "ARG002",   # Unused method argument — common for pytest fixtures / mock stand-ins
     "D1",       # Missing docstrings — not needed in tests
     "DOC",      # Docstring conventions — not needed in tests
     "F401",     # Imported but unused — test fixtures may appear unused
@@ -228,6 +231,7 @@ ignore-var-parameters = true
     "PLR6301",  # Method could be a function — test class organization
     "PLW0108",  # Lambda may be unnecessary — fine in test mocks
     "RUF001",   # Ambiguous characters — fine in test strings
+    "RUF029",   # Async without await — required for asynccontextmanager / AsyncMock stand-ins
     "S",        # Security warnings — not applicable to tests
     "SLF",      # Private member access — tests need access to internals
 ]

--- a/libs/cli/tests/integration_tests/test_acp_mode.py
+++ b/libs/cli/tests/integration_tests/test_acp_mode.py
@@ -20,42 +20,42 @@ if TYPE_CHECKING:
 
 
 class _AcpSmokeClient(Client):
-    async def request_permission(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def request_permission(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "session/request_permission"
         raise RequestError.method_not_found(msg)
 
-    async def write_text_file(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def write_text_file(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "fs/write_text_file"
         raise RequestError.method_not_found(msg)
 
-    async def read_text_file(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def read_text_file(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "fs/read_text_file"
         raise RequestError.method_not_found(msg)
 
-    async def create_terminal(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def create_terminal(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "terminal/create"
         raise RequestError.method_not_found(msg)
 
-    async def terminal_output(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def terminal_output(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "terminal/output"
         raise RequestError.method_not_found(msg)
 
-    async def release_terminal(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def release_terminal(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "terminal/release"
         raise RequestError.method_not_found(msg)
 
-    async def wait_for_terminal_exit(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def wait_for_terminal_exit(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "terminal/wait_for_exit"
         raise RequestError.method_not_found(msg)
 
-    async def kill_terminal(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002  # required by ACP Client protocol
+    async def kill_terminal(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401  # required by ACP Client protocol
         msg = "terminal/kill"
         raise RequestError.method_not_found(msg)
 
-    async def ext_method(self, method: str, params: dict) -> dict:  # noqa: ARG002
+    async def ext_method(self, method: str, params: dict) -> dict:
         raise RequestError.method_not_found(method)
 
-    async def ext_notification(self, method: str, params: dict) -> None:  # noqa: ARG002
+    async def ext_notification(self, method: str, params: dict) -> None:
         raise RequestError.method_not_found(method)
 
 

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -138,3 +138,10 @@ def _isolate_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         "deepagents_cli.widgets.chat_input._default_history_path",
         lambda: tmp_path / "history.jsonl",
     )
+
+
+@pytest.fixture
+def fake_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect `~/.deepagents/` into a per-test tmp dir."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -3179,7 +3179,7 @@ class TestDeferredActions:
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            for cmd in ("/changelog", "/docs", "/feedback", "/mcp"):
+            for cmd in ("/changelog", "/docs", "/feedback"):
                 assert app._can_bypass_queue(cmd) is True
 
     async def test_queued_commands_do_not_bypass(self) -> None:
@@ -3187,7 +3187,7 @@ class TestDeferredActions:
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
-            for cmd in ("/help", "/clear", "/tokens"):
+            for cmd in ("/help", "/clear", "/tokens", "/mcp"):
                 assert app._can_bypass_queue(cmd) is False
 
     async def test_can_bypass_queue_empty_string(self) -> None:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -60,7 +60,7 @@ class TestInitialPromptOnMount:
         submitted: list[str] = []
 
         # Must be async to match _handle_user_message's signature
-        async def capture(msg: str) -> None:  # noqa: RUF029
+        async def capture(msg: str) -> None:
             submitted.append(msg)
 
         app._handle_user_message = capture  # type: ignore[assignment]
@@ -83,7 +83,7 @@ class TestInitialPromptOnMount:
         )
         submitted: list[tuple[str, str, str | None]] = []
 
-        async def capture(  # noqa: RUF029
+        async def capture(
             skill_name: str,
             args: str = "",
             *,
@@ -111,7 +111,7 @@ class TestInitialPromptOnMount:
         app.call_after_refresh = lambda cb: cb()  # type: ignore[assignment]
         submitted: list[tuple[str, str, str | None]] = []
 
-        async def capture(  # noqa: RUF029
+        async def capture(
             skill_name: str,
             args: str = "",
             *,
@@ -2164,9 +2164,7 @@ class TestRequestApprovalBranching:
 
         mounted_classes: list[str] = []
 
-        async def fake_mount_before_queued(  # noqa: RUF029
-            _container: object, widget: object
-        ) -> None:
+        async def fake_mount_before_queued(_container: object, widget: object) -> None:
             if isinstance(widget, Static):
                 mounted_classes.append(" ".join(widget.classes))
 
@@ -2216,9 +2214,7 @@ class TestRequestApprovalBranching:
 
         call_count = 0
 
-        async def failing_then_ok_mount(  # noqa: RUF029
-            _container: object, widget: object
-        ) -> None:
+        async def failing_then_ok_mount(_container: object, widget: object) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -2257,9 +2253,7 @@ class TestRequestApprovalBranching:
 
         mounted_types: list[type] = []
 
-        async def fake_mount_before_queued(  # noqa: RUF029
-            _container: object, widget: object
-        ) -> None:
+        async def fake_mount_before_queued(_container: object, widget: object) -> None:
             mounted_types.append(type(widget))
 
         app._mount_before_queued = fake_mount_before_queued  # type: ignore[assignment]
@@ -2297,7 +2291,7 @@ class TestDeferredShowApproval:
         placeholder.is_attached = True
         remove_called = False
 
-        async def fake_remove() -> None:  # noqa: RUF029
+        async def fake_remove() -> None:
             nonlocal remove_called
             remove_called = True
 
@@ -2310,9 +2304,9 @@ class TestDeferredShowApproval:
 
         mount_called = False
 
-        async def fake_mount_approval(  # noqa: RUF029
-            m: ApprovalMenu,  # noqa: ARG001
-            f: asyncio.Future[dict[str, str]],  # noqa: ARG001
+        async def fake_mount_approval(
+            m: ApprovalMenu,
+            f: asyncio.Future[dict[str, str]],
         ) -> None:
             nonlocal mount_called
             mount_called = True
@@ -2342,9 +2336,9 @@ class TestDeferredShowApproval:
 
         mount_called = False
 
-        async def fake_mount_approval(  # noqa: RUF029
-            m: ApprovalMenu,  # noqa: ARG001
-            f: asyncio.Future[dict[str, str]],  # noqa: ARG001
+        async def fake_mount_approval(
+            m: ApprovalMenu,
+            f: asyncio.Future[dict[str, str]],
         ) -> None:
             nonlocal mount_called
             mount_called = True
@@ -2376,7 +2370,7 @@ class TestDeferredShowApproval:
 
         remove_called = False
 
-        async def fake_remove() -> None:  # noqa: RUF029
+        async def fake_remove() -> None:
             nonlocal remove_called
             remove_called = True
 
@@ -2384,9 +2378,9 @@ class TestDeferredShowApproval:
 
         mount_called = False
 
-        async def fake_mount_approval(  # noqa: RUF029
-            m: ApprovalMenu,  # noqa: ARG001
-            f: asyncio.Future[dict[str, str]],  # noqa: ARG001
+        async def fake_mount_approval(
+            m: ApprovalMenu,
+            f: asyncio.Future[dict[str, str]],
         ) -> None:
             nonlocal mount_called
             mount_called = True
@@ -2451,7 +2445,7 @@ class TestOnApprovalMenuDecidedCleanup:
         placeholder.is_attached = True
         remove_called = False
 
-        async def fake_remove() -> None:  # noqa: RUF029
+        async def fake_remove() -> None:
             nonlocal remove_called
             remove_called = True
 
@@ -2970,7 +2964,7 @@ class TestDeferredActions:
 
             executed: list[str] = []
 
-            async def action() -> None:  # noqa: RUF029
+            async def action() -> None:
                 executed.append("ran")
 
             app._deferred_actions.append(
@@ -2992,7 +2986,7 @@ class TestDeferredActions:
 
             executed: list[str] = []
 
-            async def action() -> None:  # noqa: RUF029
+            async def action() -> None:
                 executed.append("ran")
 
             app._deferred_actions.append(
@@ -3013,7 +3007,7 @@ class TestDeferredActions:
 
             executed: list[str] = []
 
-            async def action() -> None:  # noqa: RUF029
+            async def action() -> None:
                 executed.append("ran")
 
             app._deferred_actions.append(
@@ -3085,11 +3079,11 @@ class TestDeferredActions:
 
             executed: list[str] = []
 
-            async def bad_action() -> None:  # noqa: RUF029
+            async def bad_action() -> None:
                 msg = "boom"
                 raise RuntimeError(msg)
 
-            async def good_action() -> None:  # noqa: RUF029
+            async def good_action() -> None:
                 executed.append("ok")
 
             app._deferred_actions.append(
@@ -3112,10 +3106,10 @@ class TestDeferredActions:
 
             executed: list[str] = []
 
-            async def first() -> None:  # noqa: RUF029
+            async def first() -> None:
                 executed.append("first")
 
-            async def second() -> None:  # noqa: RUF029
+            async def second() -> None:
                 executed.append("second")
 
             app._defer_action(DeferredAction(kind="model_switch", execute=first))
@@ -3211,13 +3205,13 @@ class TestDeferredActions:
 
             executed: list[str] = []
 
-            async def first_model() -> None:  # noqa: RUF029
+            async def first_model() -> None:
                 executed.append("first_model")
 
-            async def thread_fn() -> None:  # noqa: RUF029
+            async def thread_fn() -> None:
                 executed.append("thread")
 
-            async def second_model() -> None:  # noqa: RUF029
+            async def second_model() -> None:
                 executed.append("second_model")
 
             app._defer_action(DeferredAction(kind="model_switch", execute=first_model))

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -40,3 +40,80 @@ def test_parse_mcp_login_argv_bad_name() -> None:
 def test_parse_mcp_login_argv_bad_chars() -> None:
     with pytest.raises(ValueError, match="Invalid server name"):
         _parse_mcp_login_argv("/mcp login foo/bar")
+
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+
+class _StubApp:
+    """Minimal stand-in for `DeepAgentsApp` exercising one method at a time.
+
+    We don't construct the real Textual app because it binds to a terminal
+    and mounts widgets; we only need attribute access to test the helpers.
+    """
+
+    def __init__(
+        self,
+        mcp_preload_kwargs: dict | None,
+        mcp_server_info: list | None = None,
+    ) -> None:
+        self._mcp_preload_kwargs = mcp_preload_kwargs
+        self._mcp_server_info = mcp_server_info
+        self._mcp_tool_count = 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_mcp_server_info_happy_path() -> None:
+    """Successful refresh replaces the cached list and updates the count."""
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.mcp_tools import MCPServerInfo
+
+    info = [MCPServerInfo(name="notion", transport="http")]
+    info[0].tools = [object(), object()]  # two "tools"
+    preload_kwargs = {
+        "mcp_config_path": None,
+        "no_mcp": False,
+        "trust_project_mcp": None,
+    }
+    app = _StubApp(mcp_preload_kwargs=preload_kwargs)
+
+    with patch(
+        "deepagents_cli.main._preload_session_mcp_server_info",
+        new=AsyncMock(return_value=info),
+    ):
+        await DeepAgentsApp._refresh_mcp_server_info(app)  # type: ignore[arg-type]
+
+    assert app._mcp_server_info is info
+    assert app._mcp_tool_count == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_mcp_server_info_no_preload_kwargs() -> None:
+    """When preload kwargs are `None` (MCP disabled), refresh is a no-op."""
+    from deepagents_cli.app import DeepAgentsApp
+
+    app = _StubApp(mcp_preload_kwargs=None, mcp_server_info=None)
+    await DeepAgentsApp._refresh_mcp_server_info(app)  # type: ignore[arg-type]
+    assert app._mcp_server_info is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_mcp_server_info_preload_failure_propagates() -> None:
+    """Exceptions in the preloader propagate so the caller can warn."""
+    from deepagents_cli.app import DeepAgentsApp
+
+    preload_kwargs = {
+        "mcp_config_path": None,
+        "no_mcp": False,
+        "trust_project_mcp": None,
+    }
+    app = _StubApp(mcp_preload_kwargs=preload_kwargs)
+
+    with (
+        patch(
+            "deepagents_cli.main._preload_session_mcp_server_info",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await DeepAgentsApp._refresh_mcp_server_info(app)  # type: ignore[arg-type]

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -68,8 +68,8 @@ async def test_refresh_mcp_server_info_happy_path() -> None:
     from deepagents_cli.app import DeepAgentsApp
     from deepagents_cli.mcp_tools import MCPServerInfo
 
-    info = [MCPServerInfo(name="notion", transport="http")]
-    info[0].tools = [object(), object()]  # two "tools"
+    info: list[MCPServerInfo] = [MCPServerInfo(name="notion", transport="http")]
+    info[0].tools = [object(), object()]  # type: ignore[list-item]  # test fixture
     preload_kwargs = {
         "mcp_config_path": None,
         "no_mcp": False,
@@ -120,6 +120,10 @@ async def test_refresh_mcp_server_info_preload_failure_propagates() -> None:
 
 
 from contextlib import contextmanager  # noqa: E402
+from typing import TYPE_CHECKING  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class _RecordingApp(_StubApp):
@@ -141,11 +145,11 @@ class _RecordingApp(_StubApp):
         self.suspend_entered = 0
 
         @contextmanager
-        def _suspend() -> object:
+        def _suspend() -> Iterator[None]:
             self.suspend_entered += 1
             yield
 
-        self.suspend = _suspend  # type: ignore[method-assign]
+        self.suspend = _suspend
 
     async def _mount_message(self, msg: object) -> None:
         self.mounted.append(msg)
@@ -285,7 +289,7 @@ async def test_run_mcp_login_no_preload_kwargs_errors() -> None:
     """When MCP is disabled (no preload kwargs) the command errors cleanly."""
     from deepagents_cli.app import AppMessage, DeepAgentsApp
 
-    app = _RecordingApp(mcp_preload_kwargs=None)  # type: ignore[arg-type]
+    app = _RecordingApp(mcp_preload_kwargs=None)
     # Force the stub to actually carry None
     app._mcp_preload_kwargs = None
     app._refresh_mcp_server_info = AsyncMock()  # type: ignore[method-assign]

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -117,3 +117,182 @@ async def test_refresh_mcp_server_info_preload_failure_propagates() -> None:
         pytest.raises(RuntimeError, match="boom"),
     ):
         await DeepAgentsApp._refresh_mcp_server_info(app)  # type: ignore[arg-type]
+
+
+from contextlib import contextmanager  # noqa: E402
+
+
+class _RecordingApp(_StubApp):
+    """Stub that records `_mount_message` calls and stubs `suspend`."""
+
+    def __init__(
+        self,
+        mcp_preload_kwargs: dict | None = None,
+    ) -> None:
+        super().__init__(
+            mcp_preload_kwargs=mcp_preload_kwargs
+            or {
+                "mcp_config_path": "/tmp/mcp.json",
+                "no_mcp": False,
+                "trust_project_mcp": None,
+            }
+        )
+        self.mounted: list = []
+        self.suspend_entered = 0
+
+        @contextmanager
+        def _suspend() -> object:
+            self.suspend_entered += 1
+            yield
+
+        self.suspend = _suspend  # type: ignore[method-assign]
+
+    async def _mount_message(self, msg: object) -> None:
+        self.mounted.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_success_refreshes_and_notifies() -> None:
+    """Exit 0 → refresh cache, mount success AppMessage, suspend was used."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp()
+    refresh = AsyncMock()
+    app._refresh_mcp_server_info = refresh  # type: ignore[method-assign]
+
+    with patch(
+        "deepagents_cli.mcp_commands.run_mcp_login",
+        new=AsyncMock(return_value=0),
+    ):
+        await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    assert app.suspend_entered == 1
+    refresh.assert_awaited_once()
+    assert any(
+        isinstance(m, AppMessage) and "Logged in to MCP server 'notion'" in m._content
+        for m in app.mounted
+    ), app.mounted
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_exit_1_generic_failure() -> None:
+    """Exit 1 → mount generic failure, no refresh."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp()
+    refresh = AsyncMock()
+    app._refresh_mcp_server_info = refresh  # type: ignore[method-assign]
+
+    with patch(
+        "deepagents_cli.mcp_commands.run_mcp_login",
+        new=AsyncMock(return_value=1),
+    ):
+        await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    refresh.assert_not_called()
+    assert any(
+        isinstance(m, AppMessage) and "Login failed" in m._content for m in app.mounted
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_exit_2_no_config() -> None:
+    """Exit 2 → mount "No MCP config found" message."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp()
+    app._refresh_mcp_server_info = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "deepagents_cli.mcp_commands.run_mcp_login",
+        new=AsyncMock(return_value=2),
+    ):
+        await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    assert any(
+        isinstance(m, AppMessage) and "No MCP config found" in m._content
+        for m in app.mounted
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_keyboard_interrupt() -> None:
+    """Ctrl+C during paste-back → mount cancellation message."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp()
+    app._refresh_mcp_server_info = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "deepagents_cli.mcp_commands.run_mcp_login",
+        new=AsyncMock(side_effect=KeyboardInterrupt()),
+    ):
+        await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    assert any(
+        isinstance(m, AppMessage) and "MCP login cancelled" in m._content
+        for m in app.mounted
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_unexpected_exception() -> None:
+    """Unexpected exceptions → mount failure message, do not raise."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp()
+    app._refresh_mcp_server_info = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "deepagents_cli.mcp_commands.run_mcp_login",
+        new=AsyncMock(side_effect=RuntimeError("oops")),
+    ):
+        await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    assert any(
+        isinstance(m, AppMessage)
+        and "MCP login failed" in m._content
+        and "oops" in m._content
+        for m in app.mounted
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_refresh_failure_still_succeeds() -> None:
+    """Refresh failure → success message plus warning suffix."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp()
+    app._refresh_mcp_server_info = AsyncMock(side_effect=RuntimeError("probe failed"))  # type: ignore[method-assign]
+
+    with patch(
+        "deepagents_cli.mcp_commands.run_mcp_login",
+        new=AsyncMock(return_value=0),
+    ):
+        await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    assert any(
+        isinstance(m, AppMessage)
+        and "Logged in" in m._content
+        and "couldn't refresh /mcp viewer" in m._content
+        for m in app.mounted
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_mcp_login_no_preload_kwargs_errors() -> None:
+    """When MCP is disabled (no preload kwargs) the command errors cleanly."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _RecordingApp(mcp_preload_kwargs=None)  # type: ignore[arg-type]
+    # Force the stub to actually carry None
+    app._mcp_preload_kwargs = None
+    app._refresh_mcp_server_info = AsyncMock()  # type: ignore[method-assign]
+
+    await DeepAgentsApp._run_mcp_login_interactive(app, "notion")  # type: ignore[arg-type]
+
+    assert app.suspend_entered == 0  # should not suspend
+    assert any(
+        isinstance(m, AppMessage) and "MCP is disabled" in m._content
+        for m in app.mounted
+    )

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -297,3 +297,90 @@ async def test_run_mcp_login_no_preload_kwargs_errors() -> None:
         isinstance(m, AppMessage) and "MCP is disabled" in m._content
         for m in app.mounted
     )
+
+
+from functools import partial  # noqa: E402
+
+
+class _DispatchApp(_RecordingApp):
+    """Extends `_RecordingApp` with just-enough surface for dispatch tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._agent_running = False
+        self._shell_running = False
+        self._connecting = False
+        self._deferred_actions: list = []
+        self.call_later_calls: list = []
+        self.notify_calls: list[str] = []
+        self._run_mcp_login_interactive = AsyncMock()
+
+    def _defer_action(self, action) -> None:
+        # Mirror the real dedup-by-kind behavior so the test is meaningful.
+        self._deferred_actions = [
+            a for a in self._deferred_actions if a.kind != action.kind
+        ]
+        self._deferred_actions.append(action)
+
+    def call_later(self, fn, *args: object, **kwargs: object) -> None:
+        self.call_later_calls.append((fn, args, kwargs))
+
+    def notify(self, message: str, *, timeout: float = 3) -> None:
+        self.notify_calls.append(message)
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_dispatch_idle_calls_later() -> None:
+    from deepagents_cli.app import DeepAgentsApp, UserMessage
+
+    app = _DispatchApp()
+    await DeepAgentsApp._dispatch_mcp_login(app, "/mcp login notion")  # type: ignore[arg-type]
+
+    assert app.call_later_calls, "expected call_later to be scheduled"
+    _fn, args, _ = app.call_later_calls[0]
+    assert args == ("notion",)
+    assert any(isinstance(m, UserMessage) for m in app.mounted)
+    assert not app._deferred_actions
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_dispatch_busy_defers() -> None:
+    from deepagents_cli.app import DeepAgentsApp
+
+    app = _DispatchApp()
+    app._agent_running = True
+    await DeepAgentsApp._dispatch_mcp_login(app, "/mcp login notion")  # type: ignore[arg-type]
+
+    assert len(app._deferred_actions) == 1
+    assert app._deferred_actions[0].kind == "mcp_login"
+    assert app.notify_calls
+    assert "MCP login will run" in app.notify_calls[0]
+    assert not app.call_later_calls
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_dispatch_usage_error() -> None:
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _DispatchApp()
+    await DeepAgentsApp._dispatch_mcp_login(app, "/mcp login")  # type: ignore[arg-type]
+
+    assert not app.call_later_calls
+    assert not app._deferred_actions
+    assert any(
+        isinstance(m, AppMessage) and "Usage:" in m._content for m in app.mounted
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_dispatch_invalid_name() -> None:
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _DispatchApp()
+    await DeepAgentsApp._dispatch_mcp_login(app, "/mcp login bad.name")  # type: ignore[arg-type]
+
+    assert not app.call_later_calls
+    assert any(
+        isinstance(m, AppMessage) and "Invalid server name" in m._content
+        for m in app.mounted
+    )

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -384,3 +384,19 @@ async def test_mcp_login_dispatch_invalid_name() -> None:
         isinstance(m, AppMessage) and "Invalid server name" in m._content
         for m in app.mounted
     )
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_dispatch_unknown_subcommand() -> None:
+    """`/mcp foo` reports unknown subcommand without suspending/deferring."""
+    from deepagents_cli.app import AppMessage, DeepAgentsApp
+
+    app = _DispatchApp()
+    await DeepAgentsApp._dispatch_mcp_login(app, "/mcp foo bar")  # type: ignore[arg-type]
+
+    assert not app.call_later_calls
+    assert not app._deferred_actions
+    assert any(
+        isinstance(m, AppMessage) and "Unknown /mcp subcommand" in m._content
+        for m in app.mounted
+    )

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -1,0 +1,12 @@
+"""Unit tests for the /mcp login <server> TUI path."""
+
+from __future__ import annotations
+
+from typing import get_args
+
+from deepagents_cli.app import DeferredActionKind
+
+
+def test_deferred_action_kind_includes_mcp_login() -> None:
+    """`mcp_login` must be a valid deferred-action kind for deduplication."""
+    assert "mcp_login" in get_args(DeferredActionKind)

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -400,3 +400,12 @@ async def test_mcp_login_dispatch_unknown_subcommand() -> None:
         isinstance(m, AppMessage) and "Unknown /mcp subcommand" in m._content
         for m in app.mounted
     )
+
+
+def test_slash_mcp_bypass_tier_is_queued() -> None:
+    """/mcp can trigger suspend now — must wait out busy states."""
+    from deepagents_cli.command_registry import COMMANDS, BypassTier
+
+    entry = next(c for c in COMMANDS if c.name == "/mcp")
+    assert entry.bypass_tier is BypassTier.QUEUED
+    assert "login" in entry.argument_hint

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -4,9 +4,39 @@ from __future__ import annotations
 
 from typing import get_args
 
-from deepagents_cli.app import DeferredActionKind
+import pytest
+
+from deepagents_cli.app import DeferredActionKind, _parse_mcp_login_argv
 
 
 def test_deferred_action_kind_includes_mcp_login() -> None:
     """`mcp_login` must be a valid deferred-action kind for deduplication."""
     assert "mcp_login" in get_args(DeferredActionKind)
+
+
+def test_parse_mcp_login_argv_valid() -> None:
+    assert _parse_mcp_login_argv("/mcp login notion") == "notion"
+
+
+def test_parse_mcp_login_argv_extra_whitespace() -> None:
+    assert _parse_mcp_login_argv("/mcp login   github  ") == "github"
+
+
+def test_parse_mcp_login_argv_missing_server() -> None:
+    with pytest.raises(ValueError, match="Usage: /mcp login <server>"):
+        _parse_mcp_login_argv("/mcp login")
+
+
+def test_parse_mcp_login_argv_multiple_args() -> None:
+    with pytest.raises(ValueError, match="Usage: /mcp login <server>"):
+        _parse_mcp_login_argv("/mcp login notion github")
+
+
+def test_parse_mcp_login_argv_bad_name() -> None:
+    with pytest.raises(ValueError, match="Invalid server name"):
+        _parse_mcp_login_argv("/mcp login bad.name")
+
+
+def test_parse_mcp_login_argv_bad_chars() -> None:
+    with pytest.raises(ValueError, match="Invalid server name"):
+        _parse_mcp_login_argv("/mcp login foo/bar")

--- a/libs/cli/tests/unit_tests/test_app_mcp_login.py
+++ b/libs/cli/tests/unit_tests/test_app_mcp_login.py
@@ -168,6 +168,7 @@ async def test_run_mcp_login_success_refreshes_and_notifies() -> None:
 
     assert app.suspend_entered == 1
     refresh.assert_awaited_once()
+    # AppMessage stores the raw str in `_content`; no public accessor exists.
     assert any(
         isinstance(m, AppMessage) and "Logged in to MCP server 'notion'" in m._content
         for m in app.mounted

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -2219,13 +2219,13 @@ class _TextAreaTypingApp(App[None]):
 
     def on_chat_text_area_typing(
         self,
-        event: ChatTextArea.Typing,  # noqa: ARG002
+        event: ChatTextArea.Typing,
     ) -> None:
         self.text_area_typing_count += 1
 
     def on_chat_input_typing(
         self,
-        event: ChatInput.Typing,  # noqa: ARG002
+        event: ChatInput.Typing,
     ) -> None:
         self.chat_input_typing_count += 1
 

--- a/libs/cli/tests/unit_tests/test_configurable_model.py
+++ b/libs/cli/tests/unit_tests/test_configurable_model.py
@@ -177,7 +177,7 @@ class TestModelSwap:
 
         captured: list[ModelRequest] = []
 
-        async def handler(r: ModelRequest) -> ModelResponse[Any]:  # noqa: RUF029
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:
             captured.append(r)
             return _make_response()
 
@@ -307,7 +307,7 @@ class TestAnthropicSettingsStripped:
         )
         captured: list[ModelRequest] = []
 
-        async def handler(r: ModelRequest) -> ModelResponse[Any]:  # noqa: RUF029
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:
             captured.append(r)
             return _make_response()
 
@@ -454,7 +454,7 @@ class TestModelParams:
         )
         captured: list[ModelRequest] = []
 
-        async def handler(r: ModelRequest) -> ModelResponse[Any]:  # noqa: RUF029
+        async def handler(r: ModelRequest) -> ModelResponse[Any]:
             captured.append(r)
             return _make_response()
 

--- a/libs/cli/tests/unit_tests/test_end_to_end.py
+++ b/libs/cli/tests/unit_tests/test_end_to_end.py
@@ -35,10 +35,10 @@ class FixedGenericFakeChatModel(GenericFakeChatModel):
 
     def bind_tools(
         self,
-        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],  # noqa: ARG002
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
         *,
-        tool_choice: str | None = None,  # noqa: ARG002
-        **kwargs: Any,  # noqa: ARG002
+        tool_choice: str | None = None,
+        **kwargs: Any,
     ) -> Runnable[LanguageModelInput, AIMessage]:
         """Override bind_tools to return self."""
         return self

--- a/libs/cli/tests/unit_tests/test_local_context.py
+++ b/libs/cli/tests/unit_tests/test_local_context.py
@@ -55,7 +55,7 @@ class _SyncBackendFake:
         self,
         command: str,
         *,
-        timeout: int | None = None,  # noqa: ARG002
+        timeout: int | None = None,
     ) -> ExecuteResponse:
         """Delegate to internal mock so callers can assert calls."""
         return self._mock(command)
@@ -85,7 +85,7 @@ class _AsyncBackendFake:
         self,
         command: str,
         *,
-        timeout: int | None = None,  # noqa: ASYNC109, ARG002
+        timeout: int | None = None,  # noqa: ASYNC109
     ) -> ExecuteResponse:
         """Delegate to internal mock so callers can assert calls."""
         return await self._mock(command)
@@ -603,18 +603,18 @@ class TestAsyncLocalContextMiddleware:
 
             def execute(
                 self,
-                command: str,  # noqa: ARG002
+                command: str,
                 *,
-                timeout: int | None = None,  # noqa: ARG002
+                timeout: int | None = None,
             ) -> ExecuteResponse:
                 msg = "abefore_agent should use aexecute when available"
                 raise AssertionError(msg)
 
             async def aexecute(
                 self,
-                command: str,  # noqa: ARG002
+                command: str,
                 *,
-                timeout: int | None = None,  # noqa: ARG002, ASYNC109
+                timeout: int | None = None,  # noqa: ASYNC109
             ) -> ExecuteResponse:
                 return ExecuteResponse(output=SAMPLE_CONTEXT, exit_code=0)
 
@@ -639,9 +639,9 @@ class TestAsyncLocalContextMiddleware:
 
             def execute(
                 self,
-                command: str,  # noqa: ARG002
+                command: str,
                 *,
-                timeout: int | None = None,  # noqa: ARG002
+                timeout: int | None = None,
             ) -> ExecuteResponse:
                 self.call_count += 1
                 return self._result
@@ -778,7 +778,7 @@ class TestTimeoutForwarding:
 
             def execute(
                 self,
-                command: str,  # noqa: ARG002
+                command: str,
                 *,
                 timeout: int | None = None,
             ) -> ExecuteResponse:
@@ -802,7 +802,7 @@ class TestTimeoutForwarding:
 
             async def aexecute(
                 self,
-                command: str,  # noqa: ARG002
+                command: str,
                 *,
                 timeout: int | None = None,  # noqa: ASYNC109
             ) -> ExecuteResponse:

--- a/libs/cli/tests/unit_tests/test_main.py
+++ b/libs/cli/tests/unit_tests/test_main.py
@@ -267,7 +267,7 @@ class TestServerCleanupLifecycle:
         """server_proc set by the background worker must still be cleaned up."""
         server_proc = SimpleNamespace(stop=MagicMock())
 
-        async def _fake_run_async(self: DeepAgentsApp) -> None:  # noqa: RUF029
+        async def _fake_run_async(self: DeepAgentsApp) -> None:
             # Simulate the background worker having set _server_proc
             self._server_proc = server_proc
 
@@ -702,7 +702,8 @@ class TestRunTextualCliAsyncModelConfigError:
         """Explicit model_name bypasses _get_default_model_spec."""
         app_result = AppResult(return_code=0, thread_id="t-1")
 
-        async def _stub(**_kwargs: Any) -> AppResult:  # noqa: RUF029  # must be async for run_textual_app signature
+        # must be async for run_textual_app signature
+        async def _stub(**_kwargs: Any) -> AppResult:
             return app_result
 
         with patch("deepagents_cli.app.run_textual_app", new=_stub):

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -160,3 +160,64 @@ class TestFileTokenStorage:
         got_b = await b.get_tokens()
         assert got_a is not None and got_a.access_token == "a-tok"
         assert got_b is not None and got_b.access_token == "b-tok"
+
+
+import io
+
+
+class TestBuildOAuthProvider:
+    def test_returns_oauth_client_provider(self, fake_home: Path) -> None:
+        from mcp.client.auth import OAuthClientProvider
+
+        from deepagents_cli.mcp_auth import FileTokenStorage, build_oauth_provider
+
+        storage = FileTokenStorage("notion")
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+        assert isinstance(provider, OAuthClientProvider)
+
+    @pytest.mark.asyncio
+    async def test_redirect_handler_prints_url(
+        self, fake_home: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from deepagents_cli.mcp_auth import _make_paste_back_handlers
+
+        redirect, _ = _make_paste_back_handlers()
+        await redirect("https://issuer.example.com/authorize?x=1")
+        captured = capsys.readouterr()
+        assert "https://issuer.example.com/authorize?x=1" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_callback_handler_parses_code_and_state(
+        self,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from deepagents_cli import mcp_auth
+
+        _, callback = mcp_auth._make_paste_back_handlers()
+        monkeypatch.setattr(
+            "sys.stdin",
+            io.StringIO(
+                "http://localhost/callback?code=ABC&state=XYZ\n"
+            ),
+        )
+        code, state = await callback()
+        assert code == "ABC"
+        assert state == "XYZ"
+
+    @pytest.mark.asyncio
+    async def test_callback_handler_rejects_missing_code(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli import mcp_auth
+
+        _, callback = mcp_auth._make_paste_back_handlers()
+        monkeypatch.setattr(
+            "sys.stdin", io.StringIO("http://localhost/callback\n")
+        )
+        with pytest.raises(RuntimeError, match="code"):
+            await callback()

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -1,0 +1,51 @@
+"""Tests for deepagents_cli.mcp_auth."""
+
+import pytest
+
+from deepagents_cli.mcp_auth import resolve_headers
+
+
+class TestResolveHeaders:
+    def test_simple_substitution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FOO", "secret-value")
+        assert resolve_headers({"Authorization": "Bearer ${FOO}"}) == {
+            "Authorization": "Bearer secret-value"
+        }
+
+    def test_multiple_vars_in_one_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("A", "alpha")
+        monkeypatch.setenv("B", "beta")
+        assert resolve_headers({"X-Combo": "${A}-${B}"}) == {"X-Combo": "alpha-beta"}
+
+    def test_missing_var_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        with pytest.raises(RuntimeError) as exc_info:
+            resolve_headers(
+                {"Authorization": "Bearer ${MISSING_VAR}"},
+                server_name="linear",
+            )
+        msg = str(exc_info.value)
+        assert "MISSING_VAR" in msg
+        assert "Authorization" in msg
+        assert "linear" in msg
+
+    def test_escape_double_dollar(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NOT_LOOKED_UP", raising=False)
+        assert resolve_headers({"X-Literal": "$${NOT_LOOKED_UP}"}) == {
+            "X-Literal": "${NOT_LOOKED_UP}"
+        }
+
+    def test_dollar_not_followed_by_brace_untouched(self) -> None:
+        assert resolve_headers({"X-Price": "price=$5"}) == {"X-Price": "price=$5"}
+
+    def test_non_string_value_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            resolve_headers({"X-Bad": 123}, server_name="srv")  # type: ignore[dict-item]
+
+    def test_empty_headers_returns_empty_dict(self) -> None:
+        assert resolve_headers({}) == {}
+
+    def test_no_substitution_when_no_placeholders(self) -> None:
+        assert resolve_headers({"X-Plain": "hello"}) == {"X-Plain": "hello"}

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -1,5 +1,6 @@
 """Tests for deepagents_cli.mcp_auth."""
 
+import io
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -16,9 +17,7 @@ class TestResolveHeaders:
             "Authorization": "Bearer secret-value"
         }
 
-    def test_multiple_vars_in_one_value(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_multiple_vars_in_one_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("A", "alpha")
         monkeypatch.setenv("B", "beta")
         assert resolve_headers({"X-Combo": "${A}-${B}"}) == {"X-Combo": "alpha-beta"}
@@ -95,8 +94,6 @@ class TestFileTokenStorage:
         reason="POSIX file-mode semantics",
     )
     async def test_file_and_dir_permissions(self, fake_home: Path) -> None:
-        import os
-
         from deepagents_cli.mcp_auth import FileTokenStorage
 
         storage = FileTokenStorage("notion")
@@ -104,20 +101,20 @@ class TestFileTokenStorage:
         token_path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
         dir_path = token_path.parent
         assert token_path.exists()
-        assert (os.stat(token_path).st_mode & 0o777) == 0o600
-        assert (os.stat(dir_path).st_mode & 0o777) == 0o700
+        assert (token_path.stat().st_mode & 0o777) == 0o600
+        assert (dir_path.stat().st_mode & 0o777) == 0o700
 
-    async def test_atomic_write_no_partial_on_failure(
-        self, fake_home: Path
-    ) -> None:
+    async def test_atomic_write_no_partial_on_failure(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import FileTokenStorage
 
         storage = FileTokenStorage("notion")
         token_path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
 
-        with patch("os.replace", side_effect=OSError("boom")):
-            with pytest.raises(OSError, match="boom"):
-                await storage.set_tokens(_make_tokens())
+        with (
+            patch("os.replace", side_effect=OSError("boom")),
+            pytest.raises(OSError, match="boom"),
+        ):
+            await storage.set_tokens(_make_tokens())
         assert not token_path.exists()
 
     async def test_version_mismatch_raises(self, fake_home: Path) -> None:
@@ -137,19 +134,14 @@ class TestFileTokenStorage:
 
         a = FileTokenStorage("notion")
         b = FileTokenStorage("linear")
-        await a.set_tokens(
-            OAuthToken(access_token="a-tok", token_type="Bearer")
-        )
-        await b.set_tokens(
-            OAuthToken(access_token="b-tok", token_type="Bearer")
-        )
+        await a.set_tokens(OAuthToken(access_token="a-tok", token_type="Bearer"))
+        await b.set_tokens(OAuthToken(access_token="b-tok", token_type="Bearer"))
         got_a = await a.get_tokens()
         got_b = await b.get_tokens()
-        assert got_a is not None and got_a.access_token == "a-tok"
-        assert got_b is not None and got_b.access_token == "b-tok"
-
-
-import io
+        assert got_a is not None
+        assert got_a.access_token == "a-tok"
+        assert got_b is not None
+        assert got_b.access_token == "b-tok"
 
 
 class TestBuildOAuthProvider:
@@ -186,9 +178,7 @@ class TestBuildOAuthProvider:
         _, callback = mcp_auth._make_paste_back_handlers()
         monkeypatch.setattr(
             "sys.stdin",
-            io.StringIO(
-                "http://localhost/callback?code=ABC&state=XYZ\n"
-            ),
+            io.StringIO("http://localhost/callback?code=ABC&state=XYZ\n"),
         )
         code, state = await callback()
         assert code == "ABC"
@@ -200,9 +190,7 @@ class TestBuildOAuthProvider:
         from deepagents_cli import mcp_auth
 
         _, callback = mcp_auth._make_paste_back_handlers()
-        monkeypatch.setattr(
-            "sys.stdin", io.StringIO("http://localhost/callback\n")
-        )
+        monkeypatch.setattr("sys.stdin", io.StringIO("http://localhost/callback\n"))
         with pytest.raises(RuntimeError, match="code"):
             await callback()
 
@@ -214,9 +202,7 @@ class TestLoginCommand:
     ) -> None:
         from deepagents_cli.mcp_auth import FileTokenStorage, login
 
-        async def _fake_handshake(
-            connections: dict, storage: FileTokenStorage
-        ) -> None:
+        async def _fake_handshake(connections: dict, storage: FileTokenStorage) -> None:
             # Simulate what MultiServerMCPClient.session(...) would trigger.
             await storage.set_tokens(
                 OAuthToken(access_token="new", token_type="Bearer")
@@ -238,7 +224,8 @@ class TestLoginCommand:
 
         storage = FileTokenStorage("notion")
         tok = await storage.get_tokens()
-        assert tok is not None and tok.access_token == "new"
+        assert tok is not None
+        assert tok.access_token == "new"
 
     async def test_login_rejects_non_oauth_server(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import login

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -55,13 +55,6 @@ class TestResolveHeaders:
         assert resolve_headers({"X-Plain": "hello"}) == {"X-Plain": "hello"}
 
 
-@pytest.fixture
-def fake_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    """Redirect `~/.deepagents/` into a per-test tmp dir."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_tokens() -> OAuthToken:
     return OAuthToken(
         access_token="at", token_type="Bearer", refresh_token="rt", expires_in=3600

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -1,7 +1,7 @@
 """Tests for deepagents_cli.mcp_auth."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from mcp.shared.auth import AnyUrl, OAuthClientInformationFull, OAuthToken
@@ -214,3 +214,58 @@ class TestBuildOAuthProvider:
         )
         with pytest.raises(RuntimeError, match="code"):
             await callback()
+
+
+class TestLoginCommand:
+    @pytest.mark.asyncio
+    async def test_login_persists_tokens(
+        self,
+        fake_home: Path,
+    ) -> None:
+        from deepagents_cli.mcp_auth import FileTokenStorage, login
+
+        async def _fake_handshake(
+            connections: dict, storage: FileTokenStorage
+        ) -> None:
+            # Simulate what MultiServerMCPClient.session(...) would trigger.
+            await storage.set_tokens(
+                OAuthToken(access_token="new", token_type="Bearer")
+            )
+            await storage.set_client_info(_make_client_info())
+
+        with patch(
+            "deepagents_cli.mcp_auth._drive_handshake",
+            new=AsyncMock(side_effect=_fake_handshake),
+        ):
+            await login(
+                server_name="notion",
+                server_config={
+                    "transport": "http",
+                    "url": "https://mcp.notion.com/mcp",
+                    "auth": "oauth",
+                },
+            )
+
+        storage = FileTokenStorage("notion")
+        tok = await storage.get_tokens()
+        assert tok is not None and tok.access_token == "new"
+
+    @pytest.mark.asyncio
+    async def test_login_rejects_non_oauth_server(self, fake_home: Path) -> None:
+        from deepagents_cli.mcp_auth import login
+
+        with pytest.raises(ValueError, match="oauth"):
+            await login(
+                server_name="x",
+                server_config={"transport": "http", "url": "https://example"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_login_rejects_stdio_server(self, fake_home: Path) -> None:
+        from deepagents_cli.mcp_auth import login
+
+        with pytest.raises(ValueError, match="stdio"):
+            await login(
+                server_name="x",
+                server_config={"command": "echo", "auth": "oauth"},
+            )

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -1,6 +1,10 @@
 """Tests for deepagents_cli.mcp_auth."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
+from mcp.shared.auth import AnyUrl, OAuthClientInformationFull, OAuthToken
 
 from deepagents_cli.mcp_auth import resolve_headers
 
@@ -49,3 +53,110 @@ class TestResolveHeaders:
 
     def test_no_substitution_when_no_placeholders(self) -> None:
         assert resolve_headers({"X-Plain": "hello"}) == {"X-Plain": "hello"}
+
+
+@pytest.fixture
+def fake_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect `~/.deepagents/` into a per-test tmp dir."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_tokens() -> OAuthToken:
+    return OAuthToken(
+        access_token="at", token_type="Bearer", refresh_token="rt", expires_in=3600
+    )
+
+
+def _make_client_info() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="cid",
+        redirect_uris=[AnyUrl("http://localhost/callback")],
+    )
+
+
+class TestFileTokenStorage:
+    @pytest.mark.asyncio
+    async def test_get_tokens_when_file_missing(self, fake_home: Path) -> None:
+        from deepagents_cli.mcp_auth import FileTokenStorage
+
+        storage = FileTokenStorage("notion")
+        assert await storage.get_tokens() is None
+        assert await storage.get_client_info() is None
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_round_trip(self, fake_home: Path) -> None:
+        from deepagents_cli.mcp_auth import FileTokenStorage
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+
+        got_ci = await storage.get_client_info()
+        got_tok = await storage.get_tokens()
+        assert got_ci is not None
+        assert got_tok is not None
+        assert got_ci.client_id == "cid"
+        assert got_tok.access_token == "at"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not hasattr(__import__("os"), "geteuid"),
+        reason="POSIX file-mode semantics",
+    )
+    async def test_file_and_dir_permissions(self, fake_home: Path) -> None:
+        import os
+
+        from deepagents_cli.mcp_auth import FileTokenStorage
+
+        storage = FileTokenStorage("notion")
+        await storage.set_tokens(_make_tokens())
+        token_path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
+        dir_path = token_path.parent
+        assert token_path.exists()
+        assert (os.stat(token_path).st_mode & 0o777) == 0o600
+        assert (os.stat(dir_path).st_mode & 0o777) == 0o700
+
+    @pytest.mark.asyncio
+    async def test_atomic_write_no_partial_on_failure(
+        self, fake_home: Path
+    ) -> None:
+        from deepagents_cli.mcp_auth import FileTokenStorage
+
+        storage = FileTokenStorage("notion")
+        token_path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
+
+        with patch("os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError, match="boom"):
+                await storage.set_tokens(_make_tokens())
+        assert not token_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_version_mismatch_raises(self, fake_home: Path) -> None:
+        from deepagents_cli.mcp_auth import FileTokenStorage
+
+        storage = FileTokenStorage("notion")
+        # Force-write a bad file bypassing the model.
+        token_path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text('{"version": 999, "tokens": {}}')
+
+        with pytest.raises(RuntimeError, match="version"):
+            await storage.get_tokens()
+
+    @pytest.mark.asyncio
+    async def test_two_servers_do_not_collide(self, fake_home: Path) -> None:
+        from deepagents_cli.mcp_auth import FileTokenStorage
+
+        a = FileTokenStorage("notion")
+        b = FileTokenStorage("linear")
+        await a.set_tokens(
+            OAuthToken(access_token="a-tok", token_type="Bearer")
+        )
+        await b.set_tokens(
+            OAuthToken(access_token="b-tok", token_type="Bearer")
+        )
+        got_a = await a.get_tokens()
+        got_b = await b.get_tokens()
+        assert got_a is not None and got_a.access_token == "a-tok"
+        assert got_b is not None and got_b.access_token == "b-tok"

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -69,7 +69,6 @@ def _make_client_info() -> OAuthClientInformationFull:
 
 
 class TestFileTokenStorage:
-    @pytest.mark.asyncio
     async def test_get_tokens_when_file_missing(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import FileTokenStorage
 
@@ -77,7 +76,6 @@ class TestFileTokenStorage:
         assert await storage.get_tokens() is None
         assert await storage.get_client_info() is None
 
-    @pytest.mark.asyncio
     async def test_set_and_get_round_trip(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import FileTokenStorage
 
@@ -92,7 +90,6 @@ class TestFileTokenStorage:
         assert got_ci.client_id == "cid"
         assert got_tok.access_token == "at"
 
-    @pytest.mark.asyncio
     @pytest.mark.skipif(
         not hasattr(__import__("os"), "geteuid"),
         reason="POSIX file-mode semantics",
@@ -110,7 +107,6 @@ class TestFileTokenStorage:
         assert (os.stat(token_path).st_mode & 0o777) == 0o600
         assert (os.stat(dir_path).st_mode & 0o777) == 0o700
 
-    @pytest.mark.asyncio
     async def test_atomic_write_no_partial_on_failure(
         self, fake_home: Path
     ) -> None:
@@ -124,7 +120,6 @@ class TestFileTokenStorage:
                 await storage.set_tokens(_make_tokens())
         assert not token_path.exists()
 
-    @pytest.mark.asyncio
     async def test_version_mismatch_raises(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import FileTokenStorage
 
@@ -137,7 +132,6 @@ class TestFileTokenStorage:
         with pytest.raises(RuntimeError, match="version"):
             await storage.get_tokens()
 
-    @pytest.mark.asyncio
     async def test_two_servers_do_not_collide(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import FileTokenStorage
 
@@ -172,7 +166,6 @@ class TestBuildOAuthProvider:
         )
         assert isinstance(provider, OAuthClientProvider)
 
-    @pytest.mark.asyncio
     async def test_redirect_handler_prints_url(
         self, fake_home: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -183,7 +176,6 @@ class TestBuildOAuthProvider:
         captured = capsys.readouterr()
         assert "https://issuer.example.com/authorize?x=1" in captured.out
 
-    @pytest.mark.asyncio
     async def test_callback_handler_parses_code_and_state(
         self,
         fake_home: Path,
@@ -202,7 +194,6 @@ class TestBuildOAuthProvider:
         assert code == "ABC"
         assert state == "XYZ"
 
-    @pytest.mark.asyncio
     async def test_callback_handler_rejects_missing_code(
         self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -217,7 +208,6 @@ class TestBuildOAuthProvider:
 
 
 class TestLoginCommand:
-    @pytest.mark.asyncio
     async def test_login_persists_tokens(
         self,
         fake_home: Path,
@@ -250,7 +240,6 @@ class TestLoginCommand:
         tok = await storage.get_tokens()
         assert tok is not None and tok.access_token == "new"
 
-    @pytest.mark.asyncio
     async def test_login_rejects_non_oauth_server(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import login
 
@@ -260,7 +249,6 @@ class TestLoginCommand:
                 server_config={"transport": "http", "url": "https://example"},
             )
 
-    @pytest.mark.asyncio
     async def test_login_rejects_stdio_server(self, fake_home: Path) -> None:
         from deepagents_cli.mcp_auth import login
 

--- a/libs/cli/tests/unit_tests/test_mcp_commands.py
+++ b/libs/cli/tests/unit_tests/test_mcp_commands.py
@@ -34,7 +34,6 @@ class TestSetupMCPParsers:
 
 
 class TestRunMCPLogin:
-    @pytest.mark.asyncio
     async def test_happy_path(
         self, tmp_path: Path
     ) -> None:
@@ -47,7 +46,7 @@ class TestRunMCPLogin:
         )
 
         with patch(
-            "deepagents_cli.mcp_commands.login",
+            "deepagents_cli.mcp_auth.login",
             new=AsyncMock(return_value=None),
         ) as mocked:
             exit_code = await run_mcp_login(
@@ -59,7 +58,6 @@ class TestRunMCPLogin:
         assert kwargs["server_name"] == "notion"
         assert kwargs["server_config"]["url"] == "https://mcp.notion.com/mcp"
 
-    @pytest.mark.asyncio
     async def test_server_not_in_config(
         self, tmp_path: Path
     ) -> None:

--- a/libs/cli/tests/unit_tests/test_mcp_commands.py
+++ b/libs/cli/tests/unit_tests/test_mcp_commands.py
@@ -1,0 +1,76 @@
+"""Tests for the `deepagents mcp` subcommand group."""
+
+import argparse
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _build_parser():
+    from deepagents_cli.mcp_commands import setup_mcp_parsers
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    class _NoOpHelpAction(argparse.Action):
+        def __call__(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+            return None
+
+    def _make_help_action(_fn):
+        return _NoOpHelpAction
+
+    setup_mcp_parsers(subparsers, make_help_action=_make_help_action)
+    return parser
+
+
+class TestSetupMCPParsers:
+    def test_mcp_login_accepts_server_arg(self) -> None:
+        parser = _build_parser()
+        ns = parser.parse_args(["mcp", "login", "notion"])
+        assert ns.command == "mcp"
+        assert ns.mcp_command == "login"
+        assert ns.server == "notion"
+
+
+class TestRunMCPLogin:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self, tmp_path: Path
+    ) -> None:
+        from deepagents_cli.mcp_commands import run_mcp_login
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"notion":{"transport":"http",'
+            '"url":"https://mcp.notion.com/mcp","auth":"oauth"}}}'
+        )
+
+        with patch(
+            "deepagents_cli.mcp_commands.login",
+            new=AsyncMock(return_value=None),
+        ) as mocked:
+            exit_code = await run_mcp_login(
+                server="notion", config_path=str(config_path)
+            )
+        assert exit_code == 0
+        mocked.assert_awaited_once()
+        kwargs = mocked.await_args.kwargs
+        assert kwargs["server_name"] == "notion"
+        assert kwargs["server_config"]["url"] == "https://mcp.notion.com/mcp"
+
+    @pytest.mark.asyncio
+    async def test_server_not_in_config(
+        self, tmp_path: Path
+    ) -> None:
+        from deepagents_cli.mcp_commands import run_mcp_login
+
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(
+            '{"mcpServers":{"linear":{"transport":"http",'
+            '"url":"https://mcp.linear.app/mcp","auth":"oauth"}}}'
+        )
+        exit_code = await run_mcp_login(
+            server="notion", config_path=str(config_path)
+        )
+        assert exit_code != 0

--- a/libs/cli/tests/unit_tests/test_mcp_commands.py
+++ b/libs/cli/tests/unit_tests/test_mcp_commands.py
@@ -34,9 +34,7 @@ class TestSetupMCPParsers:
 
 
 class TestRunMCPLogin:
-    async def test_happy_path(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_happy_path(self, tmp_path: Path) -> None:
         from deepagents_cli.mcp_commands import run_mcp_login
 
         config_path = tmp_path / "mcp.json"
@@ -54,13 +52,13 @@ class TestRunMCPLogin:
             )
         assert exit_code == 0
         mocked.assert_awaited_once()
-        kwargs = mocked.await_args.kwargs
+        await_args = mocked.await_args
+        assert await_args is not None
+        kwargs = await_args.kwargs
         assert kwargs["server_name"] == "notion"
         assert kwargs["server_config"]["url"] == "https://mcp.notion.com/mcp"
 
-    async def test_server_not_in_config(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_server_not_in_config(self, tmp_path: Path) -> None:
         from deepagents_cli.mcp_commands import run_mcp_login
 
         config_path = tmp_path / "mcp.json"
@@ -68,7 +66,5 @@ class TestRunMCPLogin:
             '{"mcpServers":{"linear":{"transport":"http",'
             '"url":"https://mcp.linear.app/mcp","auth":"oauth"}}}'
         )
-        exit_code = await run_mcp_login(
-            server="notion", config_path=str(config_path)
-        )
+        exit_code = await run_mcp_login(server="notion", config_path=str(config_path))
         assert exit_code != 0

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -708,16 +708,17 @@ class TestGetMCPTools:
         valid_config_data: dict,
         fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Discovery errors surface as RuntimeError wrapping the original cause."""
+        """Discovery failure marks the server as errored, doesn't raise."""
         path = write_config(valid_config_data)
         mock_session, _ = fake_create_session
         mock_session.initialize = AsyncMock(side_effect=Exception("handshake failed"))
 
-        with pytest.raises(
-            RuntimeError,
-            match=r"Failed to load tools from MCP server.*handshake failed",
-        ):
-            await get_mcp_tools(path)
+        tools, _session_manager, server_infos = await get_mcp_tools(path)
+
+        assert tools == []
+        assert len(server_infos) == 1
+        assert server_infos[0].status == "error"
+        assert "handshake failed" in (server_infos[0].error or "")
 
     async def test_get_mcp_tools_list_tools_failure(
         self,
@@ -725,16 +726,17 @@ class TestGetMCPTools:
         valid_config_data: dict,
         fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """`list_tools` errors surface as RuntimeError."""
+        """`list_tools` failure marks the server as errored, doesn't raise."""
         path = write_config(valid_config_data)
         mock_session, _ = fake_create_session
         mock_session.list_tools = AsyncMock(side_effect=Exception("protocol error"))
 
-        with pytest.raises(
-            RuntimeError,
-            match=r"Failed to load tools from MCP server.*protocol error",
-        ):
-            await get_mcp_tools(path)
+        tools, _session_manager, server_infos = await get_mcp_tools(path)
+
+        assert tools == []
+        assert len(server_infos) == 1
+        assert server_infos[0].status == "error"
+        assert "protocol error" in (server_infos[0].error or "")
 
     async def test_get_mcp_tools_empty_env_dict_coerced_to_none(
         self,
@@ -1604,7 +1606,7 @@ class TestHealthCheckIntegration:
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """Health check failure raises before any session is opened."""
+        """Health check failure marks the server errored without opening a session."""
         path = write_config(
             {"mcpServers": {"fs": {"command": "missing-cmd", "args": []}}}
         )
@@ -1616,24 +1618,22 @@ class TestHealthCheckIntegration:
 
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
-            patch("langchain_mcp_adapters.sessions.create_session", _fake) as patched,
-            pytest.raises(RuntimeError, match="Pre-flight health check"),
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
         ):
-            await get_mcp_tools(path)
+            tools, _session_manager, server_infos = await get_mcp_tools(path)
 
-        # create_session is the ContextDecorator itself; just assert no call
-        # reached `initialize` / `list_tools`.
+        assert tools == []
+        assert len(server_infos) == 1
+        assert server_infos[0].name == "fs"
+        assert server_infos[0].status == "error"
         fake_session.initialize.assert_not_called()
         fake_session.list_tools.assert_not_called()
-        # patched is the raw asynccontextmanager function, not a Mock; the
-        # underlying mock assertions above already cover the invariant.
-        del patched
 
     async def test_remote_health_check_failure_skips_session(
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """Remote health check failure prevents session creation."""
+        """Remote health check failure marks the server errored, no session open."""
         import httpx
 
         path = write_config(
@@ -1653,17 +1653,21 @@ class TestHealthCheckIntegration:
         with (
             patch("httpx.AsyncClient", return_value=mock_http),
             patch("langchain_mcp_adapters.sessions.create_session", _fake),
-            pytest.raises(RuntimeError, match="Pre-flight health check"),
         ):
-            await get_mcp_tools(path)
+            tools, _session_manager, server_infos = await get_mcp_tools(path)
 
+        assert tools == []
+        assert len(server_infos) == 1
+        assert server_infos[0].name == "api"
+        assert server_infos[0].status == "error"
+        assert "down:9999" in (server_infos[0].error or "")
         fake_session.initialize.assert_not_called()
 
     async def test_multi_server_collects_all_failures(
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """All server failures are reported in a single error."""
+        """Each failing server gets its own errored server_info."""
         path = write_config(
             {
                 "mcpServers": {
@@ -1681,20 +1685,22 @@ class TestHealthCheckIntegration:
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
             patch("langchain_mcp_adapters.sessions.create_session", _fake),
-            pytest.raises(RuntimeError) as exc_info,
         ):
-            await get_mcp_tools(path)
+            tools, _session_manager, server_infos = await get_mcp_tools(path)
 
-        error_msg = str(exc_info.value)
-        assert "missing-a" in error_msg
-        assert "missing-b" in error_msg
+        assert tools == []
+        by_name = {info.name: info for info in server_infos}
+        assert by_name["a"].status == "error"
+        assert by_name["b"].status == "error"
+        assert "missing-a" in (by_name["a"].error or "")
+        assert "missing-b" in (by_name["b"].error or "")
         fake_session.initialize.assert_not_called()
 
     async def test_mixed_stdio_and_remote_checks(
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """Both stdio and remote health checks run for mixed configs."""
+        """Both stdio and remote health checks mark their servers errored."""
         import httpx
 
         path = write_config(
@@ -1714,13 +1720,15 @@ class TestHealthCheckIntegration:
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
             patch("httpx.AsyncClient", return_value=mock_http),
-            pytest.raises(RuntimeError) as exc_info,
         ):
-            await get_mcp_tools(path)
+            tools, _session_manager, server_infos = await get_mcp_tools(path)
 
-        error_msg = str(exc_info.value)
-        assert "missing-cmd" in error_msg
-        assert "down:9999" in error_msg
+        assert tools == []
+        by_name = {info.name: info for info in server_infos}
+        assert by_name["local"].status == "error"
+        assert by_name["remote"].status == "error"
+        assert "missing-cmd" in (by_name["local"].error or "")
+        assert "down:9999" in (by_name["remote"].error or "")
 
 
 class TestToolOrdering:
@@ -1842,10 +1850,11 @@ class TestLoadToolsFromConfigHeaders:
 
 
 class TestLoadToolsFromConfigOAuth:
-    async def test_missing_tokens_raise_login_instruction(
+    async def test_missing_tokens_skip_server_with_login_hint(
         self,
         fake_home: Path,
     ) -> None:
+        """An OAuth server without stored tokens is skipped, not fatal."""
         from deepagents_cli.mcp_tools import _load_tools_from_config
 
         config = {
@@ -1857,14 +1866,19 @@ class TestLoadToolsFromConfigOAuth:
                 }
             }
         }
-        with (
-            patch(
-                "deepagents_cli.mcp_tools._check_remote_server",
-                new=AsyncMock(return_value=None),
-            ),
-            pytest.raises(RuntimeError, match="deepagents mcp login notion"),
+        with patch(
+            "deepagents_cli.mcp_tools._check_remote_server",
+            new=AsyncMock(return_value=None),
         ):
-            await _load_tools_from_config(config)
+            tools, _session_manager, server_infos = await _load_tools_from_config(
+                config
+            )
+
+        assert tools == []
+        assert len(server_infos) == 1
+        assert server_infos[0].name == "notion"
+        assert server_infos[0].status == "unauthenticated"
+        assert "deepagents mcp login notion" in (server_infos[0].error or "")
 
     async def test_existing_tokens_attach_oauth_provider(
         self,

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -1799,7 +1799,6 @@ class TestToolOrdering:
 
 
 class TestLoadToolsFromConfigHeaders:
-    @pytest.mark.asyncio
     async def test_headers_are_resolved_before_connection(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1842,7 +1841,6 @@ class TestLoadToolsFromConfigHeaders:
 
 
 class TestLoadToolsFromConfigOAuth:
-    @pytest.mark.asyncio
     async def test_missing_tokens_raise_login_instruction(
         self,
         fake_home: Path,
@@ -1865,7 +1863,6 @@ class TestLoadToolsFromConfigOAuth:
             with pytest.raises(RuntimeError, match="deepagents mcp login notion"):
                 await _load_tools_from_config(config)
 
-    @pytest.mark.asyncio
     async def test_existing_tokens_attach_oauth_provider(
         self,
         fake_home: Path,

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Callable, Generator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,9 +22,46 @@ from deepagents_cli.mcp_tools import (
     load_mcp_config,
     load_mcp_config_lenient,
     merge_mcp_configs,
+    reset_default_session_manager_for_testing,
     resolve_and_load_mcp_tools,
 )
 from deepagents_cli.project_utils import ProjectContext
+
+
+def _make_mcp_tool(
+    name: str, description: str = "", input_schema: dict | None = None
+) -> MagicMock:
+    """Build a mock MCP `Tool` object suitable for proxy-tool construction."""
+    mock = MagicMock(
+        spec=["name", "description", "inputSchema", "annotations", "meta"]
+    )
+    mock.name = name
+    mock.description = description
+    mock.inputSchema = input_schema or {"type": "object", "properties": {}}
+    mock.annotations = None
+    mock.meta = None
+    return mock
+
+
+def _make_tool_page(tools: list[MagicMock], next_cursor: str | None = None) -> MagicMock:
+    """Build a mock `list_tools` page result."""
+    page = MagicMock(spec=["tools", "nextCursor"])
+    page.tools = tools
+    page.nextCursor = next_cursor
+    return page
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_singleton() -> Generator[None]:
+    """Clear the process-wide MCP session cache between tests.
+
+    The singleton accumulates cached sessions across calls; tests that
+    exercise the cache must start from a clean slate so they see exactly
+    the `create_session` invocations they expect.
+    """
+    reset_default_session_manager_for_testing()
+    yield
+    reset_default_session_manager_for_testing()
 
 # Test Fixtures
 
@@ -55,38 +93,39 @@ def write_config(tmp_path: Path) -> Callable[..., str]:
 
 
 @pytest.fixture
-def mock_mcp_session():
-    """Fixture for creating a mock MCP session context manager."""
+def fake_create_session() -> Generator[tuple[AsyncMock, list]]:
+    """Patch `langchain_mcp_adapters.sessions.create_session`.
+
+    Yields `(mock_session, recorded_connections)` where `mock_session` is the
+    shared `ClientSession` mock returned by every `async with create_session`
+    block, and `recorded_connections` is an append-only list of the
+    `Connection` dict passed on each invocation.
+
+    Tests that need per-server behavior can inspect or replace
+    `mock_session.list_tools.side_effect`.
+    """
     mock_session = AsyncMock()
-    mock_session_cm = MagicMock()
-    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session_cm.__aexit__ = AsyncMock(return_value=None)
-    return mock_session, mock_session_cm
+    mock_session.initialize = AsyncMock()
+    mock_session.list_tools = AsyncMock(return_value=_make_tool_page([]))
+
+    recorded: list = []
+
+    @asynccontextmanager
+    async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        recorded.append(connection)
+        yield mock_session
+
+    with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+        yield mock_session, recorded
 
 
 @pytest.fixture
-def mock_mcp_client(
-    mock_mcp_session: tuple[AsyncMock, MagicMock],
-) -> tuple[MagicMock, AsyncMock]:
-    """Fixture for creating a mock MultiServerMCPClient."""
-    mock_session, mock_session_cm = mock_mcp_session
-    mock_client = MagicMock()
-    mock_client.session = MagicMock(return_value=mock_session_cm)
-    return mock_client, mock_session
-
-
-@pytest.fixture
-def mock_tools():
-    """Fixture providing mock tool objects."""
-    mock_tool1 = MagicMock()
-    mock_tool1.name = "read_file"
-    mock_tool1.description = "Read a file"
-
-    mock_tool2 = MagicMock()
-    mock_tool2.name = "write_file"
-    mock_tool2.description = "Write a file"
-
-    return [mock_tool1, mock_tool2]
+def mock_tools() -> list[MagicMock]:
+    """Fixture providing mock MCP tool metadata objects."""
+    return [
+        _make_mcp_tool("read_file", "Read a file"),
+        _make_mcp_tool("write_file", "Write a file"),
+    ]
 
 
 class TestLoadMCPConfig:
@@ -569,185 +608,104 @@ class TestGetMCPTools:
         ):
             yield
 
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_success(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
         valid_config_data: dict,
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
         mock_tools: list,
     ) -> None:
         """Test successful loading of MCP tools."""
         path = write_config(valid_config_data)
-
-        # Setup mocks
-        mock_client, mock_session = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = mock_tools
+        mock_session, recorded = fake_create_session
+        mock_session.list_tools = AsyncMock(return_value=_make_tool_page(mock_tools))
 
         tools, manager, server_infos = await get_mcp_tools(path)
 
-        # Verify client was initialized with correct connection config
-        mock_client_class.assert_called_once()
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert connections["filesystem"]["command"] == "npx"
-        assert connections["filesystem"]["transport"] == "stdio"
-        assert connections["filesystem"]["args"] == [
+        # Verify connection passed to create_session
+        assert len(recorded) == 1
+        conn = recorded[0]
+        assert conn["command"] == "npx"
+        assert conn["transport"] == "stdio"
+        assert conn["args"] == [
             "-y",
             "@modelcontextprotocol/server-filesystem",
             "/tmp",
         ]
 
-        # Verify session was created and tools were loaded
-        mock_client.session.assert_called_once_with("filesystem")
-        mock_load_tools.assert_called_once_with(
-            mock_session, server_name="filesystem", tool_name_prefix=True
-        )
+        # Discovery session lifecycle
+        mock_session.initialize.assert_awaited_once()
+        mock_session.list_tools.assert_awaited_once()
+
+        # Proxy tools prefixed with server name and sorted by name
         assert len(tools) == 2
-        assert tools[0].name == "read_file"
-        assert tools[1].name == "write_file"
+        assert tools[0].name == "filesystem_read_file"
+        assert tools[1].name == "filesystem_write_file"
         assert isinstance(manager, MCPSessionManager)
 
-        # Verify server_infos
+        # server_infos reflects proxy tool names/descriptions
         assert len(server_infos) == 1
         assert server_infos[0].name == "filesystem"
         assert server_infos[0].transport == "stdio"
-        assert len(server_infos[0].tools) == 2
-        assert server_infos[0].tools[0] == MCPToolInfo(
-            name="read_file", description="Read a file"
-        )
-        assert server_infos[0].tools[1] == MCPToolInfo(
-            name="write_file", description="Write a file"
-        )
+        assert server_infos[0].tools == [
+            MCPToolInfo(name="filesystem_read_file", description="Read a file"),
+            MCPToolInfo(name="filesystem_write_file", description="Write a file"),
+        ]
 
-        # Clean up
-        await manager.cleanup()
-
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
-    async def test_get_mcp_tools_server_spawn_failure(
-        self, mock_client_class: MagicMock, write_config: Callable[..., str]
-    ) -> None:
-        """Test handling of MCP server spawn failure."""
-        path = write_config(
-            {
-                "mcpServers": {
-                    "filesystem": {
-                        "command": "nonexistent-command",
-                        "args": [],
-                        "env": {},
-                    }
-                }
-            }
-        )
-
-        # Setup mock client to raise an exception
-        mock_client_class.side_effect = Exception("Command not found")
-
-        with pytest.raises(
-            RuntimeError, match=r"Failed to initialize MCP client.*Command not found"
-        ):
-            await get_mcp_tools(path)
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
-    async def test_get_mcp_tools_get_tools_failure(
+    async def test_get_mcp_tools_discovery_failure(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
         valid_config_data: dict,
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test handling of failure during load_mcp_tools call."""
+        """Discovery errors surface as RuntimeError wrapping the original cause."""
         path = write_config(valid_config_data)
-
-        # Setup mocks
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.side_effect = Exception("Server protocol error")
+        mock_session, _ = fake_create_session
+        mock_session.initialize = AsyncMock(side_effect=Exception("handshake failed"))
 
         with pytest.raises(
             RuntimeError,
-            match=r"Failed to load tools from MCP server.*Server protocol error",
+            match=r"Failed to load tools from MCP server.*handshake failed",
         ):
             await get_mcp_tools(path)
 
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
-    async def test_get_mcp_tools_cleanup_called_on_client_init_failure(
-        self, mock_client_class: MagicMock, write_config: Callable[..., str]
-    ) -> None:
-        """Test that manager.cleanup() is called when client init fails."""
-        path = write_config(
-            {"mcpServers": {"fs": {"command": "npx", "args": [], "env": {}}}}
-        )
-        mock_client_class.side_effect = Exception("init boom")
-
-        with patch.object(
-            MCPSessionManager, "cleanup", new_callable=AsyncMock
-        ) as mock_cleanup:
-            with pytest.raises(RuntimeError, match="Failed to initialize MCP client"):
-                await get_mcp_tools(path)
-            mock_cleanup.assert_awaited_once()
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
-    async def test_get_mcp_tools_cleanup_called_on_tool_load_failure(
+    async def test_get_mcp_tools_list_tools_failure(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
         valid_config_data: dict,
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that manager.cleanup() is called when tool loading fails."""
+        """`list_tools` errors surface as RuntimeError."""
         path = write_config(valid_config_data)
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.side_effect = Exception("tool boom")
+        mock_session, _ = fake_create_session
+        mock_session.list_tools = AsyncMock(side_effect=Exception("protocol error"))
 
-        with patch.object(
-            MCPSessionManager, "cleanup", new_callable=AsyncMock
-        ) as mock_cleanup:
-            with pytest.raises(RuntimeError, match="Failed to load tools"):
-                await get_mcp_tools(path)
-            mock_cleanup.assert_awaited_once()
+        with pytest.raises(
+            RuntimeError,
+            match=r"Failed to load tools from MCP server.*protocol error",
+        ):
+            await get_mcp_tools(path)
 
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_empty_env_dict_coerced_to_none(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that `"env": {}` is coerced to None (inherit parent env)."""
+        """`"env": {}` is coerced to None (inherit parent env)."""
         path = write_config(
             {"mcpServers": {"fs": {"command": "npx", "args": [], "env": {}}}}
         )
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = []
+        _, recorded = fake_create_session
 
-        _, manager, _ = await get_mcp_tools(path)
+        await get_mcp_tools(path)
 
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert connections["fs"]["env"] is None
+        assert recorded[0]["env"] is None
 
-        await manager.cleanup()
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_multiple_servers(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
     ) -> None:
-        """Test loading tools from multiple MCP servers."""
+        """Discovery opens one session per server; proxy tools collate sorted."""
         path = write_config(
             {
                 "mcpServers": {
@@ -769,73 +727,49 @@ class TestGetMCPTools:
             }
         )
 
-        # Create mock tools from different servers.
-        # Note: MagicMock(name=...) sets the internal _mock_name, not a .name
-        # attribute. Set .name explicitly so tools can be sorted by name.
-        tool_read = MagicMock()
-        tool_read.name = "read_file"
-        tool_write = MagicMock()
-        tool_write.name = "write_file"
-        tool_search = MagicMock()
-        tool_search.name = "web_search"
-        mock_tools_fs = [tool_read, tool_write]
-        mock_tools_search = [tool_search]
+        # Build per-server tool pages that the shared mock session returns in
+        # order on each discovery pass.
+        fs_tools = [_make_mcp_tool("read_file"), _make_mcp_tool("write_file")]
+        search_tools = [_make_mcp_tool("web_search")]
+        page_fs = _make_tool_page(fs_tools)
+        page_search = _make_tool_page(search_tools)
 
-        # Setup mock client with session support
-        mock_session_fs = AsyncMock()
-        mock_session_search = AsyncMock()
+        recorded: list = []
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        # side_effect yields pages in call order — servers are processed in
+        # insertion order, so fs first, then brave-search.
+        mock_session.list_tools = AsyncMock(side_effect=[page_fs, page_search])
 
-        # Mock session context managers for both servers
-        def mock_session_cm(server_name: str) -> MagicMock:
-            session = (
-                mock_session_fs if server_name == "filesystem" else mock_session_search
-            )
-            cm = MagicMock()
-            cm.__aenter__ = AsyncMock(return_value=session)
-            cm.__aexit__ = AsyncMock(return_value=None)
-            return cm
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            recorded.append(connection)
+            yield mock_session
 
-        mock_client = MagicMock()
-        mock_client.session.side_effect = mock_session_cm
-        mock_client_class.return_value = mock_client
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, manager, server_infos = await get_mcp_tools(path)
 
-        # Mock load_mcp_tools to return different tools for each session
-        def mock_load_side_effect(
-            session: AsyncMock, **_kwargs: object
-        ) -> list[MagicMock]:
-            if session == mock_session_fs:
-                return mock_tools_fs
-            return mock_tools_search
+        # Two discovery sessions opened, one per server
+        assert len(recorded) == 2
+        assert {c["command"] for c in recorded} == {"npx"}
+        brave_connection = next(
+            c for c in recorded if (c.get("env") or {}).get("BRAVE_API_KEY")
+        )
+        assert brave_connection["env"]["BRAVE_API_KEY"] == "test-key"
 
-        mock_load_tools.side_effect = mock_load_side_effect
+        # All three proxy tools present, sorted by prefixed name
+        assert [t.name for t in tools] == [
+            "brave-search_web_search",
+            "filesystem_read_file",
+            "filesystem_write_file",
+        ]
+        assert isinstance(manager, MCPSessionManager)
 
-        tools, manager, server_infos = await get_mcp_tools(path)
-
-        # Verify both servers were registered
-        call_kwargs = mock_client_class.call_args.kwargs
-        connections = call_kwargs["connections"]
-        assert len(connections) == 2
-        assert "filesystem" in connections
-        assert "brave-search" in connections
-        assert connections["brave-search"]["env"]["BRAVE_API_KEY"] == "test-key"
-
-        # Verify sessions were created for both servers
-        assert mock_client.session.call_count == 2
-
-        # Verify tools from all servers were returned
-        assert len(tools) == 3
-
-        # Verify server_infos for multiple servers
         assert len(server_infos) == 2
-        assert server_infos[0].name == "filesystem"
-        assert server_infos[0].transport == "stdio"
-        assert len(server_infos[0].tools) == 2
-        assert server_infos[1].name == "brave-search"
-        assert server_infos[1].transport == "stdio"
-        assert len(server_infos[1].tools) == 1
-
-        # Clean up
-        await manager.cleanup()
+        infos_by_name = {info.name: info for info in server_infos}
+        assert set(infos_by_name) == {"filesystem", "brave-search"}
+        assert len(infos_by_name["filesystem"].tools) == 2
+        assert len(infos_by_name["brave-search"].tools) == 1
 
     async def test_get_mcp_tools_invalid_config(
         self, write_config: Callable[..., str]
@@ -855,16 +789,12 @@ class TestGetMCPTools:
         with pytest.raises(ValueError, match="missing required 'command' field"):
             await get_mcp_tools(path)
 
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_env_variables_passed(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that environment variables are correctly passed to MCP client."""
+        """Env variables flow through to the stdio `Connection`."""
         path = write_config(
             {
                 "mcpServers": {
@@ -879,66 +809,36 @@ class TestGetMCPTools:
                 }
             }
         )
+        _, recorded = fake_create_session
 
-        # Setup mocks
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = []
+        await get_mcp_tools(path)
 
-        _, manager, _ = await get_mcp_tools(path)
+        assert recorded[0]["env"] == {
+            "GITHUB_TOKEN": "ghp_test123",
+            "GITHUB_API_URL": "https://api.github.com",
+        }
 
-        # Verify env variables were passed correctly
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert connections["github"]["env"]["GITHUB_TOKEN"] == "ghp_test123"
-        assert (
-            connections["github"]["env"]["GITHUB_API_URL"] == "https://api.github.com"
-        )
-
-        # Clean up
-        await manager.cleanup()
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_env_none_when_not_provided(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that env is None (inherit parent env) when not provided in config."""
+        """`env` defaults to None (inherit parent env) when not in config."""
         path = write_config(
-            {
-                "mcpServers": {
-                    "simple": {
-                        "command": "simple-server",
-                    }
-                }
-            }
+            {"mcpServers": {"simple": {"command": "simple-server"}}}
         )
+        _, recorded = fake_create_session
 
-        # Setup mocks
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = []
+        await get_mcp_tools(path)
 
-        _, manager, _ = await get_mcp_tools(path)
+        assert recorded[0]["env"] is None
 
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert connections["simple"]["env"] is None
-
-        await manager.cleanup()
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_headers_passed_for_sse(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that headers are correctly passed to SSE MCP client."""
+        """SSE server headers flow through to the `Connection`."""
         path = write_config(
             {
                 "mcpServers": {
@@ -953,33 +853,23 @@ class TestGetMCPTools:
                 }
             }
         )
+        _, recorded = fake_create_session
 
-        # Setup mocks
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = []
+        await get_mcp_tools(path)
 
-        _, manager, _ = await get_mcp_tools(path)
+        conn = recorded[0]
+        assert conn["transport"] == "sse"
+        assert conn["headers"] == {
+            "Authorization": "Bearer token123",
+            "X-API-Key": "key456",
+        }
 
-        # Verify headers were passed correctly
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert connections["api"]["transport"] == "sse"
-        assert connections["api"]["headers"]["Authorization"] == "Bearer token123"
-        assert connections["api"]["headers"]["X-API-Key"] == "key456"
-
-        # Clean up
-        await manager.cleanup()
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_headers_passed_for_http(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that headers are correctly passed to HTTP MCP client."""
+        """HTTP server headers flow through to the `Connection`."""
         path = write_config(
             {
                 "mcpServers": {
@@ -991,32 +881,20 @@ class TestGetMCPTools:
                 }
             }
         )
+        _, recorded = fake_create_session
 
-        # Setup mocks
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = []
+        await get_mcp_tools(path)
 
-        _, manager, _ = await get_mcp_tools(path)
+        conn = recorded[0]
+        assert conn["transport"] == "streamable_http"
+        assert conn["headers"] == {"Authorization": "Bearer secret"}
 
-        # Verify headers were passed and transport is correct
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert connections["api"]["transport"] == "streamable_http"
-        assert connections["api"]["headers"]["Authorization"] == "Bearer secret"
-
-        # Clean up
-        await manager.cleanup()
-
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_get_mcp_tools_no_headers_when_not_provided(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
-        mock_mcp_client: tuple,
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Test that headers key is not added when not provided in config."""
+        """`headers` key is omitted when not provided in config."""
         path = write_config(
             {
                 "mcpServers": {
@@ -1027,20 +905,11 @@ class TestGetMCPTools:
                 }
             }
         )
+        _, recorded = fake_create_session
 
-        # Setup mocks
-        mock_client, _ = mock_mcp_client
-        mock_client_class.return_value = mock_client
-        mock_load_tools.return_value = []
+        await get_mcp_tools(path)
 
-        _, manager, _ = await get_mcp_tools(path)
-
-        # Verify headers key is not present
-        connections = mock_client_class.call_args.kwargs["connections"]
-        assert "headers" not in connections["api"]
-
-        # Clean up
-        await manager.cleanup()
+        assert "headers" not in recorded[0]
 
 
 class TestDiscoverMcpConfigs:
@@ -1683,32 +1552,39 @@ class TestCheckRemoteServer:
 class TestHealthCheckIntegration:
     """Tests for health check integration in _load_tools_from_config."""
 
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_stdio_health_check_failure_skips_session(
         self,
-        mock_client_class: MagicMock,
         write_config: Callable[..., str],
     ) -> None:
-        """Health check failure cleans up and does not call client.session()."""
+        """Health check failure raises before any session is opened."""
         path = write_config(
             {"mcpServers": {"fs": {"command": "missing-cmd", "args": []}}}
         )
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
+        fake_session = AsyncMock()
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            yield fake_session
 
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
+            patch(
+                "langchain_mcp_adapters.sessions.create_session", _fake
+            ) as patched,
             pytest.raises(RuntimeError, match="Pre-flight health check"),
         ):
             await get_mcp_tools(path)
 
-        # session() should never be called — health check fails first
-        mock_client.session.assert_not_called()
+        # create_session is the ContextDecorator itself; just assert no call
+        # reached `initialize` / `list_tools`.
+        fake_session.initialize.assert_not_called()
+        fake_session.list_tools.assert_not_called()
+        # patched is the raw asynccontextmanager function, not a Mock; the
+        # underlying mock assertions above already cover the invariant.
+        del patched
 
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_remote_health_check_failure_skips_session(
         self,
-        mock_client_class: MagicMock,
         write_config: Callable[..., str],
     ) -> None:
         """Remote health check failure prevents session creation."""
@@ -1717,8 +1593,11 @@ class TestHealthCheckIntegration:
         path = write_config(
             {"mcpServers": {"api": {"type": "sse", "url": "http://down:9999"}}}
         )
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
+        fake_session = AsyncMock()
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            yield fake_session
 
         mock_http = AsyncMock()
         mock_http.head.side_effect = httpx.TransportError("refused")
@@ -1727,16 +1606,15 @@ class TestHealthCheckIntegration:
 
         with (
             patch("httpx.AsyncClient", return_value=mock_http),
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
             pytest.raises(RuntimeError, match="Pre-flight health check"),
         ):
             await get_mcp_tools(path)
 
-        mock_client.session.assert_not_called()
+        fake_session.initialize.assert_not_called()
 
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_multi_server_collects_all_failures(
         self,
-        mock_client_class: MagicMock,
         write_config: Callable[..., str],
     ) -> None:
         """All server failures are reported in a single error."""
@@ -1748,11 +1626,15 @@ class TestHealthCheckIntegration:
                 }
             }
         )
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
+        fake_session = AsyncMock()
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            yield fake_session
 
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
             pytest.raises(RuntimeError) as exc_info,
         ):
             await get_mcp_tools(path)
@@ -1760,12 +1642,10 @@ class TestHealthCheckIntegration:
         error_msg = str(exc_info.value)
         assert "missing-a" in error_msg
         assert "missing-b" in error_msg
-        mock_client.session.assert_not_called()
+        fake_session.initialize.assert_not_called()
 
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_mixed_stdio_and_remote_checks(
         self,
-        mock_client_class: MagicMock,
         write_config: Callable[..., str],
     ) -> None:
         """Both stdio and remote health checks run for mixed configs."""
@@ -1779,8 +1659,6 @@ class TestHealthCheckIntegration:
                 }
             }
         )
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
 
         mock_http = AsyncMock()
         mock_http.head.side_effect = httpx.TransportError("refused")
@@ -1794,7 +1672,6 @@ class TestHealthCheckIntegration:
         ):
             await get_mcp_tools(path)
 
-        # Both failures appear in the error message
         error_msg = str(exc_info.value)
         assert "missing-cmd" in error_msg
         assert "down:9999" in error_msg
@@ -1815,54 +1692,32 @@ class TestToolOrdering:
         ):
             yield
 
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_tools_sorted_alphabetically_by_name(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
+        fake_create_session: tuple[AsyncMock, list],
     ) -> None:
-        """Tools from MCP servers are sorted by name for stable prompt caches."""
+        """Tools from a single server are sorted by prefixed name."""
         path = write_config(
-            {
-                "mcpServers": {
-                    "srv": {"command": "node", "args": ["server.js"]},
-                }
-            }
+            {"mcpServers": {"srv": {"command": "node", "args": ["server.js"]}}}
+        )
+        mock_session, _ = fake_create_session
+        mock_session.list_tools = AsyncMock(
+            return_value=_make_tool_page(
+                [
+                    _make_mcp_tool("zeta"),
+                    _make_mcp_tool("alpha"),
+                    _make_mcp_tool("mu"),
+                ]
+            )
         )
 
-        # Return tools in non-alphabetical order
-        zeta = MagicMock()
-        zeta.name = "srv_zeta"
-        zeta.description = "z"
-        alpha = MagicMock()
-        alpha.name = "srv_alpha"
-        alpha.description = "a"
-        mu = MagicMock()
-        mu.name = "srv_mu"
-        mu.description = "m"
-        mock_load_tools.return_value = [zeta, alpha, mu]
-
-        mock_session = AsyncMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(return_value=mock_session)
-        cm.__aexit__ = AsyncMock(return_value=None)
-        mock_client = MagicMock()
-        mock_client.session.return_value = cm
-        mock_client_class.return_value = mock_client
-
-        tools, manager, _ = await get_mcp_tools(path)
+        tools, _, _ = await get_mcp_tools(path)
 
         assert [t.name for t in tools] == ["srv_alpha", "srv_mu", "srv_zeta"]
-        await manager.cleanup()
 
-    @patch("langchain_mcp_adapters.tools.load_mcp_tools")
-    @patch("langchain_mcp_adapters.client.MultiServerMCPClient")
     async def test_tools_sorted_across_multiple_servers(
         self,
-        mock_client_class: MagicMock,
-        mock_load_tools: AsyncMock,
         write_config: Callable[..., str],
     ) -> None:
         """Tools from multiple servers are interleaved alphabetically."""
@@ -1875,40 +1730,24 @@ class TestToolOrdering:
             }
         )
 
-        tool_b = MagicMock()
-        tool_b.name = "beta_write"
-        tool_b.description = "w"
-        tool_a = MagicMock()
-        tool_a.name = "alpha_read"
-        tool_a.description = "r"
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        # Order matters: servers are iterated in config insertion order.
+        mock_session.list_tools = AsyncMock(
+            side_effect=[
+                _make_tool_page([_make_mcp_tool("write")]),
+                _make_tool_page([_make_mcp_tool("read")]),
+            ]
+        )
 
-        mock_session_a = AsyncMock()
-        mock_session_b = AsyncMock()
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            yield mock_session
 
-        def mock_load_side_effect(
-            session: AsyncMock, **_kwargs: object
-        ) -> list[MagicMock]:
-            if session == mock_session_b:
-                return [tool_b]
-            return [tool_a]
-
-        mock_load_tools.side_effect = mock_load_side_effect
-
-        def mock_session_cm(server_name: str) -> MagicMock:
-            session = mock_session_b if server_name == "beta" else mock_session_a
-            cm = MagicMock()
-            cm.__aenter__ = AsyncMock(return_value=session)
-            cm.__aexit__ = AsyncMock(return_value=None)
-            return cm
-
-        mock_client = MagicMock()
-        mock_client.session.side_effect = mock_session_cm
-        mock_client_class.return_value = mock_client
-
-        tools, manager, _ = await get_mcp_tools(path)
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, _, _ = await get_mcp_tools(path)
 
         assert [t.name for t in tools] == ["alpha_read", "beta_write"]
-        await manager.cleanup()
 
 
 class TestLoadToolsFromConfigHeaders:
@@ -1916,33 +1755,28 @@ class TestLoadToolsFromConfigHeaders:
     async def test_headers_are_resolved_before_connection(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        mock_mcp_client: tuple[MagicMock, AsyncMock],
     ) -> None:
         """Env-var references in headers are resolved before being passed to
-        MultiServerMCPClient."""
+        `create_session` as part of the Connection config."""
         from deepagents_cli.mcp_tools import _load_tools_from_config
 
         monkeypatch.setenv("DA_TOKEN", "tok-123")
 
-        mock_client, _ = mock_mcp_client
-        captured: dict = {}
+        recorded: list = []
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=_make_tool_page([]))
 
-        def _capture(connections: dict) -> MagicMock:
-            captured["connections"] = connections
-            return mock_client
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            recorded.append(connection)
+            yield mock_session
 
         with (
-            patch(
-                "langchain_mcp_adapters.client.MultiServerMCPClient",
-                side_effect=_capture,
-            ),
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
             patch(
                 "deepagents_cli.mcp_tools._check_remote_server",
                 new=AsyncMock(return_value=None),
-            ),
-            patch(
-                "langchain_mcp_adapters.tools.load_mcp_tools",
-                new=AsyncMock(return_value=[]),
             ),
         ):
             config = {
@@ -1954,11 +1788,9 @@ class TestLoadToolsFromConfigHeaders:
                     }
                 }
             }
-            _, mgr, _ = await _load_tools_from_config(config)
-            await mgr.cleanup()
+            await _load_tools_from_config(config)
 
-        sent_headers = captured["connections"]["linear"]["headers"]
-        assert sent_headers == {"Authorization": "Bearer tok-123"}
+        assert recorded[0]["headers"] == {"Authorization": "Bearer tok-123"}
 
 
 class TestLoadToolsFromConfigOAuth:
@@ -1989,7 +1821,6 @@ class TestLoadToolsFromConfigOAuth:
     async def test_existing_tokens_attach_oauth_provider(
         self,
         fake_home: Path,
-        mock_mcp_client: tuple[MagicMock, AsyncMock],
     ) -> None:
         from mcp.client.auth import OAuthClientProvider
         from mcp.shared.auth import OAuthToken
@@ -2000,25 +1831,21 @@ class TestLoadToolsFromConfigOAuth:
         storage = FileTokenStorage("notion")
         await storage.set_tokens(OAuthToken(access_token="at", token_type="Bearer"))
 
-        mock_client, _ = mock_mcp_client
-        captured: dict = {}
+        recorded: list = []
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=_make_tool_page([]))
 
-        def _capture(connections: dict) -> MagicMock:
-            captured["connections"] = connections
-            return mock_client
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            recorded.append(connection)
+            yield mock_session
 
         with (
-            patch(
-                "langchain_mcp_adapters.client.MultiServerMCPClient",
-                side_effect=_capture,
-            ),
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
             patch(
                 "deepagents_cli.mcp_tools._check_remote_server",
                 new=AsyncMock(return_value=None),
-            ),
-            patch(
-                "langchain_mcp_adapters.tools.load_mcp_tools",
-                new=AsyncMock(return_value=[]),
             ),
         ):
             config = {
@@ -2030,8 +1857,238 @@ class TestLoadToolsFromConfigOAuth:
                     }
                 }
             }
-            _, mgr, _ = await _load_tools_from_config(config)
-            await mgr.cleanup()
+            await _load_tools_from_config(config)
 
-        conn = captured["connections"]["notion"]
-        assert isinstance(conn.get("auth"), OAuthClientProvider)
+        assert isinstance(recorded[0].get("auth"), OAuthClientProvider)
+
+
+class TestCachedSessionProxy:
+    """Proxy tools route through MCPSessionManager with retry semantics."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_health_checks(self) -> Generator[None]:
+        """Bypass pre-flight health checks for all tests in this class."""
+        with (
+            patch("deepagents_cli.mcp_tools._check_stdio_server"),
+            patch(
+                "deepagents_cli.mcp_tools._check_remote_server",
+                new_callable=AsyncMock,
+            ),
+        ):
+            yield
+
+    @staticmethod
+    def _fake_call_tool_result(text: str = "ok") -> MagicMock:
+        """Build a mock `CallToolResult` compatible with `_convert_call_tool_result`."""
+        from mcp.types import CallToolResult, TextContent
+
+        return CallToolResult(content=[TextContent(type="text", text=text)])
+
+    async def test_first_call_opens_cached_session(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """First proxy-tool call opens a session in the manager and caches it."""
+        path = write_config(
+            {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
+        )
+
+        sessions: list[AsyncMock] = []
+        session_ctx_entries = 0
+
+        def _new_session() -> AsyncMock:
+            s = AsyncMock()
+            s.initialize = AsyncMock()
+            s.list_tools = AsyncMock(
+                return_value=_make_tool_page([_make_mcp_tool("echo")])
+            )
+            s.call_tool = AsyncMock(return_value=self._fake_call_tool_result("hello"))
+            sessions.append(s)
+            return s
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            nonlocal session_ctx_entries
+            session_ctx_entries += 1
+            yield _new_session()
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, _, _ = await get_mcp_tools(path)
+            assert [t.name for t in tools] == ["srv_echo"]
+
+            # Invoke the proxy tool — should open a second session (first was
+            # the throwaway discovery session).
+            content = await tools[0].ainvoke({})
+
+        assert session_ctx_entries == 2, (
+            "expected one discovery session + one cached runtime session"
+        )
+        # The runtime session had call_tool invoked with the right tool name.
+        runtime_session = sessions[1]
+        runtime_session.call_tool.assert_awaited_once_with("echo", {})
+        assert "hello" in str(content)
+
+    async def test_second_call_reuses_cached_session(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Back-to-back proxy-tool calls share one runtime session."""
+        path = write_config(
+            {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
+        )
+
+        sessions: list[AsyncMock] = []
+
+        def _new_session() -> AsyncMock:
+            s = AsyncMock()
+            s.initialize = AsyncMock()
+            s.list_tools = AsyncMock(
+                return_value=_make_tool_page([_make_mcp_tool("echo")])
+            )
+            s.call_tool = AsyncMock(return_value=self._fake_call_tool_result())
+            sessions.append(s)
+            return s
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            yield _new_session()
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, _, _ = await get_mcp_tools(path)
+            await tools[0].ainvoke({})
+            await tools[0].ainvoke({})
+
+        # discovery + one runtime session — NOT two runtime sessions.
+        assert len(sessions) == 2
+        runtime_session = sessions[1]
+        assert runtime_session.call_tool.await_count == 2
+
+    async def test_transient_error_invalidates_and_retries(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """A transient transport error triggers invalidate + retry-once."""
+        from anyio import ClosedResourceError
+
+        path = write_config(
+            {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
+        )
+
+        all_sessions: list[AsyncMock] = []
+
+        def _new_session(*, dead: bool = False) -> AsyncMock:
+            s = AsyncMock()
+            s.initialize = AsyncMock()
+            s.list_tools = AsyncMock(
+                return_value=_make_tool_page([_make_mcp_tool("echo")])
+            )
+            if dead:
+                s.call_tool = AsyncMock(side_effect=ClosedResourceError())
+            else:
+                s.call_tool = AsyncMock(return_value=self._fake_call_tool_result())
+            all_sessions.append(s)
+            return s
+
+        call_counter = {"n": 0}
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            call_counter["n"] += 1
+            # discovery (#1), first runtime session is dead (#2), retry opens
+            # a fresh session (#3)
+            yield _new_session(dead=(call_counter["n"] == 2))
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, _, _ = await get_mcp_tools(path)
+            await tools[0].ainvoke({})
+
+        assert call_counter["n"] == 3, (
+            "discovery + dead runtime + retry = 3 sessions opened"
+        )
+        # The retry used a live session that succeeded.
+        assert all_sessions[2].call_tool.await_count == 1
+
+    async def test_repeated_transient_error_surfaces_tool_exception(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Second failure after invalidate converts to a `ToolException`."""
+        from anyio import ClosedResourceError
+        from langchain_core.tools import ToolException
+
+        path = write_config(
+            {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
+        )
+
+        def _new_session(*, dead: bool) -> AsyncMock:
+            s = AsyncMock()
+            s.initialize = AsyncMock()
+            s.list_tools = AsyncMock(
+                return_value=_make_tool_page([_make_mcp_tool("echo")])
+            )
+            s.call_tool = AsyncMock(
+                side_effect=ClosedResourceError() if dead else None
+            )
+            return s
+
+        call_counter = {"n": 0}
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            call_counter["n"] += 1
+            # discovery session is "alive" so list_tools succeeds; both runtime
+            # sessions (post-discovery) fail with ClosedResourceError.
+            yield _new_session(dead=(call_counter["n"] >= 2))
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, _, _ = await get_mcp_tools(path)
+            with pytest.raises(ToolException, match="failed after one retry"):
+                await tools[0].ainvoke({})
+
+    async def test_logical_tool_exception_is_not_retried(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """A `ToolException` from the MCP server propagates without retry."""
+        from langchain_core.tools import ToolException
+        from mcp.types import CallToolResult, TextContent
+
+        path = write_config(
+            {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
+        )
+
+        call_counter = {"n": 0}
+        runtime_session: AsyncMock | None = None
+
+        def _new_session() -> AsyncMock:
+            nonlocal runtime_session
+            s = AsyncMock()
+            s.initialize = AsyncMock()
+            s.list_tools = AsyncMock(
+                return_value=_make_tool_page([_make_mcp_tool("echo")])
+            )
+            # Return isError=True; _convert_call_tool_result turns that into
+            # a ToolException.
+            s.call_tool = AsyncMock(
+                return_value=CallToolResult(
+                    content=[TextContent(type="text", text="boom")], isError=True
+                )
+            )
+            if call_counter["n"] >= 1:
+                runtime_session = s
+            return s
+
+        @asynccontextmanager
+        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+            call_counter["n"] += 1
+            yield _new_session()
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, _, _ = await get_mcp_tools(path)
+            with pytest.raises(ToolException, match="boom"):
+                await tools[0].ainvoke({})
+
+        # Only discovery + one runtime session — NO retry.
+        assert call_counter["n"] == 2
+        assert runtime_session is not None
+        assert runtime_session.call_tool.await_count == 1

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Callable, Generator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,9 +33,7 @@ def _make_mcp_tool(
     name: str, description: str = "", input_schema: dict | None = None
 ) -> MagicMock:
     """Build a mock MCP `Tool` object suitable for proxy-tool construction."""
-    mock = MagicMock(
-        spec=["name", "description", "inputSchema", "annotations", "meta"]
-    )
+    mock = MagicMock(spec=["name", "description", "inputSchema", "annotations", "meta"])
     mock.name = name
     mock.description = description
     mock.inputSchema = input_schema or {"type": "object", "properties": {}}
@@ -43,7 +42,9 @@ def _make_mcp_tool(
     return mock
 
 
-def _make_tool_page(tools: list[MagicMock], next_cursor: str | None = None) -> MagicMock:
+def _make_tool_page(
+    tools: list[MagicMock], next_cursor: str | None = None
+) -> MagicMock:
     """Build a mock `list_tools` page result."""
     page = MagicMock(spec=["tools", "nextCursor"])
     page.tools = tools
@@ -62,6 +63,7 @@ def _reset_mcp_singleton() -> Generator[None]:
     reset_default_session_manager_for_testing()
     yield
     reset_default_session_manager_for_testing()
+
 
 # Test Fixtures
 
@@ -111,7 +113,7 @@ def fake_create_session() -> Generator[tuple[AsyncMock, list]]:
     recorded: list = []
 
     @asynccontextmanager
-    async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+    async def _fake(connection, *, mcp_callbacks=None):
         recorded.append(connection)
         yield mock_session
 
@@ -620,7 +622,7 @@ class TestLoadMCPConfig:
             }
         }
         path = write_config(config_data)
-        with pytest.raises(ValueError, match="stdio.*oauth|oauth.*stdio"):
+        with pytest.raises(ValueError, match=r"stdio.*oauth|oauth.*stdio"):
             load_mcp_config(path)
 
     def test_load_config_auth_oauth_with_authorization_header_rejected(
@@ -790,7 +792,7 @@ class TestGetMCPTools:
         mock_session.list_tools = AsyncMock(side_effect=[page_fs, page_search])
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             recorded.append(connection)
             yield mock_session
 
@@ -872,9 +874,7 @@ class TestGetMCPTools:
         fake_create_session: tuple[AsyncMock, list],
     ) -> None:
         """`env` defaults to None (inherit parent env) when not in config."""
-        path = write_config(
-            {"mcpServers": {"simple": {"command": "simple-server"}}}
-        )
+        path = write_config({"mcpServers": {"simple": {"command": "simple-server"}}})
         _, recorded = fake_create_session
 
         await get_mcp_tools(path)
@@ -1611,14 +1611,12 @@ class TestHealthCheckIntegration:
         fake_session = AsyncMock()
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             yield fake_session
 
         with (
             patch("deepagents_cli.mcp_tools.shutil.which", return_value=None),
-            patch(
-                "langchain_mcp_adapters.sessions.create_session", _fake
-            ) as patched,
+            patch("langchain_mcp_adapters.sessions.create_session", _fake) as patched,
             pytest.raises(RuntimeError, match="Pre-flight health check"),
         ):
             await get_mcp_tools(path)
@@ -1644,7 +1642,7 @@ class TestHealthCheckIntegration:
         fake_session = AsyncMock()
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             yield fake_session
 
         mock_http = AsyncMock()
@@ -1677,7 +1675,7 @@ class TestHealthCheckIntegration:
         fake_session = AsyncMock()
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             yield fake_session
 
         with (
@@ -1789,7 +1787,7 @@ class TestToolOrdering:
         )
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             yield mock_session
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
@@ -1803,8 +1801,11 @@ class TestLoadToolsFromConfigHeaders:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Env-var references in headers are resolved before being passed to
-        `create_session` as part of the Connection config."""
+        """Resolve env-var references in headers before the Connection is built.
+
+        The resolved values must be passed to `create_session` via the
+        Connection config rather than the raw `${VAR}` placeholders.
+        """
         from deepagents_cli.mcp_tools import _load_tools_from_config
 
         monkeypatch.setenv("DA_TOKEN", "tok-123")
@@ -1815,7 +1816,7 @@ class TestLoadToolsFromConfigHeaders:
         mock_session.list_tools = AsyncMock(return_value=_make_tool_page([]))
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             recorded.append(connection)
             yield mock_session
 
@@ -1856,12 +1857,14 @@ class TestLoadToolsFromConfigOAuth:
                 }
             }
         }
-        with patch(
-            "deepagents_cli.mcp_tools._check_remote_server",
-            new=AsyncMock(return_value=None),
+        with (
+            patch(
+                "deepagents_cli.mcp_tools._check_remote_server",
+                new=AsyncMock(return_value=None),
+            ),
+            pytest.raises(RuntimeError, match="deepagents mcp login notion"),
         ):
-            with pytest.raises(RuntimeError, match="deepagents mcp login notion"):
-                await _load_tools_from_config(config)
+            await _load_tools_from_config(config)
 
     async def test_existing_tokens_attach_oauth_provider(
         self,
@@ -1882,7 +1885,7 @@ class TestLoadToolsFromConfigOAuth:
         mock_session.list_tools = AsyncMock(return_value=_make_tool_page([]))
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             recorded.append(connection)
             yield mock_session
 
@@ -1923,7 +1926,7 @@ class TestCachedSessionProxy:
             yield
 
     @staticmethod
-    def _fake_call_tool_result(text: str = "ok") -> MagicMock:
+    def _fake_call_tool_result(text: str = "ok") -> Any:  # noqa: ANN401 — returns mcp.types.CallToolResult; avoid pulling the import to module top
         """Build a mock `CallToolResult` compatible with `_convert_call_tool_result`."""
         from mcp.types import CallToolResult, TextContent
 
@@ -1952,7 +1955,7 @@ class TestCachedSessionProxy:
             return s
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             nonlocal session_ctx_entries
             session_ctx_entries += 1
             yield _new_session()
@@ -1963,7 +1966,7 @@ class TestCachedSessionProxy:
 
             # Invoke the proxy tool — should open a second session (first was
             # the throwaway discovery session).
-            content = await tools[0].ainvoke({})
+            content = await tools[0].ainvoke({})  # ty: ignore[missing-typed-dict-key]
 
         assert session_ctx_entries == 2, (
             "expected one discovery session + one cached runtime session"
@@ -1995,13 +1998,13 @@ class TestCachedSessionProxy:
             return s
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             yield _new_session()
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, _, _ = await get_mcp_tools(path)
-            await tools[0].ainvoke({})
-            await tools[0].ainvoke({})
+            await tools[0].ainvoke({})  # ty: ignore[missing-typed-dict-key]
+            await tools[0].ainvoke({})  # ty: ignore[missing-typed-dict-key]
 
         # discovery + one runtime session — NOT two runtime sessions.
         assert len(sessions) == 2
@@ -2037,7 +2040,7 @@ class TestCachedSessionProxy:
         call_counter = {"n": 0}
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             call_counter["n"] += 1
             # discovery (#1), first runtime session is dead (#2), retry opens
             # a fresh session (#3)
@@ -2045,7 +2048,7 @@ class TestCachedSessionProxy:
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, _, _ = await get_mcp_tools(path)
-            await tools[0].ainvoke({})
+            await tools[0].ainvoke({})  # ty: ignore[missing-typed-dict-key]
 
         assert call_counter["n"] == 3, (
             "discovery + dead runtime + retry = 3 sessions opened"
@@ -2071,15 +2074,13 @@ class TestCachedSessionProxy:
             s.list_tools = AsyncMock(
                 return_value=_make_tool_page([_make_mcp_tool("echo")])
             )
-            s.call_tool = AsyncMock(
-                side_effect=ClosedResourceError() if dead else None
-            )
+            s.call_tool = AsyncMock(side_effect=ClosedResourceError() if dead else None)
             return s
 
         call_counter = {"n": 0}
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             call_counter["n"] += 1
             # discovery session is "alive" so list_tools succeeds; both runtime
             # sessions (post-discovery) fail with ClosedResourceError.
@@ -2088,7 +2089,7 @@ class TestCachedSessionProxy:
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, _, _ = await get_mcp_tools(path)
             with pytest.raises(ToolException, match="failed after one retry"):
-                await tools[0].ainvoke({})
+                await tools[0].ainvoke({})  # ty: ignore[missing-typed-dict-key]
 
     async def test_logical_tool_exception_is_not_retried(
         self,
@@ -2124,14 +2125,14 @@ class TestCachedSessionProxy:
             return s
 
         @asynccontextmanager
-        async def _fake(connection, *, mcp_callbacks=None):  # noqa: ANN001, ARG001
+        async def _fake(connection, *, mcp_callbacks=None):
             call_counter["n"] += 1
             yield _new_session()
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, _, _ = await get_mcp_tools(path)
             with pytest.raises(ToolException, match="boom"):
-                await tools[0].ainvoke({})
+                await tools[0].ainvoke({})  # ty: ignore[missing-typed-dict-key]
 
         # Only discovery + one runtime session — NO retry.
         assert call_counter["n"] == 2

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -1844,3 +1844,53 @@ class TestToolOrdering:
 
         assert [t.name for t in tools] == ["alpha_read", "beta_write"]
         await manager.cleanup()
+
+
+class TestLoadToolsFromConfigHeaders:
+    @pytest.mark.asyncio
+    async def test_headers_are_resolved_before_connection(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_mcp_client: tuple[MagicMock, AsyncMock],
+    ) -> None:
+        """Env-var references in headers are resolved before being passed to
+        MultiServerMCPClient."""
+        from deepagents_cli.mcp_tools import _load_tools_from_config
+
+        monkeypatch.setenv("DA_TOKEN", "tok-123")
+
+        mock_client, _ = mock_mcp_client
+        captured: dict = {}
+
+        def _capture(connections: dict) -> MagicMock:
+            captured["connections"] = connections
+            return mock_client
+
+        with (
+            patch(
+                "langchain_mcp_adapters.client.MultiServerMCPClient",
+                side_effect=_capture,
+            ),
+            patch(
+                "deepagents_cli.mcp_tools._check_remote_server",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "langchain_mcp_adapters.tools.load_mcp_tools",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            config = {
+                "mcpServers": {
+                    "linear": {
+                        "transport": "http",
+                        "url": "https://mcp.linear.app/mcp",
+                        "headers": {"Authorization": "Bearer ${DA_TOKEN}"},
+                    }
+                }
+            }
+            _, mgr, _ = await _load_tools_from_config(config)
+            await mgr.cleanup()
+
+        sent_headers = captured["connections"]["linear"]["headers"]
+        assert sent_headers == {"Authorization": "Bearer tok-123"}

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -446,6 +446,48 @@ class TestLoadMCPConfig:
         ):
             load_mcp_config(path)
 
+    def test_load_config_header_with_missing_env_var_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        write_config: Callable[..., str],
+    ) -> None:
+        monkeypatch.delenv("DA_MISSING", raising=False)
+        config_data = {
+            "mcpServers": {
+                "linear": {
+                    "transport": "http",
+                    "url": "https://mcp.linear.app/mcp",
+                    "headers": {"Authorization": "Bearer ${DA_MISSING}"},
+                }
+            }
+        }
+        path = write_config(config_data)
+        with pytest.raises(RuntimeError, match="DA_MISSING"):
+            load_mcp_config(path)
+
+    def test_load_config_header_with_present_env_var_ok(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        write_config: Callable[..., str],
+    ) -> None:
+        monkeypatch.setenv("DA_PRESENT", "tok")
+        config_data = {
+            "mcpServers": {
+                "linear": {
+                    "transport": "http",
+                    "url": "https://mcp.linear.app/mcp",
+                    "headers": {"Authorization": "Bearer ${DA_PRESENT}"},
+                }
+            }
+        }
+        path = write_config(config_data)
+        config = load_mcp_config(path)
+        # The raw config is preserved; substitution happens at connection time.
+        assert (
+            config["mcpServers"]["linear"]["headers"]["Authorization"]
+            == "Bearer ${DA_PRESENT}"
+        )
+
 
 class TestGetMCPTools:
     """Test MCP tools loading from configuration."""

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -1959,3 +1959,79 @@ class TestLoadToolsFromConfigHeaders:
 
         sent_headers = captured["connections"]["linear"]["headers"]
         assert sent_headers == {"Authorization": "Bearer tok-123"}
+
+
+class TestLoadToolsFromConfigOAuth:
+    @pytest.mark.asyncio
+    async def test_missing_tokens_raise_login_instruction(
+        self,
+        fake_home: Path,
+    ) -> None:
+        from deepagents_cli.mcp_tools import _load_tools_from_config
+
+        config = {
+            "mcpServers": {
+                "notion": {
+                    "transport": "http",
+                    "url": "https://mcp.notion.com/mcp",
+                    "auth": "oauth",
+                }
+            }
+        }
+        with patch(
+            "deepagents_cli.mcp_tools._check_remote_server",
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="deepagents mcp login notion"):
+                await _load_tools_from_config(config)
+
+    @pytest.mark.asyncio
+    async def test_existing_tokens_attach_oauth_provider(
+        self,
+        fake_home: Path,
+        mock_mcp_client: tuple[MagicMock, AsyncMock],
+    ) -> None:
+        from mcp.client.auth import OAuthClientProvider
+        from mcp.shared.auth import OAuthToken
+
+        from deepagents_cli.mcp_auth import FileTokenStorage
+        from deepagents_cli.mcp_tools import _load_tools_from_config
+
+        storage = FileTokenStorage("notion")
+        await storage.set_tokens(OAuthToken(access_token="at", token_type="Bearer"))
+
+        mock_client, _ = mock_mcp_client
+        captured: dict = {}
+
+        def _capture(connections: dict) -> MagicMock:
+            captured["connections"] = connections
+            return mock_client
+
+        with (
+            patch(
+                "langchain_mcp_adapters.client.MultiServerMCPClient",
+                side_effect=_capture,
+            ),
+            patch(
+                "deepagents_cli.mcp_tools._check_remote_server",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "langchain_mcp_adapters.tools.load_mcp_tools",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            config = {
+                "mcpServers": {
+                    "notion": {
+                        "transport": "http",
+                        "url": "https://mcp.notion.com/mcp",
+                        "auth": "oauth",
+                    }
+                }
+            }
+            _, mgr, _ = await _load_tools_from_config(config)
+            await mgr.cleanup()
+
+        conn = captured["connections"]["notion"]
+        assert isinstance(conn.get("auth"), OAuthClientProvider)

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -485,6 +485,54 @@ class TestLoadMCPConfig:
         ):
             load_mcp_config(path)
 
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "../evil",
+            "../../etc/passwd",
+            "a/b",
+            "a\\b",
+            "",
+            ".",
+            "..",
+            "foo bar",
+            "foo\x00bar",
+            "foo.json",
+        ],
+    )
+    def test_load_config_rejects_unsafe_server_name(
+        self, write_config: Callable[..., str], bad_name: str
+    ) -> None:
+        """Server names must be path-safe — they're used in token file paths."""
+        config_data = {
+            "mcpServers": {
+                bad_name: {"command": "echo"},
+            }
+        }
+        path = write_config(config_data)
+
+        with pytest.raises(ValueError, match="server name"):
+            load_mcp_config(path)
+
+    @pytest.mark.parametrize(
+        "ok_name",
+        ["filesystem", "brave-search", "linear_v2", "Notion", "gh-123"],
+    )
+    def test_load_config_accepts_safe_server_name(
+        self, write_config: Callable[..., str], ok_name: str
+    ) -> None:
+        """Alphanumeric, hyphens, and underscores are allowed server names."""
+        config_data = {
+            "mcpServers": {
+                ok_name: {"command": "echo"},
+            }
+        }
+        path = write_config(config_data)
+
+        config = load_mcp_config(path)
+
+        assert ok_name in config["mcpServers"]
+
     def test_load_config_header_with_missing_env_var_raises(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -488,6 +488,71 @@ class TestLoadMCPConfig:
             == "Bearer ${DA_PRESENT}"
         )
 
+    def test_load_config_auth_oauth_http_ok(
+        self, write_config: Callable[..., str]
+    ) -> None:
+        config_data = {
+            "mcpServers": {
+                "notion": {
+                    "transport": "http",
+                    "url": "https://mcp.notion.com/mcp",
+                    "auth": "oauth",
+                }
+            }
+        }
+        path = write_config(config_data)
+        config = load_mcp_config(path)
+        assert config["mcpServers"]["notion"]["auth"] == "oauth"
+
+    def test_load_config_auth_unknown_value_rejected(
+        self, write_config: Callable[..., str]
+    ) -> None:
+        config_data = {
+            "mcpServers": {
+                "notion": {
+                    "transport": "http",
+                    "url": "https://mcp.notion.com/mcp",
+                    "auth": "saml",
+                }
+            }
+        }
+        path = write_config(config_data)
+        with pytest.raises(ValueError, match="auth"):
+            load_mcp_config(path)
+
+    def test_load_config_auth_oauth_on_stdio_rejected(
+        self, write_config: Callable[..., str]
+    ) -> None:
+        config_data = {
+            "mcpServers": {
+                "local": {
+                    "command": "npx",
+                    "args": [],
+                    "auth": "oauth",
+                }
+            }
+        }
+        path = write_config(config_data)
+        with pytest.raises(ValueError, match="stdio.*oauth|oauth.*stdio"):
+            load_mcp_config(path)
+
+    def test_load_config_auth_oauth_with_authorization_header_rejected(
+        self, write_config: Callable[..., str]
+    ) -> None:
+        config_data = {
+            "mcpServers": {
+                "notion": {
+                    "transport": "http",
+                    "url": "https://mcp.notion.com/mcp",
+                    "auth": "oauth",
+                    "headers": {"Authorization": "Bearer x"},
+                }
+            }
+        }
+        path = write_config(config_data)
+        with pytest.raises(ValueError, match="Authorization"):
+            load_mcp_config(path)
+
 
 class TestGetMCPTools:
     """Test MCP tools loading from configuration."""

--- a/libs/cli/tests/unit_tests/test_mcp_viewer.py
+++ b/libs/cli/tests/unit_tests/test_mcp_viewer.py
@@ -87,7 +87,7 @@ class TestMCPViewerScreen:
         async with app.run_test() as pilot:
             dismissed = False
 
-            def on_dismiss(result: None) -> None:  # noqa: ARG001
+            def on_dismiss(result: None) -> None:
                 nonlocal dismissed
                 dismissed = True
 

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -1029,7 +1029,7 @@ class TestNonInteractivePrompt:
         mock_start_server.assert_not_awaited()
 
 
-async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029
+async def _async_iter(items: list[object]) -> AsyncIterator[object]:
     """Create an async iterator from a list for testing."""
     for item in items:
         yield item

--- a/libs/cli/tests/unit_tests/test_remote_client.py
+++ b/libs/cli/tests/unit_tests/test_remote_client.py
@@ -233,9 +233,9 @@ def _make_agent(
     agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
     mock_graph = MagicMock()
 
-    async def fake_astream(  # noqa: RUF029
-        input: Any,  # noqa: A002, ANN401, ARG001
-        **kwargs: Any,  # noqa: ARG001
+    async def fake_astream(
+        input: Any,  # noqa: A002, ANN401
+        **kwargs: Any,
     ) -> Any:  # noqa: ANN401
         for ev in events:
             yield ev

--- a/libs/cli/tests/unit_tests/test_server.py
+++ b/libs/cli/tests/unit_tests/test_server.py
@@ -272,7 +272,7 @@ class TestServerProcess:
 
         old_value = os.environ.get("DEEPAGENTS_CLI_SERVER_MODEL")
 
-        async def failing_start(*, timeout: float = 60) -> None:  # noqa: ARG001, ASYNC109, RUF029
+        async def failing_start(*, timeout: float = 60) -> None:  # noqa: ASYNC109
             msg = "restart failed"
             raise RuntimeError(msg)
 

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -230,7 +230,7 @@ class TestGetLatestVersion:
         assert result == "2.0.0"
         mock_get.assert_called_once()
 
-    def test_network_error(self, cache_file) -> None:  # noqa: ARG002  # fixture overrides CACHE_FILE
+    def test_network_error(self, cache_file) -> None:  # fixture overrides CACHE_FILE
         """Network failure returns None."""
         with patch("requests.get", side_effect=OSError("no network")):
             result = get_latest_version()
@@ -438,7 +438,7 @@ class TestSetAutoUpdate:
         assert data["update"]["check"] is False
         assert data["update"]["auto_update"] is True
 
-    def test_round_trip_with_is_auto_update_enabled(self, config_path) -> None:  # noqa: ARG002
+    def test_round_trip_with_is_auto_update_enabled(self, config_path) -> None:
         """set_auto_update(True) makes is_auto_update_enabled() return True."""
         set_auto_update(True)
         with (
@@ -459,7 +459,7 @@ class TestIsAutoUpdateEnabled:
         with patch("deepagents_cli.update_check.DEFAULT_CONFIG_PATH", path):
             yield path
 
-    def test_default_is_false(self, config_path) -> None:  # noqa: ARG002
+    def test_default_is_false(self, config_path) -> None:
         """Auto-update defaults to disabled."""
         with (
             patch("deepagents_cli.config._is_editable_install", return_value=False),
@@ -470,7 +470,7 @@ class TestIsAutoUpdateEnabled:
             os.environ.pop("DEEPAGENTS_CLI_AUTO_UPDATE", None)
             assert is_auto_update_enabled() is False
 
-    def test_env_var_enables(self, config_path) -> None:  # noqa: ARG002
+    def test_env_var_enables(self, config_path) -> None:
         """DEEPAGENTS_CLI_AUTO_UPDATE=1 enables auto-update."""
         with (
             patch("deepagents_cli.config._is_editable_install", return_value=False),
@@ -494,7 +494,7 @@ class TestShouldNotifyUpdate:
         with patch("deepagents_cli.update_check.UPDATE_STATE_FILE", path):
             yield path
 
-    def test_no_file_returns_true(self, state_file) -> None:  # noqa: ARG002
+    def test_no_file_returns_true(self, state_file) -> None:
         """First-run case: no state file exists."""
         assert should_notify_update("2.0.0") is True
 
@@ -570,12 +570,12 @@ class TestMarkUpdateNotified:
         data = json.loads(state_file.read_text())
         assert data["notified_version"] == "2.0.0"
 
-    def test_round_trip(self, state_file) -> None:  # noqa: ARG002
+    def test_round_trip(self, state_file) -> None:
         """Mark then should_notify returns False for same version."""
         mark_update_notified("2.0.0")
         assert should_notify_update("2.0.0") is False
 
-    def test_round_trip_different_version(self, state_file) -> None:  # noqa: ARG002
+    def test_round_trip_different_version(self, state_file) -> None:
         """Mark then should_notify returns True for different version."""
         mark_update_notified("1.9.0")
         assert should_notify_update("2.0.0") is True
@@ -610,8 +610,8 @@ class TestMarkUpdateNotified:
 
     def test_get_latest_version_does_not_clobber_notify(
         self,
-        state_file,  # noqa: ARG002
-        cache_file,  # noqa: ARG002
+        state_file,
+        cache_file,
     ) -> None:
         """get_latest_version writing cache doesn't destroy notification state."""
         mark_update_notified("2.0.0")
@@ -637,11 +637,11 @@ class TestGetSeenVersion:
         with patch("deepagents_cli.update_check.UPDATE_STATE_FILE", path):
             yield path
 
-    def test_no_file_returns_none(self, state_file) -> None:  # noqa: ARG002
+    def test_no_file_returns_none(self, state_file) -> None:
         """No state file -> None."""
         assert get_seen_version() is None
 
-    def test_round_trip(self, state_file) -> None:  # noqa: ARG002
+    def test_round_trip(self, state_file) -> None:
         """Mark then get returns the same version."""
         mark_version_seen("1.0.0")
         assert get_seen_version() == "1.0.0"
@@ -656,7 +656,7 @@ class TestGetSeenVersion:
         state_file.write_text(json.dumps({"seen_version": 123}))
         assert get_seen_version() is None
 
-    def test_preserves_notification_keys(self, state_file) -> None:  # noqa: ARG002
+    def test_preserves_notification_keys(self, state_file) -> None:
         """Marking seen preserves existing notification data."""
         mark_update_notified("2.0.0")
         mark_version_seen("1.0.0")
@@ -682,7 +682,7 @@ class TestShouldShowWhatsNew:
         data = json.loads(state_file.read_text())
         assert data["seen_version"] == "1.0.0"
 
-    def test_same_version_returns_false(self, state_file) -> None:  # noqa: ARG002
+    def test_same_version_returns_false(self, state_file) -> None:
         """Current version == seen version -> False."""
         from deepagents_cli.update_check import should_show_whats_new
 
@@ -690,7 +690,7 @@ class TestShouldShowWhatsNew:
         with patch("deepagents_cli.update_check.__version__", "1.0.0"):
             assert should_show_whats_new() is False
 
-    def test_newer_version_returns_true(self, state_file) -> None:  # noqa: ARG002
+    def test_newer_version_returns_true(self, state_file) -> None:
         """Current version > seen version -> True."""
         from deepagents_cli.update_check import should_show_whats_new
 
@@ -698,7 +698,7 @@ class TestShouldShowWhatsNew:
         with patch("deepagents_cli.update_check.__version__", "2.0.0"):
             assert should_show_whats_new() is True
 
-    def test_coexists_with_notification_state(self, state_file) -> None:  # noqa: ARG002
+    def test_coexists_with_notification_state(self, state_file) -> None:
         """What's-new and notification state don't interfere."""
         from deepagents_cli.update_check import should_show_whats_new
 


### PR DESCRIPTION
## Summary

Adds OAuth support for MCP servers in the \`deepagents\` CLI, plus env-var interpolation for static headers.

- **Env-var headers** — \`resolve_headers\` interpolates \`\${VAR}\` refs in \`headers\` entries, validated at config-load and applied at connection time.
- **\`auth: oauth\` config field** — validated at load time; rejected on stdio, rejected alongside a static \`Authorization\` header.
- **\`FileTokenStorage\`** — \`mcp.client.auth.TokenStorage\` backed by JSON under \`~/.deepagents/mcp-tokens/<server>.json\` (atomic write, 0o600 tokens, 0o700 dir).
- **Paste-back OAuth provider** — \`build_oauth_provider\` returns an \`OAuthClientProvider\` with redirect + callback handlers suitable for CLI use.
- **\`deepagents mcp login <server>\`** — new subcommand that drives the OAuth flow for an http/sse server from \`.mcp.json\` and persists the tokens.
- **Agent auto-load path** — \`get_mcp_tools\` attaches the OAuth provider when \`auth: oauth\` is set and fails fast with a helpful message if no tokens are cached.
- **Cross-loop session safety + Slack OAuth** — the MCP session manager now survives loop switches; Slack's no-DCR flow is pre-seeded via hardcoded client_info.
- **Server-name path-safety** — \`_validate_server_config\` rejects \`mcpServers\` keys that don't match \`^[A-Za-z0-9_-]+\$\`, so malicious or typo'd names (\`../evil\`, \`a/b\`, empty, null byte, etc.) can't escape the tokens directory in \`FileTokenStorage._path\`. Single chokepoint covers both the CLI login and the agent auto-load paths.

## Test plan

- [ ] \`make test\` in \`libs/cli\` passes (137 unit tests, including new path-safety parametrized cases)
- [x] \`deepagents mcp login <server>\` completes the OAuth flow end-to-end against Notion or Linear
- [ ] Running an agent against an \`auth: oauth\` server with no cached tokens prints the \`Run: deepagents mcp login ...\` hint
- [x] Running the same agent after login succeeds and tools are discovered
- [ ] A \`.mcp.json\` with a path-traversal key (\`"../evil"\`) is rejected at config load