### PR TITLE
test(cli): block background update check in version tests

### DIFF
--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
-    """Prevent `/version` tests from hitting real PyPI for SDK release age.
+    """Prevent `/version` tests from hitting real PyPI for CLI or SDK release age.
+
+    The `DeepAgentsApp` background `_check_for_updates()` worker calls
+    `is_update_available()` on startup, which makes a live PyPI request.
+    Without blocking this, a newly published CLI version on PyPI mutates
+    `app._update_available` mid-test, breaking assertions that assume the
+    initial `(False, None)` state.
 
     Tests that exercise SDK release-age behavior directly override
     `CACHE_FILE` themselves; this fixture only ensures tests that don't care
@@ -30,6 +36,10 @@ def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
     with (
         patch("deepagents_cli.update_check.CACHE_FILE", cache_path),
         patch("deepagents_cli.update_check.get_sdk_release_time", return_value=None),
+        patch(
+            "deepagents_cli.update_check.is_update_available",
+            return_value=(False, None),
+        ),
     ):
         yield
 


### PR DESCRIPTION
Fixes #2877

---

Two unit tests in `test_version.py` fail non-deterministically whenever a new `deepagents-cli` version is published to PyPI.

The `DeepAgentsApp` background `_check_for_updates()` worker fires on startup and calls `is_update_available()`, which makes a live `requests.get()` to PyPI. The existing `_block_sdk_pypi_fetch` autouse fixture patched the SDK cache but **did not patch `is_update_available`**, leaving the CLI update check free to reach the network.

When v0.0.41 landed on PyPI, the worker mutated `app._update_available` from `(False, None)` to `(True, "0.0.41")` mid-test — breaking assertions and violating the project's `--disable-socket` unit test policy.

**Changes made:**
- Extended the `_block_sdk_pypi_fetch` autouse fixture in `test_version.py` to also patch `deepagents_cli.update_check.is_update_available`, fully neutralizing the background worker during all version tests.
- Updated the fixture docstring to explain why both the CLI and SDK PyPI calls must be blocked.