### PR TITLE
feat(cli): rework `/version`, add release-age and editable-install guard

### DIFF
--- a/libs/cli/deepagents_cli/_version.py
+++ b/libs/cli/deepagents_cli/_version.py
@@ -8,6 +8,13 @@ DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
 PYPI_URL = "https://pypi.org/pypi/deepagents-cli/json"
 """PyPI JSON API endpoint for version checks."""
 
+SDK_PYPI_URL = "https://pypi.org/pypi/deepagents/json"
+"""PyPI JSON API endpoint for reading `deepagents` SDK release metadata.
+
+The CLI only reads release-age metadata from this endpoint; it never
+performs SDK update checks.
+"""
+
 CHANGELOG_URL = (
     "https://github.com/langchain-ai/deepagents/blob/main/libs/cli/CHANGELOG.md"
 )

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1689,6 +1689,7 @@ class DeepAgentsApp(App):
                     )
             else:
                 from deepagents_cli.update_check import (
+                    format_age_suffix,
                     mark_update_notified,
                     should_notify_update,
                 )
@@ -1697,8 +1698,10 @@ class DeepAgentsApp(App):
                     return
 
                 cmd = upgrade_command()
+                age_suffix = await asyncio.to_thread(format_age_suffix, latest)
                 self.notify(
-                    f"Update available: v{latest} (current: v{cli_version}). "
+                    f"Update available: v{latest} "
+                    f"(current: v{cli_version}{age_suffix}). "
                     f"Run: {cmd}\n\n"
                     f"Enable auto-updates: /auto-update",
                     severity="information",
@@ -1754,26 +1757,51 @@ class DeepAgentsApp(App):
         """Handle the `/update` slash command — check for and install updates."""
         await self._mount_message(UserMessage("/update"))
         try:
+            from deepagents_cli._version import __version__ as cli_version
+            from deepagents_cli.config import _is_editable_install
             from deepagents_cli.update_check import (
+                format_age_suffix,
                 is_update_available,
                 perform_upgrade,
                 upgrade_command,
             )
 
+            if await asyncio.to_thread(_is_editable_install):
+                age_suffix = await asyncio.to_thread(format_age_suffix, cli_version)
+                await self._mount_message(
+                    AppMessage(
+                        "Updates are not available for editable installs. "
+                        f"Currently on v{cli_version}{age_suffix}."
+                    )
+                )
+                return
+
             await self._mount_message(AppMessage("Checking for updates..."))
             available, latest = await asyncio.to_thread(
                 is_update_available, bypass_cache=True
             )
+            if latest is None:
+                await self._mount_message(
+                    AppMessage(
+                        "Could not determine the latest version. "
+                        "Check your network and try again."
+                    )
+                )
+                return
             if not available:
-                await self._mount_message(AppMessage("Already on the latest version."))
+                age_suffix = await asyncio.to_thread(format_age_suffix, cli_version)
+                await self._mount_message(
+                    AppMessage(
+                        f"Already on the latest version (v{cli_version}{age_suffix})."
+                    )
+                )
                 return
 
-            from deepagents_cli._version import __version__ as cli_version
-
+            age_suffix = await asyncio.to_thread(format_age_suffix, latest)
             await self._mount_message(
                 AppMessage(
-                    f"Update available: v{latest} (current: v{cli_version}). "
-                    "Upgrading..."
+                    f"Update available: v{latest} "
+                    f"(current: v{cli_version}{age_suffix}). Upgrading..."
                 )
             )
             success, output = await perform_upgrade()
@@ -1793,6 +1821,83 @@ class DeepAgentsApp(App):
             await self._mount_message(
                 ErrorMessage(f"Update failed: {type(exc).__name__}: {exc}")
             )
+
+    async def _handle_version_command(self) -> None:
+        """Handle the `/version` slash command — show versions and update status.
+
+        The CLI release age is served from the cache populated by the
+        background update check. The SDK release age is served from its own
+        cache; on the first call for a given SDK version (or on a cache
+        miss) this triggers a one-off PyPI fetch bounded by a 3s timeout,
+        then persists the result so subsequent calls stay local. The
+        update-available hint is sourced from `self._update_available`,
+        which reflects the last completed background check.
+        """
+        from importlib.metadata import (
+            PackageNotFoundError,
+            version as _pkg_version,
+        )
+
+        lines: list[str] = []
+        try:
+            from deepagents_cli._version import __version__ as cli_version
+            from deepagents_cli.update_check import format_age_suffix
+
+            age_suffix = await asyncio.to_thread(format_age_suffix, cli_version)
+            lines.append(f"deepagents-cli version: {cli_version}{age_suffix}")
+        except ImportError:
+            logger.debug("deepagents_cli._version module not found")
+            lines.append("deepagents-cli version: unknown")
+        except Exception:
+            logger.warning("Unexpected error looking up CLI version", exc_info=True)
+            lines.append("deepagents-cli version: unknown")
+
+        try:
+            from deepagents_cli.update_check import format_sdk_age_suffix
+
+            sdk_version = _pkg_version("deepagents")
+            sdk_age_suffix = await asyncio.to_thread(format_sdk_age_suffix, sdk_version)
+            lines.append(f"deepagents (SDK) version: {sdk_version}{sdk_age_suffix}")
+        except PackageNotFoundError:
+            logger.debug("deepagents SDK package not found in environment")
+            lines.append("deepagents (SDK) version: unknown")
+        except Exception:
+            logger.warning("Unexpected error looking up SDK version", exc_info=True)
+            lines.append("deepagents (SDK) version: unknown")
+
+        available, latest = self._update_available
+        if available and latest:
+            try:
+                from deepagents_cli.update_check import upgrade_command
+
+                cmd = upgrade_command()
+            except Exception:
+                logger.warning(
+                    "Could not resolve upgrade command for /version; "
+                    "falling back to generic pip hint",
+                    exc_info=True,
+                )
+                from deepagents_cli.update_check import FALLBACK_UPGRADE_COMMAND
+
+                cmd = FALLBACK_UPGRADE_COMMAND
+            lines.extend(("", f"Update available: v{latest}. Run: {cmd}"))
+
+        await self._mount_message(AppMessage("\n".join(lines)))
+
+        try:
+            from deepagents_cli.extras_info import (
+                format_extras_status,
+                get_extras_status,
+            )
+
+            extras_markdown = format_extras_status(get_extras_status())
+        except Exception:
+            logger.warning(
+                "Failed to collect optional dependency status", exc_info=True
+            )
+            extras_markdown = ""
+        if extras_markdown:
+            await self._mount_message(AppMessage(extras_markdown, markdown=True))
 
     async def _handle_auto_update_toggle(self) -> None:
         """Handle the `/auto-update` slash command — persist toggle immediately."""
@@ -3020,34 +3125,7 @@ class DeepAgentsApp(App):
             await self._open_url_command(command, cmd)
         elif cmd == "/version":
             await self._mount_message(UserMessage(command))
-            # Show CLI and SDK package versions
-            try:
-                from deepagents_cli._version import (
-                    __version__ as cli_version,
-                )
-
-                cli_line = f"deepagents-cli version: {cli_version}"
-            except ImportError:
-                logger.debug("deepagents_cli._version module not found")
-                cli_line = "deepagents-cli version: unknown"
-            except Exception:
-                logger.warning("Unexpected error looking up CLI version", exc_info=True)
-                cli_line = "deepagents-cli version: unknown"
-            try:
-                from importlib.metadata import (
-                    PackageNotFoundError,
-                    version as _pkg_version,
-                )
-
-                sdk_version = _pkg_version("deepagents")
-                sdk_line = f"deepagents (SDK) version: {sdk_version}"
-            except PackageNotFoundError:
-                logger.debug("deepagents SDK package not found in environment")
-                sdk_line = "deepagents (SDK) version: unknown"
-            except Exception:
-                logger.warning("Unexpected error looking up SDK version", exc_info=True)
-                sdk_line = "deepagents (SDK) version: unknown"
-            await self._mount_message(AppMessage(f"{cli_line}\n{sdk_line}"))
+            await self._handle_version_command()
         elif cmd == "/agents":
             await self._show_agent_selector()
         elif cmd == "/clear":

--- a/libs/cli/deepagents_cli/extras_info.py
+++ b/libs/cli/deepagents_cli/extras_info.py
@@ -1,0 +1,178 @@
+"""Inspect optional-dependency install status for the running distribution.
+
+Reads `Requires-Dist` metadata to report which packages declared under
+`[project.optional-dependencies]` are installed, and renders that status
+in either plain text (for stdout) or markdown (for rich UI contexts).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from importlib.metadata import (
+    PackageNotFoundError,
+    distribution,
+    version as pkg_version,
+)
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+logger = logging.getLogger(__name__)
+
+_EXTRA_MARKER_RE = re.compile(r"""extra\s*==\s*["']([^"']+)["']""")
+
+_COMPOSITE_EXTRAS: frozenset[str] = frozenset({"all-providers", "all-sandboxes"})
+"""Extras whose package set is already covered by other, more specific extras.
+
+Build backends flatten these meta-extras into their component packages
+rather than preserving the `deepagents-cli[a,b,...]` self-reference, so
+name-based filtering is the only reliable way to drop them.
+"""
+
+ExtrasStatus = dict[str, list[tuple[str, str]]]
+"""Mapping from extra name to `(package, installed_version)` tuples.
+
+Only packages that are actually installed are included. Extras whose
+declared packages are all missing are omitted entirely.
+"""
+
+
+def _extract_extra_name(marker_str: str) -> str | None:
+    """Pull the extra name out of a marker like `extra == "anthropic"`.
+
+    Args:
+        marker_str: String form of a `packaging.markers.Marker`.
+
+    Returns:
+        The quoted extra name, or `None` when the marker does not carry an
+            `extra == "..."` clause.
+    """
+    match = _EXTRA_MARKER_RE.search(marker_str)
+    return match.group(1) if match else None
+
+
+def get_extras_status(
+    distribution_name: str = "deepagents-cli",
+) -> ExtrasStatus:
+    """Return installed optional dependencies grouped by extra.
+
+    Reads `Requires-Dist` metadata from the named distribution, groups the
+    entries gated by `extra == "..."` markers under their extra name, and
+    resolves each package's installed version via `importlib.metadata`.
+    Packages that are not installed are omitted; extras whose entire
+    package list is absent are dropped.
+
+    Composite meta-extras that only bundle other extras (see
+    `_COMPOSITE_EXTRAS`) and self-references to the distribution itself
+    are skipped — their components already appear under their own extras.
+
+    Args:
+        distribution_name: Name of the installed distribution to inspect.
+
+    Returns:
+        Mapping from extra name to a sorted list of `(package, version)`
+            tuples for packages that are currently installed. An empty
+            mapping is returned when the distribution itself is not found.
+    """
+    try:
+        dist = distribution(distribution_name)
+    except PackageNotFoundError:
+        logger.debug(
+            "Distribution %s not found; cannot read optional dependencies",
+            distribution_name,
+        )
+        return {}
+
+    own_name = distribution_name.lower()
+    result: ExtrasStatus = {}
+    for raw in dist.requires or []:
+        try:
+            req = Requirement(raw)
+        except InvalidRequirement:
+            logger.warning("Could not parse Requires-Dist entry: %s", raw)
+            continue
+        if not req.marker:
+            continue
+        extra = _extract_extra_name(str(req.marker))
+        if not extra:
+            continue
+        if extra in _COMPOSITE_EXTRAS:
+            continue
+        if req.name.lower() == own_name:
+            continue
+        try:
+            version = pkg_version(req.name)
+        except PackageNotFoundError:
+            continue
+        result.setdefault(extra, []).append((req.name, version))
+
+    for items in result.values():
+        items.sort()
+    return dict(sorted(result.items()))
+
+
+def format_extras_status_plain(status: ExtrasStatus) -> str:
+    """Render an `ExtrasStatus` mapping as column-aligned plain text.
+
+    Suitable for stdout in non-interactive contexts (e.g. the `--version`
+    CLI flag) where a markdown renderer is unavailable.
+
+    Args:
+        status: Mapping returned by `get_extras_status`.
+
+    Returns:
+        Multi-line string with a heading and one `extra  package  version`
+            row per installed package.
+
+            Returns an empty string when `status` is empty.
+    """
+    if not status:
+        return ""
+    rows: list[tuple[str, str, str]] = [
+        (extra_name, pkg_name, version)
+        for extra_name, pkgs in status.items()
+        for pkg_name, version in pkgs
+    ]
+    extra_width = max(len(row[0]) for row in rows)
+    package_width = max(len(row[1]) for row in rows)
+    lines = ["Installed optional dependencies:"]
+    lines.extend(
+        f"  {extra.ljust(extra_width)}  {pkg.ljust(package_width)}  {version}"
+        for extra, pkg, version in rows
+    )
+    return "\n".join(lines)
+
+
+def format_extras_status(status: ExtrasStatus) -> str:
+    """Render an `ExtrasStatus` mapping as a markdown fragment.
+
+    Args:
+        status: Mapping returned by `get_extras_status`.
+
+    Returns:
+        Multi-line markdown string containing a heading and a pipe table
+            with `Extra`, `Package`, and `Version` columns, suitable for
+            rendering via a markdown widget.
+
+            Returns an empty string when `status` is empty.
+    """
+    if not status:
+        return ""
+    rows: list[tuple[str, str, str]] = [
+        (extra_name, pkg_name, version)
+        for extra_name, pkgs in status.items()
+        for pkg_name, version in pkgs
+    ]
+    headers = ("Extra", "Package", "Version")
+
+    def _row(cells: tuple[str, str, str]) -> str:
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [
+        "### Installed optional dependencies",
+        "",
+        _row(headers),
+        "| " + " | ".join("---" for _ in headers) + " |",
+        *(_row(row) for row in rows),
+    ]
+    return "\n".join(lines)

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -756,11 +756,27 @@ def parse_args() -> argparse.Namespace:
         help="Run as an ACP server over stdio instead of launching the Textual UI",
     )
 
+    version_text = f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}"
+    # `parse_args` runs on every invocation; keep the import-heavy metadata
+    # scan off the hot path unless the user explicitly asked for --version.
+    if any(arg in {"-v", "--version"} for arg in sys.argv[1:]):
+        try:
+            from deepagents_cli.extras_info import (
+                format_extras_status_plain,
+                get_extras_status,
+            )
+
+            extras_text = format_extras_status_plain(get_extras_status())
+        except Exception:
+            logger.warning("Unexpected error collecting optional deps", exc_info=True)
+            extras_text = ""
+        if extras_text:
+            version_text = f"{version_text}\n\n{extras_text}"
     parser.add_argument(
         "-v",
         "--version",
         action="version",
-        version=f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}",
+        version=version_text,
     )
     parser.add_argument(
         "-h",
@@ -1335,7 +1351,20 @@ def cli_main() -> None:
         except Exception:  # Best-effort SDK version lookup
             logger.debug("Unexpected error looking up SDK version", exc_info=True)
             sdk_version = "unknown"
-        print(f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}")  # noqa: T201  # CLI version output
+        output = f"deepagents-cli {__version__}\ndeepagents (SDK) {sdk_version}"
+        try:
+            from deepagents_cli.extras_info import (
+                format_extras_status_plain,
+                get_extras_status,
+            )
+
+            extras_text = format_extras_status_plain(get_extras_status())
+        except Exception:
+            logger.warning("Unexpected error collecting optional deps", exc_info=True)
+            extras_text = ""
+        if extras_text:
+            output = f"{output}\n\n{extras_text}"
+        print(output)  # noqa: T201  # CLI version output
         sys.exit(0)
 
     # ACP mode does not require Textual, so skip UI dependency checks when
@@ -1495,27 +1524,43 @@ def cli_main() -> None:
                 from rich.markup import escape
 
                 from deepagents_cli._version import __version__ as cli_version
+                from deepagents_cli.config import _is_editable_install
                 from deepagents_cli.update_check import (
+                    format_age_suffix,
                     is_update_available,
                     perform_upgrade,
                     upgrade_command,
                 )
+
+                if _is_editable_install():
+                    age_suffix = format_age_suffix(cli_version)
+                    console.print(
+                        "[bold yellow]Warning:[/bold yellow] "
+                        "Updates are not available for editable installs. "
+                        f"Currently on v{cli_version}{age_suffix}."
+                    )
+                    sys.exit(0)
 
                 console.print("Checking for updates...", style="dim")
                 available, latest = is_update_available(bypass_cache=True)
                 if latest is None:
                     console.print(
                         "[bold yellow]Warning:[/bold yellow] Could not "
-                        "reach PyPI. Check your network and try again."
+                        "determine the latest version. Check your network "
+                        "and try again."
                     )
                     sys.exit(1)
                 if not available:
-                    console.print(f"Already on the latest version (v{cli_version}).")
+                    age_suffix = format_age_suffix(cli_version)
+                    console.print(
+                        f"Already on the latest version (v{cli_version}{age_suffix})."
+                    )
                     sys.exit(0)
 
+                age_suffix = format_age_suffix(latest)
                 console.print(
                     f"Update available: v{latest} "
-                    f"(current: v{cli_version}). Upgrading..."
+                    f"(current: v{cli_version}{age_suffix}). Upgrading..."
                 )
                 success, output = asyncio.run(perform_upgrade())
                 if success:
@@ -1860,6 +1905,7 @@ def cli_main() -> None:
                 if result.update_available[0]:
                     from deepagents_cli._version import __version__ as cli_version
                     from deepagents_cli.update_check import (
+                        format_age_suffix,
                         is_auto_update_enabled,
                         mark_update_notified,
                         should_notify_update,
@@ -1869,9 +1915,12 @@ def cli_main() -> None:
                     latest = result.update_available[1]
                     if latest and should_notify_update(latest):
                         console.print()
+                        age_suffix = format_age_suffix(latest)
                         update_msg = Text("Update available: ", style="yellow bold")
                         update_msg.append(f"v{latest}", style="yellow")
-                        update_msg.append(f" (current: v{cli_version})", style="dim")
+                        update_msg.append(
+                            f" (current: v{cli_version}{age_suffix})", style="dim"
+                        )
                         console.print(update_msg)
                         cmd_hint = Text("Run: ", style="dim")
                         cmd_hint.append(upgrade_command(), style="cyan")

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -19,11 +19,11 @@ import shutil
 import sys
 import time
 import tomllib
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from packaging.version import InvalidVersion, Version
 
-from deepagents_cli._version import PYPI_URL, USER_AGENT, __version__
+from deepagents_cli._version import PYPI_URL, SDK_PYPI_URL, USER_AGENT, __version__
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -36,12 +36,23 @@ CACHE_FILE: Path = DEFAULT_CONFIG_DIR / "latest_version.json"
 UPDATE_STATE_FILE: Path = DEFAULT_CONFIG_DIR / "update_state.json"
 CACHE_TTL = 86_400  # 24 hours
 
+_SDK_RELEASE_TIMES_KEY = "sdk_release_times"
+"""`CACHE_FILE` key for cached SDK upload timestamps, keyed by version string."""
+
 InstallMethod = Literal["uv", "pip", "brew", "unknown"]
+
+FALLBACK_UPGRADE_COMMAND = "pip install --upgrade deepagents-cli"
+"""Generic upgrade hint used when install-method detection fails.
+
+Callers that surface an upgrade command in user-facing text should prefer
+`upgrade_command()`; this constant exists so those callers have something
+to render when detection raises unexpectedly.
+"""
 
 _UPGRADE_COMMANDS: dict[InstallMethod, str] = {
     "uv": "uv tool upgrade deepagents-cli",
     "brew": "brew upgrade deepagents-cli",
-    "pip": "pip install --upgrade deepagents-cli",
+    "pip": FALLBACK_UPGRADE_COMMAND,
 }
 """Upgrade commands keyed by install method.
 
@@ -157,6 +168,10 @@ def get_latest_version(
         logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
         return None
 
+    release_times = _extract_release_times(
+        payload, stable=stable, prerelease=prerelease
+    )
+
     try:
         CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
         CACHE_FILE.write_text(
@@ -164,6 +179,7 @@ def get_latest_version(
                 {
                     "version": stable,
                     "version_prerelease": prerelease,
+                    "release_times": release_times,
                     "checked_at": time.time(),
                 }
             ),
@@ -173,6 +189,234 @@ def get_latest_version(
         logger.debug("Failed to write update-check cache", exc_info=True)
 
     return prerelease if include_prereleases else stable
+
+
+def _extract_release_times(
+    payload: dict[str, Any], *, stable: str, prerelease: str | None
+) -> dict[str, str]:
+    """Pull `upload_time_iso_8601` for the given versions out of a PyPI payload.
+
+    PyPI lists per-file uploads; the first file's timestamp is used as a
+    stand-in for the release's publish time (files typically land within
+    seconds of each other). Looks up both versions under `releases[ver]`
+    rather than `payload["urls"]`, which reflects the project's
+    `info.version` and may not match `stable` when the latest on PyPI is
+    a pre-release.
+
+    Args:
+        payload: Parsed PyPI JSON response.
+        stable: Latest stable version string.
+        prerelease: Latest pre-release version string, if any.
+
+    Returns:
+        Mapping of version string to ISO-8601 upload time. Silently drops
+        versions whose timestamp is missing or malformed.
+    """
+    times: dict[str, str] = {}
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        return times
+    for ver in (stable, prerelease):
+        if not ver:
+            continue
+        files = releases.get(ver)
+        if not isinstance(files, list) or not files:
+            continue
+        ts = _upload_time(files[0])
+        if ts:
+            times[ver] = ts
+    return times
+
+
+def _upload_time(file_entry: object) -> str | None:
+    """Return `upload_time_iso_8601` from a PyPI file entry, or `None`."""
+    if not isinstance(file_entry, dict):
+        return None
+    # `isinstance(..., dict)` narrows to `dict[Unknown, Unknown]`, so `.get()`
+    # overload resolution is ambiguous. PyPI payloads are str-keyed in practice
+    # and the `isinstance(value, str)` check below validates the result anyway.
+    value = file_entry.get("upload_time_iso_8601")  # type: ignore[call-overload]
+    return value if isinstance(value, str) else None
+
+
+def get_release_time(version: str | None) -> str | None:
+    """Return the cached ISO-8601 upload time for `version`, or `None`.
+
+    Only versions captured during a prior `get_latest_version` call are
+    available; unknown versions, or a `None` input, return `None`.
+    """
+    if not version:
+        return None
+    try:
+        if CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                times = data.get("release_times")
+                if isinstance(times, dict):
+                    value = times.get(version)
+                    if isinstance(value, str):
+                        return value
+    except (OSError, json.JSONDecodeError):
+        logger.debug("Failed to read release_times from cache", exc_info=True)
+    return None
+
+
+def _format_age_from_iso(iso: str | None) -> str:
+    """Return `'released Nd ago'` for an ISO-8601 timestamp, or `""` on failure."""
+    if not iso:
+        return ""
+    from deepagents_cli.sessions import format_relative_timestamp
+
+    age = format_relative_timestamp(iso)
+    return f"released {age}" if age else ""
+
+
+def format_release_age(version: str | None) -> str:
+    """Return a human-readable age for `version` (e.g., `'released 3d ago'`).
+
+    Returns an empty string when the upload time is unknown (cache entry
+    lacks `release_times` for this version, or a `None` version) so callers
+    can concatenate unconditionally.
+    """
+    return _format_age_from_iso(get_release_time(version))
+
+
+def format_age_suffix(version: str | None) -> str:
+    """Return `", released Nd ago"` for `version`, or `""` when unknown.
+
+    The `", "` separator is included so callers can splice the age into a
+    parenthetical unconditionally — if the age is unknown, the empty
+    string collapses cleanly into the surrounding text.
+    """
+    age = format_release_age(version)
+    return f", {age}" if age else ""
+
+
+def get_sdk_release_time(
+    version: str | None, *, bypass_cache: bool = False
+) -> str | None:
+    """Return the ISO-8601 upload time for `deepagents` SDK `version`.
+
+    Reads from `CACHE_FILE` under `sdk_release_times`, falling back to a
+    single PyPI fetch on cache miss and writing the result back so
+    subsequent calls stay local.
+
+    Args:
+        version: Installed SDK version string.
+        bypass_cache: Skip the cache read and always hit PyPI.
+
+            The result is still written back to the cache.
+
+    Returns:
+        The ISO-8601 upload timestamp, or `None` on any failure (missing
+            version, unresolvable on PyPI, `requests` unavailable, or
+            network error).
+    """
+    if not version:
+        return None
+
+    try:
+        if not bypass_cache and CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                times = data.get(_SDK_RELEASE_TIMES_KEY)
+                if isinstance(times, dict):
+                    cached = times.get(version)
+                    if isinstance(cached, str):
+                        return cached
+    except (OSError, json.JSONDecodeError):
+        logger.debug("Failed to read sdk release_times from cache", exc_info=True)
+
+    try:
+        import requests
+    except ImportError:
+        logger.debug("requests unavailable — SDK release time lookup disabled")
+        return None
+
+    try:
+        resp = requests.get(
+            SDK_PYPI_URL,
+            headers={"User-Agent": USER_AGENT},
+            timeout=3,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        releases = payload.get("releases")
+        if not isinstance(releases, dict):
+            return None
+        files = releases.get(version)
+        if not isinstance(files, list) or not files:
+            return None
+        iso = _upload_time(files[0])
+    except (requests.RequestException, OSError, json.JSONDecodeError):
+        logger.debug("Failed to fetch SDK release time from PyPI", exc_info=True)
+        return None
+
+    if iso:
+        _write_sdk_release_time(version, iso)
+    return iso
+
+
+def _write_sdk_release_time(version: str, iso: str) -> None:
+    """Merge a single SDK release timestamp into `CACHE_FILE`.
+
+    A corrupt existing cache is overwritten rather than propagating the
+    decode error — otherwise every caller would keep paying the PyPI
+    round-trip because the write never succeeds.
+    """
+    data: dict[str, object] = {}
+    if CACHE_FILE.exists():
+        try:
+            raw = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning(
+                "SDK release-time cache is corrupt; overwriting", exc_info=True
+            )
+        except OSError:
+            logger.debug("Failed to read SDK release-time cache", exc_info=True)
+            return
+        else:
+            if isinstance(raw, dict):
+                data = raw
+
+    times: dict[str, str] = {}
+    existing = data.get(_SDK_RELEASE_TIMES_KEY)
+    if isinstance(existing, dict):
+        times.update(
+            {
+                k: v
+                for k, v in existing.items()
+                if isinstance(k, str) and isinstance(v, str)
+            }
+        )
+    times[version] = iso
+    data[_SDK_RELEASE_TIMES_KEY] = times
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(json.dumps(data), encoding="utf-8")
+    except OSError:
+        logger.debug("Failed to write SDK release time to cache", exc_info=True)
+
+
+def format_sdk_release_age(version: str | None) -> str:
+    """Return a human-readable age for SDK `version` (e.g., `'released 3d ago'`).
+
+    May trigger a single PyPI fetch on cache miss (3s timeout). Returns an
+    empty string on any failure so callers can concatenate unconditionally.
+    """
+    return _format_age_from_iso(get_sdk_release_time(version))
+
+
+def format_sdk_age_suffix(version: str | None) -> str:
+    """Return `", released Nd ago"` for SDK `version`, or `""` when unknown.
+
+    The `", "` separator is included so callers can splice the age into a
+    line unconditionally — if the age is unknown, the empty string
+    collapses cleanly into the surrounding text. May trigger a single
+    PyPI fetch on cache miss.
+    """
+    age = format_sdk_release_age(version)
+    return f", {age}" if age else ""
 
 
 def _read_update_state() -> dict[str, object]:
@@ -259,9 +503,13 @@ def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None
     Returns:
         A `(available, latest)` tuple.
 
-            `available` is `True` when the PyPI version is strictly newer than
-            the installed version; `latest` is the version string (or `None`
-            when the check fails).
+            `latest` is the PyPI version string when it was fetched and parsed
+            successfully, or `None` when the PyPI check itself fails (network
+            error, unparseable response, or non-PEP 440 installed version).
+            `available` is `True` only when `latest` is strictly newer than
+            the installed version. Callers can therefore distinguish "already
+            up to date" (`(False, "1.2.3")`) from "could not reach PyPI"
+            (`(False, None)`).
     """
     try:
         installed = _parse_version(__version__)
@@ -282,12 +530,10 @@ def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None
         return False, None
 
     try:
-        if _parse_version(latest) > installed:
-            return True, latest
+        return _parse_version(latest) > installed, latest
     except InvalidVersion:
         logger.debug("Failed to compare versions", exc_info=True)
-
-    return False, None
+        return False, None
 
 
 # ---------------------------------------------------------------------------

--- a/libs/cli/deepagents_cli/widgets/message_store.py
+++ b/libs/cli/deepagents_cli/widgets/message_store.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Fields on MessageData that callers are allowed to update via update_message().
-# Prevents accidental overwriting of identity fields like id/type/timestamp.
 _UPDATABLE_FIELDS: frozenset[str] = frozenset(
     {
         "content",
@@ -36,30 +34,61 @@ _UPDATABLE_FIELDS: frozenset[str] = frozenset(
         "height_hint",
     }
 )
+"""Fields on `MessageData` that callers are allowed to update via `update_message`.
+
+Prevents accidental overwriting of identity fields like `id`, `type`, or
+`timestamp`.
+"""
 
 
 class MessageType(StrEnum):
     """Types of messages in the chat."""
 
     USER = "user"
+    """Input authored by the human, rendered above the agent's response."""
+
     ASSISTANT = "assistant"
+    """Streamed agent response rendered with markdown."""
+
     TOOL = "tool"
+    """Record of a tool invocation, including its args, status, and output."""
+
     SKILL = "skill"
+    """Record of a skill invocation, carrying its SKILL.md body and metadata."""
+
     ERROR = "error"
+    """Error surfaced to the user (e.g., a failed tool call or SDK exception)."""
+
     APP = "app"
+    """App-status note from the CLI itself (version info, command feedback)."""
+
     SUMMARIZATION = "summarization"
+    """Notification that the prior conversation was summarized/offloaded."""
+
     DIFF = "diff"
+    """Unified diff preview attached to a file-modifying tool call."""
 
 
 class ToolStatus(StrEnum):
     """Status of a tool call."""
 
     PENDING = "pending"
+    """Queued for execution, typically awaiting human approval."""
+
     RUNNING = "running"
+    """Currently executing."""
+
     SUCCESS = "success"
+    """Completed without error."""
+
     ERROR = "error"
+    """Raised an exception or returned a non-zero exit status."""
+
     REJECTED = "rejected"
+    """Human explicitly denied the call at the approval prompt."""
+
     SKIPPED = "skipped"
+    """Bypassed without executing (e.g., the agent canceled the call)."""
 
 
 @dataclass
@@ -133,6 +162,13 @@ class MessageData:
 
     While `True`, the corresponding widget is actively receiving content
     chunks and should not be pruned or re-hydrated.
+    """
+
+    is_markdown: bool = False
+    """For APP messages, whether `content` is a markdown source string.
+
+    When `True`, rehydration renders the content via Rich markdown instead of
+    the plain dim-italic `AppMessage` styling.
     """
 
     height_hint: int | None = None
@@ -215,7 +251,7 @@ class MessageData:
                 return ErrorMessage(self.content, id=self.id)
 
             case MessageType.APP:
-                return AppMessage(self.content, id=self.id)
+                return AppMessage(self.content, markdown=self.is_markdown, id=self.id)
 
             case MessageType.SUMMARIZATION:
                 return SummarizationMessage(self.content, id=self.id)
@@ -340,6 +376,7 @@ class MessageData:
                 type=MessageType.APP,
                 content=str(widget._content),
                 id=widget_id,
+                is_markdown=widget._is_markdown,
             )
 
         logger.warning(

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -9,7 +9,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual import on
 from textual.containers import Vertical
@@ -32,6 +32,7 @@ from deepagents_cli.widgets._links import open_style_link
 from deepagents_cli.widgets.diff import compose_diff_lines
 
 if TYPE_CHECKING:
+    from rich.console import Console as RichConsole, ConsoleOptions, RenderResult
     from textual.app import ComposeResult
     from textual.timer import Timer
     from textual.widgets import Markdown
@@ -1685,6 +1686,59 @@ class ErrorMessage(_TimestampClickMixin, Static):
             self.styles.border_left = ("ascii", colors.error)
 
 
+class _MutedRichMarkdown:
+    """Render Rich markdown to match `AppMessage`'s muted-italic base.
+
+    Plain `AppMessage` strings render as `dim italic` via `Content.styled`
+    plus the widget's CSS. Rich's default markdown theme paints h2-h4
+    magenta and table headers/borders cyan, and doesn't apply `dim` to
+    paragraphs, so markdown blocks look visually distinct. This wrapper:
+
+    - Applies a `rich.theme.Theme` while rendering that strips the stock
+        colors while keeping structural emphasis (bold/underline/italic), and
+    - Layers `dim` over the whole document via `rich.styled.Styled` so
+        body text matches the `dim italic` baseline used elsewhere.
+    """
+
+    _THEME_OVERRIDES: ClassVar[dict[str, str]] = {
+        "markdown.h1": "bold underline",
+        "markdown.h2": "bold underline",
+        "markdown.h3": "bold",
+        "markdown.h4": "italic",
+        "markdown.table.header": "bold",
+        "markdown.table.border": "",
+    }
+
+    def __init__(self, markup: str) -> None:
+        from rich.markdown import Markdown as RichMarkdown
+
+        self._markdown = RichMarkdown(markup)
+        self._markup = markup
+
+    def __rich_console__(  # noqa: PLW3201  # Rich renderable protocol
+        self, console: RichConsole, options: ConsoleOptions
+    ) -> RenderResult:
+        from rich.styled import Styled
+        from rich.theme import Theme
+
+        theme = Theme(self._THEME_OVERRIDES, inherit=True)
+        try:
+            with console.use_theme(theme):
+                yield from Styled(self._markdown, "dim").__rich_console__(
+                    console, options
+                )
+        except Exception:
+            # Rich markdown or theme application blew up on malformed input.
+            # Fall back to the raw source so the chat view keeps rendering.
+            logger.warning(
+                "Rich markdown rendering failed; falling back to plain text",
+                exc_info=True,
+            )
+            yield from Styled(self._markup, "dim italic").__rich_console__(
+                console, options
+            )
+
+
 class AppMessage(Static):
     """Widget displaying an app message."""
 
@@ -1704,20 +1758,39 @@ class AppMessage(Static):
     }
     """
 
-    def __init__(self, message: str | Content, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        message: str | Content,
+        *,
+        markdown: bool = False,
+        **kwargs: Any,
+    ) -> None:
         """Initialize a system message.
 
         Args:
             message: The system message as a string or pre-styled `Content`.
-            **kwargs: Additional arguments passed to parent
+            markdown: When `True`, render `message` as markdown via Rich's
+                markdown renderer (tables, headings, bold, etc.).
+
+                Requires a string message — `Content` objects already carry
+                their own structure.
+            **kwargs: Additional arguments passed to parent.
+
+        Raises:
+            TypeError: If `markdown=True` is combined with a non-string
+                `message`.
         """
-        # Store raw content for serialization
         self._content = message
-        rendered = (
-            message
-            if isinstance(message, Content)
-            else Content.styled(message, "dim italic")
-        )
+        self._is_markdown = markdown
+        if markdown:
+            if not isinstance(message, str):
+                msg = "AppMessage(markdown=True) requires a string message"
+                raise TypeError(msg)
+            rendered = _MutedRichMarkdown(message)
+        elif isinstance(message, Content):
+            rendered = message
+        else:
+            rendered = Content.styled(message, "dim italic")
         super().__init__(rendered, **kwargs)
 
     def on_click(self, event: Click) -> None:

--- a/libs/cli/tests/unit_tests/test_extras_info.py
+++ b/libs/cli/tests/unit_tests/test_extras_info.py
@@ -1,0 +1,162 @@
+"""Tests for optional-dependency status inspection."""
+
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import MagicMock, patch
+
+from deepagents_cli.extras_info import (
+    format_extras_status,
+    format_extras_status_plain,
+    get_extras_status,
+)
+
+
+def test_returns_empty_when_distribution_missing() -> None:
+    assert get_extras_status("does-not-exist-pkg-xyz-abc") == {}
+
+
+def test_real_distribution_groups_entries_by_extra() -> None:
+    # `langchain-anthropic` is declared under the `anthropic` extra and
+    # also lives in the core dependency list, so it should always resolve
+    # to an installed version when the CLI itself is installed.
+    extras = get_extras_status()
+    assert "anthropic" in extras
+    pkgs = dict(extras["anthropic"])
+    assert pkgs["langchain-anthropic"]
+
+
+def test_real_distribution_skips_self_references() -> None:
+    # Composite extras like `all-providers` list `deepagents-cli[...]`
+    # entries; those should never surface as packages themselves.
+    extras = get_extras_status()
+    for pkgs in extras.values():
+        for pkg_name, _version in pkgs:
+            assert pkg_name.lower() != "deepagents-cli"
+
+
+def test_missing_packages_are_omitted() -> None:
+    mock_dist = MagicMock()
+    mock_dist.requires = [
+        "langchain-anthropic>=1.0.0 ; extra == 'anthropic'",
+        "fake-absent-package>=1.0.0 ; extra == 'custom'",
+        "partially-present>=1.0.0 ; extra == 'mixed'",
+        "also-missing>=1.0.0 ; extra == 'mixed'",
+    ]
+
+    def fake_version(name: str) -> str:
+        if name == "langchain-anthropic":
+            return "1.4.0"
+        if name == "partially-present":
+            return "2.0.0"
+        raise PackageNotFoundError(name)
+
+    with (
+        patch("deepagents_cli.extras_info.distribution", return_value=mock_dist),
+        patch("deepagents_cli.extras_info.pkg_version", side_effect=fake_version),
+    ):
+        extras = get_extras_status()
+
+    # Fully absent extras disappear; partially present extras keep only
+    # the installed packages.
+    assert extras == {
+        "anthropic": [("langchain-anthropic", "1.4.0")],
+        "mixed": [("partially-present", "2.0.0")],
+    }
+
+
+def test_skips_entries_without_extra_marker() -> None:
+    # Core dependencies (no `extra ==` marker) must be ignored; only
+    # extra-gated entries should be reported.
+    mock_dist = MagicMock()
+    mock_dist.requires = [
+        "some-core-package>=1.0.0",
+        "another-core>=1.0.0 ; python_version >= '3.11'",
+        "gated-pkg>=1.0.0 ; extra == 'foo'",
+    ]
+
+    with (
+        patch("deepagents_cli.extras_info.distribution", return_value=mock_dist),
+        patch("deepagents_cli.extras_info.pkg_version", return_value="1.2.3"),
+    ):
+        extras = get_extras_status()
+
+    assert extras == {"foo": [("gated-pkg", "1.2.3")]}
+
+
+def test_skips_composite_self_referencing_extras() -> None:
+    mock_dist = MagicMock()
+    mock_dist.requires = [
+        "deepagents-cli[anthropic,baseten] ; extra == 'some-bundle'",
+        "langchain-anthropic>=1.0.0 ; extra == 'anthropic'",
+    ]
+
+    with (
+        patch("deepagents_cli.extras_info.distribution", return_value=mock_dist),
+        patch("deepagents_cli.extras_info.pkg_version", return_value="1.0.0"),
+    ):
+        extras = get_extras_status()
+
+    # The self-reference is the only entry under `some-bundle`, so the
+    # extra should not appear at all in the output.
+    assert "some-bundle" not in extras
+    assert extras["anthropic"] == [("langchain-anthropic", "1.0.0")]
+
+
+def test_skips_known_composite_extras() -> None:
+    # The build backend flattens composite extras like `all-providers`
+    # into their component packages, so name-based filtering is needed to
+    # avoid duplicating the full list in the output.
+    mock_dist = MagicMock()
+    mock_dist.requires = [
+        "langchain-anthropic>=1.0.0 ; extra == 'all-providers'",
+        "langchain-baseten>=1.0.0 ; extra == 'all-providers'",
+        "langchain-daytona>=1.0.0 ; extra == 'all-sandboxes'",
+        "langchain-anthropic>=1.0.0 ; extra == 'anthropic'",
+    ]
+
+    with (
+        patch("deepagents_cli.extras_info.distribution", return_value=mock_dist),
+        patch("deepagents_cli.extras_info.pkg_version", return_value="1.0.0"),
+    ):
+        extras = get_extras_status()
+
+    assert "all-providers" not in extras
+    assert "all-sandboxes" not in extras
+    assert extras["anthropic"] == [("langchain-anthropic", "1.0.0")]
+
+
+def test_format_extras_status_empty() -> None:
+    assert format_extras_status({}) == ""
+
+
+def test_format_extras_status_plain_empty() -> None:
+    assert format_extras_status_plain({}) == ""
+
+
+def test_format_extras_status_plain_columns_are_aligned() -> None:
+    status = {
+        "anthropic": [("langchain-anthropic", "1.4.0")],
+        "google-genai": [("langchain-google-genai", "4.2.1")],
+    }
+    rendered = format_extras_status_plain(status)
+    lines = rendered.splitlines()
+
+    assert lines[0] == "Installed optional dependencies:"
+    # Extra column widened to the longest name (`google-genai` -> 12 chars).
+    assert lines[1] == "  anthropic     langchain-anthropic     1.4.0"
+    assert lines[2] == "  google-genai  langchain-google-genai  4.2.1"
+
+
+def test_format_extras_status_renders_markdown_table() -> None:
+    status = {
+        "anthropic": [("langchain-anthropic", "1.4.0")],
+        "daytona": [("langchain-daytona", "0.0.4")],
+    }
+    rendered = format_extras_status(status)
+    lines = rendered.splitlines()
+
+    assert lines[0] == "### Installed optional dependencies"
+    assert lines[1] == ""
+    assert lines[2] == "| Extra | Package | Version |"
+    assert lines[3] == "| --- | --- | --- |"
+    assert lines[4] == "| anthropic | langchain-anthropic | 1.4.0 |"
+    assert lines[5] == "| daytona | langchain-daytona | 0.0.4 |"

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -778,3 +778,83 @@ class TestRecentAgentIsValid:
 
         with patch("pathlib.Path.is_dir", side_effect=PermissionError("denied")):
             assert _recent_agent_is_valid("coder") is False
+
+
+class TestUpdateSubcommand:
+    """Control-flow tests for `deepagents update` and `--update`.
+
+    Each branch has a destructive or user-visible failure mode (editable
+    install would have pip clobber a dev checkout; PyPI-unreachable must
+    not be confused with up-to-date). These tests pin the dispatch order.
+    """
+
+    @staticmethod
+    def _run_update(
+        *,
+        editable: bool,
+        is_update_available_return: tuple[bool, str | None],
+    ) -> tuple[int, MagicMock, MagicMock]:
+        """Invoke `cli_main()` with `update` subcommand; return exit code + mocks."""
+        from deepagents_cli.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "update"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_cli.main.check_cli_dependencies"),
+            patch("deepagents_cli.config._is_editable_install", return_value=editable),
+            patch(
+                "deepagents_cli.update_check.is_update_available",
+                return_value=is_update_available_return,
+            ) as is_update_mock,
+            patch(
+                "deepagents_cli.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_upgrade_mock,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        return int(exc_info.value.code or 0), is_update_mock, perform_upgrade_mock
+
+    def test_editable_install_skips_upgrade(self) -> None:
+        """Editable install exits 0 without calling `is_update_available`/upgrade.
+
+        A regression here would run `pip install --upgrade` on an editable
+        checkout and overwrite the dev install.
+        """
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
+            editable=True,
+            is_update_available_return=(True, "99.0.0"),
+        )
+        assert code == 0
+        is_update_mock.assert_not_called()
+        perform_upgrade_mock.assert_not_called()
+
+    def test_pypi_unreachable_exits_nonzero(self) -> None:
+        """`(False, None)` from `is_update_available` surfaces as exit 1."""
+        code, _, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(False, None),
+        )
+        assert code == 1
+        perform_upgrade_mock.assert_not_called()
+
+    def test_up_to_date_exits_zero_without_upgrade(self) -> None:
+        """`(False, "x.y.z")` exits 0 and does not call `perform_upgrade`."""
+        code, _, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(False, "1.2.3"),
+        )
+        assert code == 0
+        perform_upgrade_mock.assert_not_called()
+
+    def test_update_available_runs_upgrade(self) -> None:
+        """`(True, "x.y.z")` triggers `perform_upgrade` and exits 0 on success."""
+        code, _, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(True, "99.0.0"),
+        )
+        assert code == 0
+        perform_upgrade_mock.assert_awaited_once()

--- a/libs/cli/tests/unit_tests/test_message_store.py
+++ b/libs/cli/tests/unit_tests/test_message_store.py
@@ -114,12 +114,43 @@ class TestMessageData:
         assert data.type == MessageType.APP
         assert data.content == "Session started"
         assert data.id == "test-app-1"
+        assert data.is_markdown is False
 
         # Deserialize
         restored = data.to_widget()
         assert isinstance(restored, AppMessage)
         assert restored._content == "Session started"
         assert restored.id == "test-app-1"
+        assert restored._is_markdown is False
+
+    def test_app_message_markdown_roundtrip(self):
+        """Markdown AppMessages must survive dehydrate/rehydrate with their flag.
+
+        Regression guard: dropping `is_markdown` from either `from_widget`
+        or `to_widget` would silently downgrade rehydrated `/version` extras
+        tables to plain-text rendering.
+        """
+        from deepagents_cli.widgets.messages import _MutedRichMarkdown
+
+        markdown_source = (
+            "### Installed optional dependencies\n"
+            "\n"
+            "| Extra | Package | Version |\n"
+            "| --- | --- | --- |\n"
+            "| anthropic | langchain-anthropic | 1.4.0 |\n"
+        )
+        original = AppMessage(markdown_source, markdown=True, id="test-app-md-1")
+
+        data = MessageData.from_widget(original)
+        assert data.type == MessageType.APP
+        assert data.content == markdown_source
+        assert data.is_markdown is True
+
+        restored = data.to_widget()
+        assert isinstance(restored, AppMessage)
+        assert restored._is_markdown is True
+        rendered = restored._Static__content  # type: ignore[attr-defined]
+        assert isinstance(rendered, _MutedRichMarkdown)
 
     def test_diff_message_roundtrip(self):
         """Test DiffMessage serialization and deserialization."""

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -18,6 +18,7 @@ from deepagents_cli.widgets.messages import (
     SummarizationMessage,
     ToolCallMessage,
     UserMessage,
+    _MutedRichMarkdown,
     _show_timestamp_toast,
     _strip_frontmatter,
     _strip_success_exit_line,
@@ -103,6 +104,87 @@ class TestAppMessageMarkupSafety:
         msg = AppMessage(pre)
         rendered = msg._Static__content  # type: ignore[attr-defined]
         assert rendered is pre
+
+    def test_app_message_markdown_uses_muted_wrapper(self) -> None:
+        """`markdown=True` should route through `_MutedRichMarkdown`."""
+        msg = AppMessage("### heading", markdown=True)
+        rendered = msg._Static__content  # type: ignore[attr-defined]
+        assert isinstance(rendered, _MutedRichMarkdown)
+
+    def test_app_message_markdown_requires_string(self) -> None:
+        """`markdown=True` with non-string input should raise `TypeError`."""
+        pre = Content.styled("styled", "bold")
+        with pytest.raises(TypeError):
+            AppMessage(pre, markdown=True)
+
+
+class TestMutedRichMarkdown:
+    """Tests for the muted markdown theme wrapper."""
+
+    _DOC = (
+        "### Installed optional dependencies\n"
+        "\n"
+        "| Extra | Package | Version |\n"
+        "| --- | --- | --- |\n"
+        "| anthropic | langchain-anthropic | 1.4.1 |\n"
+    )
+
+    @staticmethod
+    def _render(renderable: object) -> str:
+        import io
+
+        from rich.console import Console
+
+        console = Console(
+            file=io.StringIO(),
+            force_terminal=True,
+            color_system="truecolor",
+            width=80,
+            legacy_windows=False,
+        )
+        console.print(renderable)
+        return console.file.getvalue()  # type: ignore[attr-defined]
+
+    def test_strips_heading_and_table_colors(self) -> None:
+        """Muted wrapper should drop magenta/cyan from headings and tables."""
+        from rich.markdown import Markdown as RichMarkdown
+
+        baseline = self._render(RichMarkdown(self._DOC))
+        muted = self._render(_MutedRichMarkdown(self._DOC))
+
+        # Default Rich theme paints `markdown.h3` magenta (ANSI code 35)
+        # and `markdown.table.*` cyan (ANSI code 36).
+        assert "\x1b[1;35m" in baseline
+        assert "\x1b[36m" in baseline
+
+        assert "\x1b[35m" not in muted
+        assert ";35m" not in muted
+        assert "\x1b[36m" not in muted
+        assert ";36m" not in muted
+
+    def test_applies_dim_to_body_and_headings(self) -> None:
+        """Muted wrapper should layer `dim` onto body, headings, and tables."""
+        muted = self._render(_MutedRichMarkdown(self._DOC))
+
+        # `dim` is ANSI code 2. Heading should be bold+dim ("1;2"),
+        # plain cells should be dim ("2m"), and both must be present.
+        assert "\x1b[1;2m" in muted
+        assert "\x1b[2m" in muted
+
+    def test_render_failure_falls_back_to_plain_source(self) -> None:
+        """A crash inside Rich markdown rendering must not escape.
+
+        If the themed render path raises, the wrapper should emit the raw
+        source so the chat view stays up; the full stream would otherwise
+        tear down when Textual asks the widget for content.
+        """
+        wrapped = _MutedRichMarkdown("# heading\n\nbody")
+        # Force the inner Markdown renderable to raise when consumed.
+        wrapped._markdown = MagicMock()
+        wrapped._markdown.__rich_console__ = MagicMock(side_effect=RuntimeError("boom"))
+
+        rendered = self._render(wrapped)
+        assert "body" in rendered
 
 
 class TestSummarizationMessage:

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -1,6 +1,7 @@
 """Tests for model switching functionality."""
 
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -118,7 +119,7 @@ class TestModelSwitchNoOp:
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
 
-        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_init(self, message, **kwargs)
 
@@ -157,7 +158,7 @@ class TestModelSwitchErrorHandling:
         captured_errors: list[str] = []
         original_init = ErrorMessage.__init__
 
-        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
             captured_errors.append(message)
             original_init(self, message, **kwargs)
 
@@ -192,14 +193,14 @@ class TestModelSwitchErrorHandling:
         captured_errors: list[str] = []
         original_err_init = ErrorMessage.__init__
 
-        def capture_err(self: ErrorMessage, message: str, **kwargs: object) -> None:
+        def capture_err(self: ErrorMessage, message: str, **kwargs: Any) -> None:
             captured_errors.append(message)
             original_err_init(self, message, **kwargs)
 
         captured_messages: list[str] = []
         original_app_init = AppMessage.__init__
 
-        def capture_app(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_app(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_app_init(self, message, **kwargs)
 
@@ -235,7 +236,7 @@ class TestModelSwitchErrorHandling:
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
 
-        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_init(self, message, **kwargs)
 
@@ -332,7 +333,7 @@ class TestModelSwitchConcurrencyGuard:
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
 
-        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_init(self, message, **kwargs)
 
@@ -393,7 +394,7 @@ api_key_env = "FIREWORKS_API_KEY"
         captured_messages: list[str] = []
         original_app_init = AppMessage.__init__
 
-        def capture_app(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_app(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_app_init(self, message, **kwargs)
 
@@ -435,7 +436,7 @@ api_key_env = "FIREWORKS_API_KEY"
         captured_errors: list[str] = []
         original_err_init = ErrorMessage.__init__
 
-        def capture_err(self: ErrorMessage, message: str, **kwargs: object) -> None:
+        def capture_err(self: ErrorMessage, message: str, **kwargs: Any) -> None:
             captured_errors.append(message)
             original_err_init(self, message, **kwargs)
 
@@ -468,7 +469,7 @@ models = ["llama3"]
         captured_messages: list[str] = []
         original_app_init = AppMessage.__init__
 
-        def capture_app(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_app(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_app_init(self, message, **kwargs)
 
@@ -503,7 +504,7 @@ class TestModelSwitchBareModelName:
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
 
-        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_init(self, message, **kwargs)
 
@@ -538,7 +539,7 @@ class TestModelSwitchBareModelName:
         captured_errors: list[str] = []
         original_init = ErrorMessage.__init__
 
-        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
             captured_errors.append(message)
             original_init(self, message, **kwargs)
 
@@ -573,7 +574,7 @@ class TestModelSwitchBareModelName:
         captured_messages: list[str] = []
         original_init = AppMessage.__init__
 
-        def capture_init(self: AppMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
             captured_messages.append(message)
             original_init(self, message, **kwargs)
 
@@ -689,7 +690,7 @@ class TestModelCommandIntegration:
         captured_errors: list[str] = []
         original_init = ErrorMessage.__init__
 
-        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
             captured_errors.append(message)
             original_init(self, message, **kwargs)
 
@@ -708,7 +709,7 @@ class TestModelCommandIntegration:
         captured_errors: list[str] = []
         original_init = ErrorMessage.__init__
 
-        def capture_init(self: ErrorMessage, message: str, **kwargs: object) -> None:
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
             captured_errors.append(message)
             original_init(self, message, **kwargs)
 

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -12,9 +12,16 @@ from packaging.version import InvalidVersion, Version
 
 from deepagents_cli.update_check import (
     CACHE_TTL,
+    _extract_release_times,
     _latest_from_releases,
     _parse_version,
+    format_age_suffix,
+    format_release_age,
+    format_sdk_age_suffix,
+    format_sdk_release_age,
     get_latest_version,
+    get_release_time,
+    get_sdk_release_time,
     get_seen_version,
     is_auto_update_enabled,
     is_update_available,
@@ -35,10 +42,18 @@ def cache_file(tmp_path):
 
 def _mock_pypi_response(
     version: str = "99.0.0",
-    releases: dict[str, list[object]] | None = None,
+    releases: dict[str, list[dict[str, object]]] | None = None,
+    release_times: dict[str, str] | None = None,
 ) -> MagicMock:
     if releases is None:
         releases = {version: [{"filename": "fake.tar.gz"}]}
+    release_times = release_times or {}
+    # Stamp upload_time_iso_8601 onto the first file of each release so the
+    # real extraction path runs in tests.
+    for ver, iso in release_times.items():
+        files = releases.get(ver)
+        if files:
+            files[0]["upload_time_iso_8601"] = iso
     resp = MagicMock()
     resp.json.return_value = {
         "info": {"version": version},
@@ -265,6 +280,11 @@ class TestIsUpdateAvailable:
         assert latest == "99.0.0"
 
     def test_current_version(self) -> None:
+        """User on the latest version sees `available=False` but keeps `latest`.
+
+        The version string is preserved so callers can distinguish "up to date"
+        from "PyPI unreachable" (which returns `latest=None`).
+        """
         with (
             patch(
                 "deepagents_cli.update_check.get_latest_version", return_value="0.0.1"
@@ -274,7 +294,7 @@ class TestIsUpdateAvailable:
             available, latest = is_update_available()
 
         assert available is False
-        assert latest is None
+        assert latest == "0.0.1"
 
     def test_ahead_of_pypi(self) -> None:
         """Dev build ahead of PyPI should not flag an update."""
@@ -287,7 +307,7 @@ class TestIsUpdateAvailable:
             available, latest = is_update_available()
 
         assert available is False
-        assert latest is None
+        assert latest == "0.0.1"
 
     def test_fetch_failure(self) -> None:
         with patch("deepagents_cli.update_check.get_latest_version", return_value=None):
@@ -295,6 +315,27 @@ class TestIsUpdateAvailable:
 
         assert available is False
         assert latest is None
+
+    def test_up_to_date_distinguishable_from_fetch_failure(self) -> None:
+        """Callers must distinguish `None` (fetch failed) from a version string.
+
+        An up-to-date install returns `(False, "1.2.3")` and a PyPI fetch
+        failure returns `(False, None)`; collapsing the two would conflate
+        transient network errors with being on the latest release.
+        """
+        with (
+            patch(
+                "deepagents_cli.update_check.get_latest_version", return_value="1.2.3"
+            ),
+            patch("deepagents_cli.update_check.__version__", "1.2.3"),
+        ):
+            up_to_date = is_update_available()
+
+        with patch("deepagents_cli.update_check.get_latest_version", return_value=None):
+            fetch_failed = is_update_available()
+
+        assert up_to_date == (False, "1.2.3")
+        assert fetch_failed == (False, None)
 
     def test_prerelease_user_sees_newer_prerelease(self) -> None:
         """User on alpha sees a newer alpha as available."""
@@ -336,7 +377,7 @@ class TestIsUpdateAvailable:
             available, latest = is_update_available()
 
         assert available is False
-        assert latest is None
+        assert latest == "1.0.0"
 
     def test_include_prereleases_kwarg_passed(self) -> None:
         """Verify include_prereleases is True when installed version is pre-release."""
@@ -385,6 +426,427 @@ class TestIsUpdateAvailable:
 
         assert available is False
         assert latest is None
+
+
+class TestExtractReleaseTimes:
+    def test_stable_only(self) -> None:
+        payload = {
+            "releases": {
+                "1.0.0": [
+                    {
+                        "filename": "a.tar.gz",
+                        "upload_time_iso_8601": "2026-04-15T12:00:00Z",
+                    }
+                ],
+            },
+        }
+        times = _extract_release_times(payload, stable="1.0.0", prerelease=None)
+        assert times == {"1.0.0": "2026-04-15T12:00:00Z"}
+
+    def test_stable_and_prerelease(self) -> None:
+        payload = {
+            "releases": {
+                "1.0.0": [
+                    {
+                        "filename": "a.tar.gz",
+                        "upload_time_iso_8601": "2026-04-15T12:00:00Z",
+                    }
+                ],
+                "1.1.0a1": [
+                    {
+                        "filename": "b.tar.gz",
+                        "upload_time_iso_8601": "2026-04-18T09:30:00Z",
+                    }
+                ],
+            },
+        }
+        times = _extract_release_times(payload, stable="1.0.0", prerelease="1.1.0a1")
+        assert times == {
+            "1.0.0": "2026-04-15T12:00:00Z",
+            "1.1.0a1": "2026-04-18T09:30:00Z",
+        }
+
+    def test_releases_key_absent(self) -> None:
+        """Payload with no `releases` key yields an empty result."""
+        payload: dict[str, object] = {}
+        assert _extract_release_times(payload, stable="1.0.0", prerelease=None) == {}
+
+    def test_non_dict_releases_skipped(self) -> None:
+        """A non-dict `releases` value is ignored rather than crashing."""
+        payload: dict[str, object] = {"releases": []}
+        times = _extract_release_times(payload, stable="1.0.0", prerelease="1.1.0a1")
+        assert times == {}
+
+    def test_missing_release_entry(self) -> None:
+        """A version with no release entry is silently dropped."""
+        payload = {
+            "releases": {
+                "1.0.0": [
+                    {
+                        "filename": "a.tar.gz",
+                        "upload_time_iso_8601": "2026-04-15T12:00:00Z",
+                    }
+                ],
+            },
+        }
+        times = _extract_release_times(payload, stable="1.0.0", prerelease="1.1.0a1")
+        assert times == {"1.0.0": "2026-04-15T12:00:00Z"}
+
+    def test_stable_lookup_independent_of_info_version(self) -> None:
+        """Stable timestamp is read from `releases[stable]`, not `info.version`.
+
+        Regression guard: an earlier implementation used `payload["urls"][0]`,
+        which reflects the project's `info.version` and could diverge from
+        the requested `stable` when the newest release on PyPI is a
+        pre-release.
+        """
+        payload = {
+            "info": {"version": "1.1.0a1"},
+            "urls": [{"upload_time_iso_8601": "2026-04-20T00:00:00Z"}],
+            "releases": {
+                "1.0.0": [
+                    {
+                        "filename": "a.tar.gz",
+                        "upload_time_iso_8601": "2026-04-15T12:00:00Z",
+                    }
+                ],
+                "1.1.0a1": [
+                    {
+                        "filename": "b.tar.gz",
+                        "upload_time_iso_8601": "2026-04-20T00:00:00Z",
+                    }
+                ],
+            },
+        }
+        times = _extract_release_times(payload, stable="1.0.0", prerelease=None)
+        assert times == {"1.0.0": "2026-04-15T12:00:00Z"}
+
+    def test_malformed_entries_skipped(self) -> None:
+        payload = {
+            "releases": {
+                "1.0.0": [{"filename": "no-timestamp"}],
+                "1.1.0a1": [{"upload_time_iso_8601": 12345}],
+            },
+        }
+        assert (
+            _extract_release_times(payload, stable="1.0.0", prerelease="1.1.0a1") == {}
+        )
+
+
+class TestGetReleaseTime:
+    def test_reads_cached_time(self, cache_file) -> None:
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "version": "1.0.0",
+                    "release_times": {"1.0.0": "2026-04-15T12:00:00Z"},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        assert get_release_time("1.0.0") == "2026-04-15T12:00:00Z"
+
+    def test_unknown_version(self, cache_file) -> None:
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": "2026-04-15T12:00:00Z"},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        assert get_release_time("9.9.9") is None
+
+    def test_missing_cache(self, cache_file) -> None:  # noqa: ARG002
+        """No cache file yet → no known release time."""
+        assert get_release_time("1.0.0") is None
+
+    def test_cache_without_release_times_key(self, cache_file) -> None:
+        """Cache entry lacking the `release_times` field returns `None`."""
+        cache_file.write_text(
+            json.dumps({"version": "1.0.0", "checked_at": time.time()})
+        )
+        assert get_release_time("1.0.0") is None
+
+    def test_release_times_is_list_not_dict(self, cache_file) -> None:
+        """A list-shaped `release_times` (wrong type) degrades to `None`."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": ["1.0.0", "2026-04-15T12:00:00Z"],
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        assert get_release_time("1.0.0") is None
+
+    def test_corrupted_cache_json(self, cache_file) -> None:
+        """Unparseable cache contents return `None` without raising."""
+        cache_file.write_text("{not valid json")
+        assert get_release_time("1.0.0") is None
+
+    def test_none_version_returns_none(self, cache_file) -> None:  # noqa: ARG002
+        """A `None` input short-circuits without touching the cache."""
+        assert get_release_time(None) is None
+
+
+class TestFormatReleaseAge:
+    def test_returns_released_prefix(self, cache_file) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        iso = (datetime.now(tz=UTC) - timedelta(days=3)).isoformat()
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": iso},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        age = format_release_age("1.0.0")
+        assert age.startswith("released ")
+        assert age.endswith("ago")
+
+    def test_unknown_version_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        assert format_release_age("1.0.0") == ""
+
+    def test_empty_relative_timestamp_returns_empty(self, cache_file) -> None:
+        """When the relative-timestamp helper returns `""`, the wrapper does too."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": "not-a-timestamp"},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        with patch(
+            "deepagents_cli.sessions.format_relative_timestamp", return_value=""
+        ):
+            assert format_release_age("1.0.0") == ""
+
+
+class TestFormatAgeSuffix:
+    def test_returns_separator_prefixed_age(self, cache_file) -> None:
+        """Known age is prefixed with `", "` for splicing into parentheticals."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": "2026-04-15T12:00:00Z"},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        with patch(
+            "deepagents_cli.sessions.format_relative_timestamp", return_value="3d ago"
+        ):
+            assert format_age_suffix("1.0.0") == ", released 3d ago"
+
+    def test_unknown_age_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        """Unknown age collapses to `""` so callers can concat unconditionally."""
+        assert format_age_suffix("1.0.0") == ""
+
+    def test_none_version_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        assert format_age_suffix(None) == ""
+
+
+def _mock_sdk_pypi_response(
+    releases: dict[str, list[dict[str, object]]] | None = None,
+) -> MagicMock:
+    """Build a minimal PyPI response for the `deepagents` SDK.
+
+    The SDK lookup reads from the `releases` map (keyed by version) rather
+    than `info.version`, so only that field is required.
+    """
+    resp = MagicMock()
+    resp.json.return_value = {"releases": releases or {}}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestGetSdkReleaseTime:
+    def test_returns_none_for_none_version(self, cache_file) -> None:  # noqa: ARG002
+        assert get_sdk_release_time(None) is None
+
+    def test_reads_from_cache(self, cache_file) -> None:
+        """A cached SDK release time short-circuits the PyPI fetch."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "sdk_release_times": {"0.5.0": "2026-04-01T12:00:00Z"},
+                }
+            )
+        )
+        with patch("requests.get") as mock_get:
+            assert get_sdk_release_time("0.5.0") == "2026-04-01T12:00:00Z"
+            mock_get.assert_not_called()
+
+    def test_fetches_on_cache_miss(self, cache_file) -> None:
+        """On cache miss the function hits PyPI and writes the result back."""
+        iso = "2026-04-10T09:30:00Z"
+        releases = {"0.5.0": [{"upload_time_iso_8601": iso}]}
+        with patch(
+            "requests.get", return_value=_mock_sdk_pypi_response(releases=releases)
+        ):
+            assert get_sdk_release_time("0.5.0") == iso
+
+        data = json.loads(cache_file.read_text())
+        assert data["sdk_release_times"] == {"0.5.0": iso}
+
+    def test_unknown_version_returns_none(self, cache_file) -> None:  # noqa: ARG002
+        """A version PyPI doesn't know about yields `None` without raising."""
+        with patch(
+            "requests.get",
+            return_value=_mock_sdk_pypi_response(
+                releases={"0.4.0": [{"upload_time_iso_8601": "2026-01-01T00:00:00Z"}]}
+            ),
+        ):
+            assert get_sdk_release_time("9.9.9") is None
+
+    def test_network_error_returns_none(self, cache_file) -> None:  # noqa: ARG002
+        """A `requests` failure degrades to `None` without raising."""
+        import requests
+
+        with patch("requests.get", side_effect=requests.ConnectionError("boom")):
+            assert get_sdk_release_time("0.5.0") is None
+
+    def test_bypass_cache_refetches(self, cache_file) -> None:
+        """`bypass_cache=True` ignores the cached value and hits PyPI."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "sdk_release_times": {"0.5.0": "2026-01-01T00:00:00Z"},
+                }
+            )
+        )
+        fresh = "2026-04-15T12:00:00Z"
+        with patch(
+            "requests.get",
+            return_value=_mock_sdk_pypi_response(
+                releases={"0.5.0": [{"upload_time_iso_8601": fresh}]}
+            ),
+        ):
+            assert get_sdk_release_time("0.5.0", bypass_cache=True) == fresh
+
+        data = json.loads(cache_file.read_text())
+        assert data["sdk_release_times"]["0.5.0"] == fresh
+
+    def test_preserves_existing_sdk_entries(self, cache_file) -> None:
+        """Writing a new SDK timestamp leaves other cached versions intact."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "sdk_release_times": {"0.4.0": "2026-01-01T00:00:00Z"},
+                }
+            )
+        )
+        iso = "2026-04-10T09:30:00Z"
+        with patch(
+            "requests.get",
+            return_value=_mock_sdk_pypi_response(
+                releases={"0.5.0": [{"upload_time_iso_8601": iso}]}
+            ),
+        ):
+            assert get_sdk_release_time("0.5.0") == iso
+
+        data = json.loads(cache_file.read_text())
+        assert data["sdk_release_times"] == {
+            "0.4.0": "2026-01-01T00:00:00Z",
+            "0.5.0": iso,
+        }
+
+    def test_overwrites_corrupt_cache(self, cache_file) -> None:
+        """A corrupt cache JSON must be overwritten, not preserved.
+
+        Regression guard: an earlier implementation skipped the write when
+        decoding the existing cache raised, so every call paid the PyPI
+        round-trip until the file was deleted by hand.
+        """
+        cache_file.write_text("{not valid json")
+        iso = "2026-04-10T09:30:00Z"
+        with patch(
+            "requests.get",
+            return_value=_mock_sdk_pypi_response(
+                releases={"0.5.0": [{"upload_time_iso_8601": iso}]}
+            ),
+        ):
+            assert get_sdk_release_time("0.5.0") == iso
+
+        data = json.loads(cache_file.read_text())
+        assert data["sdk_release_times"] == {"0.5.0": iso}
+
+
+class TestFormatSdkReleaseAge:
+    def test_returns_released_prefix(self, cache_file) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        iso = (datetime.now(tz=UTC) - timedelta(days=2)).isoformat()
+        cache_file.write_text(json.dumps({"sdk_release_times": {"0.5.0": iso}}))
+        age = format_sdk_release_age("0.5.0")
+        assert age.startswith("released ")
+        assert age.endswith("ago")
+
+    def test_unknown_version_with_no_network_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        """Cache miss + PyPI failure collapses to `""` (no exception)."""
+        import requests
+
+        with patch("requests.get", side_effect=requests.ConnectionError("boom")):
+            assert format_sdk_release_age("0.5.0") == ""
+
+
+class TestFormatSdkAgeSuffix:
+    def test_returns_separator_prefixed_age(self, cache_file) -> None:
+        cache_file.write_text(
+            json.dumps({"sdk_release_times": {"0.5.0": "2026-04-10T12:00:00Z"}})
+        )
+        with patch(
+            "deepagents_cli.sessions.format_relative_timestamp", return_value="1w ago"
+        ):
+            assert format_sdk_age_suffix("0.5.0") == ", released 1w ago"
+
+    def test_none_version_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        assert format_sdk_age_suffix(None) == ""
+
+
+class TestGetLatestVersionReleaseTimes:
+    def test_release_times_cached_on_fresh_fetch(self, cache_file) -> None:
+        """A fresh PyPI fetch captures stable upload_time_iso_8601 into the cache."""
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "2.0.0",
+                release_times={"2.0.0": "2026-04-15T12:00:00Z"},
+            ),
+        ):
+            get_latest_version()
+
+        data = json.loads(cache_file.read_text())
+        assert data["release_times"] == {"2.0.0": "2026-04-15T12:00:00Z"}
+
+    def test_release_times_cached_for_prerelease(self, cache_file) -> None:
+        """Prerelease fetch captures both stable and prerelease timestamps."""
+        releases = {
+            "2.0.0": [{"filename": "a.tar.gz"}],
+            "2.1.0a1": [{"filename": "b.tar.gz"}],
+        }
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "2.0.0",
+                releases=releases,
+                release_times={
+                    "2.0.0": "2026-04-15T12:00:00Z",
+                    "2.1.0a1": "2026-04-18T09:30:00Z",
+                },
+            ),
+        ):
+            get_latest_version(include_prereleases=True)
+
+        data = json.loads(cache_file.read_text())
+        assert data["release_times"] == {
+            "2.0.0": "2026-04-15T12:00:00Z",
+            "2.1.0a1": "2026-04-18T09:30:00Z",
+        }
 
 
 class TestSetAutoUpdate:

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -1,15 +1,37 @@
 """Tests for version-related functionality."""
 
+from __future__ import annotations
+
 import subprocess
 import sys
 import tomllib
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from deepagents_cli._version import __version__
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
+    """Prevent `/version` tests from hitting real PyPI for SDK release age.
+
+    Tests that exercise SDK release-age behavior directly override
+    `CACHE_FILE` themselves; this fixture only ensures tests that don't care
+    about that field never make a network request on cache miss.
+    """
+    cache_path = tmp_path / "latest_version.json"
+    with (
+        patch("deepagents_cli.update_check.CACHE_FILE", cache_path),
+        patch("deepagents_cli.update_check.get_sdk_release_time", return_value=None),
+    ):
+        yield
 
 
 def test_version_matches_pyproject() -> None:
@@ -31,7 +53,7 @@ def test_version_matches_pyproject() -> None:
 
 
 def test_cli_version_flag() -> None:
-    """Verify that `--version` flag outputs the correct version."""
+    """Verify that `--version` flag outputs the correct version and extras."""
     result = subprocess.run(
         [sys.executable, "-m", "deepagents_cli.main", "--version"],
         capture_output=True,
@@ -43,6 +65,11 @@ def test_cli_version_flag() -> None:
     assert f"deepagents-cli {__version__}" in result.stdout
     sdk_version = pkg_version("deepagents")
     assert f"deepagents (SDK) {sdk_version}" in result.stdout
+    # Extras block is plain-text (no markdown table or headings).
+    assert "Installed optional dependencies:" in result.stdout
+    assert "langchain-anthropic" in result.stdout
+    assert "| Extra" not in result.stdout
+    assert "###" not in result.stdout
 
 
 async def test_version_slash_command_message_format() -> None:
@@ -59,9 +86,31 @@ async def test_version_slash_command_message_format() -> None:
         await pilot.pause()
 
         app_msgs = app.query(AppMessage)
-        content = str(app_msgs[-1]._content)
+        plain = [m for m in app_msgs if not m._is_markdown]
+        content = str(plain[-1]._content)
         assert f"deepagents-cli version: {__version__}" in content
         assert f"deepagents (SDK) version: {sdk_version}" in content
+
+
+async def test_version_slash_command_includes_optional_dependencies() -> None:
+    """Verify `/version` mounts a markdown message with the extras table."""
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._handle_command("/version")
+        await pilot.pause()
+
+        md_msgs = [m for m in app.query(AppMessage) if m._is_markdown]
+        assert md_msgs
+        source = str(md_msgs[-1]._content)
+        assert "### Installed optional dependencies" in source
+        assert "| Extra" in source
+        assert "| Package" in source
+        assert "| Version" in source
+        assert "langchain-anthropic" in source
 
 
 async def test_version_slash_command_sdk_unavailable() -> None:
@@ -83,7 +132,7 @@ async def test_version_slash_command_sdk_unavailable() -> None:
             await app._handle_command("/version")
         await pilot.pause()
 
-        app_msgs = app.query(AppMessage)
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         content = str(app_msgs[-1]._content)
         assert f"deepagents-cli version: {__version__}" in content
         assert "deepagents (SDK) version: unknown" in content
@@ -102,9 +151,180 @@ async def test_version_slash_command_cli_version_unavailable() -> None:
             await app._handle_command("/version")
         await pilot.pause()
 
-        app_msgs = app.query(AppMessage)
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         content = str(app_msgs[-1]._content)
         assert "deepagents-cli version: unknown" in content
+
+
+async def test_version_slash_command_includes_release_age(tmp_path) -> None:
+    """Verify `/version` appends the cached release age for the CLI version."""
+    import json
+    import time
+    from datetime import UTC, datetime, timedelta
+
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    cache_path = tmp_path / "latest_version.json"
+    iso = (datetime.now(tz=UTC) - timedelta(days=3)).isoformat()
+    cache_path.write_text(
+        json.dumps(
+            {
+                "release_times": {__version__: iso},
+                "checked_at": time.time(),
+            }
+        )
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch("deepagents_cli.update_check.CACHE_FILE", cache_path):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert f"deepagents-cli version: {__version__}, released " in content
+        assert "ago" in content
+
+
+async def test_version_slash_command_includes_sdk_release_age() -> None:
+    """Verify `/version` appends the cached release age for the installed SDK."""
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    sdk_version = pkg_version("deepagents")
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Override the autouse stub to simulate a populated cache.
+        with (
+            patch(
+                "deepagents_cli.update_check.get_sdk_release_time",
+                return_value="2026-04-10T12:00:00Z",
+            ),
+            patch(
+                "deepagents_cli.sessions.format_relative_timestamp",
+                return_value="1w ago",
+            ),
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert f"deepagents (SDK) version: {sdk_version}, released 1w ago" in content
+
+
+async def test_version_slash_command_mentions_update_available() -> None:
+    """Verify `/version` appends an update-available hint when one was detected."""
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._update_available = (True, "99.99.99")
+        await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Update available: v99.99.99" in content
+        assert "Run: " in content
+
+
+async def test_version_slash_command_omits_update_hint_when_up_to_date() -> None:
+    """Verify `/version` does not add the update hint when none is pending."""
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Default state — no update detected by the background check.
+        assert app._update_available == (False, None)
+        await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Update available" not in content
+
+
+async def test_update_slash_command_editable_install_short_circuits() -> None:
+    """Editable install must not invoke `perform_upgrade` from the TUI.
+
+    A regression here would run `pip install --upgrade deepagents-cli` on
+    an editable dev checkout and overwrite the local install.
+    """
+    from unittest.mock import AsyncMock
+
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_cli.config._is_editable_install",
+                return_value=True,
+            ),
+            patch("deepagents_cli.update_check.is_update_available") as is_update_mock,
+            patch(
+                "deepagents_cli.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+            ) as perform_upgrade_mock,
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        is_update_mock.assert_not_called()
+        perform_upgrade_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Updates are not available for editable installs" in content
+        assert f"Currently on v{__version__}" in content
+
+
+async def test_update_slash_command_pypi_unreachable_short_circuits() -> None:
+    """`latest is None` from `is_update_available` must not run upgrade.
+
+    Regression guard: collapsing this branch into the up-to-date message
+    would tell users they're current when the check actually failed.
+    """
+    from unittest.mock import AsyncMock
+
+    from deepagents_cli.app import DeepAgentsApp
+    from deepagents_cli.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_cli.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.update_check.is_update_available",
+                return_value=(False, None),
+            ),
+            patch(
+                "deepagents_cli.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+            ) as perform_upgrade_mock,
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        perform_upgrade_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Could not determine the latest version" in content
 
 
 def test_help_mentions_version_flag() -> None:


### PR DESCRIPTION
Rework the CLI's `/version` and `/update` surfaces around a shared release-age cache, add an editable-install guard so dev checkouts can't be clobbered by `pip install --upgrade`, and surface installed optional dependencies in both `--version` stdout and the in-app `/version` view.