### PR TITLE
style(cli): render edit diffs above the loading spinner

### DIFF
--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -677,12 +677,6 @@ async def execute_task_textual(
                                 tool_id,
                             )
 
-                        # Reshow spinner only when all in-flight tools have
-                        # completed (avoids premature "Thinking..." when
-                        # parallel tool calls are active).
-                        if adapter._set_spinner and not adapter._current_tool_messages:
-                            await adapter._set_spinner("Thinking")
-
                         # Show file operation results - always show diffs in chat
                         if record:
                             pending_text = pending_text_by_namespace.get(ns_key, "")
@@ -698,6 +692,14 @@ async def execute_task_textual(
                                 await adapter._mount_message(
                                     DiffMessage(record.diff, record.display_path)
                                 )
+
+                        # Reshow spinner only when all in-flight tools have
+                        # completed (avoids premature "Thinking..." when
+                        # parallel tool calls are active). Must happen after
+                        # the diff is mounted so the spinner stays at the
+                        # bottom of the messages container.
+                        if adapter._set_spinner and not adapter._current_tool_messages:
+                            await adapter._set_spinner("Thinking")
                         continue
 
                     # Extract token usage (before content_blocks check


### PR DESCRIPTION
When a file-edit tool completed, the `DiffMessage` was mounted after the "Thinking..." spinner got re-shown, so the diff rendered below the spinner instead of attached to the tool result. Swap the two mounts — `_set_spinner` already detects when it's no longer the last child and re-positions itself.