### PR TITLE
fix(cli): queue `/model` switches during server startup

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -6374,6 +6374,24 @@ class DeepAgentsApp(App):
             model_spec = model_spec.removeprefix(":")
 
             if not self._remote_agent():
+                if self._connecting:
+                    from functools import partial
+
+                    self._defer_action(
+                        DeferredAction(
+                            kind="model_switch",
+                            execute=partial(
+                                self._switch_model,
+                                model_spec,
+                                extra_kwargs=extra_kwargs,
+                            ),
+                        )
+                    )
+                    self.notify(
+                        "Model will switch once the session is ready.",
+                        timeout=3,
+                    )
+                    return
                 await self._mount_message(
                     ErrorMessage("Model switching requires a server-backed session.")
                 )

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -365,6 +365,86 @@ class TestModelSwitchConcurrencyGuard:
         assert app._model_switching is False
 
 
+class TestModelSwitchSessionReadiness:
+    """Tests for gating model switch on server-backed session readiness."""
+
+    async def test_defers_switch_while_connecting(self) -> None:
+        """A direct /model switch fired before `ServerReady` is queued, not failed."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        notify_mock = Mock()
+        app.notify = notify_mock  # type: ignore[method-assign]
+        app._agent = None
+        app._connecting = True
+
+        await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        assert len(app._deferred_actions) == 1
+        action = app._deferred_actions[0]
+        assert action.kind == "model_switch"
+        notify_mock.assert_called_once()
+        app._mount_message.assert_not_called()  # type: ignore[union-attr]
+        # Guard flag cleared so the deferred retry isn't a no-op.
+        assert app._model_switching is False
+
+    async def test_errors_when_agent_missing_and_not_connecting(self) -> None:
+        """Server-startup failure (no agent, not connecting) still errors."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        notify_mock = Mock()
+        app.notify = notify_mock  # type: ignore[method-assign]
+        app._agent = None
+        app._connecting = False
+
+        captured_errors: list[str] = []
+        original_init = ErrorMessage.__init__
+
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
+            captured_errors.append(message)
+            original_init(self, message, **kwargs)
+
+        with patch.object(ErrorMessage, "__init__", capture_init):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        assert app._deferred_actions == []
+        notify_mock.assert_not_called()
+        assert any("server-backed session" in msg for msg in captured_errors)
+
+    async def test_deferred_switch_completes_after_server_ready(self) -> None:
+        """End-to-end: defer during connect, drain after ready, switch completes."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        notify_mock = Mock()
+        app.notify = notify_mock  # type: ignore[method-assign]
+        app._agent = None
+        app._connecting = True
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch("deepagents_cli.model_config.save_recent_model", return_value=True),
+        ):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+            assert len(app._deferred_actions) == 1
+
+            # Simulate `ServerReady`: agent arrives, connecting flips off, drain runs.
+            app._agent = _make_remote_agent()
+            app._connecting = False
+            await app._maybe_drain_deferred()
+
+        assert app._deferred_actions == []
+        assert app._model_override == "anthropic:claude-sonnet-4-5"
+        assert settings.model_name == "claude-sonnet-4-5"
+        assert settings.model_provider == "anthropic"
+        assert app._model_switching is False
+
+
 class TestModelSwitchConfigProvider:
     """Tests for switching to config-file-defined providers."""
 


### PR DESCRIPTION
Typing `/model <spec>` before the `langgraph dev` subprocess finished coming up surfaced `Error: Model switching requires a server-backed session.` instead of doing what the user wanted. Queue the switch until `ServerReady` fires and the existing deferred-action drain can replay it against the live `RemoteAgent`.