### PR TITLE
style(cli): strip trailing annotations from `ask_user` questions

### DIFF
--- a/libs/cli/deepagents_cli/ask_user.py
+++ b/libs/cli/deepagents_cli/ask_user.py
@@ -34,7 +34,7 @@ Each question can be either:
 
 For multiple choice questions, provide a list of choices. The user can pick one or type a custom answer via the "Other" option.
 
-By default all questions are required. Set "required" to false for optional questions that the user can skip.
+By default all questions are required. Set "required" to false for optional questions that the user can skip. Do not include "(required)", "(optional)", "- optional", or similar annotations in the question text — the UI renders that separately based on the "required" field.
 
 Use this tool when:
 - You need clarification on ambiguous requirements

--- a/libs/cli/deepagents_cli/widgets/ask_user.py
+++ b/libs/cli/deepagents_cli/widgets/ask_user.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from textual.binding import Binding, BindingType
@@ -31,6 +32,27 @@ from deepagents_cli.config import (
 
 OTHER_CHOICE_LABEL = "Other (type your answer)"
 logger = logging.getLogger(__name__)
+
+_TRAILING_ANNOTATION_RE = re.compile(
+    # \u2013 = en-dash, \u2014 = em-dash.
+    r"""
+    \s*
+    (?:
+        [-\u2013\u2014]\s*(?:optional|required)
+      | \((?:optional|required)[.!?]?\)
+      | \[(?:optional|required)[.!?]?\]
+    )
+    [.!?]*
+    \s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+"""Strip LLM-appended trailing annotations like ' - optional', ' (optional)',
+or ' [required]' from question text before rendering.
+
+Defense-in-depth alongside the instruction in `ASK_USER_TOOL_DESCRIPTION`
+(`ask_user.py`). The UI already renders a `*(required)*` marker based on the
+`required` field, so any LLM-authored duplicate is redundant noise."""
 
 
 class AskUserMenu(Container):
@@ -271,7 +293,7 @@ class _QuestionWidget(Vertical):
         self._is_other_selected: bool = False
 
     def compose(self) -> ComposeResult:
-        q_text = self._question.get("question", "")
+        q_text = _TRAILING_ANNOTATION_RE.sub("", self._question.get("question", ""))
         num = self._index + 1
         suffix = " *(required)*" if self._required else ""
         # q_text is agent-authored; rendered as markdown intentionally so

--- a/libs/cli/tests/unit_tests/test_ask_user.py
+++ b/libs/cli/tests/unit_tests/test_ask_user.py
@@ -9,7 +9,11 @@ from textual.app import App, ComposeResult
 from textual.widgets import Input, Markdown, Static
 
 from deepagents_cli.tool_display import format_tool_display
-from deepagents_cli.widgets.ask_user import AskUserMenu, _QuestionWidget
+from deepagents_cli.widgets.ask_user import (
+    _TRAILING_ANNOTATION_RE,
+    AskUserMenu,
+    _QuestionWidget,
+)
 
 if TYPE_CHECKING:
     from deepagents_cli._ask_user_types import AskUserWidgetResult, Question
@@ -64,6 +68,58 @@ class TestAskUserToolDisplay:
     def test_format_no_questions_key(self) -> None:
         result = format_tool_display("ask_user", {})
         assert "ask_user" in result
+
+
+class TestTrailingAnnotationRegex:
+    """Strips LLM-appended '(optional)'/'- required' annotations from question text."""
+
+    def test_strips_dash_optional(self) -> None:
+        assert _TRAILING_ANNOTATION_RE.sub("", "Your name? - optional") == "Your name?"
+
+    def test_strips_parens_optional(self) -> None:
+        assert _TRAILING_ANNOTATION_RE.sub("", "Your name? (optional)") == "Your name?"
+
+    def test_strips_brackets_required(self) -> None:
+        assert _TRAILING_ANNOTATION_RE.sub("", "Pick one [required]") == "Pick one"
+
+    def test_strips_em_dash(self) -> None:
+        text = "Your name? \u2014 optional"
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == "Your name?"
+
+    def test_strips_en_dash(self) -> None:
+        text = "Your name? \u2013 optional"
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == "Your name?"
+
+    def test_strips_parens_required(self) -> None:
+        assert _TRAILING_ANNOTATION_RE.sub("", "Pick one (required)") == "Pick one"
+
+    def test_strips_dash_required(self) -> None:
+        assert _TRAILING_ANNOTATION_RE.sub("", "Pick one - required") == "Pick one"
+
+    def test_strips_with_trailing_whitespace(self) -> None:
+        text = "Your name? (optional)   "
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == "Your name?"
+
+    def test_strips_with_trailing_newline(self) -> None:
+        text = "Your name? (optional)\n"
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == "Your name?"
+
+    def test_strips_with_trailing_punctuation(self) -> None:
+        text = "Your name? \u2014 Optional."
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == "Your name?"
+        assert _TRAILING_ANNOTATION_RE.sub("", "Pick one (OPTIONAL!)") == "Pick one"
+
+    def test_case_insensitive(self) -> None:
+        assert _TRAILING_ANNOTATION_RE.sub("", "Your name? (Optional)") == "Your name?"
+
+    def test_preserves_trailing_word_optional_without_delimiter(self) -> None:
+        """Bare trailing 'optional' with no delimiter is not an annotation."""
+        text = "Which field is optional"
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == text
+
+    def test_leaves_question_without_annotation(self) -> None:
+        text = "What is your name?"
+        assert _TRAILING_ANNOTATION_RE.sub("", text) == text
 
 
 class TestAskUserMenu:


### PR DESCRIPTION
Stop LLM-authored `(optional)` / `- optional` annotations from duplicating the UI's own required/optional marker in `ask_user` questions. The widget already renders `*(required)*` from the `required` field, so any model-appended tag is redundant noise.