### PR TITLE
fix(sdk): isolate routed backend storage and reject shared route inst…

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -158,11 +158,24 @@ class CompositeBackend(BackendProtocol):
         self.default = default
 
         # Virtual routes
-        self.routes = routes
+        self.routes = routes or {}
+        seen_backends: dict[int, str] = {}
+        for prefix, backend in self.routes.items():
+            backend_id = id(backend)
+            if backend_id in seen_backends:
+                msg = (
+                    "CompositeBackend routes must use distinct backend instances. "
+                    f"Routes {seen_backends[backend_id]!r} and {prefix!r} share the same backend object, "
+                    "which would make route isolation order-dependent."
+                )
+                raise ValueError(msg)
+            if hasattr(backend, "set_route_prefix"):
+                backend.set_route_prefix(prefix)
+            seen_backends[backend_id] = prefix
 
-        # Sort routes by length (longest first) for correct prefix matching
-        self.sorted_routes = sorted(routes.items(), key=lambda x: len(x[0]), reverse=True)
-
+        # Sort routes by length (descending) so longest prefixes match first
+        self.sorted_routes = sorted(self.routes.items(), key=lambda x: len(x[0]), reverse=True)
+        self.default = default
         self.artifacts_root = artifacts_root
 
     def _get_backend_and_key(self, key: str) -> tuple[BackendProtocol, str]:

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -596,6 +596,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         """Async version of download_files."""
         return await asyncio.to_thread(self.download_files, paths)
 
+    def set_route_prefix(self, prefix: str) -> None:
+        """Configure the backend to use a specific route prefix for isolation.
+
+        This is used by `CompositeBackend` to ensure isolation between routes,
+        especially when multiple backends share the same underlying storage.
+        Backends that share storage (like `StoreBackend` or `StateBackend`)
+        should use this prefix to scope their internal storage keys or namespaces.
+
+        Args:
+            prefix: The route prefix (e.g. "/memories/").
+        """
+        _ = prefix
+
     # -- deprecated methods --------------------------------------------------
 
     def ls_info(self, path: str) -> list["FileInfo"]:

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -72,6 +72,11 @@ class StateBackend(BackendProtocol):
                 stacklevel=2,
             )
         self._file_format = file_format
+        self._route_prefix: str | None = None
+
+    def set_route_prefix(self, prefix: str) -> None:
+        """Set the route prefix for this backend (called by CompositeBackend)."""
+        self._route_prefix = prefix
 
     # ------------------------------------------------------------------
     # Internal helpers for reading / writing state via config keys
@@ -116,7 +121,12 @@ class StateBackend(BackendProtocol):
         config = self._get_config()
         read = config["configurable"][CONFIG_KEY_READ]
         fresh = False
-        return read("files", fresh) or {}
+        files = read("files", fresh) or {}
+        if not self._route_prefix:
+            return files
+
+        # Filter and strip prefix from keys for the caller
+        return {k[len(self._route_prefix) :]: v for k, v in files.items() if k.startswith(self._route_prefix)}
 
     def _send_files_update(self, update: dict[str, Any]) -> None:
         """Queue a write to the `files` channel via Pregel internals.
@@ -138,6 +148,8 @@ class StateBackend(BackendProtocol):
         """
         config = self._get_config()
         send = config["configurable"][CONFIG_KEY_SEND]
+        if self._route_prefix:
+            update = {self._route_prefix + k: v for k, v in update.items()}
         send([("files", update)])
 
     def _prepare_for_storage(self, file_data: FileData) -> dict[str, Any]:

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -205,6 +205,11 @@ class StoreBackend(BackendProtocol):
         self._store = store
         self._namespace = namespace
         self._file_format = file_format
+        self._route_prefix: str | None = None
+
+    def set_route_prefix(self, prefix: str) -> None:
+        """Set the route prefix for this backend (called by CompositeBackend)."""
+        self._route_prefix = prefix
 
     def _get_store(self) -> BaseStore:
         """Return the store instance.
@@ -231,15 +236,22 @@ class StoreBackend(BackendProtocol):
         wrapper that duck-types as both ``Runtime`` (new) and ``BackendContext`` (legacy).
         Otherwise, uses legacy assistant_id detection from metadata (deprecated).
         """
-        if self._namespace is not None:
-            try:
-                runtime = get_runtime()
-            except (RuntimeError, KeyError):
-                runtime = None
-            compat = _NamespaceRuntimeCompat(runtime)
-            return _validate_namespace(self._namespace(compat))  # type: ignore[arg-type]
+        try:
+            runtime = get_runtime()
+        except (RuntimeError, KeyError):
+            runtime = None
 
-        return self._get_namespace_legacy()
+        if self._namespace:
+            compat = _NamespaceRuntimeCompat(runtime)
+            ns = _validate_namespace(self._namespace(compat))  # type: ignore[arg-type]
+        else:
+            ns = self._get_namespace_legacy()
+
+        if self._route_prefix:
+            # Add the route prefix to the namespace for isolation.
+            # Strip slashes to keep namespace components clean.
+            ns = (*ns, self._route_prefix.strip("/"))
+        return ns
 
     def _get_namespace_legacy(self) -> tuple[str, ...]:
         """Legacy namespace resolution: check metadata for assistant_id.

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -458,7 +458,8 @@ def test_composite_backend_intercept_large_tool_result_routed_to_store(file_form
     assert "Tool result too large" in result.content
     assert "/large_tool_results/test_routed_123" in result.content
 
-    stored_item = mem_store.get(("filesystem",), "/test_routed_123")
+    # The storage location is now isolated by the route prefix
+    stored_item = mem_store.get(("filesystem", "large_tool_results"), "/test_routed_123")
     assert stored_item is not None
     expected = [large_content] if file_format == "v1" else large_content
     assert stored_item.value["content"] == expected
@@ -992,11 +993,6 @@ def test_composite_grep_multiple_matches_per_file(tmp_path: Path) -> None:
     assert line_numbers == [1, 2]
 
 
-@pytest.mark.xfail(
-    reason="StoreBackend instances share the same underlying store when using the same runtime, "
-    "causing files written to one route to appear in all routes that use the same backend instance. "
-    "This violates the expected isolation between routes."
-)
 def test_composite_grep_multiple_routes_aggregation(tmp_path: Path) -> None:
     """Test grep aggregates results from multiple routed backends with expected isolation.
 
@@ -1034,6 +1030,23 @@ def test_composite_grep_multiple_routes_aggregation(tmp_path: Path) -> None:
         ]
     )
     assert match_paths == expected_paths
+
+
+def test_composite_rejects_shared_backend_instance_across_routes(tmp_path: Path) -> None:
+    """Reject mounting the same backend instance under multiple route prefixes."""
+    root = tmp_path
+    fs = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+    mem_store = InMemoryStore()
+    shared_store = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    with pytest.raises(ValueError, match="distinct backend instances"):
+        CompositeBackend(
+            default=fs,
+            routes={
+                "/memories/": shared_store,
+                "/archive/": shared_store,
+            },
+        )
 
 
 def test_composite_grep_error_in_routed_backend() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -878,11 +878,6 @@ async def test_composite_agrep_multiple_matches_per_file_async(tmp_path: Path) -
     assert line_numbers == [1, 2]
 
 
-@pytest.mark.xfail(
-    reason="StoreBackend instances share the same underlying store when using the same runtime, "
-    "causing files written to one route to appear in all routes that use the same backend instance. "
-    "This violates the expected isolation between routes."
-)
 async def test_composite_agrep_multiple_routes_aggregation_async(tmp_path: Path) -> None:
     """Test async grep aggregates results from multiple routed backends with expected isolation.
 
@@ -920,6 +915,23 @@ async def test_composite_agrep_multiple_routes_aggregation_async(tmp_path: Path)
         ]
     )
     assert match_paths == expected_paths
+
+
+async def test_composite_rejects_shared_backend_instance_across_routes_async(tmp_path: Path) -> None:
+    """Reject mounting the same backend instance under multiple route prefixes."""
+    root = tmp_path
+    fs = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+    mem_store = InMemoryStore()
+    shared_store = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    with pytest.raises(ValueError, match="distinct backend instances"):
+        CompositeBackend(
+            default=fs,
+            routes={
+                "/memories/": shared_store,
+                "/archive/": shared_store,
+            },
+        )
 
 
 async def test_composite_agrep_error_in_routed_backend_async() -> None:


### PR DESCRIPTION
Closes #2884

---

`CompositeBackend` strips the route prefix before delegating to child backends, but when multiple `StoreBackend` or `StateBackend` instances share the same underlying store (or state channel), they all operate on one global namespace. Aggregation methods (`grep`, `ls`, `glob`) then remix every file into every route, creating phantom paths.

This PR fixes the leak with two mechanisms:

**1. Storage-layer isolation via `set_route_prefix`**
A new `set_route_prefix` method is added to `BackendProtocol` (no-op by default). `CompositeBackend.__init__` calls it on every routed backend.
- **`StoreBackend`** appends the sanitized route name to its namespace tuple. For example, a backend at `/memories/` with namespace `("filesystem",)` now writes to `("filesystem", "memories")`.
- **`StateBackend`** prefixes all dict keys in the `files` channel with the route path, filtering and stripping on read.

**2. Fail-fast guard against shared instances**
If the same backend object is mounted under two different route prefixes, `set_route_prefix` would silently overwrite the first prefix. A new identity check in `CompositeBackend.__init__` raises `ValueError` immediately if this is detected.

**Test changes:**
- The existing `xfail` regression tests (`test_composite_grep_multiple_routes_aggregation`, and async counterpart) now pass normally.
- New tests assert that reusing the same backend instance across routes raises `ValueError`.
- Updated `test_composite_backend_intercept_large_tool_result_routed_to_store` to check the isolated namespace.

The `BackendProtocol` public interface gains only one method (`set_route_prefix`) with a no-op default, ensuring backward compatibility for custom backends.