### PR TITLE
test(sdk): prevent langsmith tracing from exhausting fake-chat-model iterators

### DIFF
--- a/libs/deepagents/tests/unit_tests/chat_model.py
+++ b/libs/deepagents/tests/unit_tests/chat_model.py
@@ -13,6 +13,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
+from pydantic import Field
 from typing_extensions import override
 
 
@@ -27,12 +28,15 @@ class GenericFakeChatModel(BaseChatModel):
 
     Args:
         messages: An iterator over messages (use `iter()` to convert a list)
-        stream_delimiter: How to chunk content when streaming. Options:
+        stream_delimiter: How to chunk content when streaming.
+
+            Options:
+
             - None (default): Return content in a single chunk (no streaming)
             - A string delimiter (e.g., " "): Split content on this delimiter,
-              preserving the delimiter as separate chunks
+                preserving the delimiter as separate chunks
             - A regex pattern (e.g., r"(\\s)"): Split using the pattern with a capture
-              group to preserve delimiters
+                group to preserve delimiters
 
     Examples:
         # No streaming - single chunk
@@ -59,7 +63,7 @@ class GenericFakeChatModel(BaseChatModel):
         print(model.call_history[0]["kwargs"])
     """
 
-    messages: Iterator[AIMessage | str]
+    messages: Iterator[AIMessage | str] = Field(exclude=True)
     """Get an iterator over messages.
 
     This can be expanded to accept other types like Callables / dicts / strings
@@ -67,6 +71,10 @@ class GenericFakeChatModel(BaseChatModel):
 
     !!! note
         if you want to pass a list, you can use `iter` to convert it to an iterator.
+
+    Excluded from pydantic serialization so that callers which dump this model
+    (e.g. LangSmith tracing with `mode="json"`) do not consume the iterator
+    before `_generate` pulls from it.
     """
 
     call_history: list[Any] = []  # noqa: RUF012  # Test-only model class

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -3,7 +3,7 @@
 import base64
 import json
 import warnings
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterator, Sequence
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -19,6 +19,7 @@ from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool, tool
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.store.memory import InMemoryStore
+from pydantic import Field
 
 from deepagents.backends import CompositeBackend, FilesystemBackend
 from deepagents.backends.protocol import BackendProtocol, ExecuteResponse, SandboxBackendProtocol
@@ -91,6 +92,15 @@ def prepopulate_file(backend: BackendProtocol, file_path: str, content: str) -> 
 
 class FixedGenericFakeChatModel(GenericFakeChatModel):
     """Fixed version of GenericFakeChatModel that properly handles bind_tools."""
+
+    messages: Iterator[AIMessage | str] = Field(exclude=True)
+    """Override parent field to exclude from pydantic serialization.
+
+    Without this, LangSmith tracing (which dumps the model via
+    `model_dump(mode="json")`) consumes the iterator before `_generate`
+    pulls from it, exhausting the iterator and raising `StopIteration` on
+    the first real model call.
+    """
 
     def bind_tools(
         self,


### PR DESCRIPTION
Fix test fake chat models getting their `messages` iterator exhausted by LangSmith run serialization. With `LANGSMITH_TRACING=true`, every middleware-wrapped run calls `pydantic.model_dump(mode="json")` on the chat model, which walks the `Iterator[AIMessage | str]` field and consumes it — causing `StopIteration` → `RuntimeError: generator raised StopIteration` in ~150 tests.