### PR TITLE
fix(cli): keep thinking spinner visible during text streaming

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1981,7 +1981,12 @@ class DeepAgentsApp(App):
                 self._loading_widget = None
             return
 
-        messages = self.query_one("#messages", Container)
+        try:
+            messages = self.query_one("#messages", Container)
+        except NoMatches:
+            # Container was torn down (e.g. shutdown mid-stream). Skip
+            # silently so the streaming loop doesn't crash.
+            return
 
         if self._loading_widget is None:
             # Create new
@@ -1990,12 +1995,44 @@ class DeepAgentsApp(App):
         else:
             # Update existing
             self._loading_widget.set_status(status)
-            # Reposition if not already at the correct location
+            # Reposition via move_child so elapsed-time and animation state
+            # carry through; remove + re-mount would reset both.
             if not self._is_spinner_at_correct_position(messages):
-                await self._loading_widget.remove()
-                await self._mount_before_queued(messages, self._loading_widget)
+                self._reposition_spinner(messages)
         # NOTE: Don't call anchor() here - it would re-anchor and drag user back
         # to bottom if they've scrolled away during streaming
+
+    def _reposition_spinner(self, container: Container) -> None:
+        """Move the spinner to its correct position without resetting state.
+
+        The spinner must sit immediately before the first queued widget, or
+        at the very end of the container when no widgets are queued. Using
+        `move_child` preserves the widget's internal state (elapsed time,
+        animation frame) that a remove + re-mount would reset.
+
+        Args:
+            container: The messages container that hosts the spinner.
+        """
+        if self._loading_widget is None:
+            return
+        if self._loading_widget not in container.children:
+            # The caller holds a spinner reference that isn't in this
+            # container — the widget was reparented or removed by another
+            # code path. Log so the desync is visible instead of silently
+            # leaving the spinner in the wrong place.
+            logger.debug(
+                "Spinner widget not in container children; skipping reposition"
+            )
+            return
+        first_queued = self._queued_widgets[0] if self._queued_widgets else None
+        if first_queued is not None and first_queued.parent is container:
+            container.move_child(self._loading_widget, before=first_queued)
+            return
+        non_spinner = [
+            child for child in container.children if child is not self._loading_widget
+        ]
+        if non_spinner:
+            container.move_child(self._loading_widget, after=non_spinner[-1])
 
     async def _request_approval(
         self,

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -761,9 +761,6 @@ async def execute_task_textual(
                                 # Get or create assistant message for this namespace
                                 current_msg = assistant_message_by_namespace.get(ns_key)
                                 if current_msg is None:
-                                    # Hide spinner when assistant starts responding
-                                    if adapter._set_spinner:
-                                        await adapter._set_spinner(None)
                                     msg_id = f"asst-{uuid.uuid4().hex[:8]}"
                                     # Mark active BEFORE mounting so pruning
                                     # (triggered by mount) won't remove it
@@ -775,6 +772,19 @@ async def execute_task_textual(
                                     current_msg = AssistantMessage(id=msg_id)
                                     await adapter._mount_message(current_msg)
                                     assistant_message_by_namespace[ns_key] = current_msg
+                                    # Keep the Thinking spinner visible after
+                                    # the streaming message so the user still
+                                    # sees activity if the model pauses between
+                                    # finishing text and emitting its next
+                                    # action (e.g. a tool call). The mount
+                                    # above placed the new message at the end
+                                    # of the container; this re-anchors the
+                                    # spinner after it.
+                                    if (
+                                        adapter._set_spinner
+                                        and not adapter._current_tool_messages
+                                    ):
+                                        await adapter._set_spinner("Thinking")
 
                                 # Append just the new text chunk for smoother
                                 # streaming (uses MarkdownStream internally for

--- a/libs/cli/deepagents_cli/widgets/loading.py
+++ b/libs/cli/deepagents_cli/widgets/loading.py
@@ -123,8 +123,16 @@ class LoadingWidget(Static):
             yield self._hint_widget
 
     def on_mount(self) -> None:
-        """Start animation on mount."""
-        self._start_time = time()
+        """Start animation on mount.
+
+        Preserves `_start_time` when the widget is remounted (e.g., after
+        being removed and re-added for repositioning) so the elapsed-time
+        counter doesn't reset. Repositioning via `move_child` avoids the
+        remount path entirely, but this guard keeps the behavior correct
+        if any caller ever falls back to remove + mount.
+        """
+        if self._start_time is None:
+            self._start_time = time()
         self._animation_timer = self.set_interval(0.1, self._update_animation)
 
     def on_unmount(self) -> None:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1471,17 +1471,15 @@ class TestLoadingSpinnerLifecycle:
 
             assert app._loading_widget is None
 
-    async def test_reposition_stops_spinner_before_remove_completes(self) -> None:
-        """Repositioning should stop animation before delayed removal completes."""
+    async def test_reposition_preserves_spinner_state(self) -> None:
+        """Repositioning should reorder without disturbing widget state.
+
+        Repositioning uses `move_child`, which keeps the same LoadingWidget
+        instance mounted. Its animation timer and `_start_time` must carry
+        through unchanged so the "(Ns, esc to interrupt)" hint doesn't jump
+        back to 0s mid-stream.
+        """
         app = DeepAgentsApp()
-        original_remove = Widget.remove
-
-        def delayed_remove(widget: Widget) -> Awaitable[None]:
-            async def do_remove() -> None:
-                await asyncio.sleep(0.3)
-                await original_remove(widget)
-
-            return do_remove()
 
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -1497,29 +1495,61 @@ class TestLoadingSpinnerLifecycle:
             app._queued_widgets.append(queued_widget)
 
             before_tick = widget._spinner._position
+            original_timer = widget._animation_timer
+            original_start_time = widget._start_time
             await asyncio.sleep(0.25)
             assert widget._spinner._position != before_tick
-            # Pre-condition: timer must be running before the reposition so
-            # the `is None` assertion below isn't vacuously satisfied.
-            assert widget._animation_timer is not None
+            assert original_timer is not None
 
-            with patch.object(Widget, "remove", new=delayed_remove):
-                reposition_task = asyncio.create_task(app._set_spinner("Thinking"))
-                # Sleep while delayed_remove is blocking (0.3s).  Check that the
-                # timer flag is None rather than a frozen position counter: the
-                # Textual timer may fire one final tick before cancellation on slow
-                # CI runners, making a position equality check inherently racy.
-                await asyncio.sleep(0.25)
-                assert widget._animation_timer is None
-                await reposition_task
+            await app._set_spinner("Thinking")
+            await pilot.pause()
+
+            # Same instance, same timer, same start time — only DOM order changed.
+            assert app._loading_widget is widget
+            assert widget._animation_timer is original_timer
+            assert widget._start_time == original_start_time
 
             children = list(messages.children)
             assert children.index(widget) == children.index(queued_widget) - 1
 
+    async def test_reposition_moves_spinner_after_last_message_when_no_queue(
+        self,
+    ) -> None:
+        """No queued widgets: spinner must move after the last non-spinner child.
+
+        This is the common streaming case — an `AssistantMessage` mounts at
+        the end of `#messages` (landing below the spinner), and the next
+        `_set_spinner("Thinking")` call must re-anchor the spinner after it
+        via `move_child(..., after=non_spinner[-1])`. Covers the no-queued
+        branch of `_reposition_spinner` that the queued-widget test doesn't.
+        """
+        app = DeepAgentsApp()
+
+        async with app.run_test() as pilot:
             await pilot.pause()
-            new_widget = app._loading_widget
-            assert new_widget is not None
-            assert new_widget._animation_timer is not None
+            await app._set_spinner("Thinking")
+            await pilot.pause()
+
+            widget = app._loading_widget
+            assert widget is not None
+            assert not app._queued_widgets
+
+            messages = app.query_one("#messages", Container)
+            new_message = AppMessage("streamed")
+            await messages.mount(new_message)
+            await pilot.pause()
+
+            # Sanity: mount appended at the end, so spinner is now above it.
+            children = list(messages.children)
+            assert children.index(widget) < children.index(new_message)
+
+            await app._set_spinner("Thinking")
+            await pilot.pause()
+
+            # Same widget instance; spinner now sits at the end.
+            assert app._loading_widget is widget
+            children = list(messages.children)
+            assert children[-1] is widget
 
 
 class TestTraceCommand:

--- a/libs/cli/tests/unit_tests/test_loading.py
+++ b/libs/cli/tests/unit_tests/test_loading.py
@@ -63,3 +63,24 @@ class TestLoadingWidget:
 
             assert widget._animation_timer is None
             assert not pilot.app.query("LoadingWidget")
+
+    async def test_on_mount_preserves_start_time_across_remount(self) -> None:
+        """`on_mount` must not reset `_start_time` when it is already set.
+
+        The spinner is repositioned by reordering children (preserving state),
+        but if any code path falls back to remove + re-mount, the elapsed-time
+        counter must not restart — that would visibly jump the "(Ns)" hint
+        back to 0s mid-stream.
+        """
+        async with LoadingWidgetApp().run_test() as pilot:
+            widget = pilot.app.query_one("#loading", LoadingWidget)
+            original_start = widget._start_time
+            assert original_start is not None
+
+            await widget.remove()
+            await pilot.pause()
+
+            await pilot.app.mount(widget)
+            await pilot.pause()
+
+            assert widget._start_time == original_start

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -589,6 +589,11 @@ def _tool_call_message(
     )
 
 
+def _text_message(text: str) -> SimpleNamespace:
+    """Build a message-like object with content_blocks containing one text block."""
+    return SimpleNamespace(content_blocks=[{"type": "text", "text": text}])
+
+
 class TestExecuteTaskTextualParallelToolSpinner:
     """Regression tests for #1796: premature spinner with parallel tools."""
 
@@ -830,6 +835,174 @@ class TestExecuteTaskTextualParallelToolSpinner:
         thinking_calls = [i for i, s in enumerate(statuses) if s == "Thinking"]
         assert len(thinking_calls) >= 2, (
             f"Expected at least 2 Thinking calls; got {len(thinking_calls)}: {statuses}"
+        )
+
+
+class TestExecuteTaskTextualTextThenToolSpinner:
+    """Regression tests: spinner must stay visible between text and tool call.
+
+    When the assistant streams explanatory text and then emits a tool call,
+    the model often pauses between finishing the text and producing the tool
+    call. The spinner should remain visible during that pause rather than
+    disappearing as soon as the first text chunk arrives.
+    """
+
+    async def test_spinner_not_hidden_when_text_chunk_arrives(self) -> None:
+        """Streaming a text block must not hide the Thinking spinner."""
+        statuses: list[str | None] = []
+
+        async def record_spinner(status: str | None) -> None:
+            await asyncio.sleep(0)
+            statuses.append(status)
+
+        chunks = [
+            ((), "messages", (_text_message("Now I'll call a tool..."), {})),
+            ((), "messages", (_tool_call_message("ls", {"path": "."}, "tool-1"), {})),
+            ((), "messages", (ToolMessage(content="ok", tool_call_id="tool-1"), {})),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=record_spinner,
+        )
+
+        # Patch AssistantMessage so it doesn't require a real Textual DOM.
+        fake_msg = AsyncMock()
+        fake_msg.id = "asst-test"
+        with patch(
+            "deepagents_cli.textual_adapter.AssistantMessage", return_value=fake_msg
+        ):
+            await execute_task_textual(
+                user_input="hi",
+                agent=_FakeAgent(chunks),
+                assistant_id="assistant",
+                session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+                adapter=adapter,
+            )
+
+        # Expected sequence:
+        #   1. "Thinking" before astream
+        #   2. "Thinking" after mounting the streaming AssistantMessage
+        #      (re-anchor the spinner below the message so the user still
+        #      sees activity if the model pauses before the tool call)
+        #   3. None when the tool call mounts
+        #   4. "Thinking" after the tool result
+        assert statuses[0] == "Thinking"
+        assert statuses[1] == "Thinking"
+        assert None in statuses
+        assert statuses[-1] == "Thinking"
+
+        # The spinner must never be hidden before the tool call arrives.
+        first_none = statuses.index(None)
+        text_thinking_seen = statuses[:first_none].count("Thinking") >= 2
+        assert text_thinking_seen, (
+            f"Spinner was hidden during text streaming before tool call: {statuses}"
+        )
+
+    async def test_spinner_reanchors_for_text_after_tool_cycle(self) -> None:
+        """Text -> tool_call -> tool_result -> text must re-anchor the spinner.
+
+        After a tool cycle completes, the tool_call handler pops the previous
+        AssistantMessage from `assistant_message_by_namespace`, so the next
+        text chunk mounts a fresh widget. The new re-anchor call at
+        `textual_adapter.py:780-784` must fire for that second text burst so
+        the spinner stays visible between it and any follow-up tool call.
+        """
+        statuses: list[str | None] = []
+
+        async def record_spinner(status: str | None) -> None:
+            await asyncio.sleep(0)
+            statuses.append(status)
+
+        chunks = [
+            ((), "messages", (_text_message("First, I'll inspect..."), {})),
+            ((), "messages", (_tool_call_message("ls", {"path": "."}, "tool-1"), {})),
+            ((), "messages", (ToolMessage(content="ok", tool_call_id="tool-1"), {})),
+            ((), "messages", (_text_message("Now the second step..."), {})),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=record_spinner,
+        )
+
+        fake_msg = AsyncMock()
+        fake_msg.id = "asst-test"
+        with patch(
+            "deepagents_cli.textual_adapter.AssistantMessage", return_value=fake_msg
+        ):
+            await execute_task_textual(
+                user_input="hi",
+                agent=_FakeAgent(chunks),
+                assistant_id="assistant",
+                session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+                adapter=adapter,
+            )
+
+        # Expected Thinking calls:
+        #   1. Before astream (line 517)
+        #   2. After first AssistantMessage mount (re-anchor, line 784)
+        #   3. After tool result (line 705)
+        #   4. After second AssistantMessage mount (re-anchor again)
+        thinking_count = sum(1 for s in statuses if s == "Thinking")
+        assert thinking_count >= 4, (
+            f"Expected at least 4 Thinking calls including re-anchors after "
+            f"each text mount; got {thinking_count}: {statuses}"
+        )
+
+    async def test_spinner_reanchor_skipped_while_tools_pending(self) -> None:
+        """The re-anchor must be gated on `not _current_tool_messages`.
+
+        Contrived sequence: a tool call mounts (populating
+        `_current_tool_messages`), then a text chunk arrives before the tool
+        result. The new re-anchor logic must NOT call `_set_spinner("Thinking")`
+        in that window — the tool-call widget is the dominant progress
+        indicator.
+        """
+        statuses: list[str | None] = []
+
+        async def record_spinner(status: str | None) -> None:
+            await asyncio.sleep(0)
+            statuses.append(status)
+
+        chunks = [
+            ((), "messages", (_tool_call_message("ls", {"path": "."}, "tool-1"), {})),
+            ((), "messages", (_text_message("Meanwhile..."), {})),
+            ((), "messages", (ToolMessage(content="ok", tool_call_id="tool-1"), {})),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=record_spinner,
+        )
+
+        fake_msg = AsyncMock()
+        fake_msg.id = "asst-test"
+        with patch(
+            "deepagents_cli.textual_adapter.AssistantMessage", return_value=fake_msg
+        ):
+            await execute_task_textual(
+                user_input="hi",
+                agent=_FakeAgent(chunks),
+                assistant_id="assistant",
+                session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+                adapter=adapter,
+            )
+
+        # Thinking calls should be:
+        #   1. Before astream
+        #   2. After tool result (guard is back to empty)
+        # The re-anchor must NOT fire while the tool is in flight.
+        thinking_count = sum(1 for s in statuses if s == "Thinking")
+        assert thinking_count == 2, (
+            f"Expected 2 Thinking calls (start + after tool); got "
+            f"{thinking_count}: {statuses}"
         )
 
 


### PR DESCRIPTION
Keep the `Thinking` spinner visible during assistant text streaming. Previously it was hidden on the first text chunk, so when the model paused between finishing text and emitting a tool call the user saw no activity indicator. Complementary to #2847, which fixed the gap between `astream` iterations; this one sits inside a single iteration.