### PR TITLE
feat(cli): `shift+enter` newline on kitty-capable terminals

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -52,6 +52,9 @@ real PyPI release. Any non-empty value enables the flag (including `"0"` or
 EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
 """Colon-separated paths added to the skill containment allowlist."""
 
+KITTY_KEYBOARD = "DEEPAGENTS_CLI_KITTY_KEYBOARD"
+"""Override kitty-keyboard detection (`1` forces on, `0` forces off)."""
+
 LANGSMITH_PROJECT = "DEEPAGENTS_CLI_LANGSMITH_PROJECT"
 """Override LangSmith project name for agent traces."""
 

--- a/libs/cli/deepagents_cli/_textual_patches.py
+++ b/libs/cli/deepagents_cli/_textual_patches.py
@@ -8,18 +8,52 @@ Importing this module applies the patches as a side effect. Import it
 once, early, from a module that always runs before `App()` is
 instantiated (see `app.py`). If the Textual internals we patch have
 been renamed or removed (e.g. after a minor version bump), the module
-logs a warning and no-ops instead of crashing the CLI.
+logs a warning, writes the same message to stderr, and no-ops instead
+of crashing the CLI. Check `PATCH_APPLIED` after import if a later
+caller needs to surface a user-visible warning (e.g. a toast on app
+mount).
 """
 
 from __future__ import annotations
 
 import logging
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
+
+PATCH_APPLIED: bool = False
+"""Whether the `XTermParser._sequence_to_key_events` monkey-patch installed.
+
+`False` when either the import-time lookup or the attribute assignment
+failed (e.g. after a Textual pin bump renamed the private API). A
+warning is also printed to stderr before `App()` starts so the
+failure is visible to anyone launching the CLI from a shell; the flag
+is exposed for callers that want to surface a follow-up signal (e.g.
+an app-mount toast).
+"""
+
+
+def _report_patch_failure(reason: str) -> None:
+    """Log and stderr-print a patch-skipped warning.
+
+    The Textual app takes over the terminal before Python's "last
+    resort" handler can surface a `logger.warning` to the user, so we
+    also print to stderr at import time (before `App()` is
+    instantiated). The stderr message lands above the alternate-screen
+    switch and is visible to anyone running the CLI from a shell.
+    """
+    message = (
+        f"deepagents-cli: Textual keyboard parser patch skipped ({reason}). "
+        "Shift+Enter via VSCode sendSequence may not insert a newline; "
+        "check whether the Textual pin was bumped across a private-API rename."
+    )
+    logger.warning("%s", message)
+    print(message, file=sys.stderr)  # noqa: T201
+
 
 # ---------------------------------------------------------------------------
 # Patch: preserve the `alt` modifier when a single-byte sequence maps to a
@@ -36,8 +70,9 @@ logger = logging.getLogger(__name__)
 # Ctrl+<letter|@|\|]|^|_>. Only breaks for terminals that fall back to
 # legacy ESC-prefix encoding (VSCode's integrated terminal when
 # `sendSequence` bypasses xterm.js, GNOME Console, etc.) — kitty-protocol
-# terminals (Ghostty, kitty, recent iTerm2) send `CSI 13;3u` and go
-# through the extended-key regex path, which is correct.
+# terminals (Ghostty, kitty, recent iTerm2) send `CSI 13;<modifier>u`
+# (e.g. `;2u` for shift+enter, `;3u` for alt+enter) and go through the
+# extended-key regex path, which is correct.
 #
 # crossterm (used by codex, claude-code) and the Node TTY parsers
 # (used by opencode) both decode `ESC + <byte>` as `Alt+<byte>`
@@ -77,12 +112,7 @@ try:
 
     _original_sequence_to_key_events = XTermParser._sequence_to_key_events
 except (ImportError, AttributeError) as exc:  # pragma: no cover - defensive
-    logger.warning(
-        "Textual internal API unavailable; keyboard parser patch skipped (%s). "
-        "Shift+Enter via VSCode sendSequence may not insert a newline; "
-        "check whether the Textual pin was bumped across a private-API rename.",
-        exc,
-    )
+    _report_patch_failure(str(exc))
 else:
 
     def _emit_alt_keys(keys: tuple, character: str | None) -> Iterable[events.Key]:
@@ -130,4 +160,12 @@ else:
                 return
         yield from _original_sequence_to_key_events(self, sequence, alt=alt)
 
-    XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]
+    try:
+        XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]
+    except (AttributeError, TypeError) as exc:  # pragma: no cover - defensive
+        # Guards against future upstream hardening (`__slots__`, frozen
+        # class, descriptor hooks) that would reject attribute writes on
+        # `XTermParser` even though the imports succeeded.
+        _report_patch_failure(f"assignment rejected: {exc}")
+    else:
+        PATCH_APPLIED = True

--- a/libs/cli/deepagents_cli/_textual_patches.py
+++ b/libs/cli/deepagents_cli/_textual_patches.py
@@ -1,27 +1,25 @@
 """Monkey-patches for Textual bugs that block key-handling parity with other TUIs.
 
-Each patch is scoped tightly so we defer to upstream behaviour for every
+Each patch is scoped tightly so we defer to upstream behavior for every
 case that isn't known-broken. Remove a patch as soon as its upstream fix
 lands and the Textual pin is bumped.
 
 Importing this module applies the patches as a side effect. Import it
 once, early, from a module that always runs before `App()` is
-instantiated (see `app.py`).
+instantiated (see `app.py`). If the Textual internals we patch have
+been renamed or removed (e.g. after a minor version bump), the module
+logs a warning and no-ops instead of crashing the CLI.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
-
-from textual import events
-from textual._ansi_sequences import (
-    ANSI_SEQUENCES_KEYS,  # noqa: PLC2701
-    IGNORE_SEQUENCE,  # noqa: PLC2701
-)
-from textual._xterm_parser import XTermParser  # noqa: PLC2701
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Patch: preserve the `alt` modifier when a single-byte sequence maps to a
@@ -30,90 +28,106 @@ if TYPE_CHECKING:
 # Upstream `XTermParser._sequence_to_key_events` drops the `alt` flag on the
 # tuple-branch fast path, so `ESC + <byte>` sequences that VSCode's
 # `sendSequence` binding emits (e.g. `\x1b\r` for shift+enter, when the
-# user has `"text": "\r"` in `keybindings.json`) are dispatched as
+# user has `"text": "\r"` in `keybindings.json`) are dispatched as
 # plain `Key("enter")` instead of `Key("alt+enter")`.
 #
-# Affects ~32 single-byte keys that map to tuples: Enter, Space,
-# Backspace, Tab, and all Ctrl+letter. Only breaks for terminals that
-# fall back to legacy ESC-prefix encoding (VSCode's integrated terminal
-# when `sendSequence` bypasses xterm.js, GNOME Console, etc.) —
-# kitty-protocol terminals (Ghostty, kitty, recent iTerm2) send
-# `CSI 13;3u` and go through the extended-key regex path, which is
-# correct.
+# Affects all 35 single-byte keys mapped to tuples in `ANSI_SEQUENCES_KEYS`
+# — Enter, Space, Backspace, Tab, Escape (and Shift+Escape), plus every
+# Ctrl+<letter|@|\|]|^|_>. Only breaks for terminals that fall back to
+# legacy ESC-prefix encoding (VSCode's integrated terminal when
+# `sendSequence` bypasses xterm.js, GNOME Console, etc.) — kitty-protocol
+# terminals (Ghostty, kitty, recent iTerm2) send `CSI 13;3u` and go
+# through the extended-key regex path, which is correct.
 #
 # crossterm (used by codex, claude-code) and the Node TTY parsers
 # (used by opencode) both decode `ESC + <byte>` as `Alt+<byte>`
 # unconditionally, which is why those tools accept the same VSCode
 # binding out of the box.
 #
-# A secondary symptom of the same family of bugs is a ~100 ms input
-# lag on these sequences: the parser calls `_sequence_to_key_events`
-# with the full 2-byte sequence `\x1b\r` on the first pass, gets back
-# an empty iterator (neither the extended-key regex, `ANSI_SEQUENCES_KEYS`,
-# nor the single-char fallback matches), then waits
-# `constants.ESCAPE_DELAY` (100 ms) on the off chance more bytes arrive
-# before finally reissuing via `reissue_sequence_as_keys`. Adding a
-# 2-char fast path lets the parser break out of its inner loop on
-# first pass, eliminating the lag.
+# A secondary symptom of the same family of bugs is a ~100 ms input lag
+# on these sequences: when the parser receives the full 2-byte sequence
+# on its first pass it finds no match and then blocks for Textual's
+# escape-delay constant on the off chance more bytes arrive, before
+# finally reissuing as legacy alt keys. A 2-char fast path short-circuits
+# the match so the parser breaks out of its inner loop immediately.
 #
-# Upstream tracking:
-#   - Textualize/textual#6378 (issue, 2026-02-18)
-#   - Textualize/textual#6379 (open fix PR, +6/-1 lines — alt-preservation only;
-#     does not address the ESCAPE_DELAY lag on 2-char ESC-prefix sequences)
-# Remove this patch once #6379 merges *and* the lag is separately
-# resolved, then bump the Textual pin.
+# Intentional semantic change worth calling out: `\x1b\x1b` (ESC ESC) now
+# dispatches as `alt+escape` with no delay. Upstream waits the full
+# escape-delay before giving up. This matches crossterm/Node TTY and is
+# expected, not a regression.
+#
+# Upstream tracking (check before removing this file):
+#   - https://github.com/Textualize/textual/issues/6378
+# Remove this patch once the upstream fix merges *and* the lag is
+# separately resolved, then bump the Textual pin.
 # ---------------------------------------------------------------------------
 
-_original_sequence_to_key_events = XTermParser._sequence_to_key_events
-
-
-def _emit_alt_keys(keys: tuple, character: str | None) -> Iterable[events.Key]:
-    """Yield Key events with an `alt+` prefix applied to each tuple member.
-
-    `keys` is a tuple of `textual.keys.Keys` members; each exposes a
-    `.value` string.
-    """
-    for key in keys:
-        yield events.Key(f"alt+{key.value}", character)
-
-
 _ESC_PREFIX_LEN = 2
-"""Length of the `ESC + <byte>` legacy alt-modifier encoding."""
+"""Length of an `ESC + <byte>` sequence: one escape byte plus the payload
+byte whose `ANSI_SEQUENCES_KEYS` mapping we look up for the fast path."""
 
 
-def _sequence_to_key_events_with_alt(
-    self: XTermParser, sequence: str, alt: bool = False
-) -> Iterable[events.Key]:
-    r"""Drop-in replacement for `XTermParser._sequence_to_key_events`.
+try:
+    from textual import events
+    from textual._ansi_sequences import (
+        ANSI_SEQUENCES_KEYS,  # noqa: PLC2701
+        IGNORE_SEQUENCE,  # noqa: PLC2701
+    )
+    from textual._xterm_parser import XTermParser  # noqa: PLC2701
 
-    Two scoped interventions, both about the `ESC + <byte>` legacy
-    encoding of alt-modified keys:
+    _original_sequence_to_key_events = XTermParser._sequence_to_key_events
+except (ImportError, AttributeError) as exc:  # pragma: no cover - defensive
+    logger.warning(
+        "Textual internal API unavailable; keyboard parser patch skipped (%s). "
+        "Shift+Enter via VSCode sendSequence may not insert a newline; "
+        "check whether the Textual pin was bumped across a private-API rename.",
+        exc,
+    )
+else:
 
-    - **2-char fast path** (`alt=False`, `sequence == "\x1b<byte>"`):
-      short-circuit with `alt+<key>` so the parser breaks out of its
-      inner loop on the first pass instead of stalling for
-      `constants.ESCAPE_DELAY` (100 ms) waiting for more bytes.
-    - **Reissue path** (`alt=True`, single-byte sequence, tuple
-      mapping): preserve the `alt` flag that the upstream tuple branch
-      silently drops (#6378). Matches crossterm / Node TTY behaviour.
+    def _emit_alt_keys(keys: tuple, character: str | None) -> Iterable[events.Key]:
+        """Yield Key events with an `alt+` prefix applied to each tuple member.
 
-    Defers to the original method for every other case.
+        `keys` is a tuple of `textual.keys.Keys` members; each exposes a
+        `.value` string.
+        """
+        for key in keys:
+            yield events.Key(f"alt+{key.value}", character)
 
-    Yields:
-        Key events, with the `alt` modifier preserved for the known-buggy path.
-    """
-    if not alt and len(sequence) == _ESC_PREFIX_LEN and sequence[0] == "\x1b":
-        inner_keys = ANSI_SEQUENCES_KEYS.get(sequence[1])
-        if inner_keys is not IGNORE_SEQUENCE and isinstance(inner_keys, tuple):
-            yield from _emit_alt_keys(inner_keys, None)
-            return
-    if alt:
-        keys = ANSI_SEQUENCES_KEYS.get(sequence)
-        if keys is not IGNORE_SEQUENCE and isinstance(keys, tuple):
-            character = sequence if len(sequence) == 1 else None
-            yield from _emit_alt_keys(keys, character)
-            return
-    yield from _original_sequence_to_key_events(self, sequence, alt=alt)
+    def _sequence_to_key_events_with_alt(
+        self: XTermParser, sequence: str, alt: bool = False
+    ) -> Iterable[events.Key]:
+        r"""Drop-in replacement for `XTermParser._sequence_to_key_events`.
 
+        Two scoped interventions, both about the `ESC + <byte>` legacy
+        encoding of alt-modified keys:
 
-XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]
+        - **2-char fast path** (`alt=False`, `sequence == "\x1b<byte>"`):
+            short-circuit with `alt+<key>` so the parser breaks out of its
+            inner loop on the first pass instead of stalling for Textual's
+            escape-delay constant waiting for more bytes.
+        - **Reissue path** (`alt=True`, single-byte sequence, tuple
+            mapping): preserve the `alt` flag that the upstream tuple branch
+            silently drops (Textualize/textual#6378). Matches crossterm /
+            Node TTY behavior.
+
+        Defers to the original method for every other case.
+
+        Yields:
+            Key events, with the `alt` modifier preserved for the
+            known-buggy path.
+        """
+        if not alt and len(sequence) == _ESC_PREFIX_LEN and sequence[0] == "\x1b":
+            inner_keys = ANSI_SEQUENCES_KEYS.get(sequence[1])
+            if inner_keys is not IGNORE_SEQUENCE and isinstance(inner_keys, tuple):
+                yield from _emit_alt_keys(inner_keys, None)
+                return
+        if alt:
+            keys = ANSI_SEQUENCES_KEYS.get(sequence)
+            if keys is not IGNORE_SEQUENCE and isinstance(keys, tuple):
+                character = sequence if len(sequence) == 1 else None
+                yield from _emit_alt_keys(keys, character)
+                return
+        yield from _original_sequence_to_key_events(self, sequence, alt=alt)
+
+    XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]

--- a/libs/cli/deepagents_cli/_textual_patches.py
+++ b/libs/cli/deepagents_cli/_textual_patches.py
@@ -1,0 +1,119 @@
+"""Monkey-patches for Textual bugs that block key-handling parity with other TUIs.
+
+Each patch is scoped tightly so we defer to upstream behaviour for every
+case that isn't known-broken. Remove a patch as soon as its upstream fix
+lands and the Textual pin is bumped.
+
+Importing this module applies the patches as a side effect. Import it
+once, early, from a module that always runs before `App()` is
+instantiated (see `app.py`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual import events
+from textual._ansi_sequences import (
+    ANSI_SEQUENCES_KEYS,  # noqa: PLC2701
+    IGNORE_SEQUENCE,  # noqa: PLC2701
+)
+from textual._xterm_parser import XTermParser  # noqa: PLC2701
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# ---------------------------------------------------------------------------
+# Patch: preserve the `alt` modifier when a single-byte sequence maps to a
+# tuple in `ANSI_SEQUENCES_KEYS`.
+#
+# Upstream `XTermParser._sequence_to_key_events` drops the `alt` flag on the
+# tuple-branch fast path, so `ESC + <byte>` sequences that VSCode's
+# `sendSequence` binding emits (e.g. `\x1b\r` for shift+enter, when the
+# user has `"text": "\r"` in `keybindings.json`) are dispatched as
+# plain `Key("enter")` instead of `Key("alt+enter")`.
+#
+# Affects ~32 single-byte keys that map to tuples: Enter, Space,
+# Backspace, Tab, and all Ctrl+letter. Only breaks for terminals that
+# fall back to legacy ESC-prefix encoding (VSCode's integrated terminal
+# when `sendSequence` bypasses xterm.js, GNOME Console, etc.) —
+# kitty-protocol terminals (Ghostty, kitty, recent iTerm2) send
+# `CSI 13;3u` and go through the extended-key regex path, which is
+# correct.
+#
+# crossterm (used by codex, claude-code) and the Node TTY parsers
+# (used by opencode) both decode `ESC + <byte>` as `Alt+<byte>`
+# unconditionally, which is why those tools accept the same VSCode
+# binding out of the box.
+#
+# A secondary symptom of the same family of bugs is a ~100 ms input
+# lag on these sequences: the parser calls `_sequence_to_key_events`
+# with the full 2-byte sequence `\x1b\r` on the first pass, gets back
+# an empty iterator (neither the extended-key regex, `ANSI_SEQUENCES_KEYS`,
+# nor the single-char fallback matches), then waits
+# `constants.ESCAPE_DELAY` (100 ms) on the off chance more bytes arrive
+# before finally reissuing via `reissue_sequence_as_keys`. Adding a
+# 2-char fast path lets the parser break out of its inner loop on
+# first pass, eliminating the lag.
+#
+# Upstream tracking:
+#   - Textualize/textual#6378 (issue, 2026-02-18)
+#   - Textualize/textual#6379 (open fix PR, +6/-1 lines — alt-preservation only;
+#     does not address the ESCAPE_DELAY lag on 2-char ESC-prefix sequences)
+# Remove this patch once #6379 merges *and* the lag is separately
+# resolved, then bump the Textual pin.
+# ---------------------------------------------------------------------------
+
+_original_sequence_to_key_events = XTermParser._sequence_to_key_events
+
+
+def _emit_alt_keys(keys: tuple, character: str | None) -> Iterable[events.Key]:
+    """Yield Key events with an `alt+` prefix applied to each tuple member.
+
+    `keys` is a tuple of `textual.keys.Keys` members; each exposes a
+    `.value` string.
+    """
+    for key in keys:
+        yield events.Key(f"alt+{key.value}", character)
+
+
+_ESC_PREFIX_LEN = 2
+"""Length of the `ESC + <byte>` legacy alt-modifier encoding."""
+
+
+def _sequence_to_key_events_with_alt(
+    self: XTermParser, sequence: str, alt: bool = False
+) -> Iterable[events.Key]:
+    r"""Drop-in replacement for `XTermParser._sequence_to_key_events`.
+
+    Two scoped interventions, both about the `ESC + <byte>` legacy
+    encoding of alt-modified keys:
+
+    - **2-char fast path** (`alt=False`, `sequence == "\x1b<byte>"`):
+      short-circuit with `alt+<key>` so the parser breaks out of its
+      inner loop on the first pass instead of stalling for
+      `constants.ESCAPE_DELAY` (100 ms) waiting for more bytes.
+    - **Reissue path** (`alt=True`, single-byte sequence, tuple
+      mapping): preserve the `alt` flag that the upstream tuple branch
+      silently drops (#6378). Matches crossterm / Node TTY behaviour.
+
+    Defers to the original method for every other case.
+
+    Yields:
+        Key events, with the `alt` modifier preserved for the known-buggy path.
+    """
+    if not alt and len(sequence) == _ESC_PREFIX_LEN and sequence[0] == "\x1b":
+        inner_keys = ANSI_SEQUENCES_KEYS.get(sequence[1])
+        if inner_keys is not IGNORE_SEQUENCE and isinstance(inner_keys, tuple):
+            yield from _emit_alt_keys(inner_keys, None)
+            return
+    if alt:
+        keys = ANSI_SEQUENCES_KEYS.get(sequence)
+        if keys is not IGNORE_SEQUENCE and isinstance(keys, tuple):
+            character = sequence if len(sequence) == 1 else None
+            yield from _emit_alt_keys(keys, character)
+            return
+    yield from _original_sequence_to_key_events(self, sequence, alt=alt)
+
+
+XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -33,7 +33,11 @@ from textual.widgets._toast import (
     Toast as _Toast,  # noqa: PLC2701  # for Toast click routing
 )
 
-from deepagents_cli import theme
+# Applied as an import-time side effect; must come before any App is created.
+from deepagents_cli import (
+    _textual_patches,  # noqa: F401
+    theme,
+)
 from deepagents_cli._cli_context import CLIContext
 from deepagents_cli._git import (
     read_git_branch_from_filesystem,

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -498,11 +498,11 @@ def is_ascii_mode() -> bool:
 def newline_shortcut() -> str:
     """Return the terminal-appropriate label for the newline keyboard shortcut.
 
-    Prefers `Shift+Enter` when the kitty keyboard protocol is negotiated,
-    since modern terminals (kitty, WezTerm, Ghostty, recent iTerm2) can
-    distinguish it from plain `Enter`. Falls back to `Option+Enter` on
-    macOS and `Ctrl+J` elsewhere — both survive legacy terminals that
-    strip the shift modifier from `Enter`.
+    Prefers `Shift+Enter` when the terminal is known to support the kitty
+    keyboard protocol, either via conservative terminal-identity heuristics
+    or the `DEEPAGENTS_CLI_KITTY_KEYBOARD` override. Falls back to
+    `Option+Enter` on macOS and `Ctrl+J` elsewhere — both survive legacy
+    terminals that strip the shift modifier from `Enter`.
 
     Returns:
         A human-readable shortcut string,

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -496,14 +496,22 @@ def is_ascii_mode() -> bool:
 
 
 def newline_shortcut() -> str:
-    """Return the platform-native label for the newline keyboard shortcut.
+    """Return the terminal-appropriate label for the newline keyboard shortcut.
 
-    macOS labels the modifier "Option" while other platforms use Ctrl+J
-    as the most reliable cross-terminal shortcut.
+    Prefers `Shift+Enter` when the kitty keyboard protocol is negotiated,
+    since modern terminals (kitty, WezTerm, Ghostty, recent iTerm2) can
+    distinguish it from plain `Enter`. Falls back to `Option+Enter` on
+    macOS and `Ctrl+J` elsewhere — both survive legacy terminals that
+    strip the shift modifier from `Enter`.
 
     Returns:
-        A human-readable shortcut string, e.g. `'Option+Enter'` or `'Ctrl+J'`.
+        A human-readable shortcut string,
+            e.g. `'Shift+Enter'`, `'Option+Enter'`, or `'Ctrl+J'`.
     """
+    from deepagents_cli.terminal_capabilities import supports_kitty_keyboard_protocol
+
+    if supports_kitty_keyboard_protocol():
+        return "Shift+Enter"
     return "Option+Enter" if sys.platform == "darwin" else "Ctrl+J"
 
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1898,15 +1898,6 @@ def cli_main() -> None:
                 trust_flag=getattr(args, "trust_project_mcp", False),
             )
 
-            # Probe the terminal for kitty-protocol support before Textual
-            # acquires stdin. Result is cached; consumers like
-            # `config.newline_shortcut()` read it later without re-querying.
-            from deepagents_cli.terminal_capabilities import (
-                supports_kitty_keyboard_protocol,
-            )
-
-            supports_kitty_keyboard_protocol()
-
             # Run Textual CLI
             return_code = 0
             try:

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1898,6 +1898,15 @@ def cli_main() -> None:
                 trust_flag=getattr(args, "trust_project_mcp", False),
             )
 
+            # Probe the terminal for kitty-protocol support before Textual
+            # acquires stdin. Result is cached; consumers like
+            # `config.newline_shortcut()` read it later without re-querying.
+            from deepagents_cli.terminal_capabilities import (
+                supports_kitty_keyboard_protocol,
+            )
+
+            supports_kitty_keyboard_protocol()
+
             # Run Textual CLI
             return_code = 0
             try:

--- a/libs/cli/deepagents_cli/terminal_capabilities.py
+++ b/libs/cli/deepagents_cli/terminal_capabilities.py
@@ -1,111 +1,99 @@
 """Terminal capability detection.
 
-Probes the attached terminal for optional features so the CLI can
-adapt its UI (e.g. show `Shift+Enter` as the newline shortcut when the
-kitty keyboard protocol is supported, and `Ctrl+J` otherwise).
+Detect optional terminal features without reading from `stdin`.
 
-Detection runs on first access and is cached for the lifetime of the
-process. Callers must resolve capabilities before Textual's driver
-acquires stdin — running the query while Textual owns the tty will
-race with its own keypress stream.
+The CLI only uses kitty-keyboard-protocol support to choose a user-facing
+newline shortcut label. To keep startup safe on remote or high-latency PTYs,
+detection is conservative and relies on side-effect-free terminal identity
+signals plus an explicit environment-variable override.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import re
-import select
 import sys
 from functools import cache
+from typing import TYPE_CHECKING
+
+from deepagents_cli._env_vars import KITTY_KEYBOARD
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 
-_QUERY_TIMEOUT_SECONDS = 0.1
-"""Per-read timeout for the tty query. The first response byte typically
-arrives within a few ms; 100 ms is a generous ceiling that still keeps
-startup snappy on misbehaving terminals."""
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+_KNOWN_KITTY_KEYBOARD_TERMS = frozenset({"xterm-ghostty", "xterm-kitty"})
 
-_MAX_RESPONSE_BYTES = 256
-"""Cap total bytes read from the tty. Real responses are ~20 bytes;
-this guards against a hostile or broken terminal streaming indefinitely."""
 
-_KITTY_RESPONSE_RE = re.compile(rb"\x1b\[\?\d*u")
-"""Matches a kitty-protocol flags-query reply (`CSI ? <flags> u`).
+def _override_supports_kitty_keyboard_protocol(
+    env: Mapping[str, str],
+) -> bool | None:
+    """Return an explicit kitty-keyboard override from `env`, if present.
 
-A terminal that supports the protocol emits this sequence in response to
-`CSI ? u`. Terminals that do not support it stay silent for the flags
-query and only reply to the primary device attributes (DA1) query that
-follows."""
+    Accepted truthy values are `'1'`, `'true'`, `'yes'`, and `'on'`.
+    Accepted falsy values are `'0'`, `'false'`, `'no'`, and `'off'`.
+    `'auto'`, the empty string, and invalid values fall back to heuristic
+    detection.
+    """
+    raw = env.get(KITTY_KEYBOARD)
+    if raw is None:
+        return None
+
+    normalized = raw.strip().lower()
+    if normalized in {"", "auto"}:
+        return None
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+
+    logger.debug(
+        "kitty kbd detection override ignored: %s=%r",
+        KITTY_KEYBOARD,
+        raw,
+    )
+    return None
+
+
+def _terminal_identity_supports_kitty_keyboard_protocol(
+    env: Mapping[str, str],
+) -> bool:
+    """Return whether `env` identifies a terminal with built-in kitty support.
+
+    This intentionally only recognizes terminals whose environment markers
+    imply kitty-keyboard support is part of the terminal's default identity.
+    Configurable terminals such as iTerm2 and WezTerm are intentionally not
+    auto-detected because protocol support can be disabled in user settings.
+    """
+    if env.get("KITTY_WINDOW_ID"):
+        return True
+
+    term = env.get("TERM", "")
+    return term in _KNOWN_KITTY_KEYBOARD_TERMS
 
 
 @cache
 def supports_kitty_keyboard_protocol() -> bool:
-    """Return whether the attached terminal speaks the kitty keyboard protocol.
+    """Return whether the attached terminal should be treated as kitty-aware.
 
-    The protocol disambiguates modified keys like `shift+enter` and
-    `ctrl+enter` that legacy xterm-style terminals collapse onto plain
-    `enter`. Supporting terminals reply to a `CSI ? u` query with
-    `CSI ? <flags> u`.
-
-    Cached for the process lifetime. Writes to stdout and reads from
-    stdin, so call during startup — before Textual acquires the tty.
+    Detection is side-effect free: it never writes escape sequences or reads
+    queued input bytes. That means it may under-detect some configurable
+    terminals, but it will not interfere with Textual's input stream.
 
     Returns:
-        `True` when a valid response is received, `False` otherwise
-        (no tty, non-POSIX platform, or unsupported terminal).
+        `True` when the terminal is known to support the kitty keyboard
+        protocol, `False` otherwise.
     """
     if sys.platform == "win32":
         return False
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return False
-    try:
-        import termios  # POSIX-only
-        import tty
-    except ImportError:
-        return False
 
-    fd = sys.stdin.fileno()
-    try:
-        original = termios.tcgetattr(fd)
-    except termios.error as exc:
-        logger.debug("kitty kbd probe: tcgetattr failed: %s", exc)
-        return False
+    override = _override_supports_kitty_keyboard_protocol(os.environ)
+    if override is not None:
+        return override
 
-    buffer = b""
-    try:
-        tty.setcbreak(fd)
-        os.write(sys.stdout.fileno(), b"\x1b[?u\x1b[c")
-        while len(buffer) < _MAX_RESPONSE_BYTES:
-            ready, _, _ = select.select([fd], [], [], _QUERY_TIMEOUT_SECONDS)
-            if not ready:
-                break
-            chunk = os.read(fd, 64)
-            if not chunk:
-                break
-            buffer += chunk
-            # DA1 reply ends with `c` and always follows the (optional)
-            # kitty reply, so its arrival means we have everything.
-            if buffer.endswith(b"c"):
-                break
-    except OSError as exc:
-        logger.debug("kitty kbd probe: query failed: %s", exc)
-        return False
-    finally:
-        # `tcsetattr` can itself fail (fd closed mid-probe, EIO on a
-        # disappearing pty). Best-effort: log and swallow so a flaky
-        # restore doesn't crash startup.
-        try:
-            termios.tcsetattr(fd, termios.TCSANOW, original)
-        except (termios.error, OSError) as exc:
-            logger.debug("kitty kbd probe: tcsetattr restore failed: %s", exc)
-
-    return _parse_kitty_response(buffer)
-
-
-def _parse_kitty_response(data: bytes) -> bool:
-    """Return whether `data` contains a kitty-protocol flags-query reply.
-
-    Split out for unit testing without a real tty.
-    """
-    return _KITTY_RESPONSE_RE.search(data) is not None
+    return _terminal_identity_supports_kitty_keyboard_protocol(os.environ)

--- a/libs/cli/deepagents_cli/terminal_capabilities.py
+++ b/libs/cli/deepagents_cli/terminal_capabilities.py
@@ -12,11 +12,14 @@ race with its own keypress stream.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import select
 import sys
 from functools import cache
+
+logger = logging.getLogger(__name__)
 
 _QUERY_TIMEOUT_SECONDS = 0.1
 """Per-read timeout for the tty query. The first response byte typically
@@ -57,7 +60,7 @@ def supports_kitty_keyboard_protocol() -> bool:
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return False
     try:
-        import termios  # POSIX-only; imported lazily so Windows doesn't choke.
+        import termios  # POSIX-only
         import tty
     except ImportError:
         return False
@@ -65,7 +68,8 @@ def supports_kitty_keyboard_protocol() -> bool:
     fd = sys.stdin.fileno()
     try:
         original = termios.tcgetattr(fd)
-    except termios.error:
+    except termios.error as exc:
+        logger.debug("kitty kbd probe: tcgetattr failed: %s", exc)
         return False
 
     buffer = b""
@@ -84,10 +88,17 @@ def supports_kitty_keyboard_protocol() -> bool:
             # kitty reply, so its arrival means we have everything.
             if buffer.endswith(b"c"):
                 break
-    except OSError:
+    except OSError as exc:
+        logger.debug("kitty kbd probe: query failed: %s", exc)
         return False
     finally:
-        termios.tcsetattr(fd, termios.TCSANOW, original)
+        # `tcsetattr` can itself fail (fd closed mid-probe, EIO on a
+        # disappearing pty). Best-effort: log and swallow so a flaky
+        # restore doesn't crash startup.
+        try:
+            termios.tcsetattr(fd, termios.TCSANOW, original)
+        except (termios.error, OSError) as exc:
+            logger.debug("kitty kbd probe: tcsetattr restore failed: %s", exc)
 
     return _parse_kitty_response(buffer)
 

--- a/libs/cli/deepagents_cli/terminal_capabilities.py
+++ b/libs/cli/deepagents_cli/terminal_capabilities.py
@@ -1,0 +1,100 @@
+"""Terminal capability detection.
+
+Probes the attached terminal for optional features so the CLI can
+adapt its UI (e.g. show `Shift+Enter` as the newline shortcut when the
+kitty keyboard protocol is supported, and `Ctrl+J` otherwise).
+
+Detection runs on first access and is cached for the lifetime of the
+process. Callers must resolve capabilities before Textual's driver
+acquires stdin — running the query while Textual owns the tty will
+race with its own keypress stream.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import select
+import sys
+from functools import cache
+
+_QUERY_TIMEOUT_SECONDS = 0.1
+"""Per-read timeout for the tty query. The first response byte typically
+arrives within a few ms; 100 ms is a generous ceiling that still keeps
+startup snappy on misbehaving terminals."""
+
+_MAX_RESPONSE_BYTES = 256
+"""Cap total bytes read from the tty. Real responses are ~20 bytes;
+this guards against a hostile or broken terminal streaming indefinitely."""
+
+_KITTY_RESPONSE_RE = re.compile(rb"\x1b\[\?\d*u")
+"""Matches a kitty-protocol flags-query reply (`CSI ? <flags> u`).
+
+A terminal that supports the protocol emits this sequence in response to
+`CSI ? u`. Terminals that do not support it stay silent for the flags
+query and only reply to the primary device attributes (DA1) query that
+follows."""
+
+
+@cache
+def supports_kitty_keyboard_protocol() -> bool:
+    """Return whether the attached terminal speaks the kitty keyboard protocol.
+
+    The protocol disambiguates modified keys like `shift+enter` and
+    `ctrl+enter` that legacy xterm-style terminals collapse onto plain
+    `enter`. Supporting terminals reply to a `CSI ? u` query with
+    `CSI ? <flags> u`.
+
+    Cached for the process lifetime. Writes to stdout and reads from
+    stdin, so call during startup — before Textual acquires the tty.
+
+    Returns:
+        `True` when a valid response is received, `False` otherwise
+        (no tty, non-POSIX platform, or unsupported terminal).
+    """
+    if sys.platform == "win32":
+        return False
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    try:
+        import termios  # POSIX-only; imported lazily so Windows doesn't choke.
+        import tty
+    except ImportError:
+        return False
+
+    fd = sys.stdin.fileno()
+    try:
+        original = termios.tcgetattr(fd)
+    except termios.error:
+        return False
+
+    buffer = b""
+    try:
+        tty.setcbreak(fd)
+        os.write(sys.stdout.fileno(), b"\x1b[?u\x1b[c")
+        while len(buffer) < _MAX_RESPONSE_BYTES:
+            ready, _, _ = select.select([fd], [], [], _QUERY_TIMEOUT_SECONDS)
+            if not ready:
+                break
+            chunk = os.read(fd, 64)
+            if not chunk:
+                break
+            buffer += chunk
+            # DA1 reply ends with `c` and always follows the (optional)
+            # kitty reply, so its arrival means we have everything.
+            if buffer.endswith(b"c"):
+                break
+    except OSError:
+        return False
+    finally:
+        termios.tcsetattr(fd, termios.TCSANOW, original)
+
+    return _parse_kitty_response(buffer)
+
+
+def _parse_kitty_response(data: bytes) -> bool:
+    """Return whether `data` contains a kitty-protocol flags-query reply.
+
+    Split out for unit testing without a real tty.
+    """
+    return _KITTY_RESPONSE_RE.search(data) is not None

--- a/libs/cli/deepagents_cli/terminal_capabilities.py
+++ b/libs/cli/deepagents_cli/terminal_capabilities.py
@@ -50,10 +50,11 @@ def _override_supports_kitty_keyboard_protocol(
     if normalized in _FALSE_VALUES:
         return False
 
-    logger.debug(
-        "kitty kbd detection override ignored: %s=%r",
+    logger.warning(
+        "%s=%r ignored; expected one of: %s, or 'auto' to defer to detection.",
         KITTY_KEYBOARD,
         raw,
+        ", ".join(sorted(_TRUE_VALUES | _FALSE_VALUES)),
     )
     return None
 
@@ -83,17 +84,32 @@ def supports_kitty_keyboard_protocol() -> bool:
     queued input bytes. That means it may under-detect some configurable
     terminals, but it will not interfere with Textual's input stream.
 
+    Set `DEEPAGENTS_CLI_KITTY_KEYBOARD` to an accepted truthy value (`1`,
+    `true`, `yes`, `on`) to force-enable the label, a falsy value (`0`,
+    `false`, `no`, `off`) to force-disable it, or `auto`/unset to use
+    heuristic detection.
+
     Returns:
         `True` when the terminal is known to support the kitty keyboard
         protocol, `False` otherwise.
     """
     if sys.platform == "win32":
+        logger.debug("kitty kbd detection: False (win32 unsupported)")
         return False
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        logger.debug("kitty kbd detection: False (stdin/stdout not a tty)")
         return False
 
     override = _override_supports_kitty_keyboard_protocol(os.environ)
     if override is not None:
+        logger.debug("kitty kbd detection: %s (explicit override)", override)
         return override
 
-    return _terminal_identity_supports_kitty_keyboard_protocol(os.environ)
+    detected = _terminal_identity_supports_kitty_keyboard_protocol(os.environ)
+    logger.debug(
+        "kitty kbd detection: %s (terminal identity TERM=%r KITTY_WINDOW_ID=%r)",
+        detected,
+        os.environ.get("TERM", ""),
+        os.environ.get("KITTY_WINDOW_ID"),
+    )
+    return detected

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "langchain-openai>=1.1.12,<2.0.0",
 
     # UI/Terminal
+    # When bumping: re-check _textual_patches.py vs upstream #6378.
     "textual>=8.0.0,<9.0.0",
     "textual-autocomplete>=3.0.0,<5.0.0",
     "textual-speedups>=0.2.1,<1.0.0",

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -138,3 +138,18 @@ def _isolate_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         "deepagents_cli.widgets.chat_input._default_history_path",
         lambda: tmp_path / "history.jsonl",
     )
+
+
+@pytest.fixture(autouse=True)
+def _clear_kitty_kbd_probe_cache() -> None:
+    """Reset the `functools.cache` on the kitty-keyboard-protocol probe.
+
+    The probe is cached for the lifetime of the process in production,
+    but stale state leaks across tests that patch the probe function or
+    rely on platform-specific behaviour. Clearing on every test keeps
+    results deterministic regardless of file order or `pytest-xdist`
+    sharding.
+    """
+    from deepagents_cli.terminal_capabilities import supports_kitty_keyboard_protocol
+
+    supports_kitty_keyboard_protocol.cache_clear()

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -276,16 +276,42 @@ class TestSettingsGetProjectAgentMdPath:
 
 
 class TestNewlineShortcut:
-    """Tests for platform-specific newline shortcut labels."""
+    """Tests for newline shortcut labels.
+
+    The label depends on both the platform and whether the attached
+    terminal advertises kitty-keyboard-protocol support. Each test
+    patches the cached capability probe so the platform-fallback logic
+    is exercised in isolation.
+    """
+
+    def test_returns_shift_enter_when_kitty_supported(self) -> None:
+        """Should show Shift+Enter on any platform when kitty kbd is negotiated."""
+        with patch(
+            "deepagents_cli.terminal_capabilities.supports_kitty_keyboard_protocol",
+            return_value=True,
+        ):
+            assert newline_shortcut() == "Shift+Enter"
 
     def test_returns_option_enter_on_macos(self) -> None:
-        """Should show Option+Enter on darwin."""
-        with patch("deepagents_cli.config.sys.platform", "darwin"):
+        """Should show Option+Enter on darwin when kitty kbd is unavailable."""
+        with (
+            patch(
+                "deepagents_cli.terminal_capabilities.supports_kitty_keyboard_protocol",
+                return_value=False,
+            ),
+            patch("deepagents_cli.config.sys.platform", "darwin"),
+        ):
             assert newline_shortcut() == "Option+Enter"
 
     def test_returns_ctrl_j_on_non_macos(self) -> None:
-        """Should show Ctrl+J on non-darwin platforms."""
-        with patch("deepagents_cli.config.sys.platform", "linux"):
+        """Should show Ctrl+J on non-darwin platforms when kitty kbd is unavailable."""
+        with (
+            patch(
+                "deepagents_cli.terminal_capabilities.supports_kitty_keyboard_protocol",
+                return_value=False,
+            ),
+            patch("deepagents_cli.config.sys.platform", "linux"),
+        ):
             assert newline_shortcut() == "Ctrl+J"
 
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -314,6 +314,17 @@ class TestNewlineShortcut:
         ):
             assert newline_shortcut() == "Ctrl+J"
 
+    def test_returns_ctrl_j_on_win32(self) -> None:
+        """Windows falls into the non-darwin branch and must show Ctrl+J."""
+        with (
+            patch(
+                "deepagents_cli.terminal_capabilities.supports_kitty_keyboard_protocol",
+                return_value=False,
+            ),
+            patch("deepagents_cli.config.sys.platform", "win32"),
+        ):
+            assert newline_shortcut() == "Ctrl+J"
+
 
 class TestValidateModelCapabilities:
     """Tests for model capability validation."""

--- a/libs/cli/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/cli/tests/unit_tests/test_terminal_capabilities.py
@@ -62,6 +62,21 @@ class TestOverrideSupportsKittyKeyboardProtocol:
             is None
         )
 
+    def test_returns_none_for_empty_string(self) -> None:
+        """Empty string should defer to heuristic detection, not be treated as off."""
+        assert _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: ""}) is None
+
+    def test_normalizes_whitespace_and_case(self) -> None:
+        """Values lifted from `.env` files routinely carry trailing whitespace."""
+        assert (
+            _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: " TRUE "})
+            is True
+        )
+        assert (
+            _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: "Off\n"})
+            is False
+        )
+
 
 class TestTerminalIdentitySupportsKittyKeyboardProtocol:
     """Tests for the conservative terminal-identity heuristic."""

--- a/libs/cli/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/cli/tests/unit_tests/test_terminal_capabilities.py
@@ -2,13 +2,47 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import contextlib
+import termios
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 from deepagents_cli import terminal_capabilities
 from deepagents_cli.terminal_capabilities import (
+    _MAX_RESPONSE_BYTES,
     _parse_kitty_response,
     supports_kitty_keyboard_protocol,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+_FAKE_FD = 99
+"""Fake fd the mocked syscalls operate on — never hits the kernel."""
+
+
+@contextlib.contextmanager
+def _fake_tty() -> Iterator[None]:
+    """Convince the probe both streams are a real tty.
+
+    pytest's stdin capture wrapper raises from `fileno()` and isn't
+    patchable via `patch.object`, so we swap `sys.stdin`/`sys.stdout`
+    wholesale with `MagicMock`s that return a fake fd. Every syscall
+    the probe makes is mocked by the caller, so the fake fd is inert.
+    """
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = True
+    fake_stdin.fileno.return_value = _FAKE_FD
+    fake_stdout = MagicMock()
+    fake_stdout.isatty.return_value = True
+    fake_stdout.fileno.return_value = _FAKE_FD
+    with (
+        patch.object(terminal_capabilities.sys, "stdin", fake_stdin),
+        patch.object(terminal_capabilities.sys, "stdout", fake_stdout),
+        patch.object(terminal_capabilities.sys, "platform", "linux"),
+    ):
+        yield
 
 
 class TestParseKittyResponse:
@@ -39,40 +73,143 @@ class TestParseKittyResponse:
         assert _parse_kitty_response(b"\x1b[2J\x1b[H\x1b[?62c") is False
 
 
-class TestSupportsKittyKeyboardProtocol:
-    """Tests for the public capability probe.
-
-    The function is `functools.cache`-wrapped, so each test clears the
-    cache to observe fresh behaviour.
-    """
-
-    def setup_method(self) -> None:
-        """Clear the module-level cache before each test."""
-        supports_kitty_keyboard_protocol.cache_clear()
-
-    def teardown_method(self) -> None:
-        """Clear again so leftover mocked results don't leak to other tests."""
-        supports_kitty_keyboard_protocol.cache_clear()
+class TestSupportsKittyKeyboardProtocolShortCircuits:
+    """Short-circuit branches that never reach the tty query."""
 
     def test_returns_false_when_stdin_not_a_tty(self) -> None:
         """Non-interactive stdin (pipes, redirects, CI) short-circuits to False."""
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = False
+        fake_stdout = MagicMock()
+        fake_stdout.isatty.return_value = True
         with (
-            patch.object(terminal_capabilities.sys.stdin, "isatty", return_value=False),
-            patch.object(terminal_capabilities.sys.stdout, "isatty", return_value=True),
+            patch.object(terminal_capabilities.sys, "stdin", fake_stdin),
+            patch.object(terminal_capabilities.sys, "stdout", fake_stdout),
         ):
             assert supports_kitty_keyboard_protocol() is False
 
     def test_returns_false_when_stdout_not_a_tty(self) -> None:
         """Piping stdout (e.g. `deepagents ... | tee log`) short-circuits to False."""
-        stdin = terminal_capabilities.sys.stdin
-        stdout = terminal_capabilities.sys.stdout
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        fake_stdout = MagicMock()
+        fake_stdout.isatty.return_value = False
         with (
-            patch.object(stdin, "isatty", return_value=True),
-            patch.object(stdout, "isatty", return_value=False),
+            patch.object(terminal_capabilities.sys, "stdin", fake_stdin),
+            patch.object(terminal_capabilities.sys, "stdout", fake_stdout),
         ):
             assert supports_kitty_keyboard_protocol() is False
 
     def test_returns_false_on_windows(self) -> None:
         """Skip the probe on Windows — ConPTY kitty support is inconsistent."""
         with patch.object(terminal_capabilities.sys, "platform", "win32"):
+            assert supports_kitty_keyboard_protocol() is False
+
+
+class TestTtyProbePath:
+    """Tests for the termios / select / os.read portion of the probe.
+
+    These patch the low-level syscalls so we exercise the cleanup
+    contract (must restore tty state even on failure) without needing a
+    real terminal attached.
+    """
+
+    def test_tcgetattr_error_returns_false_and_does_not_write(self) -> None:
+        """If `tcgetattr` can't read tty state, bail before writing the query.
+
+        A failed `tcgetattr` means we don't have a snapshot to restore
+        to; issuing the query would leave the terminal in an unknown
+        state. The probe must short-circuit cleanly.
+        """
+        with (
+            _fake_tty(),
+            patch("termios.tcgetattr", side_effect=termios.error("no tty")),
+            patch("os.write") as write_mock,
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+            assert write_mock.call_count == 0
+
+    def test_select_timeout_returns_false_and_restores_tty(self) -> None:
+        """Terminal silent → return False, still restore original tty state."""
+        sentinel_attrs = object()
+        with (
+            _fake_tty(),
+            patch("termios.tcgetattr", return_value=sentinel_attrs),
+            patch("tty.setcbreak"),
+            patch("os.write"),
+            patch("select.select", return_value=([], [], [])),
+            patch("termios.tcsetattr") as tcsetattr_mock,
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+            tcsetattr_mock.assert_called_once_with(
+                _FAKE_FD, termios.TCSANOW, sentinel_attrs
+            )
+
+    def test_os_read_error_restores_tty_state(self) -> None:
+        """An `OSError` mid-read must still restore tty state via `finally`."""
+        sentinel_attrs = object()
+        with (
+            _fake_tty(),
+            patch("termios.tcgetattr", return_value=sentinel_attrs),
+            patch("tty.setcbreak"),
+            patch("os.write"),
+            patch("select.select", return_value=([_FAKE_FD], [], [])),
+            patch("os.read", side_effect=OSError("EIO")),
+            patch("termios.tcsetattr") as tcsetattr_mock,
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+            tcsetattr_mock.assert_called_once()
+
+    def test_positive_response_parsed_from_streamed_bytes(self) -> None:
+        """A terminal replying with `CSI ? 15 u` must be detected as supporting."""
+        replies = [b"\x1b[?15u\x1b[?62;1;4c"]
+
+        def read_stub(_fd: int, _n: int) -> bytes:
+            return replies.pop(0) if replies else b""
+
+        with (
+            _fake_tty(),
+            patch("termios.tcgetattr", return_value=object()),
+            patch("tty.setcbreak"),
+            patch("os.write"),
+            patch("select.select", return_value=([_FAKE_FD], [], [])),
+            patch("os.read", side_effect=read_stub),
+            patch("termios.tcsetattr"),
+        ):
+            assert supports_kitty_keyboard_protocol() is True
+
+    def test_response_is_capped_at_max_bytes(self) -> None:
+        """A rogue terminal streaming forever must not exceed the byte cap."""
+        read_calls: list[int] = []
+
+        def read_stub(_fd: int, n: int) -> bytes:
+            read_calls.append(n)
+            return b"x" * n
+
+        with (
+            _fake_tty(),
+            patch("termios.tcgetattr", return_value=object()),
+            patch("tty.setcbreak"),
+            patch("os.write"),
+            patch("select.select", return_value=([_FAKE_FD], [], [])),
+            patch("os.read", side_effect=read_stub),
+            patch("termios.tcsetattr"),
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+            # Bytes read are capped by the `len(buffer) < _MAX_RESPONSE_BYTES`
+            # loop guard — exact total depends on per-read chunk size but
+            # must stay within a small multiple of the cap.
+            assert sum(read_calls) < _MAX_RESPONSE_BYTES * 2
+
+    def test_tcsetattr_failure_is_swallowed(self) -> None:
+        """If the tty restore itself fails, the probe must still return normally."""
+        with (
+            _fake_tty(),
+            patch("termios.tcgetattr", return_value=object()),
+            patch("tty.setcbreak"),
+            patch("os.write"),
+            patch("select.select", return_value=([], [], [])),
+            patch("termios.tcsetattr", side_effect=termios.error("restore failed")),
+        ):
+            # Should not raise; probe returns False since no response arrived.
             assert supports_kitty_keyboard_protocol() is False

--- a/libs/cli/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/cli/tests/unit_tests/test_terminal_capabilities.py
@@ -1,0 +1,78 @@
+"""Tests for terminal capability detection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from deepagents_cli import terminal_capabilities
+from deepagents_cli.terminal_capabilities import (
+    _parse_kitty_response,
+    supports_kitty_keyboard_protocol,
+)
+
+
+class TestParseKittyResponse:
+    """Tests for `_parse_kitty_response` pattern matching.
+
+    Keeping this pure-bytes test separate from the full tty probe lets
+    us exercise every response shape without needing a real terminal.
+    """
+
+    def test_detects_flags_reply_with_digits(self) -> None:
+        """`CSI ? <flags> u` is the canonical positive response."""
+        assert _parse_kitty_response(b"\x1b[?15u\x1b[?62;1;4c") is True
+
+    def test_detects_flags_reply_with_no_digits(self) -> None:
+        """Some terminals report zero flags as `CSI ? u` (no digits)."""
+        assert _parse_kitty_response(b"\x1b[?u\x1b[?62c") is True
+
+    def test_ignores_da1_only_response(self) -> None:
+        """Terminals without kitty kbd only reply to DA1; no `?...u` segment."""
+        assert _parse_kitty_response(b"\x1b[?62;1;4c") is False
+
+    def test_ignores_empty_buffer(self) -> None:
+        """No response at all (terminal silent)."""
+        assert _parse_kitty_response(b"") is False
+
+    def test_ignores_unrelated_escape_sequences(self) -> None:
+        """Incidental escape sequences in the buffer should not false-positive."""
+        assert _parse_kitty_response(b"\x1b[2J\x1b[H\x1b[?62c") is False
+
+
+class TestSupportsKittyKeyboardProtocol:
+    """Tests for the public capability probe.
+
+    The function is `functools.cache`-wrapped, so each test clears the
+    cache to observe fresh behaviour.
+    """
+
+    def setup_method(self) -> None:
+        """Clear the module-level cache before each test."""
+        supports_kitty_keyboard_protocol.cache_clear()
+
+    def teardown_method(self) -> None:
+        """Clear again so leftover mocked results don't leak to other tests."""
+        supports_kitty_keyboard_protocol.cache_clear()
+
+    def test_returns_false_when_stdin_not_a_tty(self) -> None:
+        """Non-interactive stdin (pipes, redirects, CI) short-circuits to False."""
+        with (
+            patch.object(terminal_capabilities.sys.stdin, "isatty", return_value=False),
+            patch.object(terminal_capabilities.sys.stdout, "isatty", return_value=True),
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+
+    def test_returns_false_when_stdout_not_a_tty(self) -> None:
+        """Piping stdout (e.g. `deepagents ... | tee log`) short-circuits to False."""
+        stdin = terminal_capabilities.sys.stdin
+        stdout = terminal_capabilities.sys.stdout
+        with (
+            patch.object(stdin, "isatty", return_value=True),
+            patch.object(stdout, "isatty", return_value=False),
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+
+    def test_returns_false_on_windows(self) -> None:
+        """Skip the probe on Windows — ConPTY kitty support is inconsistent."""
+        with patch.object(terminal_capabilities.sys, "platform", "win32"):
+            assert supports_kitty_keyboard_protocol() is False

--- a/libs/cli/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/cli/tests/unit_tests/test_terminal_capabilities.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import contextlib
-import termios
+import os
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 from deepagents_cli import terminal_capabilities
+from deepagents_cli._env_vars import KITTY_KEYBOARD
 from deepagents_cli.terminal_capabilities import (
-    _MAX_RESPONSE_BYTES,
-    _parse_kitty_response,
+    _override_supports_kitty_keyboard_protocol,
+    _terminal_identity_supports_kitty_keyboard_protocol,
     supports_kitty_keyboard_protocol,
 )
 
@@ -18,25 +19,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-_FAKE_FD = 99
-"""Fake fd the mocked syscalls operate on — never hits the kernel."""
-
-
 @contextlib.contextmanager
 def _fake_tty() -> Iterator[None]:
-    """Convince the probe both streams are a real tty.
-
-    pytest's stdin capture wrapper raises from `fileno()` and isn't
-    patchable via `patch.object`, so we swap `sys.stdin`/`sys.stdout`
-    wholesale with `MagicMock`s that return a fake fd. Every syscall
-    the probe makes is mocked by the caller, so the fake fd is inert.
-    """
+    """Convince the probe both streams are attached to a tty."""
     fake_stdin = MagicMock()
     fake_stdin.isatty.return_value = True
-    fake_stdin.fileno.return_value = _FAKE_FD
     fake_stdout = MagicMock()
     fake_stdout.isatty.return_value = True
-    fake_stdout.fileno.return_value = _FAKE_FD
     with (
         patch.object(terminal_capabilities.sys, "stdin", fake_stdin),
         patch.object(terminal_capabilities.sys, "stdout", fake_stdout),
@@ -45,39 +34,87 @@ def _fake_tty() -> Iterator[None]:
         yield
 
 
-class TestParseKittyResponse:
-    """Tests for `_parse_kitty_response` pattern matching.
+class TestOverrideSupportsKittyKeyboardProtocol:
+    """Tests for the explicit environment-variable override."""
 
-    Keeping this pure-bytes test separate from the full tty probe lets
-    us exercise every response shape without needing a real terminal.
-    """
+    def test_returns_true_for_truthy_value(self) -> None:
+        """Truthy override values should force kitty support on."""
+        assert (
+            _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: "true"}) is True
+        )
 
-    def test_detects_flags_reply_with_digits(self) -> None:
-        """`CSI ? <flags> u` is the canonical positive response."""
-        assert _parse_kitty_response(b"\x1b[?15u\x1b[?62;1;4c") is True
+    def test_returns_false_for_falsy_value(self) -> None:
+        """Falsy override values should force kitty support off."""
+        assert (
+            _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: "off"}) is False
+        )
 
-    def test_detects_flags_reply_with_no_digits(self) -> None:
-        """Some terminals report zero flags as `CSI ? u` (no digits)."""
-        assert _parse_kitty_response(b"\x1b[?u\x1b[?62c") is True
+    def test_returns_none_for_auto(self) -> None:
+        """`auto` should defer to heuristic detection."""
+        assert (
+            _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: "auto"}) is None
+        )
 
-    def test_ignores_da1_only_response(self) -> None:
-        """Terminals without kitty kbd only reply to DA1; no `?...u` segment."""
-        assert _parse_kitty_response(b"\x1b[?62;1;4c") is False
+    def test_returns_none_for_invalid_value(self) -> None:
+        """Unknown override values should be ignored."""
+        assert (
+            _override_supports_kitty_keyboard_protocol({KITTY_KEYBOARD: "maybe"})
+            is None
+        )
 
-    def test_ignores_empty_buffer(self) -> None:
-        """No response at all (terminal silent)."""
-        assert _parse_kitty_response(b"") is False
 
-    def test_ignores_unrelated_escape_sequences(self) -> None:
-        """Incidental escape sequences in the buffer should not false-positive."""
-        assert _parse_kitty_response(b"\x1b[2J\x1b[H\x1b[?62c") is False
+class TestTerminalIdentitySupportsKittyKeyboardProtocol:
+    """Tests for the conservative terminal-identity heuristic."""
+
+    def test_detects_kitty_via_window_id(self) -> None:
+        """`KITTY_WINDOW_ID` is a strong signal that kitty owns the pty."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol(
+                {"KITTY_WINDOW_ID": "17", "TERM": "xterm-256color"}
+            )
+            is True
+        )
+
+    def test_detects_kitty_via_term(self) -> None:
+        """Kitty exports `TERM=xterm-kitty` by default."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol({"TERM": "xterm-kitty"})
+            is True
+        )
+
+    def test_detects_ghostty_via_term(self) -> None:
+        """Ghostty exports `TERM=xterm-ghostty` when its terminfo is available."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol(
+                {"TERM": "xterm-ghostty"}
+            )
+            is True
+        )
+
+    def test_does_not_auto_detect_wezterm(self) -> None:
+        """WezTerm leaves kitty-keyboard support behind a user setting."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol(
+                {"TERM": "xterm-256color", "TERM_PROGRAM": "WezTerm"}
+            )
+            is False
+        )
+
+    def test_does_not_auto_detect_iterm(self) -> None:
+        """iTerm2 can disable app-controlled key reporting, so stay conservative."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol(
+                {"TERM": "xterm-256color", "TERM_PROGRAM": "iTerm.app"}
+            )
+            is False
+        )
 
 
 class TestSupportsKittyKeyboardProtocolShortCircuits:
-    """Short-circuit branches that never reach the tty query."""
+    """Short-circuit branches before env heuristics are consulted."""
 
     def test_returns_false_when_stdin_not_a_tty(self) -> None:
-        """Non-interactive stdin (pipes, redirects, CI) short-circuits to False."""
+        """Non-interactive stdin should always disable kitty support."""
         fake_stdin = MagicMock()
         fake_stdin.isatty.return_value = False
         fake_stdout = MagicMock()
@@ -89,7 +126,7 @@ class TestSupportsKittyKeyboardProtocolShortCircuits:
             assert supports_kitty_keyboard_protocol() is False
 
     def test_returns_false_when_stdout_not_a_tty(self) -> None:
-        """Piping stdout (e.g. `deepagents ... | tee log`) short-circuits to False."""
+        """Piped stdout should always disable kitty support."""
         fake_stdin = MagicMock()
         fake_stdin.isatty.return_value = True
         fake_stdout = MagicMock()
@@ -101,115 +138,51 @@ class TestSupportsKittyKeyboardProtocolShortCircuits:
             assert supports_kitty_keyboard_protocol() is False
 
     def test_returns_false_on_windows(self) -> None:
-        """Skip the probe on Windows — ConPTY kitty support is inconsistent."""
+        """Skip kitty detection on Windows."""
         with patch.object(terminal_capabilities.sys, "platform", "win32"):
             assert supports_kitty_keyboard_protocol() is False
 
 
-class TestTtyProbePath:
-    """Tests for the termios / select / os.read portion of the probe.
+class TestSupportsKittyKeyboardProtocolDetection:
+    """Tests for override and heuristic behavior on an attached tty."""
 
-    These patch the low-level syscalls so we exercise the cleanup
-    contract (must restore tty state even on failure) without needing a
-    real terminal attached.
-    """
+    def test_override_can_force_true(self) -> None:
+        """Users can opt into the `Shift+Enter` hint explicitly."""
+        with _fake_tty(), patch.dict(os.environ, {KITTY_KEYBOARD: "1"}, clear=True):
+            assert supports_kitty_keyboard_protocol() is True
 
-    def test_tcgetattr_error_returns_false_and_does_not_write(self) -> None:
-        """If `tcgetattr` can't read tty state, bail before writing the query.
-
-        A failed `tcgetattr` means we don't have a snapshot to restore
-        to; issuing the query would leave the terminal in an unknown
-        state. The probe must short-circuit cleanly.
-        """
+    def test_override_can_force_false(self) -> None:
+        """Explicit disable should win over positive terminal identity signals."""
         with (
             _fake_tty(),
-            patch("termios.tcgetattr", side_effect=termios.error("no tty")),
-            patch("os.write") as write_mock,
+            patch.dict(
+                os.environ,
+                {KITTY_KEYBOARD: "0", "KITTY_WINDOW_ID": "17", "TERM": "xterm-kitty"},
+                clear=True,
+            ),
         ):
             assert supports_kitty_keyboard_protocol() is False
-            assert write_mock.call_count == 0
 
-    def test_select_timeout_returns_false_and_restores_tty(self) -> None:
-        """Terminal silent → return False, still restore original tty state."""
-        sentinel_attrs = object()
+    def test_invalid_override_falls_back_to_term_heuristic(self) -> None:
+        """Invalid overrides should not disable known-safe detection."""
         with (
             _fake_tty(),
-            patch("termios.tcgetattr", return_value=sentinel_attrs),
-            patch("tty.setcbreak"),
-            patch("os.write"),
-            patch("select.select", return_value=([], [], [])),
-            patch("termios.tcsetattr") as tcsetattr_mock,
-        ):
-            assert supports_kitty_keyboard_protocol() is False
-            tcsetattr_mock.assert_called_once_with(
-                _FAKE_FD, termios.TCSANOW, sentinel_attrs
-            )
-
-    def test_os_read_error_restores_tty_state(self) -> None:
-        """An `OSError` mid-read must still restore tty state via `finally`."""
-        sentinel_attrs = object()
-        with (
-            _fake_tty(),
-            patch("termios.tcgetattr", return_value=sentinel_attrs),
-            patch("tty.setcbreak"),
-            patch("os.write"),
-            patch("select.select", return_value=([_FAKE_FD], [], [])),
-            patch("os.read", side_effect=OSError("EIO")),
-            patch("termios.tcsetattr") as tcsetattr_mock,
-        ):
-            assert supports_kitty_keyboard_protocol() is False
-            tcsetattr_mock.assert_called_once()
-
-    def test_positive_response_parsed_from_streamed_bytes(self) -> None:
-        """A terminal replying with `CSI ? 15 u` must be detected as supporting."""
-        replies = [b"\x1b[?15u\x1b[?62;1;4c"]
-
-        def read_stub(_fd: int, _n: int) -> bytes:
-            return replies.pop(0) if replies else b""
-
-        with (
-            _fake_tty(),
-            patch("termios.tcgetattr", return_value=object()),
-            patch("tty.setcbreak"),
-            patch("os.write"),
-            patch("select.select", return_value=([_FAKE_FD], [], [])),
-            patch("os.read", side_effect=read_stub),
-            patch("termios.tcsetattr"),
+            patch.dict(
+                os.environ,
+                {KITTY_KEYBOARD: "maybe", "TERM": "xterm-kitty"},
+                clear=True,
+            ),
         ):
             assert supports_kitty_keyboard_protocol() is True
 
-    def test_response_is_capped_at_max_bytes(self) -> None:
-        """A rogue terminal streaming forever must not exceed the byte cap."""
-        read_calls: list[int] = []
-
-        def read_stub(_fd: int, n: int) -> bytes:
-            read_calls.append(n)
-            return b"x" * n
-
+    def test_returns_false_for_unrecognized_terminal(self) -> None:
+        """Unknown terminals should keep the legacy newline hint."""
         with (
             _fake_tty(),
-            patch("termios.tcgetattr", return_value=object()),
-            patch("tty.setcbreak"),
-            patch("os.write"),
-            patch("select.select", return_value=([_FAKE_FD], [], [])),
-            patch("os.read", side_effect=read_stub),
-            patch("termios.tcsetattr"),
+            patch.dict(
+                os.environ,
+                {"TERM": "xterm-256color"},
+                clear=True,
+            ),
         ):
-            assert supports_kitty_keyboard_protocol() is False
-            # Bytes read are capped by the `len(buffer) < _MAX_RESPONSE_BYTES`
-            # loop guard — exact total depends on per-read chunk size but
-            # must stay within a small multiple of the cap.
-            assert sum(read_calls) < _MAX_RESPONSE_BYTES * 2
-
-    def test_tcsetattr_failure_is_swallowed(self) -> None:
-        """If the tty restore itself fails, the probe must still return normally."""
-        with (
-            _fake_tty(),
-            patch("termios.tcgetattr", return_value=object()),
-            patch("tty.setcbreak"),
-            patch("os.write"),
-            patch("select.select", return_value=([], [], [])),
-            patch("termios.tcsetattr", side_effect=termios.error("restore failed")),
-        ):
-            # Should not raise; probe returns False since no response arrived.
             assert supports_kitty_keyboard_protocol() is False

--- a/libs/cli/tests/unit_tests/test_textual_patches.py
+++ b/libs/cli/tests/unit_tests/test_textual_patches.py
@@ -7,6 +7,10 @@ exercise the patched method directly.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+
 from textual._xterm_parser import XTermParser
 
 # Import triggers the monkey-patch.
@@ -104,6 +108,16 @@ class TestTwoCharFastPath:
         r"""`\x1b[A` (cursor up) must not be misinterpreted as alt-anything."""
         assert _keys_for("\x1b[A", alt=False) == [("up", None)]
 
+    def test_esc_esc_yields_alt_escape(self) -> None:
+        r"""`\x1b\x1b` is the intentional semantic change: immediate `alt+escape`.
+
+        Upstream waits for the full escape-delay before giving up; the
+        fast path short-circuits to `alt+escape` with zero latency,
+        matching crossterm / Node TTY. Flagged as load-bearing in the
+        patch module docstring.
+        """
+        assert _keys_for("\x1b\x1b", alt=False) == [("alt+escape", None)]
+
 
 class TestPatchInstalled:
     """Guardrail against silent upstream drift.
@@ -123,3 +137,51 @@ class TestPatchInstalled:
         patched = getattr(_textual_patches, "_sequence_to_key_events_with_alt", None)
         assert patched is not None, "patch module failed to bind replacement"
         assert XTermParser._sequence_to_key_events is patched
+
+    def test_patch_applied_flag_is_true_after_import(self) -> None:
+        """`PATCH_APPLIED` is the programmatic signal callers check on mount."""
+        assert _textual_patches.PATCH_APPLIED is True
+
+
+class TestImportSiteIntegration:
+    """Guardrails that the patch is actually installed via `app.py`.
+
+    The unit tests above import `_textual_patches` themselves, so they
+    cannot detect a regression where the side-effect import is removed
+    from `app.py`. This class uses a subprocess with a fresh interpreter
+    so it only sees the patch if some module in `deepagents_cli.app`'s
+    import graph triggers it.
+    """
+
+    def test_importing_app_installs_the_patch(self) -> None:
+        r"""`import deepagents_cli.app` must leave `XTermParser` patched.
+
+        If a refactor drops the `_textual_patches` import from `app.py`,
+        this test fails loudly. Runs in a subprocess to bypass the
+        current interpreter's already-patched state.
+        """
+        script = textwrap.dedent(
+            """
+            import sys
+            import deepagents_cli.app  # noqa: F401
+            from textual._xterm_parser import XTermParser
+
+            assert (
+                "deepagents_cli._textual_patches" in sys.modules
+            ), "patch module not imported by app.py's import graph"
+            assert (
+                XTermParser._sequence_to_key_events.__name__
+                == "_sequence_to_key_events_with_alt"
+            ), "XTermParser._sequence_to_key_events is not our replacement"
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"subprocess assertion failed:\nstdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )

--- a/libs/cli/tests/unit_tests/test_textual_patches.py
+++ b/libs/cli/tests/unit_tests/test_textual_patches.py
@@ -96,10 +96,30 @@ class TestTwoCharFastPath:
 
         Printable bytes aren't in `ANSI_SEQUENCES_KEYS` as tuples, so the
         fast path must defer — the upstream single-char branch already
-        honours `alt` for these.
+        honors `alt` for these.
         """
         assert _keys_for("\x1ba", alt=False) == []
 
     def test_longer_sequence_ignored_by_fast_path(self) -> None:
         r"""`\x1b[A` (cursor up) must not be misinterpreted as alt-anything."""
         assert _keys_for("\x1b[A", alt=False) == [("up", None)]
+
+
+class TestPatchInstalled:
+    """Guardrail against silent upstream drift.
+
+    The patch is applied as an import-time side effect. If a Textual
+    minor bump renames the private API we patch, our defensive
+    `try/except` swallows the failure — tests elsewhere still pass
+    because they call the patched function directly. This assertion
+    catches that situation loudly.
+    """
+
+    def test_xterm_parser_method_points_at_our_replacement(self) -> None:
+        """`XTermParser._sequence_to_key_events` must be our patched callable."""
+        # Access via `getattr` because the name is only defined when the
+        # defensive `try/except ImportError` at module load succeeded;
+        # ty can't narrow that statically.
+        patched = getattr(_textual_patches, "_sequence_to_key_events_with_alt", None)
+        assert patched is not None, "patch module failed to bind replacement"
+        assert XTermParser._sequence_to_key_events is patched

--- a/libs/cli/tests/unit_tests/test_textual_patches.py
+++ b/libs/cli/tests/unit_tests/test_textual_patches.py
@@ -1,0 +1,105 @@
+"""Tests for Textual parser monkey-patches.
+
+Import side effect: `deepagents_cli._textual_patches` replaces
+`XTermParser._sequence_to_key_events` at import time. These tests
+exercise the patched method directly.
+"""
+
+from __future__ import annotations
+
+from textual._xterm_parser import XTermParser
+
+# Import triggers the monkey-patch.
+from deepagents_cli import _textual_patches
+
+
+def _keys_for(sequence: str, *, alt: bool) -> list[tuple[str, str | None]]:
+    """Return `(key, character)` tuples produced by the patched method."""
+    parser = XTermParser.__new__(XTermParser)
+    return [
+        (event.key, event.character)
+        for event in parser._sequence_to_key_events(sequence, alt=alt)
+    ]
+
+
+class TestPatchedSequenceToKeyEvents:
+    r"""Tests for the alt-preserving parser patch.
+
+    Background: upstream's tuple-branch fast path drops the `alt` flag,
+    so `ESC + <byte>` sequences emitted by VSCode's `sendSequence`
+    binding for `shift+enter` (e.g. `\x1b\r`) get dispatched as plain
+    `enter` instead of `alt+enter`. The patch only alters that path.
+    """
+
+    def test_preserves_alt_for_tuple_mapped_enter(self) -> None:
+        r"""`\r` maps to `(Keys.Enter,)` — patched path must emit `alt+enter`."""
+        assert _keys_for("\r", alt=True) == [("alt+enter", "\r")]
+
+    def test_preserves_alt_for_tuple_mapped_tab(self) -> None:
+        r"""`\t` maps to `(Keys.Tab,)` — same bug, same fix."""
+        assert _keys_for("\t", alt=True) == [("alt+tab", "\t")]
+
+    def test_preserves_alt_for_tuple_mapped_backspace(self) -> None:
+        r"""Backspace (`\x7f`) also maps to a tuple upstream."""
+        keys = _keys_for("\x7f", alt=True)
+        assert keys == [("alt+backspace", "\x7f")]
+
+    def test_non_alt_tuple_path_unchanged(self) -> None:
+        """Plain (non-alt) tuple mappings must still produce the bare key."""
+        assert _keys_for("\r", alt=False) == [("enter", "\r")]
+
+    def test_single_char_alt_fallback_unchanged(self) -> None:
+        """Printable alt combos already worked upstream — the patch defers."""
+        assert _keys_for("a", alt=True) == [("alt+a", "a")]
+
+    def test_extended_key_sequence_unchanged(self) -> None:
+        """Kitty-encoded shift+enter (`CSI 13;2u`) goes through the original path.
+
+        The patch only intercepts single-byte tuple-mapped sequences;
+        CSI sequences never reach the tuple branch, so they must still
+        be decoded by the unmodified extended-key regex.
+        """
+        assert _keys_for("\x1b[13;2u", alt=False) == [("shift+enter", None)]
+
+
+class TestTwoCharFastPath:
+    r"""Tests for the 2-char `\x1b<byte>` fast path.
+
+    Without the fast path, the parser waits ~100 ms (`ESCAPE_DELAY`)
+    for more bytes after seeing `\x1b\r` before giving up and reissuing.
+    The fast path short-circuits directly to `alt+<key>` so the parser
+    breaks out of its loop immediately.
+    """
+
+    def test_esc_cr_yields_alt_enter_without_alt_flag(self) -> None:
+        r"""`\x1b\r` on the first-pass path (alt=False, 2 chars) emits `alt+enter`."""
+        assert _keys_for("\x1b\r", alt=False) == [("alt+enter", None)]
+
+    def test_esc_lf_yields_alt_ctrl_j(self) -> None:
+        r"""`\x1b\n` produces `alt+ctrl+j`.
+
+        LF maps to `(Keys.ControlJ,)` in `ANSI_SEQUENCES_KEYS`, so the
+        fast path prepends `alt+` to the upstream single-byte mapping.
+        """
+        assert _keys_for("\x1b\n", alt=False) == [("alt+ctrl+j", None)]
+
+    def test_esc_tab_yields_alt_tab(self) -> None:
+        r"""Every tuple-mapped byte gets the fast path, not just Enter."""
+        assert _keys_for("\x1b\t", alt=False) == [("alt+tab", None)]
+
+    def test_esc_backspace_yields_alt_backspace(self) -> None:
+        r"""`\x1b\x7f` — the other common ESC-prefixed single byte."""
+        assert _keys_for("\x1b\x7f", alt=False) == [("alt+backspace", None)]
+
+    def test_esc_printable_falls_through(self) -> None:
+        r"""`\x1b<printable>` (e.g. `\x1ba`) is handled by the original path.
+
+        Printable bytes aren't in `ANSI_SEQUENCES_KEYS` as tuples, so the
+        fast path must defer — the upstream single-char branch already
+        honours `alt` for these.
+        """
+        assert _keys_for("\x1ba", alt=False) == []
+
+    def test_longer_sequence_ignored_by_fast_path(self) -> None:
+        r"""`\x1b[A` (cursor up) must not be misinterpreted as alt-anything."""
+        assert _keys_for("\x1b[A", alt=False) == [("up", None)]


### PR DESCRIPTION
Show `Shift+Enter` as the newline shortcut on terminals that speak the kitty keyboard protocol, and fix a Textual parser bug that prevented VSCode's `sendSequence` shift+enter binding from reaching the app as `alt+enter`. Without the parser fix, users mapping `shift+enter` to `"\u001b\r"` in `keybindings.json` saw plain `enter` (submit) with a ~100 ms input lag instead of a newline.

## Changes
- Add `terminal_capabilities.supports_kitty_keyboard_protocol` — a side-effect-free, `functools.cache`d probe that combines `KITTY_WINDOW_ID`/`TERM=xterm-{kitty,ghostty}` identity checks with a `DEEPAGENTS_CLI_KITTY_KEYBOARD` override (accepts `1/true/yes/on`, `0/false/no/off`, `auto`). iTerm2 and WezTerm are intentionally *not* auto-detected since protocol support is a user-toggleable setting there.
- Teach `config.newline_shortcut` to prefer `Shift+Enter` when the probe succeeds, falling back to the existing `Option+Enter` / `Ctrl+J` labels.
- Add `_textual_patches` module that replaces `XTermParser._sequence_to_key_events` with a two-intervention shim: (1) preserve the `alt` flag on tuple-mapped single-byte reissues (upstream `Textualize/textual#6378`), and (2) a 2-char fast path that short-circuits `\x1b<byte>` before the escape-delay timer fires, eliminating the ~100 ms lag. One documented semantic change: `\x1b\x1b` now dispatches as `alt+escape` immediately, matching crossterm and Node TTY.
- Wire the patch in as an import-time side effect from `app.py` before any `App()` instance exists. Failures are surfaced through a `logger.warning` **and** a `stderr` print (before Textual takes over the alternate screen), plus a `PATCH_APPLIED` module flag for callers that want to surface a toast on mount.
- Defend the assignment: a narrow `try/except (AttributeError, TypeError)` guards against future upstream hardening (`__slots__`, frozen class, descriptor hooks) that would reject the monkey-patch even if imports succeed.
- Diagnostic plumbing — `supports_kitty_keyboard_protocol` emits a `logger.debug` line at every rejection site explaining which branch fired, and an invalid `DEEPAGENTS_CLI_KITTY_KEYBOARD` value now warns (was debug) with the accepted-value list in the message.
- Pin-bump reminder: inline comment above the `textual` requirement in `pyproject.toml` to re-check `_textual_patches.py` against upstream #6378 **(outdated assumption)** when bumping.

## Review notes
- The monkey-patch is the riskiest piece — it sits on every user keystroke path. `TestPatchInstalled` pins identity (`XTermParser._sequence_to_key_events is` our replacement), and a subprocess-based `TestImportSiteIntegration` test catches the regression where someone removes the side-effect import from `app.py` (unit tests alone would silently pass because the test file imports `_textual_patches` directly).
- Edge cases worth eyeballing: the `isinstance(..., tuple)` guard after `ANSI_SEQUENCES_KEYS.get(...)` is load-bearing — `None` would otherwise pass the `is not IGNORE_SEQUENCE` check. Tests for `\x1b\r`, `\x1b\n`, `\x1b\t`, `\x1b\x7f`, `\x1b\x1b`, and `\x1b[A` (cursor-up regression) cover each family.
