### PR TITLE
feat(cli): refresh footer git branch after update

### DIFF
--- a/libs/cli/deepagents_cli/_git.py
+++ b/libs/cli/deepagents_cli/_git.py
@@ -1,0 +1,236 @@
+"""Lightweight git metadata helpers for CLI state detection."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GIT_DIR_POINTER_PREFIX = "gitdir: "
+"""Prefix used by worktree-style `.git` files to point at the real git dir."""
+
+_GIT_HEAD_REF_PREFIX = "ref: "
+"""Prefix used by `HEAD` when it points at a named ref instead of a commit."""
+
+_GIT_REF_PREFIXES = ("refs/heads/", "refs/remotes/", "refs/tags/", "refs/")
+"""Known git ref prefixes stripped when formatting a branch-like display name."""
+
+_git_dir_cache: dict[str, Path] = {}
+"""Positive-only cache of resolved git metadata directories keyed by lookup path."""
+
+
+def _abbreviate_git_ref(ref: str) -> str:
+    """Convert a full git ref into a short display name.
+
+    Args:
+        ref: Full git ref name from repository metadata.
+
+    Returns:
+        The abbreviated ref name suitable for display.
+    """
+    for prefix in _GIT_REF_PREFIXES:
+        if ref.startswith(prefix):
+            return ref.removeprefix(prefix)
+    return ref
+
+
+def _parse_git_dir_pointer(git_entry: Path) -> Path | None:
+    """Resolve a `.git` file containing a `gitdir:` pointer.
+
+    Args:
+        git_entry: `.git` file to parse.
+
+    Returns:
+        The resolved git directory path, or `None` if the file is not a valid
+        gitdir pointer.
+    """
+    try:
+        raw = git_entry.read_text(encoding="utf-8").strip()
+    except OSError:
+        logger.debug("Failed to read gitdir pointer from %s", git_entry, exc_info=True)
+        return None
+
+    if not raw.startswith(_GIT_DIR_POINTER_PREFIX):
+        return None
+
+    pointer = raw.removeprefix(_GIT_DIR_POINTER_PREFIX).strip()
+    if not pointer:
+        return None
+
+    git_dir = Path(pointer)
+    if not git_dir.is_absolute():
+        git_dir = git_entry.parent / git_dir
+    return git_dir.resolve(strict=False)
+
+
+def _normalize_lookup_path(path: str | Path) -> Path:
+    """Normalize a lookup path for git metadata discovery.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        A normalized absolute path when possible, or the expanded path if full
+        resolution fails.
+    """
+    try:
+        return Path(path).expanduser().resolve(strict=False)
+    except OSError:
+        return Path(path).expanduser()
+
+
+def _find_git_dir_uncached(path: Path) -> Path | None:
+    """Locate the effective git metadata directory without using caches.
+
+    Args:
+        path: Normalized directory or file path inside a repository.
+
+    Returns:
+        The git metadata directory for the repository containing `path`, or
+        `None` when no repository can be identified.
+    """
+    current = path
+    if not current.is_dir():
+        current = current.parent
+
+    for directory in (current, *current.parents):
+        git_entry = directory / ".git"
+        if git_entry.is_dir():
+            return git_entry
+        if git_entry.is_file():
+            git_dir = _parse_git_dir_pointer(git_entry)
+            if git_dir is not None and git_dir.is_dir():
+                return git_dir
+            return None
+
+    return None
+
+
+def find_git_dir(path: str | Path) -> Path | None:
+    """Locate the effective git metadata directory for a path.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        The git metadata directory for the repository containing `path`, or
+        `None` when no repository can be identified.
+    """
+    current = _normalize_lookup_path(path)
+    key = str(current)
+    cached = _git_dir_cache.get(key)
+    if cached is not None:
+        return cached
+
+    git_dir = _find_git_dir_uncached(current)
+    if git_dir is not None:
+        _git_dir_cache[key] = git_dir
+    return git_dir
+
+
+def find_git_root(path: str | Path) -> Path | None:
+    """Locate the repository root for a path.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        The repository root containing `path`, or `None` when no repository can
+        be identified.
+    """
+    current = _normalize_lookup_path(path)
+    if not current.is_dir():
+        current = current.parent
+
+    for directory in (current, *current.parents):
+        git_entry = directory / ".git"
+        if git_entry.is_dir():
+            return directory
+        if git_entry.is_file():
+            git_dir = _parse_git_dir_pointer(git_entry)
+            if git_dir is not None and git_dir.is_dir():
+                return directory
+            return None
+
+    return None
+
+
+def read_git_branch_from_filesystem(path: str | Path) -> str | None:
+    """Read the current git branch from repository metadata.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        The abbreviated branch name, `HEAD` for detached HEAD, an empty string
+        when `path` is not inside a git repository, or `None` when metadata
+        exists but cannot be parsed confidently.
+    """
+    git_dir = find_git_dir(path)
+    if git_dir is None:
+        return ""
+
+    head_path = git_dir / "HEAD"
+    try:
+        head = head_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        logger.debug("Git HEAD file not found in %s", git_dir)
+        return None
+    except OSError:
+        logger.debug("Failed to read git HEAD from %s", git_dir, exc_info=True)
+        return None
+
+    if not head:
+        return ""
+    if head.startswith(_GIT_HEAD_REF_PREFIX):
+        ref = head.removeprefix(_GIT_HEAD_REF_PREFIX).strip()
+        return _abbreviate_git_ref(ref) if ref else None
+    return "HEAD"
+
+
+def read_git_branch_via_subprocess(path: str | Path) -> str:
+    """Fall back to `git rev-parse` for unusual repository layouts.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        The branch name reported by git, or an empty string on failure.
+    """
+    import subprocess  # noqa: S404  # stdlib subprocess fallback
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+            cwd=path,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except FileNotFoundError:
+        pass  # git not installed
+    except subprocess.TimeoutExpired:
+        logger.debug("Git branch detection timed out")
+    except OSError:
+        logger.debug("Git branch detection failed", exc_info=True)
+    return ""
+
+
+def resolve_git_branch(path: str | Path) -> str:
+    """Resolve the current git branch with a filesystem-first strategy.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        The current branch name, `HEAD` for detached HEAD, or an empty string
+        when no branch can be determined.
+    """
+    branch = read_git_branch_from_filesystem(path)
+    if branch is not None:
+        return branch
+    return read_git_branch_via_subprocess(path)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1029,16 +1029,53 @@ class DeepAgentsApp(App):
         except Exception:
             logger.warning("Git branch resolution failed", exc_info=True)
 
-    def _schedule_git_branch_refresh(self) -> None:
-        """Refresh the git branch in the background without stalling cleanup."""
-        if self._exit:
+    async def _refresh_git_branch_subprocess_fallback(self, cwd: str) -> None:
+        """Run the `git rev-parse` fallback off-thread for unusual repo layouts."""
+        try:
+            branch = await asyncio.to_thread(read_git_branch_via_subprocess, cwd)
+        except Exception:
+            logger.warning("Git branch subprocess fallback failed", exc_info=True)
             return
+        if self._status_bar:
+            self._status_bar.branch = branch
 
+    def _cancel_git_branch_refresh_task(self) -> None:
+        """Cancel and clear any in-flight background branch refresh task."""
         prior_task = self._git_branch_refresh_task
         if prior_task is not None and not prior_task.done():
             prior_task.cancel()
+        self._git_branch_refresh_task = None
 
-        refresh_task = asyncio.create_task(self._refresh_git_branch())
+    def _schedule_git_branch_refresh(self) -> None:
+        """Refresh the git branch, inline when possible.
+
+        The filesystem probe is sub-millisecond for the common repo layout, so
+        we run it synchronously and only spawn a background task for the
+        `git rev-parse` fallback. Keeping the hot path inline avoids an
+        event-loop tick plus a reactive watcher hop between a tool exiting and
+        the footer updating.
+        """
+        if self._exit:
+            return
+
+        cwd = self._cwd
+        try:
+            branch = read_git_branch_from_filesystem(cwd)
+        except Exception:
+            logger.warning("Git branch filesystem probe failed", exc_info=True)
+            return
+
+        if branch is not None:
+            if self._status_bar:
+                self._status_bar.branch = branch
+            self._cancel_git_branch_refresh_task()
+            return
+
+        # Unusual repo layout — hop to a thread for `git rev-parse`.
+        self._cancel_git_branch_refresh_task()
+        refresh_task = asyncio.create_task(
+            self._refresh_git_branch_subprocess_fallback(cwd)
+        )
         self._git_branch_refresh_task = refresh_task
 
         def _finalize_git_branch_refresh(task: asyncio.Task[None]) -> None:
@@ -1091,6 +1128,7 @@ class DeepAgentsApp(App):
             set_active_message=self._set_active_message,
             sync_message_content=self._sync_message_content,
             request_ask_user=self._request_ask_user,
+            on_tool_complete=self._schedule_git_branch_refresh,
         )
         # Wire token display callbacks
         self._ui_adapter._on_tokens_update = self._on_tokens_update

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -31,6 +31,10 @@ from textual.widgets import Static
 
 from deepagents_cli import theme
 from deepagents_cli._cli_context import CLIContext
+from deepagents_cli._git import (
+    read_git_branch_from_filesystem,
+    read_git_branch_via_subprocess,
+)
 from deepagents_cli._session_stats import (
     SessionStats,
     SpinnerStatus,
@@ -854,6 +858,9 @@ class DeepAgentsApp(App):
         self._startup_task: asyncio.Task[None] | None = None
         """Startup task reference (set in on_mount)."""
 
+        self._git_branch_refresh_task: asyncio.Task[None] | None = None
+        """Latest background git-branch refresh task, if one is running."""
+
         self._last_typed_at: float | None = None
         """Typing-aware approval deferral state."""
 
@@ -997,47 +1004,65 @@ class DeepAgentsApp(App):
 
         # Start branch resolution immediately — the thread launches now
         # (during on_mount) so by the time the first frame finishes painting
-        # the subprocess is already done. _post_paint_init fires the heavier
-        # workers (server, model creation) afterward.
+        # the filesystem probe is already done. _post_paint_init fires the
+        # heavier workers (server, model creation) afterward.
         self._startup_task = asyncio.create_task(
             self._resolve_git_branch_and_continue()
         )
 
-    async def _resolve_git_branch_and_continue(self) -> None:
-        """Resolve git branch, then schedule remaining init workers.
+    async def _refresh_git_branch(self) -> None:
+        """Resolve the current git branch and update the status bar.
 
-        Launched via `asyncio.create_task()` during `on_mount` so the subprocess
-        runs concurrently with first-paint rendering. `_post_paint_init` is
-        scheduled via `call_after_refresh` regardless of whether branch
-        resolution succeeds.
+        Reads repository metadata from `self._cwd` inline so the common path is
+        just local file I/O. Falls back to a thread-offloaded `git rev-parse`
+        only for unusual repository layouts. Swallows all errors — the status
+        bar simply stays empty (or keeps its prior value on unexpected failure)
+        if git is unavailable.
         """
         try:
-            import subprocess  # noqa: S404  # stdlib, already loaded
-
-            def _get_branch() -> str:
-                try:
-                    result = subprocess.run(
-                        ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
-                        capture_output=True,
-                        text=True,
-                        timeout=2,
-                        check=False,
-                    )
-                    if result.returncode == 0:
-                        return result.stdout.strip()
-                except FileNotFoundError:
-                    pass  # git not installed
-                except subprocess.TimeoutExpired:
-                    logger.debug("Git branch detection timed out")
-                except OSError:
-                    logger.debug("Git branch detection failed", exc_info=True)
-                return ""
-
-            branch = await asyncio.to_thread(_get_branch)
+            cwd = self._cwd
+            branch = read_git_branch_from_filesystem(cwd)
+            if branch is None:
+                branch = await asyncio.to_thread(read_git_branch_via_subprocess, cwd)
             if self._status_bar:
                 self._status_bar.branch = branch
         except Exception:
             logger.warning("Git branch resolution failed", exc_info=True)
+
+    def _schedule_git_branch_refresh(self) -> None:
+        """Refresh the git branch in the background without stalling cleanup."""
+        prior_task = self._git_branch_refresh_task
+        if prior_task is not None and not prior_task.done():
+            prior_task.cancel()
+
+        refresh_task = asyncio.create_task(self._refresh_git_branch())
+        self._git_branch_refresh_task = refresh_task
+
+        def _finalize_git_branch_refresh(task: asyncio.Task[None]) -> None:
+            if self._git_branch_refresh_task is task:
+                self._git_branch_refresh_task = None
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.warning(
+                    "Background git branch refresh failed unexpectedly",
+                    exc_info=True,
+                )
+
+        refresh_task.add_done_callback(_finalize_git_branch_refresh)
+
+    async def _resolve_git_branch_and_continue(self) -> None:
+        """Resolve git branch, then schedule remaining init workers.
+
+        Launched via `asyncio.create_task()` during `on_mount` so branch
+        detection runs concurrently with first-paint rendering.
+        `_post_paint_init` is scheduled via `call_after_refresh` regardless
+        of whether branch resolution succeeds.
+        """
+        try:
+            await self._refresh_git_branch()
         finally:
             # Always schedule post-paint init — even if branch resolution
             # fails, the app must still start the server, session, etc.
@@ -2638,6 +2663,7 @@ class DeepAgentsApp(App):
         Raises:
             CancelledError: If the command is interrupted by the user.
         """
+        refresh_started = False
         try:
             proc = await asyncio.create_subprocess_shell(
                 command,
@@ -2659,6 +2685,11 @@ class DeepAgentsApp(App):
             except asyncio.CancelledError:
                 await self._kill_shell_process()
                 raise
+
+            # Start branch refresh as soon as the shell exits so it can overlap
+            # with output rendering instead of trailing it.
+            self._schedule_git_branch_refresh()
+            refresh_started = True
 
             output = (stdout_bytes or b"").decode(errors="replace").strip()
             stderr_text = (stderr_bytes or b"").decode(errors="replace").strip()
@@ -2684,10 +2715,16 @@ class DeepAgentsApp(App):
             err_msg = f"Failed to run command: {e}"
             await self._mount_message(ErrorMessage(err_msg))
         finally:
-            await self._cleanup_shell_task()
+            await self._cleanup_shell_task(refresh_git_branch=not refresh_started)
 
-    async def _cleanup_shell_task(self) -> None:
-        """Clean up after shell command task completes or is cancelled."""
+    async def _cleanup_shell_task(self, *, refresh_git_branch: bool = True) -> None:
+        """Clean up after shell command task completes or is cancelled.
+
+        Args:
+            refresh_git_branch: Whether to schedule a footer branch refresh
+                during cleanup. Successful shell runs can launch this earlier
+                so refresh overlaps with output rendering.
+        """
         was_interrupted = self._shell_process is not None and (
             self._shell_worker is not None and self._shell_worker.is_cancelled
         )
@@ -2698,6 +2735,10 @@ class DeepAgentsApp(App):
             await self._mount_message(AppMessage("Command interrupted"))
         if self._chat_input:
             self._chat_input.set_cursor_active(active=True)
+        if refresh_git_branch:
+            # A `!` command may have changed git state (e.g. `git checkout`);
+            # re-resolve so the footer reflects the new branch.
+            self._schedule_git_branch_refresh()
         try:
             await self._maybe_drain_deferred()
         except Exception:
@@ -4552,6 +4593,8 @@ class DeepAgentsApp(App):
             self._shell_worker.cancel()
         if self._agent_running and self._agent_worker:
             self._agent_worker.cancel()
+        if self._git_branch_refresh_task is not None:
+            self._git_branch_refresh_task.cancel()
 
         # Dispatch synchronously — the event loop is about to be torn down by
         # super().exit(), so an async task would never complete.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1031,6 +1031,9 @@ class DeepAgentsApp(App):
 
     def _schedule_git_branch_refresh(self) -> None:
         """Refresh the git branch in the background without stalling cleanup."""
+        if self._exit:
+            return
+
         prior_task = self._git_branch_refresh_task
         if prior_task is not None and not prior_task.done():
             prior_task.cancel()

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3765,6 +3765,10 @@ class DeepAgentsApp(App):
         # Pass the cached approximate flag so an interrupted "+" isn't clobbered.
         self._show_tokens(approximate=self._tokens_approximate)
 
+        # Agent-executed commands and tools can mutate repo state (e.g. git
+        # checkout inside an execute call), so refresh the footer on turn end.
+        self._schedule_git_branch_refresh()
+
         try:
             await self._maybe_drain_deferred()
         except Exception:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
+from deepagents_cli._git import resolve_git_branch
 from deepagents_cli._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -578,16 +579,14 @@ hitting the default LangGraph ceiling.
 _git_branch_cache: dict[str, str | None] = {}
 """Per-cwd cache of resolved git branch names.
 
-Avoids repeated `git rev-parse` subprocess calls within the same session. Keyed
-by `str(Path.cwd())`; `None` values indicate the directory is not inside a git
-repository.
+Avoids repeated git branch resolution within the same session. Keyed by
+`str(Path.cwd())`; `None` values indicate the directory is not inside a git
+repository or that resolution failed.
 """
 
 
 def _get_git_branch() -> str | None:
     """Return the current git branch name, or `None` if not in a repo."""
-    import subprocess  # noqa: S404
-
     try:
         cwd = str(Path.cwd())
     except OSError:
@@ -597,21 +596,13 @@ def _get_git_branch() -> str | None:
         return _git_branch_cache[cwd]
 
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip() or None
-            _git_branch_cache[cwd] = branch
-            return branch
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        branch = resolve_git_branch(cwd) or None
+    except OSError:
         logger.debug("Could not determine git branch", exc_info=True)
-    _git_branch_cache[cwd] = None
-    return None
+        branch = None
+
+    _git_branch_cache[cwd] = branch
+    return branch
 
 
 def build_stream_config(

--- a/libs/cli/deepagents_cli/project_utils.py
+++ b/libs/cli/deepagents_cli/project_utils.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from deepagents_cli._env_vars import SERVER_ENV_PREFIX
+from deepagents_cli._git import find_git_root
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -133,10 +134,7 @@ def get_server_project_context(
 
 
 def find_project_root(start_path: str | Path | None = None) -> Path | None:
-    """Find the project root by looking for .git directory.
-
-    Walks up the directory tree from start_path (or cwd) looking for a .git
-    directory, which indicates the project root.
+    """Find the project root by looking for git metadata.
 
     Args:
         start_path: Directory to start searching from.
@@ -146,14 +144,7 @@ def find_project_root(start_path: str | Path | None = None) -> Path | None:
         Path to the project root if found, None otherwise.
     """
     current = Path(start_path or Path.cwd()).expanduser().resolve()
-
-    # Walk up the directory tree
-    for parent in [current, *list(current.parents)]:
-        git_dir = parent / ".git"
-        if git_dir.exists():
-            return parent
-
-    return None
+    return find_git_root(current)
 
 
 def find_project_agent_md(project_root: Path) -> list[Path]:

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -225,6 +225,7 @@ class TextualUIAdapter:
             ]
             | None
         ) = None,
+        on_tool_complete: Callable[[], None] | None = None,
     ) -> None:
         """Initialize the adapter."""
         self._mount_message = mount_message
@@ -257,6 +258,14 @@ class TextualUIAdapter:
         """Async callback for `ask_user` interrupts.
 
         When awaited, returns a `Future` that resolves to user answers.
+        """
+
+        self._on_tool_complete = on_tool_complete
+        """Sync callback fired after each `ToolMessage` is processed.
+
+        The app uses this to refresh the footer's git branch as soon as an
+        agent-executed tool (e.g. `git checkout`) returns, instead of waiting
+        for the full turn to finish.
         """
 
         # State tracking
@@ -704,6 +713,17 @@ async def execute_task_textual(
                         # bottom of the messages container.
                         if adapter._set_spinner and not adapter._current_tool_messages:
                             await adapter._set_spinner("Thinking")
+
+                        if adapter._on_tool_complete is not None:
+                            try:
+                                adapter._on_tool_complete()
+                            except Exception:
+                                # A footer refresh failure must never abort
+                                # agent streaming — log and keep going.
+                                logger.warning(
+                                    "on_tool_complete callback failed",
+                                    exc_info=True,
+                                )
                         continue
 
                     # Extract token usage (before content_blocks check

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -267,6 +267,17 @@ class TestStartupSequence:
         drain_mock.assert_awaited_once()
         queue_mock.assert_awaited_once()
 
+    async def test_schedule_git_branch_refresh_noops_during_exit(self) -> None:
+        """Shutdown should prevent new background git refresh tasks."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        app._exit = True
+
+        with patch("deepagents_cli.app.asyncio.create_task") as mock_create_task:
+            app._schedule_git_branch_refresh()
+
+        assert app._git_branch_refresh_task is None
+        mock_create_task.assert_not_called()
+
     def test_empty_startup_cmd_is_normalized_to_none(self) -> None:
         """Empty or whitespace-only `--startup-cmd` should be treated as unset."""
         for raw in ("", "   ", "\t\n"):

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -249,6 +249,24 @@ class TestStartupSequence:
         queue_mock.assert_not_awaited()
         assert app._agent_running is False
 
+    async def test_cleanup_agent_task_schedules_git_branch_refresh(self) -> None:
+        """Agent cleanup should refresh repo state after a turn completes."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        drain_mock = AsyncMock()
+        queue_mock = AsyncMock()
+        spinner_mock = AsyncMock()
+        refresh_mock = MagicMock()
+        app._process_next_from_queue = queue_mock  # type: ignore[assignment]
+        app._maybe_drain_deferred = drain_mock  # type: ignore[assignment]
+        app._set_spinner = spinner_mock  # type: ignore[assignment]
+        app._schedule_git_branch_refresh = refresh_mock  # type: ignore[assignment]
+
+        await app._cleanup_agent_task()
+
+        refresh_mock.assert_called_once_with()
+        drain_mock.assert_awaited_once()
+        queue_mock.assert_awaited_once()
+
     def test_empty_startup_cmd_is_normalized_to_none(self) -> None:
         """Empty or whitespace-only `--startup-cmd` should be treated as unset."""
         for raw in ("", "   ", "\t\n"):

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -47,6 +47,16 @@ from deepagents_cli.widgets.messages import (
 )
 
 
+async def _wait_for_branch(app: DeepAgentsApp, branch: str) -> None:
+    """Wait until the status bar reports the expected git branch."""
+    for _ in range(100):
+        if app._status_bar is not None and app._status_bar.branch == branch:
+            return
+        await asyncio.sleep(0.01)
+    msg = f"Timed out waiting for branch {branch!r}"
+    raise AssertionError(msg)
+
+
 class TestInitialPromptOnMount:
     """Test that -m initial prompt is submitted on mount."""
 
@@ -1948,6 +1958,181 @@ class TestShellCommandInterrupt:
             assert app._shell_process is None
             assert app._shell_running is False
             assert app._shell_worker is None
+
+    async def test_cleanup_refreshes_git_branch(self, tmp_path: Path) -> None:
+        """Verify branch refresh on shell cleanup.
+
+        `_cleanup_shell_task` must re-resolve the branch so commands like
+        `git checkout` are reflected in the footer.
+        """
+        import subprocess
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def _init_repo_on_feature_branch() -> None:
+            env = {
+                **os.environ,
+                "GIT_AUTHOR_NAME": "t",
+                "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "t",
+                "GIT_COMMITTER_EMAIL": "t@t",
+            }
+            for args in (
+                ["git", "init", "-q", "-b", "main"],
+                ["git", "add", "f"],
+                ["git", "commit", "-q", "-m", "init"],
+                ["git", "checkout", "-q", "-b", "feature"],
+            ):
+                if args[1] == "add":
+                    (repo / "f").write_text("x")
+                subprocess.run(args, cwd=repo, env=env, check=True, capture_output=True)
+
+        await asyncio.to_thread(_init_repo_on_feature_branch)
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            assert app._status_bar is not None
+            app._cwd = str(repo)
+            app._status_bar.branch = "stale"
+            app._shell_running = True
+            app._shell_worker = MagicMock()
+            app._shell_worker.is_cancelled = False
+            app._shell_process = None
+
+            await app._cleanup_shell_task()
+            await asyncio.wait_for(_wait_for_branch(app, "feature"), timeout=1)
+
+            assert app._status_bar.branch == "feature"
+
+    async def test_refresh_git_branch_reads_gitdir_pointer(
+        self, tmp_path: Path
+    ) -> None:
+        """Worktree-style `.git` files should resolve to the pointed git dir."""
+        repo = tmp_path / "repo"
+        worktree = tmp_path / "worktree"
+        nested = worktree / "src"
+        git_dir = repo / ".git" / "worktrees" / "feature"
+
+        nested.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        (worktree / ".git").write_text(
+            "gitdir: ../repo/.git/worktrees/feature\n",
+            encoding="utf-8",
+        )
+        (git_dir / "HEAD").write_text(
+            "ref: refs/heads/feature/nested\n",
+            encoding="utf-8",
+        )
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            assert app._status_bar is not None
+            app._cwd = str(nested)
+
+            await app._refresh_git_branch()
+
+            assert app._status_bar.branch == "feature/nested"
+
+    async def test_refresh_git_branch_uses_inline_filesystem_fast_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Common branch reads should avoid the thread-offloaded fallback."""
+        repo = tmp_path / "repo"
+        git_dir = repo / ".git"
+        git_dir.mkdir(parents=True)
+        (git_dir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+
+        app = DeepAgentsApp()
+        status_bar = MagicMock()
+        app._status_bar = status_bar
+        app._cwd = str(repo)
+
+        with patch(
+            "deepagents_cli.app.asyncio.to_thread",
+            new=AsyncMock(side_effect=AssertionError("unexpected thread hop")),
+        ):
+            await app._refresh_git_branch()
+
+        assert status_bar.branch == "feature"
+
+    async def test_cleanup_does_not_wait_for_git_branch_refresh(self) -> None:
+        """Queue cleanup should not block on the background branch refresh."""
+        app = DeepAgentsApp()
+        refresh_started = asyncio.Event()
+        release_refresh = asyncio.Event()
+        drain_mock = AsyncMock()
+        queue_mock = AsyncMock()
+
+        async def block_refresh() -> None:
+            refresh_started.set()
+            await release_refresh.wait()
+
+        app._refresh_git_branch = block_refresh  # type: ignore[assignment]
+        app._maybe_drain_deferred = drain_mock  # type: ignore[assignment]
+        app._process_next_from_queue = queue_mock  # type: ignore[assignment]
+        app._shell_running = True
+        app._shell_worker = MagicMock()
+        app._shell_worker.is_cancelled = False
+        app._shell_process = None
+
+        await app._cleanup_shell_task()
+        await asyncio.wait_for(refresh_started.wait(), timeout=1)
+
+        drain_mock.assert_awaited_once()
+        queue_mock.assert_awaited_once()
+
+        release_refresh.set()
+        refresh_task = app._git_branch_refresh_task
+        if refresh_task is not None:
+            await refresh_task
+
+    async def test_run_shell_task_starts_branch_refresh_before_render(self) -> None:
+        """Successful shell runs should overlap branch refresh with rendering."""
+        app = DeepAgentsApp()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"hello\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+        refresh_mock = MagicMock()
+        drain_mock = AsyncMock()
+        queue_mock = AsyncMock()
+
+        def assert_refresh_started(message: object) -> None:
+            if type(message).__name__ == "AssistantMessage":
+                assert refresh_mock.call_count == 1
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._schedule_git_branch_refresh = refresh_mock  # type: ignore[assignment]
+            app._maybe_drain_deferred = drain_mock  # type: ignore[assignment]
+            app._process_next_from_queue = queue_mock  # type: ignore[assignment]
+
+            with (
+                patch(
+                    "asyncio.create_subprocess_shell",
+                    return_value=mock_proc,
+                ),
+                patch(
+                    "deepagents_cli.app.AssistantMessage.write_initial_content",
+                    new=AsyncMock(),
+                ),
+                patch.object(
+                    app,
+                    "_mount_message",
+                    AsyncMock(side_effect=assert_refresh_started),
+                ),
+            ):
+                await app._run_shell_task("echo hi")
+
+        refresh_mock.assert_called_once_with()
+        drain_mock.assert_awaited_once()
+        queue_mock.assert_awaited_once()
 
     async def test_messages_queued_during_shell(self) -> None:
         """Messages should be queued while shell command runs."""

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -278,6 +278,51 @@ class TestStartupSequence:
         assert app._git_branch_refresh_task is None
         mock_create_task.assert_not_called()
 
+    async def test_schedule_git_branch_refresh_inline_fast_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Filesystem probe should update the footer without spawning a task."""
+        repo = tmp_path / "repo"
+        git_dir = repo / ".git"
+        git_dir.mkdir(parents=True)
+        (git_dir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        status_bar = MagicMock()
+        app._status_bar = status_bar
+        app._cwd = str(repo)
+
+        with patch("deepagents_cli.app.asyncio.create_task") as mock_create_task:
+            app._schedule_git_branch_refresh()
+
+        assert status_bar.branch == "feature"
+        mock_create_task.assert_not_called()
+        assert app._git_branch_refresh_task is None
+
+    async def test_schedule_git_branch_refresh_falls_back_to_subprocess(
+        self,
+    ) -> None:
+        """Unusual repo layouts should spawn the off-thread subprocess fallback."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        status_bar = MagicMock()
+        app._status_bar = status_bar
+
+        fallback_mock = AsyncMock()
+        app._refresh_git_branch_subprocess_fallback = (  # type: ignore[assignment]
+            fallback_mock
+        )
+
+        with patch(
+            "deepagents_cli.app.read_git_branch_from_filesystem",
+            return_value=None,
+        ):
+            app._schedule_git_branch_refresh()
+
+        refresh_task = app._git_branch_refresh_task
+        assert refresh_task is not None
+        await refresh_task
+        fallback_mock.assert_awaited_once_with(app._cwd)
+
     def test_empty_startup_cmd_is_normalized_to_none(self) -> None:
         """Empty or whitespace-only `--startup-cmd` should be treated as unset."""
         for raw in ("", "   ", "\t\n"):
@@ -2090,18 +2135,22 @@ class TestShellCommandInterrupt:
         assert status_bar.branch == "feature"
 
     async def test_cleanup_does_not_wait_for_git_branch_refresh(self) -> None:
-        """Queue cleanup should not block on the background branch refresh."""
+        """Queue cleanup should not block on the subprocess fallback refresh."""
         app = DeepAgentsApp()
         refresh_started = asyncio.Event()
         release_refresh = asyncio.Event()
         drain_mock = AsyncMock()
         queue_mock = AsyncMock()
 
-        async def block_refresh() -> None:
+        async def block_refresh(_cwd: str) -> None:
             refresh_started.set()
             await release_refresh.wait()
 
-        app._refresh_git_branch = block_refresh  # type: ignore[assignment]
+        # Force the subprocess fallback path so the test can observe whether
+        # cleanup awaits the background task.
+        app._refresh_git_branch_subprocess_fallback = (  # type: ignore[assignment]
+            block_refresh
+        )
         app._maybe_drain_deferred = drain_mock  # type: ignore[assignment]
         app._process_next_from_queue = queue_mock  # type: ignore[assignment]
         app._shell_running = True
@@ -2109,8 +2158,12 @@ class TestShellCommandInterrupt:
         app._shell_worker.is_cancelled = False
         app._shell_process = None
 
-        await app._cleanup_shell_task()
-        await asyncio.wait_for(refresh_started.wait(), timeout=1)
+        with patch(
+            "deepagents_cli.app.read_git_branch_from_filesystem",
+            return_value=None,
+        ):
+            await app._cleanup_shell_task()
+            await asyncio.wait_for(refresh_started.wait(), timeout=1)
 
         drain_mock.assert_awaited_once()
         queue_mock.assert_awaited_once()

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from deepagents_cli import model_config
+from deepagents_cli import _git as git_module, model_config
 from deepagents_cli._env_vars import SERVER_ENV_PREFIX
 from deepagents_cli.config import (
     RECOMMENDED_SAFE_SHELL_COMMANDS,
@@ -79,6 +79,46 @@ class TestProjectRootDetection:
         # Should find inner repo, not outer
         result = _find_project_root(inner_repo)
         assert result == inner_repo
+
+    def test_find_project_root_with_gitdir_file(self, tmp_path: Path) -> None:
+        """Test that worktree-style `.git` files resolve to the worktree root."""
+        repo = tmp_path / "repo"
+        worktree = tmp_path / "worktree"
+        nested = worktree / "src"
+        git_dir = repo / ".git" / "worktrees" / "feature"
+
+        nested.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        (worktree / ".git").write_text(
+            "gitdir: ../repo/.git/worktrees/feature\n",
+            encoding="utf-8",
+        )
+
+        result = _find_project_root(nested)
+        assert result == worktree
+
+
+class TestGitMetadataLookup:
+    """Tests for shared git metadata helpers."""
+
+    def setup_method(self) -> None:
+        """Clear git metadata caches between tests."""
+        git_module._git_dir_cache.clear()
+
+    def test_find_git_dir_reuses_cached_resolution(self, tmp_path: Path) -> None:
+        """Repeated git-dir lookups should reuse the cached result."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        expected = repo / ".git"
+
+        with patch(
+            "deepagents_cli._git._find_git_dir_uncached",
+            return_value=expected,
+        ) as mock_find:
+            assert git_module.find_git_dir(repo) == expected
+            assert git_module.find_git_dir(repo) == expected
+
+        mock_find.assert_called_once()
 
 
 class TestProjectContext:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -337,20 +337,21 @@ class TestGetGitBranch:
         config_module._git_branch_cache.clear()
 
     def test_reuses_cached_branch_for_same_working_directory(self) -> None:
-        """Repeated lookups in one repo should only spawn `git` once."""
-        result = MagicMock(returncode=0, stdout="feature-branch\n")
-
+        """Repeated lookups in one repo should only resolve the branch once."""
         with (
             patch(
                 "deepagents_cli.config.Path.cwd",
                 return_value=Path("/tmp/repo"),
             ),
-            patch("subprocess.run", return_value=result) as mock_run,
+            patch(
+                "deepagents_cli.config.resolve_git_branch",
+                return_value="feature-branch",
+            ) as mock_resolve,
         ):
             assert config_module._get_git_branch() == "feature-branch"
             assert config_module._get_git_branch() == "feature-branch"
 
-        assert mock_run.call_count == 1
+        mock_resolve.assert_called_once_with("/tmp/repo")
 
 
 class TestGetGitBranchOSError:

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -92,6 +92,24 @@ class TestTextualUIAdapterInit:
         assert adapter._on_tokens_hide is None
         assert adapter._on_tokens_show is None
 
+    def test_on_tool_complete_defaults_to_none_and_accepts_callback(self) -> None:
+        """Verify `on_tool_complete` is optional and can be assigned via init."""
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+        assert adapter._on_tool_complete is None
+
+        callback = MagicMock()
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            on_tool_complete=callback,
+        )
+        assert adapter._on_tool_complete is callback
+
     def test_set_token_callbacks(self) -> None:
         """Verify token callbacks can be assigned."""
         adapter = TextualUIAdapter(
@@ -664,6 +682,57 @@ class TestExecuteTaskTextualParallelToolSpinner:
         assert thinking_count == 2, (
             "Expected exactly 2 Thinking calls (start + after last tool); "
             f"got {thinking_count}: {statuses}"
+        )
+
+    async def test_on_tool_complete_fires_per_tool_message(self) -> None:
+        """`on_tool_complete` should fire once per `ToolMessage`, even in parallel."""
+        tool_complete = MagicMock()
+        tc = _tool_call_message
+        chunks = [
+            ((), "messages", (tc("task", {"task": "a"}, "tool-a"), {})),
+            ((), "messages", (tc("task", {"task": "b"}, "tool-b"), {})),
+            ((), "messages", (ToolMessage(content="a", tool_call_id="tool-a"), {})),
+            ((), "messages", (ToolMessage(content="b", tool_call_id="tool-b"), {})),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            on_tool_complete=tool_complete,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+            adapter=adapter,
+        )
+
+        assert tool_complete.call_count == 2
+
+    async def test_on_tool_complete_exception_is_swallowed(self) -> None:
+        """A raising `on_tool_complete` must not break agent streaming."""
+        tc = _tool_call_message
+        chunks = [
+            ((), "messages", (tc("task", {"task": "a"}, "tool-a"), {})),
+            ((), "messages", (ToolMessage(content="a", tool_call_id="tool-a"), {})),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            on_tool_complete=MagicMock(side_effect=RuntimeError("boom")),
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+            adapter=adapter,
         )
 
     async def test_spinner_shown_after_single_tool_completes(self) -> None:


### PR DESCRIPTION
Keep the footer's git branch in sync with any command that can move HEAD — interactive `!` shell commands and agent-executed tools alike. Previously the branch was probed once via `git rev-parse` at startup and never refreshed, so `!git checkout other` or an agent running the same command would leave the footer stale. Along the way, pull the ad-hoc filesystem probing into a shared `_git` module so `config.py` and `project_utils.py` stop duplicating branch/root detection.