### PR TITLE
fix(cli): restore ctrl+j newline keybinding

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -326,7 +326,7 @@ class ChatTextArea(TextArea):
 
     BINDINGS: ClassVar[list[Binding]] = [
         Binding(
-            "shift+enter,alt+enter,ctrl+enter",
+            "shift+enter,alt+enter,ctrl+enter,ctrl+j",
             "insert_newline",
             "New Line",
             show=False,


### PR DESCRIPTION
Fixes #2828

---

`Shift+Enter`, `Ctrl+Enter`, and `Alt+Enter` rely on the kitty keyboard protocol (CSI-u) which many terminals and `tmux` do not pass through, causing these chords to be indistinguishable from plain *Enter*.

Add `Ctrl+J` (ASCII line feed) to the `insert_newline` binding as a reliable cross-terminal alternative for inserting newlines