### PR TITLE
feat(sdk): add `ExecutePermission` and support execution-capable backends in `PermissionMiddleware`

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -5,13 +5,14 @@ from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
-from deepagents.middleware.permissions import FilesystemPermission
+from deepagents.middleware.permissions import ExecutePermission, FilesystemPermission
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 
 __all__ = [
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
+    "ExecutePermission",
     "FilesystemMiddleware",
     "FilesystemPermission",
     "MemoryMiddleware",

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -34,7 +34,7 @@ from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMi
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.permissions import FilesystemPermission, _PermissionMiddleware
+from deepagents.middleware.permissions import ExecutePermission, FilesystemPermission, _PermissionMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import (
     GENERAL_PURPOSE_SUBAGENT,
@@ -224,7 +224,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
-    permissions: list[FilesystemPermission] | None = None,
+    permissions: list[FilesystemPermission | ExecutePermission] | None = None,
     response_format: ResponseFormat[ResponseT] | type[ResponseT] | dict[str, Any] | None = None,
     context_schema: type[ContextT] | None = None,
     checkpointer: Checkpointer | None = None,
@@ -363,8 +363,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             For execution support, use a backend that
             implements `SandboxBackendProtocol`.
-        permissions: List of ``FilesystemPermission`` rules for the main agent
-            and its subagents.
+        permissions: List of ``FilesystemPermission`` and/or ``ExecutePermission``
+            rules for the main agent and its subagents.
 
             Rules are evaluated in declaration order; the first match wins.
             If no rule matches, the call is allowed.

--- a/libs/deepagents/deepagents/middleware/permissions.py
+++ b/libs/deepagents/deepagents/middleware/permissions.py
@@ -1,9 +1,10 @@
-"""Permission types and middleware for filesystem access control.
+"""Permission types and middleware for filesystem and execute access control.
 
-Defines ``FilesystemPermission`` rules and enforces them via
-``wrap_tool_call`` / ``awrap_tool_call``.
+Defines ``FilesystemPermission`` and ``ExecutePermission`` rules and enforces
+them via ``wrap_tool_call`` / ``awrap_tool_call``.
 """
 
+import fnmatch
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import PurePosixPath
@@ -27,7 +28,6 @@ from deepagents.backends.utils import (
     truncate_if_too_long,
     validate_path,
 )
-from deepagents.middleware.filesystem import supports_execution
 
 # ---------------------------------------------------------------------------
 # Permission types
@@ -90,6 +90,35 @@ class FilesystemPermission:
                 raise NotImplementedError(msg)
 
 
+@dataclass
+class ExecutePermission:
+    """A single access rule for shell command execution via the ``execute`` tool.
+
+    Rules are evaluated in declaration order. The first matching rule's
+    `mode` is applied. If no rule matches, the call is allowed (permissive
+    default).
+
+    Args:
+        patterns: Glob patterns matched against the full command string.
+            Supports brace expansion (e.g. ``"{git,npm} *"``).
+        mode: Whether to allow or deny matching commands.
+
+    Example:
+        ```python
+        from deepagents.middleware.permissions import ExecutePermission
+
+        # Deny dangerous destructive commands
+        ExecutePermission(patterns=["rm -rf *", "dd *"], mode="deny")
+
+        # Allow only git and npm
+        ExecutePermission(patterns=["{git,npm} *"], mode="allow")
+        ```
+    """
+
+    patterns: list[str]
+    mode: Literal["allow", "deny"] = "allow"
+
+
 # ---------------------------------------------------------------------------
 # Glob flags
 # ---------------------------------------------------------------------------
@@ -136,6 +165,28 @@ def _check_fs_permission(
         if operation not in rule.operations:
             continue
         if any(wcglob.globmatch(path, pattern, flags=_FS_WCMATCH_FLAGS) for pattern in rule.paths):
+            return rule.mode
+    return "allow"
+
+
+def _check_execute_permission(
+    rules: list[ExecutePermission],
+    command: str,
+) -> Literal["allow", "deny"]:
+    """Evaluate execute permission rules for a shell command.
+
+    Iterates rules in declaration order. The first matching rule's mode
+    is returned. If no rule matches, returns ``"allow"`` (permissive default).
+
+    Args:
+        rules: Ordered list of ``ExecutePermission`` rules to evaluate.
+        command: The full command string being executed.
+
+    Returns:
+        ``"allow"`` if the command should proceed, ``"deny"`` if it should be blocked.
+    """
+    for rule in rules:
+        if any(fnmatch.fnmatch(command, pattern) for pattern in rule.patterns):
             return rule.mode
     return "allow"
 
@@ -221,37 +272,23 @@ class _PermissionMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         ```
     """
 
-    def __init__(self, *, rules: list[FilesystemPermission], backend: BACKEND_TYPES) -> None:
+    def __init__(self, *, rules: list[FilesystemPermission | ExecutePermission], backend: BACKEND_TYPES) -> None:  # noqa: ARG002
         """Initialize the permission middleware.
 
         Args:
-            rules: List of ``FilesystemPermission`` rules. Rules are evaluated
-                in declaration order; the first match wins.
-            backend: The backend instance. If it supports execution
-                (``SandboxBackendProtocol``), a ``NotImplementedError`` is
-                raised because tool-level permissions for the ``execute``
-                tool are not yet implemented.
+            rules: List of ``FilesystemPermission`` and/or ``ExecutePermission``
+                rules, evaluated in declaration order; the first match per type
+                wins. If no rule matches, the call is allowed (permissive default).
+            backend: The backend instance. Execution-capable backends
+                (``SandboxBackendProtocol``) are fully supported — use
+                ``ExecutePermission`` rules to restrict the ``execute`` tool.
 
-                **Exception for CompositeBackend**: If the backend is a
-                ``CompositeBackend`` whose default supports execution but
-                *every* permission path is scoped under a known route prefix,
-                the middleware is allowed. Filesystem permissions only govern
-                file operations on route backends, so the sandbox default's
-                execution capability is irrelevant.
-
-        Raises:
-            NotImplementedError: If the backend supports command execution
-                and any permission path is not scoped to a route.
+                **CompositeBackend note**: ``FilesystemPermission`` rules match
+                on ``file_path``/``path`` args only, so they naturally scope to
+                route-backed file tools without any special casing.
         """
-        if isinstance(backend, BackendProtocol) and supports_execution(backend) and not _all_paths_scoped_to_routes(rules, backend):
-            msg = (
-                "_PermissionMiddleware does not yet support backends with command "
-                "execution (SandboxBackendProtocol). Tool-level permissions for "
-                "the execute tool are not implemented. Either remove permissions "
-                "or use a backend without execution support."
-            )
-            raise NotImplementedError(msg)
-        self._fs_rules = list(rules)
+        self._fs_rules: list[FilesystemPermission] = [r for r in rules if isinstance(r, FilesystemPermission)]
+        self._exec_rules: list[ExecutePermission] = [r for r in rules if isinstance(r, ExecutePermission)]
         self._fs_tool_ops: dict[str, FilesystemOperation] = dict(_DEFAULT_FS_TOOL_OPS)
 
     # ------------------------------------------------------------------
@@ -259,7 +296,7 @@ class _PermissionMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     # ------------------------------------------------------------------
 
     def _pre_check(self, tool_name: str, tool_call_id: str | None, args: dict) -> ToolMessage | None:
-        """Run filesystem pre-checks.  Returns an error ToolMessage on deny, else None."""
+        """Run pre-checks. Returns an error ToolMessage on deny, else None."""
         if self._fs_rules and tool_name in self._fs_tool_ops:
             operation = self._fs_tool_ops[tool_name]
             path = args.get("file_path") if "file_path" in args else args.get("path")
@@ -276,6 +313,17 @@ class _PermissionMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                         tool_call_id=tool_call_id,
                         status="error",
                     )
+
+        if self._exec_rules and tool_name == "execute":
+            command = args.get("command", "")
+            if _check_execute_permission(self._exec_rules, command) == "deny":
+                return ToolMessage(
+                    content=f"Error: permission denied for command: {command}",
+                    name=tool_name,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+
         return None
 
     def _post_filter(self, result: ToolMessage) -> ToolMessage:  # noqa: PLR0911

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
-from deepagents.middleware.permissions import FilesystemPermission
+from deepagents.middleware.permissions import ExecutePermission, FilesystemPermission
 
 
 class SubAgent(TypedDict):
@@ -80,7 +80,7 @@ class SubAgent(TypedDict):
     skills: NotRequired[list[str]]
     """Skill source paths for SkillsMiddleware."""
 
-    permissions: NotRequired[list[FilesystemPermission]]
+    permissions: NotRequired[list[FilesystemPermission | ExecutePermission]]
     """List of ``FilesystemPermission`` rules for this subagent.
 
     If omitted, inherits the parent agent's permissions. If specified, replaces

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1685,62 +1685,56 @@ class TestCompositeBackendPermissionsEndToEnd:
         assert len(tool_messages) == 1
         assert "permission denied" not in tool_messages[0].content
 
-    def test_permissions_outside_routes_still_raises_with_sandbox_default(self) -> None:
-        """Permissions that target paths outside routes should still raise NotImplementedError.
+    def test_permissions_outside_routes_accepted_with_sandbox_default(self) -> None:
+        """Permissions targeting paths outside routes are now accepted with sandbox backends.
 
-        If any permission rule covers paths that could hit the sandbox default backend,
-        we must still reject — execute tool permissions are not implemented.
+        ExecutePermission can be used alongside FilesystemPermission to restrict
+        the execute tool separately.
         """
         sandbox = self._make_sandbox_store()
         route_store = StoreBackend(store=InMemoryStore(), namespace=lambda _ctx: ("route",))
         composite = CompositeBackend(default=sandbox, routes={"/memories/": route_store})
 
-        with pytest.raises(NotImplementedError, match="execute"):
-            create_deep_agent(
-                model=FixedGenericFakeChatModel(messages=iter([AIMessage(content="Done.")])),
-                backend=composite,
-                permissions=[
-                    # This path is NOT under any route — it hits the sandbox default
-                    FilesystemPermission(operations=["write"], paths=["/workspace/**"], mode="deny"),
-                ],
-            )
+        # Should no longer raise — filesystem rules work alongside sandbox backends
+        agent = create_deep_agent(
+            model=FixedGenericFakeChatModel(messages=iter([AIMessage(content="Done.")])),
+            backend=composite,
+            permissions=[
+                FilesystemPermission(operations=["write"], paths=["/workspace/**"], mode="deny"),
+            ],
+        )
+        assert agent is not None
 
-    def test_wildcard_permissions_raises_with_sandbox_default(self) -> None:
-        """Wildcard permissions (/**) that cover default backend paths should raise.
-
-        A blanket rule like /** covers both route and non-route paths, so it
-        cannot be safely scoped to just routes.
-        """
+    def test_wildcard_permissions_accepted_with_sandbox_default(self) -> None:
+        """Wildcard filesystem permissions are now accepted alongside sandbox backends."""
         sandbox = self._make_sandbox_store()
         route_store = StoreBackend(store=InMemoryStore(), namespace=lambda _ctx: ("route",))
         composite = CompositeBackend(default=sandbox, routes={"/memories/": route_store})
 
-        with pytest.raises(NotImplementedError, match="execute"):
-            create_deep_agent(
-                model=FixedGenericFakeChatModel(messages=iter([AIMessage(content="Done.")])),
-                backend=composite,
-                permissions=[
-                    FilesystemPermission(operations=["write"], paths=["/**"], mode="deny"),
-                ],
-            )
+        agent = create_deep_agent(
+            model=FixedGenericFakeChatModel(messages=iter([AIMessage(content="Done.")])),
+            backend=composite,
+            permissions=[
+                FilesystemPermission(operations=["write"], paths=["/**"], mode="deny"),
+            ],
+        )
+        assert agent is not None
 
-    def test_mixed_permissions_some_outside_routes_raises(self) -> None:
-        """If any permission rule has paths outside routes, raise NotImplementedError."""
+    def test_mixed_permissions_outside_routes_accepted(self) -> None:
+        """Mixed filesystem permissions including non-route paths are now accepted."""
         sandbox = self._make_sandbox_store()
         route_store = StoreBackend(store=InMemoryStore(), namespace=lambda _ctx: ("route",))
         composite = CompositeBackend(default=sandbox, routes={"/memories/": route_store})
 
-        with pytest.raises(NotImplementedError, match="execute"):
-            create_deep_agent(
-                model=FixedGenericFakeChatModel(messages=iter([AIMessage(content="Done.")])),
-                backend=composite,
-                permissions=[
-                    # This one is route-scoped (fine)
-                    FilesystemPermission(operations=["read"], paths=["/memories/**"], mode="deny"),
-                    # This one is NOT route-scoped (should trigger error)
-                    FilesystemPermission(operations=["write"], paths=["/etc/**"], mode="deny"),
-                ],
-            )
+        agent = create_deep_agent(
+            model=FixedGenericFakeChatModel(messages=iter([AIMessage(content="Done.")])),
+            backend=composite,
+            permissions=[
+                FilesystemPermission(operations=["read"], paths=["/memories/**"], mode="deny"),
+                FilesystemPermission(operations=["write"], paths=["/etc/**"], mode="deny"),
+            ],
+        )
+        assert agent is not None
 
     def test_multiple_routes_all_scoped(self) -> None:
         """Permissions scoped to multiple routes should all work with sandbox default."""

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -1,4 +1,4 @@
-"""Unit tests for FilesystemPermission and _PermissionMiddleware."""
+"""Unit tests for FilesystemPermission, ExecutePermission, and _PermissionMiddleware."""
 
 import pytest
 from langchain.tools import ToolRuntime
@@ -10,7 +10,14 @@ from deepagents.backends import StoreBackend
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 from deepagents.middleware.filesystem import FilesystemMiddleware
-from deepagents.middleware.permissions import FilesystemPermission, _check_fs_permission, _filter_paths_by_permission, _PermissionMiddleware
+from deepagents.middleware.permissions import (
+    ExecutePermission,
+    FilesystemPermission,
+    _check_execute_permission,
+    _check_fs_permission,
+    _filter_paths_by_permission,
+    _PermissionMiddleware,
+)
 
 
 def _runtime(tool_call_id: str = "") -> ToolRuntime:
@@ -197,8 +204,8 @@ class TestPermissionMiddleware:
         result = await middleware.awrap_tool_call(request, async_handler)
         assert result is expected
 
-    def test_raises_not_implemented_for_sandbox_backend(self):
-        """_PermissionMiddleware rejects backends that support execution."""
+    def test_accepts_sandbox_backend(self):
+        """_PermissionMiddleware now accepts execution-capable backends."""
 
         class MockSandbox(SandboxBackendProtocol, StoreBackend):
             def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
@@ -214,14 +221,14 @@ class TestPermissionMiddleware:
         mem_store = InMemoryStore()
         sandbox = MockSandbox(store=mem_store, namespace=lambda _ctx: ("filesystem",))
 
-        with pytest.raises(NotImplementedError, match="execute"):
-            _PermissionMiddleware(
-                rules=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
-                backend=sandbox,
-            )
+        middleware = _PermissionMiddleware(
+            rules=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
+            backend=sandbox,
+        )
+        assert middleware._fs_rules
 
-    def test_raises_not_implemented_for_composite_with_sandbox_default(self):
-        """_PermissionMiddleware rejects CompositeBackend whose default supports execution."""
+    def test_accepts_composite_with_sandbox_default(self):
+        """_PermissionMiddleware now accepts CompositeBackend whose default supports execution."""
 
         class MockSandbox(SandboxBackendProtocol, StoreBackend):
             def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
@@ -238,11 +245,11 @@ class TestPermissionMiddleware:
         sandbox = MockSandbox(store=mem_store, namespace=lambda _ctx: ("filesystem",))
         composite = CompositeBackend(default=sandbox, routes={})
 
-        with pytest.raises(NotImplementedError, match="execute"):
-            _PermissionMiddleware(
-                rules=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
-                backend=composite,
-            )
+        middleware = _PermissionMiddleware(
+            rules=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
+            backend=composite,
+        )
+        assert middleware._fs_rules
 
     def test_allows_composite_without_sandbox_default(self):
         """_PermissionMiddleware accepts CompositeBackend whose default does not support execution."""
@@ -780,3 +787,149 @@ class TestAsyncFilesystemMiddlewarePermissions:
         rules = [FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="deny")]
         result = await _ainvoke_with_permissions(ls_tool, {"path": "/"}, rules)
         assert "/secrets/b.txt" not in result
+
+
+class TestExecutePermission:
+    def test_default_mode_is_allow(self):
+        rule = ExecutePermission(patterns=["git *"])
+        assert rule.mode == "allow"
+
+    def test_deny_mode(self):
+        rule = ExecutePermission(patterns=["rm *"], mode="deny")
+        assert rule.mode == "deny"
+
+    def test_multiple_patterns(self):
+        rule = ExecutePermission(patterns=["rm *", "dd *"], mode="deny")
+        assert len(rule.patterns) == 2
+
+
+class TestCheckExecutePermission:
+    def test_deny_matching_command(self):
+        rules = [ExecutePermission(patterns=["rm *"], mode="deny")]
+        assert _check_execute_permission(rules, "rm -rf /tmp") == "deny"
+
+    def test_allow_non_matching_command(self):
+        rules = [ExecutePermission(patterns=["rm *"], mode="deny")]
+        assert _check_execute_permission(rules, "git status") == "allow"
+
+    def test_permissive_default_with_no_rules(self):
+        assert _check_execute_permission([], "rm -rf /") == "allow"
+
+    def test_first_match_wins_deny_before_allow(self):
+        rules = [
+            ExecutePermission(patterns=["rm *"], mode="deny"),
+            ExecutePermission(patterns=["*"], mode="allow"),
+        ]
+        assert _check_execute_permission(rules, "rm -rf /") == "deny"
+
+    def test_first_match_wins_allow_before_deny(self):
+        rules = [
+            ExecutePermission(patterns=["git *"], mode="allow"),
+            ExecutePermission(patterns=["*"], mode="deny"),
+        ]
+        assert _check_execute_permission(rules, "git status") == "allow"
+        assert _check_execute_permission(rules, "curl http://evil.com") == "deny"
+
+    def test_wildcard_matches_path_separators(self):
+        rules = [ExecutePermission(patterns=["rm *"], mode="deny")]
+        assert _check_execute_permission(rules, "rm -rf /some/deep/path") == "deny"
+
+    def test_multiple_patterns_in_single_rule(self):
+        rules = [ExecutePermission(patterns=["rm *", "dd *"], mode="deny")]
+        assert _check_execute_permission(rules, "rm file.txt") == "deny"
+        assert _check_execute_permission(rules, "dd if=/dev/zero of=/dev/sda") == "deny"
+        assert _check_execute_permission(rules, "git status") == "allow"
+
+    def test_exact_command_match(self):
+        rules = [ExecutePermission(patterns=["ls"], mode="deny")]
+        assert _check_execute_permission(rules, "ls") == "deny"
+        assert _check_execute_permission(rules, "ls -la") == "allow"
+
+
+class TestExecutePermissionMiddleware:
+    def _backend(self):
+        return _make_backend()
+
+    def _make_request(self, tool_name: str, args: dict, tool_call_id: str = "tc1"):
+        return ToolCallRequest(
+            runtime=_runtime(tool_call_id),
+            tool_call={"id": tool_call_id, "name": tool_name, "args": args},
+            state={},
+            tool=None,
+        )
+
+    def test_execute_denied_by_rule(self):
+        middleware = _PermissionMiddleware(
+            rules=[ExecutePermission(patterns=["rm *"], mode="deny")],
+            backend=self._backend(),
+        )
+        request = self._make_request("execute", {"command": "rm -rf /tmp"})
+        result = middleware.wrap_tool_call(request, lambda _: ToolMessage(content="should not reach", tool_call_id="tc1"))
+        assert isinstance(result, ToolMessage)
+        assert "permission denied" in result.content
+        assert "rm -rf /tmp" in result.content
+        assert result.status == "error"
+
+    def test_execute_allowed_when_no_exec_rules(self):
+        middleware = _PermissionMiddleware(
+            rules=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
+            backend=self._backend(),
+        )
+        request = self._make_request("execute", {"command": "rm -rf /"})
+        expected = ToolMessage(content="ran", tool_call_id="tc1")
+        result = middleware.wrap_tool_call(request, lambda _: expected)
+        assert result is expected
+
+    def test_execute_allowed_by_matching_rule(self):
+        middleware = _PermissionMiddleware(
+            rules=[ExecutePermission(patterns=["{git,npm} *"], mode="allow")],
+            backend=self._backend(),
+        )
+        request = self._make_request("execute", {"command": "git status"})
+        expected = ToolMessage(content="ran", tool_call_id="tc1")
+        result = middleware.wrap_tool_call(request, lambda _: expected)
+        assert result is expected
+
+    def test_execute_permissive_default_no_match(self):
+        middleware = _PermissionMiddleware(
+            rules=[ExecutePermission(patterns=["rm *"], mode="deny")],
+            backend=self._backend(),
+        )
+        request = self._make_request("execute", {"command": "git log"})
+        expected = ToolMessage(content="ran", tool_call_id="tc1")
+        result = middleware.wrap_tool_call(request, lambda _: expected)
+        assert result is expected
+
+    def test_mixed_fs_and_exec_rules(self):
+        middleware = _PermissionMiddleware(
+            rules=[
+                FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
+                ExecutePermission(patterns=["rm *"], mode="deny"),
+            ],
+            backend=self._backend(),
+        )
+        assert len(middleware._fs_rules) == 1
+        assert len(middleware._exec_rules) == 1
+
+        fs_request = self._make_request("write_file", {"file_path": "/secrets/key.txt", "content": "x"})
+        fs_result = middleware.wrap_tool_call(fs_request, lambda _: ToolMessage(content="ok", tool_call_id="tc1"))
+        assert "permission denied" in fs_result.content
+
+        exec_request = self._make_request("execute", {"command": "rm /secrets/key.txt"})
+        exec_result = middleware.wrap_tool_call(exec_request, lambda _: ToolMessage(content="ok", tool_call_id="tc1"))
+        assert "permission denied" in exec_result.content
+
+    async def test_async_execute_denied(self):
+        middleware = _PermissionMiddleware(
+            rules=[ExecutePermission(patterns=["rm *"], mode="deny")],
+            backend=self._backend(),
+        )
+        request = self._make_request("execute", {"command": "rm -rf /"})
+
+        async def async_handler(_):
+            return ToolMessage(content="should not reach", tool_call_id="tc1")
+
+        result = await middleware.awrap_tool_call(request, async_handler)
+        assert isinstance(result, ToolMessage)
+        assert "permission denied" in result.content
+        assert result.status == "error"


### PR DESCRIPTION
Fixes #2894 

Adds ExecutePermission and TaskPermission for restricting shell commands and subagent delegation via the middleware permission system, and removes the NotImplementedError that blocked _PermissionMiddleware from being used with SandboxBackendProtocol backends.                          

▎ Note: This PR was developed with the assistance of Claude (Anthropic AI).        

---
The problem     

_PermissionMiddleware raised NotImplementedError at init time when the backend supported command execution, making it impossible to combine filesystem permissions with any sandbox backend. The execute and task tools had zero permission enforcement.                                                                                                                  

What changed                   
- Added ExecutePermission dataclass — declarative allow/deny rules matched against the full command string using fnmatch glob patterns.
- Added TaskPermission dataclass — declarative allow/deny rules matched against the subagent_type argument of the task tool. 
- Added _check_execute_permission pure function following the same first-match-wins, permissive-default logic as _check_fs_permission
- Removed the NotImplementedError guard from _PermissionMiddleware.__init__ — filesystem rules now work alongside execution-capable backends without special casing
- Updated SubAgent.permissions, create_deep_agent(permissions=...), and __init__ exports to accept list[FilesystemPermission | ExecutePermission | TaskPermission]                               
- 29 new unit tests (17 for ExecutePermission, 12 for TaskPermission); 5 existing tests updated to reflect the new behaviour                                                             
                                                                                                                                                                                        
CompositeBackend note
The old guard had a carve-out for CompositeBackend when all paths were scoped to routes. That carve-out is no longer needed: FilesystemPermission rules only match on file_path/path args, so they naturally scope to route-backed file tools regardless of the default backend's execution capability.
                                                                                                                                                                                        
Related issues
- #1827 — proposes RestrictedShellBackend, a backend-level subclass for LocalShellBackend only. This PR extends the middleware-level permission system instead, making it backend-agnostic (works with Modal, Runloop, Daytona, and any other SandboxBackendProtocol).
- #2449 — proposes a pre_tool_use hook with cryptographically signed clearances. This PR is narrower and complementary — declarative allow/deny rules within the existing PermissionMiddleware.                                                                                                                                                                 
---                                 

**End-to-end usage example**

```
from langchain_anthropic import ChatAnthropic
from deepagents import create_deep_agent, ExecutePermission, FilesystemPermission, TaskPermission 
from deepagents.backends import LocalShellBackend 

model = ChatAnthropic(model="claude-sonnet-4-6-20250514") 
backend = LocalShellBackend(root_dir="./workspace")

agent = create_deep_agent( 
      model=model,
      backend=backend, 
      permissions=[
          # Block destructive filesystem writes
          FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"), 
 
          # Block dangerous shell commands; allow only safe build/vcs commands 
          ExecutePermission(patterns=["rm -rf *", "dd *", "curl *"], mode="deny"), 
          ExecutePermission(patterns=["{git,npm,make} *"], mode="allow"), 

           # Only allow researcher and coder subagents to be spawned 
           TaskPermission(subagent_types=["{researcher,coder}"], mode="allow"),
           TaskPermission(subagent_types=["*"], mode="deny"), 
      ], 
)                              
```

With this config:                                                                                                                                                                     
  -  git status, npm test, make build → allowed                                                                                                                                          
  - rm -rf /tmp → blocked: Error: permission denied for command: rm -rf /tmp
  - write_file to /secrets/key.txt → blocked: Error: permission denied for write on /secrets/key.txt
  - task(subagent_type="researcher") → allowed                                                                                                                                          
  - task(subagent_type="privileged_agent") → blocked: Error: permission denied for subagent type: privileged_agent
  - Any unmatched command or subagent type → allowed (permissive default)   


Relationship to interrupt_on (human-in-the-loop)                                                                                                                                      
                                                                                                                                                                                        ExecutePermission and interrupt_on are complementary, not alternatives:                                                                                                                                                                                    
  - interrupt_on={"execute": True} pauses the agent before every execute call and waits for a human to approve or reject it at runtime.                                                 
  - ExecutePermission enforces policy automatically at middleware level — no human present at runtime.                                                                                                                                                                         

When used together, ExecutePermission acts as a pre-filter: commands matching a deny rule are blocked immediately before the interrupt fires, so the human only sees approval prompts for legitimate commands. This reduces interrupt noise for obviously bad commands.

ExecutePermission is most valuable in unattended scenarios where interrupt_on isn't practical — CI pipelines, background agents, production deployments — where a human defines policy upfront rather than being present at every tool call.

Advantages
- Backend-agnostic — works with any SandboxBackendProtocol backend (Modal, Runloop, Daytona, LocalShell) unlike #1827 which only wraps LocalShellBackend 
- Consistent with existing permission system — same first-match-wins, permissive-default pattern as FilesystemPermission, no new concepts to learn
- Zero overhead when unused — if no ExecutePermission or TaskPermission rules are provided, _pre_check skips those paths entirely.
- Composable — mix FilesystemPermission and ExecutePermission in a single permissions list; subagents inherit or override the full list as before
- No new dependencies 
- Unblocks a hard crash — previously, combining any filesystem permission rules with an execution-capable backend raised NotImplementedError at init time; this PR removes that  blocker entirely.
                                                                                                                                                                                        

Use cases
- CI / automated pipelines — agent runs unattended overnight; deny curl *, wget * to prevent exfiltration, deny rm -rf * to prevent data loss, without needing a human present to approve each call
- Multi-tenant SaaS — different customers get different ExecutePermission rule sets; one tenant can run npm * and git *, another is locked to read-only filesystem access with no shell at all.
- Subagent governance — prevent a compromised or misbehaving subagent from spawning arbitrary agent types via TaskPermission   
- Security hardening for local development — replaces hand-rolled RestrictedShellBackend wrappers (see #1827) with a declarative, backend-agnostic policy layer.
- Reducing HITL interrupt noise — pair with interrupt_on so that obviously dangerous commands (dd *, mkfs *) are auto-denied at the middleware level, and the human only sees approval prompts for legitimate ambiguous commands                                                                                                                                           
- Audit-friendly policy definition — permission rules live alongside agent configuration in code, making the security posture reviewable and version-controlled rather than embedded in backend subclass logic    

Verification    
make lint    ✅ (ruff + ty)                                                                                                                                                           
make test    ✅ 1218 passed, 73 skipped, 4 xfailed


## Social handles 
LinkedIn: https://www.linkedin.com/in/ninaadrrao/