### PR TITLE
docs(examples): add READMEs for all deploy examples + Supabase auth to content writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ libs/cli/TEXTUAL_PROGRESS.md
 */tmp/.DS_Store
 
 CLAUDE.md
+.worktrees/

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,8 +18,9 @@
 | [content-builder-agent](content-builder-agent/) | Content writing agent that demonstrates memory (`AGENTS.md`), skills, and subagents for blog posts, LinkedIn posts, and tweets with generated images |
 | [text-to-sql-agent](text-to-sql-agent/) | Natural language to SQL agent with planning, skill-based workflows, and the Chinook demo database |
 | [deploy-coding-agent](deploy-coding-agent/) | `deepagents deploy` example: autonomous coding agent with a LangSmith sandbox for code execution |
-| [deploy-content-writer](deploy-content-writer/) | `deepagents deploy` example: content writing agent with skills for blog posts and social media |
+| [deploy-content-writer](deploy-content-writer/) | `deepagents deploy` example: content writing agent with per-user memory and Supabase auth |
 | [deploy-mcp-docs-agent](deploy-mcp-docs-agent/) | `deepagents deploy` example: docs research agent that uses MCP tools to search LangChain documentation |
+| [deploy-gtm-agent](deploy-gtm-agent/) | `deepagents deploy` example: GTM strategy agent coordinating sync and async subagents |
 | [async-subagent-server](async-subagent-server/) | Self-hosted Agent Protocol server exposing a Deep Agents researcher as an async subagent, with a supervisor REPL |
 | [nvidia_deep_agent](nvidia_deep_agent/) | Multi-model agent with NVIDIA Nemotron Super for research and GPU-accelerated code execution via RAPIDS |
 | [ralph_mode](ralph_mode/) | Autonomous looping pattern that runs with fresh context each iteration, using the filesystem for persistence |

--- a/examples/deploy-coding-agent/README.md
+++ b/examples/deploy-coding-agent/README.md
@@ -1,0 +1,49 @@
+# deploy-coding-agent
+
+An autonomous coding agent deployed with `deepagents deploy`. Given a task description, it plans, implements, tests, and commits changes inside a LangSmith sandbox with full shell access.
+
+## Prerequisites
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Claude model access |
+| `LANGSMITH_API_KEY` | Required for deploy and the LangSmith sandbox |
+
+Copy `.env.example` to `.env` and fill in both keys.
+
+## Deploy
+
+```bash
+deepagents deploy
+```
+
+The agent is deployed using the config in `deepagents.toml`. The `[sandbox]` section provisions a LangSmith coding sandbox with a Python 3.12 image so the agent can run code safely.
+
+## What to try
+
+Once deployed, open the agent in LangSmith and send it tasks like:
+
+- `"Add a function that reverses a string and write a test for it"`
+- `"Find all TODO comments in the repo and create a summary"`
+- `"Refactor the main module to use dataclasses"`
+
+The agent follows a Plan → Implement → Review → Deliver workflow defined in `AGENTS.md`.
+
+## Structure
+
+```
+deploy-coding-agent/
+├── AGENTS.md                  # Agent instructions and workflow
+├── deepagents.toml            # Deploy config (model, sandbox)
+├── deepagents.assistant-scope.toml  # Assistant-scoped config variant
+├── mcp.json                   # MCP server config
+└── skills/
+    ├── code-review/           # Code review skill with lint helper
+    ├── coding-prefs/          # Coding style preferences
+    └── planning/              # Task planning skill
+```
+
+## Resources
+
+- [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
+- [LangSmith sandbox docs](https://docs.langchain.com/deepagents/sandbox)

--- a/examples/deploy-coding-agent/README.md
+++ b/examples/deploy-coding-agent/README.md
@@ -43,6 +43,39 @@ deploy-coding-agent/
     └── planning/              # Task planning skill
 ```
 
+## Query via SDK
+
+After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically:
+
+```python
+import asyncio
+from langgraph_sdk import get_client
+
+DEPLOY_URL = "https://<your-deployment-url>"
+
+async def main():
+    client = get_client(url=DEPLOY_URL)
+    assistants = await client.assistants.search()
+    assistant_id = assistants[0]["assistant_id"]
+
+    thread = await client.threads.create()
+
+    async for event in client.runs.stream(
+        thread["thread_id"],
+        assistant_id,
+        input={"messages": [{"role": "user", "content": "Add a hello_world function and test it"}]},
+        stream_mode="values",
+    ):
+        if isinstance(event.data, dict):
+            for msg in event.data.get("messages", []):
+                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
+                    print(msg["content"])
+
+asyncio.run(main())
+```
+
+Find your deployment URL in LangSmith under **Deployments**.
+
 ## Resources
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)

--- a/examples/deploy-coding-agent/README.md
+++ b/examples/deploy-coding-agent/README.md
@@ -45,36 +45,21 @@ deploy-coding-agent/
 
 ## Query via SDK
 
-After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically:
-
 ```python
-import asyncio
 from langgraph_sdk import get_client
 
-DEPLOY_URL = "https://<your-deployment-url>"
+client = get_client(url="https://<your-deployment-url>")
+thread = await client.threads.create()
 
-async def main():
-    client = get_client(url=DEPLOY_URL)
-    assistants = await client.assistants.search()
-    assistant_id = assistants[0]["assistant_id"]
-
-    thread = await client.threads.create()
-
-    async for event in client.runs.stream(
-        thread["thread_id"],
-        assistant_id,
-        input={"messages": [{"role": "user", "content": "Add a hello_world function and test it"}]},
-        stream_mode="values",
-    ):
-        if isinstance(event.data, dict):
-            for msg in event.data.get("messages", []):
-                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
-                    print(msg["content"])
-
-asyncio.run(main())
+async for chunk in client.runs.stream(
+    thread["thread_id"], "agent",
+    input={"messages": [{"role": "user", "content": "Add a hello_world function and test it"}]},
+    stream_mode="messages",
+):
+    print(chunk.data, end="", flush=True)
 ```
 
-Find your deployment URL in LangSmith under **Deployments**.
+Find your deployment URL in LangSmith under **Deployments**. See the [LangGraph SDK docs](https://langchain-ai.github.io/langgraph/concepts/sdk/) for more.
 
 ## Resources
 

--- a/examples/deploy-content-writer/.env.example
+++ b/examples/deploy-content-writer/.env.example
@@ -3,3 +3,7 @@ OPENAI_API_KEY=
 
 # LangSmith API key (required for deploy)
 LANGSMITH_API_KEY=
+
+# Supabase auth (required when [auth] provider = "supabase" is set in deepagents.toml)
+SUPABASE_URL=
+SUPABASE_ANON_KEY=

--- a/examples/deploy-content-writer/README.md
+++ b/examples/deploy-content-writer/README.md
@@ -1,0 +1,59 @@
+# deploy-content-writer
+
+A content writing agent deployed with `deepagents deploy`. It writes blog posts, LinkedIn posts, and tweets — and remembers each user's preferences across sessions using per-user memory scoped by their identity.
+
+This example also demonstrates **custom auth**: adding `[auth] provider = "supabase"` to `deepagents.toml` so that every user's memory is isolated to their account with zero custom code.
+
+## Prerequisites
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | GPT-4.1 model access |
+| `LANGSMITH_API_KEY` | Required for deploy |
+| `SUPABASE_URL` | Your Supabase project URL (for auth) |
+| `SUPABASE_ANON_KEY` | Your Supabase anon/public key (for auth) |
+
+Copy `.env.example` to `.env` and fill in your keys. The Supabase keys are only required if you keep the `[auth]` section in `deepagents.toml`. Remove it to deploy without authentication.
+
+## Deploy
+
+```bash
+deepagents deploy
+```
+
+On deploy, the `[auth]` section in `deepagents.toml` generates a Supabase token validator and wires it into the deployment automatically — no custom middleware needed.
+
+## How per-user memory works
+
+Each authenticated user gets their own memory files at `/memories/user/`:
+
+- `preferences.md` — the agent reads and updates this to remember tone, topics, and formatting choices
+- `context.md` — static context about the user's company and product
+
+Because auth scopes these files by user identity, one deployment serves many users without any bleed between accounts.
+
+## What to try
+
+Once deployed, open the agent in LangSmith and send it prompts like:
+
+- `"Write a blog post about the benefits of AI agents for developer teams"`
+- `"Turn this into a LinkedIn post: [paste your content]"`
+- `"I prefer a more casual tone — remember that for future posts"`
+- `"Draft three tweet variations for our new product launch"`
+
+## Structure
+
+```
+deploy-content-writer/
+├── AGENTS.md              # Agent instructions and memory workflow
+├── deepagents.toml        # Deploy config (model, auth)
+└── skills/
+    ├── blog-post/         # Long-form blog post skill
+    └── social-media/      # LinkedIn and tweet skill
+```
+
+## Resources
+
+- [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
+- [Custom auth docs](https://docs.langchain.com/deepagents/auth)
+- [Per-user memory docs](https://docs.langchain.com/deepagents/memory)

--- a/examples/deploy-content-writer/README.md
+++ b/examples/deploy-content-writer/README.md
@@ -43,37 +43,24 @@ Once deployed, open the agent in LangSmith and send it prompts like:
 
 ## Query via SDK
 
-After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically. Pass a `user_id` in `configurable` to scope per-user memory to the authenticated user:
+Pass `user_id` in `configurable` to scope per-user memory to the authenticated user:
 
 ```python
-import asyncio
 from langgraph_sdk import get_client
 
-DEPLOY_URL = "https://<your-deployment-url>"
+client = get_client(url="https://<your-deployment-url>")
+thread = await client.threads.create()
 
-async def main():
-    client = get_client(url=DEPLOY_URL)
-    assistants = await client.assistants.search()
-    assistant_id = assistants[0]["assistant_id"]
-
-    thread = await client.threads.create()
-
-    async for event in client.runs.stream(
-        thread["thread_id"],
-        assistant_id,
-        input={"messages": [{"role": "user", "content": "Write a tweet about AI agents"}]},
-        config={"configurable": {"user_id": "user-123"}},  # scopes memory per user
-        stream_mode="values",
-    ):
-        if isinstance(event.data, dict):
-            for msg in event.data.get("messages", []):
-                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
-                    print(msg["content"])
-
-asyncio.run(main())
+async for chunk in client.runs.stream(
+    thread["thread_id"], "agent",
+    input={"messages": [{"role": "user", "content": "Write a tweet about AI agents"}]},
+    config={"configurable": {"user_id": "user-123"}},
+    stream_mode="messages",
+):
+    print(chunk.data, end="", flush=True)
 ```
 
-Find your deployment URL in LangSmith under **Deployments**. See `test_user_memory.py` for a full example demonstrating memory isolation across users.
+Find your deployment URL in LangSmith under **Deployments**. See `test_user_memory.py` for a full example and the [LangGraph SDK docs](https://langchain-ai.github.io/langgraph/concepts/sdk/) for more.
 
 ## Structure
 

--- a/examples/deploy-content-writer/README.md
+++ b/examples/deploy-content-writer/README.md
@@ -41,6 +41,40 @@ Once deployed, open the agent in LangSmith and send it prompts like:
 - `"I prefer a more casual tone — remember that for future posts"`
 - `"Draft three tweet variations for our new product launch"`
 
+## Query via SDK
+
+After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically. Pass a `user_id` in `configurable` to scope per-user memory to the authenticated user:
+
+```python
+import asyncio
+from langgraph_sdk import get_client
+
+DEPLOY_URL = "https://<your-deployment-url>"
+
+async def main():
+    client = get_client(url=DEPLOY_URL)
+    assistants = await client.assistants.search()
+    assistant_id = assistants[0]["assistant_id"]
+
+    thread = await client.threads.create()
+
+    async for event in client.runs.stream(
+        thread["thread_id"],
+        assistant_id,
+        input={"messages": [{"role": "user", "content": "Write a tweet about AI agents"}]},
+        config={"configurable": {"user_id": "user-123"}},  # scopes memory per user
+        stream_mode="values",
+    ):
+        if isinstance(event.data, dict):
+            for msg in event.data.get("messages", []):
+                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
+                    print(msg["content"])
+
+asyncio.run(main())
+```
+
+Find your deployment URL in LangSmith under **Deployments**. See `test_user_memory.py` for a full example demonstrating memory isolation across users.
+
 ## Structure
 
 ```

--- a/examples/deploy-content-writer/deepagents.toml
+++ b/examples/deploy-content-writer/deepagents.toml
@@ -1,3 +1,6 @@
 [agent]
 name = "deepagents-deploy-content-writer"
 model = "openai:gpt-4.1"
+
+[auth]
+provider = "supabase"

--- a/examples/deploy-gtm-agent/README.md
+++ b/examples/deploy-gtm-agent/README.md
@@ -33,36 +33,21 @@ The agent will kick off market research, synthesize a strategy, and produce cont
 
 ## Query via SDK
 
-After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically:
-
 ```python
-import asyncio
 from langgraph_sdk import get_client
 
-DEPLOY_URL = "https://<your-deployment-url>"
+client = get_client(url="https://<your-deployment-url>")
+thread = await client.threads.create()
 
-async def main():
-    client = get_client(url=DEPLOY_URL)
-    assistants = await client.assistants.search()
-    assistant_id = assistants[0]["assistant_id"]
-
-    thread = await client.threads.create()
-
-    async for event in client.runs.stream(
-        thread["thread_id"],
-        assistant_id,
-        input={"messages": [{"role": "user", "content": "Build a GTM plan for our new Python SDK for AI agents"}]},
-        stream_mode="values",
-    ):
-        if isinstance(event.data, dict):
-            for msg in event.data.get("messages", []):
-                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
-                    print(msg["content"])
-
-asyncio.run(main())
+async for chunk in client.runs.stream(
+    thread["thread_id"], "agent",
+    input={"messages": [{"role": "user", "content": "Build a GTM plan for our new Python SDK for AI agents"}]},
+    stream_mode="messages",
+):
+    print(chunk.data, end="", flush=True)
 ```
 
-Find your deployment URL in LangSmith under **Deployments**.
+Find your deployment URL in LangSmith under **Deployments**. See the [LangGraph SDK docs](https://langchain-ai.github.io/langgraph/concepts/sdk/) for more.
 
 ## Structure
 

--- a/examples/deploy-gtm-agent/README.md
+++ b/examples/deploy-gtm-agent/README.md
@@ -1,0 +1,54 @@
+# deploy-gtm-agent
+
+A go-to-market strategy agent deployed with `deepagents deploy`. Given a product or feature, it coordinates a **sync** market-researcher subagent and an **async** content-writer subagent to produce a full GTM plan with supporting marketing materials.
+
+This example demonstrates the sync/async subagent pattern: market research blocks on results before strategy is written, while content creation runs in the background and is integrated when ready.
+
+## Prerequisites
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | Model access (gpt-5.4-nano) |
+| `LANGSMITH_API_KEY` | Required for deploy |
+
+Copy `.env` and fill in your keys.
+
+## Deploy
+
+```bash
+deepagents deploy
+```
+
+The subagents defined under `subagents/` are automatically discovered and wired in at deploy time.
+
+## What to try
+
+Once deployed, open the agent in LangSmith and send it prompts like:
+
+- `"We're launching a new Python SDK for AI agents next month — build me a GTM plan"`
+- `"Help us position our vector database product against Pinecone and Weaviate"`
+- `"We're targeting mid-market engineering teams — what channels should we prioritize?"`
+
+The agent will kick off market research, synthesize a strategy, and produce content briefs in parallel.
+
+## Structure
+
+```
+deploy-gtm-agent/
+├── AGENTS.md              # Supervisor agent instructions
+├── deepagents.toml        # Deploy config (model)
+├── mcp.json               # MCP server config
+├── skills/
+│   └── competitor-analysis/   # Competitor analysis skill
+└── subagents/
+    └── market-researcher/     # Sync subagent for market research
+        ├── AGENTS.md
+        ├── deepagents.toml
+        └── skills/
+            └── analyze-market/
+```
+
+## Resources
+
+- [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
+- [Subagents docs](https://docs.langchain.com/deepagents/subagents)

--- a/examples/deploy-gtm-agent/README.md
+++ b/examples/deploy-gtm-agent/README.md
@@ -31,6 +31,39 @@ Once deployed, open the agent in LangSmith and send it prompts like:
 
 The agent will kick off market research, synthesize a strategy, and produce content briefs in parallel.
 
+## Query via SDK
+
+After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically:
+
+```python
+import asyncio
+from langgraph_sdk import get_client
+
+DEPLOY_URL = "https://<your-deployment-url>"
+
+async def main():
+    client = get_client(url=DEPLOY_URL)
+    assistants = await client.assistants.search()
+    assistant_id = assistants[0]["assistant_id"]
+
+    thread = await client.threads.create()
+
+    async for event in client.runs.stream(
+        thread["thread_id"],
+        assistant_id,
+        input={"messages": [{"role": "user", "content": "Build a GTM plan for our new Python SDK for AI agents"}]},
+        stream_mode="values",
+    ):
+        if isinstance(event.data, dict):
+            for msg in event.data.get("messages", []):
+                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
+                    print(msg["content"])
+
+asyncio.run(main())
+```
+
+Find your deployment URL in LangSmith under **Deployments**.
+
 ## Structure
 
 ```

--- a/examples/deploy-mcp-docs-agent/README.md
+++ b/examples/deploy-mcp-docs-agent/README.md
@@ -28,6 +28,39 @@ Once deployed, open the agent in LangSmith and ask it questions like:
 
 The agent always searches the docs first and cites the page it found the answer on.
 
+## Query via SDK
+
+After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically:
+
+```python
+import asyncio
+from langgraph_sdk import get_client
+
+DEPLOY_URL = "https://<your-deployment-url>"
+
+async def main():
+    client = get_client(url=DEPLOY_URL)
+    assistants = await client.assistants.search()
+    assistant_id = assistants[0]["assistant_id"]
+
+    thread = await client.threads.create()
+
+    async for event in client.runs.stream(
+        thread["thread_id"],
+        assistant_id,
+        input={"messages": [{"role": "user", "content": "How do I add an MCP server to deepagents.toml?"}]},
+        stream_mode="values",
+    ):
+        if isinstance(event.data, dict):
+            for msg in event.data.get("messages", []):
+                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
+                    print(msg["content"])
+
+asyncio.run(main())
+```
+
+Find your deployment URL in LangSmith under **Deployments**.
+
 ## Structure
 
 ```

--- a/examples/deploy-mcp-docs-agent/README.md
+++ b/examples/deploy-mcp-docs-agent/README.md
@@ -30,36 +30,21 @@ The agent always searches the docs first and cites the page it found the answer 
 
 ## Query via SDK
 
-After deploying, use the [LangGraph SDK](https://pypi.org/project/langgraph-sdk/) to call the agent programmatically:
-
 ```python
-import asyncio
 from langgraph_sdk import get_client
 
-DEPLOY_URL = "https://<your-deployment-url>"
+client = get_client(url="https://<your-deployment-url>")
+thread = await client.threads.create()
 
-async def main():
-    client = get_client(url=DEPLOY_URL)
-    assistants = await client.assistants.search()
-    assistant_id = assistants[0]["assistant_id"]
-
-    thread = await client.threads.create()
-
-    async for event in client.runs.stream(
-        thread["thread_id"],
-        assistant_id,
-        input={"messages": [{"role": "user", "content": "How do I add an MCP server to deepagents.toml?"}]},
-        stream_mode="values",
-    ):
-        if isinstance(event.data, dict):
-            for msg in event.data.get("messages", []):
-                if isinstance(msg, dict) and msg.get("type") == "ai" and msg.get("content"):
-                    print(msg["content"])
-
-asyncio.run(main())
+async for chunk in client.runs.stream(
+    thread["thread_id"], "agent",
+    input={"messages": [{"role": "user", "content": "How do I add an MCP server to deepagents.toml?"}]},
+    stream_mode="messages",
+):
+    print(chunk.data, end="", flush=True)
 ```
 
-Find your deployment URL in LangSmith under **Deployments**.
+Find your deployment URL in LangSmith under **Deployments**. See the [LangGraph SDK docs](https://langchain-ai.github.io/langgraph/concepts/sdk/) for more.
 
 ## Structure
 

--- a/examples/deploy-mcp-docs-agent/README.md
+++ b/examples/deploy-mcp-docs-agent/README.md
@@ -1,0 +1,43 @@
+# deploy-mcp-docs-agent
+
+A documentation research agent deployed with `deepagents deploy`. It answers developer questions about LangChain, LangGraph, and Deep Agents by searching the live docs via MCP before relying on general knowledge.
+
+## Prerequisites
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Claude model access |
+| `LANGSMITH_API_KEY` | Required for deploy |
+
+## Deploy
+
+```bash
+deepagents deploy
+```
+
+The `mcp.json` wires in the LangChain docs MCP server at `https://docs.langchain.com/mcp`. No additional setup is needed — the agent discovers and uses the docs tools automatically.
+
+## What to try
+
+Once deployed, open the agent in LangSmith and ask it questions like:
+
+- `"How do I configure memory in Deep Agents?"`
+- `"What's the difference between sync and async subagents?"`
+- `"Show me how to add an MCP server to deepagents.toml"`
+- `"What models are supported for deploy?"`
+
+The agent always searches the docs first and cites the page it found the answer on.
+
+## Structure
+
+```
+deploy-mcp-docs-agent/
+├── AGENTS.md          # Agent instructions and answer format
+├── deepagents.toml    # Deploy config (model)
+└── mcp.json           # LangChain docs MCP server
+```
+
+## Resources
+
+- [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
+- [MCP server docs](https://docs.langchain.com/deepagents/mcp)


### PR DESCRIPTION
## Summary

- Adds READMEs to all four `deploy-*` examples (`deploy-coding-agent`, `deploy-content-writer`, `deploy-mcp-docs-agent`, `deploy-gtm-agent`) — each had none before
- Adds `[auth] provider = "supabase"` to `deploy-content-writer/deepagents.toml` + updates `.env.example` with Supabase keys, showcasing the new custom auth feature alongside per-user memory
- Adds `deploy-gtm-agent` to the examples index README (it was missing) and refreshes the content-writer description

## README format

Each README is intentionally lightweight for deploy examples (config-only, no `uv sync`):
- What it does + what's notable
- Prerequisites table (env vars)
- One-line deploy command
- Example prompts to try
- Directory structure

## Test plan

- [ ] Verify all four README links render correctly on GitHub
- [ ] Confirm `.env.example` in `deploy-content-writer` matches the keys validated by `[auth] provider = "supabase"`
- [ ] Check examples index table looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)