### PR TITLE
ci(evals): collapse failure analysis and reorder after results

### DIFF
--- a/.github/scripts/analyze_eval_failures.py
+++ b/.github/scripts/analyze_eval_failures.py
@@ -83,7 +83,10 @@ def _format_markdown(results: list[dict[str, str]]) -> str:
         Markdown-formatted string.
     """
     lines = [
-        f"## Failure analysis ({len(results)} failure{'s' if len(results) != 1 else ''})\n"
+        f"## Failure analysis ({len(results)} failure{'s' if len(results) != 1 else ''})\n",
+        "<details>",
+        "<summary>(click to expand)</summary>",
+        "",
     ]
     for result in results:
         lines.append(f"### `{result.get('test_name', 'unknown')}`")
@@ -92,6 +95,7 @@ def _format_markdown(results: list[dict[str, str]]) -> str:
             lines.append(f"**Category:** {category}\n")
         lines.append(result.get("analysis", ""))
         lines.append("\n---\n")
+    lines.append("</details>")
     return "\n".join(lines)
 
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -350,29 +350,6 @@ jobs:
             exit 1
           fi
 
-      - name: "🧠 Analyze eval failures"
-        if: "!cancelled() && inputs.analyze_failures"
-        continue-on-error: true
-        env:
-          ANALYSIS_MODEL: ${{ inputs.analysis_model || 'anthropic:claude-haiku-4-5-20251001' }}
-        run: uv run python ../../.github/scripts/analyze_eval_failures.py evals_report.json
-
-      - name: "📤 Upload failure analysis"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: failure-analysis-${{ strategy.job-index }}
-          path: libs/evals/failure_analysis.json
-          if-no-files-found: warn
-
-      - name: "📤 Upload eval report"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: evals-report-${{ strategy.job-index }}
-          path: libs/evals/evals_report.json
-          if-no-files-found: error
-
       - name: "📊 Post results to summary"
         if: "!cancelled()"
         run: |
@@ -464,6 +441,29 @@ jobs:
                   f.write(text)
           print(text)
           PYEOF
+
+      - name: "🧠 Analyze eval failures"
+        if: "!cancelled() && inputs.analyze_failures"
+        continue-on-error: true
+        env:
+          ANALYSIS_MODEL: ${{ inputs.analysis_model || 'anthropic:claude-haiku-4-5-20251001' }}
+        run: uv run python ../../.github/scripts/analyze_eval_failures.py evals_report.json
+
+      - name: "📤 Upload failure analysis"
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: failure-analysis-${{ strategy.job-index }}
+          path: libs/evals/failure_analysis.json
+          if-no-files-found: warn
+
+      - name: "📤 Upload eval report"
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: evals-report-${{ strategy.job-index }}
+          path: libs/evals/evals_report.json
+          if-no-files-found: error
 
   aggregate:
     name: "📋 Aggregate evals"

--- a/libs/evals/tests/unit_tests/test_analyze_eval_failures.py
+++ b/libs/evals/tests/unit_tests/test_analyze_eval_failures.py
@@ -62,6 +62,16 @@ class TestFormatMarkdown:
         md = _format_markdown(results)
         assert "**Category:** tool_use" in md
 
+    def test_wrapped_in_details_toggle(self):
+        results = [{**_SAMPLE_FAILURE, "analysis": "analysis"}]
+        md = _format_markdown(results)
+        # Heading stays outside the toggle so the count is visible collapsed.
+        heading_idx = md.index("## Failure analysis")
+        details_idx = md.index("<details>")
+        summary_idx = md.index("<summary>(click to expand)</summary>")
+        close_idx = md.index("</details>")
+        assert heading_idx < details_idx < summary_idx < close_idx
+
 
 class TestAnalyzeOne:
     async def test_returns_analysis(self):


### PR DESCRIPTION
Reorder the eval CI step summary so the results table appears before LLM failure analysis, and collapse the failure analysis into an expandable `<details>` toggle so long runs don't dominate the summary.