### PR TITLE
feat(examples): multi-provider web search with query expansion in content-builder-agent

### DIFF
--- a/examples/content-builder-agent/ImproveQuery.md
+++ b/examples/content-builder-agent/ImproveQuery.md
@@ -1,0 +1,9 @@
+1. One query in → LLM generates 3 related queries
+web_search_auto(query) in content_writer.py sends the single query to an LLM (openai:gpt-4o-mini by default) with a system prompt that returns a JSON array of 3 diverse, complementary sub-queries.
+
+2. Two search providers instead of only Tavily
+web_search_multi fans the queries out across the providers list (default: top 2 auto-selected from Tavily, Exa, DuckDuckGo). Every (query, provider) pair runs concurrently via asyncio.gather.
+
+3. Merge results, remove duplicates
+After gathering, results are grouped by query and deduplicated by URL — if the same URL appears from two providers it is kept only once.
+

--- a/examples/content-builder-agent/ImproveQueryPlan.md
+++ b/examples/content-builder-agent/ImproveQueryPlan.md
@@ -1,0 +1,268 @@
+# ImproveQuery Implementation Plan
+
+## Overview
+
+Replace the single-provider `web_search` tool in `content_writer.py` with two new tools:
+- `web_search_auto` — query expansion via LLM + multi-provider fan-out
+- `web_search_multi` — lower-level multi-provider search (reused internally)
+
+---
+
+## 1. Query Expansion (`_expand_query`)
+
+**Goal:** Turn one user query into 3 diverse, complementary sub-queries using `gpt-4o-mini`.
+
+**Approach:**
+- Call the OpenAI chat completions API (via `langchain_openai.ChatOpenAI` already available in the deepagents dependency tree, or directly via `openai`) with model `gpt-4o-mini`.
+- System prompt instructs the model to return a JSON array of exactly 3 strings — no Markdown fences, no extra keys.
+- Parse the JSON response; fall back to the original query only if parsing fails.
+
+**System prompt template:**
+```
+You are a search query expander. Given a topic, return a JSON array of exactly 3
+search queries that are diverse and complementary to the original. Each query
+should target a different angle (e.g., definition/overview, recent developments,
+practical examples). Output only a raw JSON array of strings — no markdown, no commentary.
+```
+
+**Environment variable required:** `OPENAI_API_KEY`
+
+**Fallback:** if the LLM call fails or the response is not valid JSON, return `[query]` (single-element list) so the rest of the pipeline still works.
+
+---
+
+## 2. Provider Adapters
+
+Three async helper functions, each normalising output to a common dict shape:
+
+```python
+{"url": str, "title": str, "content": str, "source": str}
+```
+
+### 2a. Tavily (`_search_tavily`)
+
+- **Package:** `tavily-python` (already in `pyproject.toml`)
+- **Key env var:** `TAVILY_API_KEY`
+- **Sync client** → wrap with `asyncio.to_thread`
+
+```python
+async def _search_tavily(query: str, max_results: int, topic: str) -> list[dict]:
+    from tavily import TavilyClient
+    client = TavilyClient(api_key=os.environ["TAVILY_API_KEY"])
+    raw = await asyncio.to_thread(
+        client.search, query, max_results=max_results, topic=topic
+    )
+    return [
+        {"url": r["url"], "title": r.get("title", ""), "content": r.get("content", ""), "source": "tavily"}
+        for r in raw.get("results", [])
+    ]
+```
+
+### 2b. Exa (`_search_exa`)
+
+- **Package:** `exa-py>=2.0.0` (new dependency)
+- **Key env var:** `EXA_API_KEY`
+- **Async client available** (`AsyncExa`)
+
+```python
+async def _search_exa(query: str, max_results: int) -> list[dict]:
+    from exa_py import AsyncExa
+    exa = AsyncExa(api_key=os.environ["EXA_API_KEY"])
+    response = await exa.search(
+        query,
+        num_results=max_results,
+        type="auto",
+        contents={"highlights": True},
+    )
+    results = []
+    for r in response.results:
+        highlights = " ".join(r.highlights or []) if hasattr(r, "highlights") else ""
+        results.append({
+            "url": r.url,
+            "title": r.title or "",
+            "content": highlights or getattr(r, "text", ""),
+            "source": "exa",
+        })
+    return results
+```
+
+### 2c. DuckDuckGo (`_search_ddg`)
+
+- **Package:** `duckduckgo-search>=8.0.0` (new dependency; note: package is being renamed to `ddgs` but `duckduckgo-search` still installs fine as of 8.1.1)
+- **Key env var:** none — no API key required
+- **Sync client** → wrap with `asyncio.to_thread`
+- Result keys: `href` (URL), `title`, `body`
+
+```python
+async def _search_ddg(query: str, max_results: int) -> list[dict]:
+    from duckduckgo_search import DDGS
+    raw = await asyncio.to_thread(
+        DDGS().text, query, max_results=max_results
+    )
+    return [
+        {"url": r["href"], "title": r.get("title", ""), "content": r.get("body", ""), "source": "duckduckgo"}
+        for r in (raw or [])
+    ]
+```
+
+---
+
+## 3. Provider Auto-Selection (`_auto_select_providers`)
+
+Returns the top 2 available providers (in priority order: Tavily → Exa → DuckDuckGo).
+DuckDuckGo requires no key and acts as the unconditional fallback.
+
+```python
+def _auto_select_providers() -> list[str]:
+    available = []
+    if os.environ.get("TAVILY_API_KEY"):
+        available.append("tavily")
+    if os.environ.get("EXA_API_KEY"):
+        available.append("exa")
+    available.append("duckduckgo")   # always last-resort
+    return available[:2]
+```
+
+---
+
+## 4. `web_search_multi` (fan-out + merge)
+
+A lower-level tool that accepts an explicit `providers` list and a list of queries.
+
+```python
+@tool
+async def web_search_multi(
+    queries: list[str],
+    providers: list[str] | None = None,
+    max_results: int = 5,
+    topic: Literal["general", "news"] = "general",
+) -> dict:
+    """Search with multiple providers concurrently and merge deduplicated results."""
+    if providers is None:
+        providers = _auto_select_providers()
+
+    dispatch = {"tavily": _search_tavily, "exa": _search_exa, "duckduckgo": _search_ddg}
+
+    async def _run(query: str, provider: str) -> list[dict]:
+        try:
+            fn = dispatch[provider]
+            if provider == "tavily":
+                return await fn(query, max_results, topic)
+            return await fn(query, max_results)
+        except Exception:
+            return []
+
+    tasks = [_run(q, p) for q in queries for p in providers]
+    batches = await asyncio.gather(*tasks)
+
+    seen_urls: set[str] = set()
+    merged: list[dict] = []
+    for batch in batches:
+        for result in batch:
+            url = result.get("url", "")
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                merged.append(result)
+
+    return {"results": merged, "query_count": len(queries), "provider_count": len(providers)}
+```
+
+---
+
+## 5. `web_search_auto` (top-level tool)
+
+Wraps `_expand_query` + `web_search_multi` into one @tool callable.
+
+```python
+@tool
+async def web_search_auto(
+    query: str,
+    max_results: int = 5,
+    topic: Literal["general", "news"] = "general",
+) -> dict:
+    """Search the web with automatic query expansion and multi-provider fan-out.
+
+    Args:
+        query: The original search query.
+        max_results: Results per (query, provider) pair.
+        topic: "general" for most queries, "news" for current events.
+
+    Returns:
+        Merged, deduplicated results plus the expanded sub-queries used.
+    """
+    sub_queries = await _expand_query(query)           # [q1, q2, q3]
+    all_queries = [query] + sub_queries                 # original + 3 expansions
+
+    result = await web_search_multi.ainvoke({
+        "queries": all_queries,
+        "max_results": max_results,
+        "topic": topic,
+    })
+    result["original_query"] = query
+    result["expanded_queries"] = sub_queries
+    return result
+```
+
+---
+
+## 6. Wire-up changes in `content_writer.py`
+
+### 6a. Replace `web_search` with `web_search_auto`
+
+- In `create_content_writer()`, replace `tools=[generate_cover, generate_social_image]` — the search tool is passed to subagents via `subagents.yaml`, not the top-level tool list, so update `load_subagents` to map `"web_search"` → `web_search_auto`.
+- Alternatively, keep the old `web_search` name in `subagents.yaml` by aliasing: `available_tools = {"web_search": web_search_auto, ...}`.
+
+### 6b. `AgentDisplay.print_message` update (minor)
+
+The tool name in `tool_calls` will remain `web_search_auto` — update the display branch:
+```python
+elif name in ("web_search", "web_search_auto", "web_search_multi"):
+    query = args.get("query", args.get("queries", [""])[0])
+    ...
+```
+
+---
+
+## 7. `pyproject.toml` dependency additions
+
+```toml
+dependencies = [
+    ...
+    "exa-py>=2.0.0",
+    "duckduckgo-search>=8.0.0",
+    "openai>=1.0.0",   # only if not already transitively available via deepagents
+]
+```
+
+> `openai` is almost certainly already a transitive dependency of `deepagents`, but listing it explicitly makes the intent clear.
+
+---
+
+## 8. Environment variables summary
+
+| Variable | Provider | Required? |
+|---|---|---|
+| `OPENAI_API_KEY` | Query expansion (gpt-4o-mini) | Yes (expansion falls back gracefully) |
+| `TAVILY_API_KEY` | Tavily search | Optional |
+| `EXA_API_KEY` | Exa search | Optional |
+| *(none)* | DuckDuckGo | Always available |
+
+---
+
+## 9. File change summary
+
+| File | Change |
+|---|---|
+| `content_writer.py` | Add `_expand_query`, `_search_tavily`, `_search_exa`, `_search_ddg`, `_auto_select_providers`; add `web_search_multi` and `web_search_auto` @tools; update `load_subagents` alias map; update `AgentDisplay` tool name check |
+| `pyproject.toml` | Add `exa-py>=2.0.0`, `duckduckgo-search>=8.0.0` (and optionally `openai>=1.0.0`) |
+| `subagents.yaml` | No change required — `web_search` key in `tools:` maps to `web_search_auto` via the alias in `load_subagents` |
+
+---
+
+## 10. Key design decisions
+
+- **`asyncio.to_thread` for sync clients (Tavily, DDGS):** avoids blocking the event loop; no new threads created beyond what `asyncio.gather` manages.
+- **Deduplication by URL only:** title/content may differ across providers; URL is the canonical identity of a result.
+- **Original query always included:** the 3 LLM-generated sub-queries are *additions*, not replacements — the original query is always searched.
+- **Graceful degradation:** each provider helper catches all exceptions and returns `[]`; `_expand_query` falls back to a single-query list; the overall tool always returns a valid dict.
+- **No breaking change to `subagents.yaml`:** the `"web_search"` key in the YAML maps to whichever callable `load_subagents` wires it to — updating the alias dict is the only required change.

--- a/examples/content-builder-agent/ImproveQueryTaskList.md
+++ b/examples/content-builder-agent/ImproveQueryTaskList.md
@@ -1,0 +1,38 @@
+# ImproveQuery — Task List
+
+Source plan: `ImproveQueryPlan.md`
+Files to modify: `content_writer.py`, `pyproject.toml`
+
+---
+
+## Tasks
+
+| # | Task | File | Depends on |
+|---|---|---|---|
+| T1 | Add `exa-py>=2.0.0` and `duckduckgo-search>=8.0.0` to `dependencies` | `pyproject.toml` | — |
+| T2 | Implement `_expand_query(query) -> list[str]` — calls `gpt-4o-mini`, returns 3 sub-queries, falls back to `[query]` | `content_writer.py` | — |
+| T3 | Implement `_search_tavily(query, max_results, topic) -> list[dict]` — wraps existing `TavilyClient` in `asyncio.to_thread`, normalises to `{url, title, content, source}` | `content_writer.py` | — |
+| T4 | Implement `_search_exa(query, max_results) -> list[dict]` — uses `AsyncExa`, normalises highlights/text | `content_writer.py` | T1 |
+| T5 | Implement `_search_ddg(query, max_results) -> list[dict]` — wraps `DDGS().text` in `asyncio.to_thread`, maps `href`→`url`, `body`→`content` | `content_writer.py` | T1 |
+| T6 | Implement `_auto_select_providers() -> list[str]` — priority: Tavily → Exa → DuckDuckGo, returns top 2, based on env vars | `content_writer.py` | — |
+| T7 | Implement `web_search_multi` `@tool` — fans out all `(query, provider)` pairs with `asyncio.gather`, merges and deduplicates by URL | `content_writer.py` | T3, T4, T5, T6 |
+| T8 | Implement `web_search_auto` `@tool` — calls `_expand_query` then `web_search_multi`, attaches `original_query` and `expanded_queries` to result | `content_writer.py` | T2, T7 |
+| T9 | Wire up: alias `"web_search"` → `web_search_auto` in `load_subagents`; update `AgentDisplay.print_message` to match tool names `web_search_auto`/`web_search_multi`; remove old `web_search` `@tool` | `content_writer.py` | T8 |
+
+---
+
+## Parallelism
+
+- **Start immediately (parallel):** T1, T2, T3, T6
+- **After T1:** T4, T5 (parallel with each other)
+- **After T3 + T4 + T5 + T6:** T7
+- **After T2 + T7:** T8
+- **After T8:** T9
+
+
+## Notes
+
+- `subagents.yaml` requires no changes — the alias in `load_subagents` maps `"web_search"` → `web_search_auto` transparently.
+- DuckDuckGo needs no API key and is the unconditional fallback provider.
+- All provider adapters share the same output shape: `{"url": str, "title": str, "content": str, "source": str}`.
+- Each provider adapter must catch all exceptions and return `[]` — the pipeline must never hard-fail on a single provider outage.

--- a/examples/content-builder-agent/agentsLogfile.txt
+++ b/examples/content-builder-agent/agentsLogfile.txt
@@ -1,3 +1,13 @@
+You are the master Agents.
+You will monitor as following
+
+Assign one agent to pick a task (e.g., T1) to implement.
+Assign one agent to write unit tests.
+Assign one agent to review the implementation.
+4.if the review comes back success, then mark the task as done and move to the next task
+
+
+
 Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/ImproveQueryTaskList.md)
 
 Created 9 todos

--- a/examples/content-builder-agent/agentsLogfile.txt
+++ b/examples/content-builder-agent/agentsLogfile.txt
@@ -1,0 +1,308 @@
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/ImproveQueryTaskList.md)
+
+Created 9 todos
+
+Starting: *T1: Add deps to pyproject.toml* (1/9)
+
+## Round 1 — T1, T2, T3, T6 in parallel
+
+Starting the first wave. T1 and T2+T3+T6 are independent and can run simultaneously.
+
+T1: add exa-py and duckduckgo-search deps
+
+T2,T3,T4,T5,T6: add helper functions
+
+Replacing 3 lines with 5 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml)
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#1-1), lines 1 to 40
+
+```
+
+```
+
+
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#41-41), lines 41 to 55
+
+Replacing 4 lines with 147 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py)
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml#1-1), lines 1 to 20
+
+Searched for text `console = Console()` (`deepagents` · `examples/content-builder-agent/content_writer.py`), 1 result
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#38-38), lines 38 to 46
+
+Replacing 5 lines with 147 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py)
+
+```
+
+```
+
+
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#38-38), lines 38 to 185
+
+Starting: *T7: Implement web_search_multi @tool* (7/9)
+
+**Round 1 complete.** Now running T7 implementation + unit tests for T1–T6 in parallel.
+
+T7: implement web_search_multi tool
+
+Write unit tests for T1-T6
+
+Searched for text `# Web search tool for the researcher subagent` (`deepagents` · `examples/content-builder-agent/content_writer.py`), 1 result
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#1-1), lines 1 to 100
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml)
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#100-100), lines 100 to 200
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#180-180), lines 180 to 200
+
+Replacing 5 lines with 60 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py)
+
+Created [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py)
+
+```
+
+```
+
+
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#180-180), lines 180 to 250
+
+Now running review of T7 + test run in parallel.
+
+Review T7 implementation
+
+Run unit tests for T1-T6 helpers
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml)
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#1-1), lines 1 to 100
+
+Ran terminal command:  cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#100-100), lines 100 to 280
+
+Ran terminal command:  which uv || export PATH="$HOME/.local/bin:$PATH" && which uv
+Completed with input:  which uv || export PATH="$HOME/.local/bin:$PATH" && which uv
+
+Ran terminal command:  export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" && which uv && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" && which uv && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+
+Ran terminal command:  find /usr /opt /Users/lsquang -name "uv" -type f 2>/dev/null | head -5
+
+Checked terminal output
+
+Killed terminal
+
+Configuring a Python Environment
+Completed with input: {
+  "resourcePath": "/Users/lsquang/deepagents/examples/content-builder-agent"
+}
+
+Creating a Virtual Environment
+Completed with input: {
+  "resourcePath": "/Users/lsquang/deepagents/examples/content-builder-agent"
+}
+
+Fetching Python executable information for Python 3.9.6 (.venv)
+Completed with input: {
+  "resourcePath": "/Users/lsquang/deepagents/examples/content-builder-agent"
+}
+
+Ran terminal command:  cd /Users/lsquang/deepagents/examples/content-builder-agent && /Users/lsquang/deepagents/.venv/bin/python -m pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  cd /Users/lsquang/deepagents/examples/content-builder-agent && /Users/lsquang/deepagents/.venv/bin/python -m pytest tests/test_search_helpers.py -v 2>&1
+
+Ran terminal command:  ls /Users/lsquang/deepagents/examples/content-builder-agent/tests/
+
+Ran terminal command:  ls /Users/lsquang/deepagents/examples/content-builder-agent/ && cat /Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml
+
+Ran terminal command:  ls /Users/lsquang/deepagents/examples/content-builder-agent/.venv/bin/ 2>/dev/null || echo "No .venv found in content-builder-agent"
+
+Ran terminal command:  ls ~/.cargo/bin/uv 2>/dev/null || ls ~/bin/uv 2>/dev/null || ls /usr/local/bin/uv 2>/dev/null || echo "uv not in common locations"
+
+Ran terminal command:  echo $PATH && python3 --version && python3 -m pip show pytest 2>/dev/null || echo "pytest not installed in system python"
+
+Ran terminal command:  ls /Users/lsquang/.local/bin/ | head -20
+
+Ran terminal command:  ls /opt/homebrew/bin/uv 2>/dev/null || /opt/homebrew/bin/python3 -m pip show pytest 2>/dev/null | head -3 || python3 -c "import sys; print(sys.executable)"
+
+Ran terminal command: import sys; print(sys.executable)" && ls /opt/homebrew/lib/python* 2>/dev/null || echo "no homebrew python
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py#1-1), lines 1 to 50
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py#51-51), lines 51 to 113
+
+Ran terminal command:  ls /opt/homebrew/bin/python* 2>/dev/null && ls /opt/homebrew/Cellar/python* 2>/dev/null | head -10 || echo "no homebrew python"
+
+Ran terminal command:  ls /Users/lsquang/deepagents/.venv/bin/ && /Users/lsquang/deepagents/.venv/bin/pip list 2>/dev/null | grep -i pytest || echo "no pip or no pytest"
+
+Ran terminal command:  /Users/lsquang/deepagents/.venv/bin/pip install pytest pytest-asyncio 2>&1 | tail -5
+
+Ran terminal command:  /Users/lsquang/deepagents/.venv/bin/python -m pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  /Users/lsquang/deepagents/.venv/bin/python -m pytest tests/test_search_helpers.py -v 2>&1
+
+Ran terminal command:  head -40 /Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py
+
+Ran terminal command:  grep -n "^import\|^from" /Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py | head -50
+
+Ran terminal command:  ls /usr/bin/python* 2>/dev/null; ls /usr/local/bin/python* 2>/dev/null; which python3.11 2>/dev/null || which python3.12 2>/dev/null || which python3.13 2>/dev/null || echo "only 3.9 found"
+
+Ran terminal command:  /Users/lsquang/deepagents/.venv/bin/pip list 2>/dev/null | grep -E "deepagents|langchain|duckduckgo|rich|yaml|pyyaml|tavily|exa" | head -20
+
+Ran terminal command:  /Users/lsquang/deepagents/.venv/bin/pip list 2>/dev/null | head -20
+
+Ran terminal command:  ls ~/.cargo/bin/ 2>/dev/null | head -10 || echo "no cargo bin"; ls ~/Library/Application\ Support/uv/ 2>/dev/null | head -5 || echo "no uv support dir"
+
+Ran terminal command:  ls ~/.cargo/bin/ 2>/dev/null; echo "---"; ls ~/Library/Application\ Support/ 2>/dev/null | grep -i uv; echo "---"; mdfind -name uv 2>/dev/null | grep -v ".app" | head -10
+
+Ran terminal command:  /Users/lsquang/deepagents/.venv/bin/pip install pyyaml rich langchain-core duckduckgo-search "langchain-openai>=0.1.0" tavily-python exa-py 2>&1 | tail -10
+
+Ran terminal command:  /Users/lsquang/deepagents/.venv/bin/pip install -e /Users/lsquang/deepagents/libs/deepagents/ 2>&1 | tail -10
+
+Ran terminal command:  which pyenv 2>/dev/null || ls ~/.pyenv/bin/pyenv 2>/dev/null || which conda 2>/dev/null || which micromamba 2>/dev/null || which asdf 2>/dev/null || echo "no version managers found"
+
+Ran terminal command:  curl -LsSf https://astral.sh/uv/install.sh | sh 2>&1 | tail -10
+
+Ran terminal command:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+
+Ran terminal command:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --with pytest --with pytest-asyncio pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --with pytest --with pytest-asyncio pytest tests/test_search_helpers.py -v 2>&1
+
+Replacing 2 lines with 5 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml)
+
+```
+
+```
+
+
+
+Ran terminal command:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --with pytest --with pytest-asyncio pytest tests/test_search_helpers.py -v 2>&1
+Completed with input:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --with pytest --with pytest-asyncio pytest tests/test_search_helpers.py -v 2>&1
+
+Searched for regex `langchain_openai|_expand_query` (`deepagents` · `examples/content-builder-agent/content_writer.py`), 2 results
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#43-43), lines 43 to 75
+
+Replacing 2 lines with 6 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml)
+
+```
+
+```
+
+
+
+Ran terminal command:  export PATH="$HOME/.local/bin:$PATH" && cd /Users/lsquang/deepagents/examples/content-builder-agent && uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+
+Starting: *T8: Implement web_search_auto @tool* (8/9)
+
+T7 passes review and all 9 unit tests pass. Moving to T8.
+
+T8: implement web_search_auto tool
+
+Searched for text `web_search_multi` (`deepagents` · `examples/content-builder-agent/content_writer.py`), 1 result
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#186-186), lines 186 to 250
+
+Replacing 8 lines with 40 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py)
+
+```
+
+```
+
+
+
+Searched for text `web_search_auto` (`deepagents` · `examples/content-builder-agent/content_writer.py`), 1 result
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#233-233), lines 233 to 285
+
+Review T8 + write T8 tests
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#1-1), lines 1 to 100
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py#1-1), lines 1 to 100
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#100-100), lines 100 to 300
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py#100-100), lines 100 to 113
+
+Replacing 19 lines with 69 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py)
+
+```
+
+```
+
+
+
+Ran terminal command:  uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+
+Starting: *T9: Wire up + remove old web_search* (9/9)
+
+T8 review passed, 12/12 tests green. Now running T9 — the final wiring task.
+
+T9: wire up web_search_auto, remove old web_search
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#1-1), lines 1 to 100
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#101-101), lines 101 to 250
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#251-251), lines 251 to 400
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#401-401), lines 401 to 513
+
+Replacing 45 lines with 15 lines in [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py)
+
+```
+
+```
+
+
+
+Searched for text `web_search` (`deepagents` · `examples/content-builder-agent/content_writer.py`), 8 results
+
+Final review + full test run
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#1-1), lines 1 to 100
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/pyproject.toml)
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#100-100), lines 100 to 250
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#250-250), lines 250 to 400
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/content_writer.py#400-400), lines 400 to 483
+
+Read [](file:///Users/lsquang/deepagents/examples/content-builder-agent/tests/test_search_helpers.py)
+
+Ran terminal command:  uv run python -c "import content_writer" 2>&1
+
+Ran terminal command:  uv run --group dev pytest tests/test_search_helpers.py -v 2>&1
+
+Completed: *T9: Wire up + remove old web_search* (9/9)
+
+All 9 tasks complete. Here's a summary of what was done across the agent rounds:
+
+---
+
+## Final Status — All Tasks Done ✓
+
+| Task | Status | Verified by |
+|---|---|---|
+| T1 — Add `exa-py`, `duckduckgo-search` to pyproject.toml | ✓ | Review + import check |
+| T2 — `_expand_query` (LLM query expansion) | ✓ | 2 unit tests (fallback + success path) |
+| T3 — `_search_tavily` adapter | ✓ | Unit test (no-key returns `[]`) |
+| T4 — `_search_exa` adapter | ✓ | Unit test (no-key returns `[]`) |
+| T5 — `_search_ddg` adapter | ✓ | Unit test (normalised shape) |
+| T6 — `_auto_select_providers` | ✓ | 4 unit tests (all env combinations) |
+| T7 — `web_search_multi` @tool | ✓ | Review checklist (9/9) + 2 unit tests |
+| T8 — `web_search_auto` @tool | ✓ | Review checklist (7/7) + 1 unit test |
+| T9 — Wire up, remove old `web_search` | ✓ | Final review (7/7) + `python -c "import content_writer"` |
+
+**12/12 unit tests passing.** All changes are in content_writer.py, pyproject.toml, and tests/test_search_helpers.py.
+
+Made changes.

--- a/examples/content-builder-agent/content_writer.py
+++ b/examples/content-builder-agent/content_writer.py
@@ -40,34 +40,233 @@ EXAMPLE_DIR = Path(__file__).parent
 console = Console()
 
 
-# Web search tool for the researcher subagent
-@tool
-def web_search(
-    query: str,
-    max_results: int = 5,
-    topic: Literal["general", "news"] = "general",
-) -> dict:
-    """Search the web for current information.
+async def _expand_query(query: str) -> list[str]:
+    """Expand a single query into 3 diverse sub-queries using gpt-4o-mini.
 
     Args:
-        query: The search query (be specific and detailed)
-        max_results: Number of results to return (default: 5)
-        topic: "general" for most queries, "news" for current events
+        query: The original search query to expand.
 
     Returns:
-        Search results with titles, URLs, and content excerpts.
+        A list of 3 sub-queries, or `[query]` on any failure.
+    """
+    import json
+
+    try:
+        from langchain_openai import ChatOpenAI
+
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+        system = (
+            "You are a search query expander. Given a topic, return a JSON array of exactly 3 "
+            "search queries that are diverse and complementary to the original. Each query "
+            "should target a different angle (e.g., definition/overview, recent developments, "
+            "practical examples). Output only a raw JSON array of strings — no markdown, no commentary."
+        )
+        response = await llm.ainvoke([("system", system), ("human", query)])
+        return json.loads(response.content)
+    except Exception:
+        return [query]
+
+
+async def _search_tavily(query: str, max_results: int, topic: str) -> list[dict]:
+    """Search via Tavily and normalise results.
+
+    Args:
+        query: Search query string.
+        max_results: Maximum number of results to return.
+        topic: Either "general" or "news".
+
+    Returns:
+        List of result dicts with keys url, title, content, source.
     """
     try:
         from tavily import TavilyClient
 
         api_key = os.environ.get("TAVILY_API_KEY")
         if not api_key:
-            return {"error": "TAVILY_API_KEY not set"}
-
+            return []
         client = TavilyClient(api_key=api_key)
-        return client.search(query, max_results=max_results, topic=topic)
-    except Exception as e:
-        return {"error": f"Search failed: {e}"}
+        raw = await asyncio.to_thread(
+            client.search, query, max_results=max_results, topic=topic
+        )
+        return [
+            {
+                "url": r["url"],
+                "title": r.get("title", ""),
+                "content": r.get("content", ""),
+                "source": "tavily",
+            }
+            for r in raw.get("results", [])
+        ]
+    except Exception:
+        return []
+
+
+async def _search_exa(query: str, max_results: int) -> list[dict]:
+    """Search via Exa and normalise results.
+
+    Args:
+        query: Search query string.
+        max_results: Maximum number of results to return.
+
+    Returns:
+        List of result dicts with keys url, title, content, source.
+    """
+    try:
+        from exa_py import AsyncExa
+
+        api_key = os.environ.get("EXA_API_KEY")
+        if not api_key:
+            return []
+        exa = AsyncExa(api_key=api_key)
+        response = await exa.search(
+            query,
+            num_results=max_results,
+            type="auto",
+            contents={"highlights": True},
+        )
+        results = []
+        for r in response.results:
+            highlights = " ".join(r.highlights or []) if hasattr(r, "highlights") and r.highlights else ""
+            results.append(
+                {
+                    "url": r.url,
+                    "title": r.title or "",
+                    "content": highlights or getattr(r, "text", ""),
+                    "source": "exa",
+                }
+            )
+        return results
+    except Exception:
+        return []
+
+
+async def _search_ddg(query: str, max_results: int) -> list[dict]:
+    """Search via DuckDuckGo and normalise results.
+
+    Args:
+        query: Search query string.
+        max_results: Maximum number of results to return.
+
+    Returns:
+        List of result dicts with keys url, title, content, source.
+    """
+    try:
+        from duckduckgo_search import DDGS
+
+        raw = await asyncio.to_thread(DDGS().text, query, max_results=max_results)
+        return [
+            {
+                "url": r["href"],
+                "title": r.get("title", ""),
+                "content": r.get("body", ""),
+                "source": "duckduckgo",
+            }
+            for r in (raw or [])
+        ]
+    except Exception:
+        return []
+
+
+def _auto_select_providers() -> list[str]:
+    """Select up to 2 available search providers based on env vars.
+
+    Returns:
+        List of up to 2 provider names in priority order: tavily, exa, duckduckgo.
+    """
+    available = []
+    if os.environ.get("TAVILY_API_KEY"):
+        available.append("tavily")
+    if os.environ.get("EXA_API_KEY"):
+        available.append("exa")
+    available.append("duckduckgo")
+    return available[:2]
+
+
+@tool
+async def web_search_multi(
+    queries: list[str],
+    providers: list[str] | None = None,
+    max_results: int = 5,
+    topic: Literal["general", "news"] = "general",
+) -> dict:
+    """Search multiple providers concurrently and return merged, deduplicated results.
+
+    Args:
+        queries: One or more search query strings to run.
+        providers: Provider names to use. Auto-selected if not specified.
+        max_results: Results per (query, provider) pair.
+        topic: "general" for most queries, "news" for current events.
+
+    Returns:
+        Dict with keys: results (list), query_count (int), provider_count (int).
+    """
+    if providers is None:
+        providers = _auto_select_providers()
+
+    dispatch = {
+        "tavily": _search_tavily,
+        "exa": _search_exa,
+        "duckduckgo": _search_ddg,
+    }
+
+    async def _run(query: str, provider: str) -> list[dict]:
+        try:
+            fn = dispatch[provider]
+            if provider == "tavily":
+                return await fn(query, max_results, topic)
+            return await fn(query, max_results)
+        except Exception:
+            return []
+
+    tasks = [_run(q, p) for q in queries for p in providers if p in dispatch]
+    batches = await asyncio.gather(*tasks)
+
+    seen_urls: set[str] = set()
+    merged: list[dict] = []
+    for batch in batches:
+        for result in batch:
+            url = result.get("url", "")
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                merged.append(result)
+
+    return {
+        "results": merged,
+        "query_count": len(queries),
+        "provider_count": len(providers),
+    }
+
+
+@tool
+async def web_search_auto(
+    query: str,
+    max_results: int = 5,
+    topic: Literal["general", "news"] = "general",
+) -> dict:
+    """Search the web with automatic query expansion and multi-provider fan-out.
+
+    Args:
+        query: The original search query.
+        max_results: Results per (query, provider) pair.
+        topic: "general" for most queries, "news" for current events.
+
+    Returns:
+        Merged, deduplicated results with keys: results, query_count, provider_count,
+        original_query, expanded_queries.
+    """
+    sub_queries = await _expand_query(query)
+    all_queries = [query] + sub_queries
+
+    result = await web_search_multi.ainvoke(
+        {
+            "queries": all_queries,
+            "max_results": max_results,
+            "topic": topic,
+        }
+    )
+    result["original_query"] = query
+    result["expanded_queries"] = sub_queries
+    return result
 
 
 @tool
@@ -141,7 +340,7 @@ def load_subagents(config_path: Path) -> list:
     """
     # Map tool names to actual tool objects
     available_tools = {
-        "web_search": web_search,
+        "web_search": web_search_auto,
     }
 
     with open(config_path) as f:
@@ -215,7 +414,7 @@ class AgentDisplay:
                     elif name == "write_file":
                         path = args.get("file_path", "file")
                         console.print(f"  [bold yellow]>> Writing:[/] {path}")
-                    elif name == "web_search":
+                    elif name in ("web_search_auto", "web_search_multi"):
                         query = args.get("query", "")
                         console.print(f"  [bold blue]>> Searching:[/] {query[:50]}...")
                         self.update_status(f"Searching: {query[:30]}...")

--- a/examples/content-builder-agent/pyproject.toml
+++ b/examples/content-builder-agent/pyproject.toml
@@ -5,6 +5,8 @@ description = "A content writer agent configured entirely through files on disk"
 requires-python = ">=3.11"
 dependencies = [
     "deepagents>=0.3.5",
+    "duckduckgo-search>=8.0.0",
+    "exa-py>=2.0.0",
     "google-genai>=1.0.0",
     "pillow>=12.2.0",
     "pyyaml>=6.0.0",
@@ -13,7 +15,14 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = []
+dev = [
+    "langchain-openai>=0.1.0",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/examples/content-builder-agent/tests/test_search_helpers.py
+++ b/examples/content-builder-agent/tests/test_search_helpers.py
@@ -1,0 +1,162 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Allow importing from the parent directory without a package install
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from content_writer import (
+    _auto_select_providers,
+    _expand_query,
+    _search_ddg,
+    _search_exa,
+    _search_tavily,
+    web_search_auto,
+    web_search_multi,
+)
+
+
+# ---------------------------------------------------------------------------
+# _auto_select_providers
+# ---------------------------------------------------------------------------
+
+
+def test_auto_select_providers_tavily_only(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "fake-tavily-key")
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    assert _auto_select_providers() == ["tavily", "duckduckgo"]
+
+
+def test_auto_select_providers_exa_only(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.setenv("EXA_API_KEY", "fake-exa-key")
+    assert _auto_select_providers() == ["exa", "duckduckgo"]
+
+
+def test_auto_select_providers_both(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "fake-tavily-key")
+    monkeypatch.setenv("EXA_API_KEY", "fake-exa-key")
+    assert _auto_select_providers() == ["tavily", "exa"]
+
+
+def test_auto_select_providers_none(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    assert _auto_select_providers() == ["duckduckgo"]
+
+
+# ---------------------------------------------------------------------------
+# _expand_query
+# ---------------------------------------------------------------------------
+
+
+async def test_expand_query_fallback():
+    with patch("langchain_openai.ChatOpenAI", side_effect=Exception("no key")):
+        result = await _expand_query("test")
+    assert result == ["test"]
+
+
+async def test_expand_query_returns_list():
+    mock_response = MagicMock()
+    mock_response.content = '["q1","q2","q3"]'
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    mock_chat_class = MagicMock(return_value=mock_llm)
+
+    with patch("langchain_openai.ChatOpenAI", mock_chat_class):
+        result = await _expand_query("my topic")
+
+    assert result == ["q1", "q2", "q3"]
+
+
+# ---------------------------------------------------------------------------
+# _search_tavily
+# ---------------------------------------------------------------------------
+
+
+async def test_search_tavily_no_key(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    result = await _search_tavily("test", 3, "general")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _search_exa
+# ---------------------------------------------------------------------------
+
+
+async def test_search_exa_no_key(monkeypatch):
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    result = await _search_exa("test", 3)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _search_ddg
+# ---------------------------------------------------------------------------
+
+
+async def test_search_ddg_returns_normalised_shape():
+    raw_result = [{"href": "http://example.com", "title": "T", "body": "B"}]
+
+    mock_ddgs_instance = MagicMock()
+    mock_ddgs_instance.text = MagicMock(return_value=raw_result)
+
+    with patch("duckduckgo_search.DDGS", return_value=mock_ddgs_instance):
+        result = await _search_ddg("test query", 3)
+
+    assert result == [
+        {"url": "http://example.com", "title": "T", "content": "B", "source": "duckduckgo"}
+    ]
+
+
+# ---------------------------------------------------------------------------
+# web_search_multi
+# ---------------------------------------------------------------------------
+
+
+async def test_web_search_multi_deduplicates_by_url():
+    """Results with the same URL from different providers appear only once."""
+    dup = {"url": "http://example.com", "title": "T", "content": "C", "source": "tavily"}
+    with patch("content_writer._auto_select_providers", return_value=["tavily", "duckduckgo"]):
+        with patch("content_writer._search_tavily", new=AsyncMock(return_value=[dup])):
+            with patch("content_writer._search_ddg", new=AsyncMock(return_value=[dup])):
+                result = await web_search_multi.ainvoke({"queries": ["test"]})
+    assert len(result["results"]) == 1
+    assert result["query_count"] == 1
+    assert result["provider_count"] == 2
+
+
+async def test_web_search_multi_provider_failure_returns_partial():
+    """A failing provider does not prevent results from other providers."""
+    good = {"url": "http://good.com", "title": "G", "content": "C", "source": "duckduckgo"}
+    with patch("content_writer._auto_select_providers", return_value=["tavily", "duckduckgo"]):
+        with patch("content_writer._search_tavily", new=AsyncMock(side_effect=RuntimeError("fail"))):
+            with patch("content_writer._search_ddg", new=AsyncMock(return_value=[good])):
+                result = await web_search_multi.ainvoke({"queries": ["test"]})
+    assert len(result["results"]) == 1
+    assert result["results"][0]["source"] == "duckduckgo"
+
+
+# ---------------------------------------------------------------------------
+# web_search_auto
+# ---------------------------------------------------------------------------
+
+
+async def test_web_search_auto_includes_expanded_queries():
+    """web_search_auto attaches original_query and expanded_queries to result."""
+    with patch("content_writer._expand_query", new=AsyncMock(return_value=["q1", "q2", "q3"])):
+        with patch("content_writer.web_search_multi") as mock_multi:
+            mock_multi.ainvoke = AsyncMock(return_value={
+                "results": [], "query_count": 4, "provider_count": 2
+            })
+            result = await web_search_auto.ainvoke({"query": "original"})
+    assert result["original_query"] == "original"
+    assert result["expanded_queries"] == ["q1", "q2", "q3"]
+    called_queries = mock_multi.ainvoke.call_args[0][0]["queries"]
+    assert called_queries[0] == "original"
+    assert len(called_queries) == 4

--- a/examples/content-builder-agent/uv.lock
+++ b/examples/content-builder-agent/uv.lock
@@ -135,11 +135,34 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "content-builder-agent"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "deepagents" },
+    { name = "duckduckgo-search" },
+    { name = "exa-py" },
     { name = "google-genai" },
     { name = "pillow" },
     { name = "pyyaml" },
@@ -147,9 +170,18 @@ dependencies = [
     { name = "tavily-python" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "langchain-openai" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "deepagents", specifier = ">=0.3.5" },
+    { name = "duckduckgo-search", specifier = ">=8.0.0" },
+    { name = "exa-py", specifier = ">=2.0.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -158,7 +190,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [
+    { name = "langchain-openai", specifier = ">=0.1.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+]
 
 [[package]]
 name = "deepagents"
@@ -192,6 +228,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "duckduckgo-search"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
+]
+
+[[package]]
+name = "exa-py"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/d2/22f8e5b83fb7ff1a5b19528b21bb908504c8b6a716309b169801881e64ff/exa_py-2.12.0.tar.gz", hash = "sha256:2cd5fe2d47d8e0221f87dcb2be0f007cc0a1f0a643b16dfc586ab1421998f4fc", size = 58731, upload-time = "2026-04-15T12:55:17.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/87/e5c458741a34c945d6b612ec54f00088a6869ffc4f3f8a7b06ae080ec6af/exa_py-2.12.0-py3-none-any.whl", hash = "sha256:78b954ca99151228e4b853bd25e58829048a9a601d6187001befa512e0143f8f", size = 73896, upload-time = "2026-04-15T12:55:16.03Z" },
 ]
 
 [[package]]
@@ -286,6 +354,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -424,7 +501,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -436,9 +513,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]
@@ -454,6 +531,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/0b/eae2305e207574dc633983a8a82a745e0ede1bce1f3a9daff24d2341fadc/langchain_google_genai-4.2.0.tar.gz", hash = "sha256:9a8d9bfc35354983ed29079cefff53c3e7c9c2a44b6ba75cc8f13a0cf8b55c33", size = 277361, upload-time = "2026-01-13T20:41:17.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/51/39942c0083139652494bb354dddf0ed397703a4882302f7b48aeca531c96/langchain_google_genai-4.2.0-py3-none-any.whl", hash = "sha256:856041aaafceff65a4ef0d5acf5731f2db95229ff041132af011aec51e8279d9", size = 66452, upload-time = "2026-01-13T20:41:16.296Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.1.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/f7/567473c9e35e32144c21467209425d99cdf865275d9556eb08b1c92db99a/langchain_openai-1.1.16.tar.gz", hash = "sha256:306f1c7f66f47bd39655e645fd1f9445d65473465a59347fa7d716596e28dfe0", size = 1116903, upload-time = "2026-04-21T19:26:21.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/95/ea040d87ecb8df9e2fef2a1c331252b116a324ab7a3bdae09928e81244e7/langchain_openai-1.1.16-py3-none-any.whl", hash = "sha256:648becb4fb86d24d56b9292e01878a05cca932bb475909bb8fb85b8c82dd1a02", size = 89202, upload-time = "2026-04-21T19:26:20.498Z" },
 ]
 
 [[package]]
@@ -533,6 +624,108 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +744,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
 ]
 
 [[package]]
@@ -765,6 +977,53 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/ca/383bdf0df3dc87b60bf73c55da526ac743d42c5155a84a9014775b895e96/primp-1.2.3.tar.gz", hash = "sha256:a531b01f57cb59e3e7a3a2b526bb151b61dc7b2e15d2f6961615a553632e2889", size = 1342866, upload-time = "2026-04-20T08:34:09.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b1/05bb7e00bd17a439aae7ed49b0c0834508e3ce50624dfa43c6dcb8b71bd0/primp-1.2.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e96d6ab40fba41039947dad0fcc42b0b56b67180883e526715720bb2d90f3bfc", size = 4360352, upload-time = "2026-04-20T08:33:52.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/db/8bb1e4b6bb715f606b53793831e7910aebeb40169e439138e9124686820a/primp-1.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:42f28679916ce080e643e7464786abeb659c8062c0f74bb411918c7f07e5b806", size = 4035926, upload-time = "2026-04-20T08:34:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/52b5e6d840be4d5a8f689d9ba82dd616c67e29e3e1d13baf6a4c9be3f4b3/primp-1.2.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:643d47cf24962331ad2b049d6bb4329dce6b18a0914490dbf09541cb38596d39", size = 4309649, upload-time = "2026-04-20T08:34:01.369Z" },
+    { url = "https://files.pythonhosted.org/packages/40/85/d98e20104429bb8393939396c2317ec6163a83d856b1fe555bf5f021e97a/primp-1.2.3-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:898a12b44af9aed20c10fd4b497314731e9f6dcab20f4aa64cf118f79df17fa0", size = 3910331, upload-time = "2026-04-20T08:33:37.294Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c7/53f11e2e2fe758830f6f208cef5bd3d0ecc6f538c0a2ca8e15a1fa502bd1/primp-1.2.3-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4bdf2b164c2908f7bdc845215dd21ebded1f2f43e9e9ae2d9a961ea56e5cb87", size = 4152054, upload-time = "2026-04-20T08:33:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5a/48e8f985daeeb58c7f1789bb6748d9aba250ea3541d787bcbcb1243abfd3/primp-1.2.3-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:036884d4c6c866c93a88e591e49f67ed160f6a9d98c779fc652cce63de62996a", size = 4443286, upload-time = "2026-04-20T08:34:07.782Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/81/42b32337bd8c7b7b8184a1fcd79fd51d4773427553a8d2036eb0a93a137d/primp-1.2.3-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bfc695c20f5c6e345abc3262bef3c246a571986db5cea73bdc41db6b166066c8", size = 4323757, upload-time = "2026-04-20T08:33:43.807Z" },
+    { url = "https://files.pythonhosted.org/packages/37/43/9ee78c283cbca7fcd635c2a9bb5633aa6568b1925958017e1a979fffe56c/primp-1.2.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13255b0826c60681478c787fbe29cfc773caf6242390fee047dac0f23f6e8c11", size = 4525772, upload-time = "2026-04-20T08:33:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/41/f10164485d84145a1ea18c7966d1ee098d1790b2088b7f122570463b7d5c/primp-1.2.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9bc40f94c8e58444befaf7e78b8aadd96e94e32789dadbe4a03785db772aa4dc", size = 4471705, upload-time = "2026-04-20T08:33:54.317Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a2/5328d66dd8f63bacfc9ef0e1e5fde66b2bb43103108fe8f01dcb2d2f0e50/primp-1.2.3-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:2e0e8e245113ab3c9fd4b36014b3a04869cf08f72e8e7f36c4f5ef46d26da090", size = 4148309, upload-time = "2026-04-20T08:33:31.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/86/4d000d3ee341e5f1e73d81fb2c84e985f23b343a1aa4234c40987ec6eae7/primp-1.2.3-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3bb50934b5e209e7da4876d3419ebc23d1425fe6f089c0cd95382d21bd8a39bd", size = 4276881, upload-time = "2026-04-20T08:33:34.414Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f5/50acc3e349d22044abf4ed7c2abaaba11a01b9ccb6a7d66a3fbc2275c590/primp-1.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b293f13078afee9d41b74c77d05a5eaeb57dfab5110648dd24bc3fb3c750a05c", size = 4775229, upload-time = "2026-04-20T08:34:10.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d6/2c482973211666fdf2c4365babf343a88ea30f753ef650121cebd4ad7ece/primp-1.2.3-cp310-abi3-win32.whl", hash = "sha256:c600dd83e9c978bf494aab072cd5bbfdd59b131f3afc353850c53373a86992e5", size = 3504032, upload-time = "2026-04-20T08:33:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/70/89/3d2032a8f5e986fcc03bc86ac98705ce2bd35ed0e182d4949c159214da6a/primp-1.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:3cbbe52a6eb51a4831d3dd35055f13b28ff5b9be2487c14ffe66922bf8028b49", size = 3872596, upload-time = "2026-04-20T08:33:46.927Z" },
+    { url = "https://files.pythonhosted.org/packages/79/00/f726d54ff00213641069a66ee2fadf17f01f77a2f1ba92de229830056419/primp-1.2.3-cp310-abi3-win_arm64.whl", hash = "sha256:03c668481b2cf34552880f4b6ebabfa913fdaeb2921ce982e42c428f451b630c", size = 3875239, upload-time = "2026-04-20T08:33:32.981Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e6/1fe1bcaf7566d7e6c9b39748f0d6ded857c80cf3252acf6aa3c6b7b8dbb0/primp-1.2.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:0148fd5c0502bb88a26217b606ebb254de44a666dac52657ff97f727577bc7ce", size = 4348055, upload-time = "2026-04-20T08:33:48.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/46/cae79466969a31d885409ce716eb5a4af66f66d1121e63ee3ddd7d666b9e/primp-1.2.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13bfc39172a083cc5520d9045a99988d7f8502458be139d6b1926de4d57e30e9", size = 4034114, upload-time = "2026-04-20T08:33:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c3/e8b24ff42ef6bf71f8b4277fd6d83a139d9b9ad14b0ffb4c76a8e9225a15/primp-1.2.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:283e751671e78cbac9f1ff72e89225d74bcd9ea08886910160f485cd78a55f2b", size = 4303794, upload-time = "2026-04-20T08:34:04.947Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b4/9c59197fee68abdc53683b65b6b0e5ea6e0f098cc2527af29edd05b22ed4/primp-1.2.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec5d94244f24c61b350791112c1687c97d144f400a7ea5d8476dbd2fad6de9af", size = 3908577, upload-time = "2026-04-20T08:33:59.567Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/25c7cfcfe33f2fa82ab8cc72f4082fc12c8f803ceb2624c787fa72c73e12/primp-1.2.3-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48d459dda86bfddce3a14b514694e0c8028f20cc461dd52e105aba400c622513", size = 4153501, upload-time = "2026-04-20T08:34:03.22Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9b/83e61b32b9049478f63c1956ff3244619691c3edf6e96b19254047756b36/primp-1.2.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d0d8441f07c948a54ff21bfc4094cd2967b5fb6f8a9ef0c9562a1eb35da0127e", size = 4440289, upload-time = "2026-04-20T08:33:24.734Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/48c351f601f204c52d5a477d7a19efcd8b7deb6478c57195fbe8bf9c3632/primp-1.2.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:728b6f63552f1bc729e0490ee69a3a9fbd39698c1578b0e6313f3779de469a8c", size = 4306848, upload-time = "2026-04-20T08:33:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9a/683b2fbb8c2df3b3d2b351e86eec0a873479b95bb804e5d882939057366b/primp-1.2.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9952509dcd8aa8750f4cdfc86b24cdcec96f9342a6525003bc3446ba466d5512", size = 4521679, upload-time = "2026-04-20T08:33:38.699Z" },
+    { url = "https://files.pythonhosted.org/packages/80/eb/bbbbc79cf4132f2beeb0a0f99f41837dd66c158d0439f59df75a2d592d0a/primp-1.2.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e74a6aa83aa65d02665ad5d0e53d7877ea8abce6f3d50ed92495f9c4c9d10e2e", size = 4469041, upload-time = "2026-04-20T08:33:51.161Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/5c/208fe1c6e9d3a28c6eae530378ac9c60fe8ae389f68a4707ef7986d5b133/primp-1.2.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1dfc4dd5bf7e4f9a45f9c7ae1256f957cc7ca8d5344f82d335129a13e1d7ffea", size = 4144925, upload-time = "2026-04-20T08:33:35.94Z" },
+    { url = "https://files.pythonhosted.org/packages/da/06/ce175b54edecf22b750da67bc095bea53f2d87d191c4461b30122c7ddd1e/primp-1.2.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:97c37df6fc7eb989f324b326e0547b23757a82f9d8b334075d4b0bd29e310723", size = 4276929, upload-time = "2026-04-20T08:33:49.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/12/a913ab53ad61fe51d44ef0f8fee6b63a897d2b9c8a4b43299d7f5decc003/primp-1.2.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ead9c8b660fa0ebb193317b85d61dd1bd840a3e97e882b33b896dc9e37ed6d63", size = 4772684, upload-time = "2026-04-20T08:33:42.456Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2f/2c3aafb2814703979bf5a216575f4478bcf6070bc6ec143056cf3b56c134/primp-1.2.3-cp314-cp314t-win32.whl", hash = "sha256:cb52db4d54105097773c0df4e2ef0ce7b42461d9d4d3ec28a0622ca2d22945bb", size = 3499126, upload-time = "2026-04-20T08:33:29.953Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f0/bad9c739a35f4cf69e2f39c01f664c9a5969e753c4cfcdc33e113cc984af/primp-1.2.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d85a44585df27038e18298f7e35335c4961926e7401edd1a1bf4f7f967b3f107", size = 3870129, upload-time = "2026-04-20T08:34:11.666Z" },
+    { url = "https://files.pythonhosted.org/packages/67/78/882563dc554c5f710b4e47c58978586c2528703435800a7a84e81b339d90/primp-1.2.3-cp314-cp314t-win_arm64.whl", hash = "sha256:6513dcb55e6b511c1ae383a3a0e887929b09d8d6b2c70e2b188b425c51471a02", size = 3874087, upload-time = "2026-04-20T08:33:58.109Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -904,6 +1163,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1189,6 +1486,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
     { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
     { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces the single-provider `web_search` tool in the `content-builder-agent` example with two new tools that improve research quality.

---

The original `web_search` tool sent one query to Tavily only. This PR adds:

**Query expansion** — `_expand_query` calls `gpt-4o-mini` to generate 3 diverse, complementary sub-queries from the original, covering different angles (overview, recent developments, practical examples). Falls back gracefully to the original query if the LLM call fails.

**Multi-provider fan-out** — `web_search_multi` dispatches all queries concurrently across up to 2 auto-selected providers (Tavily → Exa → DuckDuckGo in priority order based on available API keys). DuckDuckGo requires no key and is the unconditional fallback. All `(query, provider)` pairs run via `asyncio.gather`.

**Deduplication** — results from all providers and queries are merged and deduplicated by URL before being returned.

**`web_search_auto`** is the new top-level `@tool` that wraps both steps. It is aliased to the existing `"web_search"` key in `load_subagents` so `subagents.yaml` requires no changes.

New dependencies added to the example's `pyproject.toml`: `exa-py>=2.0.0` and `duckduckgo-search>=8.0.0`.

Unit tests cover all provider adapters, `_auto_select_providers`, `_expand_query` (success and fallback paths), `web_search_multi` (deduplication, partial-failure resilience), and `web_search_auto` (query expansion wiring). All 12 tests pass.