### PR TITLE
hotfix(cli): restore narrowed Textual keyboard parser patch

### DIFF
--- a/libs/cli/deepagents_cli/_textual_patches.py
+++ b/libs/cli/deepagents_cli/_textual_patches.py
@@ -1,0 +1,66 @@
+r"""Preserve the `alt` modifier on legacy `ESC + <byte>` sequences.
+
+Upstream `XTermParser._sequence_to_key_events` drops the `alt` flag on
+the tuple-branch fast path, so VSCode's `sendSequence` shift+enter
+binding (which writes `\x1b\r` to the PTY) arrives as bare `enter`
+instead of `alt+enter`. Tracked in Textualize/textual#6378. Remove this
+file and the Textual pin comment in `pyproject.toml` when that lands.
+
+Imported for side effect from `app.py` before any `App()` is created.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+_ESC_PREFIX_LEN = 2
+
+try:
+    from textual import events
+    from textual._ansi_sequences import (
+        ANSI_SEQUENCES_KEYS,  # noqa: PLC2701
+        IGNORE_SEQUENCE,  # noqa: PLC2701
+    )
+    from textual._xterm_parser import XTermParser  # noqa: PLC2701
+
+    _original = XTermParser._sequence_to_key_events
+except (ImportError, AttributeError) as exc:  # pragma: no cover - defensive
+    logger.warning("Textual keyboard parser patch skipped: %s", exc)
+else:
+
+    def _emit_alt(keys: tuple, character: str | None) -> Iterable[events.Key]:
+        for key in keys:
+            yield events.Key(f"alt+{key.value}", character)
+
+    def _sequence_to_key_events_with_alt(
+        self: XTermParser, sequence: str, alt: bool = False
+    ) -> Iterable[events.Key]:
+        # Fast path: \x1b<byte> on first pass. Short-circuits the ~100 ms
+        # escape-delay wait when both bytes arrive together. Semantic side
+        # effect: \x1b\x1b dispatches as `alt+escape` with no delay, matching
+        # crossterm and Node TTY.
+        if not alt and len(sequence) == _ESC_PREFIX_LEN and sequence[0] == "\x1b":
+            inner = ANSI_SEQUENCES_KEYS.get(sequence[1])
+            if inner is not IGNORE_SEQUENCE and isinstance(inner, tuple):
+                yield from _emit_alt(inner, None)
+                return
+        # Correctness fix (Textualize/textual#6378): preserve `alt` on the
+        # reissue path for single-byte tuple mappings.
+        if alt:
+            keys = ANSI_SEQUENCES_KEYS.get(sequence)
+            if keys is not IGNORE_SEQUENCE and isinstance(keys, tuple):
+                character = sequence if len(sequence) == 1 else None
+                yield from _emit_alt(keys, character)
+                return
+        yield from _original(self, sequence, alt=alt)
+
+    try:
+        XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]
+    except (AttributeError, TypeError) as exc:  # pragma: no cover - defensive
+        logger.warning("Textual keyboard parser patch assignment rejected: %s", exc)

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -33,7 +33,11 @@ from textual.widgets._toast import (
     Toast as _Toast,  # noqa: PLC2701  # for Toast click routing
 )
 
-from deepagents_cli import theme
+# Applied as an import-time side effect; must come before any App is created.
+from deepagents_cli import (
+    _textual_patches,  # noqa: F401
+    theme,
+)
 from deepagents_cli._cli_context import CLIContext
 from deepagents_cli._git import (
     read_git_branch_from_filesystem,

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "langchain-openai>=1.1.12,<2.0.0",
 
     # UI/Terminal
+    # Workaround for Textualize/textual#6378 lives in `_textual_patches.py`.
+    # On bump, run `tests/unit_tests/test_textual_patches.py` and delete the
+    # patch if the upstream issue is fixed.
     "textual>=8.0.0,<9.0.0",
     "textual-autocomplete>=3.0.0,<5.0.0",
     "textual-speedups>=0.2.1,<1.0.0",

--- a/libs/cli/tests/unit_tests/test_textual_patches.py
+++ b/libs/cli/tests/unit_tests/test_textual_patches.py
@@ -1,0 +1,92 @@
+"""Tests for the Textual keyboard parser monkey-patch.
+
+See `_textual_patches.py` and Textualize/textual#6378.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+from textual._xterm_parser import XTermParser
+
+from deepagents_cli import _textual_patches  # triggers patch
+
+
+def _keys_for(sequence: str, *, alt: bool) -> list[tuple[str, str | None]]:
+    parser = XTermParser.__new__(XTermParser)
+    return [
+        (event.key, event.character)
+        for event in parser._sequence_to_key_events(sequence, alt=alt)
+    ]
+
+
+class TestPatchedSequenceToKeyEvents:
+    r"""Targeted coverage of the two interventions in the shim."""
+
+    def test_reissue_path_preserves_alt_for_enter(self) -> None:
+        r"""Correctness fix: `\r` with `alt=True` must emit `alt+enter`.
+
+        Without the patch, the tuple branch in upstream drops `alt` and
+        VSCode `sendSequence` shift+enter arrives as bare `enter`.
+        """
+        assert _keys_for("\r", alt=True) == [("alt+enter", "\r")]
+
+    def test_fast_path_decodes_esc_cr_as_alt_enter(self) -> None:
+        r"""Fast path: `\x1b\r` with `alt=False` short-circuits to `alt+enter`.
+
+        Without the fast path, upstream stalls for ~100 ms waiting for
+        more bytes before reissuing.
+        """
+        assert _keys_for("\x1b\r", alt=False) == [("alt+enter", None)]
+
+    def test_kitty_extended_key_sequence_unchanged(self) -> None:
+        r"""Regression guard: kitty `CSI 13;2u` must still decode natively.
+
+        The patch only intercepts single-byte tuple mappings; extended
+        key sequences are handled by the unmodified upstream path.
+        """
+        assert _keys_for("\x1b[13;2u", alt=False) == [("shift+enter", None)]
+
+    def test_fast_path_double_escape_yields_alt_escape(self) -> None:
+        r"""Pin the documented semantic: `\x1b\x1b` emits `alt+escape` immediately.
+
+        Upstream Textual waits the full escape-delay before giving up; the
+        fast path short-circuits with zero latency. Any refactor that breaks
+        this should fail loudly rather than silently reverting the behavior.
+        """
+        assert _keys_for("\x1b\x1b", alt=False) == [("alt+escape", None)]
+
+    def test_fast_path_falls_through_when_inner_byte_unmapped(self) -> None:
+        r"""`\x1b<printable>` must bypass the fast path and defer to upstream.
+
+        Pins the `isinstance(inner, tuple)` guard — the `.get()` returns
+        `None` for unmapped bytes, which must not be treated as an alt key.
+        """
+        assert _keys_for("\x1bZ", alt=False) == []
+
+
+def test_app_imports_textual_patches_for_side_effect() -> None:
+    """`app.py` must import `_textual_patches` for the patch to install.
+
+    Direct-import tests would pass even if the side-effect import were
+    removed, so silently breaking shift+enter for VSCode `sendSequence`
+    users. A static AST check closes that gap without spawning a subprocess.
+    """
+    spec = importlib.util.find_spec("deepagents_cli.app")
+    assert spec is not None
+    assert spec.origin is not None
+
+    tree = ast.parse(Path(spec.origin).read_text(encoding="utf-8"))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == "deepagents_cli"
+        for alias in node.names
+    }
+    assert "_textual_patches" in imported, (
+        "deepagents_cli/app.py must import `_textual_patches` as a side "
+        "effect; removing it silently breaks shift+enter via VSCode "
+        "sendSequence. See `_textual_patches.py` for context."
+    )


### PR DESCRIPTION
Restore a narrowed version of the `XTermParser` monkey-patch dropped in #2872. The intervening hotfix left `shift+enter` broken for users with a stale `workbench.action.terminal.sendSequence` binding in VSCode's `keybindings.json` — an entry commonly installed by Claude Code's `/terminal-setup` and persistent even on VSCode 1.109.5+ where kitty protocol support landed in xterm.js.