### PR TITLE
feat(cli): `--max-turns` flag for non-interactive mode

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -571,6 +571,17 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--max-turns",
+        dest="max_turns",
+        type=int,
+        metavar="N",
+        # Mirror of non_interactive._MAX_HITL_ITERATIONS — keep in sync.
+        help="Maximum number of agentic turns before stopping (max 50). "
+        "Useful for CI/CD pipelines to prevent runaway agents. "
+        "Requires -n or piped stdin.",
+    )
+
+    parser.add_argument(
         "--stdin",
         action="store_true",
         help="Read input from stdin explicitly (instead of auto-detection)",
@@ -1363,6 +1374,16 @@ def cli_main() -> None:
             )
             sys.exit(2)
 
+        if getattr(args, "max_turns", None) is not None and not args.non_interactive_message:
+            from rich.console import Console as _Console
+
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --max-turns requires "
+                "--non-interactive (-n) or piped stdin\n"
+                "  deepagents -n 'refactor auth module' --max-turns 5"
+            )
+            sys.exit(2)
+
         if (args.quiet or args.no_stream) and not args.non_interactive_message:
             # Print to stderr (not the module-level stdout console) and exit
             # with code 2 to match the POSIX convention for usage errors, as
@@ -1639,6 +1660,7 @@ def cli_main() -> None:
                     mcp_config_path=getattr(args, "mcp_config", None),
                     no_mcp=getattr(args, "no_mcp", False),
                     trust_project_mcp=getattr(args, "trust_project_mcp", False),
+                    max_turns=getattr(args, "max_turns", None),
                 )
             )
             sys.exit(exit_code)

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -612,6 +612,7 @@ async def _run_agent_loop(
     stream: bool = True,
     message_kwargs: dict[str, Any] | None = None,
     thread_url_lookup: ThreadUrlLookupState | None = None,
+    max_turns: int | None = None,
 ) -> None:
     """Run the agent and handle HITL interrupts until the task completes.
 
@@ -633,6 +634,9 @@ async def _run_agent_loop(
             dict (e.g., `additional_kwargs` for persisted skill metadata).
         thread_url_lookup: Optional non-blocking lookup state for rendering
             a fast-follow LangSmith thread link.
+        max_turns: Optional user-supplied cap on agentic turns. Honoured only
+            up to `_MAX_HITL_ITERATIONS` — values above that are silently
+            clamped to the hard ceiling.
 
     Raises:
         HITLIterationLimitError: If the HITL iteration limit is exceeded.
@@ -652,14 +656,27 @@ async def _run_agent_loop(
     # Initial stream
     await _stream_agent(agent, stream_input, config, state, console, file_op_tracker)
 
+    # Honour --max-turns but never exceed the hard safety ceiling.
+    effective_limit = (
+        min(max_turns, _MAX_HITL_ITERATIONS)
+        if max_turns is not None
+        else _MAX_HITL_ITERATIONS
+    )
+
     # Handle HITL interrupts
     iterations = 0
     while state.interrupt_occurred:
         iterations += 1
-        if iterations > _MAX_HITL_ITERATIONS:
+        if iterations > effective_limit:
+            limit_source = (
+                f"--max-turns {max_turns}"
+                if max_turns is not None and max_turns <= _MAX_HITL_ITERATIONS
+                else f"the internal safety limit of {_MAX_HITL_ITERATIONS}"
+            )
             msg = (
-                f"Exceeded {_MAX_HITL_ITERATIONS} HITL interrupt rounds. "
-                "The agent may be stuck retrying rejected commands."
+                f"Exceeded {effective_limit} agentic turns ({limit_source}). "
+                "The agent may be stuck retrying rejected commands. "
+                "Increase --max-turns or break the task into smaller steps."
             )
             raise HITLIterationLimitError(msg)
         state.interrupt_occurred = False
@@ -759,6 +776,7 @@ async def run_non_interactive(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool = False,
+    max_turns: int | None = None,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -808,6 +826,9 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
+        max_turns: Optional cap on agentic turns. Values above
+            `_MAX_HITL_ITERATIONS` are silently clamped to that ceiling so
+            the hard safety limit is always honoured.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
@@ -1007,6 +1028,7 @@ async def run_non_interactive(
                 stream=stream,
                 message_kwargs=message_kwargs,
                 thread_url_lookup=thread_url_lookup,
+                max_turns=max_turns,
             )
 
     except KeyboardInterrupt:

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -246,6 +246,86 @@ class TestSkillFlagValidation:
         assert exc_info.value.code == 2
 
 
+class TestMaxTurnsArgument:
+    """Tests for --max-turns argument parsing and validation."""
+
+    def test_parses_integer(self, mock_argv: MockArgvType) -> None:
+        """--max-turns N stores an integer."""
+        with mock_argv("-n", "task", "--max-turns", "5"):
+            parsed = parse_args()
+            assert parsed.max_turns == 5
+
+    def test_not_specified_is_none(self, mock_argv: MockArgvType) -> None:
+        """max_turns is None when --max-turns is not provided."""
+        with mock_argv():
+            parsed = parse_args()
+            assert parsed.max_turns is None
+
+    def test_combined_with_non_interactive(self, mock_argv: MockArgvType) -> None:
+        """--max-turns works alongside -n and other flags."""
+        with mock_argv("-n", "deploy app", "--max-turns", "10", "--shell-allow-list", "ls"):
+            parsed = parse_args()
+            assert parsed.non_interactive_message == "deploy app"
+            assert parsed.max_turns == 10
+            assert parsed.shell_allow_list == "ls"
+
+    def test_requires_non_interactive_mode(self) -> None:
+        """--max-turns without -n or piped stdin exits with code 2."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "--max-turns", "5"]),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 2
+
+    def test_forwarded_to_run_non_interactive(self) -> None:
+        """--max-turns value is forwarded to run_non_interactive as max_turns."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys, "argv", ["deepagents", "-n", "do the thing", "--max-turns", "3"]
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_cli.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+        assert mock_run.await_args.kwargs["max_turns"] == 3  # type: ignore[union-attr]
+
+    def test_not_forwarded_as_none_when_omitted(self) -> None:
+        """When --max-turns is omitted, max_turns=None is forwarded."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "-n", "do the thing"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_cli.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+        assert mock_run.await_args.kwargs["max_turns"] is None  # type: ignore[union-attr]
+
+
 class TestModelParamsArgument:
     """Tests for --model-params argument parsing."""
 

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -13,10 +13,13 @@ from rich.text import Text
 
 from deepagents_cli.config import SHELL_ALLOW_ALL, ModelResult
 from deepagents_cli.non_interactive import (
+    HITLIterationLimitError,
     ThreadUrlLookupState,
+    _MAX_HITL_ITERATIONS,
     _build_non_interactive_header,
     _collect_action_request_warnings,
     _make_hitl_decision,
+    _run_agent_loop,
     _start_langsmith_thread_url_lookup,
     run_non_interactive,
 )
@@ -1027,6 +1030,229 @@ class TestNonInteractivePrompt:
 
         assert result == 1
         mock_start_server.assert_not_awaited()
+
+
+def _make_interrupt_chunk(interrupt_id: str = "i1") -> tuple:
+    """Return a stream chunk that triggers one HITL interrupt.
+
+    The interrupt value is a dict that would normally need to pass the
+    HITLRequest Pydantic validator.  Tests that call this helper must also
+    patch ``_HITL_REQUEST_ADAPTER.validate_python`` to pass-through so that
+    validation is bypassed and ``state.interrupt_occurred`` is set correctly.
+    """
+    interrupt = MagicMock()
+    interrupt.id = interrupt_id
+    interrupt.value = {
+        "action_requests": [{"name": "read_file", "args": {"path": "/tmp/f"}}]
+    }
+    return ("", "updates", {"__interrupt__": [interrupt]})
+
+
+def _make_looping_agent() -> MagicMock:
+    """Return a mock agent whose astream always yields one interrupt chunk."""
+    chunk = _make_interrupt_chunk()
+    mock_agent = MagicMock()
+    mock_agent.astream = MagicMock(side_effect=lambda *a, **kw: _async_iter([chunk]))
+    return mock_agent
+
+
+class TestMaxTurns:
+    """Tests for max_turns parameter in _run_agent_loop."""
+
+    async def test_raises_after_user_limit(self) -> None:
+        """HITLIterationLimitError is raised after max_turns HITL iterations."""
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=1,
+                )
+        assert "--max-turns 1" in str(exc_info.value)
+
+    async def test_error_message_names_user_flag(self) -> None:
+        """Error message references --max-turns and tells the user how to fix it."""
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=2,
+                )
+        msg = str(exc_info.value)
+        assert "--max-turns 2" in msg
+        assert "Increase --max-turns" in msg
+
+    async def test_ceiling_clamping_fires_internal_limit(self) -> None:
+        """max_turns above _MAX_HITL_ITERATIONS is silently clamped to the ceiling."""
+        # Patch ceiling to 2 so the test finishes quickly.
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch("deepagents_cli.non_interactive._MAX_HITL_ITERATIONS", 2),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=9999,
+                )
+        assert "internal safety limit" in str(exc_info.value)
+
+    async def test_no_max_turns_defaults_to_ceiling(self) -> None:
+        """Omitting max_turns causes the internal safety limit message to appear."""
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch("deepagents_cli.non_interactive._MAX_HITL_ITERATIONS", 1),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=None,
+                )
+        assert "internal safety limit" in str(exc_info.value)
+
+    async def test_max_turns_forwarded_from_run_non_interactive(self) -> None:
+        """run_non_interactive passes max_turns through to _run_agent_loop."""
+        mock_agent = MagicMock()
+        mock_agent.astream = MagicMock(return_value=_async_iter([]))
+        mock_server_proc = MagicMock()
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive._run_agent_loop",
+                new_callable=AsyncMock,
+            ) as mock_loop,
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+                return_value=(mock_agent, mock_server_proc, None),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            await run_non_interactive(message="task", max_turns=7)
+
+        _, kwargs = mock_loop.call_args
+        assert kwargs.get("max_turns") == 7
+
+    async def test_max_turns_none_forwarded_by_default(self) -> None:
+        """run_non_interactive forwards max_turns=None when not supplied."""
+        mock_agent = MagicMock()
+        mock_agent.astream = MagicMock(return_value=_async_iter([]))
+        mock_server_proc = MagicMock()
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive._run_agent_loop",
+                new_callable=AsyncMock,
+            ) as mock_loop,
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+                return_value=(mock_agent, mock_server_proc, None),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            await run_non_interactive(message="task")
+
+        _, kwargs = mock_loop.call_args
+        assert kwargs.get("max_turns") is None
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029


### PR DESCRIPTION
Adds a `--max-turns N` flag to non-interactive mode so users can bound how many agentic turns the agent takes before stopping. Fixes #2826

**Before** — no way to bound turns; only a silent internal cap of 50:
```bash
deepagents -n "refactor the auth module"
# runs until task completes or hits the hidden 50-turn ceiling
```

**After** — explicit, user-controlled cap:
```bash
deepagents -n "refactor the auth module" --max-turns 5
# Error: Exceeded 5 agentic turns (--max-turns 5).
# The agent may be stuck retrying rejected commands.
# Increase --max-turns or break the task into smaller steps.
```

Values above the internal `_MAX_HITL_ITERATIONS` ceiling (50) are silently clamped so the hard safety limit is always honoured. Flag is rejected with exit code 2 when used without `-n` or piped stdin.

**Verification:** 12 new unit tests added across `test_non_interactive.py` and `test_main_args.py` covering the limit logic, ceiling clamping, error message content, validation, and forwarding through `run_non_interactive`.

## Social handles (optional)
Twitter: @
LinkedIn: https://www.linkedin.com/in/ninaadrrao/