### PR TITLE
feat(harbor,sdk): migrate LangSmith env from templates to snapshots

### DIFF
--- a/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
     from deepagents.backends.protocol import SandboxBackendProtocol
 
 
+SNAPSHOT_NAME = "deepagents-cli"
+DEFAULT_IMAGE = "python:3"
+DEFAULT_FS_CAPACITY = 16 * 1024**3  # 16 GiB -- mirrors CLI _LangSmithProvider default.
+
+
 class TestLangSmithSandboxStandard(SandboxIntegrationTests):
     @pytest.fixture(scope="class")
     def sandbox(self) -> Iterator[SandboxBackendProtocol]:
@@ -24,11 +29,25 @@ class TestLangSmithSandboxStandard(SandboxIntegrationTests):
             raise RuntimeError(msg)
 
         client = SandboxClient(api_key=api_key)
-        ls_sandbox = client.create_sandbox(template_name="deepagents-cli")
+
+        # Server-side filter keeps this quick even with many snapshots in the
+        # workspace. name_contains is a case-insensitive substring match, so
+        # match the exact name client-side.
+        existing = client.list_snapshots(name_contains=SNAPSHOT_NAME)
+        ready = any(snap.name == SNAPSHOT_NAME and snap.status == "ready" for snap in existing)
+        if not ready:
+            client.create_snapshot(
+                name=SNAPSHOT_NAME,
+                docker_image=DEFAULT_IMAGE,
+                fs_capacity_bytes=DEFAULT_FS_CAPACITY,
+            )
+
+        ls_sandbox = client.create_sandbox(snapshot_name=SNAPSHOT_NAME)
         backend = LangSmithSandbox(sandbox=ls_sandbox)
         try:
             yield backend
         finally:
+            # Never delete the snapshot -- it is shared across test runs.
             client.delete_sandbox(ls_sandbox.name)
 
     @pytest.mark.xfail(reason="LangSmith runs as root and ignores file permissions")

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -247,7 +247,7 @@ class LangSmithEnvironment(BaseEnvironment):
         self._snapshot_name = snapshot_name
 
         sandbox = await client.create_sandbox(
-            snapshot_name=snapshot_name,  # ty: ignore[unknown-argument]
+            snapshot_name=snapshot_name,
             vcpus=vcpus,
             mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
@@ -311,7 +311,7 @@ class LangSmithEnvironment(BaseEnvironment):
                 ready, or if ``create_snapshot`` fails.
         """
         snapshots = await client.list_snapshots(
-            name_contains=snapshot_name,  # ty: ignore[unknown-argument]
+            name_contains=snapshot_name,
         )
         for snap in snapshots:
             if snap.name != snapshot_name:

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import re
 import shlex
 from pathlib import Path
@@ -24,9 +23,8 @@ if TYPE_CHECKING:
 
 
 _DEFAULT_EXEC_TIMEOUT_SEC = 30 * 60
-_MB_PER_GB = 1024
+_BYTES_PER_MB = 1024 * 1024
 _MAX_NAME_LEN = 63
-_SESSION_HASH_LEN = 8
 
 
 class LangSmithEnvironment(BaseEnvironment):
@@ -39,12 +37,16 @@ class LangSmithEnvironment(BaseEnvironment):
             deepagents_harbor.langsmith_environment:LangSmithEnvironment ...
 
     The environment reads the task's Dockerfile to extract the base image,
-    creates a LangSmith template + sandbox with the appropriate resources, and
-    delegates all exec/file operations to the LangSmith sandbox SDK.
+    ensures a LangSmith snapshot exists for that image (building it on first
+    use), and boots a sandbox from it with the task's resource config applied
+    at `create_sandbox` time.
 
-    Each trial gets its own template (named with the session ID) so that
-    concurrent trials never race on shared resources during creation or
-    teardown.
+    Snapshots are keyed purely by image and are **shared across trials**.
+    They are intentionally never deleted on `stop()` — rebuilding the same
+    image for every trial would be wasteful, and the LangSmith workspace is
+    the canonical place to prune them manually. Per-trial vCPU / memory /
+    filesystem sizing lives on `create_sandbox`, not on the snapshot, so
+    sharing is safe.
     """
 
     def __init__(
@@ -70,7 +72,7 @@ class LangSmithEnvironment(BaseEnvironment):
         self._session_id = session_id
         self._sandbox: AsyncSandbox | None = None
         self._client: AsyncSandboxClient | None = None
-        self._template_name: str | None = None
+        self._snapshot_name: str | None = None
         self._default_cwd: str | None = None
         super().__init__(
             environment_dir,
@@ -180,45 +182,43 @@ class LangSmithEnvironment(BaseEnvironment):
             name = f"h-{name}"
         return name[:_MAX_NAME_LEN].rstrip("-")
 
-    # -- Template naming -------------------------------------------------------
+    # -- Snapshot naming -------------------------------------------------------
 
     @staticmethod
-    def _build_template_name(image: str, session_id: str) -> str:
-        """Build a unique LangSmith template name within the 63-char limit.
+    def _build_snapshot_name(image: str) -> str:
+        """Build a deterministic LangSmith snapshot name for `image`.
 
-        Previous implementation concatenated `harbor-{image}-{session}` and
-        truncated to 63 characters. When the image name was long the unique
-        session suffix was silently chopped off, causing name collisions across
-        concurrent matrix jobs.
-
-        This version reserves 8 hex characters (from a SHA-256 of the full
-        session ID) as a suffix so uniqueness is guaranteed regardless of
-        image-name length.
+        Snapshots are shared across trials in the new model, so the name is
+        derived solely from the (sanitized) image reference — no session hash.
+        Multiple concurrent trials that resolve to the same image will reuse
+        the same snapshot.
 
         Args:
-            image: Container image reference (e.g. `alexgshaw/foo:tag`).
-            session_id: Unique trial session identifier.
+            image: Container image reference (e.g. `python:3.12-slim` or
+                `alexgshaw/foo:tag`).
 
         Returns:
-            A sanitized name of at most 63 characters, guaranteed unique per
-                `session_id`.
+            A sanitized name of the form ``harbor-{sanitized_image}``, at most
+            63 characters, suitable for a LangSmith snapshot name.
         """
         sanitized_image = LangSmithEnvironment._sanitize_name(image)
-        session_suffix = hashlib.sha256(session_id.encode()).hexdigest()[:_SESSION_HASH_LEN]
-        # "harbor-" (7) + "-" (1) + suffix (8) = 16 reserved chars
-        max_image_len = _MAX_NAME_LEN - len("harbor-") - 1 - _SESSION_HASH_LEN
+        max_image_len = _MAX_NAME_LEN - len("harbor-")
         truncated_image = sanitized_image[:max_image_len].rstrip("-")
-        return f"harbor-{truncated_image}-{session_suffix}"
+        return f"harbor-{truncated_image}"
 
     # -- Lifecycle -------------------------------------------------------------
 
     async def start(self, force_build: bool) -> None:  # noqa: ARG002  # required by BaseEnvironment interface
         """Provision a LangSmith sandbox from the task's Dockerfile image.
 
+        Ensures a shared snapshot exists for the resolved image, then boots a
+        sandbox from it with per-trial resource limits applied at
+        `create_sandbox` time.
+
         Args:
             force_build: Accepted for interface compatibility but unused.
-                Each trial creates its own template, so there is nothing
-                to force-rebuild.
+                Snapshots are shared across trials; the first trial to touch
+                a given image builds it, every subsequent trial reuses it.
         """
         image = self._resolve_image()
 
@@ -237,37 +237,32 @@ class LangSmithEnvironment(BaseEnvironment):
         client = AsyncSandboxClient(api_key=api_key)
         self._client = client
 
-        template_name = self._build_template_name(image, self._session_id)
+        snapshot_name = self._build_snapshot_name(image)
 
-        cpu = f"{self.task_env_config.cpus * 1000}m"
-        memory_mb = self.task_env_config.memory_mb
-        memory = f"{memory_mb}Mi" if memory_mb < _MB_PER_GB else f"{memory_mb // _MB_PER_GB}Gi"
-        storage_gi = max(1, (self.task_env_config.storage_mb + _MB_PER_GB - 1) // _MB_PER_GB)
-        storage = f"{storage_gi}Gi"
+        vcpus = self.task_env_config.cpus
+        mem_bytes = self.task_env_config.memory_mb * _BYTES_PER_MB
+        fs_capacity_bytes = self.task_env_config.storage_mb * _BYTES_PER_MB
 
-        await client.create_template(
-            name=template_name,
-            image=image,
-            cpu=cpu,
-            memory=memory,
-            storage=storage,
-        )
-        logger.info(
-            "Created LangSmith template '%s' (image=%s, cpu=%s, mem=%s, disk=%s)",
-            template_name,
-            image,
-            cpu,
-            memory,
-            storage,
-        )
-        self._template_name = template_name
+        await self._ensure_snapshot(client, snapshot_name, image, fs_capacity_bytes)
+        self._snapshot_name = snapshot_name
 
         sandbox = await client.create_sandbox(
-            template_name=template_name,
+            snapshot_name=snapshot_name,  # ty: ignore[unknown-argument]
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
+            fs_capacity_bytes=fs_capacity_bytes,
             timeout=120,
         )
         self._sandbox = sandbox
-        logger.info("Created LangSmith sandbox '%s'", sandbox.name)
+        logger.info(
+            "Created LangSmith sandbox '%s' from snapshot '%s' "
+            "(vcpus=%s, mem_bytes=%s, fs_capacity_bytes=%s)",
+            sandbox.name,
+            snapshot_name,
+            vcpus,
+            mem_bytes,
+            fs_capacity_bytes,
+        )
 
         await sandbox.run(
             f"mkdir -p {EnvironmentPaths.agent_dir} {EnvironmentPaths.verifier_dir}"
@@ -281,6 +276,71 @@ class LangSmithEnvironment(BaseEnvironment):
             sandbox.name,
             self._default_cwd,
         )
+
+    @staticmethod
+    async def _ensure_snapshot(
+        client: AsyncSandboxClient,
+        snapshot_name: str,
+        image: str,
+        fs_capacity_bytes: int,
+    ) -> None:
+        """Guarantee a ready LangSmith snapshot named ``snapshot_name`` exists.
+
+        Uses the server-side ``name_contains`` filter to keep the lookup cheap
+        even when the workspace accumulates many snapshots, then matches the
+        exact name client-side (``name_contains`` is a case-insensitive
+        substring match, so it can return unrelated entries).
+
+        Behavior:
+          - If a snapshot with the exact name is ``ready`` -> return.
+          - If it exists but is in any other state -> raise ``RuntimeError``
+            with a clear instruction to wait for it to finish or delete it.
+          - Otherwise -> build it via ``create_snapshot`` (blocks until ready).
+
+        The helper does not return an ID: downstream callers pass
+        ``snapshot_name`` straight to ``create_sandbox``.
+
+        Args:
+            client: Async LangSmith sandbox client.
+            snapshot_name: Name of the snapshot to ensure.
+            image: Docker image reference to build from if missing.
+            fs_capacity_bytes: Filesystem capacity used when building.
+
+        Raises:
+            RuntimeError: If a snapshot with the same name exists but is not
+                ready, or if ``create_snapshot`` fails.
+        """
+        snapshots = await client.list_snapshots(
+            name_contains=snapshot_name,  # ty: ignore[unknown-argument]
+        )
+        for snap in snapshots:
+            if snap.name != snapshot_name:
+                continue
+            if snap.status == "ready":
+                logger.debug("Reusing existing LangSmith snapshot '%s'", snapshot_name)
+                return
+            msg = (
+                f"LangSmith snapshot '{snapshot_name}' exists but is in state "
+                f"'{snap.status}'. Wait for it to finish building, or delete "
+                f"it to rebuild."
+            )
+            raise RuntimeError(msg)
+
+        logger.info(
+            "Building LangSmith snapshot '%s' from image '%s' "
+            "(first run for this image may take a few minutes)",
+            snapshot_name,
+            image,
+        )
+        try:
+            await client.create_snapshot(
+                name=snapshot_name,
+                docker_image=image,
+                fs_capacity_bytes=fs_capacity_bytes,
+            )
+        except Exception as create_err:
+            msg = f"Failed to build LangSmith snapshot '{snapshot_name}': {create_err}"
+            raise RuntimeError(msg) from create_err
 
     @staticmethod
     async def _detect_workdir(sandbox: AsyncSandbox) -> str:
@@ -322,14 +382,14 @@ class LangSmithEnvironment(BaseEnvironment):
         return fallback if fallback != "/" else "/app"
 
     async def stop(self, delete: bool) -> None:
-        """Tear down the LangSmith sandbox and its dedicated template.
+        """Tear down the LangSmith sandbox.
 
-        Deletes the sandbox first so the template has no remaining
-        dependents and can be safely removed.
+        The backing snapshot is **never** deleted here: snapshots are shared
+        across trials and are only cleaned up manually in the LangSmith
+        workspace.
 
         Args:
-            delete: If True, delete the sandbox and template before
-                closing the client.
+            delete: If True, delete the sandbox before closing the client.
         """
         if self._sandbox and self._client and delete:
             try:
@@ -341,21 +401,11 @@ class LangSmithEnvironment(BaseEnvironment):
                     self._sandbox.name,
                     exc_info=True,
                 )
-        if self._template_name and self._client and delete:
-            try:
-                await self._client.delete_template(self._template_name)
-                logger.info("Deleted LangSmith template '%s'", self._template_name)
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Failed to delete template '%s' -- resource may be leaked",
-                    self._template_name,
-                    exc_info=True,
-                )
         if self._client:
             await self._client.aclose()
         self._sandbox = None
         self._client = None
-        self._template_name = None
+        self._snapshot_name = None
         self._default_cwd = None
 
     # -- Command execution -----------------------------------------------------

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # Harbor runtime
     "harbor>=0.1.12",
     # LangSmith for observability
-    "langsmith>=0.7.31",
+    "langsmith>=0.7.34",
     # Sandbox runtimes
     "dockerfile-parse>=2.0.1",
     "modal>=0.64.0",

--- a/libs/evals/tests/unit_tests/test_langsmith_environment.py
+++ b/libs/evals/tests/unit_tests/test_langsmith_environment.py
@@ -111,11 +111,33 @@ def _make_env(
     )
 
 
-def _mock_async_client() -> MagicMock:
-    """Build a mock AsyncSandboxClient wired for start() tests."""
+@dataclass
+class _FakeSnapshot:
+    """Stand-in for langsmith Snapshot with a safe ``name`` attribute.
+
+    MagicMock reserves ``.name`` as a descriptor for the mock itself, so we
+    use a plain dataclass here to make assertions on ``snap.name`` behave
+    normally.
+    """
+
+    name: str
+    status: str = "ready"
+    id: str = "snap-id-test"
+
+
+def _mock_async_client(*, existing_snapshots: list[Any] | None = None) -> AsyncMock:
+    """Build a mock AsyncSandboxClient wired for start() tests.
+
+    Defaults mirror the "happy path": no existing snapshot → `create_snapshot`
+    will be invoked → `create_sandbox` returns a fake sandbox. Tests can
+    override by passing `existing_snapshots` or reassigning the individual
+    method mocks.
+    """
     mock = AsyncMock()
     fake_sb = _FakeSandbox()
     mock.create_sandbox.return_value = fake_sb
+    mock.list_snapshots = AsyncMock(return_value=existing_snapshots or [])
+    mock.create_snapshot = AsyncMock(return_value=_FakeSnapshot(name="snap-test", status="ready"))
     return mock
 
 
@@ -304,7 +326,12 @@ class TestSanitizeName:
 
 
 class TestResourceConversion:
-    """Tests for task resource config → LangSmith format."""
+    """Tests for task resource config → LangSmith create_sandbox/create_snapshot kwargs.
+
+    Memory and CPU live on ``create_sandbox`` (vcpus/mem_bytes). Filesystem
+    capacity is passed to both ``create_snapshot`` (when building) and
+    ``create_sandbox`` so per-trial disk sizing takes effect.
+    """
 
     async def test_memory_under_1gb(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path, memory_mb=512)
@@ -315,7 +342,7 @@ class TestResourceConversion:
 
             await env.start(force_build=True)
 
-            assert mock_client.create_template.call_args.kwargs["memory"] == "512Mi"
+            assert mock_client.create_sandbox.call_args.kwargs["mem_bytes"] == 512 * 1024 * 1024
 
     async def test_memory_over_1gb(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path, memory_mb=2048)
@@ -326,7 +353,7 @@ class TestResourceConversion:
 
             await env.start(force_build=True)
 
-            assert mock_client.create_template.call_args.kwargs["memory"] == "2Gi"
+            assert mock_client.create_sandbox.call_args.kwargs["mem_bytes"] == 2048 * 1024 * 1024
 
     async def test_cpu_conversion(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path, cpus=2)
@@ -337,9 +364,9 @@ class TestResourceConversion:
 
             await env.start(force_build=True)
 
-            assert mock_client.create_template.call_args.kwargs["cpu"] == "2000m"
+            assert mock_client.create_sandbox.call_args.kwargs["vcpus"] == 2
 
-    async def test_storage_always_gi(self, tmp_path: Path) -> None:
+    async def test_storage_bytes_on_snapshot_and_sandbox(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path, storage_mb=10240)
 
         with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
@@ -348,9 +375,16 @@ class TestResourceConversion:
 
             await env.start(force_build=True)
 
-            assert mock_client.create_template.call_args.kwargs["storage"] == "10Gi"
+            expected_bytes = 10240 * 1024 * 1024
+            assert (
+                mock_client.create_snapshot.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
+            assert (
+                mock_client.create_sandbox.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
 
-    async def test_storage_rounds_up(self, tmp_path: Path) -> None:
+    async def test_storage_passes_exact_bytes(self, tmp_path: Path) -> None:
+        """No more Gi rounding -- we forward whatever the task requested, byte-for-byte."""
         env = _make_env(tmp_path, storage_mb=1500)
 
         with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
@@ -359,17 +393,85 @@ class TestResourceConversion:
 
             await env.start(force_build=True)
 
-            assert mock_client.create_template.call_args.kwargs["storage"] == "2Gi"
+            expected_bytes = 1500 * 1024 * 1024
+            assert (
+                mock_client.create_snapshot.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
+            assert (
+                mock_client.create_sandbox.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
 
 
-class TestStartTemplateProvisioning:
-    """Tests for per-session template creation in start().
+class TestStartSnapshotProvisioning:
+    """Tests for shared-per-image snapshot provisioning in start().
 
-    Each trial creates its own template unconditionally — there is no
-    template reuse, conditional deletion, or force-rebuild logic.
+    Snapshots are keyed purely by image and reused across trials; trial-local
+    resource sizing moves onto ``create_sandbox``.
     """
 
-    async def test_always_creates_template(self, tmp_path: Path) -> None:
+    async def test_builds_snapshot_when_missing(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client(existing_snapshots=[])
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+            mock_client.create_snapshot.assert_called_once()
+            kwargs = mock_client.create_snapshot.call_args.kwargs
+            assert kwargs["name"] == expected_name
+            assert kwargs["docker_image"] == "ubuntu:24.04"
+
+    async def test_reuses_existing_ready_snapshot(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client(
+                existing_snapshots=[_FakeSnapshot(name=expected_name, status="ready")]
+            )
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            mock_client.create_snapshot.assert_not_called()
+            create_kwargs = mock_client.create_sandbox.call_args.kwargs
+            assert create_kwargs["snapshot_name"] == expected_name
+            assert "snapshot_id" not in create_kwargs
+            assert "template_name" not in create_kwargs
+
+    async def test_raises_when_existing_snapshot_not_ready(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client(
+                existing_snapshots=[_FakeSnapshot(name=expected_name, status="building")]
+            )
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="building"):
+                await env.start(force_build=False)
+
+            mock_client.create_snapshot.assert_not_called()
+            mock_client.create_sandbox.assert_not_called()
+
+    async def test_list_snapshots_called_with_name_contains(self, tmp_path: Path) -> None:
+        """Readiness check must use the server-side ``name_contains`` filter."""
+        env = _make_env(tmp_path)
+        expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            mock_client.list_snapshots.assert_awaited_once_with(name_contains=expected_name)
+
+    async def test_creates_sandbox_from_snapshot(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
 
         with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
@@ -378,9 +480,16 @@ class TestStartTemplateProvisioning:
 
             await env.start(force_build=False)
 
-            mock_client.create_template.assert_called_once()
-            mock_client.get_template.assert_not_called()
-            mock_client.delete_template.assert_not_called()
+            expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+            mock_client.create_sandbox.assert_called_once()
+            kwargs = mock_client.create_sandbox.call_args.kwargs
+            assert kwargs["snapshot_name"] == expected_name
+            assert kwargs["vcpus"] == 1
+            assert kwargs["mem_bytes"] == 2048 * 1024 * 1024
+            assert kwargs["fs_capacity_bytes"] == 10240 * 1024 * 1024
+            assert kwargs["timeout"] == 120
+            assert "template_name" not in kwargs
+            assert "snapshot_id" not in kwargs
 
     async def test_force_build_is_noop(self, tmp_path: Path) -> None:
         """force_build accepted for interface compat but does not change calls."""
@@ -399,80 +508,37 @@ class TestStartTemplateProvisioning:
             mock_cls.return_value = mock_b
             await env_b.start(force_build=True)
 
-        assert mock_a.create_template.call_count == mock_b.create_template.call_count == 1
-        mock_b.get_template.assert_not_called()
-        mock_b.delete_template.assert_not_called()
-
-    async def test_template_name_derived_from_image(self, tmp_path: Path) -> None:
-        env = _make_env(tmp_path, docker_image="ghcr.io/my-org/my-image:v1.2")
-
-        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
-            mock_client = _mock_async_client()
-            mock_cls.return_value = mock_client
-
-            await env.start(force_build=False)
-
-            expected = LangSmithEnvironment._build_template_name(
-                "ghcr.io/my-org/my-image:v1.2", "test-session-001"
-            )
-            mock_client.create_template.assert_called_once()
-            assert mock_client.create_template.call_args.kwargs["name"] == expected
-
-    async def test_creates_sandbox_from_template(self, tmp_path: Path) -> None:
-        env = _make_env(tmp_path)
-
-        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
-            mock_client = _mock_async_client()
-            mock_cls.return_value = mock_client
-
-            await env.start(force_build=False)
-
-            expected_name = LangSmithEnvironment._build_template_name(
-                "ubuntu:24.04", "test-session-001"
-            )
-            mock_client.create_sandbox.assert_called_once_with(
-                template_name=expected_name,
-                timeout=120,
-            )
+        assert mock_a.create_sandbox.call_count == mock_b.create_sandbox.call_count == 1
 
 
-class TestBuildTemplateName:
-    """Tests for _build_template_name uniqueness guarantees."""
+class TestBuildSnapshotName:
+    """Tests for _build_snapshot_name shape and sharing contract."""
 
-    def test_short_image_includes_session_context(self) -> None:
-        name = LangSmithEnvironment._build_template_name("ubuntu:24.04", "sess-001")
+    def test_starts_with_harbor_prefix(self) -> None:
+        name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
         assert name.startswith("harbor-")
         assert len(name) <= 63
 
     def test_long_image_stays_within_limit(self) -> None:
         long_image = "alexgshaw/log-summary-date-ranges:20251031"
-        name = LangSmithEnvironment._build_template_name(long_image, "session-abc")
+        name = LangSmithEnvironment._build_snapshot_name(long_image)
         assert len(name) <= 63
 
-    def test_different_sessions_produce_different_names(self) -> None:
-        """Regression: long image names must not cause name collisions."""
-        image = "alexgshaw/log-summary-date-ranges:20251031"
-        names = {
-            LangSmithEnvironment._build_template_name(image, f"task__{suffix}")
-            for suffix in ("yTtDpUN", "aRm97it", "3k4jKqE")
-        }
-        assert len(names) == 3
-
-    def test_collision_regression_multi_source(self) -> None:
-        image = "alexgshaw/multi-source-data-merger:20251031"
-        names = {
-            LangSmithEnvironment._build_template_name(image, f"task__{suffix}")
-            for suffix in ("yZW2Gye", "yurd9SN", "csWfiWu")
-        }
-        assert len(names) == 3
-
     def test_deterministic(self) -> None:
-        a = LangSmithEnvironment._build_template_name("img:v1", "session-x")
-        b = LangSmithEnvironment._build_template_name("img:v1", "session-x")
+        a = LangSmithEnvironment._build_snapshot_name("img:v1")
+        b = LangSmithEnvironment._build_snapshot_name("img:v1")
         assert a == b
 
+    def test_same_image_different_sessions_share_name(self) -> None:
+        """Snapshots are shared across trials: name depends on image alone."""
+        image = "alexgshaw/log-summary-date-ranges:20251031"
+        # _build_snapshot_name takes no session_id; calling it from multiple
+        # "trials" must produce the exact same name.
+        names = {LangSmithEnvironment._build_snapshot_name(image) for _ in range(5)}
+        assert len(names) == 1
+
     def test_name_starts_with_letter(self) -> None:
-        name = LangSmithEnvironment._build_template_name("123image:latest", "s1")
+        name = LangSmithEnvironment._build_snapshot_name("123image:latest")
         assert name[0].isalpha()
 
 
@@ -679,7 +745,7 @@ class TestWorkdirDetection:
         env = _make_env(tmp_path)
         env._sandbox = _FakeSandbox()  # type: ignore[assignment]
         env._client = AsyncMock()
-        env._template_name = "tmpl"
+        env._snapshot_name = "snap-tmpl"
         env._default_cwd = "/app"
 
         await env.stop(delete=False)
@@ -803,68 +869,74 @@ class TestFileOps:
 
 
 class TestStop:
-    """Tests for teardown."""
+    """Tests for teardown.
 
-    async def test_stop_deletes_sandbox_and_template(self, tmp_path: Path) -> None:
+    Snapshots are shared resources — ``stop()`` must never delete them,
+    regardless of the ``delete`` flag.
+    """
+
+    async def test_stop_deletes_sandbox_but_not_snapshot(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         mock_client = AsyncMock()
         mock_sandbox = _FakeSandbox(name="my-sandbox")
         env._sandbox = mock_sandbox  # type: ignore[assignment]
         env._client = mock_client
-        env._template_name = "my-template"
+        env._snapshot_name = "harbor-ubuntu-24-04"
 
         await env.stop(delete=True)
 
         mock_client.delete_sandbox.assert_called_once_with("my-sandbox")
-        mock_client.delete_template.assert_called_once_with("my-template")
+        mock_client.delete_snapshot.assert_not_called()
         mock_client.aclose.assert_called_once()
         assert env._sandbox is None
         assert env._client is None
+        assert env._snapshot_name is None
 
     async def test_stop_no_delete_skips_cleanup(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         mock_client = AsyncMock()
         env._sandbox = _FakeSandbox()  # type: ignore[assignment]
         env._client = mock_client
-        env._template_name = "tmpl"
+        env._snapshot_name = "snap-tmpl"
 
         await env.stop(delete=False)
 
         mock_client.delete_sandbox.assert_not_called()
-        mock_client.delete_template.assert_not_called()
+        mock_client.delete_snapshot.assert_not_called()
         mock_client.aclose.assert_called_once()
 
     async def test_stop_continues_after_sandbox_delete_fails(self, tmp_path: Path) -> None:
-        """If sandbox deletion fails, template deletion and aclose still run."""
+        """If sandbox deletion fails, aclose still runs and snapshot is untouched."""
         env = _make_env(tmp_path)
         mock_client = AsyncMock()
         mock_client.delete_sandbox.side_effect = RuntimeError("API timeout")
         env._sandbox = _FakeSandbox(name="my-sandbox")  # type: ignore[assignment]
         env._client = mock_client
-        env._template_name = "my-template"
+        env._snapshot_name = "harbor-my-image"
 
         await env.stop(delete=True)
 
         mock_client.delete_sandbox.assert_called_once_with("my-sandbox")
-        mock_client.delete_template.assert_called_once_with("my-template")
+        mock_client.delete_snapshot.assert_not_called()
         mock_client.aclose.assert_called_once()
         assert env._sandbox is None
         assert env._client is None
-        assert env._template_name is None
+        assert env._snapshot_name is None
 
     async def test_stop_clean_after_failed_start(self, tmp_path: Path) -> None:
-        """If create_template fails, _template_name stays None and stop is safe."""
+        """If create_snapshot fails, _snapshot_name stays None and stop is safe."""
         env = _make_env(tmp_path)
 
         with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.create_template.side_effect = RuntimeError("API 422")
+            mock_client = _mock_async_client()
+            mock_client.create_snapshot = AsyncMock(side_effect=RuntimeError("API 422"))
             mock_cls.return_value = mock_client
 
             with pytest.raises(RuntimeError, match="API 422"):
                 await env.start(force_build=False)
 
-        assert env._template_name is None
+        assert env._snapshot_name is None
         assert env._sandbox is None
 
         await env.stop(delete=True)
+        mock_client.delete_snapshot.assert_not_called()

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1307,7 +1307,7 @@ requires-dist = [
     { name = "langchain-quickjs", editable = "../partners/quickjs" },
     { name = "langchain-repl", editable = "../repl" },
     { name = "langchain-xai", specifier = ">=1.0.0" },
-    { name = "langsmith", specifier = ">=0.7.31" },
+    { name = "langsmith", specifier = ">=0.7.34" },
     { name = "matplotlib", marker = "extra == 'charts'", specifier = ">=3.9.0" },
     { name = "modal", specifier = ">=0.64.0" },
     { name = "nltk", specifier = ">=3.9.0" },
@@ -2787,7 +2787,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.32"
+version = "0.7.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2800,9 +2800,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/3c/f5b2444909632fa9f11a0d2a12b960f5fc1edf1f0c9c222e78cb5ef8df18/langsmith-0.7.34.tar.gz", hash = "sha256:1b1fd637e129ae41d5fc8eebf23483816cd1251d61cffb21ce5203858561e70c", size = 4390970, upload-time = "2026-04-23T13:51:43.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/94/c011bc7e045e6da6aaab9d2adb2f3cefdb382fc038f09ef0865ac3214978/langsmith-0.7.34-py3-none-any.whl", hash = "sha256:52478123a74403b320230625d90810b5d8b88d3cd275b3eae6d2f696d40053ce", size = 376754, upload-time = "2026-04-23T13:51:41.767Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Migrates the LangSmith harbor env (and its integration-test fixture) from the deprecated template API to shared-per-image snapshots, matching the CLI migration shipped in #2824. `start()` now resolves snapshots by name via `list_snapshots(name_contains=...)` / `create_sandbox(snapshot_name=...)` and routes per-trial vCPU / memory / filesystem limits onto `create_sandbox`; `stop()` never deletes the shared snapshot.

Touches `libs/deepagents` (integration-test fixture only) alongside `libs/evals` because the shared snapshot fixture has to move to the new API in lock-step with the harbor env.

## SDK dependency

The Python-side new-kwargs support was added in langchain-ai/langsmith-sdk#2769 (Python `snapshot_name` on `create_sandbox` + `name_contains`/`limit`/`offset` on `list_snapshots`) and released in `langsmith==0.7.34` on PyPI on 2026-04-23 (release PR: langchain-ai/langsmith-sdk#2778). JS parity (#2770) shipped earlier in `langsmith@0.5.22` (#2774) but is not consumed here.

`libs/evals/pyproject.toml` now pins `langsmith>=0.7.34`; the two `# ty: ignore[unknown-argument]` suppressions that the original draft mentioned have been removed (`ty check` is clean); `libs/evals/uv.lock` has been regenerated.

## How did you verify your code works?

- `uv run --group test ruff check` clean on changed files
- `uv run --group test ty check deepagents_evals/ deepagents_harbor/ tests/unit_tests/` — clean (no "unused ignore" warnings)
- `uv run --group test pytest tests/unit_tests/ -q` in `libs/evals` — **253 passed**
- Integration test `libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py` against live LangSmith prod — **81 passed, 4 xfailed** (the markers explicitly declared in the file). Exercises the full new API end-to-end: `list_snapshots(name_contains=...)` → `create_snapshot` (when missing) → `create_sandbox(snapshot_name=...)` → `delete_sandbox(...)`. Verified post-run that the shared `deepagents-cli` snapshot is preserved (`status='ready'`) and the sandbox was cleaned up (0 leftovers).
- One pre-existing `@pytest.mark.xfail(strict=True)` from #2694 on `test_awrite_aread_adownload_large_text_with_escaped_content` surfaces as an XPASS against the 0.7.34 SDK — orthogonal to this PR; a follow-up cleanup will drop that stale marker.

---

_Used Cursor (Claude Opus 4.7) to draft the migration following an existing plan; all code reviewed and tested locally._

Made with [Cursor](https://cursor.com)


---

BEGIN_COMMIT_OVERRIDE
refactor(harbor,sdk): migrate LangSmith env from templates to snapshots
END_COMMIT_OVERRIDE
