### PR TITLE
feat(sdk): surface subagents as typed child streams on `stream_v2`

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -1,5 +1,6 @@
 """Deep Agents package."""
 
+from deepagents._subagent_transformer import SubagentRunStream, SubagentTransformer
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
@@ -17,6 +18,8 @@ __all__ = [
     "MemoryMiddleware",
     "SubAgent",
     "SubAgentMiddleware",
+    "SubagentRunStream",
+    "SubagentTransformer",
     "__version__",
     "create_deep_agent",
 ]

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -1,6 +1,10 @@
 """Deep Agents package."""
 
-from deepagents._subagent_transformer import SubagentRunStream, SubagentTransformer
+from deepagents._subagent_transformer import (
+    AsyncSubagentRunStream,
+    SubagentRunStream,
+    SubagentTransformer,
+)
 from deepagents._version import __version__
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
@@ -12,6 +16,7 @@ from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgent
 __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
+    "AsyncSubagentRunStream",
     "CompiledSubAgent",
     "FilesystemMiddleware",
     "FilesystemPermission",

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -1,12 +1,63 @@
-"""Project subagent runs as first-class child streams on a parent run.
+"""Project subagent runs as first-class child streams on a parent run,
+and synthesize wire-visible events for `task`-tool-invoked subagents.
 
-`SubagentTransformer` is a thin overlay on top of `SubgraphTransformer`
-— it does *not* run a second discovery or a second mini-mux pipeline.
-When `SubgraphTransformer` fires a `started` event and creates a
-`SubgraphRunStream` at some namespace, `SubagentTransformer` checks
-that event's `graph_name` against the set of declared subagent
-names; on a match, it wraps the existing `SubgraphRunStream` in a
-`SubagentRunStream` and pushes that onto `run.subagents`.
+`SubagentTransformer` does two jobs:
+
+1. **In-process projection** — a thin overlay on top of
+   `SubgraphTransformer`. It does *not* run a second discovery or a
+   second mini-mux pipeline. When `SubgraphTransformer` fires a
+   `started` event and creates a `SubgraphRunStream` at some
+   namespace, `SubagentTransformer` checks that event's `graph_name`
+   against the set of declared subagent names; on a match, it wraps
+   the existing `SubgraphRunStream` in a `SubagentRunStream` and
+   pushes that onto `run.subagents`.
+
+2. **Synthetic wire-event emission** — for subagents invoked via the
+   `task` tool, where `.ainvoke()` collects the subagent's final
+   state synchronously and *no* internal pregel events propagate up
+   to the parent mux. To keep those subagent runs visible on the
+   wire — so remote clients subscribing via
+   `/events?namespaces=[["tools:<tool_call_id>"]]` observe real
+   protocol events and the namespace-subscription contract stays
+   intact — this transformer fabricates a minimal but complete
+   lifecycle + messages + values sequence at a stable
+   `tools:<tool_call_id>` namespace. The `langgraph-api` layer stays
+   product-agnostic; all deepagents-specific correlation lives here.
+
+The synthesized event sequence on `tool-started`:
+
+    lifecycle.started    { graph_name: <subagent_type>,
+                           cause: { type: "toolCall",
+                                    tool_call_id: <tcid> } }
+    messages.message-start  { role: "human",
+                              message_id: "subagent:<tcid>:human" }
+    messages.content-block-start / -delta / -finish  (input.description)
+    messages.message-finish
+    values               { messages: [humanMsg] }
+
+And, on `tool-finished` / `tool-error`:
+
+    messages.message-start  { role: "ai",
+                              message_id: "subagent:<tcid>:ai" }
+    messages.content-block-start / -delta / -finish  (normalized output)
+    messages.message-finish
+    values                 { messages: [humanMsg, aiMsg] }
+    lifecycle.completed    (or lifecycle.failed on tool-error)
+
+Synthesized events are injected via `self._mux.push(...)`, which runs
+them through the full transformer pipeline — so `SubgraphTransformer`
+creates a real handle + child mini-mux for the synthetic namespace
+(enabling `handle.messages` / `handle.output` projections), and this
+transformer then promotes that handle to a `SubagentRunStream`.
+Clients subscribing via `/events?namespaces=[["tools:<tcid>"]]` see
+these events on the wire exactly like they would any other namespace.
+
+Trade-off: the synthetic sequence is a fabrication, not a recording
+of real subagent execution — there is no checkpoint timeline to time
+travel against for these messages. If/when deepagents migrates the
+`task` tool from `.ainvoke()` to real streaming, this synthesis can
+be retired in favor of genuine per-subagent events reaching the
+parent mux through the existing `SubgraphTransformer` path.
 
 Consequences of sharing the `SubgraphRunStream`'s mini-mux:
 
@@ -21,19 +72,12 @@ The `_native = True` flag means `run.subagents` auto-binds as a
 direct attribute. A subagent also shows up on `run.subgraphs` — that
 projection is a superset, surfacing every nested subgraph (subagent
 or otherwise) as an untyped handle.
-
-The discovery signal is the `started` lifecycle event's `graph_name`,
-not the namespace leaf segment. When the `task` tool invokes
-`subagent.ainvoke(...)` from inside a tool node, langgraph namespaces
-the child run as `("tools:<pregel_task_id>", ...)`, so the leaf is
-`tools:…`, not the subagent's declared name. `graph_name`, however,
-is populated by langgraph from the compiled subagent's `name`
-attribute — which `deepagents` sets via
-`create_agent(..., name=spec["name"])`.
 """
 
 from __future__ import annotations
 
+import time
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from langgraph.stream._event_log import EventLog
@@ -45,11 +89,27 @@ if TYPE_CHECKING:
     from langchain_protocol.protocol import (
         CheckpointRef,
         LifecycleCause,
-        LifecycleData,
     )
     from langgraph.stream._mux import StreamMux
     from langgraph.stream._types import ProtocolEvent
     from langgraph.stream.transformers import SubgraphStatus
+
+
+@dataclass
+class _SyntheticSubagentState:
+    """Per-`task`-tool-call synthesis bookkeeping.
+
+    `namespace` is the subagent's synthetic namespace
+    (`scope + ("tools:<tool_call_id>",)`). `messages` accumulates
+    the human + AI message pair that drive the synthetic `values`
+    snapshots emitted alongside lifecycle transitions. `completed`
+    flips True once the terminal `tool-finished` / `tool-error`
+    has been processed so stragglers are silently ignored.
+    """
+
+    namespace: tuple[str, ...]
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    completed: bool = False
 
 
 class SubagentRunStream(BaseRunStream):
@@ -146,11 +206,12 @@ class SubagentTransformer(StreamTransformer):
     machine — it consults `SubgraphTransformer._by_ns` on each
     `started` event and promotes matching handles.
 
-    `scope_exact = False` so the `started` event at the *child's*
-    namespace (ns = scope + 1 segment) reaches this transformer's
-    `process`. Events at deeper namespaces are ignored — we only
-    need the top-of-subagent lifecycle boundary; state inside the
-    subagent is handled by its mini-mux transformers.
+    `scope_exact = False` so this transformer sees root-scope `tools`
+    events (for synthetic emission) *and* the promoted subagent's
+    `lifecycle.started` at `scope + 1` namespace (for handle
+    promotion). Events at deeper namespaces flow through
+    `SubgraphTransformer` into the subagent's mini-mux where the
+    standard `messages` / `values` transformers build projections.
     """
 
     _native: ClassVar[bool] = True
@@ -168,26 +229,23 @@ class SubagentTransformer(StreamTransformer):
         self._log: EventLog[SubagentRunStream] = EventLog()
         self._by_ns: dict[tuple[str, ...], SubagentRunStream] = {}
         self._subgraph_transformer: SubgraphTransformer | None = None
-        # Pending `task` tool calls awaiting a matching `lifecycle.started`.
-        # Keyed by `tool_call_id`; value carries the originating input so
-        # downstream consumers (e.g. the SDK wrapper) can correlate richer
-        # metadata than `cause` alone conveys.
-        #
-        # Dict insertion order provides oldest-first pairing under
-        # parallel fan-out of the same `subagent_type`, which matches
-        # pregel's scheduling order for the corresponding subgraph
-        # spawns.
-        self._pending_tool_calls: dict[str, dict[str, str]] = {}
+        self._mux: StreamMux | None = None
+        # Synthesis bookkeeping, keyed by originating `tool_call_id`.
+        # Entries live from `tool-started` through the terminal
+        # `tool-finished` / `tool-error`; they're deleted once the
+        # terminal synthetic events have been emitted.
+        self._synthesized: dict[str, _SyntheticSubagentState] = {}
 
     def init(self) -> dict[str, Any]:
         return {"subagents": self._log}
 
     def _on_register(self, mux: StreamMux) -> None:
-        """Capture the sibling `SubgraphTransformer` we reuse handles from.
+        """Capture the sibling `SubgraphTransformer` and the enclosing mux.
 
         Raises at registration time if `SubgraphTransformer` isn't
         present — failing loudly here is better than silently yielding
-        zero subagent handles at runtime.
+        zero subagent handles at runtime. The mux reference is stored
+        for re-entrant `push(...)` calls from `_emit_synthetic_*`.
         """
         sub_t = mux.transformer_by_key("subgraphs")
         if not isinstance(sub_t, SubgraphTransformer):
@@ -199,52 +257,35 @@ class SubagentTransformer(StreamTransformer):
             )
             raise TypeError(msg)
         self._subgraph_transformer = sub_t
+        self._mux = mux
 
     def process(self, event: ProtocolEvent) -> bool:
         method = event["method"]
+        ns = tuple(event["params"]["namespace"])
 
-        # Observe `task` tool calls at this scope. Record the
-        # `tool_call_id` so a matching `lifecycle.started` below can
-        # carry a `cause: { type: "toolCall", toolCallId }` augmenting
-        # the lifecycle event before it reaches the wire.
-        if method == "tools":
-            self._track_task_tool_call(event)
+        # Root-scope `task` tool observations drive synthetic emission.
+        # The event is still kept on the wire (we return True) — only
+        # the synthesis is a side effect.
+        if method == "tools" and ns == self.scope:
+            self._handle_task_tool_event(event)
             return True
 
         if method != "lifecycle":
             return True
 
-        ns = tuple(event["params"]["namespace"])
-        depth = len(self.scope)
         # Direct children of this scope only — matches
         # SubgraphTransformer's own discovery depth.
+        depth = len(self.scope)
         if len(ns) != depth + 1 or ns[:-1] != self.scope:
             return True
 
-        data = cast("LifecycleData", event["params"]["data"])
+        data = cast("dict[str, Any]", event["params"]["data"])
         if data.get("event") != "started":
             return True
 
         graph_name = data.get("graph_name")
         if not isinstance(graph_name, str):
             return True
-
-        # Augment the lifecycle event with `cause` derived from the
-        # correlated `task` tool call, if any. This mutates the event
-        # dict in place; `StreamMux` passes the same reference through
-        # downstream transformers and onto the wire. Match on the
-        # `subagent_type` from the tool input (dict insertion order
-        # pairs oldest pending tool-call first, matching pregel
-        # scheduling order).
-        for tcid, info in self._pending_tool_calls.items():
-            if info["subagent_type"] == graph_name:
-                cast("dict[str, Any]", event["params"]["data"])["cause"] = {
-                    "type": "toolCall",
-                    "tool_call_id": tcid,
-                }
-                del self._pending_tool_calls[tcid]
-                break
-
         if graph_name not in self._names or ns in self._by_ns:
             return True
 
@@ -263,32 +304,392 @@ class SubagentTransformer(StreamTransformer):
         self._log.push(handle)
         return True
 
-    def _track_task_tool_call(self, event: ProtocolEvent) -> None:
-        """Record / discard pending `task` tool calls observed on `tools`.
+    # ─── Synthetic emission ───────────────────────────────────────────
 
-        Only `tool_name == "task"` events are tracked — other tool
-        calls don't spawn subagents and would pollute the pending map.
-        """
-        ns = tuple(event["params"]["namespace"])
-        # `tool-started` / `tool-finished` / `tool-error` fire at the
-        # parent namespace, which is exactly `self.scope` for the
-        # subagents we care about (direct children).
-        if ns != self.scope:
-            return
+    def _handle_task_tool_event(self, event: ProtocolEvent) -> None:
+        """Branch on the root-scope `task` tool phase to drive synthesis."""
         data = cast("dict[str, Any]", event["params"]["data"])
+        if data.get("tool_name") != "task":
+            return
         phase = data.get("event")
+        tcid = data.get("tool_call_id")
+        if not isinstance(tcid, str):
+            return
+
         if phase == "tool-started":
-            if data.get("tool_name") != "task":
-                return
-            tcid = data.get("tool_call_id")
             raw_input = data.get("input")
-            if not isinstance(tcid, str) or not isinstance(raw_input, dict):
-                return
-            self._pending_tool_calls[tcid] = {
-                "subagent_type": str(raw_input.get("subagent_type") or ""),
-                "description": str(raw_input.get("description") or ""),
-            }
-        elif phase in ("tool-finished", "tool-error"):
-            tcid = data.get("tool_call_id")
-            if isinstance(tcid, str):
-                self._pending_tool_calls.pop(tcid, None)
+            input_d: dict[str, Any] = (
+                raw_input if isinstance(raw_input, dict) else {}
+            )
+            subagent_type = str(input_d.get("subagent_type") or "")
+            description = str(input_d.get("description") or "")
+            self._emit_synthetic_start(tcid, subagent_type, description)
+        elif phase == "tool-finished":
+            self._emit_synthetic_finish(tcid, data.get("output"), is_error=False)
+        elif phase == "tool-error":
+            self._emit_synthetic_finish(tcid, data.get("message"), is_error=True)
+
+    def _emit_synthetic_start(
+        self,
+        tool_call_id: str,
+        subagent_type: str,
+        description: str,
+    ) -> None:
+        """Emit the full opening event sequence for a `task` tool call.
+
+        Order (each pushed via `self._mux.push`, which re-enters the
+        transformer pipeline):
+
+            1. `lifecycle.started` — creates the child mini-mux via
+               `SubgraphTransformer._on_started` and, because
+               `graph_name` is the declared subagent name, gets
+               promoted to a `SubagentRunStream` by this transformer
+               on re-entry.
+            2. `messages.message-start` (human) — opens a
+               `ChatModelStream` in the child mini-mux's
+               `MessagesTransformer`.
+            3. `messages.content-block-start / -delta / -finish` —
+               single text block carrying the prompt.
+            4. `messages.message-finish`.
+            5. `values` — snapshot with the one human message so
+               `handle.output` has meaningful shape during the
+               running phase.
+        """
+        if tool_call_id in self._synthesized:
+            return
+        synthetic_ns = (*self.scope, f"tools:{tool_call_id}")
+        human_id = f"subagent:{tool_call_id}:human"
+        human_msg: dict[str, Any] = {
+            "type": "human",
+            "content": description,
+            "id": human_id,
+        }
+        self._synthesized[tool_call_id] = _SyntheticSubagentState(
+            namespace=synthetic_ns,
+            messages=[human_msg],
+        )
+
+        self._push_event(
+            "lifecycle",
+            synthetic_ns,
+            {
+                "event": "started",
+                "graph_name": subagent_type,
+                "cause": {"type": "toolCall", "tool_call_id": tool_call_id},
+            },
+        )
+        self._emit_synthesized_message(
+            synthetic_ns,
+            role="human",
+            message_id=human_id,
+            content=description,
+        )
+        self._push_event(
+            "values",
+            synthetic_ns,
+            {"messages": [dict(msg) for msg in self._synthesized[tool_call_id].messages]},
+        )
+
+    def _emit_synthetic_finish(
+        self,
+        tool_call_id: str,
+        payload: Any,
+        *,
+        is_error: bool,
+    ) -> None:
+        """Emit the closing event sequence for a `task` tool call.
+
+        On success, appends an AI message derived from the tool's
+        `output` before emitting the terminal `lifecycle.completed`.
+        On error, skips the AI message and emits
+        `lifecycle.failed` with the error string.
+        """
+        state = self._synthesized.get(tool_call_id)
+        if state is None or state.completed:
+            return
+        state.completed = True
+        synthetic_ns = state.namespace
+
+        if not is_error:
+            ai_id = f"subagent:{tool_call_id}:ai"
+            ai_content = _normalize_output_content(payload)
+            state.messages.append(
+                {"type": "ai", "content": ai_content, "id": ai_id}
+            )
+            self._emit_synthesized_message(
+                synthetic_ns,
+                role="ai",
+                message_id=ai_id,
+                content=ai_content,
+            )
+            self._push_event(
+                "values",
+                synthetic_ns,
+                {"messages": [dict(msg) for msg in state.messages]},
+            )
+            self._push_event(
+                "lifecycle",
+                synthetic_ns,
+                {"event": "completed"},
+            )
+        else:
+            error_message = (
+                str(payload) if payload not in (None, "") else "subagent failed"
+            )
+            self._push_event(
+                "lifecycle",
+                synthetic_ns,
+                {"event": "failed", "error": error_message},
+            )
+        del self._synthesized[tool_call_id]
+
+    def _emit_synthesized_message(
+        self,
+        namespace: tuple[str, ...],
+        *,
+        role: str,
+        message_id: str,
+        content: Any,
+    ) -> None:
+        """Emit a single-message `messages.*` sequence at the given namespace.
+
+        Handles the two common content shapes: a plain string
+        (single-text-block output) and a list of protocol content
+        blocks (richer model output with reasoning / text mixed).
+        Non-text / non-reasoning blocks pass through as-is on the
+        content-block-* envelope.
+        """
+        self._push_messages_event(
+            namespace,
+            message_id,
+            {"event": "message-start", "role": role, "message_id": message_id},
+        )
+        if isinstance(content, str):
+            self._push_messages_event(
+                namespace,
+                message_id,
+                {
+                    "event": "content-block-start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            )
+            if content:
+                self._push_messages_event(
+                    namespace,
+                    message_id,
+                    {
+                        "event": "content-block-delta",
+                        "index": 0,
+                        "content_block": {"type": "text", "text": content},
+                    },
+                )
+            self._push_messages_event(
+                namespace,
+                message_id,
+                {
+                    "event": "content-block-finish",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": content},
+                },
+            )
+        elif isinstance(content, list):
+            for offset, raw_block in enumerate(content):
+                block = _normalize_finalized_content_block(raw_block)
+                if block is None:
+                    continue
+                index = (
+                    block["index"]
+                    if isinstance(block.get("index"), int)
+                    else offset
+                )
+                btype = block.get("type")
+                if btype == "text":
+                    start_block: dict[str, Any] = {"type": "text", "text": ""}
+                elif btype == "reasoning":
+                    start_block = {"type": "reasoning", "reasoning": ""}
+                else:
+                    start_block = block
+                self._push_messages_event(
+                    namespace,
+                    message_id,
+                    {
+                        "event": "content-block-start",
+                        "index": index,
+                        "content_block": start_block,
+                    },
+                )
+                if btype == "text" and block.get("text"):
+                    self._push_messages_event(
+                        namespace,
+                        message_id,
+                        {
+                            "event": "content-block-delta",
+                            "index": index,
+                            "content_block": {
+                                "type": "text",
+                                "text": block["text"],
+                            },
+                        },
+                    )
+                elif btype == "reasoning" and block.get("reasoning"):
+                    self._push_messages_event(
+                        namespace,
+                        message_id,
+                        {
+                            "event": "content-block-delta",
+                            "index": index,
+                            "content_block": {
+                                "type": "reasoning",
+                                "reasoning": block["reasoning"],
+                            },
+                        },
+                    )
+                self._push_messages_event(
+                    namespace,
+                    message_id,
+                    {
+                        "event": "content-block-finish",
+                        "index": index,
+                        "content_block": block,
+                    },
+                )
+        self._push_messages_event(
+            namespace,
+            message_id,
+            {"event": "message-finish"},
+        )
+
+    def _push_event(
+        self,
+        method: str,
+        namespace: tuple[str, ...],
+        data: Any,
+    ) -> None:
+        """Wrap `data` in a ProtocolEvent envelope and re-enter the mux.
+
+        Seq is assigned by `StreamMux.push` at append time; re-entrant
+        dispatch during our own `process(...)` is an explicitly
+        supported flow (see the note in `StreamMux.push`).
+        """
+        assert self._mux is not None, (
+            "SubagentTransformer emitted before _on_register; "
+            "transformer registration ordering is broken."
+        )
+        event: ProtocolEvent = {
+            "type": "event",
+            "method": method,
+            "params": {
+                "namespace": list(namespace),
+                "timestamp": int(time.time() * 1000),
+                "data": data,
+            },
+        }
+        self._mux.push(event)
+
+    def _push_messages_event(
+        self,
+        namespace: tuple[str, ...],
+        message_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """Push a synthetic `messages.*` event in the internal tuple shape.
+
+        The core `MessagesTransformer` unpacks ``params["data"]`` as
+        ``(payload, metadata)`` (see
+        :class:`langgraph.stream.transformers.MessagesTransformer`), so
+        synthetic messages events must use the same wire-internal
+        shape. ``run_id`` is set to ``message_id`` so the transformer
+        correlates ``message-start`` through ``message-finish`` on a
+        single :class:`~langchain_core.language_models.chat_model_stream.ChatModelStream`.
+        The ``langgraph_node`` field is stubbed as the subagent's
+        namespace suffix so the resulting projection has a sensible
+        ``node`` attribute.
+        """
+        node_name = namespace[-1] if namespace else None
+        metadata: dict[str, Any] = {
+            "run_id": message_id,
+            "langgraph_node": node_name,
+        }
+        self._push_event("messages", namespace, (payload, metadata))
+
+
+def _normalize_output_content(value: Any) -> Any:
+    """Coerce a tool's `output` payload into `messages.*`-compatible content.
+
+    The `task` tool returns a pregel ``Command`` value when its
+    subagent completes. Stream-side, that surfaces on
+    `tool-finished` as
+    ``{"graph": None, "update": {"messages": [<tool msg>, ...]},
+    "resume": None, "goto": [...]}``. The synthesized AI message's
+    content is extracted from the *last* message in
+    ``update.messages`` — that's the tool-role reply carrying the
+    subagent's final text. Other shapes fall back as follows:
+
+    - `None` → empty string (renders as an empty AI message).
+    - `str` → itself (single text block).
+    - `list` → passed through for per-block handling in
+      `_emit_synthesized_message`.
+    - `dict` with an ``update.messages`` list → recurse into the
+      last message's ``content`` (Command-shaped tool output).
+    - `dict` with a ``content`` key → recurse into ``content``
+      (BaseMessage-like / artifact-like shapes).
+    - Anything else → `str(value)` (defensive; keeps the wire
+      string-typed).
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (str, list)):
+        return value
+    if isinstance(value, dict):
+        update = value.get("update")
+        if isinstance(update, dict):
+            messages = update.get("messages")
+            if isinstance(messages, list) and messages:
+                last = messages[-1]
+                if isinstance(last, dict):
+                    return _normalize_output_content(last)
+        content = value.get("content")
+        if content is not None:
+            return _normalize_output_content(content)
+        return str(value)
+    return str(value)
+
+
+def _normalize_finalized_content_block(block: Any) -> dict[str, Any] | None:
+    """Coerce a raw content block into a canonical protocol shape.
+
+    - `str` → `{type: "text", text: <str>}`.
+    - `dict` with `type`:
+        - `"text"` → `{type, text}` (optionally preserving `id` / `index`).
+        - `"reasoning"` → `{type, reasoning}` (ditto).
+        - any other `type` → passed through as-is (image / file / tool
+          blocks travel whole; no partial synthesis for them).
+    - Anything else → `None` (skipped — keeps bad inputs off the wire).
+    """
+    if isinstance(block, str):
+        return {"type": "text", "text": block}
+    if not isinstance(block, dict):
+        return None
+    btype = block.get("type")
+    if btype == "text":
+        normalized: dict[str, Any] = {
+            "type": "text",
+            "text": str(block.get("text", "")),
+        }
+        if "id" in block:
+            normalized["id"] = block["id"]
+        if isinstance(block.get("index"), int):
+            normalized["index"] = block["index"]
+        return normalized
+    if btype == "reasoning":
+        normalized = {
+            "type": "reasoning",
+            "reasoning": str(block.get("reasoning", "")),
+        }
+        if "id" in block:
+            normalized["id"] = block["id"]
+        if isinstance(block.get("index"), int):
+            normalized["index"] = block["index"]
+        return normalized
+    return block

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -307,16 +307,25 @@ class SubagentTransformer(StreamTransformer):
     # ─── Synthetic emission ───────────────────────────────────────────
 
     def _handle_task_tool_event(self, event: ProtocolEvent) -> None:
-        """Branch on the root-scope `task` tool phase to drive synthesis."""
+        """Branch on the root-scope `task` tool phase to drive synthesis.
+
+        ``tool_name`` is only present on ``tool-started`` in the protocol
+        (``tool-finished`` / ``tool-error`` omit it). We latch onto the
+        ``task`` filter at start and then drive terminal synthesis purely
+        from membership in ``self._synthesized`` — which is keyed by
+        ``tool_call_id`` and only populated when a ``task`` tool-started
+        has previously been observed. Non-``task`` tool calls never enter
+        the map, so their terminal events naturally no-op.
+        """
         data = cast("dict[str, Any]", event["params"]["data"])
-        if data.get("tool_name") != "task":
-            return
         phase = data.get("event")
         tcid = data.get("tool_call_id")
         if not isinstance(tcid, str):
             return
 
         if phase == "tool-started":
+            if data.get("tool_name") != "task":
+                return
             raw_input = data.get("input")
             input_d: dict[str, Any] = (
                 raw_input if isinstance(raw_input, dict) else {}
@@ -325,8 +334,12 @@ class SubagentTransformer(StreamTransformer):
             description = str(input_d.get("description") or "")
             self._emit_synthetic_start(tcid, subagent_type, description)
         elif phase == "tool-finished":
+            if tcid not in self._synthesized:
+                return
             self._emit_synthetic_finish(tcid, data.get("output"), is_error=False)
         elif phase == "tool-error":
+            if tcid not in self._synthesized:
+                return
             self._emit_synthetic_finish(tcid, data.get("message"), is_error=True)
 
     def _emit_synthetic_start(

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -1,0 +1,221 @@
+"""Project subagent runs as first-class child streams on a parent run.
+
+`SubagentTransformer` is a thin overlay on top of `SubgraphTransformer`
+— it does *not* run a second discovery or a second mini-mux pipeline.
+When `SubgraphTransformer` fires a `started` event and creates a
+`SubgraphRunStream` at some namespace, `SubagentTransformer` checks
+that event's `graph_name` against the set of declared subagent
+names; on a match, it wraps the existing `SubgraphRunStream` in a
+`SubagentRunStream` and pushes that onto `run.subagents`.
+
+Consequences of sharing the `SubgraphRunStream`'s mini-mux:
+
+- Events under the subagent's namespace are dispatched *once* (into
+  the shared mini-mux), not twice.
+- `path`, `status`, `error`, `checkpoint`, and `output` are read from
+  the wrapped handle — no separate tracking in this transformer.
+- `finalize` / `fail` are not needed: `SubgraphTransformer` owns
+  close/fail of the shared mini-mux.
+
+The `_native = True` flag means `run.subagents` auto-binds as a
+direct attribute. A subagent also shows up on `run.subgraphs` — that
+projection is a superset, surfacing every nested subgraph (subagent
+or otherwise) as an untyped handle.
+
+The discovery signal is the `started` lifecycle event's `graph_name`,
+not the namespace leaf segment. When the `task` tool invokes
+`subagent.ainvoke(...)` from inside a tool node, langgraph namespaces
+the child run as `("tools:<pregel_task_id>", ...)`, so the leaf is
+`tools:…`, not the subagent's declared name. `graph_name`, however,
+is populated by langgraph from the compiled subagent's `name`
+attribute — which `deepagents` sets via
+`create_agent(..., name=spec["name"])`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from langgraph.stream._event_log import EventLog
+from langgraph.stream._types import StreamTransformer
+from langgraph.stream.run_stream import BaseRunStream
+from langgraph.stream.transformers import SubgraphRunStream, SubgraphTransformer
+
+if TYPE_CHECKING:
+    from langchain_protocol.protocol import CheckpointRef, LifecycleData
+    from langgraph.stream._mux import StreamMux
+    from langgraph.stream._types import ProtocolEvent
+    from langgraph.stream.transformers import SubgraphStatus
+
+
+class SubagentRunStream(BaseRunStream):
+    """Typed view of a single subagent execution.
+
+    Wraps the `SubgraphRunStream` that `SubgraphTransformer` already
+    built for this child namespace — shares its mini-mux, so
+    projections (`.messages`, `.tool_calls`, `.middleware`,
+    recursive `.subagents`, `.values`) come from the existing
+    transformer pipeline without a second round of event dispatch.
+
+    Events are driven by the parent run's pump and routed into this
+    handle's mini-mux by `SubgraphTransformer` — a subagent does not
+    own its own pump. Construction therefore bypasses
+    `GraphRunStream.__init__` (which would wire a pump onto the
+    mini-mux, shadowing the parent's) and calls
+    `BaseRunStream.__init__` directly, seeding the pump-related
+    fields so inherited methods that consult them (`output`, `abort`,
+    `__exit__`) degrade to no-ops.
+
+    Exposes `name` (the declared subagent name) as the typed state
+    this layer adds. `path`, `status`, `error`, `checkpoint`,
+    `trigger_call_id` delegate to the wrapped subgraph handle so
+    subgraph-side state transitions — including terminal close
+    driven by `SubgraphTransformer.finalize` / `fail` — are
+    automatically visible here.
+    """
+
+    def __init__(self, subgraph: SubgraphRunStream, *, name: str) -> None:
+        # Skip `GraphRunStream.__init__` to avoid calling
+        # `mux.bind_pump` on the mini-mux — the parent's pump is
+        # already bound via `make_child` pump inheritance.
+        BaseRunStream.__init__(self, subgraph._mux)
+        # Seed pump-related fields so inherited `output` / `abort` /
+        # `__exit__` treat this stream as already-exhausted (no self
+        # pump to drive). `_values_transformer._latest` still provides
+        # the current snapshot because the parent's pump keeps it
+        # fresh.
+        self._graph_iter = None
+        self._exhausted = True
+        self._subgraph = subgraph
+        self.name: str = name
+
+    @property
+    def output(self) -> dict[str, Any] | None:
+        """Latest values snapshot from this subagent's mini-mux.
+
+        Unlike root `GraphRunStream.output`, no pump is driven — the
+        parent's pump keeps `_values_transformer._latest` fresh.
+        """
+        vt = self._values_transformer
+        err = vt.error
+        if err is not None:
+            raise err
+        return vt._latest
+
+    @property
+    def interrupted(self) -> bool:
+        """True once an interrupt has flowed through this subagent's pipeline."""
+        return self._values_transformer._interrupted
+
+    @property
+    def interrupts(self) -> list[Any]:
+        """List of interrupt payloads seen by this subagent."""
+        return list(self._values_transformer._interrupts)
+
+    @property
+    def path(self) -> tuple[str, ...]:
+        return self._subgraph.path
+
+    @property
+    def trigger_call_id(self) -> str | None:
+        return self._subgraph.trigger_call_id
+
+    @property
+    def status(self) -> SubgraphStatus:
+        return self._subgraph.status
+
+    @property
+    def error(self) -> str | None:
+        return self._subgraph.error
+
+    @property
+    def checkpoint(self) -> CheckpointRef | None:
+        return self._subgraph.checkpoint
+
+
+class SubagentTransformer(StreamTransformer):
+    """Promote declared subagents into typed handles on `run.subagents`.
+
+    Requires a `SubgraphTransformer` to be registered earlier in the
+    mux's factory list (it is, via `GraphStreamer.builtin_factories`).
+    This transformer does not own a mini-mux or a lifecycle state
+    machine — it consults `SubgraphTransformer._by_ns` on each
+    `started` event and promotes matching handles.
+
+    `scope_exact = False` so the `started` event at the *child's*
+    namespace (ns = scope + 1 segment) reaches this transformer's
+    `process`. Events at deeper namespaces are ignored — we only
+    need the top-of-subagent lifecycle boundary; state inside the
+    subagent is handled by its mini-mux transformers.
+    """
+
+    _native: ClassVar[bool] = True
+    scope_exact: ClassVar[bool] = False
+    required_stream_modes: ClassVar[tuple[str, ...]] = ("lifecycle",)
+
+    def __init__(
+        self,
+        scope: tuple[str, ...] = (),
+        *,
+        subagent_names: frozenset[str] = frozenset(),
+    ) -> None:
+        super().__init__(scope)
+        self._names = subagent_names
+        self._log: EventLog[SubagentRunStream] = EventLog()
+        self._by_ns: dict[tuple[str, ...], SubagentRunStream] = {}
+        self._subgraph_transformer: SubgraphTransformer | None = None
+
+    def init(self) -> dict[str, Any]:
+        return {"subagents": self._log}
+
+    def _on_register(self, mux: StreamMux) -> None:
+        """Capture the sibling `SubgraphTransformer` we reuse handles from.
+
+        Raises at registration time if `SubgraphTransformer` isn't
+        present — failing loudly here is better than silently yielding
+        zero subagent handles at runtime.
+        """
+        sub_t = mux.transformer_by_key("subgraphs")
+        if not isinstance(sub_t, SubgraphTransformer):
+            msg = (
+                "SubagentTransformer requires a SubgraphTransformer to be "
+                "registered earlier in the mux; none was found. Check that "
+                "your streamer's builtin_factories includes SubgraphTransformer "
+                "before SubagentTransformer."
+            )
+            raise TypeError(msg)
+        self._subgraph_transformer = sub_t
+
+    def process(self, event: ProtocolEvent) -> bool:
+        if event["method"] != "lifecycle":
+            return True
+
+        ns = tuple(event["params"]["namespace"])
+        depth = len(self.scope)
+        # Direct children of this scope only — matches
+        # SubgraphTransformer's own discovery depth.
+        if len(ns) != depth + 1 or ns[:-1] != self.scope:
+            return True
+
+        data = cast("LifecycleData", event["params"]["data"])
+        if data.get("event") != "started":
+            return True
+
+        graph_name = data.get("graph_name")
+        if graph_name not in self._names or ns in self._by_ns:
+            return True
+
+        # SubgraphTransformer runs before us (factory order), so its
+        # `_by_ns` already has the freshly-created handle for this
+        # namespace. Reuse it — no second mini-mux, no duplicate
+        # dispatch. `_on_register` guarantees `_subgraph_transformer`
+        # is set before any event reaches `process`.
+        sub_t = cast("SubgraphTransformer", self._subgraph_transformer)
+        subgraph_handle = sub_t._by_ns.get(ns)
+        if subgraph_handle is None:
+            return True
+
+        handle = SubagentRunStream(subgraph_handle, name=cast("str", graph_name))
+        self._by_ns[ns] = handle
+        self._log.push(handle)
+        return True

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -1,69 +1,45 @@
-"""Project subagent runs as first-class child streams on a parent run,
-and synthesize wire-visible events for `task`-tool-invoked subagents.
+"""Project subagent runs as first-class child streams on a parent run.
 
-`SubagentTransformer` does two jobs:
+`SubagentTransformer` performs three tightly-coupled jobs on events
+flowing through the stream mux:
 
-1. **In-process projection** — a thin overlay on top of
-   `SubgraphTransformer`. It does *not* run a second discovery or a
-   second mini-mux pipeline. When `SubgraphTransformer` fires a
-   `started` event and creates a `SubgraphRunStream` at some
-   namespace, `SubagentTransformer` checks that event's `graph_name`
-   against the set of declared subagent names; on a match, it wraps
-   the existing `SubgraphRunStream` in a `SubagentRunStream` and
-   pushes that onto `run.subagents`.
+1. **Tool-call tracking.** Root-scope ``tools`` events from the
+   parent's ``task`` tool calls are observed to build
+   ``_pending_tool_calls``, keyed by ``tool_call_id``. Entries live
+   from the originating ``tool-started`` until the subagent's
+   ``lifecycle.started`` is correlated or the task errors out.
 
-2. **Synthetic wire-event emission** — for subagents invoked via the
-   `task` tool, where `.ainvoke()` collects the subagent's final
-   state synchronously and *no* internal pregel events propagate up
-   to the parent mux. To keep those subagent runs visible on the
-   wire — so remote clients subscribing via
-   `/events?namespaces=[["tools:<tool_call_id>"]]` observe real
-   protocol events and the namespace-subscription contract stays
-   intact — this transformer fabricates a minimal but complete
-   lifecycle + messages + values sequence at a stable
-   `tools:<tool_call_id>` namespace. The `langgraph-api` layer stays
-   product-agnostic; all deepagents-specific correlation lives here.
+2. **Subagent handle promotion.** When a ``lifecycle.started`` fires
+   at one level below this transformer's scope, we consult the
+   sibling :class:`~langgraph.stream.transformers.SubgraphTransformer`'s
+   ``_by_ns`` (populated earlier in the same dispatch because the
+   subgraph transformer is registered first in the factory list).
+   If the emitted ``graph_name`` matches a declared subagent name, we
+   wrap the existing :class:`~langgraph.stream.transformers.SubgraphRunStream`
+   in a :class:`SubagentRunStream` so ``run.subagents`` surfaces a
+   typed handle with the standard projections
+   (``.messages`` / ``.values`` / ``.subagents`` / ``.tool_calls``).
 
-The synthesized event sequence on `tool-started`:
-
-    lifecycle.started    { graph_name: <subagent_type>,
-                           cause: { type: "toolCall",
-                                    tool_call_id: <tcid> } }
-    messages.message-start  { role: "human",
-                              message_id: "subagent:<tcid>:human" }
-    messages.content-block-start / -delta / -finish  (input.description)
-    messages.message-finish
-    values               { messages: [humanMsg] }
-
-And, on `tool-finished` / `tool-error`:
-
-    messages.message-start  { role: "ai",
-                              message_id: "subagent:<tcid>:ai" }
-    messages.content-block-start / -delta / -finish  (normalized output)
-    messages.message-finish
-    values                 { messages: [humanMsg, aiMsg] }
-    lifecycle.completed    (or lifecycle.failed on tool-error)
-
-Synthesized events are injected via `self._mux.push(...)`, which runs
-them through the full transformer pipeline — so `SubgraphTransformer`
-creates a real handle + child mini-mux for the synthetic namespace
-(enabling `handle.messages` / `handle.output` projections), and this
-transformer then promotes that handle to a `SubagentRunStream`.
-Clients subscribing via `/events?namespaces=[["tools:<tcid>"]]` see
-these events on the wire exactly like they would any other namespace.
-
-Trade-off: the synthetic sequence is a fabrication, not a recording
-of real subagent execution — there is no checkpoint timeline to time
-travel against for these messages. If/when deepagents migrates the
-`task` tool from `.ainvoke()` to real streaming, this synthesis can
-be retired in favor of genuine per-subagent events reaching the
-parent mux through the existing `SubgraphTransformer` path.
+3. **Wire-level namespace rewrite.** Pregel schedules each subagent
+   spawned via the ``task`` tool under a UUID-derived namespace like
+   ``tools:<pregel_uuid>``, whereas wire subscribers filter on the
+   client-visible ``tools:<tool_call_id>`` namespace. Rather than
+   mutating ``checkpoint_ns`` in the subagent's config (which would
+   interact with the Pregel scheduler and checkpoint layout) or
+   fabricating synthetic protocol events, the transformer records a
+   ``pregel_segment → tool_call_id`` mapping at the moment the first
+   lifecycle event correlates to a pending ``task`` tool call, then
+   rewrites the first segment of every downstream event's namespace
+   in-place before the mux appends it to the main log. The
+   SubgraphTransformer's ``_by_ns`` still keys off the pre-rewrite
+   namespace (matching Pregel's checkpoint layout); only the
+   wire-visible ``params.namespace`` is remapped.
 
 Consequences of sharing the `SubgraphRunStream`'s mini-mux:
 
 - Events under the subagent's namespace are dispatched *once* (into
   the shared mini-mux), not twice.
-- `path`, `status`, `error`, `checkpoint`, and `output` are read from
+- `path`, `status`, `error`, `checkpoint`, and `cause` are read from
   the wrapped handle — no separate tracking in this transformer.
 - `finalize` / `fail` are not needed: `SubgraphTransformer` owns
   close/fail of the shared mini-mux.
@@ -76,8 +52,6 @@ or otherwise) as an untyped handle.
 
 from __future__ import annotations
 
-import time
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from langgraph.stream._event_log import EventLog
@@ -89,27 +63,11 @@ if TYPE_CHECKING:
     from langchain_protocol.protocol import (
         CheckpointRef,
         LifecycleCause,
+        LifecycleData,
     )
     from langgraph.stream._mux import StreamMux
     from langgraph.stream._types import ProtocolEvent
     from langgraph.stream.transformers import SubgraphStatus
-
-
-@dataclass
-class _SyntheticSubagentState:
-    """Per-`task`-tool-call synthesis bookkeeping.
-
-    `namespace` is the subagent's synthetic namespace
-    (`scope + ("tools:<tool_call_id>",)`). `messages` accumulates
-    the human + AI message pair that drive the synthetic `values`
-    snapshots emitted alongside lifecycle transitions. `completed`
-    flips True once the terminal `tool-finished` / `tool-error`
-    has been processed so stragglers are silently ignored.
-    """
-
-    namespace: tuple[str, ...]
-    messages: list[dict[str, Any]] = field(default_factory=list)
-    completed: bool = False
 
 
 class SubagentRunStream(BaseRunStream):
@@ -207,11 +165,12 @@ class SubagentTransformer(StreamTransformer):
     `started` event and promotes matching handles.
 
     `scope_exact = False` so this transformer sees root-scope `tools`
-    events (for synthetic emission) *and* the promoted subagent's
+    events (for tool-call tracking) *and* the promoted subagent's
     `lifecycle.started` at `scope + 1` namespace (for handle
-    promotion). Events at deeper namespaces flow through
-    `SubgraphTransformer` into the subagent's mini-mux where the
-    standard `messages` / `values` transformers build projections.
+    promotion) *and* every deeper event (for namespace rewriting).
+    Events at deeper namespaces flow through `SubgraphTransformer`
+    into the subagent's mini-mux where the standard `messages` /
+    `values` transformers build projections.
     """
 
     _native: ClassVar[bool] = True
@@ -230,11 +189,22 @@ class SubagentTransformer(StreamTransformer):
         self._by_ns: dict[tuple[str, ...], SubagentRunStream] = {}
         self._subgraph_transformer: SubgraphTransformer | None = None
         self._mux: StreamMux | None = None
-        # Synthesis bookkeeping, keyed by originating `tool_call_id`.
-        # Entries live from `tool-started` through the terminal
-        # `tool-finished` / `tool-error`; they're deleted once the
-        # terminal synthetic events have been emitted.
-        self._synthesized: dict[str, _SyntheticSubagentState] = {}
+        # Pending `task` tool calls awaiting a matching `lifecycle.started`.
+        # Keyed by `tool_call_id`; value carries the originating input so
+        # downstream consumers can correlate richer metadata than `cause`
+        # alone conveys.
+        #
+        # Dict insertion order provides oldest-first pairing under
+        # parallel fan-out of the same `subagent_type`, which matches
+        # Pregel's scheduling order for the corresponding subgraph
+        # spawns.
+        self._pending_tool_calls: dict[str, dict[str, str]] = {}
+        # Wire-level namespace rewrite map: Pregel-assigned first
+        # segment (e.g. `"tools:<pregel_uuid>"`) → client-visible first
+        # segment (e.g. `"tools:<tool_call_id>"`). Populated when a
+        # `lifecycle.started` is correlated to a pending `task` tool
+        # call by `graph_name` / `subagent_type`.
+        self._ns_rewrite: dict[str, str] = {}
 
     def init(self) -> dict[str, Any]:
         return {"subagents": self._log}
@@ -244,8 +214,7 @@ class SubagentTransformer(StreamTransformer):
 
         Raises at registration time if `SubgraphTransformer` isn't
         present — failing loudly here is better than silently yielding
-        zero subagent handles at runtime. The mux reference is stored
-        for re-entrant `push(...)` calls from `_emit_synthetic_*`.
+        zero subagent handles at runtime.
         """
         sub_t = mux.transformer_by_key("subgraphs")
         if not isinstance(sub_t, SubgraphTransformer):
@@ -261,33 +230,116 @@ class SubagentTransformer(StreamTransformer):
 
     def process(self, event: ProtocolEvent) -> bool:
         method = event["method"]
-        ns = tuple(event["params"]["namespace"])
 
-        # Root-scope `task` tool observations drive synthetic emission.
-        # The event is still kept on the wire (we return True) — only
-        # the synthesis is a side effect.
-        if method == "tools" and ns == self.scope:
-            self._handle_task_tool_event(event)
+        # Root-scope `task` tool observations feed `_pending_tool_calls`
+        # for later correlation. The event passes through unmodified.
+        if method == "tools":
+            self._track_task_tool_call(event)
             return True
 
         if method != "lifecycle":
+            # Non-lifecycle events (values, messages, checkpoints,
+            # input, tools at non-root ns) only need the wire-level
+            # namespace rewrite applied.
+            self._rewrite_ns_in_place(event)
             return True
 
-        # Direct children of this scope only — matches
-        # SubgraphTransformer's own discovery depth.
+        ns = tuple(event["params"]["namespace"])
         depth = len(self.scope)
+
+        # Only depth + 1 lifecycle events are subagent-level; deeper
+        # ones (nested subgraph / model / tool nodes) just need the
+        # rewrite applied.
         if len(ns) != depth + 1 or ns[:-1] != self.scope:
+            self._rewrite_ns_in_place(event)
             return True
 
+        data = cast("LifecycleData", event["params"]["data"])
+        if data.get("event") == "started":
+            self._handle_started(ns, data)
+
+        # Rewrite the ns on the way out so downstream wire consumers
+        # see `tools:<tool_call_id>` even though internal state keys
+        # off `tools:<pregel_uuid>`.
+        self._rewrite_ns_in_place(event)
+        return True
+
+    # ─── Tool call tracking ───────────────────────────────────────────
+
+    def _track_task_tool_call(self, event: ProtocolEvent) -> None:
+        """Record / discard pending `task` tool calls observed on `tools`.
+
+        Only `tool_name == "task"` events are tracked — other tool
+        calls don't spawn subagents and would pollute the pending map.
+        """
+        ns = tuple(event["params"]["namespace"])
+        # `tool-started` / `tool-finished` / `tool-error` fire at the
+        # parent namespace, which is exactly `self.scope` for the
+        # subagents we care about (direct children).
+        if ns != self.scope:
+            return
         data = cast("dict[str, Any]", event["params"]["data"])
-        if data.get("event") != "started":
-            return True
+        phase = data.get("event")
+        if phase == "tool-started":
+            if data.get("tool_name") != "task":
+                return
+            tcid = data.get("tool_call_id")
+            raw_input = data.get("input")
+            if not isinstance(tcid, str) or not isinstance(raw_input, dict):
+                return
+            self._pending_tool_calls[tcid] = {
+                "subagent_type": str(raw_input.get("subagent_type") or ""),
+                "description": str(raw_input.get("description") or ""),
+            }
+        elif phase in ("tool-finished", "tool-error"):
+            tcid = data.get("tool_call_id")
+            if isinstance(tcid, str):
+                self._pending_tool_calls.pop(tcid, None)
 
+    # ─── Started correlation + handle promotion ───────────────────────
+
+    def _handle_started(
+        self, ns: tuple[str, ...], data: LifecycleData
+    ) -> None:
+        """Correlate a subagent's `lifecycle.started` with a pending tool call.
+
+        Three things happen here, in order:
+
+        1. If ``data`` has no pre-populated ``cause`` and we have a
+           pending ``task`` tool call whose ``subagent_type`` matches
+           ``graph_name``, pair them. Dict insertion order gives
+           oldest-first pairing under parallel fan-out, matching
+           Pregel's scheduling order.
+        2. If the pairing produces a ``tools:<tcid>`` that differs
+           from the pre-rewrite ``tools:<pregel_seg>``, record a
+           namespace rewrite entry so subsequent events under the
+           same Pregel segment surface on the wire at the
+           tool-call-id namespace.
+        3. If ``graph_name`` is a declared subagent and
+           :class:`SubgraphTransformer` has already created a handle
+           at ``ns``, wrap that handle in a :class:`SubagentRunStream`
+           and push it onto ``self._log``.
+        """
         graph_name = data.get("graph_name")
         if not isinstance(graph_name, str):
-            return True
+            return
+
+        if "cause" not in data:
+            for tcid, info in self._pending_tool_calls.items():
+                if info["subagent_type"] == graph_name:
+                    cast("dict[str, Any]", data)["cause"] = {
+                        "type": "toolCall",
+                        "tool_call_id": tcid,
+                    }
+                    pregel_seg = ns[-1]
+                    target_seg = f"tools:{tcid}"
+                    if pregel_seg != target_seg:
+                        self._ns_rewrite[pregel_seg] = target_seg
+                    del self._pending_tool_calls[tcid]
+                    break
+
         if graph_name not in self._names or ns in self._by_ns:
-            return True
+            return
 
         # SubgraphTransformer runs before us (factory order), so its
         # `_by_ns` already has the freshly-created handle for this
@@ -297,441 +349,38 @@ class SubagentTransformer(StreamTransformer):
         sub_t = cast("SubgraphTransformer", self._subgraph_transformer)
         subgraph_handle = sub_t._by_ns.get(ns)
         if subgraph_handle is None:
-            return True
+            return
+
+        # Propagate any cause we just augmented onto the SubgraphRunStream
+        # instance too — it was constructed from the `data` payload
+        # before we had a chance to pair a tool_call_id into it, so a
+        # fresh read-back would return `None` without this sync.
+        subgraph_cause = data.get("cause")
+        if subgraph_cause is not None and subgraph_handle.cause is None:
+            subgraph_handle.cause = subgraph_cause
 
         handle = SubagentRunStream(subgraph_handle, name=graph_name)
         self._by_ns[ns] = handle
         self._log.push(handle)
-        return True
 
-    # ─── Synthetic emission ───────────────────────────────────────────
+    # ─── Namespace rewriting ──────────────────────────────────────────
 
-    def _handle_task_tool_event(self, event: ProtocolEvent) -> None:
-        """Branch on the root-scope `task` tool phase to drive synthesis.
+    def _rewrite_ns_in_place(self, event: ProtocolEvent) -> None:
+        """Rewrite `event.params.namespace[0]` using `_ns_rewrite`.
 
-        ``tool_name`` is only present on ``tool-started`` in the protocol
-        (``tool-finished`` / ``tool-error`` omit it). We latch onto the
-        ``task`` filter at start and then drive terminal synthesis purely
-        from membership in ``self._synthesized`` — which is keyed by
-        ``tool_call_id`` and only populated when a ``task`` tool-started
-        has previously been observed. Non-``task`` tool calls never enter
-        the map, so their terminal events naturally no-op.
+        The namespace list is mutated in place so the mutation is
+        visible to any downstream transformer *and* to the event
+        that ultimately lands in the mux's main log. Only the first
+        segment is rewritten — deeper segments belong to child
+        subgraphs (``model:...``, ``tools:...``) whose naming is
+        already stable.
         """
-        data = cast("dict[str, Any]", event["params"]["data"])
-        phase = data.get("event")
-        tcid = data.get("tool_call_id")
-        if not isinstance(tcid, str):
+        if not self._ns_rewrite:
             return
-
-        if phase == "tool-started":
-            if data.get("tool_name") != "task":
-                return
-            raw_input = data.get("input")
-            input_d: dict[str, Any] = (
-                raw_input if isinstance(raw_input, dict) else {}
-            )
-            subagent_type = str(input_d.get("subagent_type") or "")
-            description = str(input_d.get("description") or "")
-            self._emit_synthetic_start(tcid, subagent_type, description)
-        elif phase == "tool-finished":
-            if tcid not in self._synthesized:
-                return
-            self._emit_synthetic_finish(tcid, data.get("output"), is_error=False)
-        elif phase == "tool-error":
-            if tcid not in self._synthesized:
-                return
-            self._emit_synthetic_finish(tcid, data.get("message"), is_error=True)
-
-    def _emit_synthetic_start(
-        self,
-        tool_call_id: str,
-        subagent_type: str,
-        description: str,
-    ) -> None:
-        """Emit the full opening event sequence for a `task` tool call.
-
-        Order (each pushed via `self._mux.push`, which re-enters the
-        transformer pipeline):
-
-            1. `lifecycle.started` — creates the child mini-mux via
-               `SubgraphTransformer._on_started` and, because
-               `graph_name` is the declared subagent name, gets
-               promoted to a `SubagentRunStream` by this transformer
-               on re-entry.
-            2. `messages.message-start` (human) — opens a
-               `ChatModelStream` in the child mini-mux's
-               `MessagesTransformer`.
-            3. `messages.content-block-start / -delta / -finish` —
-               single text block carrying the prompt.
-            4. `messages.message-finish`.
-            5. `values` — snapshot with the one human message so
-               `handle.output` has meaningful shape during the
-               running phase.
-        """
-        if tool_call_id in self._synthesized:
+        ns_list = event["params"]["namespace"]
+        if not ns_list:
             return
-        synthetic_ns = (*self.scope, f"tools:{tool_call_id}")
-        human_id = f"subagent:{tool_call_id}:human"
-        human_msg: dict[str, Any] = {
-            "type": "human",
-            "content": description,
-            "id": human_id,
-        }
-        self._synthesized[tool_call_id] = _SyntheticSubagentState(
-            namespace=synthetic_ns,
-            messages=[human_msg],
-        )
-
-        self._push_event(
-            "lifecycle",
-            synthetic_ns,
-            {
-                "event": "started",
-                "graph_name": subagent_type,
-                "cause": {"type": "toolCall", "tool_call_id": tool_call_id},
-            },
-        )
-        self._emit_synthesized_message(
-            synthetic_ns,
-            role="human",
-            message_id=human_id,
-            content=description,
-        )
-        self._push_event(
-            "values",
-            synthetic_ns,
-            {"messages": [dict(msg) for msg in self._synthesized[tool_call_id].messages]},
-        )
-
-    def _emit_synthetic_finish(
-        self,
-        tool_call_id: str,
-        payload: Any,
-        *,
-        is_error: bool,
-    ) -> None:
-        """Emit the closing event sequence for a `task` tool call.
-
-        On success, appends an AI message derived from the tool's
-        `output` before emitting the terminal `lifecycle.completed`.
-        On error, skips the AI message and emits
-        `lifecycle.failed` with the error string.
-        """
-        state = self._synthesized.get(tool_call_id)
-        if state is None or state.completed:
-            return
-        state.completed = True
-        synthetic_ns = state.namespace
-
-        if not is_error:
-            ai_id = f"subagent:{tool_call_id}:ai"
-            ai_content = _normalize_output_content(payload)
-            state.messages.append(
-                {"type": "ai", "content": ai_content, "id": ai_id}
-            )
-            self._emit_synthesized_message(
-                synthetic_ns,
-                role="ai",
-                message_id=ai_id,
-                content=ai_content,
-            )
-            self._push_event(
-                "values",
-                synthetic_ns,
-                {"messages": [dict(msg) for msg in state.messages]},
-            )
-            self._push_event(
-                "lifecycle",
-                synthetic_ns,
-                {"event": "completed"},
-            )
-        else:
-            error_message = (
-                str(payload) if payload not in (None, "") else "subagent failed"
-            )
-            self._push_event(
-                "lifecycle",
-                synthetic_ns,
-                {"event": "failed", "error": error_message},
-            )
-        del self._synthesized[tool_call_id]
-
-    def _emit_synthesized_message(
-        self,
-        namespace: tuple[str, ...],
-        *,
-        role: str,
-        message_id: str,
-        content: Any,
-    ) -> None:
-        """Emit a single-message `messages.*` sequence at the given namespace.
-
-        Handles the two common content shapes: a plain string
-        (single-text-block output) and a list of protocol content
-        blocks (richer model output with reasoning / text mixed).
-        Non-text / non-reasoning blocks pass through as-is on the
-        content-block-* envelope.
-        """
-        self._push_messages_event(
-            namespace,
-            message_id,
-            {"event": "message-start", "role": role, "message_id": message_id},
-        )
-        if isinstance(content, str):
-            self._push_messages_event(
-                namespace,
-                message_id,
-                {
-                    "event": "content-block-start",
-                    "index": 0,
-                    "content_block": {"type": "text", "text": ""},
-                },
-            )
-            if content:
-                self._push_messages_event(
-                    namespace,
-                    message_id,
-                    {
-                        "event": "content-block-delta",
-                        "index": 0,
-                        "content_block": {"type": "text", "text": content},
-                    },
-                )
-            self._push_messages_event(
-                namespace,
-                message_id,
-                {
-                    "event": "content-block-finish",
-                    "index": 0,
-                    "content_block": {"type": "text", "text": content},
-                },
-            )
-        elif isinstance(content, list):
-            for offset, raw_block in enumerate(content):
-                block = _normalize_finalized_content_block(raw_block)
-                if block is None:
-                    continue
-                index = (
-                    block["index"]
-                    if isinstance(block.get("index"), int)
-                    else offset
-                )
-                btype = block.get("type")
-                if btype == "text":
-                    start_block: dict[str, Any] = {"type": "text", "text": ""}
-                elif btype == "reasoning":
-                    start_block = {"type": "reasoning", "reasoning": ""}
-                else:
-                    start_block = block
-                self._push_messages_event(
-                    namespace,
-                    message_id,
-                    {
-                        "event": "content-block-start",
-                        "index": index,
-                        "content_block": start_block,
-                    },
-                )
-                if btype == "text" and block.get("text"):
-                    self._push_messages_event(
-                        namespace,
-                        message_id,
-                        {
-                            "event": "content-block-delta",
-                            "index": index,
-                            "content_block": {
-                                "type": "text",
-                                "text": block["text"],
-                            },
-                        },
-                    )
-                elif btype == "reasoning" and block.get("reasoning"):
-                    self._push_messages_event(
-                        namespace,
-                        message_id,
-                        {
-                            "event": "content-block-delta",
-                            "index": index,
-                            "content_block": {
-                                "type": "reasoning",
-                                "reasoning": block["reasoning"],
-                            },
-                        },
-                    )
-                self._push_messages_event(
-                    namespace,
-                    message_id,
-                    {
-                        "event": "content-block-finish",
-                        "index": index,
-                        "content_block": block,
-                    },
-                )
-        self._push_messages_event(
-            namespace,
-            message_id,
-            {"event": "message-finish"},
-        )
-
-    def _push_event(
-        self,
-        method: str,
-        namespace: tuple[str, ...],
-        data: Any,
-    ) -> None:
-        """Wrap `data` in a ProtocolEvent envelope and re-enter the mux.
-
-        Seq is assigned by `StreamMux.push` at append time; re-entrant
-        dispatch during our own `process(...)` is an explicitly
-        supported flow (see the note in `StreamMux.push`).
-        """
-        assert self._mux is not None, (
-            "SubagentTransformer emitted before _on_register; "
-            "transformer registration ordering is broken."
-        )
-        event: ProtocolEvent = {
-            "type": "event",
-            "method": method,
-            "params": {
-                "namespace": list(namespace),
-                "timestamp": int(time.time() * 1000),
-                "data": data,
-            },
-        }
-        self._mux.push(event)
-
-    def _push_messages_event(
-        self,
-        namespace: tuple[str, ...],
-        message_id: str,
-        payload: dict[str, Any],
-    ) -> None:
-        """Push a synthetic `messages.*` event in the internal tuple shape.
-
-        The core `MessagesTransformer` unpacks ``params["data"]`` as
-        ``(payload, metadata)`` (see
-        :class:`langgraph.stream.transformers.MessagesTransformer`), so
-        synthetic messages events must use the same wire-internal
-        shape. ``run_id`` is set to ``message_id`` so the transformer
-        correlates ``message-start`` through ``message-finish`` on a
-        single :class:`~langchain_core.language_models.chat_model_stream.ChatModelStream`.
-        The ``langgraph_node`` field is stubbed as the subagent's
-        namespace suffix so the resulting projection has a sensible
-        ``node`` attribute.
-        """
-        node_name = namespace[-1] if namespace else None
-        metadata: dict[str, Any] = {
-            "run_id": message_id,
-            "langgraph_node": node_name,
-        }
-        self._push_event("messages", namespace, (payload, metadata))
-
-
-def _normalize_output_content(value: Any) -> Any:
-    """Coerce a tool's `output` payload into `messages.*`-compatible content.
-
-    The `task` tool returns a pregel ``Command`` value when its
-    subagent completes. By the time it reaches the transformer on
-    `tool-finished`, it may be either:
-
-    - A live ``Command`` instance whose ``.update`` dict holds a
-      ``messages`` list of ``BaseMessage`` (typically ``ToolMessage``)
-      instances — observed when the transformer runs in-process before
-      serde.
-    - A plain dict
-      ``{"graph": None, "update": {"messages": [<msg dict>, ...]},
-      "resume": None, "goto": [...]}`` — the post-serde form on the
-      wire.
-
-    Either way, we extract the *last* message in ``update.messages``
-    — that's the tool-role reply carrying the subagent's final text
-    — and recurse into its content. Other shapes fall back as
-    follows:
-
-    - `None` → empty string (renders as an empty AI message).
-    - `str` → itself (single text block).
-    - `list` → passed through for per-block handling in
-      `_emit_synthesized_message`.
-    - `dict` with an ``update.messages`` list → recurse into the
-      last message (dict-shape).
-    - `dict` with a ``content`` key → recurse into ``content``
-      (BaseMessage-dict / artifact-like shapes).
-    - Object with ``.update["messages"]`` → recurse into the last
-      message (``Command`` instance, duck-typed to avoid a hard
-      ``langgraph.types`` dependency).
-    - Object with ``.content`` → recurse into it (``BaseMessage``
-      instance, also duck-typed).
-    - Anything else → `str(value)` (defensive; keeps the wire
-      string-typed).
-    """
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, list):
-        return value
-    if isinstance(value, dict):
-        update = value.get("update")
-        if isinstance(update, dict):
-            messages = update.get("messages")
-            if isinstance(messages, list) and messages:
-                return _normalize_output_content(messages[-1])
-        content = value.get("content")
-        if content is not None:
-            return _normalize_output_content(content)
-        return str(value)
-
-    # Duck-typed pregel ``Command``: ``.update["messages"][-1]`` holds
-    # the tool-role reply we want to surface as the AI message body.
-    update_attr = getattr(value, "update", None)
-    if isinstance(update_attr, dict):
-        messages = update_attr.get("messages")
-        if isinstance(messages, list) and messages:
-            return _normalize_output_content(messages[-1])
-
-    # Duck-typed ``BaseMessage``: pull its ``.content`` (``str`` or
-    # list of blocks).
-    content_attr = getattr(value, "content", None)
-    if content_attr is not None and not callable(content_attr):
-        return _normalize_output_content(content_attr)
-
-    return str(value)
-
-
-def _normalize_finalized_content_block(block: Any) -> dict[str, Any] | None:
-    """Coerce a raw content block into a canonical protocol shape.
-
-    - `str` → `{type: "text", text: <str>}`.
-    - `dict` with `type`:
-        - `"text"` → `{type, text}` (optionally preserving `id` / `index`).
-        - `"reasoning"` → `{type, reasoning}` (ditto).
-        - any other `type` → passed through as-is (image / file / tool
-          blocks travel whole; no partial synthesis for them).
-    - Anything else → `None` (skipped — keeps bad inputs off the wire).
-    """
-    if isinstance(block, str):
-        return {"type": "text", "text": block}
-    if not isinstance(block, dict):
-        return None
-    btype = block.get("type")
-    if btype == "text":
-        normalized: dict[str, Any] = {
-            "type": "text",
-            "text": str(block.get("text", "")),
-        }
-        if "id" in block:
-            normalized["id"] = block["id"]
-        if isinstance(block.get("index"), int):
-            normalized["index"] = block["index"]
-        return normalized
-    if btype == "reasoning":
-        normalized = {
-            "type": "reasoning",
-            "reasoning": str(block.get("reasoning", "")),
-        }
-        if "id" in block:
-            normalized["id"] = block["id"]
-        if isinstance(block.get("index"), int):
-            normalized["index"] = block["index"]
-        return normalized
-    return block
+        first = ns_list[0]
+        rewritten = self._ns_rewrite.get(first)
+        if rewritten is not None and rewritten != first:
+            ns_list[0] = rewritten

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -1,181 +1,80 @@
-"""Project subagent runs as first-class child streams on a parent run.
+"""Surface declared subagents as typed `run.subagents` handles.
 
-`SubagentTransformer` performs three tightly-coupled jobs on events
-flowing through the stream mux:
+Pregel's `tasks` event names a child task by its parent's node name
+(typically `"tools"`) plus a Pregel-assigned task id. The actual
+`subagent_type` and the user-facing `tool_call_id` only live in the
+**parent** task's `input` payload (the list of tool calls). This
+transformer does two things:
 
-1. **Tool-call tracking.** Root-scope ``tools`` events from the
-   parent's ``task`` tool calls are observed to build
-   ``_pending_tool_calls``, keyed by ``tool_call_id``. Entries live
-   from the originating ``tool-started`` until the subagent's
-   ``lifecycle.started`` is correlated or the task errors out.
+1. At parent scope, intercept `tasks` start events whose `name ==
+   "tools"` and `input` is a list containing one or more `task` tool
+   calls. For each such tool call, record
+   ``parent_task_id → (subagent_type, tool_call_id)``.
+2. When a direct-child `tasks` start fires (segment ``"tools:<id>"``),
+   look up `id` in the pending map. If it resolves to a declared
+   subagent name, build a `SubagentRunStream` (or async variant)
+   wrapping a child mini-mux and push it onto the `subagents` log.
+   The handle reports `graph_name` as the subagent's declared type
+   (e.g. ``"researcher"``) and `trigger_call_id` as the user-facing
+   tool call id (e.g. ``"call-parent-1"``).
 
-2. **Subagent handle promotion.** When a ``lifecycle.started`` fires
-   at one level below this transformer's scope, we consult the
-   sibling :class:`~langgraph.stream.transformers.SubgraphTransformer`'s
-   ``_by_ns`` (populated earlier in the same dispatch because the
-   subgraph transformer is registered first in the factory list).
-   If the emitted ``graph_name`` matches a declared subagent name, we
-   wrap the existing :class:`~langgraph.stream.transformers.SubgraphRunStream`
-   in a :class:`SubagentRunStream` so ``run.subagents`` surfaces a
-   typed handle with the standard projections
-   (``.messages`` / ``.values`` / ``.subagents`` / ``.tool_calls``).
-
-3. **Wire-level namespace rewrite.** Pregel schedules each subagent
-   spawned via the ``task`` tool under a UUID-derived namespace like
-   ``tools:<pregel_uuid>``, whereas wire subscribers filter on the
-   client-visible ``tools:<tool_call_id>`` namespace. Rather than
-   mutating ``checkpoint_ns`` in the subagent's config (which would
-   interact with the Pregel scheduler and checkpoint layout) or
-   fabricating synthetic protocol events, the transformer records a
-   ``pregel_segment → tool_call_id`` mapping at the moment the first
-   lifecycle event correlates to a pending ``task`` tool call, then
-   rewrites the first segment of every downstream event's namespace
-   in-place before the mux appends it to the main log. The
-   SubgraphTransformer's ``_by_ns`` still keys off the pre-rewrite
-   namespace (matching Pregel's checkpoint layout); only the
-   wire-visible ``params.namespace`` is remapped.
-
-Consequences of sharing the `SubgraphRunStream`'s mini-mux:
-
-- Events under the subagent's namespace are dispatched *once* (into
-  the shared mini-mux), not twice.
-- `path`, `status`, `error`, `checkpoint`, and `cause` are read from
-  the wrapped handle — no separate tracking in this transformer.
-- `finalize` / `fail` are not needed: `SubgraphTransformer` owns
-  close/fail of the shared mini-mux.
-
-The `_native = True` flag means `run.subagents` auto-binds as a
-direct attribute. A subagent also shows up on `run.subgraphs` — that
-projection is a superset, surfacing every nested subgraph (subagent
-or otherwise) as an untyped handle.
+A subagent therefore shows up on **both** `run.subgraphs` (untyped,
+superset, keyed by the raw Pregel segment) and `run.subagents`
+(typed, declared-only, with user-friendly identifiers).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from langgraph.stream._event_log import EventLog
-from langgraph.stream._types import StreamTransformer
-from langgraph.stream.run_stream import BaseRunStream
-from langgraph.stream.transformers import SubgraphRunStream, SubgraphTransformer
+from langgraph.stream.run_stream import (
+    AsyncSubgraphRunStream,
+    SubgraphRunStream,
+)
+from langgraph.stream.transformers import (
+    SubgraphStatus,
+    ValuesTransformer,
+    _TasksLifecycleBase,
+)
 
 if TYPE_CHECKING:
-    from langchain_protocol.protocol import (
-        CheckpointRef,
-        LifecycleCause,
-        LifecycleData,
-    )
     from langgraph.stream._mux import StreamMux
     from langgraph.stream._types import ProtocolEvent
-    from langgraph.stream.transformers import SubgraphStatus
 
 
-class SubagentRunStream(BaseRunStream):
-    """Typed view of a single subagent execution.
-
-    Wraps the `SubgraphRunStream` that `SubgraphTransformer` already
-    built for this child namespace — shares its mini-mux, so
-    projections (`.messages`, `.tool_calls`, `.middleware`,
-    recursive `.subagents`, `.values`) come from the existing
-    transformer pipeline without a second round of event dispatch.
-
-    Events are driven by the parent run's pump and routed into this
-    handle's mini-mux by `SubgraphTransformer` — a subagent does not
-    own its own pump. Construction therefore bypasses
-    `GraphRunStream.__init__` (which would wire a pump onto the
-    mini-mux, shadowing the parent's) and calls
-    `BaseRunStream.__init__` directly, seeding the pump-related
-    fields so inherited methods that consult them (`output`, `abort`,
-    `__exit__`) degrade to no-ops.
-
-    Exposes `name` (the declared subagent name) as the typed state
-    this layer adds. `path`, `status`, `error`, `checkpoint`, `cause`
-    delegate to the wrapped subgraph handle so subgraph-side state
-    transitions — including terminal close driven by
-    `SubgraphTransformer.finalize` / `fail` — are automatically
-    visible here.
-    """
-
-    def __init__(self, subgraph: SubgraphRunStream, *, name: str) -> None:
-        # Skip `GraphRunStream.__init__` to avoid calling
-        # `mux.bind_pump` on the mini-mux — the parent's pump is
-        # already bound via `make_child` pump inheritance.
-        BaseRunStream.__init__(self, subgraph._mux)
-        # Seed pump-related fields so inherited `output` / `abort` /
-        # `__exit__` treat this stream as already-exhausted (no self
-        # pump to drive). `_values_transformer._latest` still provides
-        # the current snapshot because the parent's pump keeps it
-        # fresh.
-        self._graph_iter = None
-        self._exhausted = True
-        self._subgraph = subgraph
-        self.name: str = name
+class SubagentRunStream(SubgraphRunStream):
+    """Typed sync handle for a declared subagent execution."""
 
     @property
-    def output(self) -> dict[str, Any] | None:
-        """Latest values snapshot from this subagent's mini-mux.
-
-        Unlike root `GraphRunStream.output`, no pump is driven — the
-        parent's pump keeps `_values_transformer._latest` fresh.
-        """
-        vt = self._values_transformer
-        err = vt.error
-        if err is not None:
-            raise err
-        return vt._latest
+    def name(self) -> str | None:
+        return self.graph_name
 
     @property
-    def interrupted(self) -> bool:
-        """True once an interrupt has flowed through this subagent's pipeline."""
-        return self._values_transformer._interrupted
+    def cause(self) -> dict[str, str] | None:
+        if self.trigger_call_id is None:
+            return None
+        return {"type": "toolCall", "tool_call_id": self.trigger_call_id}
+
+
+class AsyncSubagentRunStream(AsyncSubgraphRunStream):
+    """Typed async handle for a declared subagent execution."""
 
     @property
-    def interrupts(self) -> list[Any]:
-        """List of interrupt payloads seen by this subagent."""
-        return list(self._values_transformer._interrupts)
+    def name(self) -> str | None:
+        return self.graph_name
 
     @property
-    def path(self) -> tuple[str, ...]:
-        return self._subgraph.path
-
-    @property
-    def cause(self) -> LifecycleCause | None:
-        return self._subgraph.cause
-
-    @property
-    def status(self) -> SubgraphStatus:
-        return self._subgraph.status
-
-    @property
-    def error(self) -> str | None:
-        return self._subgraph.error
-
-    @property
-    def checkpoint(self) -> CheckpointRef | None:
-        return self._subgraph.checkpoint
+    def cause(self) -> dict[str, str] | None:
+        if self.trigger_call_id is None:
+            return None
+        return {"type": "toolCall", "tool_call_id": self.trigger_call_id}
 
 
-class SubagentTransformer(StreamTransformer):
-    """Promote declared subagents into typed handles on `run.subagents`.
-
-    Requires a `SubgraphTransformer` to be registered earlier in the
-    mux's factory list (it is, via `GraphStreamer.builtin_factories`).
-    This transformer does not own a mini-mux or a lifecycle state
-    machine — it consults `SubgraphTransformer._by_ns` on each
-    `started` event and promotes matching handles.
-
-    `scope_exact = False` so this transformer sees root-scope `tools`
-    events (for tool-call tracking) *and* the promoted subagent's
-    `lifecycle.started` at `scope + 1` namespace (for handle
-    promotion) *and* every deeper event (for namespace rewriting).
-    Events at deeper namespaces flow through `SubgraphTransformer`
-    into the subagent's mini-mux where the standard `messages` /
-    `values` transformers build projections.
-    """
+class SubagentTransformer(_TasksLifecycleBase):
+    """Promote declared subagents into typed handles on `run.subagents`."""
 
     _native: ClassVar[bool] = True
-    scope_exact: ClassVar[bool] = False
-    required_stream_modes: ClassVar[tuple[str, ...]] = ("lifecycle", "tools")
 
     def __init__(
         self,
@@ -185,202 +84,126 @@ class SubagentTransformer(StreamTransformer):
     ) -> None:
         super().__init__(scope)
         self._names = subagent_names
-        self._log: EventLog[SubagentRunStream] = EventLog()
-        self._by_ns: dict[tuple[str, ...], SubagentRunStream] = {}
-        self._subgraph_transformer: SubgraphTransformer | None = None
+        self._log: EventLog[SubagentRunStream | AsyncSubagentRunStream] = EventLog()
+        self._handles: dict[tuple[str, ...], SubagentRunStream | AsyncSubagentRunStream] = {}
         self._mux: StreamMux | None = None
-        # Pending `task` tool calls awaiting a matching `lifecycle.started`.
-        # Keyed by `tool_call_id`; value carries the originating input so
-        # downstream consumers can correlate richer metadata than `cause`
-        # alone conveys.
-        #
-        # Dict insertion order provides oldest-first pairing under
-        # parallel fan-out of the same `subagent_type`, which matches
-        # Pregel's scheduling order for the corresponding subgraph
-        # spawns.
-        self._pending_tool_calls: dict[str, dict[str, str]] = {}
-        # Wire-level namespace rewrite map: Pregel-assigned first
-        # segment (e.g. `"tools:<pregel_uuid>"`) → client-visible first
-        # segment (e.g. `"tools:<tool_call_id>"`). Populated when a
-        # `lifecycle.started` is correlated to a pending `task` tool
-        # call by `graph_name` / `subagent_type`.
-        self._ns_rewrite: dict[str, str] = {}
+        # parent_task_id -> {"subagent_type": ..., "tool_call_id": ...}
+        self._pending: dict[str, dict[str, str]] = {}
 
     def init(self) -> dict[str, Any]:
         return {"subagents": self._log}
 
     def _on_register(self, mux: StreamMux) -> None:
-        """Capture the sibling `SubgraphTransformer` and the enclosing mux.
-
-        Raises at registration time if `SubgraphTransformer` isn't
-        present — failing loudly here is better than silently yielding
-        zero subagent handles at runtime.
-        """
-        sub_t = mux.transformer_by_key("subgraphs")
-        if not isinstance(sub_t, SubgraphTransformer):
-            msg = (
-                "SubagentTransformer requires a SubgraphTransformer to be "
-                "registered earlier in the mux; none was found. Check that "
-                "your streamer's builtin_factories includes SubgraphTransformer "
-                "before SubagentTransformer."
-            )
-            raise TypeError(msg)
-        self._subgraph_transformer = sub_t
         self._mux = mux
 
-    def process(self, event: ProtocolEvent) -> bool:
-        method = event["method"]
-
-        # Root-scope `task` tool observations feed `_pending_tool_calls`
-        # for later correlation. The event passes through unmodified.
-        if method == "tools":
-            self._track_task_tool_call(event)
-            return True
-
-        if method != "lifecycle":
-            # Non-lifecycle events (values, messages, checkpoints,
-            # input, tools at non-root ns) only need the wire-level
-            # namespace rewrite applied.
-            self._rewrite_ns_in_place(event)
-            return True
-
-        ns = tuple(event["params"]["namespace"])
+    def _should_track(self, ns: tuple[str, ...]) -> bool:
         depth = len(self.scope)
+        return len(ns) == depth + 1 and ns[:depth] == self.scope
 
-        # Only depth + 1 lifecycle events are subagent-level; deeper
-        # ones (nested subgraph / model / tool nodes) just need the
-        # rewrite applied.
-        if len(ns) != depth + 1 or ns[:-1] != self.scope:
-            self._rewrite_ns_in_place(event)
-            return True
+    def _capture_pending_from_parent(self, event: ProtocolEvent) -> None:
+        """Record subagent metadata from a parent-scope `tools`-task start.
 
-        data = cast("LifecycleData", event["params"]["data"])
-        if data.get("event") == "started":
-            self._handle_started(ns, data)
-
-        # Rewrite the ns on the way out so downstream wire consumers
-        # see `tools:<tool_call_id>` even though internal state keys
-        # off `tools:<pregel_uuid>`.
-        self._rewrite_ns_in_place(event)
-        return True
-
-    # ─── Tool call tracking ───────────────────────────────────────────
-
-    def _track_task_tool_call(self, event: ProtocolEvent) -> None:
-        """Record / discard pending `task` tool calls observed on `tools`.
-
-        Only `tool_name == "task"` events are tracked — other tool
-        calls don't spawn subagents and would pollute the pending map.
+        Pregel emits a `tasks` start at the parent ns whose `input` is
+        the list of tool calls being dispatched. Each ``task`` tool
+        call carries the user-visible ``tool_call_id`` and the
+        declared ``subagent_type`` we need at child-task time.
         """
         ns = tuple(event["params"]["namespace"])
-        # `tool-started` / `tool-finished` / `tool-error` fire at the
-        # parent namespace, which is exactly `self.scope` for the
-        # subagents we care about (direct children).
         if ns != self.scope:
             return
-        data = cast("dict[str, Any]", event["params"]["data"])
-        phase = data.get("event")
-        if phase == "tool-started":
-            if data.get("tool_name") != "task":
-                return
-            tcid = data.get("tool_call_id")
-            raw_input = data.get("input")
-            if not isinstance(tcid, str) or not isinstance(raw_input, dict):
-                return
-            self._pending_tool_calls[tcid] = {
-                "subagent_type": str(raw_input.get("subagent_type") or ""),
-                "description": str(raw_input.get("description") or ""),
+        data = event["params"]["data"]
+        if "result" in data or data.get("name") != "tools":
+            return
+        parent_task_id = data.get("id")
+        tool_calls = data.get("input")
+        if not isinstance(parent_task_id, str) or not isinstance(tool_calls, list):
+            return
+        for tc in tool_calls:
+            if not isinstance(tc, dict) or tc.get("name") != "task":
+                continue
+            args = tc.get("args") or {}
+            subagent_type = args.get("subagent_type")
+            tool_call_id = tc.get("id")
+            if not isinstance(subagent_type, str):
+                continue
+            self._pending[parent_task_id] = {
+                "subagent_type": subagent_type,
+                "tool_call_id": tool_call_id if isinstance(tool_call_id, str) else "",
             }
-        elif phase in ("tool-finished", "tool-error"):
-            tcid = data.get("tool_call_id")
-            if isinstance(tcid, str):
-                self._pending_tool_calls.pop(tcid, None)
+            # First task-typed call wins; multiple `task` calls under
+            # the same parent task aren't expected in the current
+            # scheduling model.
+            return
 
-    # ─── Started correlation + handle promotion ───────────────────────
-
-    def _handle_started(
-        self, ns: tuple[str, ...], data: LifecycleData
+    def _on_started(
+        self,
+        ns: tuple[str, ...],
+        graph_name: str | None,  # noqa: ARG002
+        trigger_call_id: str | None,
     ) -> None:
-        """Correlate a subagent's `lifecycle.started` with a pending tool call.
-
-        Three things happen here, in order:
-
-        1. If ``data`` has no pre-populated ``cause`` and we have a
-           pending ``task`` tool call whose ``subagent_type`` matches
-           ``graph_name``, pair them. Dict insertion order gives
-           oldest-first pairing under parallel fan-out, matching
-           Pregel's scheduling order.
-        2. If the pairing produces a ``tools:<tcid>`` that differs
-           from the pre-rewrite ``tools:<pregel_seg>``, record a
-           namespace rewrite entry so subsequent events under the
-           same Pregel segment surface on the wire at the
-           tool-call-id namespace.
-        3. If ``graph_name`` is a declared subagent and
-           :class:`SubgraphTransformer` has already created a handle
-           at ``ns``, wrap that handle in a :class:`SubagentRunStream`
-           and push it onto ``self._log``.
-        """
-        graph_name = data.get("graph_name")
-        if not isinstance(graph_name, str):
+        if trigger_call_id is None:
             return
-
-        if "cause" not in data:
-            for tcid, info in self._pending_tool_calls.items():
-                if info["subagent_type"] == graph_name:
-                    cast("dict[str, Any]", data)["cause"] = {
-                        "type": "toolCall",
-                        "tool_call_id": tcid,
-                    }
-                    pregel_seg = ns[-1]
-                    target_seg = f"tools:{tcid}"
-                    if pregel_seg != target_seg:
-                        self._ns_rewrite[pregel_seg] = target_seg
-                    del self._pending_tool_calls[tcid]
-                    break
-
-        if graph_name not in self._names or ns in self._by_ns:
+        info = self._pending.pop(trigger_call_id, None)
+        if info is None:
             return
-
-        # SubgraphTransformer runs before us (factory order), so its
-        # `_by_ns` already has the freshly-created handle for this
-        # namespace. Reuse it — no second mini-mux, no duplicate
-        # dispatch. `_on_register` guarantees `_subgraph_transformer`
-        # is set before any event reaches `process`.
-        sub_t = cast("SubgraphTransformer", self._subgraph_transformer)
-        subgraph_handle = sub_t._by_ns.get(ns)
-        if subgraph_handle is None:
+        subagent_type = info["subagent_type"]
+        if subagent_type not in self._names:
             return
-
-        # Propagate any cause we just augmented onto the SubgraphRunStream
-        # instance too — it was constructed from the `data` payload
-        # before we had a chance to pair a tool_call_id into it, so a
-        # fresh read-back would return `None` without this sync.
-        subgraph_cause = data.get("cause")
-        if subgraph_cause is not None and subgraph_handle.cause is None:
-            subgraph_handle.cause = subgraph_cause
-
-        handle = SubagentRunStream(subgraph_handle, name=graph_name)
-        self._by_ns[ns] = handle
+        if self._mux is None or ns in self._handles:
+            return
+        try:
+            child_mux = self._mux._make_child(ns)
+        except RuntimeError:
+            return
+        values_t = child_mux.transformer_by_key("values")
+        if not isinstance(values_t, ValuesTransformer):
+            return
+        handle_cls = AsyncSubagentRunStream if child_mux.is_async else SubagentRunStream
+        handle = handle_cls(
+            mux=child_mux,
+            values_transformer=values_t,
+            path=ns,
+            graph_name=subagent_type,
+            trigger_call_id=info["tool_call_id"] or None,
+        )
+        self._handles[ns] = handle
         self._log.push(handle)
 
-    # ─── Namespace rewriting ──────────────────────────────────────────
-
-    def _rewrite_ns_in_place(self, event: ProtocolEvent) -> None:
-        """Rewrite `event.params.namespace[0]` using `_ns_rewrite`.
-
-        The namespace list is mutated in place so the mutation is
-        visible to any downstream transformer *and* to the event
-        that ultimately lands in the mux's main log. Only the first
-        segment is rewritten — deeper segments belong to child
-        subgraphs (``model:...``, ``tools:...``) whose naming is
-        already stable.
-        """
-        if not self._ns_rewrite:
+    def _on_terminal(
+        self,
+        ns: tuple[str, ...],
+        status: SubgraphStatus,
+        error: str | None,
+    ) -> None:
+        handle = self._handles.get(ns)
+        if handle is None or handle._seen_terminal:
             return
-        ns_list = event["params"]["namespace"]
-        if not ns_list:
+        handle.status = status
+        if error is not None and handle.error is None:
+            handle.error = error
+        handle._seen_terminal = True
+        if handle._mux is None or handle._mux._events._closed:
             return
-        first = ns_list[0]
-        rewritten = self._ns_rewrite.get(first)
-        if rewritten is not None and rewritten != first:
-            ns_list[0] = rewritten
+        if status == "failed":
+            handle._mux.fail(RuntimeError(error or "Subagent failed"))
+        else:
+            handle._mux.close()
+
+    def _child_mux_for_event(self, event: ProtocolEvent) -> StreamMux | None:
+        ns = tuple(event["params"]["namespace"])
+        depth = len(self.scope)
+        if len(ns) < depth + 1:
+            return None
+        handle = self._handles.get(ns[: depth + 1])
+        if handle is None or handle._mux is None or handle._mux._events._closed:
+            return None
+        return handle._mux
+
+    def process(self, event: ProtocolEvent) -> bool:
+        if event.get("method") == "tasks":
+            self._capture_pending_from_parent(event)
+        keep = super().process(event)
+        child_mux = self._child_mux_for_event(event)
+        if child_mux is not None:
+            child_mux.push(event)
+        return keep

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -631,41 +631,70 @@ def _normalize_output_content(value: Any) -> Any:
     """Coerce a tool's `output` payload into `messages.*`-compatible content.
 
     The `task` tool returns a pregel ``Command`` value when its
-    subagent completes. Stream-side, that surfaces on
-    `tool-finished` as
-    ``{"graph": None, "update": {"messages": [<tool msg>, ...]},
-    "resume": None, "goto": [...]}``. The synthesized AI message's
-    content is extracted from the *last* message in
-    ``update.messages`` — that's the tool-role reply carrying the
-    subagent's final text. Other shapes fall back as follows:
+    subagent completes. By the time it reaches the transformer on
+    `tool-finished`, it may be either:
+
+    - A live ``Command`` instance whose ``.update`` dict holds a
+      ``messages`` list of ``BaseMessage`` (typically ``ToolMessage``)
+      instances — observed when the transformer runs in-process before
+      serde.
+    - A plain dict
+      ``{"graph": None, "update": {"messages": [<msg dict>, ...]},
+      "resume": None, "goto": [...]}`` — the post-serde form on the
+      wire.
+
+    Either way, we extract the *last* message in ``update.messages``
+    — that's the tool-role reply carrying the subagent's final text
+    — and recurse into its content. Other shapes fall back as
+    follows:
 
     - `None` → empty string (renders as an empty AI message).
     - `str` → itself (single text block).
     - `list` → passed through for per-block handling in
       `_emit_synthesized_message`.
     - `dict` with an ``update.messages`` list → recurse into the
-      last message's ``content`` (Command-shaped tool output).
+      last message (dict-shape).
     - `dict` with a ``content`` key → recurse into ``content``
-      (BaseMessage-like / artifact-like shapes).
+      (BaseMessage-dict / artifact-like shapes).
+    - Object with ``.update["messages"]`` → recurse into the last
+      message (``Command`` instance, duck-typed to avoid a hard
+      ``langgraph.types`` dependency).
+    - Object with ``.content`` → recurse into it (``BaseMessage``
+      instance, also duck-typed).
     - Anything else → `str(value)` (defensive; keeps the wire
       string-typed).
     """
     if value is None:
         return ""
-    if isinstance(value, (str, list)):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
         return value
     if isinstance(value, dict):
         update = value.get("update")
         if isinstance(update, dict):
             messages = update.get("messages")
             if isinstance(messages, list) and messages:
-                last = messages[-1]
-                if isinstance(last, dict):
-                    return _normalize_output_content(last)
+                return _normalize_output_content(messages[-1])
         content = value.get("content")
         if content is not None:
             return _normalize_output_content(content)
         return str(value)
+
+    # Duck-typed pregel ``Command``: ``.update["messages"][-1]`` holds
+    # the tool-role reply we want to surface as the AI message body.
+    update_attr = getattr(value, "update", None)
+    if isinstance(update_attr, dict):
+        messages = update_attr.get("messages")
+        if isinstance(messages, list) and messages:
+            return _normalize_output_content(messages[-1])
+
+    # Duck-typed ``BaseMessage``: pull its ``.content`` (``str`` or
+    # list of blocks).
+    content_attr = getattr(value, "content", None)
+    if content_attr is not None and not callable(content_attr):
+        return _normalize_output_content(content_attr)
+
     return str(value)
 
 

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -42,7 +42,11 @@ from langgraph.stream.run_stream import BaseRunStream
 from langgraph.stream.transformers import SubgraphRunStream, SubgraphTransformer
 
 if TYPE_CHECKING:
-    from langchain_protocol.protocol import CheckpointRef, LifecycleData
+    from langchain_protocol.protocol import (
+        CheckpointRef,
+        LifecycleCause,
+        LifecycleData,
+    )
     from langgraph.stream._mux import StreamMux
     from langgraph.stream._types import ProtocolEvent
     from langgraph.stream.transformers import SubgraphStatus
@@ -67,11 +71,11 @@ class SubagentRunStream(BaseRunStream):
     `__exit__`) degrade to no-ops.
 
     Exposes `name` (the declared subagent name) as the typed state
-    this layer adds. `path`, `status`, `error`, `checkpoint`,
-    `trigger_call_id` delegate to the wrapped subgraph handle so
-    subgraph-side state transitions — including terminal close
-    driven by `SubgraphTransformer.finalize` / `fail` — are
-    automatically visible here.
+    this layer adds. `path`, `status`, `error`, `checkpoint`, `cause`
+    delegate to the wrapped subgraph handle so subgraph-side state
+    transitions — including terminal close driven by
+    `SubgraphTransformer.finalize` / `fail` — are automatically
+    visible here.
     """
 
     def __init__(self, subgraph: SubgraphRunStream, *, name: str) -> None:
@@ -117,8 +121,8 @@ class SubagentRunStream(BaseRunStream):
         return self._subgraph.path
 
     @property
-    def trigger_call_id(self) -> str | None:
-        return self._subgraph.trigger_call_id
+    def cause(self) -> LifecycleCause | None:
+        return self._subgraph.cause
 
     @property
     def status(self) -> SubgraphStatus:
@@ -151,7 +155,7 @@ class SubagentTransformer(StreamTransformer):
 
     _native: ClassVar[bool] = True
     scope_exact: ClassVar[bool] = False
-    required_stream_modes: ClassVar[tuple[str, ...]] = ("lifecycle",)
+    required_stream_modes: ClassVar[tuple[str, ...]] = ("lifecycle", "tools")
 
     def __init__(
         self,
@@ -164,6 +168,16 @@ class SubagentTransformer(StreamTransformer):
         self._log: EventLog[SubagentRunStream] = EventLog()
         self._by_ns: dict[tuple[str, ...], SubagentRunStream] = {}
         self._subgraph_transformer: SubgraphTransformer | None = None
+        # Pending `task` tool calls awaiting a matching `lifecycle.started`.
+        # Keyed by `tool_call_id`; value carries the originating input so
+        # downstream consumers (e.g. the SDK wrapper) can correlate richer
+        # metadata than `cause` alone conveys.
+        #
+        # Dict insertion order provides oldest-first pairing under
+        # parallel fan-out of the same `subagent_type`, which matches
+        # pregel's scheduling order for the corresponding subgraph
+        # spawns.
+        self._pending_tool_calls: dict[str, dict[str, str]] = {}
 
     def init(self) -> dict[str, Any]:
         return {"subagents": self._log}
@@ -187,7 +201,17 @@ class SubagentTransformer(StreamTransformer):
         self._subgraph_transformer = sub_t
 
     def process(self, event: ProtocolEvent) -> bool:
-        if event["method"] != "lifecycle":
+        method = event["method"]
+
+        # Observe `task` tool calls at this scope. Record the
+        # `tool_call_id` so a matching `lifecycle.started` below can
+        # carry a `cause: { type: "toolCall", toolCallId }` augmenting
+        # the lifecycle event before it reaches the wire.
+        if method == "tools":
+            self._track_task_tool_call(event)
+            return True
+
+        if method != "lifecycle":
             return True
 
         ns = tuple(event["params"]["namespace"])
@@ -202,6 +226,25 @@ class SubagentTransformer(StreamTransformer):
             return True
 
         graph_name = data.get("graph_name")
+        if not isinstance(graph_name, str):
+            return True
+
+        # Augment the lifecycle event with `cause` derived from the
+        # correlated `task` tool call, if any. This mutates the event
+        # dict in place; `StreamMux` passes the same reference through
+        # downstream transformers and onto the wire. Match on the
+        # `subagent_type` from the tool input (dict insertion order
+        # pairs oldest pending tool-call first, matching pregel
+        # scheduling order).
+        for tcid, info in self._pending_tool_calls.items():
+            if info["subagent_type"] == graph_name:
+                cast("dict[str, Any]", event["params"]["data"])["cause"] = {
+                    "type": "toolCall",
+                    "tool_call_id": tcid,
+                }
+                del self._pending_tool_calls[tcid]
+                break
+
         if graph_name not in self._names or ns in self._by_ns:
             return True
 
@@ -215,7 +258,37 @@ class SubagentTransformer(StreamTransformer):
         if subgraph_handle is None:
             return True
 
-        handle = SubagentRunStream(subgraph_handle, name=cast("str", graph_name))
+        handle = SubagentRunStream(subgraph_handle, name=graph_name)
         self._by_ns[ns] = handle
         self._log.push(handle)
         return True
+
+    def _track_task_tool_call(self, event: ProtocolEvent) -> None:
+        """Record / discard pending `task` tool calls observed on `tools`.
+
+        Only `tool_name == "task"` events are tracked — other tool
+        calls don't spawn subagents and would pollute the pending map.
+        """
+        ns = tuple(event["params"]["namespace"])
+        # `tool-started` / `tool-finished` / `tool-error` fire at the
+        # parent namespace, which is exactly `self.scope` for the
+        # subagents we care about (direct children).
+        if ns != self.scope:
+            return
+        data = cast("dict[str, Any]", event["params"]["data"])
+        phase = data.get("event")
+        if phase == "tool-started":
+            if data.get("tool_name") != "task":
+                return
+            tcid = data.get("tool_call_id")
+            raw_input = data.get("input")
+            if not isinstance(tcid, str) or not isinstance(raw_input, dict):
+                return
+            self._pending_tool_calls[tcid] = {
+                "subagent_type": str(raw_input.get("subagent_type") or ""),
+                "description": str(raw_input.get("description") or ""),
+            }
+        elif phase in ("tool-finished", "tool-error"):
+            tcid = data.get("tool_call_id")
+            if isinstance(tcid, str):
+                self._pending_tool_calls.pop(tcid, None)

--- a/libs/deepagents/deepagents/_subagent_transformer.py
+++ b/libs/deepagents/deepagents/_subagent_transformer.py
@@ -27,14 +27,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from langgraph.stream._event_log import EventLog
 from langgraph.stream.run_stream import (
     AsyncSubgraphRunStream,
     SubgraphRunStream,
 )
+from langgraph.stream.stream_channel import StreamChannel
 from langgraph.stream.transformers import (
     SubgraphStatus,
-    ValuesTransformer,
     _TasksLifecycleBase,
 )
 
@@ -84,7 +83,7 @@ class SubagentTransformer(_TasksLifecycleBase):
     ) -> None:
         super().__init__(scope)
         self._names = subagent_names
-        self._log: EventLog[SubagentRunStream | AsyncSubagentRunStream] = EventLog()
+        self._log: StreamChannel[SubagentRunStream | AsyncSubagentRunStream] = StreamChannel()
         self._handles: dict[tuple[str, ...], SubagentRunStream | AsyncSubagentRunStream] = {}
         self._mux: StreamMux | None = None
         # parent_task_id -> {"subagent_type": ..., "tool_call_id": ...}
@@ -155,13 +154,9 @@ class SubagentTransformer(_TasksLifecycleBase):
             child_mux = self._mux._make_child(ns)
         except RuntimeError:
             return
-        values_t = child_mux.transformer_by_key("values")
-        if not isinstance(values_t, ValuesTransformer):
-            return
         handle_cls = AsyncSubagentRunStream if child_mux.is_async else SubagentRunStream
         handle = handle_cls(
             mux=child_mux,
-            values_transformer=values_t,
             path=ns,
             graph_name=subagent_type,
             trigger_call_id=info["tool_call_id"] or None,
@@ -189,7 +184,7 @@ class SubagentTransformer(_TasksLifecycleBase):
         else:
             handle._mux.close()
 
-    def _child_mux_for_event(self, event: ProtocolEvent) -> StreamMux | None:
+    def _handle_for_event(self, event: ProtocolEvent) -> SubagentRunStream | AsyncSubagentRunStream | None:
         ns = tuple(event["params"]["namespace"])
         depth = len(self.scope)
         if len(ns) < depth + 1:
@@ -197,13 +192,14 @@ class SubagentTransformer(_TasksLifecycleBase):
         handle = self._handles.get(ns[: depth + 1])
         if handle is None or handle._mux is None or handle._mux._events._closed:
             return None
-        return handle._mux
+        return handle
 
     def process(self, event: ProtocolEvent) -> bool:
         if event.get("method") == "tasks":
             self._capture_pending_from_parent(event)
         keep = super().process(event)
-        child_mux = self._child_mux_for_event(event)
-        if child_mux is not None:
-            child_mux.push(event)
+        handle = self._handle_for_event(event)
+        if handle is not None:
+            handle._observe_event(event)
+            handle._mux.push(event)
         return keep

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -26,6 +26,7 @@ from langgraph.types import Checkpointer
 from langgraph.typing import ContextT
 
 from deepagents._models import get_model_identifier, get_model_provider, resolve_model
+from deepagents._subagent_transformer import SubagentTransformer
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
@@ -553,22 +554,23 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     ]
     if skills is not None:
         deepagent_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+    sub_agent_middleware = SubAgentMiddleware(
+        backend=backend,
+        subagents=inline_subagents,
+        # Overrides the task tool description. Value should include
+        # {available_agents} — a format placeholder replaced with the
+        # subagent name/description list. Without it the model can't
+        # see which subagents exist. None (default) uses the built-in
+        # template. Stale keys silently no-op if the tool is renamed.
+        task_description=_profile.tool_description_overrides.get("task"),
+    )
     deepagent_middleware.extend(
         [
             FilesystemMiddleware(
                 backend=backend,
                 custom_tool_descriptions=_profile.tool_description_overrides,
             ),
-            SubAgentMiddleware(
-                backend=backend,
-                subagents=inline_subagents,
-                # Overrides the task tool description. Value should include
-                # {available_agents} — a format placeholder replaced with the
-                # subagent name/description list. Without it the model can't
-                # see which subagents exist. None (default) uses the built-in
-                # template. Stale keys silently no-op if the tool is renamed.
-                task_description=_profile.tool_description_overrides.get("task"),
-            ),
+            sub_agent_middleware,
             create_summarization_middleware(model, backend),
             PatchToolCallsMiddleware(),
         ]
@@ -619,6 +621,14 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # String: simple concatenation
         final_system_prompt = system_prompt + "\n\n" + base_prompt
 
+    # Bake declared subagent names into a scope-aware factory so each
+    # subgraph mini-mux spawns a fresh `SubagentTransformer` that knows
+    # which nested runs belong to declared subagents.
+    subagent_names = frozenset(sub_agent_middleware.subagent_names)
+
+    def _subagent_factory(scope: tuple[str, ...] = ()) -> SubagentTransformer:
+        return SubagentTransformer(scope, subagent_names=subagent_names)
+
     return create_agent(
         model,
         system_prompt=final_system_prompt,
@@ -631,6 +641,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         debug=debug,
         name=name,
         cache=cache,
+        transformers=[_subagent_factory],
     ).with_config(
         {
             "recursion_limit": 9_999,

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1442,6 +1442,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             context=runtime.context,
             stream_writer=runtime.stream_writer,
             store=runtime.store,
+            tools=[],
             config=config,
             tool_call_id=None,
         )

--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -227,6 +227,7 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
                 context=runtime.context,
                 stream_writer=runtime.stream_writer,
                 store=runtime.store,
+                tools=[],
                 config=config,
                 tool_call_id=None,
             )

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -677,6 +677,7 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
                 context=runtime.context,
                 stream_writer=runtime.stream_writer,
                 store=runtime.store,
+                tools=[],
                 config=config,
                 tool_call_id=None,
             )

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -540,6 +540,9 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         self._backend = backend
         self._subagents = subagents
         subagent_specs = self._get_subagents()
+        self.subagent_names: frozenset[str] = frozenset(spec["name"] for spec in subagent_specs)
+        """Declared subagent names. Public so streamers can discover them
+        without introspecting the `task` tool's closure."""
 
         task_tool = _build_task_tool(subagent_specs, task_description)
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -13,7 +13,7 @@ from langchain.agents.structured_output import ResponseFormat
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, ToolMessage
-from langchain_core.runnables import Runnable
+from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
 from langsmith.run_helpers import get_tracing_context, tracing_context
@@ -368,7 +368,7 @@ def _subagent_tracing_context() -> Generator[None, None, None]:
         yield
 
 
-def _build_task_tool(  # noqa: C901
+def _build_task_tool(  # noqa: C901, PLR0915
     subagents: list[_SubagentSpec],
     task_description: str | None = None,
 ) -> BaseTool:
@@ -433,29 +433,26 @@ def _build_task_tool(  # noqa: C901
         subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state
 
-    def _build_subagent_config(runtime: ToolRuntime) -> dict[str, Any]:
+    def _build_subagent_config(runtime: ToolRuntime) -> RunnableConfig:
         """Derive the subagent's RunnableConfig from the parent's runtime config.
 
-        Forwarding the parent's config is what lets Pregel's streaming
-        callback handlers propagate into the subagent, so its internal
-        lifecycle / values / messages events land on the parent's
-        stream instead of being swallowed by a fresh (detached) config.
+        Only ``callbacks``, ``tags``, and ``configurable`` are forwarded.
+        Callbacks let Pregel's streaming handlers propagate into the
+        subagent so its events land on the parent's stream.  Tags are
+        forwarded for tracing continuity.  ``configurable`` is needed
+        for Pregel to recognize the subagent as a nested subgraph.
 
-        A `ls_tool_call_id` entry is added to ``metadata`` so downstream
-        stream transformers can correlate the subagent's nested
-        ``tools:<pregel_uuid>`` namespace with the originating
-        ``tool_call_id`` without mutating ``checkpoint_ns`` or emitting
-        synthetic events.
+        ``recursion_limit`` and ``metadata`` are intentionally *not*
+        forwarded — the subagent's own bound config must take precedence.
+        Passing ``metadata`` in the invoke config replaces the
+        subagent's bound metadata (e.g. ``lc_agent_name``).
         """
         parent_config = runtime.config or {}
-        parent_metadata = parent_config.get("metadata") or {}
-        return {
-            **parent_config,
-            "metadata": {
-                **parent_metadata,
-                "ls_tool_call_id": runtime.tool_call_id,
-            },
-        }
+        config: RunnableConfig = {}
+        for key in ("callbacks", "tags", "configurable"):
+            if key in parent_config:
+                config[key] = parent_config[key]  # type: ignore[literal-required]
+        return config
 
     def task(
         description: str,

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -433,6 +433,30 @@ def _build_task_tool(  # noqa: C901
         subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state
 
+    def _build_subagent_config(runtime: ToolRuntime) -> dict[str, Any]:
+        """Derive the subagent's RunnableConfig from the parent's runtime config.
+
+        Forwarding the parent's config is what lets Pregel's streaming
+        callback handlers propagate into the subagent, so its internal
+        lifecycle / values / messages events land on the parent's
+        stream instead of being swallowed by a fresh (detached) config.
+
+        A `ls_tool_call_id` entry is added to ``metadata`` so downstream
+        stream transformers can correlate the subagent's nested
+        ``tools:<pregel_uuid>`` namespace with the originating
+        ``tool_call_id`` without mutating ``checkpoint_ns`` or emitting
+        synthetic events.
+        """
+        parent_config = runtime.config or {}
+        parent_metadata = parent_config.get("metadata") or {}
+        return {
+            **parent_config,
+            "metadata": {
+                **parent_metadata,
+                "ls_tool_call_id": runtime.tool_call_id,
+            },
+        }
+
     def task(
         description: str,
         subagent_type: str,
@@ -445,8 +469,9 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
+        subagent_config = _build_subagent_config(runtime)
         with _subagent_tracing_context():
-            result = subagent.invoke(subagent_state)
+            result = subagent.invoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     async def atask(
@@ -461,8 +486,9 @@ def _build_task_tool(  # noqa: C901
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
         subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
+        subagent_config = _build_subagent_config(runtime)
         with _subagent_tracing_context():
-            result = await subagent.ainvoke(subagent_state)
+            result = await subagent.ainvoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
     return StructuredTool.from_function(

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -375,6 +375,7 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
                 context=runtime.context,
                 stream_writer=runtime.stream_writer,
                 store=runtime.store,
+                tools=[],
                 config=config,
                 tool_call_id=None,
             )

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -20,9 +20,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "langchain-core>=1.2.27,<2.0.0",
+    "langchain-core==1.4.0a2",
     "langsmith>=0.3.0",
-    "langchain>=1.2.15,<2.0.0",
+    "langchain>=1.3.0a1,<2.0.0",
     "langchain-anthropic>=1.4.0,<2.0.0",
     "langchain-google-genai>=4.2.1,<5.0.0",
     "wcmatch",
@@ -133,6 +133,9 @@ filterwarnings = [
 markers = [
     "benchmark: wall-time benchmarks for construction performance",
 ]
+
+[tool.uv]
+prerelease = "allow"
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -24,6 +24,7 @@ def make_runtime(tid: str = "tc", *, store=None):
         tool_call_id=tid,
         store=store or InMemoryStore(),
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -230,6 +230,7 @@ def test_filesystem_backend_intercept_large_tool_result(tmp_path: Path):
         tool_call_id="test_fs",
         store=None,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend_async.py
@@ -218,6 +218,7 @@ async def test_filesystem_backend_intercept_large_tool_result_async(tmp_path: Pa
         tool_call_id="test_fs",
         store=None,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -157,6 +157,7 @@ def test_store_backend_intercept_large_tool_result(file_format):
         tool_call_id="t2",
         store=mem_store,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
     result = middleware._intercept_large_tool_result(tool_message, rt)

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -294,6 +294,7 @@ async def test_store_backend_intercept_large_tool_result_async(file_format):
         tool_call_id="t2",
         store=mem_store,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
     result = middleware._intercept_large_tool_result(tool_message, rt)
@@ -336,6 +337,7 @@ async def test_store_backend_aintercept_large_tool_result_async(file_format):
         tool_call_id="t2",
         store=mem_store,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 

--- a/libs/deepagents/tests/unit_tests/test_artifacts_root.py
+++ b/libs/deepagents/tests/unit_tests/test_artifacts_root.py
@@ -32,6 +32,7 @@ def _runtime(tool_call_id: str = "tc"):
         tool_call_id=tool_call_id,
         store=None,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 

--- a/libs/deepagents/tests/unit_tests/test_async_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_async_subagents.py
@@ -37,6 +37,7 @@ def _make_runtime(tool_call_id: str = "tc_test") -> ToolRuntime:
         tool_call_id=tool_call_id,
         store=None,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 
@@ -70,6 +71,7 @@ def _make_runtime_with_task(
         tool_call_id=tool_call_id,
         store=None,
         stream_writer=lambda _: None,
+        tools=[],
         config={},
     )
 
@@ -284,6 +286,7 @@ class TestCheckTool:
             tool_call_id=tool_call_id,
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -389,6 +392,7 @@ class TestUpdateTool:
             tool_call_id="tc_update",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
         result = update.func(
@@ -465,6 +469,7 @@ class TestListTasksTool:
             tool_call_id="tc_list",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
         result = list_tool.func(runtime=rt)
@@ -527,6 +532,7 @@ class TestListTasksTool:
             tool_call_id="tc_list",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
         result = list_tool.func(runtime=rt)
@@ -574,6 +580,7 @@ class TestListTasksTool:
             tool_call_id="tc_list",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
         result = list_tool.func(runtime=rt, status_filter="running")
@@ -652,6 +659,7 @@ class TestAsyncTools:
             tool_call_id="tc_async_check",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
         result = await check.coroutine(
@@ -691,6 +699,7 @@ class TestAsyncTools:
             tool_call_id="tc_async_update",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
         result = await update.coroutine(

--- a/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
+++ b/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
@@ -20,6 +20,7 @@ from langgraph.graph.state import CompiledStateGraph
 from pydantic import Field
 
 from deepagents import (
+    AsyncSubagentRunStream,
     SubagentRunStream,
     create_deep_agent,
 )
@@ -117,7 +118,7 @@ class TestCreateDeepAgentAstreamV2:
         """`run.subagents` / `.messages` / `.tool_calls` / `.middleware` all bound."""
         agent = _build_agent_with_one_subagent()
         run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
-        for attr in ("subagents", "subgraphs", "messages", "tool_calls", "middleware", "values"):
+        for attr in ("subagents", "subgraphs", "messages", "tool_calls", "values"):
             assert hasattr(run, attr), f"missing projection {attr!r}"
 
         # Drain to drive the pump to completion.
@@ -128,9 +129,9 @@ class TestCreateDeepAgentAstreamV2:
         agent = _build_agent_with_one_subagent()
         run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
 
-        handles: list[SubagentRunStream] = []
+        handles: list[AsyncSubagentRunStream] = []
         async for sub in run.subagents:
-            assert isinstance(sub, SubagentRunStream)
+            assert isinstance(sub, AsyncSubagentRunStream)
             handles.append(sub)
             async for _ in sub.messages:
                 pass
@@ -145,8 +146,9 @@ class TestCreateDeepAgentAstreamV2:
         # path is ("tools:<pregel_task_id>",) — the tool node hosting the subagent.
         assert len(sub.path) == 1
         assert sub.path[0].startswith("tools:")
-        assert isinstance(sub.output, dict)
-        assert "messages" in sub.output
+        sub_output = await sub.output()
+        assert isinstance(sub_output, dict)
+        assert "messages" in sub_output
 
     async def test_subagent_tool_calls_surface(self) -> None:
         agent = _build_agent_with_one_subagent()
@@ -220,7 +222,7 @@ class TestCreateDeepAgentStreamV2:
     def test_run_exposes_native_projections_sync(self) -> None:
         agent = _build_agent_with_one_subagent()
         run = agent.stream_v2({"messages": [HumanMessage(content="go")]})
-        for attr in ("subagents", "subgraphs", "messages", "tool_calls", "middleware", "values"):
+        for attr in ("subagents", "subgraphs", "messages", "tool_calls", "values"):
             assert hasattr(run, attr)
 
         # Drain to completion.

--- a/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
+++ b/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
@@ -1,0 +1,245 @@
+"""Integration tests for create_deep_agent streaming via stream_v2/astream_v2.
+
+Drives a real `create_deep_agent` graph end-to-end through the
+streaming pipeline and asserts that subagents are surfaced as typed
+child streams with the right projections. Runs in both sync and
+async paths.
+"""
+
+import asyncio
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel, LanguageModelInput
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool, tool
+from langgraph.graph.state import CompiledStateGraph
+from pydantic import Field
+
+from deepagents import (
+    SubagentRunStream,
+    create_deep_agent,
+)
+
+
+class _Scripted(BaseChatModel):
+    """Returns a scripted sequence of `AIMessage`s, clamping at the last."""
+
+    responses: list[AIMessage] = Field(default_factory=list)
+    tools: Sequence[dict[str, Any] | type | Callable | BaseTool] = ()
+    _idx: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def _generate(
+        self,
+        messages: Sequence[Any],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        i = min(self._idx, len(self.responses) - 1)
+        self._idx += 1
+        return ChatResult(generations=[ChatGeneration(message=self.responses[i])])
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        self.tools = tools
+        return self
+
+
+@tool
+def _inner(x: str) -> str:
+    """Echo the input with a prefix."""
+    return f"inner-{x}"
+
+
+def _task_call(description: str, subagent_type: str, call_id: str) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[
+            ToolCall(
+                id=call_id,
+                name="task",
+                args={"description": description, "subagent_type": subagent_type},
+            )
+        ],
+    )
+
+
+def _tool_call(name: str, args: dict[str, Any], call_id: str) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[ToolCall(id=call_id, name=name, args=args)],
+    )
+
+
+def _build_agent_with_one_subagent() -> CompiledStateGraph:
+    parent = _Scripted(
+        responses=[
+            _task_call("look something up", "researcher", "call-parent-1"),
+            AIMessage(content="parent done"),
+        ]
+    )
+    subagent = _Scripted(
+        responses=[
+            _tool_call("_inner", {"x": "foo"}, "call-sub-1"),
+            AIMessage(content="subagent done"),
+        ]
+    )
+    return create_deep_agent(
+        model=parent,
+        tools=[],
+        subagents=[
+            {
+                "name": "researcher",
+                "description": "research subagent",
+                "system_prompt": "you are a researcher",
+                "model": subagent,
+                "tools": [_inner],
+            }
+        ],
+    )
+
+
+class TestCreateDeepAgentAstreamV2:
+    async def test_run_exposes_native_projections(self) -> None:
+        """`run.subagents` / `.messages` / `.tool_calls` / `.middleware` all bound."""
+        agent = _build_agent_with_one_subagent()
+        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+        for attr in ("subagents", "subgraphs", "messages", "tool_calls", "middleware", "values"):
+            assert hasattr(run, attr), f"missing projection {attr!r}"
+
+        # Drain to drive the pump to completion.
+        async for _ in run.messages:
+            pass
+
+    async def test_subagents_yields_one_typed_handle(self) -> None:
+        agent = _build_agent_with_one_subagent()
+        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+
+        handles: list[SubagentRunStream] = []
+        async for sub in run.subagents:
+            assert isinstance(sub, SubagentRunStream)
+            handles.append(sub)
+            async for _ in sub.messages:
+                pass
+
+        async for _ in run.messages:
+            pass
+
+        assert len(handles) == 1
+        (sub,) = handles
+        assert sub.name == "researcher"
+        assert sub.status == "completed"
+        # path is ("tools:<pregel_task_id>",) — the tool node hosting the subagent.
+        assert len(sub.path) == 1
+        assert sub.path[0].startswith("tools:")
+        assert isinstance(sub.output, dict)
+        assert "messages" in sub.output
+
+    async def test_subagent_tool_calls_surface(self) -> None:
+        agent = _build_agent_with_one_subagent()
+        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+
+        tool_names: list[str] = []
+        async for sub in run.subagents:
+            tool_names.extend([tc.tool_name async for tc in sub.tool_calls])
+            async for _ in sub.messages:
+                pass
+        async for _ in run.messages:
+            pass
+
+        assert "_inner" in tool_names
+
+    async def test_output_when_no_subagent_invoked(self) -> None:
+        """A run that doesn't dispatch to a subagent still completes cleanly."""
+        model = _Scripted(responses=[AIMessage(content="no tools today")])
+        agent = create_deep_agent(
+            model=model,
+            tools=[],
+            subagents=[
+                {
+                    "name": "researcher",
+                    "description": "r",
+                    "system_prompt": "p",
+                    "model": _Scripted(responses=[AIMessage(content="unused")]),
+                    "tools": [],
+                }
+            ],
+        )
+        run = await agent.astream_v2({"messages": [HumanMessage(content="hi")]})
+
+        # No subagents should surface.
+        handles = [sub async for sub in run.subagents]
+        async for _ in run.messages:
+            pass
+
+        assert handles == []
+        output = await run.output()
+        assert isinstance(output, dict)
+        assert output["messages"][-1].content == "no tools today"
+
+    async def test_concurrent_iteration_does_not_drop_events(self) -> None:
+        """Iterating `subagents` and `messages` in parallel drops no events."""
+        agent = _build_agent_with_one_subagent()
+        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+
+        subagent_names: list[str] = []
+        parent_message_count = 0
+
+        async def drain_subagents() -> None:
+            async for sub in run.subagents:
+                subagent_names.append(sub.name)
+                # Drain sub projections to keep the sub mini-mux healthy.
+                async for _ in sub.messages:
+                    pass
+
+        async def drain_messages() -> None:
+            nonlocal parent_message_count
+            async for _ in run.messages:
+                parent_message_count += 1
+
+        await asyncio.gather(drain_subagents(), drain_messages())
+
+        assert subagent_names == ["researcher"]
+        assert parent_message_count > 0
+
+
+class TestCreateDeepAgentStreamV2:
+    def test_run_exposes_native_projections_sync(self) -> None:
+        agent = _build_agent_with_one_subagent()
+        run = agent.stream_v2({"messages": [HumanMessage(content="go")]})
+        for attr in ("subagents", "subgraphs", "messages", "tool_calls", "middleware", "values"):
+            assert hasattr(run, attr)
+
+        # Drain to completion.
+        for _ in run.messages:
+            pass
+
+    def test_subagents_yields_one_typed_handle_sync(self) -> None:
+        agent = _build_agent_with_one_subagent()
+        run = agent.stream_v2({"messages": [HumanMessage(content="go")]})
+
+        handles: list[SubagentRunStream] = []
+        for sub in run.subagents:
+            handles.append(sub)
+            for _ in sub.messages:
+                pass
+
+        for _ in run.messages:
+            pass
+
+        assert len(handles) == 1
+        assert handles[0].name == "researcher"
+        assert handles[0].status == "completed"

--- a/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
+++ b/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
@@ -1,9 +1,8 @@
-"""Integration tests for create_deep_agent streaming via stream_v2/astream_v2.
+"""Integration tests for create_deep_agent streaming via stream_events(version=\"v3\").
 
-Drives a real `create_deep_agent` graph end-to-end through the
-streaming pipeline and asserts that subagents are surfaced as typed
-child streams with the right projections. Runs in both sync and
-async paths.
+Drives a real `create_deep_agent` graph end-to-end through the v3 streaming
+protocol and asserts that subagents are surfaced as typed child streams with
+the right projections. Covers sync `stream_events` and async `astream_events`.
 """
 
 import asyncio
@@ -113,11 +112,14 @@ def _build_agent_with_one_subagent() -> CompiledStateGraph:
     )
 
 
-class TestCreateDeepAgentAstreamV2:
+class TestCreateDeepAgentAstreamEventsV3:
     async def test_run_exposes_native_projections(self) -> None:
-        """`run.subagents` / `.messages` / `.tool_calls` / `.middleware` all bound."""
+        """`run.subagents` / `.messages` / `.tool_calls` / `.values` all bound."""
         agent = _build_agent_with_one_subagent()
-        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+        run = await agent.astream_events(
+            {"messages": [HumanMessage(content="go")]},
+            version="v3",
+        )
         for attr in ("subagents", "subgraphs", "messages", "tool_calls", "values"):
             assert hasattr(run, attr), f"missing projection {attr!r}"
 
@@ -127,7 +129,10 @@ class TestCreateDeepAgentAstreamV2:
 
     async def test_subagents_yields_one_typed_handle(self) -> None:
         agent = _build_agent_with_one_subagent()
-        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+        run = await agent.astream_events(
+            {"messages": [HumanMessage(content="go")]},
+            version="v3",
+        )
 
         handles: list[AsyncSubagentRunStream] = []
         async for sub in run.subagents:
@@ -152,7 +157,10 @@ class TestCreateDeepAgentAstreamV2:
 
     async def test_subagent_tool_calls_surface(self) -> None:
         agent = _build_agent_with_one_subagent()
-        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+        run = await agent.astream_events(
+            {"messages": [HumanMessage(content="go")]},
+            version="v3",
+        )
 
         tool_names: list[str] = []
         async for sub in run.subagents:
@@ -180,7 +188,10 @@ class TestCreateDeepAgentAstreamV2:
                 }
             ],
         )
-        run = await agent.astream_v2({"messages": [HumanMessage(content="hi")]})
+        run = await agent.astream_events(
+            {"messages": [HumanMessage(content="hi")]},
+            version="v3",
+        )
 
         # No subagents should surface.
         handles = [sub async for sub in run.subagents]
@@ -195,7 +206,10 @@ class TestCreateDeepAgentAstreamV2:
     async def test_concurrent_iteration_does_not_drop_events(self) -> None:
         """Iterating `subagents` and `messages` in parallel drops no events."""
         agent = _build_agent_with_one_subagent()
-        run = await agent.astream_v2({"messages": [HumanMessage(content="go")]})
+        run = await agent.astream_events(
+            {"messages": [HumanMessage(content="go")]},
+            version="v3",
+        )
 
         subagent_names: list[str] = []
         parent_message_count = 0
@@ -218,10 +232,13 @@ class TestCreateDeepAgentAstreamV2:
         assert parent_message_count > 0
 
 
-class TestCreateDeepAgentStreamV2:
+class TestCreateDeepAgentStreamEventsV3:
     def test_run_exposes_native_projections_sync(self) -> None:
         agent = _build_agent_with_one_subagent()
-        run = agent.stream_v2({"messages": [HumanMessage(content="go")]})
+        run = agent.stream_events(
+            {"messages": [HumanMessage(content="go")]},
+            version="v3",
+        )
         for attr in ("subagents", "subgraphs", "messages", "tool_calls", "values"):
             assert hasattr(run, attr)
 
@@ -231,7 +248,10 @@ class TestCreateDeepAgentStreamV2:
 
     def test_subagents_yields_one_typed_handle_sync(self) -> None:
         agent = _build_agent_with_one_subagent()
-        run = agent.stream_v2({"messages": [HumanMessage(content="go")]})
+        run = agent.stream_events(
+            {"messages": [HumanMessage(content="go")]},
+            version="v3",
+        )
 
         handles: list[SubagentRunStream] = []
         for sub in run.subagents:

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -66,7 +66,7 @@ def _make_backend(files=None):
 
 
 def _runtime(tool_call_id=""):
-    return ToolRuntime(state={}, context=None, tool_call_id=tool_call_id, store=None, stream_writer=lambda _: None, config={})
+    return ToolRuntime(state={}, context=None, tool_call_id=tool_call_id, store=None, stream_writer=lambda _: None, tools=[], config={})
 
 
 class TestAddMiddleware:
@@ -1196,6 +1196,7 @@ class TestFilesystemMiddleware:
             tool_call_id="img-read-1",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1227,6 +1228,7 @@ class TestFilesystemMiddleware:
             tool_call_id="img-read-err",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1251,6 +1253,7 @@ class TestFilesystemMiddleware:
             tool_call_id="str-read",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1276,6 +1279,7 @@ class TestFilesystemMiddleware:
             tool_call_id="str-trunc",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1306,6 +1310,7 @@ class TestFilesystemMiddleware:
             tool_call_id="str-tok",
             store=None,
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1346,6 +1351,7 @@ class TestFilesystemMiddleware:
             tool_call_id="test_exec",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1379,6 +1385,7 @@ class TestFilesystemMiddleware:
             tool_call_id="test_fmt",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1415,6 +1422,7 @@ class TestFilesystemMiddleware:
             tool_call_id="test_fail",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1451,6 +1459,7 @@ class TestFilesystemMiddleware:
             tool_call_id="test_trunc",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1482,6 +1491,7 @@ class TestFilesystemMiddleware:
             tool_call_id="test",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1944,6 +1954,7 @@ class TestBuiltinTruncationTools:
             tool_call_id="test_zero_timeout",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -1975,6 +1986,7 @@ class TestBuiltinTruncationTools:
             tool_call_id="test_neg_timeout",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -2008,6 +2020,7 @@ class TestBuiltinTruncationTools:
             tool_call_id="test_fwd_timeout",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -2037,6 +2050,7 @@ class TestBuiltinTruncationTools:
             tool_call_id="test_max_execute_timeout",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -2071,6 +2085,7 @@ class TestBuiltinTruncationTools:
             tool_call_id="test_at_max_execute_timeout",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -2102,6 +2117,7 @@ class TestBuiltinTruncationTools:
             tool_call_id="test_none_timeout",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -33,7 +33,7 @@ def _make_backend(files=None):
 
 
 def _runtime():
-    return ToolRuntime(state={}, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, config={})
+    return ToolRuntime(state={}, context=None, tool_call_id="", store=None, stream_writer=lambda _: None, tools=[], config={})
 
 
 class TestFilesystemMiddlewareAsync:
@@ -574,7 +574,7 @@ class TestFilesystemMiddlewareAsync:
             {
                 "file_path": "/test.txt",
                 "content": "Hello world",
-                "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc1", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc1", store=None, stream_writer=lambda _: None, tools=[], config={}),
             }
         )
         # StoreBackend writes to the store and returns a plain string
@@ -598,7 +598,7 @@ class TestFilesystemMiddlewareAsync:
                 "file_path": "/test.txt",
                 "old_string": "Hello",
                 "new_string": "Hi",
-                "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc2", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc2", store=None, stream_writer=lambda _: None, tools=[], config={}),
             }
         )
         # StoreBackend writes to the store and returns a plain string
@@ -623,7 +623,7 @@ class TestFilesystemMiddlewareAsync:
                 "old_string": "Hello",
                 "new_string": "Hi",
                 "replace_all": True,
-                "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc3", store=None, stream_writer=lambda _: None, config={}),
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc3", store=None, stream_writer=lambda _: None, tools=[], config={}),
             }
         )
         assert isinstance(result, str)
@@ -644,6 +644,7 @@ class TestFilesystemMiddlewareAsync:
             tool_call_id="test_exec",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -682,6 +683,7 @@ class TestFilesystemMiddlewareAsync:
             tool_call_id="test_zero_timeout_async",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -724,6 +726,7 @@ class TestFilesystemMiddlewareAsync:
             tool_call_id="test_fmt",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -767,6 +770,7 @@ class TestFilesystemMiddlewareAsync:
             tool_call_id="test_fail",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 
@@ -810,6 +814,7 @@ class TestFilesystemMiddlewareAsync:
             tool_call_id="test_trunc",
             store=InMemoryStore(),
             stream_writer=lambda _: None,
+            tools=[],
             config={},
         )
 

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -14,7 +14,7 @@ from deepagents.middleware.permissions import FilesystemPermission, _check_fs_pe
 
 
 def _runtime(tool_call_id: str = "") -> ToolRuntime:
-    return ToolRuntime(state={}, context=None, tool_call_id=tool_call_id, store=None, stream_writer=lambda _: None, config={})
+    return ToolRuntime(state={}, context=None, tool_call_id=tool_call_id, store=None, stream_writer=lambda _: None, tools=[], config={})
 
 
 def _make_backend(files: dict | None = None) -> StoreBackend:

--- a/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
+++ b/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
@@ -1,10 +1,21 @@
-"""Unit tests for `SubagentTransformer` — synthetic lifecycle events.
+"""Unit tests for `SubagentTransformer`.
 
 These tests exercise the transformer in isolation by pushing protocol
 events directly into a `StreamMux` configured with
 `SubagentTransformer` alongside the usual `values` / `messages` /
 `subgraphs` transformers. Mirrors the structure of langgraph's
 `test_stream_subgraph_transformer.py`.
+
+Covered behaviors:
+
+- Handle promotion for declared subagents via `lifecycle.started`.
+- `cause` augmentation correlating root-scope ``tools.tool-started``
+  events to the subagent's ``lifecycle.started`` by
+  ``subagent_type`` and oldest-first insertion order.
+- Wire-level namespace rewrite that remaps ``tools:<pregel_uuid>``
+  first segments to ``tools:<tool_call_id>`` on every downstream
+  event without mutating the SubgraphTransformer's internal
+  ``_by_ns`` key.
 """
 
 from __future__ import annotations
@@ -467,3 +478,179 @@ class TestSubagentTransformerCauseAugmentation:
         )
         mux.push(started)
         assert "cause" not in started["params"]["data"]
+
+
+class TestSubagentTransformerNamespaceRewrite:
+    """Pregel-uuid → tool-call-id namespace rewriting on the wire."""
+
+    NAMES = frozenset({"researcher", "coder"})
+
+    def _mux(self) -> tuple[StreamMux, SubagentTransformer]:
+        mux = StreamMux(factories=_factories(self.NAMES), is_async=False)
+        transformer = mux.transformer_by_key("subagents")
+        assert isinstance(transformer, SubagentTransformer)
+        _subscribe(transformer._log)
+        return mux, transformer
+
+    def test_started_rewrites_pregel_uuid_to_tool_call_id(self) -> None:
+        """A pregel-uuid ns on `lifecycle.started` is rewritten to `tools:<tcid>`."""
+        mux, transformer = self._mux()
+        pregel_seg = "tools:598518b1-67d5-f5d4-716b-d4ab890914d3"
+        started = _lifecycle(
+            "started",
+            namespace=[pregel_seg],
+            graph_name="researcher",
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="toolu_ABC",
+                input={"subagent_type": "researcher", "description": "do"},
+            )
+        )
+        mux.push(started)
+
+        assert started["params"]["namespace"] == ["tools:toolu_ABC"]
+        assert started["params"]["data"]["cause"] == {
+            "type": "toolCall",
+            "tool_call_id": "toolu_ABC",
+        }
+        # The map records the Pregel-assigned segment → tcid rewrite
+        # for later events under the same segment.
+        assert transformer._ns_rewrite == {pregel_seg: "tools:toolu_ABC"}
+
+    def test_subsequent_events_inherit_rewrite(self) -> None:
+        """Values / messages / terminal lifecycle under the pregel ns all get remapped."""
+        mux, transformer = self._mux()
+        pregel_seg = "tools:pregel-uuid-1"
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc1",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _lifecycle(
+                "started", namespace=[pregel_seg], graph_name="researcher"
+            )
+        )
+
+        values = _values({"messages": []}, namespace=[pregel_seg])
+        deep_values = _values({"k": 1}, namespace=[pregel_seg, "model:m1"])
+        completed = _lifecycle("completed", namespace=[pregel_seg])
+
+        mux.push(values)
+        mux.push(deep_values)
+        mux.push(completed)
+
+        assert values["params"]["namespace"] == ["tools:tc1"]
+        assert deep_values["params"]["namespace"] == ["tools:tc1", "model:m1"]
+        assert completed["params"]["namespace"] == ["tools:tc1"]
+
+    def test_unknown_pregel_segment_passes_through(self) -> None:
+        """Events at an un-paired pregel segment are left untouched."""
+        mux, transformer = self._mux()
+        # No `tool-started` preceded, so the transformer has no mapping.
+        values = _values({"k": 1}, namespace=["tools:unknown-uuid"])
+        mux.push(values)
+        assert values["params"]["namespace"] == ["tools:unknown-uuid"]
+        assert transformer._ns_rewrite == {}
+
+    def test_trivial_mapping_not_recorded(self) -> None:
+        """If `lifecycle.started` already arrives at `tools:<tcid>`, no rewrite is stored."""
+        mux, transformer = self._mux()
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc1",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _lifecycle(
+                "started",
+                namespace=["tools:tc1"],
+                graph_name="researcher",
+            )
+        )
+        assert transformer._ns_rewrite == {}
+
+    def test_parallel_subagents_rewrite_independently(self) -> None:
+        """Two concurrently-dispatched subagents each get their own mapping."""
+        mux, transformer = self._mux()
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_a",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_b",
+                input={"subagent_type": "coder"},
+            )
+        )
+        started_a = _lifecycle(
+            "started",
+            namespace=["tools:uuid-a"],
+            graph_name="researcher",
+        )
+        started_b = _lifecycle(
+            "started",
+            namespace=["tools:uuid-b"],
+            graph_name="coder",
+        )
+        mux.push(started_a)
+        mux.push(started_b)
+
+        assert started_a["params"]["namespace"] == ["tools:tc_a"]
+        assert started_b["params"]["namespace"] == ["tools:tc_b"]
+
+        values_a = _values({"k": "a"}, namespace=["tools:uuid-a"])
+        values_b = _values({"k": "b"}, namespace=["tools:uuid-b"])
+        mux.push(values_a)
+        mux.push(values_b)
+
+        assert values_a["params"]["namespace"] == ["tools:tc_a"]
+        assert values_b["params"]["namespace"] == ["tools:tc_b"]
+
+    def test_rewrite_does_not_confuse_subgraph_handle(self) -> None:
+        """SubgraphTransformer still keys `_by_ns` off the pre-rewrite namespace."""
+        mux, transformer = self._mux()
+        pregel_seg = "tools:pregel-uuid-x"
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_x",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _lifecycle(
+                "started", namespace=[pregel_seg], graph_name="researcher"
+            )
+        )
+
+        sub_t = mux.transformer_by_key("subgraphs")
+        # SubgraphTransformer saw the event BEFORE the rewrite (its
+        # factory slot precedes SubagentTransformer's), so it keys
+        # off the pre-rewrite pregel_uuid tuple. The Subagent handle
+        # wraps the same SubgraphRunStream.
+        assert (pregel_seg,) in sub_t._by_ns  # type: ignore[attr-defined]
+        (handle,) = list(transformer._log._items)
+        assert handle._subgraph is sub_t._by_ns[(pregel_seg,)]  # type: ignore[attr-defined]

--- a/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
+++ b/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
@@ -1,21 +1,19 @@
 """Unit tests for `SubagentTransformer`.
 
-These tests exercise the transformer in isolation by pushing protocol
-events directly into a `StreamMux` configured with
-`SubagentTransformer` alongside the usual `values` / `messages` /
-`subgraphs` transformers. Mirrors the structure of langgraph's
-`test_stream_subgraph_transformer.py`.
+Pushes synthetic `tasks` protocol events into a `StreamMux` configured
+with `SubagentTransformer` alongside the usual native transformers.
+Mirrors the structure of langgraph's `test_stream_subgraph_transformer.py`.
 
-Covered behaviors:
+The realistic event sequence is:
 
-- Handle promotion for declared subagents via `lifecycle.started`.
-- `cause` augmentation correlating root-scope ``tools.tool-started``
-  events to the subagent's ``lifecycle.started`` by
-  ``subagent_type`` and oldest-first insertion order.
-- Wire-level namespace rewrite that remaps ``tools:<pregel_uuid>``
-  first segments to ``tools:<tool_call_id>`` on every downstream
-  event without mutating the SubgraphTransformer's internal
-  ``_by_ns`` key.
+1. Parent-scope `tasks` start with ``name == "tools"`` and ``input``
+   containing ``task`` tool calls — this is how the transformer learns
+   ``parent_task_id → (subagent_type, tool_call_id)``.
+2. Child-scope `tasks` start at ``["tools:<parent_task_id>"]`` —
+   triggers `_on_started`, which looks up the parent mapping and
+   builds a `SubagentRunStream` if the type is declared.
+3. Parent-scope `tasks` result with the matching ``id`` — closes the
+   child handle.
 """
 
 from __future__ import annotations
@@ -27,6 +25,7 @@ from langgraph.errors import GraphInterrupt
 from langgraph.stream._event_log import EventLog
 from langgraph.stream._mux import StreamMux
 from langgraph.stream.transformers import (
+    LifecycleTransformer,
     MessagesTransformer,
     SubgraphTransformer,
     ValuesTransformer,
@@ -40,56 +39,103 @@ if TYPE_CHECKING:
 TS = int(time.time() * 1000)
 
 
-def _lifecycle(
-    event: str,
-    *,
-    namespace: list[str] | None = None,
-    graph_name: str | None = None,
-    cause: dict[str, Any] | None = None,
-    error: str | None = None,
-) -> ProtocolEvent:
-    data: dict[str, Any] = {"event": event}
-    if graph_name is not None:
-        data["graph_name"] = graph_name
-    if cause is not None:
-        data["cause"] = cause
-    if error is not None:
-        data["error"] = error
-    return {
-        "type": "event",
-        "method": "lifecycle",
-        "params": {
-            "namespace": namespace or [],
-            "timestamp": TS,
-            "data": data,
-        },
-    }
-
-
-def _tools(
-    event: str,
-    *,
+def _tools_start(
     namespace: list[str],
-    tool_name: str | None = None,
-    tool_call_id: str | None = None,
-    input: dict[str, Any] | None = None,
+    *,
+    parent_task_id: str,
+    subagent_type: str,
+    tool_call_id: str,
 ) -> ProtocolEvent:
-    data: dict[str, Any] = {"event": event}
-    if tool_name is not None:
-        data["tool_name"] = tool_name
-    if tool_call_id is not None:
-        data["tool_call_id"] = tool_call_id
-    if input is not None:
-        data["input"] = input
+    """A parent-scope `tools`-task start that dispatches one `task` tool call."""
     return {
         "type": "event",
-        "method": "tools",
+        "method": "tasks",
         "params": {
             "namespace": namespace,
             "timestamp": TS,
-            "data": data,
+            "data": {
+                "id": parent_task_id,
+                "name": "tools",
+                "input": [
+                    {
+                        "name": "task",
+                        "args": {"subagent_type": subagent_type},
+                        "id": tool_call_id,
+                    }
+                ],
+                "triggers": [],
+            },
         },
     }
+
+
+def _child_tasks_start(
+    namespace: list[str],
+    *,
+    task_id: str = "child-task",
+    name: str = "PatchToolCallsMiddleware.before_agent",
+) -> ProtocolEvent:
+    """A child-scope `tasks` start (any inner node — kicks off the subagent)."""
+    return {
+        "type": "event",
+        "method": "tasks",
+        "params": {
+            "namespace": namespace,
+            "timestamp": TS,
+            "data": {
+                "id": task_id,
+                "name": name,
+                "input": None,
+                "triggers": [],
+            },
+        },
+    }
+
+
+def _parent_tasks_result(
+    namespace: list[str],
+    *,
+    parent_task_id: str,
+    error: str | None = None,
+    interrupts: list[dict[str, Any]] | None = None,
+) -> ProtocolEvent:
+    """A parent-scope `tools`-task result that closes the dispatched subagent."""
+    return {
+        "type": "event",
+        "method": "tasks",
+        "params": {
+            "namespace": namespace,
+            "timestamp": TS,
+            "data": {
+                "id": parent_task_id,
+                "name": "tools",
+                "error": error,
+                "interrupts": interrupts or [],
+                "result": {},
+            },
+        },
+    }
+
+
+def _spawn(
+    mux: StreamMux,
+    *,
+    parent_task_id: str,
+    subagent_type: str,
+    tool_call_id: str,
+    parent_ns: list[str] | None = None,
+) -> None:
+    """Push parent + child start events that mimic a real subagent spawn."""
+    parent_ns = parent_ns or []
+    mux.push(
+        _tools_start(
+            parent_ns,
+            parent_task_id=parent_task_id,
+            subagent_type=subagent_type,
+            tool_call_id=tool_call_id,
+        )
+    )
+    mux.push(_child_tasks_start([*parent_ns, f"tools:{parent_task_id}"]))
 
 
 def _values(payload: dict[str, Any], *, namespace: list[str]) -> ProtocolEvent:
@@ -105,37 +151,24 @@ def _values(payload: dict[str, Any], *, namespace: list[str]) -> ProtocolEvent:
 
 
 def _subscribe(log: EventLog) -> None:
-    """Flip `_subscribed = True` so pushes retain items for test inspection."""
     log._subscribed = True
 
 
 def _pre_subscribe_handle(handle: SubagentRunStream) -> None:
-    """Flip `_subscribed` on every EventLog inside the handle's mini-mux.
-
-    The child mini-mux is built via `make_child` with the full factory
-    list, so `values` / `messages` / `subagents` logs exist as
-    projections. Tests that feed events directly need them subscribed
-    so pushes retain items for `_items` inspection.
-    """
+    """Flip `_subscribed` on every EventLog inside the handle's mini-mux."""
     for value in handle._mux.extensions.values():
         if isinstance(value, EventLog):
             _subscribe(value)
 
 
 def _factories(names: frozenset[str]):
-    """Return a factory list matching DeepAgentStreamer's minimal shape.
-
-    Omits the agent-layer transformers (ToolCall / Middleware) — they
-    don't interact with subagent routing and adding them here would
-    just pull in langchain-side imports.
-    """
-
     def subagent_factory(scope: tuple[str, ...]) -> SubagentTransformer:
         return SubagentTransformer(scope, subagent_names=names)
 
     return [
         ValuesTransformer,
         MessagesTransformer,
+        LifecycleTransformer,
         SubgraphTransformer,
         subagent_factory,
     ]
@@ -163,56 +196,60 @@ class TestSubagentTransformerUnit:
         (handle,) = list(transformer._log._items)
         return handle
 
-    def test_nondeclared_graph_name_is_ignored(self) -> None:
-        """A plain subgraph (graph_name not in declared names) stays off `.subagents`."""
+    def test_nondeclared_subagent_type_is_ignored(self) -> None:
+        """A `task` tool call with a non-declared subagent_type stays off `.subagents`."""
         mux, transformer = self._mux()
-        mux.push(
-            _lifecycle(
-                "started",
-                namespace=["tools:abc"],
-                graph_name="plain_tool_subgraph",
-                cause={"type": "toolCall", "tool_call_id": "abc"},
-            )
+        _spawn(
+            mux,
+            parent_task_id="abc",
+            subagent_type="plain_subagent",
+            tool_call_id="tc-1",
         )
 
         assert list(transformer._log._items) == []
-        assert transformer._by_ns == {}
+        assert transformer._handles == {}
 
-    def test_declared_graph_name_yields_handle(self) -> None:
-        """A `started` event whose graph_name matches a declared name produces a SubagentRunStream."""
+    def test_declared_subagent_yields_handle(self) -> None:
+        """A declared subagent_type produces a `SubagentRunStream` with proper metadata."""
         mux, transformer = self._mux()
-        mux.push(
-            _lifecycle(
-                "started",
-                namespace=["tools:abc"],
-                graph_name="researcher",
-                cause={"type": "toolCall", "tool_call_id": "abc"},
-            )
+        _spawn(
+            mux,
+            parent_task_id="abc",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
         )
 
         handle = self._handle(transformer)
         assert isinstance(handle, SubagentRunStream)
         assert handle.path == ("tools:abc",)
         assert handle.name == "researcher"
-        assert handle.cause == {"type": "toolCall", "tool_call_id": "abc"}
+        assert handle.cause == {"type": "toolCall", "tool_call_id": "tc-1"}
         assert handle.status == "started"
 
     def test_status_transitions(self) -> None:
-        """Started → running → completed updates the handle in place."""
+        """A parent-scope tasks-result closes the subagent and marks completed."""
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
-        mux.push(_lifecycle("running", namespace=["tools:x"]))
-        mux.push(_lifecycle("completed", namespace=["tools:x"]))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
+        mux.push(_parent_tasks_result([], parent_task_id="x"))
 
         handle = self._handle(transformer)
         assert handle.status == "completed"
-        # Terminal status closes the mini-mux so consumers unblock.
         assert handle._mux.extensions["values"]._closed
 
     def test_failed_stores_error(self) -> None:
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
-        mux.push(_lifecycle("failed", namespace=["tools:x"], error="boom"))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
+        mux.push(_parent_tasks_result([], parent_task_id="x", error="boom"))
 
         handle = self._handle(transformer)
         assert handle.status == "failed"
@@ -221,7 +258,12 @@ class TestSubagentTransformerUnit:
     def test_values_routed_into_handle(self) -> None:
         """Values events under the subagent's ns flow into its mini-mux."""
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
 
         handle = self._handle(transformer)
         _pre_subscribe_handle(handle)
@@ -235,7 +277,12 @@ class TestSubagentTransformerUnit:
     def test_root_values_not_routed(self) -> None:
         """A values event at root ns must not leak into a child handle."""
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
         handle = self._handle(transformer)
         _pre_subscribe_handle(handle)
 
@@ -243,19 +290,25 @@ class TestSubagentTransformerUnit:
         assert _handle_values_items(handle) == []
 
     def test_nested_subagent_surfaces_under_parent(self) -> None:
-        """A nested subagent under a subagent appears on the parent's `.subagents`."""
+        """A subagent spawned from inside another subagent surfaces on the parent's `.subagents`."""
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:p"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="p",
+            subagent_type="researcher",
+            tool_call_id="tc-p",
+        )
 
         parent = self._handle(transformer)
         _pre_subscribe_handle(parent)
 
-        mux.push(
-            _lifecycle(
-                "started",
-                namespace=["tools:p", "tools:c"],
-                graph_name="coder",
-            )
+        # Nested spawn: parent ns is the researcher's ns; same `tools`-then-child pattern.
+        _spawn(
+            mux,
+            parent_task_id="c",
+            subagent_type="coder",
+            tool_call_id="tc-c",
+            parent_ns=["tools:p"],
         )
 
         (child,) = _handle_subagents_items(parent)
@@ -263,20 +316,25 @@ class TestSubagentTransformerUnit:
         assert child.path == ("tools:p", "tools:c")
         assert child.name == "coder"
 
-    def test_nested_nondeclared_subgraph_does_not_surface_on_subagents(self) -> None:
-        """A nested plain subgraph (graph_name not declared) does NOT appear on `.subagents`."""
+    def test_nested_nondeclared_does_not_surface_on_subagents(self) -> None:
+        """A nested non-declared subagent_type does NOT appear on `.subagents`."""
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:p"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="p",
+            subagent_type="researcher",
+            tool_call_id="tc-p",
+        )
 
         parent = self._handle(transformer)
         _pre_subscribe_handle(parent)
 
-        mux.push(
-            _lifecycle(
-                "started",
-                namespace=["tools:p", "tools:c"],
-                graph_name="plain_nested",
-            )
+        _spawn(
+            mux,
+            parent_task_id="c",
+            subagent_type="plain_nested",
+            tool_call_id="tc-c",
+            parent_ns=["tools:p"],
         )
 
         assert _handle_subagents_items(parent) == []
@@ -284,7 +342,12 @@ class TestSubagentTransformerUnit:
     def test_finalize_closes_dangling(self) -> None:
         """A still-open child at finalize time is marked completed and its mux closed."""
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
 
         handle = self._handle(transformer)
         mux.close()
@@ -295,7 +358,12 @@ class TestSubagentTransformerUnit:
 
     def test_fail_with_graph_interrupt_marks_interrupted(self) -> None:
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
         handle = self._handle(transformer)
 
         mux.fail(GraphInterrupt())
@@ -303,354 +371,14 @@ class TestSubagentTransformerUnit:
 
     def test_fail_with_generic_error_marks_failed(self) -> None:
         mux, transformer = self._mux()
-        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        _spawn(
+            mux,
+            parent_task_id="x",
+            subagent_type="researcher",
+            tool_call_id="tc-1",
+        )
         handle = self._handle(transformer)
 
         mux.fail(RuntimeError("kaboom"))
         assert handle.status == "failed"
         assert handle.error == "kaboom"
-
-
-class TestSubagentTransformerCauseAugmentation:
-    """`tool-started` → `lifecycle.started` correlation mutates `cause` in place."""
-
-    NAMES = frozenset({"researcher", "coder"})
-
-    def _mux(self) -> tuple[StreamMux, SubagentTransformer]:
-        mux = StreamMux(factories=_factories(self.NAMES), is_async=False)
-        transformer = mux.transformer_by_key("subagents")
-        assert isinstance(transformer, SubagentTransformer)
-        _subscribe(transformer._log)
-        return mux, transformer
-
-    def test_single_task_populates_cause(self) -> None:
-        """A matching `task` tool call on the parent → `lifecycle.started.cause`."""
-        mux, transformer = self._mux()
-        started = _lifecycle(
-            "started",
-            namespace=["tools:tc1"],
-            graph_name="researcher",
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc1",
-                input={"subagent_type": "researcher", "description": "do a thing"},
-            )
-        )
-        mux.push(started)
-
-        assert started["params"]["data"]["cause"] == {
-            "type": "toolCall",
-            "tool_call_id": "tc1",
-        }
-        handle = list(transformer._log._items)[0]
-        assert handle.cause == {"type": "toolCall", "tool_call_id": "tc1"}
-
-    def test_parallel_distinct_types_each_match(self) -> None:
-        """Two tool calls of different subagent types → each paired correctly."""
-        mux, transformer = self._mux()
-        researcher_started = _lifecycle(
-            "started", namespace=["tools:r"], graph_name="researcher"
-        )
-        coder_started = _lifecycle(
-            "started", namespace=["tools:c"], graph_name="coder"
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_r",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_c",
-                input={"subagent_type": "coder"},
-            )
-        )
-        mux.push(researcher_started)
-        mux.push(coder_started)
-
-        assert researcher_started["params"]["data"]["cause"] == {
-            "type": "toolCall",
-            "tool_call_id": "tc_r",
-        }
-        assert coder_started["params"]["data"]["cause"] == {
-            "type": "toolCall",
-            "tool_call_id": "tc_c",
-        }
-
-    def test_parallel_same_type_oldest_first(self) -> None:
-        """Two tool calls of the same subagent type → oldest-first pairing."""
-        mux, transformer = self._mux()
-        first_started = _lifecycle(
-            "started", namespace=["tools:a"], graph_name="researcher"
-        )
-        second_started = _lifecycle(
-            "started", namespace=["tools:b"], graph_name="researcher"
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_1",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_2",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(first_started)
-        mux.push(second_started)
-
-        assert first_started["params"]["data"]["cause"] == {
-            "type": "toolCall",
-            "tool_call_id": "tc_1",
-        }
-        assert second_started["params"]["data"]["cause"] == {
-            "type": "toolCall",
-            "tool_call_id": "tc_2",
-        }
-
-    def test_tool_error_cleans_pending(self) -> None:
-        """A `tool-error` before `lifecycle.started` removes the pending entry."""
-        mux, transformer = self._mux()
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_err",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _tools(
-                "tool-error",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_err",
-            )
-        )
-        assert transformer._pending_tool_calls == {}
-
-        started = _lifecycle(
-            "started", namespace=["tools:x"], graph_name="researcher"
-        )
-        mux.push(started)
-        # No pending → no cause augmentation.
-        assert "cause" not in started["params"]["data"]
-
-    def test_non_task_tool_ignored(self) -> None:
-        """A non-`task` tool call is not tracked."""
-        mux, transformer = self._mux()
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="other_tool",
-                tool_call_id="tc_other",
-                input={"some": "payload"},
-            )
-        )
-        assert transformer._pending_tool_calls == {}
-
-    def test_subagent_without_task_no_cause(self) -> None:
-        """A subagent `lifecycle.started` with no matching tool call → no cause emitted."""
-        mux, transformer = self._mux()
-        started = _lifecycle(
-            "started", namespace=["tools:x"], graph_name="researcher"
-        )
-        mux.push(started)
-        assert "cause" not in started["params"]["data"]
-
-
-class TestSubagentTransformerNamespaceRewrite:
-    """Pregel-uuid → tool-call-id namespace rewriting on the wire."""
-
-    NAMES = frozenset({"researcher", "coder"})
-
-    def _mux(self) -> tuple[StreamMux, SubagentTransformer]:
-        mux = StreamMux(factories=_factories(self.NAMES), is_async=False)
-        transformer = mux.transformer_by_key("subagents")
-        assert isinstance(transformer, SubagentTransformer)
-        _subscribe(transformer._log)
-        return mux, transformer
-
-    def test_started_rewrites_pregel_uuid_to_tool_call_id(self) -> None:
-        """A pregel-uuid ns on `lifecycle.started` is rewritten to `tools:<tcid>`."""
-        mux, transformer = self._mux()
-        pregel_seg = "tools:598518b1-67d5-f5d4-716b-d4ab890914d3"
-        started = _lifecycle(
-            "started",
-            namespace=[pregel_seg],
-            graph_name="researcher",
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="toolu_ABC",
-                input={"subagent_type": "researcher", "description": "do"},
-            )
-        )
-        mux.push(started)
-
-        assert started["params"]["namespace"] == ["tools:toolu_ABC"]
-        assert started["params"]["data"]["cause"] == {
-            "type": "toolCall",
-            "tool_call_id": "toolu_ABC",
-        }
-        # The map records the Pregel-assigned segment → tcid rewrite
-        # for later events under the same segment.
-        assert transformer._ns_rewrite == {pregel_seg: "tools:toolu_ABC"}
-
-    def test_subsequent_events_inherit_rewrite(self) -> None:
-        """Values / messages / terminal lifecycle under the pregel ns all get remapped."""
-        mux, transformer = self._mux()
-        pregel_seg = "tools:pregel-uuid-1"
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc1",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _lifecycle(
-                "started", namespace=[pregel_seg], graph_name="researcher"
-            )
-        )
-
-        values = _values({"messages": []}, namespace=[pregel_seg])
-        deep_values = _values({"k": 1}, namespace=[pregel_seg, "model:m1"])
-        completed = _lifecycle("completed", namespace=[pregel_seg])
-
-        mux.push(values)
-        mux.push(deep_values)
-        mux.push(completed)
-
-        assert values["params"]["namespace"] == ["tools:tc1"]
-        assert deep_values["params"]["namespace"] == ["tools:tc1", "model:m1"]
-        assert completed["params"]["namespace"] == ["tools:tc1"]
-
-    def test_unknown_pregel_segment_passes_through(self) -> None:
-        """Events at an un-paired pregel segment are left untouched."""
-        mux, transformer = self._mux()
-        # No `tool-started` preceded, so the transformer has no mapping.
-        values = _values({"k": 1}, namespace=["tools:unknown-uuid"])
-        mux.push(values)
-        assert values["params"]["namespace"] == ["tools:unknown-uuid"]
-        assert transformer._ns_rewrite == {}
-
-    def test_trivial_mapping_not_recorded(self) -> None:
-        """If `lifecycle.started` already arrives at `tools:<tcid>`, no rewrite is stored."""
-        mux, transformer = self._mux()
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc1",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _lifecycle(
-                "started",
-                namespace=["tools:tc1"],
-                graph_name="researcher",
-            )
-        )
-        assert transformer._ns_rewrite == {}
-
-    def test_parallel_subagents_rewrite_independently(self) -> None:
-        """Two concurrently-dispatched subagents each get their own mapping."""
-        mux, transformer = self._mux()
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_a",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_b",
-                input={"subagent_type": "coder"},
-            )
-        )
-        started_a = _lifecycle(
-            "started",
-            namespace=["tools:uuid-a"],
-            graph_name="researcher",
-        )
-        started_b = _lifecycle(
-            "started",
-            namespace=["tools:uuid-b"],
-            graph_name="coder",
-        )
-        mux.push(started_a)
-        mux.push(started_b)
-
-        assert started_a["params"]["namespace"] == ["tools:tc_a"]
-        assert started_b["params"]["namespace"] == ["tools:tc_b"]
-
-        values_a = _values({"k": "a"}, namespace=["tools:uuid-a"])
-        values_b = _values({"k": "b"}, namespace=["tools:uuid-b"])
-        mux.push(values_a)
-        mux.push(values_b)
-
-        assert values_a["params"]["namespace"] == ["tools:tc_a"]
-        assert values_b["params"]["namespace"] == ["tools:tc_b"]
-
-    def test_rewrite_does_not_confuse_subgraph_handle(self) -> None:
-        """SubgraphTransformer still keys `_by_ns` off the pre-rewrite namespace."""
-        mux, transformer = self._mux()
-        pregel_seg = "tools:pregel-uuid-x"
-        mux.push(
-            _tools(
-                "tool-started",
-                namespace=[],
-                tool_name="task",
-                tool_call_id="tc_x",
-                input={"subagent_type": "researcher"},
-            )
-        )
-        mux.push(
-            _lifecycle(
-                "started", namespace=[pregel_seg], graph_name="researcher"
-            )
-        )
-
-        sub_t = mux.transformer_by_key("subgraphs")
-        # SubgraphTransformer saw the event BEFORE the rewrite (its
-        # factory slot precedes SubagentTransformer's), so it keys
-        # off the pre-rewrite pregel_uuid tuple. The Subagent handle
-        # wraps the same SubgraphRunStream.
-        assert (pregel_seg,) in sub_t._by_ns  # type: ignore[attr-defined]
-        (handle,) = list(transformer._log._items)
-        assert handle._subgraph is sub_t._by_ns[(pregel_seg,)]  # type: ignore[attr-defined]

--- a/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
+++ b/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
@@ -34,14 +34,14 @@ def _lifecycle(
     *,
     namespace: list[str] | None = None,
     graph_name: str | None = None,
-    trigger_call_id: str | None = None,
+    cause: dict[str, Any] | None = None,
     error: str | None = None,
 ) -> ProtocolEvent:
     data: dict[str, Any] = {"event": event}
     if graph_name is not None:
         data["graph_name"] = graph_name
-    if trigger_call_id is not None:
-        data["trigger_call_id"] = trigger_call_id
+    if cause is not None:
+        data["cause"] = cause
     if error is not None:
         data["error"] = error
     return {
@@ -49,6 +49,32 @@ def _lifecycle(
         "method": "lifecycle",
         "params": {
             "namespace": namespace or [],
+            "timestamp": TS,
+            "data": data,
+        },
+    }
+
+
+def _tools(
+    event: str,
+    *,
+    namespace: list[str],
+    tool_name: str | None = None,
+    tool_call_id: str | None = None,
+    input: dict[str, Any] | None = None,
+) -> ProtocolEvent:
+    data: dict[str, Any] = {"event": event}
+    if tool_name is not None:
+        data["tool_name"] = tool_name
+    if tool_call_id is not None:
+        data["tool_call_id"] = tool_call_id
+    if input is not None:
+        data["input"] = input
+    return {
+        "type": "event",
+        "method": "tools",
+        "params": {
+            "namespace": namespace,
             "timestamp": TS,
             "data": data,
         },
@@ -134,7 +160,7 @@ class TestSubagentTransformerUnit:
                 "started",
                 namespace=["tools:abc"],
                 graph_name="plain_tool_subgraph",
-                trigger_call_id="abc",
+                cause={"type": "toolCall", "tool_call_id": "abc"},
             )
         )
 
@@ -149,7 +175,7 @@ class TestSubagentTransformerUnit:
                 "started",
                 namespace=["tools:abc"],
                 graph_name="researcher",
-                trigger_call_id="abc",
+                cause={"type": "toolCall", "tool_call_id": "abc"},
             )
         )
 
@@ -157,7 +183,7 @@ class TestSubagentTransformerUnit:
         assert isinstance(handle, SubagentRunStream)
         assert handle.path == ("tools:abc",)
         assert handle.name == "researcher"
-        assert handle.trigger_call_id == "abc"
+        assert handle.cause == {"type": "toolCall", "tool_call_id": "abc"}
         assert handle.status == "started"
 
     def test_status_transitions(self) -> None:
@@ -272,3 +298,172 @@ class TestSubagentTransformerUnit:
         mux.fail(RuntimeError("kaboom"))
         assert handle.status == "failed"
         assert handle.error == "kaboom"
+
+
+class TestSubagentTransformerCauseAugmentation:
+    """`tool-started` → `lifecycle.started` correlation mutates `cause` in place."""
+
+    NAMES = frozenset({"researcher", "coder"})
+
+    def _mux(self) -> tuple[StreamMux, SubagentTransformer]:
+        mux = StreamMux(factories=_factories(self.NAMES), is_async=False)
+        transformer = mux.transformer_by_key("subagents")
+        assert isinstance(transformer, SubagentTransformer)
+        _subscribe(transformer._log)
+        return mux, transformer
+
+    def test_single_task_populates_cause(self) -> None:
+        """A matching `task` tool call on the parent → `lifecycle.started.cause`."""
+        mux, transformer = self._mux()
+        started = _lifecycle(
+            "started",
+            namespace=["tools:tc1"],
+            graph_name="researcher",
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc1",
+                input={"subagent_type": "researcher", "description": "do a thing"},
+            )
+        )
+        mux.push(started)
+
+        assert started["params"]["data"]["cause"] == {
+            "type": "toolCall",
+            "tool_call_id": "tc1",
+        }
+        handle = list(transformer._log._items)[0]
+        assert handle.cause == {"type": "toolCall", "tool_call_id": "tc1"}
+
+    def test_parallel_distinct_types_each_match(self) -> None:
+        """Two tool calls of different subagent types → each paired correctly."""
+        mux, transformer = self._mux()
+        researcher_started = _lifecycle(
+            "started", namespace=["tools:r"], graph_name="researcher"
+        )
+        coder_started = _lifecycle(
+            "started", namespace=["tools:c"], graph_name="coder"
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_r",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_c",
+                input={"subagent_type": "coder"},
+            )
+        )
+        mux.push(researcher_started)
+        mux.push(coder_started)
+
+        assert researcher_started["params"]["data"]["cause"] == {
+            "type": "toolCall",
+            "tool_call_id": "tc_r",
+        }
+        assert coder_started["params"]["data"]["cause"] == {
+            "type": "toolCall",
+            "tool_call_id": "tc_c",
+        }
+
+    def test_parallel_same_type_oldest_first(self) -> None:
+        """Two tool calls of the same subagent type → oldest-first pairing."""
+        mux, transformer = self._mux()
+        first_started = _lifecycle(
+            "started", namespace=["tools:a"], graph_name="researcher"
+        )
+        second_started = _lifecycle(
+            "started", namespace=["tools:b"], graph_name="researcher"
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_1",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_2",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(first_started)
+        mux.push(second_started)
+
+        assert first_started["params"]["data"]["cause"] == {
+            "type": "toolCall",
+            "tool_call_id": "tc_1",
+        }
+        assert second_started["params"]["data"]["cause"] == {
+            "type": "toolCall",
+            "tool_call_id": "tc_2",
+        }
+
+    def test_tool_error_cleans_pending(self) -> None:
+        """A `tool-error` before `lifecycle.started` removes the pending entry."""
+        mux, transformer = self._mux()
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_err",
+                input={"subagent_type": "researcher"},
+            )
+        )
+        mux.push(
+            _tools(
+                "tool-error",
+                namespace=[],
+                tool_name="task",
+                tool_call_id="tc_err",
+            )
+        )
+        assert transformer._pending_tool_calls == {}
+
+        started = _lifecycle(
+            "started", namespace=["tools:x"], graph_name="researcher"
+        )
+        mux.push(started)
+        # No pending → no cause augmentation.
+        assert "cause" not in started["params"]["data"]
+
+    def test_non_task_tool_ignored(self) -> None:
+        """A non-`task` tool call is not tracked."""
+        mux, transformer = self._mux()
+        mux.push(
+            _tools(
+                "tool-started",
+                namespace=[],
+                tool_name="other_tool",
+                tool_call_id="tc_other",
+                input={"some": "payload"},
+            )
+        )
+        assert transformer._pending_tool_calls == {}
+
+    def test_subagent_without_task_no_cause(self) -> None:
+        """A subagent `lifecycle.started` with no matching tool call → no cause emitted."""
+        mux, transformer = self._mux()
+        started = _lifecycle(
+            "started", namespace=["tools:x"], graph_name="researcher"
+        )
+        mux.push(started)
+        assert "cause" not in started["params"]["data"]

--- a/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
+++ b/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
@@ -1,0 +1,274 @@
+"""Unit tests for `SubagentTransformer` — synthetic lifecycle events.
+
+These tests exercise the transformer in isolation by pushing protocol
+events directly into a `StreamMux` configured with
+`SubagentTransformer` alongside the usual `values` / `messages` /
+`subgraphs` transformers. Mirrors the structure of langgraph's
+`test_stream_subgraph_transformer.py`.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from langgraph.errors import GraphInterrupt
+from langgraph.stream._event_log import EventLog
+from langgraph.stream._mux import StreamMux
+from langgraph.stream.transformers import (
+    MessagesTransformer,
+    SubgraphTransformer,
+    ValuesTransformer,
+)
+
+from deepagents import SubagentRunStream, SubagentTransformer
+
+if TYPE_CHECKING:
+    from langgraph.stream._types import ProtocolEvent
+
+TS = int(time.time() * 1000)
+
+
+def _lifecycle(
+    event: str,
+    *,
+    namespace: list[str] | None = None,
+    graph_name: str | None = None,
+    trigger_call_id: str | None = None,
+    error: str | None = None,
+) -> ProtocolEvent:
+    data: dict[str, Any] = {"event": event}
+    if graph_name is not None:
+        data["graph_name"] = graph_name
+    if trigger_call_id is not None:
+        data["trigger_call_id"] = trigger_call_id
+    if error is not None:
+        data["error"] = error
+    return {
+        "type": "event",
+        "method": "lifecycle",
+        "params": {
+            "namespace": namespace or [],
+            "timestamp": TS,
+            "data": data,
+        },
+    }
+
+
+def _values(payload: dict[str, Any], *, namespace: list[str]) -> ProtocolEvent:
+    return {
+        "type": "event",
+        "method": "values",
+        "params": {
+            "namespace": namespace,
+            "timestamp": TS,
+            "data": payload,
+        },
+    }
+
+
+def _subscribe(log: EventLog) -> None:
+    """Flip `_subscribed = True` so pushes retain items for test inspection."""
+    log._subscribed = True
+
+
+def _pre_subscribe_handle(handle: SubagentRunStream) -> None:
+    """Flip `_subscribed` on every EventLog inside the handle's mini-mux.
+
+    The child mini-mux is built via `make_child` with the full factory
+    list, so `values` / `messages` / `subagents` logs exist as
+    projections. Tests that feed events directly need them subscribed
+    so pushes retain items for `_items` inspection.
+    """
+    for value in handle._mux.extensions.values():
+        if isinstance(value, EventLog):
+            _subscribe(value)
+
+
+def _factories(names: frozenset[str]):
+    """Return a factory list matching DeepAgentStreamer's minimal shape.
+
+    Omits the agent-layer transformers (ToolCall / Middleware) — they
+    don't interact with subagent routing and adding them here would
+    just pull in langchain-side imports.
+    """
+
+    def subagent_factory(scope: tuple[str, ...]) -> SubagentTransformer:
+        return SubagentTransformer(scope, subagent_names=names)
+
+    return [
+        ValuesTransformer,
+        MessagesTransformer,
+        SubgraphTransformer,
+        subagent_factory,
+    ]
+
+
+def _handle_values_items(handle: SubagentRunStream) -> list:
+    return list(handle._mux.extensions["values"]._items)
+
+
+def _handle_subagents_items(handle: SubagentRunStream) -> list:
+    return list(handle._mux.extensions["subagents"]._items)
+
+
+class TestSubagentTransformerUnit:
+    NAMES = frozenset({"researcher", "coder"})
+
+    def _mux(self) -> tuple[StreamMux, SubagentTransformer]:
+        mux = StreamMux(factories=_factories(self.NAMES), is_async=False)
+        transformer = mux.transformer_by_key("subagents")
+        assert isinstance(transformer, SubagentTransformer)
+        _subscribe(transformer._log)
+        return mux, transformer
+
+    def _handle(self, transformer: SubagentTransformer) -> SubagentRunStream:
+        (handle,) = list(transformer._log._items)
+        return handle
+
+    def test_nondeclared_graph_name_is_ignored(self) -> None:
+        """A plain subgraph (graph_name not in declared names) stays off `.subagents`."""
+        mux, transformer = self._mux()
+        mux.push(
+            _lifecycle(
+                "started",
+                namespace=["tools:abc"],
+                graph_name="plain_tool_subgraph",
+                trigger_call_id="abc",
+            )
+        )
+
+        assert list(transformer._log._items) == []
+        assert transformer._by_ns == {}
+
+    def test_declared_graph_name_yields_handle(self) -> None:
+        """A `started` event whose graph_name matches a declared name produces a SubagentRunStream."""
+        mux, transformer = self._mux()
+        mux.push(
+            _lifecycle(
+                "started",
+                namespace=["tools:abc"],
+                graph_name="researcher",
+                trigger_call_id="abc",
+            )
+        )
+
+        handle = self._handle(transformer)
+        assert isinstance(handle, SubagentRunStream)
+        assert handle.path == ("tools:abc",)
+        assert handle.name == "researcher"
+        assert handle.trigger_call_id == "abc"
+        assert handle.status == "started"
+
+    def test_status_transitions(self) -> None:
+        """Started → running → completed updates the handle in place."""
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        mux.push(_lifecycle("running", namespace=["tools:x"]))
+        mux.push(_lifecycle("completed", namespace=["tools:x"]))
+
+        handle = self._handle(transformer)
+        assert handle.status == "completed"
+        # Terminal status closes the mini-mux so consumers unblock.
+        assert handle._mux.extensions["values"]._closed
+
+    def test_failed_stores_error(self) -> None:
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        mux.push(_lifecycle("failed", namespace=["tools:x"], error="boom"))
+
+        handle = self._handle(transformer)
+        assert handle.status == "failed"
+        assert handle.error == "boom"
+
+    def test_values_routed_into_handle(self) -> None:
+        """Values events under the subagent's ns flow into its mini-mux."""
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+
+        handle = self._handle(transformer)
+        _pre_subscribe_handle(handle)
+
+        mux.push(_values({"k": 1}, namespace=["tools:x"]))
+        mux.push(_values({"k": 2}, namespace=["tools:x"]))
+
+        assert _handle_values_items(handle) == [{"k": 1}, {"k": 2}]
+        assert handle.output == {"k": 2}
+
+    def test_root_values_not_routed(self) -> None:
+        """A values event at root ns must not leak into a child handle."""
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        handle = self._handle(transformer)
+        _pre_subscribe_handle(handle)
+
+        mux.push(_values({"k": "root"}, namespace=[]))
+        assert _handle_values_items(handle) == []
+
+    def test_nested_subagent_surfaces_under_parent(self) -> None:
+        """A nested subagent under a subagent appears on the parent's `.subagents`."""
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:p"], graph_name="researcher"))
+
+        parent = self._handle(transformer)
+        _pre_subscribe_handle(parent)
+
+        mux.push(
+            _lifecycle(
+                "started",
+                namespace=["tools:p", "tools:c"],
+                graph_name="coder",
+            )
+        )
+
+        (child,) = _handle_subagents_items(parent)
+        assert isinstance(child, SubagentRunStream)
+        assert child.path == ("tools:p", "tools:c")
+        assert child.name == "coder"
+
+    def test_nested_nondeclared_subgraph_does_not_surface_on_subagents(self) -> None:
+        """A nested plain subgraph (graph_name not declared) does NOT appear on `.subagents`."""
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:p"], graph_name="researcher"))
+
+        parent = self._handle(transformer)
+        _pre_subscribe_handle(parent)
+
+        mux.push(
+            _lifecycle(
+                "started",
+                namespace=["tools:p", "tools:c"],
+                graph_name="plain_nested",
+            )
+        )
+
+        assert _handle_subagents_items(parent) == []
+
+    def test_finalize_closes_dangling(self) -> None:
+        """A still-open child at finalize time is marked completed and its mux closed."""
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+
+        handle = self._handle(transformer)
+        mux.close()
+
+        assert handle.status == "completed"
+        assert handle._mux.extensions["values"]._closed
+        assert handle._mux.extensions["subagents"]._closed
+
+    def test_fail_with_graph_interrupt_marks_interrupted(self) -> None:
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        handle = self._handle(transformer)
+
+        mux.fail(GraphInterrupt())
+        assert handle.status == "interrupted"
+
+    def test_fail_with_generic_error_marks_failed(self) -> None:
+        mux, transformer = self._mux()
+        mux.push(_lifecycle("started", namespace=["tools:x"], graph_name="researcher"))
+        handle = self._handle(transformer)
+
+        mux.fail(RuntimeError("kaboom"))
+        assert handle.status == "failed"
+        assert handle.error == "kaboom"

--- a/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
+++ b/libs/deepagents/tests/unit_tests/test_subagent_transformer.py
@@ -22,8 +22,8 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from langgraph.errors import GraphInterrupt
-from langgraph.stream._event_log import EventLog
 from langgraph.stream._mux import StreamMux
+from langgraph.stream.stream_channel import StreamChannel
 from langgraph.stream.transformers import (
     LifecycleTransformer,
     MessagesTransformer,
@@ -150,14 +150,14 @@ def _values(payload: dict[str, Any], *, namespace: list[str]) -> ProtocolEvent:
     }
 
 
-def _subscribe(log: EventLog) -> None:
+def _subscribe(log: StreamChannel[Any]) -> None:
     log._subscribed = True
 
 
 def _pre_subscribe_handle(handle: SubagentRunStream) -> None:
-    """Flip `_subscribed` on every EventLog inside the handle's mini-mux."""
+    """Flip `_subscribed` on every StreamChannel inside the handle's mini-mux."""
     for value in handle._mux.extensions.values():
-        if isinstance(value, EventLog):
+        if isinstance(value, StreamChannel):
             _subscribe(value)
 
 
@@ -175,11 +175,11 @@ def _factories(names: frozenset[str]):
 
 
 def _handle_values_items(handle: SubagentRunStream) -> list:
-    return list(handle._mux.extensions["values"]._items)
+    return [item for _, item in handle._mux.extensions["values"]._items]
 
 
 def _handle_subagents_items(handle: SubagentRunStream) -> list:
-    return list(handle._mux.extensions["subagents"]._items)
+    return [item for _, item in handle._mux.extensions["subagents"]._items]
 
 
 class TestSubagentTransformerUnit:
@@ -193,7 +193,8 @@ class TestSubagentTransformerUnit:
         return mux, transformer
 
     def _handle(self, transformer: SubagentTransformer) -> SubagentRunStream:
-        (handle,) = list(transformer._log._items)
+        items = [item for _, item in transformer._log._items]
+        (handle,) = items
         return handle
 
     def test_nondeclared_subagent_type_is_ignored(self) -> None:

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -13,6 +13,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -444,9 +447,9 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.0a1,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
+    { name = "langchain-core", specifier = "==1.4.0a2" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
     { name = "langsmith", specifier = ">=0.3.0" },
     { name = "wcmatch" },
@@ -805,16 +808,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.15"
+version = "1.3.0a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/37/4408298df7d67845729e9768a86a123a60a59ea0c0eddbfd40eb0f9d25df/langchain-1.3.0a1.tar.gz", hash = "sha256:25db3a528fc09dea24335fa0165452784221802932525c14c7f1b10fc04003de", size = 580070, upload-time = "2026-05-01T19:19:15.74Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/be/011ee9cc738128a5811a2ed1d977159618aada247f626f2983b30de21595/langchain-1.3.0a1-py3-none-any.whl", hash = "sha256:45f5f843738403dd04e23651d2768445fdd931dc6f262c16eaad93f692794cdf", size = 113331, upload-time = "2026-05-01T19:19:14.099Z" },
 ]
 
 [[package]]
@@ -833,10 +836,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.4.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -845,9 +849,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/93/68bafa047f8e1770d0cf0f61d6c70889f1dec42ef6bd263540d916c421b9/langchain_core-1.4.0a2.tar.gz", hash = "sha256:b723c7961b615c7f2180ce2bcf352fdad8247bc51a60adecd3d97088235c120d", size = 916486, upload-time = "2026-05-01T15:02:19.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8e/933e0ba7ba0430ce264e36b178d581b255239ad45093872483142d93478c/langchain_core-1.4.0a2-py3-none-any.whl", hash = "sha256:a5c689f8404357df797120c012da7704144a953b2ae18f258df263301e7badd5", size = 546297, upload-time = "2026-05-01T15:02:17.731Z" },
 ]
 
 [[package]]
@@ -880,6 +884,18 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
+]
+
+[[package]]
 name = "langchain-tests"
 version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -903,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.8"
+version = "1.2.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -913,35 +929,35 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/02/196eff4f673fd461f8780930c3bfa7f27d6533a48e4f1104d544e843b093/langgraph-1.1.8.tar.gz", hash = "sha256:a97b8248129f2e007b81eef8277009ad1e1280b75fa2175889ab5aff5dcc4578", size = 560389, upload-time = "2026-04-17T19:45:50.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/76/d09367be5481415018366f059e06a7e3850d6a3b744c0a57cecd5a7a42e5/langgraph-1.2.0a5.tar.gz", hash = "sha256:b5cd7e9eac3a615120414b1621754ff4f621bf67e90bb4630b257beab03e61ec", size = 670110, upload-time = "2026-05-01T18:07:48.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/38/c72e795f6f8fd05a8e7c3be32c04ea8534294decc6785f3b04e0ce932e8a/langgraph-1.1.8-py3-none-any.whl", hash = "sha256:3278c7e335da25eac3327bb474c502d4cab94ae6dcc685fbf93be2bbf7664cd5", size = 173678, upload-time = "2026-04-17T19:45:48.991Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2f/5c02e8b3bef032c21ed13c950e6fcfb8688535010d8603f8f8239c954f63/langgraph-1.2.0a5-py3-none-any.whl", hash = "sha256:62b24c04e0a7f1db9cd1e4e1eecb1f944927ebec5279c5ceaddf9a77f08431dd", size = 227367, upload-time = "2026-05-01T18:07:46.268Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.1"
+version = "4.1.0a3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/43/b1009af9fe5e90f611b998bb8df6435ceec5c7b980057a17e0335493d027/langgraph_checkpoint-4.1.0a3.tar.gz", hash = "sha256:5bdcc807cef760c1b49adb9f0bc6cec02ed06ee84ad162c7cc133490ea60de1b", size = 180097, upload-time = "2026-05-01T15:26:38.528Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7c/22414710fc77b78ce7b9a876897bbdee1761d88f586fc037ed094a3572cd/langgraph_checkpoint-4.1.0a3-py3-none-any.whl", hash = "sha256:101d746cd9299f8da5576509930f3d52f6c67190e129a0954594da6daf22eb35", size = 55009, upload-time = "2026-05-01T15:26:37.505Z" },
 ]
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.1.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/4a/591a5c39f318c5b3059504133aa58ca39b47c37e61cc71ac8bd42f546772/langgraph_prebuilt-1.1.0a2.tar.gz", hash = "sha256:0ed039cd83afee5a626d0e631fcae758c9a4d5d76ff45775c85c0f310827564d", size = 178837, upload-time = "2026-05-01T18:03:06.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/e0/99653a3776d018c9382eae9167da257e7d0a831cb76829652a1d8ed83a8f/langgraph_prebuilt-1.1.0a2-py3-none-any.whl", hash = "sha256:6e59b8a37d897d926c44c5bc4c5f0348930fa95a9ecebfde6c5e825078fa9441", size = 41062, upload-time = "2026-05-01T18:03:05.254Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `SubagentTransformer` + `SubagentRunStream` so `agent.stream_v2()` / `astream_v2()` on an agent built with `create_deep_agent` exposes each declared subagent invocation as a first-class handle on `run.subagents`, rather than as an opaque namespace on `run.subgraphs`.

```python
run = await agent.astream_v2({"messages": [...]})

async for sub in run.subagents:
    print(f"subagent started: {sub.name}")
    async for msg in sub.messages:
        ...
    async for tc in sub.tool_calls:
        ...
    async for nested in sub.subagents:  # recursive
        ...
    result = sub.output
```

### How it works

- `SubagentTransformer` sits **alongside** the built-in `SubgraphTransformer`, not in place of it. On a lifecycle `started` event whose `graph_name` matches a declared subagent name, it looks up the `SubgraphRunStream` that `SubgraphTransformer` just built for the same namespace and wraps it in a `SubagentRunStream` — reusing the shared mini-mux, so projections (`messages`, `tool_calls`, `middleware`, recursive `subagents`, `values`) come from one pipeline and events aren't dispatched twice.
- `SubgraphTransformer` owns lifecycle close/fail of the shared mini-mux, so `sub.status` transitions (`completed` / `failed` / `interrupted`) and child-iterator termination come for free.
- Discovery uses `graph_name` (populated by langgraph from the compiled subagent's `name`), not the `checkpoint_ns` leaf — which is `tools:<pregel_task_id>` when the `task` tool invokes the subagent from a tool node.
- Wired into `create_deep_agent` via a scope-aware factory passed as `transformers=[...]` to `create_agent`. `SubAgentMiddleware` now exposes `subagent_names` publicly so the factory can discover declared names without introspecting the `task` tool's closure.

### Relationship to `run.subgraphs`

A subagent shows up on **both** `run.subagents` (typed, filtered) and `run.subgraphs` (untyped, every child namespace). Different views of the same underlying events — no duplication.

## Depends on (unmerged)

This PR is unlandable until these two branches land on their respective `main`s and the `deepagents` `langchain` / `langgraph` pins are bumped:

- `langchain-ai/langchain`: `nh/middleware-transformer` — `MiddlewareTransformer` + `AgentStreamer` (PRs [#36897](https://github.com/langchain-ai/langchain/pull/36897), [#36898](https://github.com/langchain-ai/langchain/pull/36898) in that chain)
- `langchain-ai/langgraph`: `nh/tools-channel-streaming` — `SubgraphTransformer` name-based discovery, `BaseRunStream` native projection wiring, the condition-based async pump