### PR TITLE
feat(cli): `--startup-cmd` flag

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -523,6 +523,7 @@ class DeepAgentsApp(App):
         resume_thread: str | None = None,
         initial_prompt: str | None = None,
         initial_skill: str | None = None,
+        startup_cmd: str | None = None,
         mcp_server_info: list[MCPServerInfo] | None = None,
         profile_override: dict[str, Any] | None = None,
         server_proc: ServerProcess | None = None,
@@ -554,6 +555,11 @@ class DeepAgentsApp(App):
                 Requires `server_kwargs` to be set; ignored otherwise.
             initial_prompt: Optional prompt to auto-submit when session starts
             initial_skill: Optional skill name to invoke when session starts.
+            startup_cmd: Optional shell command to run at startup before the
+                first prompt is accepted.
+
+                Output is rendered in the transcript and non-zero exits warn but
+                do not abort the session.
             mcp_server_info: MCP server metadata for the `/mcp` viewer.
             profile_override: Extra profile fields from `--profile-override`,
                 retained so later profile-aware behavior stays consistent with
@@ -646,6 +652,15 @@ class DeepAgentsApp(App):
         """Skill name to auto-invoke after first paint (from `--skill`).
 
         Normalized to lowercase; `None` when not provided.
+        """
+
+        self._startup_cmd = (
+            startup_cmd.strip() if startup_cmd and startup_cmd.strip() else None
+        )
+        """Shell command to run once before the first prompt, from
+        `--startup-cmd`.
+
+        Cleared to `None` after it runs so later server swaps cannot re-run it.
         """
 
         self._mcp_server_info = mcp_server_info
@@ -781,6 +796,14 @@ class DeepAgentsApp(App):
         self._processing_pending = False
         """Re-entry guard for `_process_next_from_queue` so only one drain
         loop runs at a time."""
+
+        self._startup_sequence_running = False
+        """True while post-connect startup work is still being sequenced.
+
+        Covers resumed-history hydration, `--startup-cmd`, and the handoff to
+        the first queued or initial submission so user input stays serialized
+        until the session reaches its first stable busy/idle state.
+        """
 
         # Message queue & store
         self._pending_messages: deque[QueuedMessage] = deque()
@@ -1104,22 +1127,14 @@ class DeepAgentsApp(App):
             group="startup-tool-check",
         )
 
-        # Auto-submit initial prompt or skill if provided via -m / --skill.
-        # This check must come first because _lc_thread_id and _agent are
-        # always set (even for brand-new sessions), so an elif after the
-        # thread-history branch would never execute.
-        # When connecting, defer until on_deep_agents_app_server_ready fires.
-        # NOTE: _schedule_initial_submission() has a side effect (queues a
-        # task via call_after_refresh); short-circuit ensures it only runs
-        # when not connecting — the deferred path handles the connecting case.
-        if (
-            not self._connecting
-            and not self._schedule_initial_submission()
-            and self._lc_thread_id
-            and self._agent
-        ):
+        # Session-start sequence (history -> `--startup-cmd` -> initial prompt/
+        # skill -> queue drain). When connecting, defer until
+        # `on_deep_agents_app_server_ready` fires; otherwise run it now so the
+        # non-connecting path (pre-built agent) also honors `--startup-cmd` and
+        # serializes startup against user input.
+        if not self._connecting:
             self.call_after_refresh(
-                lambda: asyncio.create_task(self._load_thread_history())
+                lambda: asyncio.create_task(self._run_session_start_sequence())
             )
 
     async def _init_session_state(self) -> None:
@@ -1425,13 +1440,14 @@ class DeepAgentsApp(App):
         except NoMatches:
             logger.warning("Welcome banner not found during server ready transition")
 
-        # Handle deferred initial prompt, skill, or thread history
-        if not self._schedule_initial_submission() and (
-            self._lc_thread_id and self._agent
-        ):
-            self.call_after_refresh(
-                lambda: asyncio.create_task(self._load_thread_history())
-            )
+        # Session-start sequence: load resumed history, run `--startup-cmd`
+        # (if any), then dispatch the initial prompt/skill and drain
+        # user-typed messages. Sequenced through a single task so the
+        # startup command always resolves before the agent sees any user
+        # input.
+        self.call_after_refresh(
+            lambda: asyncio.create_task(self._run_session_start_sequence())
+        )
 
         # Drain deferred actions (e.g. model/thread switch queued during connection)
         # if the agent is not actively running. Wrapped in a helper so that
@@ -1452,13 +1468,6 @@ class DeepAgentsApp(App):
                         )
 
             self.call_after_refresh(lambda: asyncio.create_task(_safe_drain()))
-
-        # Drain any messages the user typed while the server was starting.
-        # (If an initial submission exists, its cleanup path will drain the queue.)
-        if self._pending_messages and not self._has_initial_submission():
-            self.call_after_refresh(
-                lambda: asyncio.create_task(self._process_next_from_queue())
-            )
 
     def on_deep_agents_app_server_start_failed(self, event: ServerStartFailed) -> None:
         """Handle background server startup failure."""
@@ -2320,18 +2329,102 @@ class DeepAgentsApp(App):
             self._initial_prompt and self._initial_prompt.strip()
         )
 
-    def _schedule_initial_submission(self) -> bool:
-        """Schedule the startup prompt or skill after the next refresh.
+    async def _run_session_start_sequence(self) -> None:
+        """Load history, run `--startup-cmd`, then dispatch initial work.
 
-        Returns:
-            `True` when a startup submission was queued, `False` otherwise.
+        Single entry point for the post-connect sequence. Sequencing the
+        startup command before any user-facing agent work guarantees the
+        agent never observes input until the command has completed.
         """
-        if not self._has_initial_submission():
-            return False
-        self.call_after_refresh(
-            lambda: asyncio.create_task(self._submit_initial_submission())
-        )
-        return True
+        self._startup_sequence_running = True
+        try:
+            should_load_history = bool(self._lc_thread_id and self._agent) and (
+                self._resume_thread_intent is not None
+                or not self._has_initial_submission()
+            )
+            if should_load_history:
+                await self._load_thread_history()
+
+            if self._startup_cmd:
+                cmd = self._startup_cmd
+                # One-shot: clear to avoid re-running on any subsequent server swap.
+                self._startup_cmd = None
+                await self._run_startup_command(cmd)
+
+            if self._has_initial_submission():
+                await self._submit_initial_submission()
+                return
+        finally:
+            self._startup_sequence_running = False
+
+        if self._agent_running or self._shell_running:
+            return
+
+        try:
+            await self._maybe_drain_deferred()
+        except Exception:
+            logger.exception(
+                "Failed to drain deferred actions after startup sequencing"
+            )
+            with suppress(Exception):
+                await self._mount_message(
+                    ErrorMessage(
+                        "A deferred action failed during startup. "
+                        "You may need to retry the operation."
+                    )
+                )
+
+        if self._pending_messages:
+            await self._process_next_from_queue()
+
+    async def _run_startup_command(self, command: str) -> None:
+        """Execute the `--startup-cmd` and render its output in the transcript.
+
+        Uses the same worker-backed subprocess path as the interactive `!`
+        shell prefix, with an app-style header (since the user did not type
+        the command). Non-zero exit is already rendered as an error by
+        `_run_shell_task` but does not abort the session.
+
+        Raises:
+            CancelledError: If the worker is cancelled (e.g. Esc/Ctrl+C);
+                re-raised so `_run_shell_task`'s finally can clean up.
+        """
+        try:
+            await self._mount_message(
+                AppMessage(
+                    Content.from_markup("Running startup command: $cmd", cmd=command)
+                )
+            )
+        except Exception:
+            logger.warning("Failed to mount startup-command header", exc_info=True)
+
+        self._shell_running = True
+        if self._chat_input:
+            self._chat_input.set_cursor_active(active=False)
+
+        try:
+            worker = self.run_worker(self._run_shell_task(command), exclusive=False)
+        except Exception:
+            # `run_worker` failed synchronously — `_run_shell_task`'s finally
+            # never fires, so reset the busy flags here or the UI stays wedged.
+            logger.exception("Failed to schedule startup-command worker")
+            self._shell_running = False
+            self._shell_worker = None
+            if self._chat_input:
+                self._chat_input.set_cursor_active(active=True)
+            with suppress(Exception):
+                await self._mount_message(
+                    ErrorMessage("Failed to start startup command; continuing session.")
+                )
+            return
+
+        self._shell_worker = worker
+        try:
+            await worker.wait()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Startup command worker raised unexpectedly")
 
     async def _submit_initial_submission(self) -> None:
         """Submit the startup prompt or skill after the UI is ready."""
@@ -2405,10 +2498,15 @@ class DeepAgentsApp(App):
             )
             return
 
-        # If agent/shell is running or server is still starting up, enqueue
-        # instead of processing. Messages queued during connection are drained
-        # once the server is ready (see on_deep_agents_app_server_ready).
-        if self._agent_running or self._shell_running or self._connecting:
+        # If the app is busy or still sequencing startup work, enqueue instead
+        # of processing. Messages queued during startup are drained once the
+        # session reaches its first stable idle/running state.
+        if (
+            self._agent_running
+            or self._shell_running
+            or self._connecting
+            or self._startup_sequence_running
+        ):
             if mode == "command" and self._can_bypass_queue(value.lower().strip()):
                 await self._process_message(value, mode)
                 return
@@ -2574,7 +2672,8 @@ class DeepAgentsApp(App):
                         "You may need to retry the operation."
                     )
                 )
-        await self._process_next_from_queue()
+        if not self._startup_sequence_running:
+            await self._process_next_from_queue()
 
     async def _kill_shell_process(self) -> None:
         """Terminate the running shell command process.
@@ -3601,7 +3700,8 @@ class DeepAgentsApp(App):
                 )
 
         # Process next message from queue if any
-        await self._process_next_from_queue()
+        if not self._startup_sequence_running:
+            await self._process_next_from_queue()
 
     @staticmethod
     def _convert_messages_to_data(messages: list[Any]) -> list[MessageData]:
@@ -4194,8 +4294,8 @@ class DeepAgentsApp(App):
         self._deferred_actions.append(action)
 
     async def _maybe_drain_deferred(self) -> None:
-        """Drain deferred actions unless a server connection is still in progress."""
-        if not self._connecting:
+        """Drain deferred actions unless startup sequencing is still in progress."""
+        if not self._connecting and not self._startup_sequence_running:
             await self._drain_deferred_actions()
 
     async def _drain_deferred_actions(self) -> None:
@@ -5529,6 +5629,7 @@ async def run_textual_app(
     resume_thread: str | None = None,
     initial_prompt: str | None = None,
     initial_skill: str | None = None,
+    startup_cmd: str | None = None,
     mcp_server_info: list[MCPServerInfo] | None = None,
     profile_override: dict[str, Any] | None = None,
     server_proc: ServerProcess | None = None,
@@ -5559,6 +5660,9 @@ async def run_textual_app(
             Resolved asynchronously during TUI startup.
         initial_prompt: Optional prompt to auto-submit when session starts.
         initial_skill: Optional skill name to invoke when session starts.
+        startup_cmd: Optional shell command to run at startup before the first
+            prompt is accepted. Output is rendered in the transcript and
+            non-zero exits warn but do not abort the session.
         mcp_server_info: MCP server metadata for the `/mcp` viewer.
         profile_override: Extra profile fields from `--profile-override`,
             retained so later profile-aware behavior stays consistent with
@@ -5586,6 +5690,7 @@ async def run_textual_app(
         resume_thread=resume_thread,
         initial_prompt=initial_prompt,
         initial_skill=initial_skill,
+        startup_cmd=startup_cmd,
         mcp_server_info=mcp_server_info,
         profile_override=profile_override,
         server_proc=server_proc,

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -615,6 +615,14 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--startup-cmd",
+        dest="startup_cmd",
+        metavar="CMD",
+        help="Shell command to run at startup, before the first prompt "
+        "(output shown, non-zero exit warns but does not abort)",
+    )
+
+    parser.add_argument(
         "-n",
         "--non-interactive",
         dest="non_interactive_message",
@@ -777,6 +785,7 @@ async def run_textual_cli_async(
     resume_thread: str | None = None,
     initial_prompt: str | None = None,
     initial_skill: str | None = None,
+    startup_cmd: str | None = None,
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
@@ -813,6 +822,10 @@ async def run_textual_cli_async(
             Resolved asynchronously inside the TUI.
         initial_prompt: Optional prompt to auto-submit when session starts
         initial_skill: Optional skill name to invoke when the session starts.
+        startup_cmd: Shell command to run at startup before the first prompt.
+
+            Output is rendered in the transcript; non-zero exits warn but
+            do not abort the session.
         mcp_config_path: Optional path to MCP servers JSON configuration file.
 
             Merged on top of auto-discovered configs (highest precedence).
@@ -899,6 +912,7 @@ async def run_textual_cli_async(
             resume_thread=resume_thread,
             initial_prompt=initial_prompt,
             initial_skill=initial_skill,
+            startup_cmd=startup_cmd,
             profile_override=profile_override,
             server_kwargs=server_kwargs,
             mcp_preload_kwargs=mcp_preload_kwargs,
@@ -1729,6 +1743,7 @@ def cli_main() -> None:
                     sandbox_id=args.sandbox_id,
                     sandbox_setup=getattr(args, "sandbox_setup", None),
                     initial_skill=getattr(args, "initial_skill", None),
+                    startup_cmd=getattr(args, "startup_cmd", None),
                     quiet=args.quiet,
                     stream=not args.no_stream,
                     mcp_config_path=getattr(args, "mcp_config", None),
@@ -1795,6 +1810,7 @@ def cli_main() -> None:
                         resume_thread=resume_thread,
                         initial_prompt=getattr(args, "initial_prompt", None),
                         initial_skill=getattr(args, "initial_skill", None),
+                        startup_cmd=getattr(args, "startup_cmd", None),
                         mcp_config_path=getattr(args, "mcp_config", None),
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,

--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -761,6 +761,134 @@ def _build_non_interactive_header(
     return Text.assemble(*parts)
 
 
+async def _run_startup_command(
+    command: str,
+    console: Console,
+    *,
+    quiet: bool,
+) -> None:
+    """Run the `--startup-cmd` shell command before the agent loop.
+
+    Stdout and stderr are routed through `console`. In `--quiet` mode the
+    caller wires `console` to stderr so agent output on stdout stays clean;
+    otherwise both streams land on stdout alongside the agent's response.
+    Non-zero exits and timeouts emit a yellow warning but do not abort the
+    session — the non-zero exit code is logged, not propagated.
+
+    Args:
+        command: Shell command to execute (subject to shell expansion).
+        console: Rich console for status messages. Respects `quiet`.
+        quiet: When `True`, suppresses the "Running startup command" header
+            so piped output stays minimal; warnings still appear (on stderr
+            when the caller wired the console there).
+    """
+    import asyncio
+    import sys
+
+    if not quiet:
+        console.print(Text(f"Running startup command: {command}", style="dim"))
+
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=(sys.platform != "win32"),
+        )
+    except OSError as e:
+        console.print(
+            "[yellow]Warning:[/yellow] startup command failed to launch: "
+            f"{escape_markup(str(e))}"
+        )
+        return
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=60
+        )
+    except TimeoutError:
+        if proc.returncode is None:
+            try:
+                if sys.platform != "win32":
+                    import os
+                    import signal
+
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                else:
+                    proc.kill()
+            except ProcessLookupError:
+                pass
+            except OSError:
+                logger.warning(
+                    "Failed to terminate startup command (pid=%s)",
+                    proc.pid,
+                    exc_info=True,
+                )
+            else:
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=5)
+                except TimeoutError:
+                    logger.warning(
+                        "Startup command (pid=%s) did not exit after termination; "
+                        "sending SIGKILL",
+                        proc.pid,
+                    )
+                    try:
+                        if sys.platform != "win32":
+                            import os
+                            import signal
+
+                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                        else:
+                            proc.kill()
+                    except ProcessLookupError:
+                        pass
+                    except OSError:
+                        logger.warning(
+                            "Failed to SIGKILL startup command (pid=%s); "
+                            "process may leak",
+                            proc.pid,
+                            exc_info=True,
+                        )
+                    try:
+                        await proc.wait()
+                    except ProcessLookupError:
+                        pass
+                    except OSError:
+                        logger.warning(
+                            "Failed to reap startup command (pid=%s) after SIGKILL",
+                            proc.pid,
+                            exc_info=True,
+                        )
+                except ProcessLookupError:
+                    pass
+                except OSError:
+                    logger.warning(
+                        "Failed to wait on startup command (pid=%s) after SIGTERM; "
+                        "process may leak",
+                        proc.pid,
+                        exc_info=True,
+                    )
+        console.print("[yellow]Warning:[/yellow] startup command timed out (60s limit)")
+        return
+
+    stdout_text = (stdout_bytes or b"").decode(errors="replace").rstrip("\n")
+    stderr_text = (stderr_bytes or b"").decode(errors="replace").rstrip("\n")
+    if stdout_text:
+        # Wrap in `Text` so Rich treats the shell output as literal — otherwise
+        # brackets in tool output (e.g. `[INFO]`, `[1/3]`) would be parsed as
+        # markup and either silently stripped or raise `MarkupError`.
+        console.print(Text(stdout_text), highlight=False)
+    if stderr_text:
+        console.print(Text(stderr_text, style="dim"), highlight=False)
+
+    if proc.returncode:
+        console.print(
+            "[yellow]Warning:[/yellow] startup command exited with code "
+            f"{proc.returncode} — continuing anyway"
+        )
+
+
 async def run_non_interactive(
     message: str,
     assistant_id: str = "agent",
@@ -771,6 +899,7 @@ async def run_non_interactive(
     sandbox_setup: str | None = None,
     *,
     initial_skill: str | None = None,
+    startup_cmd: str | None = None,
     profile_override: dict[str, Any] | None = None,
     quiet: bool = False,
     stream: bool = True,
@@ -810,6 +939,11 @@ async def run_non_interactive(
             after creation.
         initial_skill: Optional skill name whose `SKILL.md` instructions wrap
             the user message before sending it to the agent.
+        startup_cmd: Shell command to run at startup, before the agent runs.
+
+            Output follows the same console routing as other CLI messages:
+            stdout by default, stderr when `-q` is set. Non-zero exits and
+            timeouts warn but do not abort the task.
         profile_override: Extra profile fields from `--profile-override`.
 
             Merged on top of config file profile overrides.
@@ -838,6 +972,9 @@ async def run_non_interactive(
     # stderr=True routes all console.print() to stderr; agent response text
     # uses _write_text() -> sys.stdout directly.
     console = Console(stderr=True) if quiet else Console()
+
+    if startup_cmd and startup_cmd.strip():
+        await _run_startup_command(startup_cmd.strip(), console, quiet=quiet)
 
     message_kwargs: dict[str, Any] | None = None
     if initial_skill and initial_skill.strip():

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -111,6 +111,9 @@ def show_help() -> None:
     console.print("  -m, --message TEXT         Initial prompt to auto-submit on start")
     console.print("  --skill NAME              Invoke a skill when the session starts")
     console.print(
+        "  --startup-cmd CMD         Shell command to run at startup, before first prompt"  # noqa: E501
+    )
+    console.print(
         "  -y, --auto-approve         Auto-approve all tool calls (toggle: Shift+Tab)"
     )
     console.print("  --sandbox TYPE             Remote sandbox for execution")

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -41,6 +41,7 @@ _TIPS: list[str] = [
     "Use /skill-creator to build reusable agent skills",
     "Use /auto-update to toggle automatic CLI updates",
     "Use /agents to browse and switch between your available agents",
+    "Use --startup-cmd to run a shell command before the first prompt",
 ]
 """Rotating tips shown in the welcome footer.
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -129,9 +129,151 @@ class TestInitialPromptOnMount:
                 mcp_server_info=[],
             )
         )
-        await asyncio.sleep(0)
+        # Server-ready schedules `_run_session_start_sequence` onto the loop.
+        # A few yields keep the test stable across that async handoff.
+        for _ in range(3):
+            await asyncio.sleep(0)
 
         assert submitted == [("code-review", "review this diff", None)]
+
+
+class TestStartupSequence:
+    """Tests for post-connect startup sequencing."""
+
+    async def test_resumed_history_loads_before_startup_command(self) -> None:
+        """Resumed threads should mount prior history before startup output."""
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            thread_id="thread-123",
+            resume_thread="thread-123",
+            startup_cmd="echo hi",
+        )
+        order: list[str] = []
+
+        async def capture_history(  # noqa: RUF029
+            *,
+            thread_id: str | None = None,
+            preloaded_payload: object | None = None,
+        ) -> None:
+            del thread_id, preloaded_payload
+            order.append("history")
+
+        async def capture_startup(command: str) -> None:  # noqa: RUF029
+            assert command == "echo hi"
+            order.append("startup")
+
+        app._load_thread_history = capture_history  # type: ignore[assignment]
+        app._run_startup_command = capture_startup  # type: ignore[assignment]
+
+        await app._run_session_start_sequence()
+
+        assert order == ["history", "startup"]
+        assert app._startup_sequence_running is False
+
+    async def test_startup_cleanup_defers_queue_until_initial_submission(self) -> None:
+        """Queued input should wait until startup submission owns the agent slot."""
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            thread_id="thread-123",
+            initial_prompt="hello world",
+            startup_cmd="echo hi",
+        )
+        order: list[str] = []
+
+        async def capture_startup(command: str) -> None:
+            assert command == "echo hi"
+            order.append("startup")
+            app._pending_messages.append(
+                QueuedMessage(text="typed during startup", mode="normal")
+            )
+            await app._cleanup_shell_task()
+
+        async def capture_initial_submission() -> None:  # noqa: RUF029
+            order.append("initial")
+            app._agent_running = True
+
+        queue_mock = AsyncMock()
+        app._run_startup_command = capture_startup  # type: ignore[assignment]
+        app._submit_initial_submission = (  # type: ignore[assignment]
+            capture_initial_submission
+        )
+        app._process_next_from_queue = queue_mock  # type: ignore[assignment]
+
+        await app._run_session_start_sequence()
+
+        assert order == ["startup", "initial"]
+        queue_mock.assert_not_awaited()
+        assert len(app._pending_messages) == 1
+        assert app._pending_messages[0].text == "typed during startup"
+        assert app._startup_sequence_running is False
+
+    async def test_cleanup_shell_task_defers_queue_during_startup(self) -> None:
+        """`_cleanup_shell_task` must not drain the queue while sequencing."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        app._startup_sequence_running = True
+        app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
+        drain_mock = AsyncMock()
+        queue_mock = AsyncMock()
+        app._process_next_from_queue = queue_mock  # type: ignore[assignment]
+        app._maybe_drain_deferred = drain_mock  # type: ignore[assignment]
+
+        await app._cleanup_shell_task()
+
+        queue_mock.assert_not_awaited()
+        assert app._shell_running is False
+
+    async def test_cleanup_agent_task_defers_queue_during_startup(self) -> None:
+        """`_cleanup_agent_task` must not drain the queue while sequencing."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        app._startup_sequence_running = True
+        app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
+        drain_mock = AsyncMock()
+        queue_mock = AsyncMock()
+        spinner_mock = AsyncMock()
+        app._process_next_from_queue = queue_mock  # type: ignore[assignment]
+        app._maybe_drain_deferred = drain_mock  # type: ignore[assignment]
+        app._set_spinner = spinner_mock  # type: ignore[assignment]
+
+        await app._cleanup_agent_task()
+
+        queue_mock.assert_not_awaited()
+        assert app._agent_running is False
+
+    def test_empty_startup_cmd_is_normalized_to_none(self) -> None:
+        """Empty or whitespace-only `--startup-cmd` should be treated as unset."""
+        for raw in ("", "   ", "\t\n"):
+            app = DeepAgentsApp(
+                agent=MagicMock(), thread_id="thread-123", startup_cmd=raw
+            )
+            assert app._startup_cmd is None, f"Expected {raw!r} to normalize to None"
+
+    async def test_startup_cmd_cleared_after_execution(self) -> None:
+        """`_startup_cmd` should be cleared before the command runs (one-shot)."""
+        app = DeepAgentsApp(
+            agent=MagicMock(), thread_id="thread-123", startup_cmd="echo hi"
+        )
+        observed_cmd: list[str] = []
+        observed_attr_during_run: list[str | None] = []
+
+        async def capture_startup(command: str) -> None:  # noqa: RUF029
+            observed_cmd.append(command)
+            observed_attr_during_run.append(app._startup_cmd)
+
+        async def stub_history(  # noqa: RUF029
+            *,
+            thread_id: str | None = None,
+            preloaded_payload: object | None = None,
+        ) -> None:
+            del thread_id, preloaded_payload
+
+        app._run_startup_command = capture_startup  # type: ignore[assignment]
+        app._load_thread_history = stub_history  # type: ignore[assignment]
+
+        await app._run_session_start_sequence()
+
+        assert observed_cmd == ["echo hi"]
+        assert observed_attr_during_run == [None]
+        assert app._startup_cmd is None
 
 
 class TestAppCSSValidation:

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -71,6 +71,39 @@ class TestInitialSkillArg:
         assert args.initial_prompt == "review this patch"
 
 
+class TestStartupCmdArg:
+    """Tests for `--startup-cmd` pre-prompt shell command argument."""
+
+    def test_flag_sets_startup_cmd(self) -> None:
+        """Verify `--startup-cmd` stores the requested command."""
+        with patch.object(sys, "argv", ["deepagents", "--startup-cmd", "git status"]):
+            args = parse_args()
+        assert args.startup_cmd == "git status"
+
+    def test_no_flag(self) -> None:
+        """Verify `startup_cmd` defaults to `None`."""
+        with patch.object(sys, "argv", ["deepagents"]):
+            args = parse_args()
+        assert args.startup_cmd is None
+
+    def test_with_non_interactive(self) -> None:
+        """Verify `--startup-cmd` works alongside `-n`."""
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "deepagents",
+                "--startup-cmd",
+                "echo hi",
+                "-n",
+                "do the thing",
+            ],
+        ):
+            args = parse_args()
+        assert args.startup_cmd == "echo hi"
+        assert args.non_interactive_message == "do the thing"
+
+
 class TestResumeArg:
     """Tests for -r/--resume thread resume argument."""
 

--- a/libs/cli/tests/unit_tests/test_non_interactive.py
+++ b/libs/cli/tests/unit_tests/test_non_interactive.py
@@ -1,10 +1,11 @@
 """Tests for non-interactive mode HITL decision logic."""
 
 import io
+import signal
 import sys
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from langchain_core.messages import AIMessage
@@ -24,6 +25,7 @@ from deepagents_cli.non_interactive import (
     _collect_action_request_warnings,
     _make_hitl_decision,
     _run_agent_loop,
+    _run_startup_command,
     _start_langsmith_thread_url_lookup,
     run_non_interactive,
 )
@@ -1380,6 +1382,181 @@ class TestMaxTurns:
             result = await run_non_interactive(message="task", max_turns=1)
 
         assert result == 124
+
+
+class TestRunStartupCommand:
+    """Tests for `_run_startup_command` (`--startup-cmd`)."""
+
+    async def test_successful_command_prints_stdout(self) -> None:
+        """Exit 0 with stdout — output should be routed through the console."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        await _run_startup_command("echo hello-startup", console, quiet=False)
+
+        output = buf.getvalue()
+        assert "Running startup command: echo hello-startup" in output
+        assert "hello-startup" in output
+        assert "Warning" not in output
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="`false` is POSIX-only")
+    async def test_non_zero_exit_warns_but_does_not_raise(self) -> None:
+        """Non-zero exit emits a yellow warning and keeps the session alive."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        # `false` is guaranteed to exit 1 on POSIX.
+        await _run_startup_command("false", console, quiet=False)
+
+        output = buf.getvalue()
+        assert "Warning" in output
+        assert "exited with code 1" in output
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell redirection")
+    async def test_stderr_routed_through_console(self) -> None:
+        """Commands that write to stderr should render under the dim stream."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        await _run_startup_command("sh -c 'echo oops 1>&2'", console, quiet=False)
+
+        output = buf.getvalue()
+        assert "oops" in output
+
+    async def test_stdout_with_brackets_does_not_raise(self) -> None:
+        """Shell output with `[...]` must not be parsed as Rich markup."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        # Unbalanced/unknown markup would raise `MarkupError` if parsed.
+        await _run_startup_command(
+            "printf '[INFO] starting [1/3]\\n'", console, quiet=False
+        )
+
+        output = buf.getvalue()
+        assert "[INFO] starting [1/3]" in output
+        assert "Warning" not in output
+
+    async def test_quiet_mode_suppresses_header(self) -> None:
+        """In quiet mode, the "Running" header should not appear."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        await _run_startup_command("echo hi", console, quiet=True)
+
+        output = buf.getvalue()
+        assert "Running startup command" not in output
+        assert "hi" in output
+
+    async def test_launch_failure_warns(self) -> None:
+        """Unlaunchable commands warn instead of crashing."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        with patch(
+            "asyncio.create_subprocess_shell",
+            side_effect=OSError("boom"),
+        ):
+            await _run_startup_command("whatever", console, quiet=False)
+
+        output = buf.getvalue()
+        assert "Warning" in output
+        assert "failed to launch" in output
+
+    async def test_timeout_kills_process_group_on_posix(self) -> None:
+        """Timeouts should terminate the whole POSIX process group."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError())
+        mock_proc.wait = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        mock_proc.kill = MagicMock()
+
+        with (
+            patch("asyncio.create_subprocess_shell", return_value=mock_proc),
+            patch.object(sys, "platform", "darwin"),
+            patch("os.getpgid", return_value=12345),
+            patch("os.killpg") as mock_killpg,
+        ):
+            await _run_startup_command("sleep 999", console, quiet=False)
+
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
+        mock_proc.kill.assert_not_called()
+        assert "timed out" in buf.getvalue()
+
+    async def test_timeout_escalates_to_sigkill_when_sigterm_ignored(self) -> None:
+        """If SIGTERM + 5s wait also times out, SIGKILL must follow."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        # First `communicate` raises TimeoutError (hit 60s limit).
+        # First `wait` raises TimeoutError (hit 5s post-SIGTERM grace).
+        # Second `wait` returns normally (post-SIGKILL reap).
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError())
+        mock_proc.wait = AsyncMock(side_effect=[TimeoutError(), None])
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        mock_proc.kill = MagicMock()
+
+        with (
+            patch("asyncio.create_subprocess_shell", return_value=mock_proc),
+            patch.object(sys, "platform", "darwin"),
+            patch("os.getpgid", return_value=12345),
+            patch("os.killpg") as mock_killpg,
+        ):
+            await _run_startup_command("sleep 999", console, quiet=False)
+
+        assert mock_killpg.call_args_list == [
+            call(12345, signal.SIGTERM),
+            call(12345, signal.SIGKILL),
+        ]
+        mock_proc.kill.assert_not_called()
+        assert "timed out" in buf.getvalue()
+
+    async def test_timeout_uses_proc_kill_on_windows(self) -> None:
+        """Windows has no process groups; fall back to `proc.kill()`."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError())
+        mock_proc.wait = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        mock_proc.kill = MagicMock()
+
+        with (
+            patch("asyncio.create_subprocess_shell", return_value=mock_proc),
+            patch.object(sys, "platform", "win32"),
+            patch("os.killpg") as mock_killpg,
+        ):
+            await _run_startup_command("sleep 999", console, quiet=False)
+
+        mock_proc.kill.assert_called_once()
+        mock_killpg.assert_not_called()
+        assert "timed out" in buf.getvalue()
+
+    async def test_empty_command_is_not_executed(self) -> None:
+        """Whitespace-only `--startup-cmd` should be treated as unset."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        with patch(
+            "asyncio.create_subprocess_shell",
+            new=AsyncMock(),
+        ) as mock_spawn:
+            # `run_non_interactive` strips and skips when empty; replicate
+            # that contract here by not calling through when stripped empty.
+            command = "   "
+            if command.strip():
+                await _run_startup_command(command.strip(), console, quiet=False)
+
+        mock_spawn.assert_not_called()
+        assert buf.getvalue() == ""
 
 
 async def _async_iter(items: list[object]) -> AsyncIterator[object]:  # noqa: RUF029

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -306,6 +306,10 @@ class TestBuildWelcomeFooter:
         assert "Tip: " in plain
         assert any(tip in plain for tip in _TIPS)
 
+    def test_startup_cmd_tip_registered(self) -> None:
+        """New `--startup-cmd` flag must have a discoverability tip."""
+        assert any("--startup-cmd" in tip for tip in _TIPS)
+
     def test_tip_varies_across_calls(self) -> None:
         """Tips should rotate (not always the same)."""
         seen = {build_welcome_footer().plain for _ in range(50)}


### PR DESCRIPTION
Add a `--startup-cmd` flag that runs a shell command once before the first prompt. Useful for priming context — `git status`, environment checks, `ls` — without pasting it as the first message. Works in both interactive (Textual) and `-n` non-interactive modes.