### PR TITLE
style(cli): stretch chat input and status bar to full width

### DIFF
--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -37,7 +37,6 @@ Screen {
 #bottom-app-container {
     height: auto;
     margin-top: 1;
-    padding: 0 1;
 }
 
 /* Input area */
@@ -99,7 +98,6 @@ Screen {
 #status-bar {
     height: 1;
     dock: bottom;
-    margin-bottom: 1;
 }
 
 /* Tool approval widgets */

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -77,7 +77,6 @@ class StatusBar(Horizontal):
         height: 1;
         dock: bottom;
         background: $surface;
-        padding: 0 1;
     }
 
     StatusBar .status-mode {


### PR DESCRIPTION
Reclaim horizontal and vertical space around the chat input and status bar so both stretch edge-to-edge. The `margin-bottom: 1` on `#status-bar` left an empty line below the footer (originally reserved for a Textual `Footer` that was never added), and the matching `padding: 0 1` on `#bottom-app-container` and `StatusBar` inset both widgets by a column on each side.