### PR TITLE
feat(cli): `--max-turns` flag on non-interactive mode

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -571,6 +571,17 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--max-turns",
+        dest="max_turns",
+        type=int,
+        metavar="N",
+        # Mirror of non_interactive._MAX_HITL_ITERATIONS — keep in sync.
+        help="Maximum number of agentic turns before stopping (max 50). "
+        "Useful for CI/CD pipelines to prevent runaway agents. "
+        "Requires -n or piped stdin.",
+    )
+
+    parser.add_argument(
         "--stdin",
         action="store_true",
         help="Read input from stdin explicitly (instead of auto-detection)",
@@ -1363,6 +1374,16 @@ def cli_main() -> None:
             )
             sys.exit(2)
 
+        if getattr(args, "max_turns", None) is not None and not args.non_interactive_message:
+            from rich.console import Console as _Console
+
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --max-turns requires "
+                "--non-interactive (-n) or piped stdin\n"
+                "  deepagents -n 'refactor auth module' --max-turns 5"
+            )
+            sys.exit(2)
+
         if (args.quiet or args.no_stream) and not args.non_interactive_message:
             # Print to stderr (not the module-level stdout console) and exit
             # with code 2 to match the POSIX convention for usage errors, as
@@ -1639,6 +1660,7 @@ def cli_main() -> None:
                     mcp_config_path=getattr(args, "mcp_config", None),
                     no_mcp=getattr(args, "no_mcp", False),
                     trust_project_mcp=getattr(args, "trust_project_mcp", False),
+                    max_turns=getattr(args, "max_turns", None),
                 )
             )
             sys.exit(exit_code)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1374,7 +1374,8 @@ def cli_main() -> None:
             )
             sys.exit(2)
 
-        if getattr(args, "max_turns", None) is not None and not args.non_interactive_message:
+        max_turns_set = getattr(args, "max_turns", None) is not None
+        if max_turns_set and not args.non_interactive_message:
             from rich.console import Console as _Console
 
             _Console(stderr=True).print(

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -639,15 +639,16 @@ def parse_args() -> argparse.Namespace:
         "instead of streaming token-by-token. Requires -n or piped stdin.",
     )
 
+    from deepagents_cli.ui import positive_int
+
     parser.add_argument(
         "--max-turns",
         dest="max_turns",
-        type=int,
+        type=positive_int,
         metavar="N",
-        # Mirror of non_interactive._MAX_HITL_ITERATIONS — keep in sync.
-        help="Maximum number of agentic turns before stopping (max 50). "
-        "Useful for CI/CD pipelines to prevent runaway agents. "
-        "Requires -n or piped stdin.",
+        help="Maximum number of agentic turns before stopping (must be >= 1). "
+        "Overrides the internal safety default. Useful for CI/CD pipelines "
+        "to prevent runaway agents. Requires -n or piped stdin.",
     )
 
     parser.add_argument(

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -634,9 +634,11 @@ async def _run_agent_loop(
             dict (e.g., `additional_kwargs` for persisted skill metadata).
         thread_url_lookup: Optional non-blocking lookup state for rendering
             a fast-follow LangSmith thread link.
-        max_turns: Optional user-supplied cap on agentic turns. Honoured only
-            up to `_MAX_HITL_ITERATIONS` — values above that are silently
-            clamped to the hard ceiling.
+        max_turns: Optional user-supplied cap on agentic turns.
+
+            When set, the user's value is honoured verbatim and overrides the
+            internal safety default; exceeding it
+            raises `HITLIterationLimitError`.
 
     Raises:
         HITLIterationLimitError: If the HITL iteration limit is exceeded.
@@ -656,12 +658,11 @@ async def _run_agent_loop(
     # Initial stream
     await _stream_agent(agent, stream_input, config, state, console, file_op_tracker)
 
-    # Honour --max-turns but never exceed the hard safety ceiling.
-    effective_limit = (
-        min(max_turns, _MAX_HITL_ITERATIONS)
-        if max_turns is not None
-        else _MAX_HITL_ITERATIONS
-    )
+    # When --max-turns is explicitly set, honour the user's value verbatim;
+    # the operator has opted in to a specific bound. The internal default
+    # only applies when no flag is provided, guarding against unbounded
+    # runaway loops in scripts that forgot to set one.
+    effective_limit = max_turns if max_turns is not None else _MAX_HITL_ITERATIONS
 
     # Handle HITL interrupts
     iterations = 0
@@ -670,8 +671,8 @@ async def _run_agent_loop(
         if iterations > effective_limit:
             limit_source = (
                 f"--max-turns {max_turns}"
-                if max_turns is not None and max_turns <= _MAX_HITL_ITERATIONS
-                else f"the internal safety limit of {_MAX_HITL_ITERATIONS}"
+                if max_turns is not None
+                else f"the internal safety default of {_MAX_HITL_ITERATIONS}"
             )
             msg = (
                 f"Exceeded {effective_limit} agentic turns ({limit_source}). "
@@ -826,9 +827,10 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
-        max_turns: Optional cap on agentic turns. Values above
-            `_MAX_HITL_ITERATIONS` are silently clamped to that ceiling so
-            the hard safety limit is always honoured.
+        max_turns: Optional cap on agentic turns.
+
+            When set, overrides the internal safety default; exceeding it
+            raises `HITLIterationLimitError`.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -616,8 +616,9 @@ async def _run_agent_loop(
 ) -> None:
     """Run the agent and handle HITL interrupts until the task completes.
 
-    The loop processes at most `_MAX_HITL_ITERATIONS` rounds to prevent
-    runaway retries (e.g. the agent repeatedly attempting rejected commands).
+    The loop is capped at `max_turns` when set,
+    otherwise `_MAX_HITL_ITERATIONS`, to prevent runaway retries
+    (e.g. the agent repeatedly attempting rejected commands).
 
     Args:
         agent: The agent (Pregel or RemoteAgent).
@@ -634,14 +635,13 @@ async def _run_agent_loop(
             dict (e.g., `additional_kwargs` for persisted skill metadata).
         thread_url_lookup: Optional non-blocking lookup state for rendering
             a fast-follow LangSmith thread link.
-        max_turns: Optional user-supplied cap on agentic turns.
+        max_turns: Optional cap on total agentic turns (initial response plus
+            HITL resumes).
 
-            When set, the user's value is honoured verbatim and overrides the
-            internal safety default; exceeding it
-            raises `HITLIterationLimitError`.
+            When `None`, falls back to `_MAX_HITL_ITERATIONS`.
 
     Raises:
-        HITLIterationLimitError: If the HITL iteration limit is exceeded.
+        HITLIterationLimitError: If the effective turn limit is exceeded.
     """
     spinner = None if quiet else _ConsoleSpinner(console)
     state = StreamState(quiet=quiet, stream=stream, spinner=spinner)
@@ -658,17 +658,16 @@ async def _run_agent_loop(
     # Initial stream
     await _stream_agent(agent, stream_input, config, state, console, file_op_tracker)
 
-    # When --max-turns is explicitly set, honour the user's value verbatim;
-    # the operator has opted in to a specific bound. The internal default
-    # only applies when no flag is provided, guarding against unbounded
-    # runaway loops in scripts that forgot to set one.
+    # The internal default applies when --max-turns is omitted, guarding
+    # against unbounded runaway loops in scripts that forgot to set one.
     effective_limit = max_turns if max_turns is not None else _MAX_HITL_ITERATIONS
 
-    # Handle HITL interrupts
-    iterations = 0
+    # The initial stream above counts as turn 1; each HITL resume is a further
+    # turn. Raise before starting a resume that would exceed the budget so the
+    # user-facing count matches the flag's semantics.
+    turns = 1
     while state.interrupt_occurred:
-        iterations += 1
-        if iterations > effective_limit:
+        if turns >= effective_limit:
             limit_source = (
                 f"--max-turns {max_turns}"
                 if max_turns is not None
@@ -680,6 +679,7 @@ async def _run_agent_loop(
                 "Increase --max-turns or break the task into smaller steps."
             )
             raise HITLIterationLimitError(msg)
+        turns += 1
         state.interrupt_occurred = False
         state.hitl_response.clear()
         _process_hitl_interrupts(state, console)
@@ -827,13 +827,13 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
-        max_turns: Optional cap on agentic turns.
-
-            When set, overrides the internal safety default; exceeding it
-            raises `HITLIterationLimitError`.
+        max_turns: Optional cap on total agentic turns. When `None`, the
+            internal safety default applies.
 
     Returns:
-        Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
+        Exit code: 0 for success, 1 for error, 124 when the `--max-turns`
+            budget was exceeded (matching GNU `timeout`), 130 for keyboard
+            interrupt.
     """
     # stderr=True routes all console.print() to stderr; agent response text
     # uses _write_text() -> sys.stdout directly.
@@ -1043,7 +1043,9 @@ async def run_non_interactive(
             "that are not in the allow-list. Consider expanding the "
             "--shell-allow-list or adjusting the task.[/yellow]"
         )
-        return 1
+        # Dedicated exit code (matches GNU `timeout`) so CI can distinguish
+        # a turn-budget hit from a generic failure that also returns 1.
+        return 124
     except (ValueError, OSError) as e:
         logger.exception("Error during non-interactive execution")
         console.print(f"\n[red]Error: {escape_markup(str(e))}[/red]")

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -612,6 +612,7 @@ async def _run_agent_loop(
     stream: bool = True,
     message_kwargs: dict[str, Any] | None = None,
     thread_url_lookup: ThreadUrlLookupState | None = None,
+    max_turns: int | None = None,
 ) -> None:
     """Run the agent and handle HITL interrupts until the task completes.
 
@@ -633,6 +634,9 @@ async def _run_agent_loop(
             dict (e.g., `additional_kwargs` for persisted skill metadata).
         thread_url_lookup: Optional non-blocking lookup state for rendering
             a fast-follow LangSmith thread link.
+        max_turns: Optional user-supplied cap on agentic turns. Honoured only
+            up to `_MAX_HITL_ITERATIONS` — values above that are silently
+            clamped to the hard ceiling.
 
     Raises:
         HITLIterationLimitError: If the HITL iteration limit is exceeded.
@@ -652,14 +656,27 @@ async def _run_agent_loop(
     # Initial stream
     await _stream_agent(agent, stream_input, config, state, console, file_op_tracker)
 
+    # Honour --max-turns but never exceed the hard safety ceiling.
+    effective_limit = (
+        min(max_turns, _MAX_HITL_ITERATIONS)
+        if max_turns is not None
+        else _MAX_HITL_ITERATIONS
+    )
+
     # Handle HITL interrupts
     iterations = 0
     while state.interrupt_occurred:
         iterations += 1
-        if iterations > _MAX_HITL_ITERATIONS:
+        if iterations > effective_limit:
+            limit_source = (
+                f"--max-turns {max_turns}"
+                if max_turns is not None and max_turns <= _MAX_HITL_ITERATIONS
+                else f"the internal safety limit of {_MAX_HITL_ITERATIONS}"
+            )
             msg = (
-                f"Exceeded {_MAX_HITL_ITERATIONS} HITL interrupt rounds. "
-                "The agent may be stuck retrying rejected commands."
+                f"Exceeded {effective_limit} agentic turns ({limit_source}). "
+                "The agent may be stuck retrying rejected commands. "
+                "Increase --max-turns or break the task into smaller steps."
             )
             raise HITLIterationLimitError(msg)
         state.interrupt_occurred = False
@@ -759,6 +776,7 @@ async def run_non_interactive(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool = False,
+    max_turns: int | None = None,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -808,6 +826,9 @@ async def run_non_interactive(
         trust_project_mcp: When `True`, allow project-level stdio MCP
             servers. When `False` (default), project stdio servers are
             silently skipped.
+        max_turns: Optional cap on agentic turns. Values above
+            `_MAX_HITL_ITERATIONS` are silently clamped to that ceiling so
+            the hard safety limit is always honoured.
 
     Returns:
         Exit code: 0 for success, 1 for error, 130 for keyboard interrupt.
@@ -1007,6 +1028,7 @@ async def run_non_interactive(
                 stream=stream,
                 message_kwargs=message_kwargs,
                 thread_url_lookup=thread_url_lookup,
+                max_turns=max_turns,
             )
 
     except KeyboardInterrupt:

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -113,6 +113,9 @@ def show_help() -> None:
     console.print(
         "  --no-stream                Buffer full response instead of streaming"
     )
+    console.print(
+        "  --max-turns N              Max agentic turns before stopping (needs -n)"
+    )
     console.print("  --stdin                    Read input from stdin explicitly")
     console.print(
         "  --json                     Emit machine-readable JSON for commands"

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -4,6 +4,8 @@ This module is imported at CLI startup to wire `-h` actions into the
 argparse tree.  It must stay lightweight — no SDK or langchain imports.
 """
 
+import argparse
+
 from rich.markup import escape
 
 from deepagents_cli import theme
@@ -16,6 +18,29 @@ from deepagents_cli.config import (
 
 _JSON_OPTION_LINE = "  --json                  Emit machine-readable JSON"
 _HELP_OPTION_LINE = "  -h, --help              Show this help message"
+
+
+def positive_int(value: str) -> int:
+    """Argparse type for integer arguments that must be >= 1.
+
+    Args:
+        value: Raw CLI argument string to parse.
+
+    Returns:
+        Parsed positive integer.
+
+    Raises:
+        argparse.ArgumentTypeError: If `value` is not an integer or is < 1.
+    """
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        msg = f"invalid int value: {value!r}"
+        raise argparse.ArgumentTypeError(msg) from exc
+    if parsed < 1:
+        msg = f"must be a positive integer (>= 1), got {parsed}"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
 
 
 def _print_option_section(*lines: str, title: str = "Options") -> None:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1348,6 +1348,9 @@ class TestLoadingSpinnerLifecycle:
             before_tick = widget._spinner._position
             await asyncio.sleep(0.25)
             assert widget._spinner._position != before_tick
+            # Pre-condition: timer must be running before the reposition so
+            # the `is None` assertion below isn't vacuously satisfied.
+            assert widget._animation_timer is not None
 
             with patch.object(Widget, "remove", new=delayed_remove):
                 reposition_task = asyncio.create_task(app._set_spinner("Thinking"))

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1348,11 +1348,14 @@ class TestLoadingSpinnerLifecycle:
             await asyncio.sleep(0.25)
             assert widget._spinner._position != before_tick
 
-            frozen_position = widget._spinner._position
             with patch.object(Widget, "remove", new=delayed_remove):
                 reposition_task = asyncio.create_task(app._set_spinner("Thinking"))
+                # Sleep while delayed_remove is blocking (0.3s).  Check that the
+                # timer flag is None rather than a frozen position counter: the
+                # Textual timer may fire one final tick before cancellation on slow
+                # CI runners, making a position equality check inherently racy.
                 await asyncio.sleep(0.25)
-                assert widget._spinner._position == frozen_position
+                assert widget._animation_timer is None
                 await reposition_task
 
             children = list(messages.children)

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1310,12 +1310,18 @@ class TestLoadingSpinnerLifecycle:
             before_tick = widget._spinner._position
             await asyncio.sleep(0.25)
             assert widget._spinner._position != before_tick
+            # Pre-condition: timer must be running before hide so the `is None`
+            # assertion below isn't vacuously satisfied.
+            assert widget._animation_timer is not None
 
-            frozen_position = widget._spinner._position
             with patch.object(Widget, "remove", new=delayed_remove):
                 hide_task = asyncio.create_task(app._set_spinner(None))
+                # Sleep while delayed_remove is blocking (0.3s).  Check the
+                # timer flag rather than a frozen position counter: the
+                # Textual timer may fire one final tick before cancellation
+                # on slow CI runners, making position equality racy.
                 await asyncio.sleep(0.25)
-                assert widget._spinner._position == frozen_position
+                assert widget._animation_timer is None
                 await hide_task
 
             assert app._loading_widget is None

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -327,6 +327,18 @@ class TestMaxTurnsArgument:
             cli_main()
         assert mock_run.await_args.kwargs["max_turns"] is None  # type: ignore[union-attr]
 
+    @pytest.mark.parametrize("bad_value", ["0", "-1", "-50", "abc"])
+    def test_rejects_non_positive_and_non_integer(
+        self, mock_argv: MockArgvType, bad_value: str
+    ) -> None:
+        """Argparse rejects 0, negatives, and non-integers with exit 2."""
+        with (
+            mock_argv("-n", "task", "--max-turns", bad_value),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code == 2
+
 
 class TestModelParamsArgument:
     """Tests for --model-params argument parsing."""

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -263,7 +263,9 @@ class TestMaxTurnsArgument:
 
     def test_combined_with_non_interactive(self, mock_argv: MockArgvType) -> None:
         """--max-turns works alongside -n and other flags."""
-        with mock_argv("-n", "deploy app", "--max-turns", "10", "--shell-allow-list", "ls"):
+        with mock_argv(
+            "-n", "deploy app", "--max-turns", "10", "--shell-allow-list", "ls"
+        ):
             parsed = parse_args()
             assert parsed.non_interactive_message == "deploy app"
             assert parsed.max_turns == 10

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -246,6 +246,86 @@ class TestSkillFlagValidation:
         assert exc_info.value.code == 2
 
 
+class TestMaxTurnsArgument:
+    """Tests for --max-turns argument parsing and validation."""
+
+    def test_parses_integer(self, mock_argv: MockArgvType) -> None:
+        """--max-turns N stores an integer."""
+        with mock_argv("-n", "task", "--max-turns", "5"):
+            parsed = parse_args()
+            assert parsed.max_turns == 5
+
+    def test_not_specified_is_none(self, mock_argv: MockArgvType) -> None:
+        """max_turns is None when --max-turns is not provided."""
+        with mock_argv():
+            parsed = parse_args()
+            assert parsed.max_turns is None
+
+    def test_combined_with_non_interactive(self, mock_argv: MockArgvType) -> None:
+        """--max-turns works alongside -n and other flags."""
+        with mock_argv("-n", "deploy app", "--max-turns", "10", "--shell-allow-list", "ls"):
+            parsed = parse_args()
+            assert parsed.non_interactive_message == "deploy app"
+            assert parsed.max_turns == 10
+            assert parsed.shell_allow_list == "ls"
+
+    def test_requires_non_interactive_mode(self) -> None:
+        """--max-turns without -n or piped stdin exits with code 2."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "--max-turns", "5"]),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 2
+
+    def test_forwarded_to_run_non_interactive(self) -> None:
+        """--max-turns value is forwarded to run_non_interactive as max_turns."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys, "argv", ["deepagents", "-n", "do the thing", "--max-turns", "3"]
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_cli.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+        assert mock_run.await_args.kwargs["max_turns"] == 3  # type: ignore[union-attr]
+
+    def test_not_forwarded_as_none_when_omitted(self) -> None:
+        """When --max-turns is omitted, max_turns=None is forwarded."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "-n", "do the thing"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_cli.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+        assert mock_run.await_args.kwargs["max_turns"] is None  # type: ignore[union-attr]
+
+
 class TestModelParamsArgument:
     """Tests for --model-params argument parsing."""
 

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -285,6 +285,31 @@ class TestMaxTurnsArgument:
             cli_main()
         assert exc_info.value.code == 2
 
+    def test_allowed_with_piped_stdin(self) -> None:
+        """--max-turns without -n is allowed when stdin is piped."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.return_value = "piped task"
+        with (
+            patch.object(sys, "argv", ["deepagents", "--max-turns", "5"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_optional_tools", return_value=[]),
+            # Skip the /dev/tty dance — os.open would fail in test sandboxes
+            # and the real code path already tolerates that failure.
+            patch("os.open", side_effect=OSError("No tty in test sandbox")),
+            patch(
+                "deepagents_cli.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 0
+        assert mock_run.await_args.kwargs["max_turns"] == 5  # type: ignore[union-attr]
+
     def test_forwarded_to_run_non_interactive(self) -> None:
         """--max-turns value is forwarded to run_non_interactive as max_turns."""
         from deepagents_cli.main import cli_main

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -3,19 +3,23 @@
 import io
 import sys
 from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import RunnableConfig
 from rich.style import Style
 from rich.text import Text
 
 from deepagents_cli.config import SHELL_ALLOW_ALL, ModelResult
 from deepagents_cli.non_interactive import (
+    _MAX_HITL_ITERATIONS,
     HITLIterationLimitError,
     ThreadUrlLookupState,
-    _MAX_HITL_ITERATIONS,
     _build_non_interactive_header,
     _collect_action_request_warnings,
     _make_hitl_decision,
@@ -1052,7 +1056,7 @@ def _make_looping_agent() -> MagicMock:
     """Return a mock agent whose astream always yields one interrupt chunk."""
     chunk = _make_interrupt_chunk()
     mock_agent = MagicMock()
-    mock_agent.astream = MagicMock(side_effect=lambda *a, **kw: _async_iter([chunk]))
+    mock_agent.astream = MagicMock(side_effect=lambda *_, **__: _async_iter([chunk]))
     return mock_agent
 
 
@@ -1065,7 +1069,7 @@ class TestMaxTurns:
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
         file_op_tracker.complete_with_message.return_value = None
-        config: dict = {"configurable": {"thread_id": "t1"}}
+        config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
 
         with (
             patch(
@@ -1073,15 +1077,22 @@ class TestMaxTurns:
             ),
             patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
             patch("deepagents_cli.non_interactive.settings") as mock_settings,
-            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch(
+                "deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER"
+            ) as mock_adapter,
         ):
             mock_settings.shell_allow_list = None
             mock_settings.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
-                    agent, "task", config, console, file_op_tracker,
-                    quiet=True, max_turns=1,
+                    agent,
+                    "task",
+                    config,
+                    console,
+                    file_op_tracker,
+                    quiet=True,
+                    max_turns=1,
                 )
         assert "--max-turns 1" in str(exc_info.value)
 
@@ -1091,7 +1102,7 @@ class TestMaxTurns:
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
         file_op_tracker.complete_with_message.return_value = None
-        config: dict = {"configurable": {"thread_id": "t1"}}
+        config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
 
         with (
             patch(
@@ -1099,15 +1110,22 @@ class TestMaxTurns:
             ),
             patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
             patch("deepagents_cli.non_interactive.settings") as mock_settings,
-            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch(
+                "deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER"
+            ) as mock_adapter,
         ):
             mock_settings.shell_allow_list = None
             mock_settings.model_name = ""
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
-                    agent, "task", config, console, file_op_tracker,
-                    quiet=True, max_turns=2,
+                    agent,
+                    "task",
+                    config,
+                    console,
+                    file_op_tracker,
+                    quiet=True,
+                    max_turns=2,
                 )
         msg = str(exc_info.value)
         assert "--max-turns 2" in msg
@@ -1120,7 +1138,7 @@ class TestMaxTurns:
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
         file_op_tracker.complete_with_message.return_value = None
-        config: dict = {"configurable": {"thread_id": "t1"}}
+        config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
 
         with (
             patch(
@@ -1128,7 +1146,9 @@ class TestMaxTurns:
             ),
             patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
             patch("deepagents_cli.non_interactive.settings") as mock_settings,
-            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch(
+                "deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER"
+            ) as mock_adapter,
             patch("deepagents_cli.non_interactive._MAX_HITL_ITERATIONS", 2),
         ):
             mock_settings.shell_allow_list = None
@@ -1136,8 +1156,13 @@ class TestMaxTurns:
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
-                    agent, "task", config, console, file_op_tracker,
-                    quiet=True, max_turns=9999,
+                    agent,
+                    "task",
+                    config,
+                    console,
+                    file_op_tracker,
+                    quiet=True,
+                    max_turns=9999,
                 )
         assert "internal safety limit" in str(exc_info.value)
 
@@ -1147,7 +1172,7 @@ class TestMaxTurns:
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
         file_op_tracker.complete_with_message.return_value = None
-        config: dict = {"configurable": {"thread_id": "t1"}}
+        config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
 
         with (
             patch(
@@ -1155,7 +1180,9 @@ class TestMaxTurns:
             ),
             patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
             patch("deepagents_cli.non_interactive.settings") as mock_settings,
-            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch(
+                "deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER"
+            ) as mock_adapter,
             patch("deepagents_cli.non_interactive._MAX_HITL_ITERATIONS", 1),
         ):
             mock_settings.shell_allow_list = None
@@ -1163,8 +1190,13 @@ class TestMaxTurns:
             mock_adapter.validate_python.side_effect = lambda v: v
             with pytest.raises(HITLIterationLimitError) as exc_info:
                 await _run_agent_loop(
-                    agent, "task", config, console, file_op_tracker,
-                    quiet=True, max_turns=None,
+                    agent,
+                    "task",
+                    config,
+                    console,
+                    file_op_tracker,
+                    quiet=True,
+                    max_turns=None,
                 )
         assert "internal safety limit" in str(exc_info.value)
 

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -1040,9 +1040,9 @@ def _make_interrupt_chunk(interrupt_id: str = "i1") -> tuple:
     """Return a stream chunk that triggers one HITL interrupt.
 
     The interrupt value is a dict that would normally need to pass the
-    HITLRequest Pydantic validator.  Tests that call this helper must also
-    patch ``_HITL_REQUEST_ADAPTER.validate_python`` to pass-through so that
-    validation is bypassed and ``state.interrupt_occurred`` is set correctly.
+    HITLRequest Pydantic validator. Tests that call this helper must also
+    patch `_HITL_REQUEST_ADAPTER.validate_python` to pass-through so that
+    validation is bypassed and `state.interrupt_occurred` is set correctly.
     """
     interrupt = MagicMock()
     interrupt.id = interrupt_id
@@ -1131,9 +1131,12 @@ class TestMaxTurns:
         assert "--max-turns 2" in msg
         assert "Increase --max-turns" in msg
 
-    async def test_ceiling_clamping_fires_internal_limit(self) -> None:
-        """max_turns above _MAX_HITL_ITERATIONS is silently clamped to the ceiling."""
-        # Patch ceiling to 2 so the test finishes quickly.
+    async def test_max_turns_above_default_is_honoured(self) -> None:
+        """User's --max-turns overrides the internal safety default (no clamp)."""
+        # Patch the default ceiling to 2 — if the old clamp logic were still
+        # in place, max_turns=4 would be truncated to 2 and the agent would
+        # only run 3 astream calls before raising. Without clamping, the
+        # loop must run 5 astream calls (1 initial + 4 HITL rounds).
         agent = _make_looping_agent()
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
@@ -1162,12 +1165,16 @@ class TestMaxTurns:
                     console,
                     file_op_tracker,
                     quiet=True,
-                    max_turns=9999,
+                    max_turns=4,
                 )
-        assert "internal safety limit" in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert "Exceeded 4 agentic turns" in msg
+        assert "--max-turns 4" in msg
+        assert "internal safety default" not in msg
+        assert agent.astream.call_count == 5
 
-    async def test_no_max_turns_defaults_to_ceiling(self) -> None:
-        """Omitting max_turns causes the internal safety limit message to appear."""
+    async def test_no_max_turns_uses_internal_default(self) -> None:
+        """Omitting max_turns falls back to the internal safety default."""
         agent = _make_looping_agent()
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
@@ -1198,7 +1205,8 @@ class TestMaxTurns:
                     quiet=True,
                     max_turns=None,
                 )
-        assert "internal safety limit" in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert "internal safety default of 1" in msg
 
     async def test_max_turns_forwarded_from_run_non_interactive(self) -> None:
         """run_non_interactive passes max_turns through to _run_agent_loop."""
@@ -1285,6 +1293,44 @@ class TestMaxTurns:
 
         _, kwargs = mock_loop.call_args
         assert kwargs.get("max_turns") is None
+
+    async def test_honours_full_user_budget_before_raising(self) -> None:
+        """With max_turns=N, N full HITL rounds run before the guard trips.
+
+        Pins the off-by-one semantics: `iterations > effective_limit` (strict
+        >) must allow exactly N HITL iterations on top of the initial stream.
+        If the guard flipped to `>=`, call_count would be N instead of N+1.
+        """
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER"
+            ) as mock_adapter,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError):
+                await _run_agent_loop(
+                    agent,
+                    "task",
+                    config,
+                    console,
+                    file_op_tracker,
+                    quiet=True,
+                    max_turns=3,
+                )
+        assert agent.astream.call_count == 4  # 1 initial + 3 HITL rounds
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -3,7 +3,7 @@
 import io
 import sys
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1131,12 +1131,12 @@ class TestMaxTurns:
         assert "--max-turns 2" in msg
         assert "Increase --max-turns" in msg
 
-    async def test_max_turns_above_default_is_honoured(self) -> None:
+    async def test_max_turns_above_default_is_honored(self) -> None:
         """User's --max-turns overrides the internal safety default (no clamp)."""
-        # Patch the default ceiling to 2 — if the old clamp logic were still
-        # in place, max_turns=4 would be truncated to 2 and the agent would
-        # only run 3 astream calls before raising. Without clamping, the
-        # loop must run 5 astream calls (1 initial + 4 HITL rounds).
+        # Pin the no-clamp invariant: with _MAX_HITL_ITERATIONS patched to 2
+        # and max_turns=4, the loop must run 4 astream calls (1 initial + 3
+        # HITL resumes) before the guard trips. If max_turns were clamped by
+        # the internal default, we'd see only 2 calls.
         agent = _make_looping_agent()
         console = Console(quiet=True)
         file_op_tracker = MagicMock()
@@ -1171,7 +1171,7 @@ class TestMaxTurns:
         assert "Exceeded 4 agentic turns" in msg
         assert "--max-turns 4" in msg
         assert "internal safety default" not in msg
-        assert agent.astream.call_count == 5
+        assert agent.astream.call_count == 4
 
     async def test_no_max_turns_uses_internal_default(self) -> None:
         """Omitting max_turns falls back to the internal safety default."""
@@ -1294,12 +1294,12 @@ class TestMaxTurns:
         _, kwargs = mock_loop.call_args
         assert kwargs.get("max_turns") is None
 
-    async def test_honours_full_user_budget_before_raising(self) -> None:
-        """With max_turns=N, N full HITL rounds run before the guard trips.
+    async def test_honors_full_user_budget_before_raising(self) -> None:
+        """With max_turns=N, exactly N agentic turns run before the guard trips.
 
-        Pins the off-by-one semantics: `iterations > effective_limit` (strict
-        >) must allow exactly N HITL iterations on top of the initial stream.
-        If the guard flipped to `>=`, call_count would be N instead of N+1.
+        Pins the counting semantics: the initial stream is turn 1, each HITL
+        resume adds one more turn, and the guard trips on the (N+1)-th call.
+        Flipping the check from `>=` to `>` would allow N+1 astream calls.
         """
         agent = _make_looping_agent()
         console = Console(quiet=True)
@@ -1330,7 +1330,56 @@ class TestMaxTurns:
                     quiet=True,
                     max_turns=3,
                 )
-        assert agent.astream.call_count == 4  # 1 initial + 3 HITL rounds
+        assert agent.astream.call_count == 3  # 1 initial + 2 HITL resumes = 3 turns
+
+    async def test_limit_hit_returns_exit_code_124(self) -> None:
+        """run_non_interactive returns 124 when --max-turns is exhausted.
+
+        A dedicated exit code (matching GNU `timeout`) lets CI distinguish
+        budget exhaustion from generic failures, which still return 1.
+        """
+        looping_agent = _make_looping_agent()
+        mock_server_proc = MagicMock()
+
+        async def fake_run_agent_loop(*_args: Any, **_kwargs: Any) -> None:  # noqa: RUF029
+            msg = "Exceeded 1 agentic turns (--max-turns 1)."
+            raise HITLIterationLimitError(msg)
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive._run_agent_loop",
+                new=fake_run_agent_loop,
+            ),
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+                return_value=(looping_agent, mock_server_proc, None),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            result = await run_non_interactive(message="task", max_turns=1)
+
+        assert result == 124
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -13,10 +13,13 @@ from rich.text import Text
 
 from deepagents_cli.config import SHELL_ALLOW_ALL, ModelResult
 from deepagents_cli.non_interactive import (
+    HITLIterationLimitError,
     ThreadUrlLookupState,
+    _MAX_HITL_ITERATIONS,
     _build_non_interactive_header,
     _collect_action_request_warnings,
     _make_hitl_decision,
+    _run_agent_loop,
     _start_langsmith_thread_url_lookup,
     run_non_interactive,
 )
@@ -1027,6 +1030,229 @@ class TestNonInteractivePrompt:
 
         assert result == 1
         mock_start_server.assert_not_awaited()
+
+
+def _make_interrupt_chunk(interrupt_id: str = "i1") -> tuple:
+    """Return a stream chunk that triggers one HITL interrupt.
+
+    The interrupt value is a dict that would normally need to pass the
+    HITLRequest Pydantic validator.  Tests that call this helper must also
+    patch ``_HITL_REQUEST_ADAPTER.validate_python`` to pass-through so that
+    validation is bypassed and ``state.interrupt_occurred`` is set correctly.
+    """
+    interrupt = MagicMock()
+    interrupt.id = interrupt_id
+    interrupt.value = {
+        "action_requests": [{"name": "read_file", "args": {"path": "/tmp/f"}}]
+    }
+    return ("", "updates", {"__interrupt__": [interrupt]})
+
+
+def _make_looping_agent() -> MagicMock:
+    """Return a mock agent whose astream always yields one interrupt chunk."""
+    chunk = _make_interrupt_chunk()
+    mock_agent = MagicMock()
+    mock_agent.astream = MagicMock(side_effect=lambda *a, **kw: _async_iter([chunk]))
+    return mock_agent
+
+
+class TestMaxTurns:
+    """Tests for max_turns parameter in _run_agent_loop."""
+
+    async def test_raises_after_user_limit(self) -> None:
+        """HITLIterationLimitError is raised after max_turns HITL iterations."""
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=1,
+                )
+        assert "--max-turns 1" in str(exc_info.value)
+
+    async def test_error_message_names_user_flag(self) -> None:
+        """Error message references --max-turns and tells the user how to fix it."""
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=2,
+                )
+        msg = str(exc_info.value)
+        assert "--max-turns 2" in msg
+        assert "Increase --max-turns" in msg
+
+    async def test_ceiling_clamping_fires_internal_limit(self) -> None:
+        """max_turns above _MAX_HITL_ITERATIONS is silently clamped to the ceiling."""
+        # Patch ceiling to 2 so the test finishes quickly.
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch("deepagents_cli.non_interactive._MAX_HITL_ITERATIONS", 2),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=9999,
+                )
+        assert "internal safety limit" in str(exc_info.value)
+
+    async def test_no_max_turns_defaults_to_ceiling(self) -> None:
+        """Omitting max_turns causes the internal safety limit message to appear."""
+        agent = _make_looping_agent()
+        console = Console(quiet=True)
+        file_op_tracker = MagicMock()
+        file_op_tracker.complete_with_message.return_value = None
+        config: dict = {"configurable": {"thread_id": "t1"}}
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.dispatch_hook", new_callable=AsyncMock
+            ),
+            patch("deepagents_cli.non_interactive.dispatch_hook_fire_and_forget"),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch("deepagents_cli.non_interactive._HITL_REQUEST_ADAPTER") as mock_adapter,
+            patch("deepagents_cli.non_interactive._MAX_HITL_ITERATIONS", 1),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.model_name = ""
+            mock_adapter.validate_python.side_effect = lambda v: v
+            with pytest.raises(HITLIterationLimitError) as exc_info:
+                await _run_agent_loop(
+                    agent, "task", config, console, file_op_tracker,
+                    quiet=True, max_turns=None,
+                )
+        assert "internal safety limit" in str(exc_info.value)
+
+    async def test_max_turns_forwarded_from_run_non_interactive(self) -> None:
+        """run_non_interactive passes max_turns through to _run_agent_loop."""
+        mock_agent = MagicMock()
+        mock_agent.astream = MagicMock(return_value=_async_iter([]))
+        mock_server_proc = MagicMock()
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive._run_agent_loop",
+                new_callable=AsyncMock,
+            ) as mock_loop,
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+                return_value=(mock_agent, mock_server_proc, None),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            await run_non_interactive(message="task", max_turns=7)
+
+        _, kwargs = mock_loop.call_args
+        assert kwargs.get("max_turns") == 7
+
+    async def test_max_turns_none_forwarded_by_default(self) -> None:
+        """run_non_interactive forwards max_turns=None when not supplied."""
+        mock_agent = MagicMock()
+        mock_agent.astream = MagicMock(return_value=_async_iter([]))
+        mock_server_proc = MagicMock()
+
+        with (
+            patch(
+                "deepagents_cli.non_interactive.create_model",
+                return_value=ModelResult(
+                    model=MagicMock(),
+                    model_name="test-model",
+                    provider="test",
+                ),
+            ),
+            patch(
+                "deepagents_cli.non_interactive.generate_thread_id",
+                return_value="test-thread",
+            ),
+            patch("deepagents_cli.non_interactive.settings") as mock_settings,
+            patch(
+                "deepagents_cli.non_interactive.build_langsmith_thread_url",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_cli.non_interactive._run_agent_loop",
+                new_callable=AsyncMock,
+            ) as mock_loop,
+            patch(
+                "deepagents_cli.server_manager.start_server_and_get_agent",
+                new_callable=AsyncMock,
+                return_value=(mock_agent, mock_server_proc, None),
+            ),
+        ):
+            mock_settings.shell_allow_list = None
+            mock_settings.has_tavily = False
+            mock_settings.model_name = None
+
+            await run_non_interactive(message="task")
+
+        _, kwargs = mock_loop.call_args
+        assert kwargs.get("max_turns") is None
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029

--- a/libs/cli/tests/unit_tests/test_ui.py
+++ b/libs/cli/tests/unit_tests/test_ui.py
@@ -1,5 +1,9 @@
 """Unit tests for UI rendering utilities."""
 
+import argparse
+
+import pytest
+
 from deepagents_cli.config import get_glyphs
 from deepagents_cli.tool_display import (
     _format_content_block,
@@ -8,6 +12,7 @@ from deepagents_cli.tool_display import (
     format_tool_message_content,
     truncate_value,
 )
+from deepagents_cli.ui import positive_int
 
 
 class TestFormatTimeout:
@@ -349,3 +354,35 @@ class TestFormatContentBlock:
         block = {"type": "data", "value": object()}
         result = _format_content_block(block)
         assert "type" in result
+
+
+class TestPositiveInt:
+    """Direct tests for the `positive_int` argparse type converter."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("1", 1),
+            ("42", 42),
+            ("+5", 5),
+            (" 7 ", 7),
+            ("0001", 1),
+        ],
+    )
+    def test_accepts_positive_integers(self, raw: str, expected: int) -> None:
+        """Valid positive integers are parsed, including leading/trailing space."""
+        assert positive_int(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["0", "-1", "-42"])
+    def test_rejects_non_positive(self, raw: str) -> None:
+        """Zero and negatives surface as ArgumentTypeError with the expected copy."""
+        with pytest.raises(argparse.ArgumentTypeError) as exc_info:
+            positive_int(raw)
+        assert "positive integer" in str(exc_info.value)
+
+    @pytest.mark.parametrize("raw", ["abc", "5.0", "", "  ", "1e2", "1,000"])
+    def test_rejects_non_integer(self, raw: str) -> None:
+        """Non-integer strings (including floats and empty) raise ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError) as exc_info:
+            positive_int(raw)
+        assert "invalid int value" in str(exc_info.value)


### PR DESCRIPTION
Closes #2826

---

- Adds `--max-turns N` CLI flag that caps the number of agentic turns in non-interactive mode (`-n` / piped stdin)
  - The flag is clamped against the internal `_MAX_HITL_ITERATIONS = 50` safety ceiling — whichever is lower wins
- Exits with code 2 and a helpful message if `--max-turns` is used without `-n`
- Help screen updated

## Motivation

Long-running or misbehaving agents in CI/CD pipelines can loop indefinitely. `--max-turns` gives operators a hard upper bound (e.g. `deepagents -n 'fix tests' --max-turns 10`) without having to touch SDK internals.