### PR TITLE
ix(sdk): prevent premature cancellation of long-running tool calls.

### DIFF
--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,44 +1,115 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
-from langgraph.types import Overwrite
+from langgraph.types import Command, Overwrite
+
+logger = logging.getLogger(__name__)
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
     """Middleware to patch dangling tool calls in the messages history."""
 
+    def __init__(self) -> None:
+        """Initialize the middleware."""
+        super().__init__()
+        self._in_flight: set[str] = set()
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Wrap the tool call to track its in-flight execution."""
+        tool_call_id = request.tool_call.get("id")
+        if tool_call_id:
+            self._in_flight.add(tool_call_id)
+
+        try:
+            return handler(request)
+        finally:
+            if tool_call_id:
+                self._in_flight.discard(tool_call_id)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Wrap the tool call to track its in-flight execution."""
+        tool_call_id = request.tool_call.get("id")
+        if tool_call_id:
+            self._in_flight.add(tool_call_id)
+
+        try:
+            return await handler(request)
+        finally:
+            if tool_call_id:
+                self._in_flight.discard(tool_call_id)
+
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
         """Before the agent runs, handle dangling tool calls from any AIMessage."""
+        return self._process_state(state)
+
+    async def abefore_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Async hook before agent runs. Waits for in-flight tools to complete cancellation."""
+        if self._in_flight:
+            logger.info(
+                "PatchToolCallsMiddleware: Holding before_agent to allow %d in-flight tool calls to complete or cancel.", len(self._in_flight)
+            )
+            # Wait up to a short period for tasks to exit their finally blocks
+            for _ in range(20):
+                if not self._in_flight:
+                    break
+                await asyncio.sleep(0.05)
+            if self._in_flight:
+                logger.warning("PatchToolCallsMiddleware: Some tool calls remain in-flight after waiting: %s", self._in_flight)
+
+        return self._process_state(state)
+
+    def _process_state(self, state: AgentState) -> dict[str, Any] | None:
+        """Core logic to handle dangling tool calls."""
         messages = state["messages"]
         if not messages:
             return None
 
-        answered_ids = {msg.tool_call_id for msg in messages if msg.type == "tool"}  # ty: ignore[unresolved-attribute]
+        answered_ids = {msg.tool_call_id for msg in messages if isinstance(msg, ToolMessage)}
 
-        if not any(
-            tool_call["id"] not in answered_ids for msg in messages if isinstance(msg, AIMessage) and msg.tool_calls for tool_call in msg.tool_calls
-        ):
+        dangling_found = any(
+            tool_call["id"] not in answered_ids and tool_call["id"] not in self._in_flight
+            for msg in messages
+            if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None)
+            for tool_call in msg.tool_calls
+        )
+
+        if not dangling_found:
             return None
+
+        logger.info("PatchToolCallsMiddleware: Found dangling tool calls. Injecting cancellation ToolMessage.")
 
         patched_messages = []
         for msg in messages:
             patched_messages.append(msg)
-            if isinstance(msg, AIMessage) and msg.tool_calls:
-                patched_messages.extend(
-                    ToolMessage(
-                        content=(
-                            f"Tool call {tool_call['name']} with id {tool_call['id']} was "
-                            "cancelled - another message came in before it could be completed."
-                        ),
-                        name=tool_call["name"],
-                        tool_call_id=tool_call["id"],
-                    )
-                    for tool_call in msg.tool_calls
-                    if tool_call["id"] not in answered_ids
-                )
+            if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+                for tool_call in msg.tool_calls:
+                    if tool_call["id"] not in answered_ids and tool_call["id"] not in self._in_flight:
+                        logger.info("PatchToolCallsMiddleware: Cancelling tool call %s (%s)", tool_call["name"], tool_call["id"])
+                        patched_messages.append(
+                            ToolMessage(
+                                content=(
+                                    f"Tool call {tool_call['name']} with id {tool_call['id']} was "
+                                    "cancelled - another message came in before it could be completed."
+                                ),
+                                name=tool_call["name"],
+                                tool_call_id=tool_call["id"],
+                            )
+                        )
 
         return {"messages": Overwrite(patched_messages)}

--- a/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
@@ -1,0 +1,213 @@
+"""Unit tests for PatchToolCallsMiddleware."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+# Import directly from the module file to avoid deepagents/__init__.py
+# which eagerly imports graph.py → langchain_anthropic (not installed in test env)
+_mod_path = Path(__file__).parent.parent.parent.parent / "deepagents" / "middleware" / "patch_tool_calls.py"
+_spec = importlib.util.spec_from_file_location("patch_tool_calls", _mod_path)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+PatchToolCallsMiddleware = _mod.PatchToolCallsMiddleware
+
+
+def _make_runtime() -> MagicMock:
+    return MagicMock()
+
+
+def _state(messages: list) -> dict:
+    return {"messages": messages}
+
+
+def _ai_with_tool_call(tool_id: str = "tc-1", name: str = "my_tool") -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"id": tool_id, "name": name, "args": {}}],
+    )
+
+
+def _tool_message(tool_id: str = "tc-1", name: str = "my_tool") -> ToolMessage:
+    return ToolMessage(content="result", name=name, tool_call_id=tool_id)
+
+
+class TestNoDangling:
+    """No patching needed when all tool calls have been answered."""
+
+    def test_empty_messages_returns_none(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        result = mw.before_agent(_state([]), _make_runtime())
+        assert result is None
+
+    def test_no_tool_calls_returns_none(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        state = _state([HumanMessage(content="hi"), AIMessage(content="hello")])
+        assert mw.before_agent(state, _make_runtime()) is None
+
+    def test_answered_tool_call_returns_none(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        state = _state([_ai_with_tool_call("tc-1"), _tool_message("tc-1")])
+        assert mw.before_agent(state, _make_runtime()) is None
+
+
+class TestDanglingCancellation:
+    """Dangling tool calls should be patched with a cancellation ToolMessage."""
+
+    def test_dangling_call_gets_cancellation(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        ai_msg = _ai_with_tool_call("tc-1", "playwright_browser_navigate")
+        state = _state([ai_msg])
+
+        result = mw.before_agent(state, _make_runtime())
+
+        assert result is not None
+        messages = result["messages"].value
+        assert len(messages) == 2
+        cancel_msg = messages[1]
+        assert isinstance(cancel_msg, ToolMessage)
+        assert cancel_msg.tool_call_id == "tc-1"
+        assert "cancelled" in cancel_msg.content
+
+    def test_only_unanswered_calls_are_cancelled(self) -> None:
+        """If one call is answered and one is not, only the unanswered is patched."""
+        mw = PatchToolCallsMiddleware()
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "tc-1", "name": "tool_a", "args": {}},
+                {"id": "tc-2", "name": "tool_b", "args": {}},
+            ],
+        )
+        tool_answer = _tool_message("tc-1", "tool_a")
+        state = _state([ai_msg, tool_answer])
+
+        result = mw.before_agent(state, _make_runtime())
+
+        assert result is not None
+        messages = result["messages"].value
+        # ai_msg + cancel for tc-2 (inserted right after AIMessage) + tool_answer
+        assert len(messages) == 3
+        cancel_msg = messages[1]
+        assert cancel_msg.tool_call_id == "tc-2"
+
+
+class TestInFlightProtection:
+    """Tool calls registered as in-flight must not be cancelled."""
+
+    def test_in_flight_call_is_not_cancelled(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        mw._in_flight.add("tc-1")
+        ai_msg = _ai_with_tool_call("tc-1")
+        state = _state([ai_msg])
+
+        result = mw.before_agent(state, _make_runtime())
+        assert result is None
+
+    def test_in_flight_cleared_after_sync_wrap(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = MagicMock(return_value=_tool_message("tc-1"))
+
+        mw.wrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    def test_in_flight_cleared_on_sync_exception(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = MagicMock(side_effect=RuntimeError("tool failed"))
+
+        with pytest.raises(RuntimeError):
+            mw.wrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    async def test_in_flight_cleared_after_async_wrap(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = AsyncMock(return_value=_tool_message("tc-1"))
+
+        await mw.awrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    async def test_in_flight_cleared_on_async_exception(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = AsyncMock(side_effect=RuntimeError("async tool failed"))
+
+        with pytest.raises(RuntimeError):
+            await mw.awrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    async def test_in_flight_cleared_on_cancellation(self) -> None:
+        """Simulates asyncio.CancelledError (e.g. Playwright timeout)."""
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-playwright"}
+        handler = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await mw.awrap_tool_call(request, handler)
+
+        assert "tc-playwright" not in mw._in_flight
+
+
+class TestAbforeAgentWaiting:
+    """abefore_agent must wait for in-flight tools to clear before proceeding."""
+
+    async def test_abefore_agent_no_in_flight_returns_immediately(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        state = _state([_ai_with_tool_call("tc-1")])
+        result = await mw.abefore_agent(state, _make_runtime())
+        # No in-flight, so the dangling call should be cancelled normally
+        assert result is not None
+
+    async def test_abefore_agent_waits_for_in_flight_to_clear(self) -> None:
+        """If in-flight clears asynchronously, abefore_agent should not cancel it."""
+        mw = PatchToolCallsMiddleware()
+        mw._in_flight.add("tc-1")
+
+        async def _clear_after_delay() -> None:
+            await asyncio.sleep(0.02)
+            mw._in_flight.discard("tc-1")
+
+        _background_tasks = set()
+        task = asyncio.create_task(_clear_after_delay())
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+        ai_msg = _ai_with_tool_call("tc-1")
+        state = _state([ai_msg, _tool_message("tc-1")])
+
+        result = await mw.abefore_agent(state, _make_runtime())
+        # tc-1 was answered so no dangling once in-flight is cleared
+        assert result is None
+
+    async def test_abefore_agent_cancels_if_still_in_flight_after_timeout(self) -> None:
+        """If tool stays in-flight past the wait window, the in-flight ID is still protected.
+
+        The in-flight ID is not cancelled because we cannot verify the tool truly abandoned.
+        """
+        mw = PatchToolCallsMiddleware()
+        mw._in_flight.add("tc-stuck")
+
+        ai_msg = _ai_with_tool_call("tc-stuck")
+        # No corresponding ToolMessage → dangling, but still in-flight
+        state = _state([ai_msg])
+
+        result = await mw.abefore_agent(state, _make_runtime())
+        # tc-stuck is still in _in_flight, so it is NOT cancelled (protected)
+        assert result is None


### PR DESCRIPTION
**Fixes #2471**

This PR resolves a race condition where long-running tools (e.g. Playwright navigation) were incorrectly marked as dangling and cancelled by the middleware. I've implemented in-flight tracking to ensure active tools are protected during the agent loop.

Q. How was this verified?
Passed 14 unit tests in `libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py` covering various race conditions and async cancellations.

**Note-** 
I have Used generative AI to assist with implementation and test generation. Also I  checked manually as well regarding Unit Test cases for verifications.
