### PR TITLE
refactor(cli): use langsmith sandbox snapshots instead of templates

### DIFF
--- a/libs/cli/deepagents_cli/deploy/bundler.py
+++ b/libs/cli/deepagents_cli/deploy/bundler.py
@@ -15,9 +15,9 @@ Reads the canonical project layout:
 
 ...and writes everything `langgraph deploy` needs to a build directory.
 
-AGENTS.md and skills are read-only at runtime.  When a ``user/``
-directory is present, a per-user ``AGENTS.md`` is seeded (from
-``user/AGENTS.md`` if provided, otherwise empty) and is writable
+AGENTS.md and skills are read-only at runtime.  When a `user/`
+directory is present, a per-user `AGENTS.md` is seeded (from
+`user/AGENTS.md` if provided, otherwise empty) and is writable
 at runtime.
 """
 
@@ -204,10 +204,10 @@ def _build_seed(
             "user_memories":  { "/AGENTS.md": "..." }
         }
 
-    ``memories`` and ``skills`` are read-only at runtime.
-    ``user_memories`` contains a single writable ``AGENTS.md`` mounted at
-    ``/memories/user/``, namespaced per user_id.  If the project has a
-    ``user/`` directory (even if empty), an ``AGENTS.md`` is always seeded.
+    `memories` and `skills` are read-only at runtime.
+    `user_memories` contains a single writable `AGENTS.md` mounted at
+    `/memories/user/`, namespaced per user_id.  If the project has a
+    `user/` directory (even if empty), an `AGENTS.md` is always seeded.
     """
     memories: dict[str, str] = {f"/{AGENTS_MD_FILENAME}": system_prompt}
     skills: dict[str, str] = {}

--- a/libs/cli/deepagents_cli/deploy/bundler.py
+++ b/libs/cli/deepagents_cli/deploy/bundler.py
@@ -279,7 +279,7 @@ def _render_deploy_graph(
 
     return DEPLOY_GRAPH_TEMPLATE.format(
         model=config.agent.model,
-        sandbox_template=config.sandbox.template,
+        sandbox_snapshot=config.sandbox.template,
         sandbox_image=config.sandbox.image,
         sandbox_scope=config.sandbox.scope,
         sandbox_block=sandbox_block,

--- a/libs/cli/deepagents_cli/deploy/config.py
+++ b/libs/cli/deepagents_cli/deploy/config.py
@@ -82,19 +82,33 @@ class SandboxConfig:
     The whole section is optional. When omitted (or `provider = "none"`)
     the runtime falls back to an in-process `StateBackend` and tools
     like `execute` become no-ops.
-
-    `scope` controls how the sandbox cache keys are built:
-
-    - `"thread"` (default): one sandbox per thread. Different threads
-        get different sandboxes, same thread reuses across turns.
-    - `"assistant"`: one sandbox per assistant. All threads of the
-        same assistant share a single sandbox and its filesystem.
     """
 
     provider: SandboxProvider = "none"
+    """Sandbox backend identifier (`"none"` disables the sandbox)."""
+
     template: str = "deepagents-deploy"
+    """LangSmith snapshot name the deployed graph boots from.
+
+    The TOML key is kept as `template` for backward compatibility with
+    existing `deepagents.toml` files — LangSmith's API renamed "template"
+    to "snapshot" in 0.7.32, but this field name did not. The default
+    `"deepagents-deploy"` is distinct from the interactive CLI default
+    (`deepagents-cli`) so production deployments can be rebuilt
+    independently of local-CLI snapshots.
+    """
+
     image: str = "python:3"
+    """Docker image used to build the snapshot when it does not yet exist."""
+
     scope: SandboxScope = "thread"
+    """How sandbox cache keys are built.
+
+    - `"thread"` (default): one sandbox per thread. Different threads get
+        different sandboxes; the same thread reuses across turns.
+    - `"assistant"`: one sandbox per assistant. All threads of the same
+        assistant share a single sandbox and its filesystem.
+    """
 
 
 @dataclass(frozen=True)
@@ -102,7 +116,10 @@ class DeployConfig:
     """Top-level deploy configuration parsed from `deepagents.toml`."""
 
     agent: AgentConfig
+    """Parsed `[agent]` section — core agent identity (name + model)."""
+
     sandbox: SandboxConfig = field(default_factory=SandboxConfig)
+    """Parsed `[sandbox]` section — provider, snapshot name, image, scope."""
 
     def validate(self, project_root: Path) -> list[str]:
         """Validate config against the filesystem.
@@ -238,9 +255,9 @@ def _parse_subagent_config(data: dict[str, Any], subagent_dir: Path) -> SubAgent
 
 
 def load_subagents(project_root: Path) -> dict[str, SubAgentProject]:
-    """Discover and load subagent projects from ``subagents/``.
+    """Discover and load subagent projects from `subagents/`.
 
-    Returns a dict keyed by subagent name. If the ``subagents/`` directory
+    Returns a dict keyed by subagent name. If the `subagents/` directory
     does not exist or is empty, returns an empty dict.
 
     Raises:

--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -29,7 +29,7 @@ SANDBOX_BLOCK_LANGSMITH = '''\
 from deepagents.backends.langsmith import LangSmithSandbox
 
 _SANDBOXES: dict = {}
-_SANDBOX_FS_CAPACITY_BYTES = 4 * 1024**3
+_SANDBOX_FS_CAPACITY_BYTES = 16 * 1024**3
 
 
 def _get_or_create_sandbox(cache_key):

--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -3,13 +3,13 @@
 These templates are rendered by the bundler with values from
 `~deepagents_cli.deploy.config.DeployConfig`.
 
-The generated ``deploy_graph.py`` uses a ``CompositeBackend`` with all
-managed content under ``/memories/`` — ``/memories/AGENTS.md``,
-``/memories/skills/``, and ``/memories/user/`` (per-user templates) —
-backed by ``StoreBackend`` instances.  The configured sandbox is the
+The generated `deploy_graph.py` uses a `CompositeBackend` with all
+managed content under `/memories/` — `/memories/AGENTS.md`,
+`/memories/skills/`, and `/memories/user/` (per-user templates) —
+backed by `StoreBackend` instances.  The configured sandbox is the
 default writable backend.  Write access is controlled via
-``FilesystemPermission`` rules derived from each file's YAML frontmatter
-``permissions`` field.
+`FilesystemPermission` rules derived from each file's YAML frontmatter
+`permissions` field.
 
 There is no hub path and no custom Python tools.
 """
@@ -33,7 +33,12 @@ _SANDBOX_FS_CAPACITY_BYTES = 16 * 1024**3
 
 
 def _get_or_create_sandbox(cache_key):
-    """Get or create a LangSmith sandbox cached by ``cache_key``."""
+    """Get or create a LangSmith sandbox cached by `cache_key`.
+
+    Uses raw `os.environ` (not the CLI's `resolve_env_var`) because the
+    deployed bundle cannot import `deepagents_cli` internals;
+    `DEEPAGENTS_CLI_`-prefixed vars are not honored here.
+    """
     if cache_key in _SANDBOXES:
         return _SANDBOXES[cache_key]
 
@@ -42,8 +47,13 @@ def _get_or_create_sandbox(cache_key):
     api_key = (
         os.environ.get("LANGSMITH_SANDBOX_API_KEY")
         or os.environ.get("LANGSMITH_API_KEY")
-        or os.environ["LANGCHAIN_API_KEY"]
+        or os.environ.get("LANGCHAIN_API_KEY")
     )
+    if not api_key:
+        raise RuntimeError(
+            "No LangSmith sandbox API key found. Set "
+            "LANGSMITH_SANDBOX_API_KEY, LANGSMITH_API_KEY, or LANGCHAIN_API_KEY."
+        )
     client = SandboxClient(api_key=api_key)
 
     snapshot_id = os.environ.get("LANGSMITH_SANDBOX_SNAPSHOT_ID")
@@ -51,23 +61,46 @@ def _get_or_create_sandbox(cache_key):
         snapshot_name = (
             os.environ.get("LANGSMITH_SANDBOX_SNAPSHOT_NAME") or SANDBOX_SNAPSHOT
         )
-        snapshot_id = next(
-            (
-                snap.id
-                for snap in client.list_snapshots()
-                if snap.name == snapshot_name and snap.status == "ready"
-            ),
-            None,
-        )
+        try:
+            snapshots = client.list_snapshots()
+        except Exception as e:
+            raise RuntimeError(f"Failed to list snapshots: {e}") from e
+
+        snapshot_id = None
+        non_ready_status = None
+        for snap in snapshots:
+            if snap.name != snapshot_name:
+                continue
+            if snap.status == "ready":
+                snapshot_id = snap.id
+                break
+            non_ready_status = snap.status
+
         if snapshot_id is None:
-            snapshot = client.create_snapshot(
-                name=snapshot_name,
-                docker_image=SANDBOX_IMAGE,
-                fs_capacity_bytes=_SANDBOX_FS_CAPACITY_BYTES,
-            )
+            if non_ready_status is not None:
+                raise RuntimeError(
+                    f"Snapshot {snapshot_name!r} exists but is "
+                    f"in state {non_ready_status!r}. Wait for it to finish "
+                    "building, or delete it to rebuild."
+                )
+            try:
+                snapshot = client.create_snapshot(
+                    name=snapshot_name,
+                    docker_image=SANDBOX_IMAGE,
+                    fs_capacity_bytes=_SANDBOX_FS_CAPACITY_BYTES,
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to build snapshot {snapshot_name!r}: {e}"
+                ) from e
             snapshot_id = snapshot.id
 
-    sandbox = client.create_sandbox(snapshot_id=snapshot_id)
+    try:
+        sandbox = client.create_sandbox(snapshot_id=snapshot_id)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to create sandbox from snapshot {snapshot_id!r}: {e}"
+        ) from e
     backend = LangSmithSandbox(sandbox)
     _SANDBOXES[cache_key] = backend
     logger.info(
@@ -77,6 +110,7 @@ def _get_or_create_sandbox(cache_key):
     )
     return backend
 '''
+"""Sandbox creation block for the LangSmith provider."""
 
 SANDBOX_BLOCK_DAYTONA = '''\
 from langchain_daytona import DaytonaSandbox
@@ -85,7 +119,7 @@ _SANDBOXES: dict = {}
 
 
 def _get_or_create_sandbox(cache_key):
-    """Get or create a Daytona sandbox cached by ``cache_key``."""
+    """Get or create a Daytona sandbox cached by `cache_key`."""
     if cache_key in _SANDBOXES:
         return _SANDBOXES[cache_key]
 
@@ -98,6 +132,7 @@ def _get_or_create_sandbox(cache_key):
     logger.info("Created Daytona sandbox %s for cache_key %s", sandbox.id, cache_key)
     return backend
 '''
+"""Sandbox creation block for the Daytona provider."""
 
 SANDBOX_BLOCK_MODAL = '''\
 from langchain_modal import ModalSandbox
@@ -106,7 +141,7 @@ _SANDBOXES: dict = {}
 
 
 def _get_or_create_sandbox(cache_key):
-    """Get or create a Modal sandbox cached by ``cache_key``."""
+    """Get or create a Modal sandbox cached by `cache_key`."""
     if cache_key in _SANDBOXES:
         return _SANDBOXES[cache_key]
 
@@ -119,6 +154,7 @@ def _get_or_create_sandbox(cache_key):
     logger.info("Created Modal sandbox for cache_key %s", cache_key)
     return backend
 '''
+"""Sandbox creation block for the Modal provider."""
 
 SANDBOX_BLOCK_RUNLOOP = '''\
 from langchain_runloop import RunloopSandbox
@@ -127,7 +163,7 @@ _SANDBOXES: dict = {}
 
 
 def _get_or_create_sandbox(cache_key):
-    """Get or create a Runloop devbox cached by ``cache_key``."""
+    """Get or create a Runloop devbox cached by `cache_key`."""
     if cache_key in _SANDBOXES:
         return _SANDBOXES[cache_key]
 
@@ -140,6 +176,7 @@ def _get_or_create_sandbox(cache_key):
     logger.info("Created Runloop devbox %s for cache_key %s", devbox.id, cache_key)
     return backend
 '''
+"""Sandbox creation block for the Runloop provider."""
 
 SANDBOX_BLOCK_NONE = '''\
 from deepagents.backends.state import StateBackend
@@ -154,6 +191,7 @@ def _get_or_create_sandbox(cache_key):  # noqa: ARG001
         _STATE_BACKEND = StateBackend()
     return _STATE_BACKEND
 '''
+"""Fallback block used when no sandbox provider is configured."""
 
 SANDBOX_BLOCKS = {
     "langsmith": (SANDBOX_BLOCK_LANGSMITH, None),
@@ -162,7 +200,7 @@ SANDBOX_BLOCKS = {
     "runloop": (SANDBOX_BLOCK_RUNLOOP, "langchain-runloop"),
     "none": (SANDBOX_BLOCK_NONE, None),
 }
-"""Map of provider -> (sandbox_block, requires_partner_package)."""
+"""Map of `provider -> (sandbox_block, requires_partner_package)`."""
 
 
 # ---------------------------------------------------------------------------
@@ -328,7 +366,7 @@ async def _load_subagent_mcp_tools(mcp_config):
 # User memories are namespaced per (assistant_id, user_id) so each
 # user gets their own copy.  Template files are seeded on first access
 # (only if not already present).  Write access is controlled per-file
-# via frontmatter ``permissions: read-write`` declarations.
+# via frontmatter `permissions: read-write` declarations.
 #
 # The bundler ships `_seed.json` containing all payloads; the factory
 # seeds each namespace once per (process, assistant_id) and user
@@ -491,7 +529,7 @@ _SEEDED_USERS: set[tuple[str, str]] = set()
 
 
 async def _seed_store_if_needed(store, assistant_id: str) -> None:
-    """Seed memories + skills under ``assistant_id`` once per process."""
+    """Seed memories + skills under `assistant_id` once per process."""
     if assistant_id in _SEEDED_ASSISTANTS:
         return
     _SEEDED_ASSISTANTS.add(assistant_id)
@@ -568,7 +606,7 @@ def _make_namespace_factory(assistant_id: str, *extra: str):
 def _make_user_namespace_factory(assistant_id: str):
     """Return a namespace factory that includes the user_id.
 
-    Uses ``rt.server_info.user.identity`` from custom auth.  The platform
+    Uses `rt.server_info.user.identity` from custom auth.  The platform
     always injects user_id from auth, so no configurable fallback is needed.
     """
     def _factory(rt):
@@ -630,8 +668,8 @@ def _build_backend_factory(assistant_id: str):
 async def make_graph(config: RunnableConfig, runtime: "ServerRuntime"):
     """Async graph factory.
 
-    Accepts the invocation's ``RunnableConfig`` for ``assistant_id`` and
-    the ``ServerRuntime`` for ``store`` and ``user.identity``.  Seeds
+    Accepts the invocation's `RunnableConfig` for `assistant_id` and
+    the `ServerRuntime` for `store` and `user.identity`.  Seeds
     memories + skills once per (process, assistant_id), and user memories
     once per (process, assistant_id, user_id).  Gracefully skips user
     memory features when no user_id is available.
@@ -695,6 +733,7 @@ async def make_graph(config: RunnableConfig, runtime: "ServerRuntime"):
 
 graph = make_graph
 '''
+"""Generated `deploy_graph.py` source — the server entry point."""
 
 
 # ---------------------------------------------------------------------------
@@ -713,3 +752,4 @@ dependencies = [
 [tool.setuptools]
 py-modules = []
 """
+"""Generated `pyproject.toml` source for the deployed bundle."""

--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -29,6 +29,7 @@ SANDBOX_BLOCK_LANGSMITH = '''\
 from deepagents.backends.langsmith import LangSmithSandbox
 
 _SANDBOXES: dict = {}
+_SANDBOX_FS_CAPACITY_BYTES = 4 * 1024**3
 
 
 def _get_or_create_sandbox(cache_key):
@@ -36,7 +37,7 @@ def _get_or_create_sandbox(cache_key):
     if cache_key in _SANDBOXES:
         return _SANDBOXES[cache_key]
 
-    from langsmith.sandbox import ResourceNotFoundError, SandboxClient
+    from langsmith.sandbox import SandboxClient
 
     api_key = (
         os.environ.get("LANGSMITH_SANDBOX_API_KEY")
@@ -45,12 +46,23 @@ def _get_or_create_sandbox(cache_key):
     )
     client = SandboxClient(api_key=api_key)
 
-    try:
-        client.get_template(SANDBOX_TEMPLATE)
-    except ResourceNotFoundError:
-        client.create_template(name=SANDBOX_TEMPLATE, image=SANDBOX_IMAGE)
+    snapshot_id = next(
+        (
+            snap.id
+            for snap in client.list_snapshots()
+            if snap.name == SANDBOX_SNAPSHOT and snap.status == "ready"
+        ),
+        None,
+    )
+    if snapshot_id is None:
+        snapshot = client.create_snapshot(
+            name=SANDBOX_SNAPSHOT,
+            docker_image=SANDBOX_IMAGE,
+            fs_capacity_bytes=_SANDBOX_FS_CAPACITY_BYTES,
+        )
+        snapshot_id = snapshot.id
 
-    sandbox = client.create_sandbox(template_name=SANDBOX_TEMPLATE)
+    sandbox = client.create_sandbox(snapshot_id=snapshot_id)
     backend = LangSmithSandbox(sandbox)
     _SANDBOXES[cache_key] = backend
     logger.info(
@@ -352,7 +364,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SANDBOX_TEMPLATE = {sandbox_template!r}
+SANDBOX_SNAPSHOT = {sandbox_snapshot!r}
 SANDBOX_IMAGE = {sandbox_image!r}
 
 # Mount points inside the composite backend.

--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -46,21 +46,26 @@ def _get_or_create_sandbox(cache_key):
     )
     client = SandboxClient(api_key=api_key)
 
-    snapshot_id = next(
-        (
-            snap.id
-            for snap in client.list_snapshots()
-            if snap.name == SANDBOX_SNAPSHOT and snap.status == "ready"
-        ),
-        None,
-    )
-    if snapshot_id is None:
-        snapshot = client.create_snapshot(
-            name=SANDBOX_SNAPSHOT,
-            docker_image=SANDBOX_IMAGE,
-            fs_capacity_bytes=_SANDBOX_FS_CAPACITY_BYTES,
+    snapshot_id = os.environ.get("LANGSMITH_SANDBOX_SNAPSHOT_ID")
+    if not snapshot_id:
+        snapshot_name = (
+            os.environ.get("LANGSMITH_SANDBOX_SNAPSHOT_NAME") or SANDBOX_SNAPSHOT
         )
-        snapshot_id = snapshot.id
+        snapshot_id = next(
+            (
+                snap.id
+                for snap in client.list_snapshots()
+                if snap.name == snapshot_name and snap.status == "ready"
+            ),
+            None,
+        )
+        if snapshot_id is None:
+            snapshot = client.create_snapshot(
+                name=snapshot_name,
+                docker_image=SANDBOX_IMAGE,
+                fs_capacity_bytes=_SANDBOX_FS_CAPACITY_BYTES,
+            )
+            snapshot_id = snapshot.id
 
     sandbox = client.create_sandbox(snapshot_id=snapshot_id)
     backend = LangSmithSandbox(sandbox)

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -283,6 +283,8 @@ class _LangSmithProvider(SandboxProvider):
         """
         from deepagents.backends.langsmith import LangSmithSandbox
 
+        from deepagents_cli.model_config import resolve_env_var
+
         if kwargs:
             msg = f"Received unsupported arguments: {list(kwargs.keys())}"
             raise TypeError(msg)
@@ -295,11 +297,17 @@ class _LangSmithProvider(SandboxProvider):
                 raise RuntimeError(msg) from e
             return LangSmithSandbox(sandbox)
 
-        snapshot_name = snapshot or _LANGSMITH_DEFAULT_SNAPSHOT
-        image = snapshot_image or _LANGSMITH_DEFAULT_IMAGE
-        capacity = fs_capacity_bytes or _LANGSMITH_DEFAULT_FS_CAPACITY_BYTES
-
-        snapshot_id = self._ensure_snapshot(snapshot_name, image, capacity)
+        # Explicit snapshot ID wins — skip name lookup and auto-build.
+        env_snapshot_id = resolve_env_var("LANGSMITH_SANDBOX_SNAPSHOT_ID")
+        if env_snapshot_id:
+            snapshot_id = env_snapshot_id
+            snapshot_name = env_snapshot_id
+        else:
+            env_snapshot_name = resolve_env_var("LANGSMITH_SANDBOX_SNAPSHOT_NAME")
+            snapshot_name = snapshot or env_snapshot_name or _LANGSMITH_DEFAULT_SNAPSHOT
+            image = snapshot_image or _LANGSMITH_DEFAULT_IMAGE
+            capacity = fs_capacity_bytes or _LANGSMITH_DEFAULT_FS_CAPACITY_BYTES
+            snapshot_id = self._ensure_snapshot(snapshot_name, image, capacity)
 
         try:
             sandbox = self._client.create_sandbox(

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from deepagents.backends.protocol import SandboxBackendProtocol
-    from langsmith.sandbox import SandboxTemplate
 
 
 def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) -> None:
@@ -205,17 +204,21 @@ def _import_provider_module(
         raise ImportError(msg) from exc
 
 
-_LANGSMITH_DEFAULT_TEMPLATE = "deepagents-cli"
-"""Default LangSmith sandbox template name used when no template is specified."""
+_LANGSMITH_DEFAULT_SNAPSHOT = "deepagents-cli"
+"""Default LangSmith sandbox snapshot name used when none is specified."""
 
 _LANGSMITH_DEFAULT_IMAGE = "python:3"
-"""Default Docker image for LangSmith sandboxes when no image is provided."""
+"""Default Docker image for LangSmith sandbox snapshots when none is provided."""
+
+_LANGSMITH_DEFAULT_FS_CAPACITY_BYTES = 4 * 1024**3
+"""Default filesystem capacity (4 GiB) for LangSmith sandbox snapshots."""
 
 
 class _LangSmithProvider(SandboxProvider):
     """LangSmith sandbox provider implementation.
 
-    Manages LangSmith sandbox lifecycle using the LangSmith SDK.
+    Manages LangSmith sandbox lifecycle using the LangSmith SDK, booting
+    sandboxes from snapshots built from a Docker image.
     """
 
     def __init__(self, api_key: str | None = None) -> None:
@@ -255,25 +258,28 @@ class _LangSmithProvider(SandboxProvider):
         *,
         sandbox_id: str | None = None,
         timeout: int = 180,
-        template: str | None = None,
-        template_image: str | None = None,
+        snapshot: str | None = None,
+        snapshot_image: str | None = None,
+        fs_capacity_bytes: int | None = None,
         **kwargs: Any,
     ) -> SandboxBackendProtocol:
         """Get existing or create new LangSmith sandbox.
 
         Args:
-            sandbox_id: Optional existing sandbox name to reuse
-            timeout: Timeout in seconds for sandbox startup
-            template: Template name for the sandbox
-            template_image: Docker image for the template
-            **kwargs: Additional LangSmith-specific parameters
+            sandbox_id: Optional existing sandbox name to reuse.
+            timeout: Timeout in seconds for sandbox startup.
+            snapshot: Snapshot name to boot from. Resolved to a snapshot ID,
+                creating the snapshot from `snapshot_image` if missing.
+            snapshot_image: Docker image used when building the snapshot.
+            fs_capacity_bytes: Filesystem capacity when building the snapshot.
+            **kwargs: Additional LangSmith-specific parameters.
 
         Returns:
-            `LangSmithSandbox` instance
+            `LangSmithSandbox` instance.
 
         Raises:
-            RuntimeError: If sandbox connection or startup fails
-            TypeError: If unsupported keyword arguments are provided
+            RuntimeError: If sandbox connection or startup fails.
+            TypeError: If unsupported keyword arguments are provided.
         """
         from deepagents.backends.langsmith import LangSmithSandbox
 
@@ -289,22 +295,18 @@ class _LangSmithProvider(SandboxProvider):
                 raise RuntimeError(msg) from e
             return LangSmithSandbox(sandbox)
 
-        resolved_template_name, resolved_image_name = self._resolve_template(
-            template, template_image
-        )
+        snapshot_name = snapshot or _LANGSMITH_DEFAULT_SNAPSHOT
+        image = snapshot_image or _LANGSMITH_DEFAULT_IMAGE
+        capacity = fs_capacity_bytes or _LANGSMITH_DEFAULT_FS_CAPACITY_BYTES
 
-        # Create new sandbox - ensure template exists first
-        self._ensure_template(resolved_template_name, resolved_image_name)
+        snapshot_id = self._ensure_snapshot(snapshot_name, image, capacity)
 
         try:
             sandbox = self._client.create_sandbox(
-                template_name=resolved_template_name, timeout=timeout
+                snapshot_id=snapshot_id, timeout=timeout
             )
         except Exception as e:
-            msg = (
-                f"Failed to create sandbox from template "
-                f"'{resolved_template_name}': {e}"
-            )
+            msg = f"Failed to create sandbox from snapshot '{snapshot_name}': {e}"
             raise RuntimeError(msg) from e
 
         # Verify sandbox is ready by polling
@@ -334,55 +336,44 @@ class _LangSmithProvider(SandboxProvider):
         """
         self._client.delete_sandbox(sandbox_id)
 
-    @staticmethod
-    def _resolve_template(
-        template: SandboxTemplate | str | None,
-        template_image: str | None = None,
-    ) -> tuple[str, str]:
-        """Resolve template name and image from kwargs.
+    def _ensure_snapshot(
+        self,
+        snapshot_name: str,
+        image: str,
+        fs_capacity_bytes: int,
+    ) -> str:
+        """Resolve a snapshot by name, building it from `image` if missing.
+
+        The LangSmith API exposes snapshots by ID, so we list and filter by
+        name. When the snapshot does not exist, we build it with
+        `create_snapshot`, which blocks until the snapshot is ready.
 
         Returns:
-            Tuple of `(template_name, template_image)`.
-
-                Always returns values, using defaults if not provided.
-        """
-        resolved_image = template_image or _LANGSMITH_DEFAULT_IMAGE
-        if template is None:
-            return _LANGSMITH_DEFAULT_TEMPLATE, resolved_image
-        if isinstance(template, str):
-            return template, resolved_image
-        # SandboxTemplate object - extract image if not provided
-        if template_image is None and template.image:
-            resolved_image = template.image
-        return template.name, resolved_image
-
-    def _ensure_template(
-        self,
-        template_name: str,
-        template_image: str,
-    ) -> None:
-        """Ensure template exists, creating it if needed.
+            The snapshot ID ready to be passed to `create_sandbox`.
 
         Raises:
-            RuntimeError: If template check or creation fails
+            RuntimeError: If listing or building the snapshot fails.
         """
-        from langsmith.sandbox import ResourceNotFoundError
+        try:
+            snapshots = self._client.list_snapshots()
+        except Exception as e:
+            msg = f"Failed to list snapshots: {e}"
+            raise RuntimeError(msg) from e
+
+        for snap in snapshots:
+            if snap.name == snapshot_name and snap.status == "ready":
+                return snap.id
 
         try:
-            self._client.get_template(template_name)
-        except ResourceNotFoundError as e:
-            if e.resource_type != "template":
-                msg = f"Unexpected resource not found: {e}"
-                raise RuntimeError(msg) from e
-            # Template doesn't exist, create it
-            try:
-                self._client.create_template(name=template_name, image=template_image)
-            except Exception as create_err:
-                msg = f"Failed to create template '{template_name}': {create_err}"
-                raise RuntimeError(msg) from create_err
-        except Exception as e:
-            msg = f"Failed to check template '{template_name}': {e}"
-            raise RuntimeError(msg) from e
+            snapshot = self._client.create_snapshot(
+                name=snapshot_name,
+                docker_image=image,
+                fs_capacity_bytes=fs_capacity_bytes,
+            )
+        except Exception as create_err:
+            msg = f"Failed to build snapshot '{snapshot_name}': {create_err}"
+            raise RuntimeError(msg) from create_err
+        return snapshot.id
 
 
 class _DaytonaProvider(SandboxProvider):

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -210,8 +210,8 @@ _LANGSMITH_DEFAULT_SNAPSHOT = "deepagents-cli"
 _LANGSMITH_DEFAULT_IMAGE = "python:3"
 """Default Docker image for LangSmith sandbox snapshots when none is provided."""
 
-_LANGSMITH_DEFAULT_FS_CAPACITY_BYTES = 4 * 1024**3
-"""Default filesystem capacity (4 GiB) for LangSmith sandbox snapshots."""
+_LANGSMITH_DEFAULT_FS_CAPACITY_BYTES = 16 * 1024**3
+"""Default filesystem capacity (16 GiB) for LangSmith sandbox snapshots."""
 
 
 class _LangSmithProvider(SandboxProvider):

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -268,8 +268,13 @@ class _LangSmithProvider(SandboxProvider):
         Args:
             sandbox_id: Optional existing sandbox name to reuse.
             timeout: Timeout in seconds for sandbox startup.
-            snapshot: Snapshot name to boot from. Resolved to a snapshot ID,
-                creating the snapshot from `snapshot_image` if missing.
+            snapshot: Snapshot name to boot from.
+
+                Resolved to a snapshot ID, creating the snapshot from
+                `snapshot_image` if missing. Overridden by the env vars
+                `LANGSMITH_SANDBOX_SNAPSHOT_ID` (ID, wins over everything)
+                and `LANGSMITH_SANDBOX_SNAPSHOT_NAME` (name, wins over this
+                kwarg).
             snapshot_image: Docker image used when building the snapshot.
             fs_capacity_bytes: Filesystem capacity when building the snapshot.
             **kwargs: Additional LangSmith-specific parameters.
@@ -353,14 +358,20 @@ class _LangSmithProvider(SandboxProvider):
         """Resolve a snapshot by name, building it from `image` if missing.
 
         The LangSmith API exposes snapshots by ID, so we list and filter by
-        name. When the snapshot does not exist, we build it with
+        name. Only snapshots with `status == "ready"` are returned; a
+        matching-name snapshot in a non-ready state (`"building"`,
+        `"failed"`, etc.) raises rather than triggering a duplicate build,
+        which would mask the in-flight/failed snapshot.
+
+        When no matching snapshot exists at all, we build one with
         `create_snapshot`, which blocks until the snapshot is ready.
 
         Returns:
             The snapshot ID ready to be passed to `create_sandbox`.
 
         Raises:
-            RuntimeError: If listing or building the snapshot fails.
+            RuntimeError: If listing or building the snapshot fails, or if
+                a matching-name snapshot exists but is not ready.
         """
         try:
             snapshots = self._client.list_snapshots()
@@ -368,9 +379,21 @@ class _LangSmithProvider(SandboxProvider):
             msg = f"Failed to list snapshots: {e}"
             raise RuntimeError(msg) from e
 
+        non_ready_status: str | None = None
         for snap in snapshots:
-            if snap.name == snapshot_name and snap.status == "ready":
+            if snap.name != snapshot_name:
+                continue
+            if snap.status == "ready":
                 return snap.id
+            non_ready_status = snap.status
+
+        if non_ready_status is not None:
+            msg = (
+                f"Snapshot '{snapshot_name}' exists but is in state "
+                f"'{non_ready_status}'. Wait for it to finish building, or "
+                f"delete it to rebuild."
+            )
+            raise RuntimeError(msg)
 
         try:
             snapshot = self._client.create_snapshot(

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "markdownify>=0.13.0,<2.0.0",
 
     # Sandbox integrations
-    "langsmith[sandbox]>=0.7.7",
+    "langsmith[sandbox]>=0.7.32",
 
     # Tools
     "tavily-python>=0.7.21,<1.0.0",

--- a/libs/cli/tests/unit_tests/deploy/test_bundler.py
+++ b/libs/cli/tests/unit_tests/deploy/test_bundler.py
@@ -221,6 +221,45 @@ class TestRenderDeployGraph:
             result = _render_deploy_graph(config, mcp_present=False)
             compile(result, f"<deploy_graph_{provider}>", "exec")
 
+    def test_langsmith_block_uses_snapshot_api(self) -> None:
+        """Generated langsmith block must reference the snapshot API surface.
+
+        Catches drift between the `sandbox_snapshot` bundler variable and the
+        `SANDBOX_SNAPSHOT` reference inside the generated block, as well as
+        silent removal of the snapshot env vars.
+        """
+        config = _minimal_config(provider="langsmith")
+        result = _render_deploy_graph(config, mcp_present=False)
+
+        # Snapshot API symbols must appear (not the old template API).
+        assert "SANDBOX_SNAPSHOT" in result
+        assert "list_snapshots()" in result
+        assert "create_snapshot(" in result
+        assert "snapshot_id=snapshot_id" in result
+        assert "LANGSMITH_SANDBOX_SNAPSHOT_ID" in result
+        assert "LANGSMITH_SANDBOX_SNAPSHOT_NAME" in result
+
+        # Legacy template API must be gone.
+        assert "SANDBOX_TEMPLATE" not in result
+        assert "template_name=" not in result
+        assert "get_template(" not in result
+
+    def test_langsmith_block_wraps_errors_with_runtime_error(self) -> None:
+        """Generated langsmith block must wrap SDK calls in RuntimeError.
+
+        Mirrors `_LangSmithProvider._ensure_snapshot` so deployed agents
+        surface actionable errors instead of raw SDK tracebacks.
+        """
+        config = _minimal_config(provider="langsmith")
+        result = _render_deploy_graph(config, mcp_present=False)
+
+        assert "Failed to list snapshots" in result
+        assert "Failed to build snapshot" in result
+        assert "Failed to create sandbox from snapshot" in result
+        # API-key fallback must not raise KeyError on missing env vars.
+        assert 'os.environ["LANGCHAIN_API_KEY"]' not in result
+        assert "No LangSmith sandbox API key found" in result
+
     def test_skills_prefix_under_memories(self) -> None:
         config = _minimal_config()
         result = _render_deploy_graph(config, mcp_present=False)

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -377,7 +377,9 @@ class TestLangSmithSnapshotResolution:
         monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
         monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", "custom-snap")
 
-        existing = MagicMock(name="custom-snap", id="snap-xyz", status="ready")
+        # `MagicMock(name=...)` sets the mock's repr, not `.name` — the
+        # explicit assignment below is load-bearing for the filter to match.
+        existing = MagicMock(id="snap-xyz", status="ready")
         existing.name = "custom-snap"
         mock_client.list_snapshots.return_value = [existing]
 
@@ -429,7 +431,7 @@ class TestLangSmithSnapshotResolution:
         mock_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """With no env vars, falls back to `deepagents-cli` snapshot name."""
+        """With no env vars, falls back to `deepagents-cli` + 16 GiB."""
         monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
         monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", raising=False)
         mock_client.list_snapshots.return_value = []
@@ -437,4 +439,67 @@ class TestLangSmithSnapshotResolution:
 
         provider.get_or_create()
 
-        assert mock_client.create_snapshot.call_args.kwargs["name"] == "deepagents-cli"
+        kwargs = mock_client.create_snapshot.call_args.kwargs
+        assert kwargs["name"] == "deepagents-cli"
+        assert kwargs["docker_image"] == "python:3"
+        assert kwargs["fs_capacity_bytes"] == 16 * 1024**3
+
+    def test_list_snapshots_failure_raises_runtime_error(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SDK failure during `list_snapshots` is wrapped in `RuntimeError`."""
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", raising=False)
+        mock_client.list_snapshots.side_effect = Exception("network down")
+
+        with pytest.raises(RuntimeError, match="Failed to list snapshots"):
+            provider.get_or_create()
+
+        mock_client.create_snapshot.assert_not_called()
+        mock_client.create_sandbox.assert_not_called()
+
+    def test_create_snapshot_failure_raises_runtime_error(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SDK failure during `create_snapshot` is wrapped with name context."""
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", "broken-snap")
+        mock_client.list_snapshots.return_value = []
+        mock_client.create_snapshot.side_effect = Exception("quota exceeded")
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"Failed to build snapshot 'broken-snap'",
+        ):
+            provider.get_or_create()
+
+        mock_client.create_sandbox.assert_not_called()
+
+    def test_non_ready_matching_snapshot_raises_instead_of_rebuilding(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Matching-name snapshot in non-ready state must not silently rebuild."""
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", "in-flight")
+
+        building = MagicMock(id="snap-build-1", status="building")
+        building.name = "in-flight"
+        mock_client.list_snapshots.return_value = [building]
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"Snapshot 'in-flight' exists but is in state 'building'",
+        ):
+            provider.get_or_create()
+
+        mock_client.create_snapshot.assert_not_called()
+        mock_client.create_sandbox.assert_not_called()

--- a/libs/cli/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/cli/tests/unit_tests/test_sandbox_factory.py
@@ -319,3 +319,122 @@ class TestVerifySandboxDeps:
     def test_skips_unknown_provider(self) -> None:
         """Unknown providers are passed through for downstream handling."""
         verify_sandbox_deps("unknown_provider")  # should not raise
+
+
+class TestLangSmithSnapshotResolution:
+    """Env-var-driven snapshot resolution in `_LangSmithProvider.get_or_create`."""
+
+    @staticmethod
+    def _make_ready_sandbox() -> MagicMock:
+        """Mock Sandbox whose readiness poll succeeds immediately."""
+        sandbox = MagicMock()
+        sandbox.run.return_value = MagicMock(exit_code=0)
+        return sandbox
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Mock SandboxClient that yields a ready sandbox from create_sandbox."""
+        client = MagicMock()
+        client.create_sandbox.return_value = self._make_ready_sandbox()
+        return client
+
+    @pytest.fixture
+    def provider(self, mock_client: MagicMock, monkeypatch: pytest.MonkeyPatch):
+        """Build `_LangSmithProvider` with its SandboxClient patched."""
+        monkeypatch.setenv("LANGSMITH_API_KEY", "fake")
+        with patch("langsmith.sandbox.SandboxClient", return_value=mock_client):
+            from deepagents_cli.integrations.sandbox_factory import (
+                _LangSmithProvider,
+            )
+
+            return _LangSmithProvider()
+
+    def test_snapshot_id_env_var_boots_directly_without_listing(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`LANGSMITH_SANDBOX_SNAPSHOT_ID` skips name lookup and auto-build."""
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", "snap-abc123")
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", raising=False)
+
+        provider.get_or_create()
+
+        mock_client.list_snapshots.assert_not_called()
+        mock_client.create_snapshot.assert_not_called()
+        mock_client.create_sandbox.assert_called_once()
+        kwargs = mock_client.create_sandbox.call_args.kwargs
+        assert kwargs["snapshot_id"] == "snap-abc123"
+
+    def test_snapshot_name_env_var_overrides_default(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`LANGSMITH_SANDBOX_SNAPSHOT_NAME` is used as the lookup name."""
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", "custom-snap")
+
+        existing = MagicMock(name="custom-snap", id="snap-xyz", status="ready")
+        existing.name = "custom-snap"
+        mock_client.list_snapshots.return_value = [existing]
+
+        provider.get_or_create()
+
+        mock_client.list_snapshots.assert_called_once()
+        mock_client.create_snapshot.assert_not_called()
+        assert mock_client.create_sandbox.call_args.kwargs["snapshot_id"] == "snap-xyz"
+
+    def test_snapshot_name_env_var_triggers_build_when_missing(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unknown snapshot name triggers `create_snapshot` with that name."""
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", "built-snap")
+        mock_client.list_snapshots.return_value = []
+        built = MagicMock(id="snap-built")
+        mock_client.create_snapshot.return_value = built
+
+        provider.get_or_create()
+
+        mock_client.create_snapshot.assert_called_once()
+        assert mock_client.create_snapshot.call_args.kwargs["name"] == "built-snap"
+        kwargs = mock_client.create_sandbox.call_args.kwargs
+        assert kwargs["snapshot_id"] == "snap-built"
+
+    def test_snapshot_id_wins_over_name(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`_ID` takes precedence — `_NAME` is ignored when both are set."""
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", "snap-id-wins")
+        monkeypatch.setenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", "ignored-name")
+
+        provider.get_or_create()
+
+        mock_client.list_snapshots.assert_not_called()
+        kwargs = mock_client.create_sandbox.call_args.kwargs
+        assert kwargs["snapshot_id"] == "snap-id-wins"
+
+    def test_defaults_when_no_env_vars(
+        self,
+        provider,
+        mock_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With no env vars, falls back to `deepagents-cli` snapshot name."""
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_ID", raising=False)
+        monkeypatch.delenv("LANGSMITH_SANDBOX_SNAPSHOT_NAME", raising=False)
+        mock_client.list_snapshots.return_value = []
+        mock_client.create_snapshot.return_value = MagicMock(id="snap-default")
+
+        provider.get_or_create()
+
+        assert mock_client.create_snapshot.call_args.kwargs["name"] == "deepagents-cli"

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -1215,7 +1215,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.15,<1.0.0" },
     { name = "langgraph-sdk", specifier = ">=0.3.11,<1.0.0" },
-    { name = "langsmith", extras = ["sandbox"], specifier = ">=0.7.7" },
+    { name = "langsmith", extras = ["sandbox"], specifier = ">=0.7.32" },
     { name = "markdownify", specifier = ">=0.13.0,<2.0.0" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
@@ -3104,7 +3104,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.31"
+version = "0.7.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3117,9 +3117,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/11/696019490992db5c87774dc20515529ef42a01e1d770fb754ed6d9b12fb0/langsmith-0.7.31.tar.gz", hash = "sha256:331ee4f7c26bb5be4022b9859b7d7b122cbf8c9d01d9f530114c1914b0349ffb", size = 1178480, upload-time = "2026-04-14T17:55:41.242Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a1/a013cf458c301cda86a213dd153ce0a01c93f1ab5833f951e6a44c9763ce/langsmith-0.7.31-py3-none-any.whl", hash = "sha256:0291d49203f6e80dda011af1afda61eb0595a4d697adb684590a8805e1d61fb6", size = 373276, upload-time = "2026-04-14T17:55:39.677Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
 ]
 
 [package.optional-dependencies]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1196,7 +1196,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], specifier = ">=0.4.15,<1.0.0" },
     { name = "langgraph-sdk", specifier = ">=0.3.11,<1.0.0" },
-    { name = "langsmith", extras = ["sandbox"], specifier = ">=0.7.7" },
+    { name = "langsmith", extras = ["sandbox"], specifier = ">=0.7.32" },
     { name = "markdownify", specifier = ">=0.13.0,<2.0.0" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },


### PR DESCRIPTION
## Summary

Switch the LangSmith sandbox provider and the deploy code generator from the
template-based API to the new **snapshot-based** API in `langsmith-sdk` 0.7.32
(`create_snapshot` / `create_sandbox(snapshot_id=...)`).

- `_LangSmithProvider.get_or_create` now resolves a named snapshot via
  `list_snapshots` and builds it from a Docker image if missing (4 GiB default
  filesystem capacity).
- `SANDBOX_BLOCK_LANGSMITH` (generated `deploy_graph.py` code) uses the same
  snapshot flow.
- The user-facing TOML field `[sandbox].template` is unchanged for backward
  compatibility — its value is now the snapshot name.
- Bumped `langsmith[sandbox]>=0.7.32` in `libs/cli/pyproject.toml`.

## Release Note

`deepagents --sandbox langsmith` and the `deepagents deploy` generator now
boot sandboxes from snapshots (via the new `langsmith-sdk` snapshot API)
instead of templates. The first run builds the `deepagents-cli` snapshot from
`python:3`; subsequent runs reuse it. Requires `langsmith>=0.7.32`.

## Test Plan

- [x] `make lint` / `ruff check` clean on changed files
- [x] `make format --check` clean on changed files
- [x] `uv run --group test pytest tests/unit_tests/test_sandbox_factory.py tests/unit_tests/deploy/test_bundler.py` — 100 passed
- [x] `uv run --group test pytest tests/integration_tests/test_sandbox_factory.py::TestLangSmithIntegration --timeout=600` against real LangSmith — 8 passed, 8 skipped (opt-in edge cases). Verified: `_ensure_snapshot` → `list_snapshots` → reuses existing `deepagents-cli` snapshot → `create_sandbox(snapshot_id=...)` → execute + upload/download work end-to-end.
- [x] Manual CLI smoke test: `deepagents --sandbox langsmith --model anthropic:claude-sonnet-4-5` → agent called `execute("uname -a && python3 -c \"print(2+2)\"")` → sandbox `sb-6b6c1069-bd69-4a50-9d1e-ce1006f9643b` (Linux 6.12.47 x86_64) returned `4` with exit 0.