### PR TITLE
feat(sdk): add fork mode to subagents for prompt-cache reuse

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -52,6 +52,9 @@ real PyPI release. Any non-empty value enables the flag (including `"0"` or
 EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
 """Colon-separated paths added to the skill containment allowlist."""
 
+FORK_SUBAGENT = "DEEPAGENTS_CLI_FORK_SUBAGENT"
+"""Make CLI-loaded custom subagents inherit the parent conversation context."""
+
 KITTY_KEYBOARD = "DEEPAGENTS_CLI_KITTY_KEYBOARD"
 """Override kitty-keyboard detection (`1` forces on, `0` forces off)."""
 

--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 from langchain.agents.middleware.types import AgentMiddleware
 
 from deepagents_cli import theme
+from deepagents_cli._env_vars import FORK_SUBAGENT
 from deepagents_cli.config import (
     _ShellAllowAll,
     config,
@@ -1041,6 +1042,7 @@ def create_cli_agent(
         else settings.get_project_agents_dir()
     )
 
+    force_fork_subagents = os.environ.get(FORK_SUBAGENT) == "1"
     for subagent_meta in list_subagents(
         user_agents_dir=user_agents_dir,
         project_agents_dir=project_agents_dir,
@@ -1050,7 +1052,9 @@ def create_cli_agent(
             "description": subagent_meta["description"],
             "system_prompt": subagent_meta["system_prompt"],
         }
-        if subagent_meta["model"]:
+        if force_fork_subagents:
+            subagent["fork"] = True
+        elif subagent_meta["model"]:
             subagent["model"] = subagent_meta["model"]
         if restrictive_shell_allow_list is not None:
             subagent["middleware"] = [
@@ -1058,7 +1062,7 @@ def create_cli_agent(
             ]
         custom_subagents.append(subagent)
 
-    if restrictive_shell_allow_list is not None:
+    if force_fork_subagents or restrictive_shell_allow_list is not None:
         from deepagents.middleware.subagents import (
             GENERAL_PURPOSE_SUBAGENT,
             SubAgent as RuntimeSubAgent,
@@ -1072,8 +1076,13 @@ def create_cli_agent(
                 "name": GENERAL_PURPOSE_SUBAGENT["name"],
                 "description": GENERAL_PURPOSE_SUBAGENT["description"],
                 "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
-                "middleware": [ShellAllowListMiddleware(restrictive_shell_allow_list)],
             }
+            if force_fork_subagents:
+                general_purpose_subagent["fork"] = True
+            if restrictive_shell_allow_list is not None:
+                general_purpose_subagent["middleware"] = [
+                    ShellAllowListMiddleware(restrictive_shell_allow_list)
+                ]
             custom_subagents.append(general_purpose_subagent)
 
     # Build middleware stack based on enabled features

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from langchain.messages import ToolCall
     from langgraph.runtime import Runtime
 
+from deepagents_cli._env_vars import FORK_SUBAGENT
 from deepagents_cli.agent import (
     DEFAULT_AGENT_NAME,
     _format_edit_file_description,
@@ -2171,6 +2172,61 @@ class TestCreateCliAgentShellMiddlewareWiring:
             assert not any(
                 isinstance(mw, ShellAllowListMiddleware) for mw in middleware
             ), f"Subagent {subagent['name']!r} should not have shell middleware"
+
+    def test_fork_subagent_env_marks_cli_subagents_as_fork(
+        self, tmp_path: Path
+    ) -> None:
+        """`DEEPAGENTS_CLI_FORK_SUBAGENT=1` forks CLI-loaded subagents."""
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+
+        subagent_meta = {
+            "name": "researcher",
+            "description": "Researches things",
+            "system_prompt": "Investigate the task thoroughly.",
+            "model": "anthropic:claude-haiku-4-5-20251001",
+        }
+
+        with (
+            patch.dict("os.environ", {FORK_SUBAGENT: "1"}, clear=False),
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware"),
+            patch(
+                "deepagents_cli.agent.list_subagents",
+                return_value=[subagent_meta],
+            ),
+            patch(
+                "deepagents_cli.agent.create_deep_agent",
+                return_value=mock_agent,
+            ) as mock_create,
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=False,
+            )
+
+        _, kwargs = mock_create.call_args
+        subagents = kwargs["subagents"]
+        assert subagents is not None
+        researcher = next(
+            subagent for subagent in subagents if subagent["name"] == "researcher"
+        )
+        general_purpose = next(
+            subagent for subagent in subagents if subagent["name"] == "general-purpose"
+        )
+        assert researcher["fork"] is True
+        assert "model" not in researcher
+        assert general_purpose["fork"] is True
 
 
 def _mock_agents_dir(agents_dir: Path) -> Mock:

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -215,6 +215,61 @@ def _apply_tool_description_overrides(
     return copied_tools
 
 
+def _compose_fork_system_prompt(
+    parent_prompt: str | SystemMessage,
+    fork_suffix: str,
+) -> str:
+    """Compose a forked subagent's system prompt as ``parent + fork_suffix``.
+
+    Keeping the parent prefix byte-identical maximises prompt-cache alignment
+    across every provider (Anthropic ``cache_control``, OpenAI automatic,
+    Gemini implicit). The fork's own ``system_prompt`` is appended as a
+    suffix so the fork can still add instructions without breaking the shared
+    prefix.
+
+    If the parent supplied a ``SystemMessage`` rather than a bare string, its
+    text content blocks are joined into a string. Non-text blocks (images,
+    attachments) are dropped — they have no meaning in the forked subagent's
+    context and would not participate in prompt-cache alignment anyway.
+    """
+    if isinstance(parent_prompt, SystemMessage):
+        text_parts: list[str] = []
+        for block in parent_prompt.content_blocks:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+        parent_text = "".join(text_parts)
+    else:
+        parent_text = parent_prompt
+    return parent_text + "\n\n" + fork_suffix
+
+
+def _validate_fork_model_matches_parent(
+    subagent_name: str,
+    parent_model: BaseChatModel,
+    subagent_model: BaseChatModel,
+) -> None:
+    """Raise if the resolved subagent model does not match the parent's.
+
+    Prompt cache is keyed per-model on every provider. A forked subagent that
+    silently runs on a different model would burn tokens and hide the bug,
+    so mismatches fail loudly at build time.
+    """
+    parent_provider = get_model_provider(parent_model)
+    fork_provider = get_model_provider(subagent_model)
+    parent_id = get_model_identifier(parent_model)
+    fork_id = get_model_identifier(subagent_model)
+    if parent_provider != fork_provider or parent_id != fork_id:
+        msg = (
+            f"Forked subagent '{subagent_name}' must use the same model as the parent agent. "
+            f"Parent: {parent_provider}:{parent_id}. Subagent: {fork_provider}:{fork_id}. "
+            "Prompt cache is per-model on every provider; a mismatched model cannot share the "
+            "cached prefix. Omit 'model' from the subagent spec to inherit the parent's model."
+        )
+        raise ValueError(msg)
+
+
 def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
     model: str | BaseChatModel | None = None,
     tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
@@ -439,6 +494,20 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
     backend = backend if backend is not None else StateBackend()
 
+    # Assemble the parent's final system prompt up front so forked subagents
+    # can compose their prompts against a byte-identical prefix. Without this,
+    # the parent prefix would drift from what the child sees and prompt-cache
+    # hits would never fire.
+    base_prompt = _profile.base_system_prompt if _profile.base_system_prompt is not None else BASE_AGENT_PROMPT
+    if _profile.system_prompt_suffix is not None:
+        base_prompt = base_prompt + "\n\n" + _profile.system_prompt_suffix
+    if system_prompt is None:
+        final_system_prompt: str | SystemMessage = base_prompt
+    elif isinstance(system_prompt, SystemMessage):
+        final_system_prompt = SystemMessage(content_blocks=[*system_prompt.content_blocks, {"type": "text", "text": f"\n\n{base_prompt}"}])
+    else:
+        final_system_prompt = system_prompt + "\n\n" + base_prompt
+
     # Build general-purpose subagent with default middleware stack
     gp_middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(),
@@ -484,11 +553,27 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             continue
         if "runnable" in spec:
             # CompiledSubAgent - use as-is
+            if spec.get("fork"):
+                msg = (
+                    f"CompiledSubAgent '{spec['name']}' cannot set fork=True. "
+                    "Compiled subagents own their own system prompt and graph; "
+                    "splice the parent prefix manually if needed."
+                )
+                raise ValueError(msg)
             inline_subagents.append(spec)
         else:
-            # SubAgent - fill in defaults and prepend base middleware
-            raw_subagent_model = spec.get("model", model)
+            is_fork = bool(spec.get("fork", False))
+            # SubAgent - fill in defaults and prepend base middleware.
+            # A forked subagent defaults to the parent's model if none is
+            # specified (prompt cache is per-model; sharing the parent's
+            # model is the only way the cached prefix can be reused).
+            if is_fork and "model" not in spec:
+                raw_subagent_model: str | BaseChatModel = model
+            else:
+                raw_subagent_model = spec.get("model", model)
             subagent_model = resolve_model(raw_subagent_model)
+            if is_fork:
+                _validate_fork_model_matches_parent(spec["name"], model, subagent_model)
 
             _subagent_spec = raw_subagent_model if isinstance(raw_subagent_model, str) else None
             _subagent_profile = _harness_profile_for_model(subagent_model, _subagent_spec)
@@ -539,6 +624,12 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             }
             if subagent_interrupt_on is not None:
                 processed_spec["interrupt_on"] = subagent_interrupt_on
+            if is_fork:
+                # Pin the composed prompt so the subagent's prefix is
+                # byte-identical to the parent's, which is what enables
+                # prompt-cache reuse on every supported provider.
+                processed_spec["system_prompt"] = _compose_fork_system_prompt(final_system_prompt, spec["system_prompt"])
+                processed_spec["fork"] = True
             inline_subagents.append(processed_spec)
 
     # If an agent with general purpose name already exists in subagents, then don't add it
@@ -604,20 +695,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # _PermissionMiddleware must be last so it sees all tools from prior middleware
     if permissions:
         deepagent_middleware.append(_PermissionMiddleware(rules=permissions, backend=backend))
-
-    # Assemble base prompt: use _profile.base_system_prompt if set, else
-    # BASE_AGENT_PROMPT, then append profile suffix if present.
-    # Finally prepend user system_prompt (handled below).
-    base_prompt = _profile.base_system_prompt if _profile.base_system_prompt is not None else BASE_AGENT_PROMPT
-    if _profile.system_prompt_suffix is not None:
-        base_prompt = base_prompt + "\n\n" + _profile.system_prompt_suffix
-    if system_prompt is None:
-        final_system_prompt: str | SystemMessage = base_prompt
-    elif isinstance(system_prompt, SystemMessage):
-        final_system_prompt = SystemMessage(content_blocks=[*system_prompt.content_blocks, {"type": "text", "text": f"\n\n{base_prompt}"}])
-    else:
-        # String: simple concatenation
-        final_system_prompt = system_prompt + "\n\n" + base_prompt
 
     return create_agent(
         model,

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -7,12 +7,13 @@ middleware.
 
 import logging
 import warnings
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from typing import Any, cast
 
 from langchain.agents import AgentState, create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse, ResponseT, _InputAgentState, _OutputAgentState
+from langchain.agents.middleware.types import AgentMiddleware, ResponseT, _InputAgentState, _OutputAgentState
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
@@ -30,7 +31,7 @@ from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
-from deepagents.middleware.async_subagents import ASYNC_TASK_SYSTEM_PROMPT, AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware, _build_async_subagent_system_prompt
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
@@ -38,10 +39,11 @@ from deepagents.middleware.permissions import FilesystemPermission, _PermissionM
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import (
     GENERAL_PURPOSE_SUBAGENT,
-    TASK_SYSTEM_PROMPT,
     CompiledSubAgent,
     SubAgent,
     SubAgentMiddleware,
+    _build_fork_subagent_system_prompt,
+    _prepare_forked_subagent_spec,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
 from deepagents.profiles import _get_harness_profile, _HarnessProfile
@@ -216,48 +218,6 @@ def _apply_tool_description_overrides(
     return copied_tools
 
 
-class _ForkSystemPromptPadding(AgentMiddleware[Any, Any, Any]):
-    """Appends a fixed text block to the system message at model-call time.
-
-    The forked subagent's middleware stack must inject the same system-text
-    content in the same byte-for-byte order as the parent's stack, otherwise
-    the prompt cache's longest-prefix-match breaks early. This middleware
-    stands in for the parent's ``SubAgentMiddleware`` at the same position
-    in the chain, injecting the same ``TASK_SYSTEM_PROMPT + available-agents``
-    block — but without giving the fork the ``task`` tool (so forks cannot
-    recursively spawn more subagents).
-    """
-
-    def __init__(self, text: str, *, name: str) -> None:
-        super().__init__()
-        self._text = text
-        self._name = name
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    def wrap_model_call(
-        self,
-        request: ModelRequest[Any],
-        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
-    ) -> ModelResponse[Any]:
-        from deepagents.middleware._utils import append_to_system_message  # noqa: PLC0415
-
-        new_system_message = append_to_system_message(request.system_message, self._text)
-        return handler(request.override(system_message=new_system_message))
-
-    async def awrap_model_call(
-        self,
-        request: ModelRequest[Any],
-        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
-    ) -> ModelResponse[Any]:
-        from deepagents.middleware._utils import append_to_system_message  # noqa: PLC0415
-
-        new_system_message = append_to_system_message(request.system_message, self._text)
-        return await handler(request.override(system_message=new_system_message))
-
-
 def _validate_fork_model_matches_parent(
     subagent_name: str,
     parent_model: BaseChatModel,
@@ -281,6 +241,18 @@ def _validate_fork_model_matches_parent(
             "cached prefix. Omit 'model' from the subagent spec to inherit the parent's model."
         )
         raise ValueError(msg)
+
+
+@dataclass(slots=True)
+class _PendingForkSpec:
+    """Fork spec plus middleware fragments that need the final subagent list."""
+
+    spec: SubAgent
+    middleware_before_sync_padding: list[AgentMiddleware[Any, Any, Any]]
+    middleware_before_async_padding: list[AgentMiddleware[Any, Any, Any]]
+    parent_middleware: list[AgentMiddleware[Any, Any, Any]]
+    user_middleware: list[AgentMiddleware[Any, Any, Any]]
+    middleware_after_user: list[AgentMiddleware[Any, Any, Any]]
 
 
 def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
@@ -559,6 +531,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # Set up subagent middleware
     inline_subagents: list[SubAgent | CompiledSubAgent] = []
     async_subagents: list[AsyncSubAgent] = []
+    pending_fork_specs: list[_PendingForkSpec] = []
     for spec in subagents or []:
         if "graph_id" in spec:
             # Then spec is an AsyncSubAgent
@@ -605,17 +578,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             subagent_skills = spec.get("skills")
             if is_fork:
-                # Fork composition is deferred: the middleware list must mirror
-                # the parent's stack ordering (TodoList, Skills, Filesystem,
-                # <SubAgentMiddleware slot>, Summarize, PatchToolCalls, ...)
-                # so system-text additions happen in the same byte order. The
-                # ``<SubAgentMiddleware slot>`` is filled with a padding
-                # middleware that injects the same ``TASK_SYSTEM_PROMPT +
-                # available-agents`` text the parent's SubAgentMiddleware
-                # would — but without giving the fork the ``task`` tool. The
-                # agents list is only complete after the default
-                # general-purpose spec is inserted, so we build the stack
-                # below in a post-loop pass.
                 processed_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]
                     **spec,
                     "model": subagent_model,
@@ -624,13 +586,47 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 if subagent_interrupt_on is not None:
                     processed_spec["interrupt_on"] = subagent_interrupt_on
                 processed_spec["fork"] = True
-                fork_dict = cast("dict[str, Any]", processed_spec)
-                fork_dict["_fork_user_system_prompt"] = spec["system_prompt"]
-                fork_dict["_fork_profile"] = _subagent_profile
-                fork_dict["_fork_permissions"] = subagent_permissions
-                fork_dict["_fork_skills"] = skills if skills is not None else subagent_skills
-                fork_dict["_fork_parent_middleware"] = list(middleware or [])
-                fork_dict["_fork_user_middleware"] = list(spec.get("middleware", []))
+
+                fork_skills = skills if skills is not None else subagent_skills
+                middleware_before_sync_padding: list[AgentMiddleware[Any, Any, Any]] = [TodoListMiddleware()]
+                if fork_skills:
+                    middleware_before_sync_padding.append(SkillsMiddleware(backend=backend, sources=fork_skills))
+                middleware_before_sync_padding.append(
+                    FilesystemMiddleware(
+                        backend=backend,
+                        custom_tool_descriptions=_subagent_profile.tool_description_overrides,
+                    )
+                )
+                middleware_before_async_padding: list[AgentMiddleware[Any, Any, Any]] = [
+                    create_summarization_middleware(subagent_model, backend),
+                    PatchToolCallsMiddleware(),
+                ]
+                middleware_after_user: list[AgentMiddleware[Any, Any, Any]] = [
+                    *_resolve_extra_middleware(_subagent_profile),
+                ]
+                if _subagent_profile.excluded_tools:
+                    middleware_after_user.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
+                middleware_after_user.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+                if memory is not None:
+                    middleware_after_user.append(
+                        MemoryMiddleware(
+                            backend=backend,
+                            sources=memory,
+                            add_cache_control=True,
+                        )
+                    )
+                if subagent_permissions:
+                    middleware_after_user.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
+                pending_fork_specs.append(
+                    _PendingForkSpec(
+                        spec=processed_spec,
+                        middleware_before_sync_padding=middleware_before_sync_padding,
+                        middleware_before_async_padding=middleware_before_async_padding,
+                        parent_middleware=list(middleware or []),
+                        user_middleware=list(spec.get("middleware", [])),
+                        middleware_after_user=middleware_after_user,
+                    )
+                )
             else:
                 # Non-fork subagent: build middleware list now (no fork-specific ordering requirements).
                 subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
@@ -675,101 +671,25 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # Add a general purpose subagent if it doesn't exist yet
         inline_subagents.insert(0, general_purpose_spec)
 
-    # Finish fork composition now that the full agents list is known.
-    #
-    # Goal: byte-for-byte match between the parent's runtime system message
-    # and the fork's, so Anthropic's longest-prefix-match serves the fork
-    # from the parent's cache entry — covering not just the system prompt
-    # but the inherited messages that follow it.
-    #
-    # Two things must line up:
-    #   1. The ``system_prompt`` handed to the fork's ``create_agent`` is
-    #      exactly the parent's final top-level system prompt, preserving
-    #      string prompts and ``SystemMessage`` content blocks as-is.
-    #   2. The fork's middleware stack mirrors the parent's stack ordering.
-    #      Each middleware that appends to the system message (TodoList,
-    #      Skills, Filesystem, ...) runs in the same order, so the running
-    #      byte stream matches. The parent's ``SubAgentMiddleware`` slot is
-    #      filled with a padding middleware that appends the same
-    #      ``TASK_SYSTEM_PROMPT + available-agents`` text the parent's
-    #      SubAgentMiddleware would — without giving the fork the ``task``
-    #      tool (so forks cannot recursively spawn subagents).
-    #
-    # The preamble that rides inside the trailing HumanMessage then
-    # corrects any claims from that inherited system text that do not
-    # match the fork's real environment.
-    agents_desc_for_fork = "\n".join(f"- {s['name']}: {s['description']}" for s in inline_subagents)
-    fork_subagent_padding_text = TASK_SYSTEM_PROMPT + "\n\nAvailable subagent types:\n" + agents_desc_for_fork
-    if async_subagents:
-        async_agents_desc_for_fork = "\n".join(f"- {s['name']}: {s['description']}" for s in async_subagents)
-        fork_async_padding_text = ASYNC_TASK_SYSTEM_PROMPT + "\n\nAvailable async subagent types:\n" + async_agents_desc_for_fork
-    else:
-        fork_async_padding_text = None
-    for fork_spec in inline_subagents:
-        if not fork_spec.get("fork"):
-            continue
-        fork_dict = cast("dict[str, Any]", fork_spec)
-        user_role_text: str = fork_dict.pop("_fork_user_system_prompt", "")
-        fork_profile: _HarnessProfile = fork_dict.pop("_fork_profile")
-        fork_permissions = fork_dict.pop("_fork_permissions")
-        fork_skills = fork_dict.pop("_fork_skills")
-        fork_parent_middleware = fork_dict.pop("_fork_parent_middleware")
-        fork_user_middleware = fork_dict.pop("_fork_user_middleware")
-
-        # Build middleware stack in parent order: TodoList, (Skills), Filesystem,
-        # <padding for SubAgentMiddleware>, Summarize, PatchToolCalls, user
-        # middleware, provider, (exclusions), caching, (permissions).
-        fork_middleware: list[AgentMiddleware[Any, Any, Any]] = [TodoListMiddleware()]
-        if fork_skills:
-            fork_middleware.append(SkillsMiddleware(backend=backend, sources=fork_skills))
-        fork_middleware.append(
-            FilesystemMiddleware(
-                backend=backend,
-                custom_tool_descriptions=fork_profile.tool_description_overrides,
+    if pending_fork_specs:
+        sync_padding = _build_fork_subagent_system_prompt(inline_subagents)
+        async_padding = _build_async_subagent_system_prompt(async_subagents) if async_subagents else None
+        for fork in pending_fork_specs:
+            prepared = _prepare_forked_subagent_spec(
+                fork.spec,
+                parent_system_prompt=final_system_prompt,
+                sync_prompt_padding_text=sync_padding,
+                async_prompt_padding_text=async_padding,
+                middleware_before_sync_padding=fork.middleware_before_sync_padding,
+                middleware_before_async_padding=fork.middleware_before_async_padding,
+                parent_middleware=fork.parent_middleware,
+                user_middleware=fork.user_middleware,
+                middleware_after_user=fork.middleware_after_user,
             )
-        )
-        fork_middleware.append(_ForkSystemPromptPadding(text=fork_subagent_padding_text, name="ForkSubAgentSystemPromptPadding"))
-        fork_middleware.extend(
-            [
-                create_summarization_middleware(fork_dict["model"], backend),
-                PatchToolCallsMiddleware(),
-            ]
-        )
-        if fork_async_padding_text is not None:
-            fork_middleware.append(_ForkSystemPromptPadding(text=fork_async_padding_text, name="ForkAsyncSubAgentSystemPromptPadding"))
-        fork_middleware.extend(fork_parent_middleware)
-        fork_middleware.extend(fork_user_middleware)
-        fork_middleware.extend(_resolve_extra_middleware(fork_profile))
-        if fork_profile.excluded_tools:
-            fork_middleware.append(_ToolExclusionMiddleware(excluded=fork_profile.excluded_tools))
-        fork_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
-        if memory is not None:
-            fork_middleware.append(
-                MemoryMiddleware(
-                    backend=backend,
-                    sources=memory,
-                    add_cache_control=True,
-                )
-            )
-        if fork_permissions:
-            fork_middleware.append(_PermissionMiddleware(rules=fork_permissions, backend=backend))
-
-        fork_dict["middleware"] = fork_middleware
-        fork_dict["system_prompt"] = final_system_prompt
-
-        fork_tool_names = [n for n in (_tool_name(t) for t in fork_spec.get("tools", []) or []) if n]
-        tools_line = ", ".join(f"`{n}`" for n in fork_tool_names) if fork_tool_names else "(none — rely on built-in filesystem/todo tools)"
-        preamble = (
-            f"You are running as a forked subagent named `{fork_spec['name']}`. "
-            "The system prompt above was inherited verbatim from the parent agent to "
-            "preserve prompt-cache reuse; it may mention capabilities that do not apply "
-            "to you. Your actual environment:\n"
-            f"\n- Your declared tools: {tools_line}"
-            "\n- You do NOT have the `task` tool. You cannot spawn further subagents."
-            "\n\nYour role as this subagent:\n"
-            f"{user_role_text}"
-        )
-        fork_dict["subagent_system_prompt"] = preamble
+            for idx, candidate in enumerate(inline_subagents):
+                if candidate is fork.spec:
+                    inline_subagents[idx] = prepared
+                    break
 
     # Build main agent middleware stack
     deepagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -218,31 +218,6 @@ def _apply_tool_description_overrides(
     return copied_tools
 
 
-def _validate_fork_model_matches_parent(
-    subagent_name: str,
-    parent_model: BaseChatModel,
-    subagent_model: BaseChatModel,
-) -> None:
-    """Raise if the resolved subagent model does not match the parent's.
-
-    Prompt cache is keyed per-model on every provider. A forked subagent that
-    silently runs on a different model would burn tokens and hide the bug,
-    so mismatches fail loudly at build time.
-    """
-    parent_provider = get_model_provider(parent_model)
-    fork_provider = get_model_provider(subagent_model)
-    parent_id = get_model_identifier(parent_model)
-    fork_id = get_model_identifier(subagent_model)
-    if parent_provider != fork_provider or parent_id != fork_id:
-        msg = (
-            f"Forked subagent '{subagent_name}' must use the same model as the parent agent. "
-            f"Parent: {parent_provider}:{parent_id}. Subagent: {fork_provider}:{fork_id}. "
-            "Prompt cache is per-model on every provider; a mismatched model cannot share the "
-            "cached prefix. Omit 'model' from the subagent spec to inherit the parent's model."
-        )
-        raise ValueError(msg)
-
-
 @dataclass(slots=True)
 class _PendingForkSpec:
     """Fork spec plus middleware fragments that need the final subagent list."""
@@ -253,6 +228,119 @@ class _PendingForkSpec:
     parent_middleware: list[AgentMiddleware[Any, Any, Any]]
     user_middleware: list[AgentMiddleware[Any, Any, Any]]
     middleware_after_user: list[AgentMiddleware[Any, Any, Any]]
+
+
+def _prepare_standard_subagent_spec(
+    spec: SubAgent,
+    *,
+    model: BaseChatModel,
+    tools: list[BaseTool | Callable | dict[str, Any]] | None,
+    profile: _HarnessProfile,
+    backend: BackendProtocol | BackendFactory,
+    permissions: list[FilesystemPermission] | None,
+    interrupt_on: dict[str, bool | InterruptOnConfig] | None,
+) -> SubAgent:
+    """Fill defaults and middleware for a non-fork declarative subagent."""
+    middleware: list[AgentMiddleware[Any, Any, Any]] = [
+        TodoListMiddleware(),
+        FilesystemMiddleware(
+            backend=backend,
+            custom_tool_descriptions=profile.tool_description_overrides,
+        ),
+        create_summarization_middleware(model, backend),
+        PatchToolCallsMiddleware(),
+    ]
+    if spec.get("skills"):
+        middleware.append(SkillsMiddleware(backend=backend, sources=spec["skills"]))
+    middleware.extend(spec.get("middleware", []))
+    middleware.extend(_resolve_extra_middleware(profile))
+    if profile.excluded_tools:
+        middleware.append(_ToolExclusionMiddleware(excluded=profile.excluded_tools))
+    middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+    if permissions:
+        middleware.append(_PermissionMiddleware(rules=permissions, backend=backend))
+
+    processed = cast(
+        "SubAgent",
+        {
+            **spec,
+            "model": model,
+            "tools": tools or [],
+            "middleware": middleware,
+        },
+    )
+    if interrupt_on is not None:
+        processed["interrupt_on"] = interrupt_on
+    return processed
+
+
+def _prepare_pending_fork_spec(
+    spec: SubAgent,
+    *,
+    model: BaseChatModel,
+    tools: list[BaseTool | Callable | dict[str, Any]] | None,
+    profile: _HarnessProfile,
+    backend: BackendProtocol | BackendFactory,
+    parent_skills: list[str] | None,
+    parent_middleware: Sequence[AgentMiddleware],
+    memory: list[str] | None,
+    permissions: list[FilesystemPermission] | None,
+    interrupt_on: dict[str, bool | InterruptOnConfig] | None,
+) -> _PendingForkSpec:
+    """Prepare the fork pieces that do not depend on the final subagent list."""
+    if "model" in spec:
+        msg = (
+            f"Forked subagent '{spec['name']}' cannot declare a model. "
+            "Forked subagents always inherit the parent agent's model."
+        )
+        raise ValueError(msg)
+
+    processed: SubAgent = {  # ty: ignore[missing-typed-dict-key]
+        **spec,
+        "model": model,
+        "tools": tools or [],
+        "fork": True,
+    }
+    if interrupt_on is not None:
+        processed["interrupt_on"] = interrupt_on
+
+    fork_skills = parent_skills if parent_skills is not None else spec.get("skills")
+    middleware_before_sync_padding: list[AgentMiddleware[Any, Any, Any]] = [TodoListMiddleware()]
+    if fork_skills:
+        middleware_before_sync_padding.append(SkillsMiddleware(backend=backend, sources=fork_skills))
+    middleware_before_sync_padding.append(
+        FilesystemMiddleware(
+            backend=backend,
+            custom_tool_descriptions=profile.tool_description_overrides,
+        )
+    )
+
+    middleware_after_user: list[AgentMiddleware[Any, Any, Any]] = [*_resolve_extra_middleware(profile)]
+    if profile.excluded_tools:
+        middleware_after_user.append(_ToolExclusionMiddleware(excluded=profile.excluded_tools))
+    middleware_after_user.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+    if memory is not None:
+        middleware_after_user.append(
+            MemoryMiddleware(
+                backend=backend,
+                sources=memory,
+                add_cache_control=True,
+            )
+        )
+    if permissions:
+        middleware_after_user.append(_PermissionMiddleware(rules=permissions, backend=backend))
+
+    return _PendingForkSpec(
+        spec=processed,
+        middleware_before_sync_padding=middleware_before_sync_padding,
+        middleware_before_async_padding=[
+            create_summarization_middleware(model, backend),
+            PatchToolCallsMiddleware(),
+        ],
+        parent_middleware=list(parent_middleware),
+        user_middleware=list(spec.get("middleware", [])),
+        middleware_after_user=middleware_after_user,
+    )
 
 
 def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
@@ -549,17 +637,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             inline_subagents.append(spec)
         else:
             is_fork = bool(spec.get("fork", False))
-            # SubAgent - fill in defaults and prepend base middleware.
-            # A forked subagent defaults to the parent's model if none is
-            # specified (prompt cache is per-model; sharing the parent's
-            # model is the only way the cached prefix can be reused).
-            if is_fork and "model" not in spec:
-                raw_subagent_model: str | BaseChatModel = model
-            else:
-                raw_subagent_model = spec.get("model", model)
+            # Forks always use the parent model; non-forks may override it.
+            raw_subagent_model: str | BaseChatModel = model if is_fork else spec.get("model", model)
             subagent_model = resolve_model(raw_subagent_model)
-            if is_fork:
-                _validate_fork_model_matches_parent(spec["name"], model, subagent_model)
 
             _subagent_spec = raw_subagent_model if isinstance(raw_subagent_model, str) else None
             _subagent_profile = _harness_profile_for_model(subagent_model, _subagent_spec)
@@ -576,93 +656,31 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 _subagent_profile.tool_description_overrides,
             )
 
-            subagent_skills = spec.get("skills")
             if is_fork:
-                processed_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]
-                    **spec,
-                    "model": subagent_model,
-                    "tools": subagent_tools or [],
-                }
-                if subagent_interrupt_on is not None:
-                    processed_spec["interrupt_on"] = subagent_interrupt_on
-                processed_spec["fork"] = True
-
-                fork_skills = skills if skills is not None else subagent_skills
-                middleware_before_sync_padding: list[AgentMiddleware[Any, Any, Any]] = [TodoListMiddleware()]
-                if fork_skills:
-                    middleware_before_sync_padding.append(SkillsMiddleware(backend=backend, sources=fork_skills))
-                middleware_before_sync_padding.append(
-                    FilesystemMiddleware(
-                        backend=backend,
-                        custom_tool_descriptions=_subagent_profile.tool_description_overrides,
-                    )
+                pending = _prepare_pending_fork_spec(
+                    spec,
+                    model=subagent_model,
+                    tools=subagent_tools,
+                    profile=_subagent_profile,
+                    backend=backend,
+                    parent_skills=skills,
+                    parent_middleware=middleware,
+                    memory=memory,
+                    permissions=subagent_permissions,
+                    interrupt_on=subagent_interrupt_on,
                 )
-                middleware_before_async_padding: list[AgentMiddleware[Any, Any, Any]] = [
-                    create_summarization_middleware(subagent_model, backend),
-                    PatchToolCallsMiddleware(),
-                ]
-                middleware_after_user: list[AgentMiddleware[Any, Any, Any]] = [
-                    *_resolve_extra_middleware(_subagent_profile),
-                ]
-                if _subagent_profile.excluded_tools:
-                    middleware_after_user.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
-                middleware_after_user.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
-                if memory is not None:
-                    middleware_after_user.append(
-                        MemoryMiddleware(
-                            backend=backend,
-                            sources=memory,
-                            add_cache_control=True,
-                        )
-                    )
-                if subagent_permissions:
-                    middleware_after_user.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
-                pending_fork_specs.append(
-                    _PendingForkSpec(
-                        spec=processed_spec,
-                        middleware_before_sync_padding=middleware_before_sync_padding,
-                        middleware_before_async_padding=middleware_before_async_padding,
-                        parent_middleware=list(middleware or []),
-                        user_middleware=list(spec.get("middleware", [])),
-                        middleware_after_user=middleware_after_user,
-                    )
-                )
+                processed_spec = pending.spec
+                pending_fork_specs.append(pending)
             else:
-                # Non-fork subagent: build middleware list now (no fork-specific ordering requirements).
-                subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
-                    TodoListMiddleware(),
-                    FilesystemMiddleware(
-                        backend=backend,
-                        custom_tool_descriptions=_subagent_profile.tool_description_overrides,
-                    ),
-                    create_summarization_middleware(subagent_model, backend),
-                    PatchToolCallsMiddleware(),
-                ]
-                if subagent_skills:
-                    subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
-                subagent_middleware.extend(spec.get("middleware", []))
-
-                # Provider-specific middleware for this subagent's model
-                subagent_middleware.extend(_resolve_extra_middleware(_subagent_profile))
-                if _subagent_profile.excluded_tools:
-                    subagent_middleware.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
-
-                # Prompt caching
-                subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
-                if subagent_permissions:
-                    subagent_middleware.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
-
-                processed_spec = cast(
-                    "SubAgent",
-                    {
-                        **spec,
-                        "model": subagent_model,
-                        "tools": subagent_tools or [],
-                        "middleware": subagent_middleware,
-                    },
+                processed_spec = _prepare_standard_subagent_spec(
+                    spec,
+                    model=subagent_model,
+                    tools=subagent_tools,
+                    profile=_subagent_profile,
+                    backend=backend,
+                    permissions=subagent_permissions,
+                    interrupt_on=subagent_interrupt_on,
                 )
-                if subagent_interrupt_on is not None:
-                    processed_spec["interrupt_on"] = subagent_interrupt_on
             inline_subagents.append(processed_spec)
 
     # If an agent with general purpose name already exists in subagents, then don't add it

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -7,12 +7,12 @@ middleware.
 
 import logging
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, cast
 
 from langchain.agents import AgentState, create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware, InterruptOnConfig, TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware, ResponseT, _InputAgentState, _OutputAgentState
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse, ResponseT, _InputAgentState, _OutputAgentState
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
@@ -38,6 +38,7 @@ from deepagents.middleware.permissions import FilesystemPermission, _PermissionM
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import (
     GENERAL_PURPOSE_SUBAGENT,
+    TASK_SYSTEM_PROMPT,
     CompiledSubAgent,
     SubAgent,
     SubAgentMiddleware,
@@ -215,34 +216,61 @@ def _apply_tool_description_overrides(
     return copied_tools
 
 
-def _compose_fork_system_prompt(
-    parent_prompt: str | SystemMessage,
-    fork_suffix: str,
-) -> str:
-    """Compose a forked subagent's system prompt as ``parent + fork_suffix``.
+class _ForkSystemPromptPadding(AgentMiddleware[Any, Any, Any]):
+    """Appends a fixed text block to the system message at model-call time.
 
-    Keeping the parent prefix byte-identical maximises prompt-cache alignment
-    across every provider (Anthropic ``cache_control``, OpenAI automatic,
-    Gemini implicit). The fork's own ``system_prompt`` is appended as a
-    suffix so the fork can still add instructions without breaking the shared
-    prefix.
-
-    If the parent supplied a ``SystemMessage`` rather than a bare string, its
-    text content blocks are joined into a string. Non-text blocks (images,
-    attachments) are dropped — they have no meaning in the forked subagent's
-    context and would not participate in prompt-cache alignment anyway.
+    The forked subagent's middleware stack must inject the same system-text
+    content in the same byte-for-byte order as the parent's stack, otherwise
+    the prompt cache's longest-prefix-match breaks early. This middleware
+    stands in for the parent's ``SubAgentMiddleware`` at the same position
+    in the chain, injecting the same ``TASK_SYSTEM_PROMPT + available-agents``
+    block — but without giving the fork the ``task`` tool (so forks cannot
+    recursively spawn more subagents).
     """
-    if isinstance(parent_prompt, SystemMessage):
+
+    def __init__(self, text: str) -> None:
+        super().__init__()
+        self._text = text
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        from deepagents.middleware._utils import append_to_system_message  # noqa: PLC0415
+
+        new_system_message = append_to_system_message(request.system_message, self._text)
+        return handler(request.override(system_message=new_system_message))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any]:
+        from deepagents.middleware._utils import append_to_system_message  # noqa: PLC0415
+
+        new_system_message = append_to_system_message(request.system_message, self._text)
+        return await handler(request.override(system_message=new_system_message))
+
+
+def _flatten_system_prompt(prompt: str | SystemMessage) -> str:
+    """Return the parent system prompt as a plain string.
+
+    Used to feed the parent's system prompt into the fork's runnable verbatim.
+    If the parent supplied a ``SystemMessage``, its text content blocks are
+    joined into a string; non-text blocks (images, attachments) are dropped
+    since they have no meaning in the forked subagent's context and would
+    not participate in prompt-cache alignment anyway.
+    """
+    if isinstance(prompt, SystemMessage):
         text_parts: list[str] = []
-        for block in parent_prompt.content_blocks:
+        for block in prompt.content_blocks:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text")
                 if isinstance(text, str):
                     text_parts.append(text)
-        parent_text = "".join(text_parts)
-    else:
-        parent_text = parent_prompt
-    return parent_text + "\n\n" + fork_suffix
+        return "".join(text_parts)
+    return prompt
 
 
 def _validate_fork_model_matches_parent(
@@ -580,32 +608,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             # Resolve permissions: subagent's own rules take priority, else inherit parent's
             subagent_permissions = spec.get("permissions", permissions)
-
-            # Build middleware: base stack + skills (if specified) + user's middleware
-            subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
-                TodoListMiddleware(),
-                FilesystemMiddleware(
-                    backend=backend,
-                    custom_tool_descriptions=_subagent_profile.tool_description_overrides,
-                ),
-                create_summarization_middleware(subagent_model, backend),
-                PatchToolCallsMiddleware(),
-            ]
-            subagent_skills = spec.get("skills")
-            if subagent_skills:
-                subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
-            subagent_middleware.extend(spec.get("middleware", []))
-
-            # Provider-specific middleware for this subagent's model
-            subagent_middleware.extend(_resolve_extra_middleware(_subagent_profile))
-            if _subagent_profile.excluded_tools:
-                subagent_middleware.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
-
-            # Prompt caching
-            subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
-            if subagent_permissions:
-                subagent_middleware.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
-
             subagent_interrupt_on = spec.get("interrupt_on", interrupt_on)
 
             # Inherit parent tools unless the subagent declares its own.
@@ -616,20 +618,69 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 _subagent_profile.tool_description_overrides,
             )
 
-            processed_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]
-                **spec,
-                "model": subagent_model,
-                "tools": subagent_tools or [],
-                "middleware": subagent_middleware,
-            }
-            if subagent_interrupt_on is not None:
-                processed_spec["interrupt_on"] = subagent_interrupt_on
+            subagent_skills = spec.get("skills")
             if is_fork:
-                # Pin the composed prompt so the subagent's prefix is
-                # byte-identical to the parent's, which is what enables
-                # prompt-cache reuse on every supported provider.
-                processed_spec["system_prompt"] = _compose_fork_system_prompt(final_system_prompt, spec["system_prompt"])
+                # Fork composition is deferred: the middleware list must mirror
+                # the parent's stack ordering (TodoList, Skills, Filesystem,
+                # <SubAgentMiddleware slot>, Summarize, PatchToolCalls, ...)
+                # so system-text additions happen in the same byte order. The
+                # ``<SubAgentMiddleware slot>`` is filled with a padding
+                # middleware that injects the same ``TASK_SYSTEM_PROMPT +
+                # available-agents`` text the parent's SubAgentMiddleware
+                # would — but without giving the fork the ``task`` tool. The
+                # agents list is only complete after the default
+                # general-purpose spec is inserted, so we build the stack
+                # below in a post-loop pass.
+                processed_spec: SubAgent = {  # ty: ignore[missing-typed-dict-key]
+                    **spec,
+                    "model": subagent_model,
+                    "tools": subagent_tools or [],
+                }
+                if subagent_interrupt_on is not None:
+                    processed_spec["interrupt_on"] = subagent_interrupt_on
                 processed_spec["fork"] = True
+                fork_dict = cast("dict[str, Any]", processed_spec)
+                fork_dict["_fork_user_system_prompt"] = spec["system_prompt"]
+                fork_dict["_fork_profile"] = _subagent_profile
+                fork_dict["_fork_permissions"] = subagent_permissions
+                fork_dict["_fork_skills"] = subagent_skills
+                fork_dict["_fork_user_middleware"] = list(spec.get("middleware", []))
+            else:
+                # Non-fork subagent: build middleware list now (no fork-specific ordering requirements).
+                subagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [
+                    TodoListMiddleware(),
+                    FilesystemMiddleware(
+                        backend=backend,
+                        custom_tool_descriptions=_subagent_profile.tool_description_overrides,
+                    ),
+                    create_summarization_middleware(subagent_model, backend),
+                    PatchToolCallsMiddleware(),
+                ]
+                if subagent_skills:
+                    subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
+                subagent_middleware.extend(spec.get("middleware", []))
+
+                # Provider-specific middleware for this subagent's model
+                subagent_middleware.extend(_resolve_extra_middleware(_subagent_profile))
+                if _subagent_profile.excluded_tools:
+                    subagent_middleware.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
+
+                # Prompt caching
+                subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+                if subagent_permissions:
+                    subagent_middleware.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
+
+                processed_spec = cast(
+                    "SubAgent",
+                    {
+                        **spec,
+                        "model": subagent_model,
+                        "tools": subagent_tools or [],
+                        "middleware": subagent_middleware,
+                    },
+                )
+                if subagent_interrupt_on is not None:
+                    processed_spec["interrupt_on"] = subagent_interrupt_on
             inline_subagents.append(processed_spec)
 
     # If an agent with general purpose name already exists in subagents, then don't add it
@@ -637,6 +688,88 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     if not any(spec["name"] == GENERAL_PURPOSE_SUBAGENT["name"] for spec in inline_subagents):
         # Add a general purpose subagent if it doesn't exist yet
         inline_subagents.insert(0, general_purpose_spec)
+
+    # Finish fork composition now that the full agents list is known.
+    #
+    # Goal: byte-for-byte match between the parent's runtime system message
+    # and the fork's, so Anthropic's longest-prefix-match serves the fork
+    # from the parent's cache entry — covering not just the system prompt
+    # but the inherited messages that follow it.
+    #
+    # Two things must line up:
+    #   1. The ``system_prompt`` handed to the fork's ``create_agent`` is
+    #      what that agent sends as its initial SystemMessage. We set it to
+    #      the parent's flattened top-level system prompt (same bytes the
+    #      parent's ``create_agent`` sees).
+    #   2. The fork's middleware stack mirrors the parent's stack ordering.
+    #      Each middleware that appends to the system message (TodoList,
+    #      Skills, Filesystem, ...) runs in the same order, so the running
+    #      byte stream matches. The parent's ``SubAgentMiddleware`` slot is
+    #      filled with a padding middleware that appends the same
+    #      ``TASK_SYSTEM_PROMPT + available-agents`` text the parent's
+    #      SubAgentMiddleware would — without giving the fork the ``task``
+    #      tool (so forks cannot recursively spawn subagents).
+    #
+    # The preamble that rides inside the trailing HumanMessage then
+    # corrects any claims from that inherited system text that do not
+    # match the fork's real environment.
+    agents_desc_for_fork = "\n".join(f"- {s['name']}: {s['description']}" for s in inline_subagents)
+    fork_subagent_padding_text = TASK_SYSTEM_PROMPT + "\n\nAvailable subagent types:\n" + agents_desc_for_fork
+    flattened_parent_system = _flatten_system_prompt(final_system_prompt)
+
+    for fork_spec in inline_subagents:
+        if not fork_spec.get("fork"):
+            continue
+        fork_dict = cast("dict[str, Any]", fork_spec)
+        user_role_text: str = fork_dict.pop("_fork_user_system_prompt", "")
+        fork_profile: _HarnessProfile = fork_dict.pop("_fork_profile")
+        fork_permissions = fork_dict.pop("_fork_permissions")
+        fork_skills = fork_dict.pop("_fork_skills")
+        fork_user_middleware = fork_dict.pop("_fork_user_middleware")
+
+        # Build middleware stack in parent order: TodoList, (Skills), Filesystem,
+        # <padding for SubAgentMiddleware>, Summarize, PatchToolCalls, user
+        # middleware, provider, (exclusions), caching, (permissions).
+        fork_middleware: list[AgentMiddleware[Any, Any, Any]] = [TodoListMiddleware()]
+        if fork_skills:
+            fork_middleware.append(SkillsMiddleware(backend=backend, sources=fork_skills))
+        fork_middleware.append(
+            FilesystemMiddleware(
+                backend=backend,
+                custom_tool_descriptions=fork_profile.tool_description_overrides,
+            )
+        )
+        fork_middleware.append(_ForkSystemPromptPadding(text=fork_subagent_padding_text))
+        fork_middleware.extend(
+            [
+                create_summarization_middleware(fork_dict["model"], backend),
+                PatchToolCallsMiddleware(),
+            ]
+        )
+        fork_middleware.extend(fork_user_middleware)
+        fork_middleware.extend(_resolve_extra_middleware(fork_profile))
+        if fork_profile.excluded_tools:
+            fork_middleware.append(_ToolExclusionMiddleware(excluded=fork_profile.excluded_tools))
+        fork_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+        if fork_permissions:
+            fork_middleware.append(_PermissionMiddleware(rules=fork_permissions, backend=backend))
+
+        fork_dict["middleware"] = fork_middleware
+        fork_dict["system_prompt"] = flattened_parent_system
+
+        fork_tool_names = [n for n in (_tool_name(t) for t in fork_spec.get("tools", []) or []) if n]
+        tools_line = ", ".join(f"`{n}`" for n in fork_tool_names) if fork_tool_names else "(none — rely on built-in filesystem/todo tools)"
+        preamble = (
+            f"You are running as a forked subagent named `{fork_spec['name']}`. "
+            "The system prompt above was inherited verbatim from the parent agent to "
+            "preserve prompt-cache reuse; it may mention capabilities that do not apply "
+            "to you. Your actual environment:\n"
+            f"\n- Your declared tools: {tools_line}"
+            "\n- You do NOT have the `task` tool. You cannot spawn further subagents."
+            "\n\nYour role as this subagent:\n"
+            f"{user_role_text}"
+        )
+        fork_dict["subagent_system_prompt"] = preamble
 
     # Build main agent middleware stack
     deepagent_middleware: list[AgentMiddleware[Any, Any, Any]] = [

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -30,7 +30,7 @@ from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
-from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
+from deepagents.middleware.async_subagents import ASYNC_TASK_SYSTEM_PROMPT, AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
@@ -228,9 +228,14 @@ class _ForkSystemPromptPadding(AgentMiddleware[Any, Any, Any]):
     recursively spawn more subagents).
     """
 
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, *, name: str) -> None:
         super().__init__()
         self._text = text
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def wrap_model_call(
         self,
@@ -251,26 +256,6 @@ class _ForkSystemPromptPadding(AgentMiddleware[Any, Any, Any]):
 
         new_system_message = append_to_system_message(request.system_message, self._text)
         return await handler(request.override(system_message=new_system_message))
-
-
-def _flatten_system_prompt(prompt: str | SystemMessage) -> str:
-    """Return the parent system prompt as a plain string.
-
-    Used to feed the parent's system prompt into the fork's runnable verbatim.
-    If the parent supplied a ``SystemMessage``, its text content blocks are
-    joined into a string; non-text blocks (images, attachments) are dropped
-    since they have no meaning in the forked subagent's context and would
-    not participate in prompt-cache alignment anyway.
-    """
-    if isinstance(prompt, SystemMessage):
-        text_parts: list[str] = []
-        for block in prompt.content_blocks:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if isinstance(text, str):
-                    text_parts.append(text)
-        return "".join(text_parts)
-    return prompt
 
 
 def _validate_fork_model_matches_parent(
@@ -643,7 +628,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 fork_dict["_fork_user_system_prompt"] = spec["system_prompt"]
                 fork_dict["_fork_profile"] = _subagent_profile
                 fork_dict["_fork_permissions"] = subagent_permissions
-                fork_dict["_fork_skills"] = subagent_skills
+                fork_dict["_fork_skills"] = skills if skills is not None else subagent_skills
+                fork_dict["_fork_parent_middleware"] = list(middleware or [])
                 fork_dict["_fork_user_middleware"] = list(spec.get("middleware", []))
             else:
                 # Non-fork subagent: build middleware list now (no fork-specific ordering requirements).
@@ -698,9 +684,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     #
     # Two things must line up:
     #   1. The ``system_prompt`` handed to the fork's ``create_agent`` is
-    #      what that agent sends as its initial SystemMessage. We set it to
-    #      the parent's flattened top-level system prompt (same bytes the
-    #      parent's ``create_agent`` sees).
+    #      exactly the parent's final top-level system prompt, preserving
+    #      string prompts and ``SystemMessage`` content blocks as-is.
     #   2. The fork's middleware stack mirrors the parent's stack ordering.
     #      Each middleware that appends to the system message (TodoList,
     #      Skills, Filesystem, ...) runs in the same order, so the running
@@ -715,8 +700,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # match the fork's real environment.
     agents_desc_for_fork = "\n".join(f"- {s['name']}: {s['description']}" for s in inline_subagents)
     fork_subagent_padding_text = TASK_SYSTEM_PROMPT + "\n\nAvailable subagent types:\n" + agents_desc_for_fork
-    flattened_parent_system = _flatten_system_prompt(final_system_prompt)
-
+    if async_subagents:
+        async_agents_desc_for_fork = "\n".join(f"- {s['name']}: {s['description']}" for s in async_subagents)
+        fork_async_padding_text = ASYNC_TASK_SYSTEM_PROMPT + "\n\nAvailable async subagent types:\n" + async_agents_desc_for_fork
+    else:
+        fork_async_padding_text = None
     for fork_spec in inline_subagents:
         if not fork_spec.get("fork"):
             continue
@@ -725,6 +713,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         fork_profile: _HarnessProfile = fork_dict.pop("_fork_profile")
         fork_permissions = fork_dict.pop("_fork_permissions")
         fork_skills = fork_dict.pop("_fork_skills")
+        fork_parent_middleware = fork_dict.pop("_fork_parent_middleware")
         fork_user_middleware = fork_dict.pop("_fork_user_middleware")
 
         # Build middleware stack in parent order: TodoList, (Skills), Filesystem,
@@ -739,23 +728,34 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 custom_tool_descriptions=fork_profile.tool_description_overrides,
             )
         )
-        fork_middleware.append(_ForkSystemPromptPadding(text=fork_subagent_padding_text))
+        fork_middleware.append(_ForkSystemPromptPadding(text=fork_subagent_padding_text, name="ForkSubAgentSystemPromptPadding"))
         fork_middleware.extend(
             [
                 create_summarization_middleware(fork_dict["model"], backend),
                 PatchToolCallsMiddleware(),
             ]
         )
+        if fork_async_padding_text is not None:
+            fork_middleware.append(_ForkSystemPromptPadding(text=fork_async_padding_text, name="ForkAsyncSubAgentSystemPromptPadding"))
+        fork_middleware.extend(fork_parent_middleware)
         fork_middleware.extend(fork_user_middleware)
         fork_middleware.extend(_resolve_extra_middleware(fork_profile))
         if fork_profile.excluded_tools:
             fork_middleware.append(_ToolExclusionMiddleware(excluded=fork_profile.excluded_tools))
         fork_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+        if memory is not None:
+            fork_middleware.append(
+                MemoryMiddleware(
+                    backend=backend,
+                    sources=memory,
+                    add_cache_control=True,
+                )
+            )
         if fork_permissions:
             fork_middleware.append(_PermissionMiddleware(rules=fork_permissions, backend=backend))
 
         fork_dict["middleware"] = fork_middleware
-        fork_dict["system_prompt"] = flattened_parent_system
+        fork_dict["system_prompt"] = final_system_prompt
 
         fork_tool_names = [n for n in (_tool_name(t) for t in fork_spec.get("tools", []) or []) if n]
         tools_line = ", ".join(f"`{n}`" for n in fork_tool_names) if fork_tool_names else "(none — rely on built-in filesystem/todo tools)"

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -289,10 +289,7 @@ def _prepare_pending_fork_spec(
 ) -> _PendingForkSpec:
     """Prepare the fork pieces that do not depend on the final subagent list."""
     if "model" in spec:
-        msg = (
-            f"Forked subagent '{spec['name']}' cannot declare a model. "
-            "Forked subagents always inherit the parent agent's model."
-        )
+        msg = f"Forked subagent '{spec['name']}' cannot declare a model. Forked subagents always inherit the parent agent's model."
         raise ValueError(msg)
 
     processed: SubAgent = {  # ty: ignore[missing-typed-dict-key]

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -211,6 +211,17 @@ You have access to async subagent tools that launch background tasks on remote L
 - When you want to run multiple tasks concurrently and collect results later"""
 
 
+def _build_async_subagent_system_prompt(
+    async_subagents: list[AsyncSubAgent],
+    system_prompt: str | None = ASYNC_TASK_SYSTEM_PROMPT,
+) -> str | None:
+    """Build the system prompt block appended by `AsyncSubAgentMiddleware`."""
+    if not system_prompt:
+        return system_prompt
+    agents_desc = "\n".join(f"- {a['name']}: {a['description']}" for a in async_subagents)
+    return system_prompt + "\n\nAvailable async subagent types:\n" + agents_desc
+
+
 def _resolve_headers(spec: AsyncSubAgent) -> dict[str, str]:
     """Build headers for a remote Agent Protocol server.
 
@@ -921,11 +932,7 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         self.tools = _build_async_subagent_tools(async_subagents)
 
-        if system_prompt:
-            agents_desc = "\n".join(f"- {a['name']}: {a['description']}" for a in async_subagents)
-            self.system_prompt: str | None = system_prompt + "\n\nAvailable async subagent types:\n" + agents_desc
-        else:
-            self.system_prompt = system_prompt
+        self.system_prompt = _build_async_subagent_system_prompt(async_subagents, system_prompt)
 
     def wrap_model_call(
         self,

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -11,7 +11,7 @@ from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRe
 from langchain.agents.structured_output import ResponseFormat
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
@@ -94,17 +94,19 @@ class SubAgent(TypedDict):
     """Whether to fork the parent agent's context into the subagent.
 
     When ``True``, the subagent inherits the parent agent's system prompt and
-    full message history as its starting context, with the parent's prompt
-    composed as a prefix and the subagent's own ``system_prompt`` appended as
-    a suffix. The description argument passed through the ``task`` tool is
-    seeded as an additional ``HumanMessage`` after the inherited history.
+    full message history **byte-for-byte** so every provider's prompt cache
+    can serve the fork's invocation. To preserve the prefix unchanged, the
+    subagent's own ``system_prompt`` is **not** placed in the system slot —
+    instead it is injected as a preamble into the trailing ``HumanMessage``
+    that carries the task description, yielding a final message list of
+    ``[parent system prompt, ...parent messages..., HumanMessage(preamble +
+    description)]``. The system message and every inherited message block are
+    therefore identical to what the parent already sent, so Anthropic's
+    ``cache_control`` breakpoint (and the equivalent on OpenAI / Gemini 2.5)
+    hits on the full parent prefix — not just the system portion.
 
-    The primary benefit is prompt-cache reuse: because the subagent's prefix
-    matches the parent's exactly, every provider's cache path fires on the
-    second and subsequent invocations — Anthropic via
-    ``cache_control`` markers, OpenAI via its automatic Responses-API cache,
-    and Gemini 2.5 via implicit caching. Isolation semantics are unchanged:
-    only the subagent's final message is surfaced back to the parent.
+    Isolation semantics are unchanged: only the subagent's final message is
+    surfaced back to the parent as a ``ToolMessage``.
 
     The subagent's ``model`` must resolve to the same provider and model id
     as the parent. If omitted, it defaults to the parent's model. A mismatch
@@ -371,6 +373,38 @@ class _SubagentSpec(TypedDict):
     description: str
     runnable: Runnable
     fork: NotRequired[bool]
+    # Fork mode only: the fork's own `system_prompt` (from the user-facing
+    # `SubAgent` spec), routed here instead of into the runnable's actual
+    # system slot. The runnable's system slot carries the parent's prompt
+    # verbatim so the prompt cache aligns; this string is prepended to the
+    # task description inside the trailing HumanMessage.
+    subagent_system_prompt: NotRequired[str]
+
+
+def _messages_before_current_task_call(messages: Sequence[Any], tool_call_id: str | None) -> list[Any]:
+    """Return parent messages before the AI turn that requested this task call.
+
+    Forks need to inherit the prefix the parent model actually consumed, not
+    the tool-call bookkeeping appended while the current `task` tool is being
+    executed. Keeping the current AIMessage(tool_calls=[...]) in the fork would
+    make the fork diverge immediately after the cached user/context messages.
+    """
+    copied = list(messages)
+    if not tool_call_id:
+        return copied
+
+    for idx in range(len(copied) - 1, -1, -1):
+        msg = copied[idx]
+        if isinstance(msg, AIMessage):
+            tool_calls = getattr(msg, "tool_calls", None) or []
+            if any(call.get("id") == tool_call_id for call in tool_calls):
+                return copied[:idx]
+
+    for idx in range(len(copied) - 1, -1, -1):
+        msg = copied[idx]
+        if isinstance(msg, ToolMessage) and msg.tool_call_id == tool_call_id:
+            return copied[:idx]
+    return copied
 
 
 FORKED_SUBAGENT_MARKER = "[forked — inherits full conversation context]"
@@ -413,6 +447,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
     # Build the graphs dict and descriptions from the unified spec list
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
     subagent_fork_flags: dict[str, bool] = {spec["name"]: bool(spec.get("fork", False)) for spec in subagents}
+    subagent_system_prompts: dict[str, str] = {spec["name"]: spec.get("subagent_system_prompt", "") or "" for spec in subagents}
 
     def _format_agent_line(s: _SubagentSpec) -> str:
         if s.get("fork"):
@@ -475,8 +510,17 @@ def _build_task_tool(  # noqa: C901, PLR0915
         # Create a new state dict to avoid mutating the original
         subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
         if is_fork:
-            parent_messages = list(runtime.state.get("messages", []))
-            subagent_state["messages"] = [*parent_messages, HumanMessage(content=description)]
+            parent_messages = _messages_before_current_task_call(
+                runtime.state.get("messages", []),
+                runtime.tool_call_id,
+            )
+            # The fork's own instructions ride along inside the trailing
+            # HumanMessage so the parent's system prompt and inherited message
+            # history stay byte-for-byte identical, which is what lets the
+            # provider's prompt cache serve the full parent prefix.
+            preamble = subagent_system_prompts.get(subagent_type, "")
+            final_content = f"{preamble}\n\n{description}" if preamble else description
+            subagent_state["messages"] = [*parent_messages, HumanMessage(content=final_content)]
         else:
             subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state, is_fork
@@ -666,6 +710,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                         response_format=spec.get("response_format"),
                     ),
                     "fork": bool(spec.get("fork", False)),
+                    "subagent_system_prompt": spec.get("subagent_system_prompt", "") or "",
                 }
             )
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -108,9 +108,9 @@ class SubAgent(TypedDict):
     Isolation semantics are unchanged: only the subagent's final message is
     surfaced back to the parent as a ``ToolMessage``.
 
-    The subagent's ``model`` must resolve to the same provider and model id
-    as the parent. If omitted, it defaults to the parent's model. A mismatch
-    raises ``ValueError`` at build time — cache is per-model on every provider.
+    The subagent cannot declare ``model`` when ``fork`` is true. Forked
+    subagents always inherit the parent's model because cache is per-model on
+    every provider.
 
     Not supported on ``CompiledSubAgent`` (raises at build time): a compiled
     subagent owns its own system prompt and graph, so there is no clean way
@@ -197,12 +197,23 @@ DEFAULT_SUBAGENT_PROMPT = "In order to complete the objective that the user asks
 # 1. The messages key is handled explicitly to ensure only the final message is included
 # 2. The todos and structured_response keys are excluded as they do not have a defined reducer
 #    and no clear meaning for returning them from a subagent to the main agent.
-# 3. The skills_metadata and memory_contents keys are automatically excluded from subagent output
-#    via PrivateStateAttr annotations on their respective state schemas. However, they must ALSO
-#    be explicitly filtered from runtime.state when invoking a subagent to prevent parent state
-#    from leaking to child agents (e.g., the general-purpose subagent loads its own skills via
-#    SkillsMiddleware).
-_EXCLUDED_STATE_KEYS = {"messages", "todos", "structured_response", "skills_metadata", "memory_contents"}
+# 3. The skills_metadata, memory_contents, and local_context keys are automatically excluded
+#    from subagent output via PrivateStateAttr annotations on their respective state schemas.
+#    However, they must ALSO be explicitly filtered from runtime.state when invoking a subagent
+#    to prevent parent state from leaking to child agents (e.g., the general-purpose subagent
+#    loads its own skills via SkillsMiddleware).
+_EXCLUDED_STATE_KEYS = {
+    "messages",
+    "todos",
+    "structured_response",
+    "skills_metadata",
+    "memory_contents",
+    "local_context",
+}
+
+# Forks intentionally inherit only state keys listed here; `messages` are
+# handled explicitly below to preserve the cache-aligned conversation prefix.
+_FORK_INHERITED_STATE_KEYS: frozenset[str] = frozenset()
 
 
 class TaskToolSchema(BaseModel):
@@ -537,6 +548,14 @@ forked subagent is registered. Teaches the main agent to pass only the task
 delta instead of re-stating context the fork already has."""
 
 
+ALL_FORKED_USAGE_GUIDANCE = (
+    "\n\n### Subagent context\n"
+    "Subagents inherit the full conversation context, so only a minimal "
+    "task-specific instruction is needed in `description`."
+)
+"""Guidance block appended when every subagent is forked."""
+
+
 def _build_task_tool(  # noqa: C901, PLR0915
     subagents: list[_SubagentSpec],
     task_description: str | None = None,
@@ -555,9 +574,10 @@ def _build_task_tool(  # noqa: C901, PLR0915
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
     subagent_fork_flags: dict[str, bool] = {spec["name"]: bool(spec.get("fork", False)) for spec in subagents}
     subagent_system_prompts: dict[str, str] = {spec["name"]: spec.get("subagent_system_prompt", "") or "" for spec in subagents}
+    all_forked = bool(subagents) and all(subagent_fork_flags.values())
 
     def _format_agent_line(s: _SubagentSpec) -> str:
-        if s.get("fork"):
+        if s.get("fork") and not all_forked:
             return f"- {s['name']} {FORKED_SUBAGENT_MARKER}: {s['description']}"
         return f"- {s['name']}: {s['description']}"
 
@@ -572,7 +592,9 @@ def _build_task_tool(  # noqa: C901, PLR0915
     else:
         description = task_description
 
-    if any_forked:
+    if all_forked:
+        description = description + ALL_FORKED_USAGE_GUIDANCE
+    elif any_forked:
         description = description + FORK_USAGE_GUIDANCE
 
     def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
@@ -615,8 +637,8 @@ def _build_task_tool(  # noqa: C901, PLR0915
         subagent = subagent_graphs[subagent_type]
         is_fork = subagent_fork_flags.get(subagent_type, False)
         # Create a new state dict to avoid mutating the original
-        subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
         if is_fork:
+            subagent_state = {k: runtime.state[k] for k in _FORK_INHERITED_STATE_KEYS if k in runtime.state}
             parent_messages = _messages_before_current_task_call(
                 runtime.state.get("messages", []),
                 runtime.tool_call_id,
@@ -627,6 +649,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
             final_content = f"{preamble}\n\n{description}" if preamble else description
             subagent_state["messages"] = [*parent_messages, HumanMessage(content=final_content)]
         else:
+            subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
             subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state, is_fork
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -528,16 +528,9 @@ available-agents list. Also scanned by tests to verify the list rendering."""
 
 FORK_USAGE_GUIDANCE = (
     "\n\n### Forked subagents\n"
-    f"Some subagents above are marked `{FORKED_SUBAGENT_MARKER}`. A forked "
-    "subagent already sees the entire conversation up to this point — the "
-    "main agent's system prompt, prior user and assistant messages, and all "
-    "tool results. **Do not restate shared context in the `description`.** "
-    "Pass only the task delta: the specific action you want the subagent to "
-    "take, plus any pointers (file paths, message references, artifact ids) "
-    "that disambiguate what to act on. Restating inherited context costs "
-    "tokens and defeats the cache reuse that fork mode is designed to "
-    "provide. Non-forked subagents are stateless and still require full "
-    "context in `description` as before."
+    f"Subagents marked `{FORKED_SUBAGENT_MARKER}` inherit the full "
+    "conversation context, so only a minimal task-specific instruction is "
+    "needed in `description`."
 )
 """Guidance block appended to the task tool description when at least one
 forked subagent is registered. Teaches the main agent to pass only the task
@@ -628,10 +621,8 @@ def _build_task_tool(  # noqa: C901, PLR0915
                 runtime.state.get("messages", []),
                 runtime.tool_call_id,
             )
-            # The fork's own instructions ride along inside the trailing
-            # HumanMessage so the parent's system prompt and inherited message
-            # history stay byte-for-byte identical, which is what lets the
-            # provider's prompt cache serve the full parent prefix.
+            # Keep fork-specific instructions out of the system prompt so the
+            # inherited parent prefix remains cache-aligned.
             preamble = subagent_system_prompts.get(subagent_type, "")
             final_content = f"{preamble}\n\n{description}" if preamble else description
             subagent_state["messages"] = [*parent_messages, HumanMessage(content=final_content)]

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -197,19 +197,12 @@ DEFAULT_SUBAGENT_PROMPT = "In order to complete the objective that the user asks
 # 1. The messages key is handled explicitly to ensure only the final message is included
 # 2. The todos and structured_response keys are excluded as they do not have a defined reducer
 #    and no clear meaning for returning them from a subagent to the main agent.
-# 3. The skills_metadata, memory_contents, and local_context keys are automatically excluded
-#    from subagent output via PrivateStateAttr annotations on their respective state schemas.
-#    However, they must ALSO be explicitly filtered from runtime.state when invoking a subagent
-#    to prevent parent state from leaking to child agents (e.g., the general-purpose subagent
-#    loads its own skills via SkillsMiddleware).
-_EXCLUDED_STATE_KEYS = {
-    "messages",
-    "todos",
-    "structured_response",
-    "skills_metadata",
-    "memory_contents",
-    "local_context",
-}
+# 3. The skills_metadata and memory_contents keys are automatically excluded from subagent output
+#    via PrivateStateAttr annotations on their respective state schemas. However, they must ALSO
+#    be explicitly filtered from runtime.state when invoking a subagent to prevent parent state
+#    from leaking to child agents (e.g., the general-purpose subagent loads its own skills via
+#    SkillsMiddleware).
+_EXCLUDED_STATE_KEYS = {"messages", "todos", "structured_response", "skills_metadata", "memory_contents"}
 
 # Forks intentionally inherit only state keys listed here; `messages` are
 # handled explicitly below to preserve the cache-aligned conversation prefix.

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -11,7 +11,7 @@ from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRe
 from langchain.agents.structured_output import ResponseFormat
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
@@ -381,6 +381,120 @@ class _SubagentSpec(TypedDict):
     subagent_system_prompt: NotRequired[str]
 
 
+class _SystemPromptPaddingMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Append a fixed text block to the system message without adding tools."""
+
+    def __init__(self, text: str, *, name: str) -> None:
+        super().__init__()
+        self._text = text
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        new_system_message = append_to_system_message(request.system_message, self._text)
+        return handler(request.override(system_message=new_system_message))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any]:
+        new_system_message = append_to_system_message(request.system_message, self._text)
+        return await handler(request.override(system_message=new_system_message))
+
+
+def _build_subagent_system_prompt(
+    subagents: Sequence[SubAgent | CompiledSubAgent | _SubagentSpec],
+    system_prompt: str | None = TASK_SYSTEM_PROMPT,
+) -> str | None:
+    """Build the system prompt block appended by `SubAgentMiddleware`."""
+    if not system_prompt or not subagents:
+        return system_prompt
+    agents_desc = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
+    return system_prompt + "\n\nAvailable subagent types:\n" + agents_desc
+
+
+def _build_fork_subagent_system_prompt(
+    subagents: Sequence[SubAgent | CompiledSubAgent | _SubagentSpec],
+) -> str:
+    """Build the task-tool prompt block used to align forked subagent cache."""
+    system_prompt = _build_subagent_system_prompt(subagents)
+    if system_prompt is None:
+        msg = "Forked subagent cache alignment requires a subagent system prompt."
+        raise ValueError(msg)
+    return system_prompt
+
+
+def _prepare_forked_subagent_spec(
+    spec: SubAgent,
+    *,
+    parent_system_prompt: str | SystemMessage,
+    sync_prompt_padding_text: str,
+    async_prompt_padding_text: str | None,
+    middleware_before_sync_padding: Sequence[AgentMiddleware[Any, Any, Any]],
+    middleware_before_async_padding: Sequence[AgentMiddleware[Any, Any, Any]],
+    parent_middleware: Sequence[AgentMiddleware[Any, Any, Any]],
+    user_middleware: Sequence[AgentMiddleware[Any, Any, Any]],
+    middleware_after_user: Sequence[AgentMiddleware[Any, Any, Any]],
+) -> SubAgent:
+    """Finalize a forked `SubAgent` spec without leaking recursive task tools."""
+    fork_middleware: list[AgentMiddleware[Any, Any, Any]] = [
+        *middleware_before_sync_padding,
+        _SystemPromptPaddingMiddleware(
+            text=sync_prompt_padding_text,
+            name="ForkSubAgentSystemPromptPadding",
+        ),
+        *middleware_before_async_padding,
+    ]
+    if async_prompt_padding_text is not None:
+        fork_middleware.append(
+            _SystemPromptPaddingMiddleware(
+                text=async_prompt_padding_text,
+                name="ForkAsyncSubAgentSystemPromptPadding",
+            )
+        )
+    fork_middleware.extend(parent_middleware)
+    fork_middleware.extend(user_middleware)
+    fork_middleware.extend(middleware_after_user)
+
+    fork_tool_names = []
+    for tool in spec.get("tools", []) or []:
+        name = getattr(tool, "name", None)
+        if name is None and isinstance(tool, dict):
+            value = cast("dict[str, Any]", tool).get("name")
+            name = value if isinstance(value, str) else None
+        if isinstance(name, str):
+            fork_tool_names.append(name)
+    tools_line = ", ".join(f"`{n}`" for n in fork_tool_names) if fork_tool_names else "(none — rely on built-in filesystem/todo tools)"
+    subagent_system_prompt = (
+        f"You are running as a forked subagent named `{spec['name']}`. "
+        "The system prompt above was inherited verbatim from the parent agent to "
+        "preserve prompt-cache reuse; it may mention capabilities that do not apply "
+        "to you. Your actual environment:\n"
+        f"\n- Your declared tools: {tools_line}"
+        "\n- You do NOT have the `task` tool. You cannot spawn further subagents."
+        "\n\nYour role as this subagent:\n"
+        f"{spec['system_prompt']}"
+    )
+
+    return cast(
+        "SubAgent",
+        {
+            **spec,
+            "system_prompt": parent_system_prompt,
+            "middleware": fork_middleware,
+            "subagent_system_prompt": subagent_system_prompt,
+        },
+    )
+
+
 def _messages_before_current_task_call(messages: Sequence[Any], tool_call_id: str | None) -> list[Any]:
     """Return parent messages before the AI turn that requested this task call.
 
@@ -646,12 +760,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         task_tool = _build_task_tool(subagent_specs, task_description)
 
-        # Build system prompt with available agents
-        if system_prompt and subagent_specs:
-            agents_desc = "\n".join(f"- {s['name']}: {s['description']}" for s in subagent_specs)
-            self.system_prompt = system_prompt + "\n\nAvailable subagent types:\n" + agents_desc
-        else:
-            self.system_prompt = system_prompt
+        self.system_prompt = _build_subagent_system_prompt(subagent_specs, system_prompt)
 
         self.tools = [task_tool]
 

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -90,6 +90,33 @@ class SubAgent(TypedDict):
     ``_PermissionMiddleware`` is appended last in the middleware stack.
     """
 
+    fork: NotRequired[bool]
+    """Whether to fork the parent agent's context into the subagent.
+
+    When ``True``, the subagent inherits the parent agent's system prompt and
+    full message history as its starting context, with the parent's prompt
+    composed as a prefix and the subagent's own ``system_prompt`` appended as
+    a suffix. The description argument passed through the ``task`` tool is
+    seeded as an additional ``HumanMessage`` after the inherited history.
+
+    The primary benefit is prompt-cache reuse: because the subagent's prefix
+    matches the parent's exactly, every provider's cache path fires on the
+    second and subsequent invocations — Anthropic via
+    ``cache_control`` markers, OpenAI via its automatic Responses-API cache,
+    and Gemini 2.5 via implicit caching. Isolation semantics are unchanged:
+    only the subagent's final message is surfaced back to the parent.
+
+    The subagent's ``model`` must resolve to the same provider and model id
+    as the parent. If omitted, it defaults to the parent's model. A mismatch
+    raises ``ValueError`` at build time — cache is per-model on every provider.
+
+    Not supported on ``CompiledSubAgent`` (raises at build time): a compiled
+    subagent owns its own system prompt and graph, so there is no clean way
+    to splice in the parent's prefix.
+
+    Default: ``False``.
+    """
+
     response_format: NotRequired[ResponseFormat[Any] | type | dict[str, Any]]
     """Structured output response format for the subagent.
 
@@ -343,9 +370,33 @@ class _SubagentSpec(TypedDict):
     name: str
     description: str
     runnable: Runnable
+    fork: NotRequired[bool]
 
 
-def _build_task_tool(  # noqa: C901
+FORKED_SUBAGENT_MARKER = "[forked — inherits full conversation context]"
+"""Annotation rendered next to a forked subagent's name in the task tool's
+available-agents list. Also scanned by tests to verify the list rendering."""
+
+
+FORK_USAGE_GUIDANCE = (
+    "\n\n### Forked subagents\n"
+    f"Some subagents above are marked `{FORKED_SUBAGENT_MARKER}`. A forked "
+    "subagent already sees the entire conversation up to this point — the "
+    "main agent's system prompt, prior user and assistant messages, and all "
+    "tool results. **Do not restate shared context in the `description`.** "
+    "Pass only the task delta: the specific action you want the subagent to "
+    "take, plus any pointers (file paths, message references, artifact ids) "
+    "that disambiguate what to act on. Restating inherited context costs "
+    "tokens and defeats the cache reuse that fork mode is designed to "
+    "provide. Non-forked subagents are stateless and still require full "
+    "context in `description` as before."
+)
+"""Guidance block appended to the task tool description when at least one
+forked subagent is registered. Teaches the main agent to pass only the task
+delta instead of re-stating context the fork already has."""
+
+
+def _build_task_tool(  # noqa: C901, PLR0915
     subagents: list[_SubagentSpec],
     task_description: str | None = None,
 ) -> BaseTool:
@@ -361,7 +412,15 @@ def _build_task_tool(  # noqa: C901
     """
     # Build the graphs dict and descriptions from the unified spec list
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
-    subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
+    subagent_fork_flags: dict[str, bool] = {spec["name"]: bool(spec.get("fork", False)) for spec in subagents}
+
+    def _format_agent_line(s: _SubagentSpec) -> str:
+        if s.get("fork"):
+            return f"- {s['name']} {FORKED_SUBAGENT_MARKER}: {s['description']}"
+        return f"- {s['name']}: {s['description']}"
+
+    subagent_description_str = "\n".join(_format_agent_line(s) for s in subagents)
+    any_forked = any(subagent_fork_flags.values())
 
     # Use custom description if provided, otherwise use default template
     if task_description is None:
@@ -370,6 +429,9 @@ def _build_task_tool(  # noqa: C901
         description = task_description.format(available_agents=subagent_description_str)
     else:
         description = task_description
+
+    if any_forked:
+        description = description + FORK_USAGE_GUIDANCE
 
     def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
         # Validate that the result contains a 'messages' key
@@ -402,13 +464,33 @@ def _build_task_tool(  # noqa: C901
             }
         )
 
-    def _validate_and_prepare_state(subagent_type: str, description: str, runtime: ToolRuntime) -> tuple[Runnable, dict]:
-        """Prepare state for invocation."""
+    def _validate_and_prepare_state(subagent_type: str, description: str, runtime: ToolRuntime) -> tuple[Runnable, dict, bool]:
+        """Prepare state for invocation.
+
+        Returns the resolved runnable, the seeded state dict, and a bool
+        indicating whether this invocation is running in fork mode.
+        """
         subagent = subagent_graphs[subagent_type]
+        is_fork = subagent_fork_flags.get(subagent_type, False)
         # Create a new state dict to avoid mutating the original
         subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
-        subagent_state["messages"] = [HumanMessage(content=description)]
-        return subagent, subagent_state
+        if is_fork:
+            parent_messages = list(runtime.state.get("messages", []))
+            subagent_state["messages"] = [*parent_messages, HumanMessage(content=description)]
+        else:
+            subagent_state["messages"] = [HumanMessage(content=description)]
+        return subagent, subagent_state, is_fork
+
+    def _build_subagent_config(runtime: ToolRuntime, *, is_fork: bool) -> RunnableConfig:
+        """Build the RunnableConfig for a subagent invocation.
+
+        Forked subagents get ``ls_agent_type="fork-subagent"`` so LangSmith
+        filtering can distinguish fork runs (where cache-read metrics matter)
+        from regular subagent runs.
+        """
+        agent_type = "fork-subagent" if is_fork else "subagent"
+        # Don't merge all fields because this will block out manual `.with_config`
+        return {"configurable": {**runtime.config.get("configurable", {}), "ls_agent_type": agent_type}}
 
     def task(
         description: str,
@@ -421,10 +503,8 @@ def _build_task_tool(  # noqa: C901
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
-        subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-
-        # Don't merge all fields because this will block out manual `.with_config`
-        subagent_config: RunnableConfig = {"configurable": {**runtime.config.get("configurable", {}), "ls_agent_type": "subagent"}}
+        subagent, subagent_state, is_fork = _validate_and_prepare_state(subagent_type, description, runtime)
+        subagent_config = _build_subagent_config(runtime, is_fork=is_fork)
         result = subagent.invoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
@@ -439,9 +519,8 @@ def _build_task_tool(  # noqa: C901
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
-        subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
-        # Don't merge all fields because this will block out manual `.with_config`
-        subagent_config: RunnableConfig = {"configurable": {**runtime.config.get("configurable", {}), "ls_agent_type": "subagent"}}
+        subagent, subagent_state, is_fork = _validate_and_prepare_state(subagent_type, description, runtime)
+        subagent_config = _build_subagent_config(runtime, is_fork=is_fork)
         result = await subagent.ainvoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
@@ -544,7 +623,14 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             if "runnable" in spec:
                 # CompiledSubAgent - use as-is
                 compiled = cast("CompiledSubAgent", spec)
-                specs.append({"name": compiled["name"], "description": compiled["description"], "runnable": compiled["runnable"]})
+                if compiled.get("fork"):
+                    msg = (
+                        f"CompiledSubAgent '{compiled['name']}' cannot set fork=True. "
+                        "Compiled subagents own their own system prompt and graph; "
+                        "splice the parent prefix manually if needed."
+                    )
+                    raise ValueError(msg)
+                specs.append({"name": compiled["name"], "description": compiled["description"], "runnable": compiled["runnable"], "fork": False})
                 continue
 
             # SubAgent - validate required fields
@@ -579,6 +665,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                         name=spec["name"],
                         response_format=spec.get("response_format"),
                     ),
+                    "fork": bool(spec.get("fork", False)),
                 }
             )
 

--- a/libs/deepagents/tests/integration_tests/fork_cache_utils.py
+++ b/libs/deepagents/tests/integration_tests/fork_cache_utils.py
@@ -1,0 +1,191 @@
+"""Shared integration-test helpers for fork prompt-cache verification."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import HumanMessage
+
+from deepagents.graph import create_deep_agent
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from uuid import UUID
+
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.outputs import LLMResult
+
+
+class AgentLike(Protocol):
+    """Minimal protocol for the compiled agent returned by `create_deep_agent`."""
+
+    def invoke(self, input_: object, config: object | None = None) -> object:
+        """Invoke the compiled agent."""
+
+
+_FILLER_SENTENCE = (
+    "You are an exhaustive research assistant. You help the user synthesize "
+    "long-form technical documentation into concise, actionable summaries. "
+    "You always cite your sources, flag uncertainty, and prefer precise "
+    "terminology over colloquialisms. "
+)
+LARGE_SHARED_PREFIX = _FILLER_SENTENCE * 120
+
+_FORK_PREAMBLE_MARKER = "You are running as a forked subagent"
+_PARENT_PREFIX_MARKER = "exhaustive research assistant"
+_NONFORK_SUBAGENT_MARKER = "Reply with exactly one short sentence."
+
+LARGE_USER_MESSAGE_TEXT = (
+    "Background context (do not respond to this, just keep it in mind): "
+    "Organizations accumulate institutional knowledge across many sources. "
+    "Policies, runbooks, design docs, incident reports, and personal notes "
+    "all carry context that agents need to act correctly. "
+) * 400
+LARGE_USER_MESSAGE_APPROX_TOKENS = 6000
+
+
+class UsageCapture(BaseCallbackHandler):
+    """Records per-LLM-call cache metrics, classified by agent."""
+
+    def __init__(self, cache_read_tokens: Callable[[Any], int]) -> None:
+        self._cache_read_tokens = cache_read_tokens
+        self.events: list[dict[str, Any]] = []
+        self._run_class: dict[Any, str] = {}
+        self.system_texts: list[tuple[str, str]] = []
+        self.messages_summaries: list[tuple[str, list[str]]] = []
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[Any]],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        system_text = ""
+        last_human_text = ""
+        summary: list[str] = []
+        for msg_list in messages:
+            for msg in msg_list:
+                mtype = getattr(msg, "type", "?") or "?"
+                content = str(getattr(msg, "content", "") or "")
+                summary.append(f"{mtype}: len={len(content)} preview={content[:60]!r}")
+                if mtype == "system":
+                    system_text += content
+                elif mtype == "human":
+                    last_human_text = content
+
+        has_parent = _PARENT_PREFIX_MARKER in system_text
+        has_fork_preamble = _FORK_PREAMBLE_MARKER in last_human_text
+        has_nonfork_subagent = _NONFORK_SUBAGENT_MARKER in system_text
+        if has_parent and has_fork_preamble:
+            agent_type = "fork-subagent"
+        elif has_nonfork_subagent and not has_parent:
+            agent_type = "subagent"
+        else:
+            agent_type = "main"
+        self._run_class[run_id] = agent_type
+        self.system_texts.append((agent_type, system_text))
+        self.messages_summaries.append((agent_type, summary))
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        agent_type = self._run_class.pop(run_id, "main")
+        for gen_list in response.generations:
+            for gen in gen_list:
+                msg = getattr(gen, "message", None)
+                self.events.append(
+                    {
+                        "agent_type": agent_type,
+                        "cache_read": self._cache_read_tokens(msg),
+                    }
+                )
+
+
+def build_fork_agent(model: BaseChatModel, *, fork: bool = True) -> AgentLike:
+    """Build the common deepagent used by live prompt-cache tests."""
+    return cast(
+        "AgentLike",
+        create_deep_agent(
+            model=model,
+            system_prompt=LARGE_SHARED_PREFIX,
+            tools=[],
+            subagents=[
+                {
+                    "name": "worker",
+                    "description": "Worker subagent that answers briefly.",
+                    "system_prompt": "Reply with exactly one short sentence.",
+                    "tools": [],
+                    "fork": fork,
+                },
+            ],
+        ),
+    )
+
+
+def invoke_twice_with_large_message(agent: AgentLike, capture: UsageCapture) -> None:
+    """Warm the provider cache, then invoke the same parent/fork prefix again."""
+    large_delegate = (
+        "Your only job right now is to call the `task` tool with "
+        "subagent_type='worker' and description='say hi'. "
+        "Do not produce any other output. Do not summarize the context below.\n\n"
+        "<context>\n" + LARGE_USER_MESSAGE_TEXT + "\n</context>\n\n"
+        "Now call the `task` tool as instructed above. No other output."
+    )
+    agent.invoke(
+        {"messages": [HumanMessage(content=large_delegate)]},
+        config={"callbacks": [capture]},
+    )
+    agent.invoke(
+        {"messages": [HumanMessage(content=large_delegate)]},
+        config={"callbacks": [capture]},
+    )
+
+
+def assert_fork_reuses_inherited_message_cache(capture: UsageCapture, *, provider: str) -> None:
+    """Assert fork cache reads cover the inherited large message, not just system text."""
+    fork_events = [e for e in capture.events if e["agent_type"] == "fork-subagent"]
+    main_events = [e for e in capture.events if e["agent_type"] == "main"]
+    assert fork_events, f"No fork-subagent LLM calls observed for {provider}. Events: {capture.events}"
+    assert main_events, f"No main-agent LLM calls observed for {provider}. Events: {capture.events}"
+
+    max_parent_read = max((e["cache_read"] for e in main_events), default=0)
+    max_fork_read = max(e["cache_read"] for e in fork_events)
+    assert max_parent_read >= LARGE_USER_MESSAGE_APPROX_TOKENS, (
+        f"{provider} parent did not cache the large HumanMessage. "
+        f"max parent cache_read={max_parent_read}, expected >= {LARGE_USER_MESSAGE_APPROX_TOKENS}. "
+        f"All events: {capture.events}"
+    )
+
+    expected_floor = max_parent_read - 4_000
+    if max_fork_read >= expected_floor:
+        return
+
+    parent_sys = next((t for a, t in capture.system_texts if a == "main"), "")
+    fork_sys = next((t for a, t in capture.system_texts if a == "fork-subagent"), "")
+    divergence_at = next(
+        (i for i in range(min(len(parent_sys), len(fork_sys))) if parent_sys[i] != fork_sys[i]),
+        min(len(parent_sys), len(fork_sys)),
+    )
+    context_slice = slice(max(0, divergence_at - 80), divergence_at + 200)
+    parent_msgs = next((s for a, s in capture.messages_summaries if a == "main"), [])
+    fork_msgs = next((s for a, s in capture.messages_summaries if a == "fork-subagent"), [])
+    msg = (
+        f"{provider} fork cache_read did not cover the inherited large HumanMessage.\n"
+        f"  max parent cache_read = {max_parent_read}  (system + large_msg)\n"
+        f"  max fork   cache_read = {max_fork_read}\n"
+        f"  expected fork_read    >= {expected_floor}\n\n"
+        f"  parent system len = {len(parent_sys)}\n"
+        f"  fork   system len = {len(fork_sys)}\n"
+        f"  system diverge at byte = {divergence_at}\n"
+        f"  parent system near split = {parent_sys[context_slice]!r}\n"
+        f"  fork   system near split = {fork_sys[context_slice]!r}\n\n"
+        f"  parent non-system messages:\n    " + "\n    ".join(parent_msgs) + "\n  fork non-system messages:\n    " + "\n    ".join(fork_msgs)
+    )
+    raise AssertionError(msg)

--- a/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
+++ b/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
@@ -1,14 +1,13 @@
 """End-to-end verification that fork mode preserves Anthropic prompt caching.
 
 Runs against a live Claude Haiku 4.5 endpoint. The test sends two back-to-back
-invocations that route through a forked subagent and asserts the fork's second
-invocation hits the prompt cache. A negative control asserts that a non-fork
-subagent (same structure, `fork=False`) does not hit the cache on the second
-run — the delta confirms fork is what unlocks the reuse.
+parent invocations with a large user message, then verifies the forked
+subagent reads at least as much cached input as the parent. That proves the
+fork reuses the parent's full cached prefix, including inherited messages.
 
-Haiku's minimum cacheable block is 2048 tokens (vs. 1024 for Sonnet/Opus). The
-shared system prompt below is sized well above that floor so the cache
-breakpoint actually fires.
+Haiku's minimum cacheable block is 2048 tokens (vs. 1024 for Sonnet/Opus).
+The shared system prompt and the injected HumanMessage below are both sized
+well above that floor so cache breakpoints can actually fire.
 """
 
 from __future__ import annotations
@@ -40,16 +39,22 @@ _FILLER_SENTENCE = (
 LARGE_SHARED_PREFIX = _FILLER_SENTENCE * 120  # ~3500+ tokens, safely above 2048
 
 
-_FORK_SUFFIX_MARKER = "Reply with exactly one short sentence."
-"""Text unique to the worker subagent's own system_prompt. Used below to
-classify which agent made each LLM call by inspecting the system message
-content — ``ls_agent_type`` is propagated via the LangSmith tracer, not the
-callback's ``metadata``, so we cannot key on it here."""
+_FORK_PREAMBLE_MARKER = "You are running as a forked subagent"
+"""Text present only in the preamble that ``graph.py`` prepends to a forked
+subagent's trailing HumanMessage. Used to classify fork LLM calls by
+inspecting the last user-role message. ``ls_agent_type`` propagates through
+the LangSmith tracer, not the callback's ``metadata``, so we cannot key on
+it here."""
 
 _PARENT_PREFIX_MARKER = "exhaustive research assistant"
-"""Text unique to the main agent's large shared system prompt. Combined
-with ``_FORK_SUFFIX_MARKER``, its presence distinguishes a fork call (both
-markers) from a non-fork subagent call (suffix only)."""
+"""Text unique to the main agent's large shared system prompt. Present on
+both main-agent and forked-subagent calls (fork inherits the parent system
+byte-for-byte), so this alone does not distinguish them — pair it with
+the preamble marker below to classify."""
+
+_NONFORK_SUBAGENT_MARKER = "Reply with exactly one short sentence."
+"""Text that appears only in the non-fork subagent's system_prompt slot.
+Present on non-fork subagent calls, absent on main and fork calls."""
 
 
 class _UsageCapture(BaseCallbackHandler):
@@ -71,6 +76,12 @@ class _UsageCapture(BaseCallbackHandler):
     def __init__(self) -> None:
         self.events: list[dict[str, Any]] = []
         self._run_class: dict[Any, str] = {}
+        # Keep the system text each call saw so a failing assertion can pinpoint
+        # where the parent's and fork's system messages diverge.
+        self.system_texts: list[tuple[str, str]] = []  # (agent_type, system_text)
+        # Same for the full non-system message list, so we can spot divergence
+        # anywhere in the prefix, not just the system portion.
+        self.messages_summaries: list[tuple[str, list[str]]] = []  # (agent_type, [type: content-preview])
 
     def on_chat_model_start(
         self,
@@ -81,18 +92,29 @@ class _UsageCapture(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         system_text = ""
+        last_human_text = ""
+        summary: list[str] = []
         for msg_list in messages:
             for msg in msg_list:
-                if getattr(msg, "type", None) == "system":
-                    system_text += str(getattr(msg, "content", "") or "")
+                mtype = getattr(msg, "type", "?") or "?"
+                content = str(getattr(msg, "content", "") or "")
+                summary.append(f"{mtype}: len={len(content)} preview={content[:60]!r}")
+                if mtype == "system":
+                    system_text += content
+                elif mtype == "human":
+                    last_human_text = content
         has_parent = _PARENT_PREFIX_MARKER in system_text
-        has_fork_suffix = _FORK_SUFFIX_MARKER in system_text
-        if has_parent and has_fork_suffix:
-            self._run_class[run_id] = "fork-subagent"
-        elif has_fork_suffix:
-            self._run_class[run_id] = "subagent"
+        has_fork_preamble = _FORK_PREAMBLE_MARKER in last_human_text
+        has_nonfork_subagent = _NONFORK_SUBAGENT_MARKER in system_text
+        if has_parent and has_fork_preamble:
+            agent_type = "fork-subagent"
+        elif has_nonfork_subagent and not has_parent:
+            agent_type = "subagent"
         else:
-            self._run_class[run_id] = "main"
+            agent_type = "main"
+        self._run_class[run_id] = agent_type
+        self.system_texts.append((agent_type, system_text))
+        self.messages_summaries.append((agent_type, summary))
 
     def on_llm_end(
         self,
@@ -139,84 +161,111 @@ def _build_agent(*, fork: bool) -> object:
     )
 
 
-_DELEGATE_PROMPT = "Call the `task` tool with subagent_type='worker' and description='say hi'. Do this immediately."
+# Large HumanMessage used to prove the parent caches message content and the
+# fork reuses that same cached prefix. Sized well above the 2048-token Haiku
+# floor so a cache breakpoint on the last message can fire.
+_LARGE_USER_MESSAGE_TEXT = (
+    "Background context (do not respond to this, just keep it in mind): "
+    "Organizations accumulate institutional knowledge across many sources. "
+    "Policies, runbooks, design docs, incident reports, and personal notes "
+    "all carry context that agents need to act correctly. "
+) * 400
+_LARGE_USER_MESSAGE_APPROX_TOKENS = 6000  # conservative lower bound
 
 
 class TestForkPromptCachingAnthropic:
-    """Live verification that fork mode reuses the Anthropic prompt cache.
+    """Live verification of the fork implementation's prompt-cache behavior."""
 
-    The whole point of ``fork=True`` is that the subagent's prefix matches
-    the parent's byte-for-byte, so the provider's prompt cache serves the
-    second invocation. These tests verify that directly by capturing every
-    LLM call via a callback and filtering for events tagged
-    ``ls_agent_type="fork-subagent"``.
-    """
+    def test_fork_caches_inherited_messages_not_just_system_prompt(self) -> None:
+        """Fork cache reads should include inherited messages, not just the system prompt.
 
-    def test_fork_subagent_reuses_prompt_cache_across_invocations(self) -> None:
-        """Forked subagent's second call must read a meaningful chunk of tokens from cache.
+        Anthropic's prompt cache is a running prefix of bytes: the cache entry
+        written at any message-block boundary depends on every byte that came
+        before it. This test proves the parent caches a large HumanMessage,
+        then asserts the fork can reuse the same cached prefix before adding
+        its own final HumanMessage.
 
-        Two back-to-back invocations of the agent, each asking it to delegate
-        to a forked subagent. Across the two fork calls, at least one must
-        report ``cache_read_input_tokens > 0``. The exact boundary between
-        creation and read depends on prior cache state, so we only assert
-        the reuse — it's the signal that proves the fork's prefix aligns
-        with a previously-seen prefix.
+        Concretely:
+
+        1. Run the deepagent twice with the same large HumanMessage,
+           delegating to a forked subagent. The fork inherits the parent's
+           message history.
+
+        2. Assert the parent's second call reads the large message from cache,
+           proving normal interaction caches message content.
+
+        3. Assert the fork's cache_read is close to the parent's cache_read.
+           If it is much lower, the fork is only reusing the system-prompt
+           portion and missing inherited messages.
         """
+        # Run the forked deepagent with the same large HumanMessage twice.
+        # Delegation instruction is placed FIRST and LAST so the model can't
+        # miss it when the middle of the message is filled with background
+        # context. The middle chunk is what we actually want the fork to inherit.
         capture = _UsageCapture()
         agent = _build_agent(fork=True)
-
+        large_delegate = (
+            "Your only job right now is to call the `task` tool with "
+            "subagent_type='worker' and description='say hi'. "
+            "Do not produce any other output. Do not summarize the context below.\n\n"
+            "<context>\n" + _LARGE_USER_MESSAGE_TEXT + "\n</context>\n\n"
+            "Now call the `task` tool as instructed above. No other output."
+        )
         agent.invoke(
-            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
+            {"messages": [HumanMessage(content=large_delegate)]},
             config={"callbacks": [capture]},
         )
         agent.invoke(
-            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
+            {"messages": [HumanMessage(content=large_delegate)]},
             config={"callbacks": [capture]},
         )
 
         fork_events = [e for e in capture.events if e["agent_type"] == "fork-subagent"]
-        assert fork_events, (
-            f"No fork-subagent LLM calls were observed. All events: {capture.events}. "
-            "The model may have ignored the `task` tool; update the delegate prompt."
-        )
-        assert any(e["cache_read"] > 0 for e in fork_events), (
-            f"Fork subagent never reused the prompt cache. Fork events: {fork_events}. "
-            "The fork's prefix drifted between invocations — check that "
-            "_compose_fork_system_prompt is byte-stable and that no middleware "
-            "between fork composition and the model mutates the system message."
+        main_events = [e for e in capture.events if e["agent_type"] == "main"]
+        assert fork_events, f"No fork-subagent LLM calls observed. Events: {capture.events}"
+        assert main_events, f"No main-agent LLM calls observed. Events: {capture.events}"
+
+        # If fork preserved caching end-to-end, fork's cache_read would cover
+        # both the parent's system prompt AND the inherited large HumanMessage
+        # — i.e., at least as much as the parent's own cache_read, since fork
+        # sees the same prefix (system + parent messages) plus a tiny tail.
+        max_parent_read = max((e["cache_read"] for e in main_events), default=0)
+        max_fork_read = max(e["cache_read"] for e in fork_events)
+        assert max_parent_read >= _LARGE_USER_MESSAGE_APPROX_TOKENS, (
+            f"Parent did not cache the large HumanMessage. "
+            f"max parent cache_read={max_parent_read}, expected >= {_LARGE_USER_MESSAGE_APPROX_TOKENS}. "
+            f"All events: {capture.events}"
         )
 
-    def test_nonfork_subagent_does_not_reuse_prompt_cache(self) -> None:
-        """Negative control: ``fork=False`` subagent shows zero cache reuse.
-
-        A non-fork subagent is seeded with only ``[HumanMessage(description)]``
-        and its own tiny system prompt (far under Haiku's 2048-token floor),
-        so its prefix does not align with any previous call and no cache
-        breakpoint can fire. If this test ever shows a cache read, either
-        the fork and non-fork paths have converged (a real regression) or
-        ambient cross-call caching is masking the fork-specific behavior.
-        """
-        capture = _UsageCapture()
-        agent = _build_agent(fork=False)
-
-        agent.invoke(
-            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
-            config={"callbacks": [capture]},
-        )
-        agent.invoke(
-            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
-            config={"callbacks": [capture]},
-        )
-
-        subagent_events = [e for e in capture.events if e["agent_type"] == "subagent"]
-        assert subagent_events, (
-            f"No subagent LLM calls were observed. All events: {capture.events}. "
-            "The model may have ignored the `task` tool; update the delegate prompt."
-        )
-        for event in subagent_events:
-            assert event["cache_read"] == 0, (
-                f"Non-fork subagent unexpectedly reused the prompt cache: {event}. "
-                "This defeats the fork-vs-non-fork distinction — either the fork "
-                "path is silently active when it should not be, or ambient caching "
-                "is sharing prefix state in a way the middleware doesn't control."
+        # Floor: the fork should read roughly what the parent read (system +
+        # message), minus a modest allowance for provider-side token-accounting
+        # differences caused by the fork's extra trailing task message. The
+        # previous broken implementation read only the system portion (~10k);
+        # with the inherited message cached, this should stay near the parent
+        # read (~30k+ in this test).
+        expected_floor = max_parent_read - 4_000
+        if max_fork_read < expected_floor:
+            # Pinpoint where the parent's and fork's system messages diverge
+            # so the failure is actionable without re-running under pdb.
+            parent_sys = next((t for a, t in capture.system_texts if a == "main"), "")
+            fork_sys = next((t for a, t in capture.system_texts if a == "fork-subagent"), "")
+            divergence_at = next(
+                (i for i in range(min(len(parent_sys), len(fork_sys))) if parent_sys[i] != fork_sys[i]),
+                min(len(parent_sys), len(fork_sys)),
             )
+            context_slice = slice(max(0, divergence_at - 80), divergence_at + 200)
+            parent_msgs = next((s for a, s in capture.messages_summaries if a == "main"), [])
+            fork_msgs = next((s for a, s in capture.messages_summaries if a == "fork-subagent"), [])
+            msg = (
+                f"Fork cache_read did not cover the inherited large HumanMessage.\n"
+                f"  max parent cache_read = {max_parent_read}  (system + large_msg)\n"
+                f"  max fork   cache_read = {max_fork_read}\n"
+                f"  expected fork_read    >= {expected_floor}\n\n"
+                f"  parent system len = {len(parent_sys)}\n"
+                f"  fork   system len = {len(fork_sys)}\n"
+                f"  system diverge at byte = {divergence_at}\n"
+                f"  parent system near split = {parent_sys[context_slice]!r}\n"
+                f"  fork   system near split = {fork_sys[context_slice]!r}\n\n"
+                f"  parent non-system messages:\n    " + "\n    ".join(parent_msgs) + "\n  fork non-system messages:\n    " + "\n    ".join(fork_msgs)
+            )
+            raise AssertionError(msg)

--- a/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
+++ b/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
@@ -66,8 +66,8 @@ class _UsageCapture(BaseCallbackHandler):
     and read when it ends.
 
     Classes:
-    - ``fork-subagent``: system message contains both the parent prefix
-      and the worker's fork suffix — the composed fork prompt.
+    - ``fork-subagent``: system message contains the parent prefix and the
+      trailing HumanMessage contains the fork preamble marker.
     - ``subagent``: system message contains only the worker's suffix —
       non-fork subagent.
     - ``main``: everything else — the top-level agent's own calls.

--- a/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
+++ b/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
@@ -1,0 +1,222 @@
+"""End-to-end verification that fork mode preserves Anthropic prompt caching.
+
+Runs against a live Claude Haiku 4.5 endpoint. The test sends two back-to-back
+invocations that route through a forked subagent and asserts the fork's second
+invocation hits the prompt cache. A negative control asserts that a non-fork
+subagent (same structure, `fork=False`) does not hit the cache on the second
+run — the delta confirms fork is what unlocks the reuse.
+
+Haiku's minimum cacheable block is 2048 tokens (vs. 1024 for Sonnet/Opus). The
+shared system prompt below is sized well above that floor so the cache
+breakpoint actually fires.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import HumanMessage
+
+from deepagents.graph import create_deep_agent
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from langchain_core.outputs import LLMResult
+
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+
+# Haiku's prompt-cache minimum is 2048 tokens. Build a deterministic prefix
+# well above that floor so we're not racing the boundary when tokenizers
+# drift slightly between model versions.
+_FILLER_SENTENCE = (
+    "You are an exhaustive research assistant. You help the user synthesize "
+    "long-form technical documentation into concise, actionable summaries. "
+    "You always cite your sources, flag uncertainty, and prefer precise "
+    "terminology over colloquialisms. "
+)
+LARGE_SHARED_PREFIX = _FILLER_SENTENCE * 120  # ~3500+ tokens, safely above 2048
+
+
+_FORK_SUFFIX_MARKER = "Reply with exactly one short sentence."
+"""Text unique to the worker subagent's own system_prompt. Used below to
+classify which agent made each LLM call by inspecting the system message
+content — ``ls_agent_type`` is propagated via the LangSmith tracer, not the
+callback's ``metadata``, so we cannot key on it here."""
+
+_PARENT_PREFIX_MARKER = "exhaustive research assistant"
+"""Text unique to the main agent's large shared system prompt. Combined
+with ``_FORK_SUFFIX_MARKER``, its presence distinguishes a fork call (both
+markers) from a non-fork subagent call (suffix only)."""
+
+
+class _UsageCapture(BaseCallbackHandler):
+    """Records per-LLM-call cache metrics, classified by agent.
+
+    Classification works by pairing ``on_chat_model_start`` (where the full
+    message list is visible) with ``on_llm_end`` (where usage metadata is
+    available). Each run_id's classification is set when the call starts
+    and read when it ends.
+
+    Classes:
+    - ``fork-subagent``: system message contains both the parent prefix
+      and the worker's fork suffix — the composed fork prompt.
+    - ``subagent``: system message contains only the worker's suffix —
+      non-fork subagent.
+    - ``main``: everything else — the top-level agent's own calls.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        self._run_class: dict[Any, str] = {}
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[Any]],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        system_text = ""
+        for msg_list in messages:
+            for msg in msg_list:
+                if getattr(msg, "type", None) == "system":
+                    system_text += str(getattr(msg, "content", "") or "")
+        has_parent = _PARENT_PREFIX_MARKER in system_text
+        has_fork_suffix = _FORK_SUFFIX_MARKER in system_text
+        if has_parent and has_fork_suffix:
+            self._run_class[run_id] = "fork-subagent"
+        elif has_fork_suffix:
+            self._run_class[run_id] = "subagent"
+        else:
+            self._run_class[run_id] = "main"
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        agent_type = self._run_class.pop(run_id, "main")
+        for gen_list in response.generations:
+            for gen in gen_list:
+                msg = getattr(gen, "message", None)
+                # Read raw Anthropic fields directly rather than the normalized
+                # ``usage_metadata.input_token_details`` path: LangChain's
+                # normalizer zeroes ``cache_creation`` whenever the ephemeral
+                # TTL breakdown is present, making that surface unusable for
+                # verifying cache writes. See
+                # https://github.com/langchain-ai/langchain/issues/36991.
+                usage = (getattr(msg, "response_metadata", None) or {}).get("usage", {})
+                self.events.append(
+                    {
+                        "agent_type": agent_type,
+                        "cache_read": int(usage.get("cache_read_input_tokens", 0)),
+                        "cache_creation": int(usage.get("cache_creation_input_tokens", 0)),
+                    }
+                )
+
+
+def _build_agent(*, fork: bool) -> object:
+    model = ChatAnthropic(model=HAIKU_MODEL, temperature=0)
+    return create_deep_agent(
+        model=model,
+        system_prompt=LARGE_SHARED_PREFIX,
+        tools=[],
+        subagents=[
+            {
+                "name": "worker",
+                "description": "Worker subagent that answers briefly.",
+                "system_prompt": "Reply with exactly one short sentence.",
+                "tools": [],
+                "fork": fork,
+            },
+        ],
+    )
+
+
+_DELEGATE_PROMPT = "Call the `task` tool with subagent_type='worker' and description='say hi'. Do this immediately."
+
+
+class TestForkPromptCachingAnthropic:
+    """Live verification that fork mode reuses the Anthropic prompt cache.
+
+    The whole point of ``fork=True`` is that the subagent's prefix matches
+    the parent's byte-for-byte, so the provider's prompt cache serves the
+    second invocation. These tests verify that directly by capturing every
+    LLM call via a callback and filtering for events tagged
+    ``ls_agent_type="fork-subagent"``.
+    """
+
+    def test_fork_subagent_reuses_prompt_cache_across_invocations(self) -> None:
+        """Forked subagent's second call must read a meaningful chunk of tokens from cache.
+
+        Two back-to-back invocations of the agent, each asking it to delegate
+        to a forked subagent. Across the two fork calls, at least one must
+        report ``cache_read_input_tokens > 0``. The exact boundary between
+        creation and read depends on prior cache state, so we only assert
+        the reuse — it's the signal that proves the fork's prefix aligns
+        with a previously-seen prefix.
+        """
+        capture = _UsageCapture()
+        agent = _build_agent(fork=True)
+
+        agent.invoke(
+            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
+            config={"callbacks": [capture]},
+        )
+        agent.invoke(
+            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
+            config={"callbacks": [capture]},
+        )
+
+        fork_events = [e for e in capture.events if e["agent_type"] == "fork-subagent"]
+        assert fork_events, (
+            f"No fork-subagent LLM calls were observed. All events: {capture.events}. "
+            "The model may have ignored the `task` tool; update the delegate prompt."
+        )
+        assert any(e["cache_read"] > 0 for e in fork_events), (
+            f"Fork subagent never reused the prompt cache. Fork events: {fork_events}. "
+            "The fork's prefix drifted between invocations — check that "
+            "_compose_fork_system_prompt is byte-stable and that no middleware "
+            "between fork composition and the model mutates the system message."
+        )
+
+    def test_nonfork_subagent_does_not_reuse_prompt_cache(self) -> None:
+        """Negative control: ``fork=False`` subagent shows zero cache reuse.
+
+        A non-fork subagent is seeded with only ``[HumanMessage(description)]``
+        and its own tiny system prompt (far under Haiku's 2048-token floor),
+        so its prefix does not align with any previous call and no cache
+        breakpoint can fire. If this test ever shows a cache read, either
+        the fork and non-fork paths have converged (a real regression) or
+        ambient cross-call caching is masking the fork-specific behavior.
+        """
+        capture = _UsageCapture()
+        agent = _build_agent(fork=False)
+
+        agent.invoke(
+            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
+            config={"callbacks": [capture]},
+        )
+        agent.invoke(
+            {"messages": [HumanMessage(content=_DELEGATE_PROMPT)]},
+            config={"callbacks": [capture]},
+        )
+
+        subagent_events = [e for e in capture.events if e["agent_type"] == "subagent"]
+        assert subagent_events, (
+            f"No subagent LLM calls were observed. All events: {capture.events}. "
+            "The model may have ignored the `task` tool; update the delegate prompt."
+        )
+        for event in subagent_events:
+            assert event["cache_read"] == 0, (
+                f"Non-fork subagent unexpectedly reused the prompt cache: {event}. "
+                "This defeats the fork-vs-non-fork distinction — either the fork "
+                "path is silently active when it should not be, or ambient caching "
+                "is sharing prefix state in a way the middleware doesn't control."
+            )

--- a/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
+++ b/libs/deepagents/tests/integration_tests/test_fork_caching_anthropic.py
@@ -1,271 +1,38 @@
-"""End-to-end verification that fork mode preserves Anthropic prompt caching.
-
-Runs against a live Claude Haiku 4.5 endpoint. The test sends two back-to-back
-parent invocations with a large user message, then verifies the forked
-subagent reads at least as much cached input as the parent. That proves the
-fork reuses the parent's full cached prefix, including inherited messages.
-
-Haiku's minimum cacheable block is 2048 tokens (vs. 1024 for Sonnet/Opus).
-The shared system prompt and the injected HumanMessage below are both sized
-well above that floor so cache breakpoints can actually fire.
-"""
+"""End-to-end verification that fork mode preserves Anthropic prompt caching."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 from langchain_anthropic import ChatAnthropic
-from langchain_core.callbacks import BaseCallbackHandler
-from langchain_core.messages import HumanMessage
 
-from deepagents.graph import create_deep_agent
-
-if TYPE_CHECKING:
-    from uuid import UUID
-
-    from langchain_core.outputs import LLMResult
+from tests.integration_tests.fork_cache_utils import (
+    UsageCapture,
+    assert_fork_reuses_inherited_message_cache,
+    build_fork_agent,
+    invoke_twice_with_large_message,
+)
 
 HAIKU_MODEL = "claude-haiku-4-5-20251001"
 
-# Haiku's prompt-cache minimum is 2048 tokens. Build a deterministic prefix
-# well above that floor so we're not racing the boundary when tokenizers
-# drift slightly between model versions.
-_FILLER_SENTENCE = (
-    "You are an exhaustive research assistant. You help the user synthesize "
-    "long-form technical documentation into concise, actionable summaries. "
-    "You always cite your sources, flag uncertainty, and prefer precise "
-    "terminology over colloquialisms. "
-)
-LARGE_SHARED_PREFIX = _FILLER_SENTENCE * 120  # ~3500+ tokens, safely above 2048
 
-
-_FORK_PREAMBLE_MARKER = "You are running as a forked subagent"
-"""Text present only in the preamble that ``graph.py`` prepends to a forked
-subagent's trailing HumanMessage. Used to classify fork LLM calls by
-inspecting the last user-role message. ``ls_agent_type`` propagates through
-the LangSmith tracer, not the callback's ``metadata``, so we cannot key on
-it here."""
-
-_PARENT_PREFIX_MARKER = "exhaustive research assistant"
-"""Text unique to the main agent's large shared system prompt. Present on
-both main-agent and forked-subagent calls (fork inherits the parent system
-byte-for-byte), so this alone does not distinguish them — pair it with
-the preamble marker below to classify."""
-
-_NONFORK_SUBAGENT_MARKER = "Reply with exactly one short sentence."
-"""Text that appears only in the non-fork subagent's system_prompt slot.
-Present on non-fork subagent calls, absent on main and fork calls."""
-
-
-class _UsageCapture(BaseCallbackHandler):
-    """Records per-LLM-call cache metrics, classified by agent.
-
-    Classification works by pairing ``on_chat_model_start`` (where the full
-    message list is visible) with ``on_llm_end`` (where usage metadata is
-    available). Each run_id's classification is set when the call starts
-    and read when it ends.
-
-    Classes:
-    - ``fork-subagent``: system message contains the parent prefix and the
-      trailing HumanMessage contains the fork preamble marker.
-    - ``subagent``: system message contains only the worker's suffix —
-      non-fork subagent.
-    - ``main``: everything else — the top-level agent's own calls.
-    """
-
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-        self._run_class: dict[Any, str] = {}
-        # Keep the system text each call saw so a failing assertion can pinpoint
-        # where the parent's and fork's system messages diverge.
-        self.system_texts: list[tuple[str, str]] = []  # (agent_type, system_text)
-        # Same for the full non-system message list, so we can spot divergence
-        # anywhere in the prefix, not just the system portion.
-        self.messages_summaries: list[tuple[str, list[str]]] = []  # (agent_type, [type: content-preview])
-
-    def on_chat_model_start(
-        self,
-        serialized: dict[str, Any],
-        messages: list[list[Any]],
-        *,
-        run_id: UUID,
-        **kwargs: Any,
-    ) -> None:
-        system_text = ""
-        last_human_text = ""
-        summary: list[str] = []
-        for msg_list in messages:
-            for msg in msg_list:
-                mtype = getattr(msg, "type", "?") or "?"
-                content = str(getattr(msg, "content", "") or "")
-                summary.append(f"{mtype}: len={len(content)} preview={content[:60]!r}")
-                if mtype == "system":
-                    system_text += content
-                elif mtype == "human":
-                    last_human_text = content
-        has_parent = _PARENT_PREFIX_MARKER in system_text
-        has_fork_preamble = _FORK_PREAMBLE_MARKER in last_human_text
-        has_nonfork_subagent = _NONFORK_SUBAGENT_MARKER in system_text
-        if has_parent and has_fork_preamble:
-            agent_type = "fork-subagent"
-        elif has_nonfork_subagent and not has_parent:
-            agent_type = "subagent"
-        else:
-            agent_type = "main"
-        self._run_class[run_id] = agent_type
-        self.system_texts.append((agent_type, system_text))
-        self.messages_summaries.append((agent_type, summary))
-
-    def on_llm_end(
-        self,
-        response: LLMResult,
-        *,
-        run_id: UUID,
-        **kwargs: Any,
-    ) -> None:
-        agent_type = self._run_class.pop(run_id, "main")
-        for gen_list in response.generations:
-            for gen in gen_list:
-                msg = getattr(gen, "message", None)
-                # Read raw Anthropic fields directly rather than the normalized
-                # ``usage_metadata.input_token_details`` path: LangChain's
-                # normalizer zeroes ``cache_creation`` whenever the ephemeral
-                # TTL breakdown is present, making that surface unusable for
-                # verifying cache writes. See
-                # https://github.com/langchain-ai/langchain/issues/36991.
-                usage = (getattr(msg, "response_metadata", None) or {}).get("usage", {})
-                self.events.append(
-                    {
-                        "agent_type": agent_type,
-                        "cache_read": int(usage.get("cache_read_input_tokens", 0)),
-                        "cache_creation": int(usage.get("cache_creation_input_tokens", 0)),
-                    }
-                )
-
-
-def _build_agent(*, fork: bool) -> object:
-    model = ChatAnthropic(model=HAIKU_MODEL, temperature=0)
-    return create_deep_agent(
-        model=model,
-        system_prompt=LARGE_SHARED_PREFIX,
-        tools=[],
-        subagents=[
-            {
-                "name": "worker",
-                "description": "Worker subagent that answers briefly.",
-                "system_prompt": "Reply with exactly one short sentence.",
-                "tools": [],
-                "fork": fork,
-            },
-        ],
-    )
-
-
-# Large HumanMessage used to prove the parent caches message content and the
-# fork reuses that same cached prefix. Sized well above the 2048-token Haiku
-# floor so a cache breakpoint on the last message can fire.
-_LARGE_USER_MESSAGE_TEXT = (
-    "Background context (do not respond to this, just keep it in mind): "
-    "Organizations accumulate institutional knowledge across many sources. "
-    "Policies, runbooks, design docs, incident reports, and personal notes "
-    "all carry context that agents need to act correctly. "
-) * 400
-_LARGE_USER_MESSAGE_APPROX_TOKENS = 6000  # conservative lower bound
+def _anthropic_cache_read_tokens(msg: object) -> int:
+    """Return Anthropic cache-read tokens from raw provider usage metadata."""
+    # Read raw Anthropic fields directly rather than the normalized
+    # ``usage_metadata.input_token_details`` path: LangChain's normalizer
+    # zeroes ``cache_creation`` whenever the ephemeral TTL breakdown is
+    # present, making that surface unusable for verifying cache writes. See
+    # https://github.com/langchain-ai/langchain/issues/36991.
+    usage = (getattr(msg, "response_metadata", None) or {}).get("usage", {})
+    return int(usage.get("cache_read_input_tokens", 0))
 
 
 class TestForkPromptCachingAnthropic:
-    """Live verification of the fork implementation's prompt-cache behavior."""
+    """Live verification of fork prompt-cache behavior on Anthropic."""
 
     def test_fork_caches_inherited_messages_not_just_system_prompt(self) -> None:
-        """Fork cache reads should include inherited messages, not just the system prompt.
+        """Fork cache reads should include inherited messages, not just the system prompt."""
+        capture = UsageCapture(_anthropic_cache_read_tokens)
+        agent = build_fork_agent(ChatAnthropic(model_name=HAIKU_MODEL, temperature=0))
 
-        Anthropic's prompt cache is a running prefix of bytes: the cache entry
-        written at any message-block boundary depends on every byte that came
-        before it. This test proves the parent caches a large HumanMessage,
-        then asserts the fork can reuse the same cached prefix before adding
-        its own final HumanMessage.
+        invoke_twice_with_large_message(agent, capture)
 
-        Concretely:
-
-        1. Run the deepagent twice with the same large HumanMessage,
-           delegating to a forked subagent. The fork inherits the parent's
-           message history.
-
-        2. Assert the parent's second call reads the large message from cache,
-           proving normal interaction caches message content.
-
-        3. Assert the fork's cache_read is close to the parent's cache_read.
-           If it is much lower, the fork is only reusing the system-prompt
-           portion and missing inherited messages.
-        """
-        # Run the forked deepagent with the same large HumanMessage twice.
-        # Delegation instruction is placed FIRST and LAST so the model can't
-        # miss it when the middle of the message is filled with background
-        # context. The middle chunk is what we actually want the fork to inherit.
-        capture = _UsageCapture()
-        agent = _build_agent(fork=True)
-        large_delegate = (
-            "Your only job right now is to call the `task` tool with "
-            "subagent_type='worker' and description='say hi'. "
-            "Do not produce any other output. Do not summarize the context below.\n\n"
-            "<context>\n" + _LARGE_USER_MESSAGE_TEXT + "\n</context>\n\n"
-            "Now call the `task` tool as instructed above. No other output."
-        )
-        agent.invoke(
-            {"messages": [HumanMessage(content=large_delegate)]},
-            config={"callbacks": [capture]},
-        )
-        agent.invoke(
-            {"messages": [HumanMessage(content=large_delegate)]},
-            config={"callbacks": [capture]},
-        )
-
-        fork_events = [e for e in capture.events if e["agent_type"] == "fork-subagent"]
-        main_events = [e for e in capture.events if e["agent_type"] == "main"]
-        assert fork_events, f"No fork-subagent LLM calls observed. Events: {capture.events}"
-        assert main_events, f"No main-agent LLM calls observed. Events: {capture.events}"
-
-        # If fork preserved caching end-to-end, fork's cache_read would cover
-        # both the parent's system prompt AND the inherited large HumanMessage
-        # — i.e., at least as much as the parent's own cache_read, since fork
-        # sees the same prefix (system + parent messages) plus a tiny tail.
-        max_parent_read = max((e["cache_read"] for e in main_events), default=0)
-        max_fork_read = max(e["cache_read"] for e in fork_events)
-        assert max_parent_read >= _LARGE_USER_MESSAGE_APPROX_TOKENS, (
-            f"Parent did not cache the large HumanMessage. "
-            f"max parent cache_read={max_parent_read}, expected >= {_LARGE_USER_MESSAGE_APPROX_TOKENS}. "
-            f"All events: {capture.events}"
-        )
-
-        # Floor: the fork should read roughly what the parent read (system +
-        # message), minus a modest allowance for provider-side token-accounting
-        # differences caused by the fork's extra trailing task message. The
-        # previous broken implementation read only the system portion (~10k);
-        # with the inherited message cached, this should stay near the parent
-        # read (~30k+ in this test).
-        expected_floor = max_parent_read - 4_000
-        if max_fork_read < expected_floor:
-            # Pinpoint where the parent's and fork's system messages diverge
-            # so the failure is actionable without re-running under pdb.
-            parent_sys = next((t for a, t in capture.system_texts if a == "main"), "")
-            fork_sys = next((t for a, t in capture.system_texts if a == "fork-subagent"), "")
-            divergence_at = next(
-                (i for i in range(min(len(parent_sys), len(fork_sys))) if parent_sys[i] != fork_sys[i]),
-                min(len(parent_sys), len(fork_sys)),
-            )
-            context_slice = slice(max(0, divergence_at - 80), divergence_at + 200)
-            parent_msgs = next((s for a, s in capture.messages_summaries if a == "main"), [])
-            fork_msgs = next((s for a, s in capture.messages_summaries if a == "fork-subagent"), [])
-            msg = (
-                f"Fork cache_read did not cover the inherited large HumanMessage.\n"
-                f"  max parent cache_read = {max_parent_read}  (system + large_msg)\n"
-                f"  max fork   cache_read = {max_fork_read}\n"
-                f"  expected fork_read    >= {expected_floor}\n\n"
-                f"  parent system len = {len(parent_sys)}\n"
-                f"  fork   system len = {len(fork_sys)}\n"
-                f"  system diverge at byte = {divergence_at}\n"
-                f"  parent system near split = {parent_sys[context_slice]!r}\n"
-                f"  fork   system near split = {fork_sys[context_slice]!r}\n\n"
-                f"  parent non-system messages:\n    " + "\n    ".join(parent_msgs) + "\n  fork non-system messages:\n    " + "\n    ".join(fork_msgs)
-            )
-            raise AssertionError(msg)
+        assert_fork_reuses_inherited_message_cache(capture, provider="Anthropic")

--- a/libs/deepagents/tests/integration_tests/test_fork_caching_openai.py
+++ b/libs/deepagents/tests/integration_tests/test_fork_caching_openai.py
@@ -1,0 +1,35 @@
+"""End-to-end verification that fork mode preserves OpenAI prompt caching."""
+
+from __future__ import annotations
+
+from langchain_openai import ChatOpenAI
+
+from tests.integration_tests.fork_cache_utils import (
+    UsageCapture,
+    assert_fork_reuses_inherited_message_cache,
+    build_fork_agent,
+    invoke_twice_with_large_message,
+)
+
+OPENAI_MODEL = "gpt-5.4"
+
+
+def _openai_cache_read_tokens(msg: object) -> int:
+    """Return OpenAI cached prompt tokens from the raw provider usage shape."""
+    response_metadata = getattr(msg, "response_metadata", None) or {}
+    usage = response_metadata["token_usage"]
+    prompt_details = usage["prompt_tokens_details"]
+    return int(prompt_details["cached_tokens"])
+
+
+class TestForkPromptCachingOpenAI:
+    """Live verification of fork prompt-cache behavior on OpenAI."""
+
+    def test_fork_caches_inherited_messages_not_just_system_prompt(self) -> None:
+        """Fork cache reads should include inherited messages, not just the system prompt."""
+        capture = UsageCapture(_openai_cache_read_tokens)
+        agent = build_fork_agent(ChatOpenAI(model_name=OPENAI_MODEL, temperature=0))
+
+        invoke_twice_with_large_message(agent, capture)
+
+        assert_fork_reuses_inherited_message_cache(capture, provider="OpenAI")

--- a/libs/deepagents/tests/unit_tests/test_fork_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_fork_subagents.py
@@ -1,7 +1,7 @@
 """Fork-mode subagent tests — imported into test_subagents.py.
 
 Split out to keep test_subagents.py readable; the fork path touches seeding,
-prompt composition, model validation, and telemetry.
+prompt composition, model inheritance, and telemetry.
 """
 
 from __future__ import annotations
@@ -591,8 +591,7 @@ class TestForkSubagents:
 
     def test_fork_without_model_inherits_parent_model(self) -> None:
         parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="noop")]))
-        # Should build without raising; model validation passes because
-        # fork inherits the parent instance itself.
+        # Should build without raising; fork inherits the parent instance.
         create_deep_agent(
             model=parent_model,
             subagents=[
@@ -606,11 +605,10 @@ class TestForkSubagents:
             ],
         )
 
-    def test_fork_with_mismatched_model_raises(self) -> None:
+    def test_fork_with_explicit_model_raises(self) -> None:
         parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="noop")]))
-        # Different provider derived from the class name → validation rejects.
-        mismatched = _RecordingChatModel()
-        with pytest.raises(ValueError, match="Forked subagent 'forked' must use the same model"):
+        explicit_model = _RecordingChatModel()
+        with pytest.raises(ValueError, match="Forked subagent 'forked' cannot declare a model"):
             create_deep_agent(
                 model=parent_model,
                 subagents=[
@@ -618,7 +616,7 @@ class TestForkSubagents:
                         "name": "forked",
                         "description": "Fork worker.",
                         "system_prompt": "FORK",
-                        "model": mismatched,
+                        "model": explicit_model,
                         "tools": [],
                         "fork": True,
                     }

--- a/libs/deepagents/tests/unit_tests/test_fork_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_fork_subagents.py
@@ -1,0 +1,321 @@
+"""Fork-mode subagent tests — imported into test_subagents.py.
+
+Split out to keep test_subagents.py readable; the fork path touches seeding,
+prompt composition, model validation, and telemetry.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain.tools import ToolRuntime
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from deepagents.graph import create_deep_agent
+from deepagents.middleware.subagents import (
+    FORK_USAGE_GUIDANCE,
+    FORKED_SUBAGENT_MARKER,
+    CompiledSubAgent,
+    _build_task_tool,
+)
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+    from langchain_core.runnables import RunnableConfig
+
+
+class _RecordingChatModel(BaseChatModel):
+    """Fake chat model that records every call's input messages.
+
+    Returns a tool call invoking the configured subagent on the first call and
+    plain final assistant messages afterwards. One instance serves both parent
+    and fork (fork inherits parent's model by design), so the recorded_calls
+    list lets tests inspect the messages seen by each.
+    """
+
+    recorded_calls: list[list[Any]] = []  # noqa: RUF012  # pydantic field, per-instance
+    scripted_subagent: str = "forked"
+    scripted_task_description: str = "do it"
+    _call_idx: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "recording"
+
+    def _generate(
+        self,
+        messages: Sequence[Any],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.recorded_calls.append(list(messages))
+        idx = self._call_idx
+        self._call_idx += 1
+        if idx == 0:
+            response: AIMessage = AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {
+                            "description": self.scripted_task_description,
+                            "subagent_type": self.scripted_subagent,
+                        },
+                        "id": "call-fork-1",
+                        "type": "tool_call",
+                    }
+                ],
+            )
+        else:
+            response = AIMessage(content="fork final response")
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> Any:  # type: ignore[override]  # noqa: ANN401
+        return self
+
+
+class _RecordingRunnable(Runnable):
+    """Stub subagent runnable that records state and config on each invoke."""
+
+    def __init__(self, response_text: str = "done") -> None:
+        self.state_inputs: list[dict[str, Any]] = []
+        self.configs: list[RunnableConfig | None] = []
+        self._response_text = response_text
+
+    def invoke(self, input: dict[str, Any], config: RunnableConfig | None = None, **_: Any) -> dict[str, Any]:  # noqa: A002
+        self.state_inputs.append(input)
+        self.configs.append(config)
+        return {"messages": [AIMessage(content=self._response_text)]}
+
+    async def ainvoke(self, input: dict[str, Any], config: RunnableConfig | None = None, **_: Any) -> dict[str, Any]:  # noqa: A002
+        return self.invoke(input, config)
+
+
+def _make_tool_runtime(*, state: dict[str, Any], tool_call_id: str = "tc-1") -> ToolRuntime:
+    return ToolRuntime(
+        state=state,
+        context=None,
+        tool_call_id=tool_call_id,
+        store=None,
+        stream_writer=lambda _: None,
+        config={},
+    )
+
+
+class TestForkSubagents:
+    """Fork-mode subagent behavior — context inheritance, prompt composition, telemetry."""
+
+    def test_fork_prepends_parent_messages_when_seeding_state(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        plain_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+                {"name": "plain", "description": "Stateless worker.", "runnable": plain_runnable, "fork": False},
+            ]
+        )
+
+        parent_msgs = [HumanMessage(content="parent Q"), AIMessage(content="parent A")]
+        runtime = _make_tool_runtime(state={"messages": parent_msgs})
+        task_tool.func(description="do thing", subagent_type="forked", runtime=runtime)
+
+        seeded = fork_runnable.state_inputs[0]["messages"]
+        assert [m.content for m in seeded] == ["parent Q", "parent A", "do thing"]
+        assert isinstance(seeded[-1], HumanMessage)
+
+        runtime2 = _make_tool_runtime(state={"messages": parent_msgs}, tool_call_id="tc-2")
+        task_tool.func(description="do thing 2", subagent_type="plain", runtime=runtime2)
+        seeded_plain = plain_runnable.state_inputs[0]["messages"]
+        assert len(seeded_plain) == 1
+        assert isinstance(seeded_plain[0], HumanMessage)
+        assert seeded_plain[0].content == "do thing 2"
+
+    def test_fork_sets_ls_agent_type_to_fork_subagent(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        plain_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+                {"name": "plain", "description": "Stateless worker.", "runnable": plain_runnable, "fork": False},
+            ]
+        )
+
+        task_tool.func(
+            description="x",
+            subagent_type="forked",
+            runtime=_make_tool_runtime(state={"messages": []}),
+        )
+        task_tool.func(
+            description="y",
+            subagent_type="plain",
+            runtime=_make_tool_runtime(state={"messages": []}, tool_call_id="tc-2"),
+        )
+
+        assert fork_runnable.configs[0]["configurable"]["ls_agent_type"] == "fork-subagent"
+        assert plain_runnable.configs[0]["configurable"]["ls_agent_type"] == "subagent"
+
+    def test_forked_subagent_rendered_with_marker_and_guidance(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        plain_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+                {"name": "plain", "description": "Stateless worker.", "runnable": plain_runnable, "fork": False},
+            ]
+        )
+
+        description = task_tool.description
+        assert f"forked {FORKED_SUBAGENT_MARKER}: Fork worker." in description
+        assert "- plain: Stateless worker." in description
+        plain_line = description.split("- plain:")[1].split("\n")[0]
+        assert FORKED_SUBAGENT_MARKER not in plain_line
+        assert FORK_USAGE_GUIDANCE in description
+
+    def test_no_fork_no_marker_or_guidance(self) -> None:
+        task_tool = _build_task_tool(
+            [
+                {"name": "plain", "description": "Stateless.", "runnable": _RecordingRunnable(), "fork": False},
+            ]
+        )
+        assert FORKED_SUBAGENT_MARKER not in task_tool.description
+        assert FORK_USAGE_GUIDANCE not in task_tool.description
+
+    def test_fork_composes_parent_prefix_and_inherits_message_history(self) -> None:
+        """End-to-end: fork's model call receives parent's composed system prompt and messages.
+
+        This is the test that actually proves cache alignment is possible —
+        the fork's input prefix (system message + history) matches the
+        parent's. Providers cache off that prefix.
+        """
+        model = _RecordingChatModel()
+        agent = create_deep_agent(
+            model=model,
+            system_prompt="PARENT_PROMPT_PREFIX",
+            subagents=[
+                {
+                    "name": "forked",
+                    "description": "Fork worker.",
+                    "system_prompt": "FORK_SUFFIX",
+                    "tools": [],
+                    "fork": True,
+                }
+            ],
+        )
+        agent.invoke({"messages": [HumanMessage(content="MAIN_USER_MSG")]})
+
+        # First call is the parent's, second is the fork's.
+        assert len(model.recorded_calls) >= 2
+        fork_input = model.recorded_calls[1]
+
+        system_messages = [m for m in fork_input if isinstance(m, SystemMessage)]
+        assert system_messages, "Fork did not receive a SystemMessage"
+        system_text = system_messages[0].text if hasattr(system_messages[0], "text") else str(system_messages[0].content)
+        assert "PARENT_PROMPT_PREFIX" in system_text
+        assert "FORK_SUFFIX" in system_text
+        assert system_text.index("PARENT_PROMPT_PREFIX") < system_text.index("FORK_SUFFIX")
+
+        human_texts = [getattr(m, "content", "") for m in fork_input if isinstance(m, HumanMessage)]
+        assert "MAIN_USER_MSG" in human_texts, (
+            f"Fork did not inherit parent's HumanMessage — cache prefix cannot align. HumanMessages seen: {human_texts}"
+        )
+
+    def test_fork_without_model_inherits_parent_model(self) -> None:
+        parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="noop")]))
+        # Should build without raising; model validation passes because
+        # fork inherits the parent instance itself.
+        create_deep_agent(
+            model=parent_model,
+            subagents=[
+                {
+                    "name": "forked",
+                    "description": "Fork worker.",
+                    "system_prompt": "FORK",
+                    "tools": [],
+                    "fork": True,
+                }
+            ],
+        )
+
+    def test_fork_with_mismatched_model_raises(self) -> None:
+        parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="noop")]))
+        # Different provider derived from the class name → validation rejects.
+        mismatched = _RecordingChatModel()
+        with pytest.raises(ValueError, match="Forked subagent 'forked' must use the same model"):
+            create_deep_agent(
+                model=parent_model,
+                subagents=[
+                    {
+                        "name": "forked",
+                        "description": "Fork worker.",
+                        "system_prompt": "FORK",
+                        "model": mismatched,
+                        "tools": [],
+                        "fork": True,
+                    }
+                ],
+            )
+
+    def test_compiled_subagent_with_fork_raises(self) -> None:
+        parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="noop")]))
+        with pytest.raises(ValueError, match="CompiledSubAgent 'compiled-one' cannot set fork=True"):
+            create_deep_agent(
+                model=parent_model,
+                subagents=[
+                    {
+                        "name": "compiled-one",
+                        "description": "Compiled.",
+                        "runnable": RunnableLambda(lambda _: {"messages": [AIMessage(content="ok")]}),
+                        "fork": True,  # type: ignore[typeddict-unknown-key]
+                    }
+                ],
+            )
+
+    def test_subagent_intermediate_messages_do_not_leak_to_parent(self) -> None:
+        """Isolation guarantee — fork and non-fork alike return only the final message to the parent."""
+        intermediate = AIMessage(content="SUBAGENT_INTERMEDIATE_SHOULD_NOT_LEAK")
+        final = AIMessage(content="subagent final")
+        mock_subagent = RunnableLambda(lambda _: {"messages": [intermediate, final]})
+
+        parent_chat_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {"description": "do it", "subagent_type": "compiled-spy"},
+                                "id": "call_spy",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done"),
+                ]
+            )
+        )
+        agent = create_deep_agent(
+            model=parent_chat_model,
+            subagents=[
+                CompiledSubAgent(
+                    name="compiled-spy",
+                    description="spy",
+                    runnable=mock_subagent,
+                ),
+            ],
+        )
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="start")]},
+            config={"configurable": {"thread_id": f"fork-leak-{uuid.uuid4().hex}"}},
+        )
+        contents = [getattr(m, "content", "") for m in result["messages"]]
+        assert "SUBAGENT_INTERMEDIATE_SHOULD_NOT_LEAK" not in contents

--- a/libs/deepagents/tests/unit_tests/test_fork_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_fork_subagents.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable, RunnableLambda
 
@@ -139,6 +139,41 @@ class TestForkSubagents:
         assert isinstance(seeded_plain[0], HumanMessage)
         assert seeded_plain[0].content == "do thing 2"
 
+    def test_fork_drops_current_task_tool_call_from_seeded_state(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+            ]
+        )
+
+        parent_msgs = [
+            HumanMessage(content="cached parent context"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {"description": "do thing", "subagent_type": "forked"},
+                        "id": "tc-current",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(content="current tool bookkeeping", tool_call_id="tc-current"),
+        ]
+
+        task_tool.func(
+            description="do thing",
+            subagent_type="forked",
+            runtime=_make_tool_runtime(state={"messages": parent_msgs}, tool_call_id="tc-current"),
+        )
+
+        seeded = fork_runnable.state_inputs[0]["messages"]
+        assert [m.content for m in seeded] == ["cached parent context", "do thing"]
+        assert all(not isinstance(m, AIMessage) for m in seeded)
+        assert all(not isinstance(m, ToolMessage) for m in seeded)
+
     def test_fork_sets_ls_agent_type_to_fork_subagent(self) -> None:
         fork_runnable = _RecordingRunnable()
         plain_runnable = _RecordingRunnable()
@@ -214,18 +249,30 @@ class TestForkSubagents:
 
         # First call is the parent's, second is the fork's.
         assert len(model.recorded_calls) >= 2
+        parent_input = model.recorded_calls[0]
         fork_input = model.recorded_calls[1]
 
-        system_messages = [m for m in fork_input if isinstance(m, SystemMessage)]
-        assert system_messages, "Fork did not receive a SystemMessage"
-        system_text = system_messages[0].text if hasattr(system_messages[0], "text") else str(system_messages[0].content)
-        assert "PARENT_PROMPT_PREFIX" in system_text
-        assert "FORK_SUFFIX" in system_text
-        assert system_text.index("PARENT_PROMPT_PREFIX") < system_text.index("FORK_SUFFIX")
+        # Fork's system message must match the parent's byte-for-byte (no
+        # suffix appended) so the cached prefix can be reused.
+        parent_system_text = next(str(m.content) for m in parent_input if isinstance(m, SystemMessage))
+        fork_system_text = next(str(m.content) for m in fork_input if isinstance(m, SystemMessage))
+        assert fork_system_text == parent_system_text, (
+            "Fork's system message diverges from the parent's. That breaks prompt-cache alignment for every downstream message block."
+        )
 
-        human_texts = [getattr(m, "content", "") for m in fork_input if isinstance(m, HumanMessage)]
-        assert "MAIN_USER_MSG" in human_texts, (
-            f"Fork did not inherit parent's HumanMessage — cache prefix cannot align. HumanMessages seen: {human_texts}"
+        # Parent's HumanMessage is inherited by the fork.
+        fork_human_contents = [str(m.content) for m in fork_input if isinstance(m, HumanMessage)]
+        assert any("MAIN_USER_MSG" in c for c in fork_human_contents), (
+            f"Fork did not inherit parent's HumanMessage. HumanMessages seen: {fork_human_contents}"
+        )
+
+        # The fork's own `system_prompt` ("FORK_SUFFIX") rides inside the
+        # trailing HumanMessage as a preamble, not in the system slot.
+        assert "FORK_SUFFIX" not in fork_system_text, "Fork's own system_prompt leaked into the system slot — cache prefix will diverge."
+        last_human = next(m for m in reversed(fork_input) if isinstance(m, HumanMessage))
+        assert "FORK_SUFFIX" in str(last_human.content), (
+            f"Fork's own instructions were not injected as a preamble into the "
+            f"trailing HumanMessage. Last HumanMessage content: {last_human.content!r}"
         )
 
     def test_fork_without_model_inherits_parent_model(self) -> None:

--- a/libs/deepagents/tests/unit_tests/test_fork_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_fork_subagents.py
@@ -10,13 +10,16 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
 from langchain.tools import ToolRuntime
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable, RunnableLambda
 
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.graph import create_deep_agent
+from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.subagents import (
     FORK_USAGE_GUIDANCE,
     FORKED_SUBAGENT_MARKER,
@@ -26,7 +29,8 @@ from deepagents.middleware.subagents import (
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
 
     from langchain_core.callbacks import CallbackManagerForLLMRun
     from langchain_core.runnables import RunnableConfig
@@ -42,6 +46,7 @@ class _RecordingChatModel(BaseChatModel):
     """
 
     recorded_calls: list[list[Any]] = []  # noqa: RUF012  # pydantic field, per-instance
+    bound_tools_calls: list[list[Any]] = []  # noqa: RUF012  # pydantic field, per-instance
     scripted_subagent: str = "forked"
     scripted_task_description: str = "do it"
     _call_idx: int = 0
@@ -80,7 +85,26 @@ class _RecordingChatModel(BaseChatModel):
         return ChatResult(generations=[ChatGeneration(message=response)])
 
     def bind_tools(self, tools: Any, **kwargs: Any) -> Any:  # type: ignore[override]  # noqa: ANN401
+        try:
+            self.bound_tools_calls.append(list(tools))
+        except TypeError:
+            self.bound_tools_calls.append([tools])
         return self
+
+
+class _SystemAppendingMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Test middleware that appends deterministic text to the system prompt."""
+
+    def __init__(self, text: str) -> None:
+        super().__init__()
+        self._text = text
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        return handler(request.override(system_message=append_to_system_message(request.system_message, self._text)))
 
 
 class _RecordingRunnable(Runnable):
@@ -109,6 +133,62 @@ def _make_tool_runtime(*, state: dict[str, Any], tool_call_id: str = "tc-1") -> 
         stream_writer=lambda _: None,
         config={},
     )
+
+
+def _system_text(messages: list[Any]) -> str:
+    return next(str(m.content) for m in messages if isinstance(m, SystemMessage))
+
+
+def _tool_names(tools: list[Any]) -> set[str]:
+    names: set[str] = set()
+    for tool in tools:
+        name = tool.get("name") if isinstance(tool, dict) else getattr(tool, "name", None)
+        if isinstance(name, str):
+            names.add(name)
+    return names
+
+
+def _make_fork_agent(model: _RecordingChatModel, **kwargs: Any) -> Runnable:
+    return create_deep_agent(
+        model=model,
+        system_prompt="PARENT_PROMPT_PREFIX",
+        subagents=[
+            {
+                "name": "forked",
+                "description": "Fork worker.",
+                "system_prompt": "FORK_SUFFIX",
+                "tools": [],
+                "fork": True,
+            }
+        ],
+        **kwargs,
+    )
+
+
+def _invoke_and_capture_parent_fork(model: _RecordingChatModel, **kwargs: Any) -> tuple[list[Any], list[Any]]:
+    agent = _make_fork_agent(model, **kwargs)
+    agent.invoke({"messages": [HumanMessage(content="MAIN_USER_MSG")]})
+
+    assert len(model.recorded_calls) >= 2
+    return model.recorded_calls[0], model.recorded_calls[1]
+
+
+def _write_skill(root: Path, *, name: str = "parity-skill") -> str:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: Skill for fork prompt parity.
+---
+
+# {name}
+
+Keep prompt cache prefixes stable.
+""",
+        encoding="utf-8",
+    )
+    return str(root)
 
 
 class TestForkSubagents:
@@ -173,6 +253,96 @@ class TestForkSubagents:
         assert [m.content for m in seeded] == ["cached parent context", "do thing"]
         assert all(not isinstance(m, AIMessage) for m in seeded)
         assert all(not isinstance(m, ToolMessage) for m in seeded)
+
+    def test_fork_drops_entire_current_ai_turn_with_parallel_task_calls(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+            ]
+        )
+
+        parent_msgs = [
+            HumanMessage(content="cached parent context"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {"description": "first task", "subagent_type": "forked"},
+                        "id": "tc-current",
+                        "type": "tool_call",
+                    },
+                    {
+                        "name": "task",
+                        "args": {"description": "parallel sibling", "subagent_type": "forked"},
+                        "id": "tc-sibling",
+                        "type": "tool_call",
+                    },
+                ],
+            ),
+        ]
+
+        task_tool.func(
+            description="first task",
+            subagent_type="forked",
+            runtime=_make_tool_runtime(state={"messages": parent_msgs}, tool_call_id="tc-current"),
+        )
+
+        seeded = fork_runnable.state_inputs[0]["messages"]
+        assert [m.content for m in seeded] == ["cached parent context", "first task"]
+        assert all(not isinstance(m, AIMessage) for m in seeded)
+
+    def test_fork_preserves_prior_completed_tool_history_when_trimming_current_task(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+            ]
+        )
+
+        prior_tool_call = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "search",
+                    "args": {"query": "cacheable context"},
+                    "id": "tc-prior",
+                    "type": "tool_call",
+                }
+            ],
+        )
+        prior_tool_result = ToolMessage(content="prior result", tool_call_id="tc-prior")
+        parent_msgs = [
+            HumanMessage(content="earlier user context"),
+            prior_tool_call,
+            prior_tool_result,
+            AIMessage(content="prior answer"),
+            HumanMessage(content="current cached request"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {"description": "fork now", "subagent_type": "forked"},
+                        "id": "tc-current",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+        ]
+
+        task_tool.func(
+            description="fork now",
+            subagent_type="forked",
+            runtime=_make_tool_runtime(state={"messages": parent_msgs}, tool_call_id="tc-current"),
+        )
+
+        seeded = fork_runnable.state_inputs[0]["messages"]
+        assert seeded[:-1] == parent_msgs[:-1]
+        assert seeded[-1].content == "fork now"
+        assert prior_tool_call in seeded
+        assert prior_tool_result in seeded
 
     def test_fork_sets_ls_agent_type_to_fork_subagent(self) -> None:
         fork_runnable = _RecordingRunnable()
@@ -274,6 +444,150 @@ class TestForkSubagents:
             f"Fork's own instructions were not injected as a preamble into the "
             f"trailing HumanMessage. Last HumanMessage content: {last_human.content!r}"
         )
+
+    def test_fork_system_prompt_matches_parent_with_memory(self, tmp_path: Path) -> None:
+        backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        memory_path = str(tmp_path / "AGENTS.md")
+        backend.upload_files([(memory_path, b"# Memory\nPreserve this cached memory block.")])
+        model = _RecordingChatModel()
+
+        parent_input, fork_input = _invoke_and_capture_parent_fork(
+            model,
+            backend=backend,
+            memory=[memory_path],
+        )
+
+        parent_system = _system_text(parent_input)
+        fork_system = _system_text(fork_input)
+        assert parent_system == fork_system
+        assert "Preserve this cached memory block." in parent_system
+
+    def test_fork_system_prompt_matches_parent_with_async_subagents(self) -> None:
+        model = _RecordingChatModel()
+        agent = create_deep_agent(
+            model=model,
+            system_prompt="PARENT_PROMPT_PREFIX",
+            subagents=[
+                {
+                    "name": "remote-researcher",
+                    "description": "Remote async worker.",
+                    "graph_id": "remote_graph",
+                },
+                {
+                    "name": "forked",
+                    "description": "Fork worker.",
+                    "system_prompt": "FORK_SUFFIX",
+                    "tools": [],
+                    "fork": True,
+                },
+            ],
+        )
+        agent.invoke({"messages": [HumanMessage(content="MAIN_USER_MSG")]})
+
+        parent_system = _system_text(model.recorded_calls[0])
+        fork_system = _system_text(model.recorded_calls[1])
+        assert parent_system == fork_system
+        assert "Available async subagent types:" in parent_system
+        assert "- remote-researcher: Remote async worker." in parent_system
+
+    def test_fork_system_prompt_matches_parent_with_top_level_skills(self, tmp_path: Path) -> None:
+        skills_root = _write_skill(tmp_path / "skills")
+        backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        model = _RecordingChatModel()
+
+        parent_input, fork_input = _invoke_and_capture_parent_fork(
+            model,
+            backend=backend,
+            skills=[skills_root],
+        )
+
+        parent_system = _system_text(parent_input)
+        fork_system = _system_text(fork_input)
+        assert parent_system == fork_system
+        assert "Skill for fork prompt parity." in parent_system
+
+    def test_fork_system_prompt_matches_parent_with_top_level_system_middleware(self) -> None:
+        model = _RecordingChatModel()
+
+        parent_input, fork_input = _invoke_and_capture_parent_fork(
+            model,
+            middleware=[_SystemAppendingMiddleware("CUSTOM_PARENT_SYSTEM_APPEND")],
+        )
+
+        parent_system = _system_text(parent_input)
+        fork_system = _system_text(fork_input)
+        assert parent_system == fork_system
+        assert "CUSTOM_PARENT_SYSTEM_APPEND" in parent_system
+
+    def test_fork_available_agents_block_matches_parent_with_multiple_subagents(self) -> None:
+        model = _RecordingChatModel()
+        agent = create_deep_agent(
+            model=model,
+            system_prompt="PARENT_PROMPT_PREFIX",
+            subagents=[
+                {
+                    "name": "plain",
+                    "description": "Plain worker.",
+                    "system_prompt": "PLAIN",
+                    "tools": [],
+                },
+                {
+                    "name": "forked",
+                    "description": "Fork worker.",
+                    "system_prompt": "FORK_SUFFIX",
+                    "tools": [],
+                    "fork": True,
+                },
+            ],
+        )
+        agent.invoke({"messages": [HumanMessage(content="MAIN_USER_MSG")]})
+
+        parent_system = _system_text(model.recorded_calls[0])
+        fork_system = _system_text(model.recorded_calls[1])
+        assert parent_system == fork_system
+        assert "- general-purpose: General-purpose agent for researching complex questions" in parent_system
+        assert "- plain: Plain worker." in parent_system
+        assert "- forked: Fork worker." in parent_system
+
+    def test_fork_does_not_receive_recursive_task_tool(self) -> None:
+        model = _RecordingChatModel()
+        agent = _make_fork_agent(model)
+        agent.invoke({"messages": [HumanMessage(content="MAIN_USER_MSG")]})
+
+        assert len(model.bound_tools_calls) >= 2
+        parent_tool_names = _tool_names(model.bound_tools_calls[0])
+        fork_tool_names = _tool_names(model.bound_tools_calls[1])
+        assert "task" in parent_tool_names
+        assert "task" not in fork_tool_names
+
+    def test_fork_preserves_system_message_content_blocks(self) -> None:
+        model = _RecordingChatModel()
+        system_prompt = SystemMessage(
+            content=[
+                {"type": "text", "text": "PARENT_BLOCK_A"},
+                {"type": "text", "text": "\nPARENT_BLOCK_B"},
+            ]
+        )
+        agent = create_deep_agent(
+            model=model,
+            system_prompt=system_prompt,
+            subagents=[
+                {
+                    "name": "forked",
+                    "description": "Fork worker.",
+                    "system_prompt": "FORK_SUFFIX",
+                    "tools": [],
+                    "fork": True,
+                }
+            ],
+        )
+        agent.invoke({"messages": [HumanMessage(content="MAIN_USER_MSG")]})
+
+        parent_system_message = next(m for m in model.recorded_calls[0] if isinstance(m, SystemMessage))
+        fork_system_message = next(m for m in model.recorded_calls[1] if isinstance(m, SystemMessage))
+        assert fork_system_message.content == parent_system_message.content
+        assert "PARENT_BLOCK_A" in str(parent_system_message.content)
+        assert "PARENT_BLOCK_B" in str(parent_system_message.content)
 
     def test_fork_without_model_inherits_parent_model(self) -> None:
         parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="noop")]))

--- a/libs/deepagents/tests/unit_tests/test_fork_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_fork_subagents.py
@@ -21,6 +21,7 @@ from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.graph import create_deep_agent
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.subagents import (
+    ALL_FORKED_USAGE_GUIDANCE,
     FORK_USAGE_GUIDANCE,
     FORKED_SUBAGENT_MARKER,
     CompiledSubAgent,
@@ -148,6 +149,17 @@ def _tool_names(tools: list[Any]) -> set[str]:
     return names
 
 
+def _tool_description(tools: list[Any], name: str) -> str:
+    for tool in tools:
+        tool_name = tool.get("name") if isinstance(tool, dict) else getattr(tool, "name", None)
+        if tool_name != name:
+            continue
+        description = tool.get("description") if isinstance(tool, dict) else getattr(tool, "description", "")
+        return str(description)
+    msg = f"Tool {name!r} not found"
+    raise AssertionError(msg)
+
+
 def _make_fork_agent(model: _RecordingChatModel, **kwargs: Any) -> Runnable:
     return create_deep_agent(
         model=model,
@@ -218,6 +230,60 @@ class TestForkSubagents:
         assert len(seeded_plain) == 1
         assert isinstance(seeded_plain[0], HumanMessage)
         assert seeded_plain[0].content == "do thing 2"
+
+    def test_subagent_state_excludes_parent_private_context(self) -> None:
+        fork_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "forked", "description": "Fork worker.", "runnable": fork_runnable, "fork": True},
+            ]
+        )
+
+        task_tool.func(
+            description="do thing",
+            subagent_type="forked",
+            runtime=_make_tool_runtime(
+                state={
+                    "messages": [HumanMessage(content="parent Q")],
+                    "local_context": "cli local context",
+                    "skills_metadata": [{"name": "skill"}],
+                    "memory_contents": "memory",
+                    "custom_state": "should not leak",
+                }
+            ),
+        )
+
+        seeded = fork_runnable.state_inputs[0]
+        assert "local_context" not in seeded
+        assert "skills_metadata" not in seeded
+        assert "memory_contents" not in seeded
+        assert "custom_state" not in seeded
+        assert [m.content for m in seeded["messages"]] == ["parent Q", "do thing"]
+
+    def test_nonfork_subagent_keeps_parent_custom_state(self) -> None:
+        plain_runnable = _RecordingRunnable()
+        task_tool = _build_task_tool(
+            [
+                {"name": "plain", "description": "Plain worker.", "runnable": plain_runnable, "fork": False},
+            ]
+        )
+
+        task_tool.func(
+            description="do thing",
+            subagent_type="plain",
+            runtime=_make_tool_runtime(
+                state={
+                    "messages": [HumanMessage(content="parent Q")],
+                    "local_context": "cli local context",
+                    "custom_state": "kept",
+                }
+            ),
+        )
+
+        seeded = plain_runnable.state_inputs[0]
+        assert seeded["custom_state"] == "kept"
+        assert "local_context" not in seeded
+        assert [m.content for m in seeded["messages"]] == ["do thing"]
 
     def test_fork_drops_current_task_tool_call_from_seeded_state(self) -> None:
         fork_runnable = _RecordingRunnable()
@@ -393,6 +459,21 @@ class TestForkSubagents:
         )
         assert FORKED_SUBAGENT_MARKER not in task_tool.description
         assert FORK_USAGE_GUIDANCE not in task_tool.description
+        assert ALL_FORKED_USAGE_GUIDANCE not in task_tool.description
+
+    def test_all_forked_subagents_use_default_context_guidance(self) -> None:
+        task_tool = _build_task_tool(
+            [
+                {"name": "alpha", "description": "First fork.", "runnable": _RecordingRunnable(), "fork": True},
+                {"name": "beta", "description": "Second fork.", "runnable": _RecordingRunnable(), "fork": True},
+            ]
+        )
+
+        assert "- alpha: First fork." in task_tool.description
+        assert "- beta: Second fork." in task_tool.description
+        assert FORKED_SUBAGENT_MARKER not in task_tool.description
+        assert FORK_USAGE_GUIDANCE not in task_tool.description
+        assert ALL_FORKED_USAGE_GUIDANCE in task_tool.description
 
     def test_fork_composes_parent_prefix_and_inherits_message_history(self) -> None:
         """End-to-end: fork's model call receives parent's composed system prompt and messages.

--- a/libs/deepagents/tests/unit_tests/test_fork_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_fork_subagents.py
@@ -231,7 +231,7 @@ class TestForkSubagents:
         assert isinstance(seeded_plain[0], HumanMessage)
         assert seeded_plain[0].content == "do thing 2"
 
-    def test_subagent_state_excludes_parent_private_context(self) -> None:
+    def test_fork_subagent_uses_include_list_for_parent_state(self) -> None:
         fork_runnable = _RecordingRunnable()
         task_tool = _build_task_tool(
             [
@@ -260,7 +260,7 @@ class TestForkSubagents:
         assert "custom_state" not in seeded
         assert [m.content for m in seeded["messages"]] == ["parent Q", "do thing"]
 
-    def test_nonfork_subagent_keeps_parent_custom_state(self) -> None:
+    def test_nonfork_subagent_state_seeding_is_unchanged(self) -> None:
         plain_runnable = _RecordingRunnable()
         task_tool = _build_task_tool(
             [
@@ -282,7 +282,7 @@ class TestForkSubagents:
 
         seeded = plain_runnable.state_inputs[0]
         assert seeded["custom_state"] == "kept"
-        assert "local_context" not in seeded
+        assert seeded["local_context"] == "cli local context"
         assert [m.content for m in seeded["messages"]] == ["do thing"]
 
     def test_fork_drops_current_task_tool_call_from_seeded_state(self) -> None:


### PR DESCRIPTION
Adds opt-in forked subagents for prompt-cache reuse.

When `SubAgent(fork=True)` is used, the subagent inherits the parent agent's model, system prompt, and message prefix so the provider can reuse the parent's prompt-cache entry. The fork's own `system_prompt` is intentionally not placed in the system slot; it is injected as a preamble into the trailing task `HumanMessage`, keeping the inherited prefix byte-identical to what the parent already sent.

Forks inherit only the cache-relevant message prefix. The current `task` tool-call turn is trimmed out before seeding the fork, private/runtime state such as skills metadata, memory contents, and CLI local context is not copied, and only the fork's final answer returns to the parent as a `ToolMessage`.

The invalid model state is now unrepresentable: forked subagents cannot declare `model` at all and always use the parent model. `CompiledSubAgent(fork=True)` is rejected because compiled subagents own their graph and system prompt.

The `task` tool description now teaches the parent agent how much context to pass. Mixed fork/non-fork setups annotate only forked subagents; all-fork setups use default guidance that subagents inherit context. Fork calls are tagged as `ls_agent_type="fork-subagent"` for trace filtering.

This also adds `DEEPAGENTS_CLI_FORK_SUBAGENT=1` for the CLI. When set, CLI-loaded custom subagents are created as forks, subagent-local model frontmatter is ignored, and the CLI passes an explicit forked `general-purpose` subagent when needed.

Implementation notes:

1. `graph.py` still owns high-level agent assembly: parent prompt construction, model resolution, defaulting, and middleware stack assembly.
2. Subagent middleware owns the fork-specific prompt-padding helpers and final fork spec preparation, so sync/async subagent prompt text has one source of truth.
3. Fork middleware mirrors the parent system-prompt append order without giving the fork the recursive `task` tool.

Areas worth careful review:

1. Fork cache correctness depends on the fork seeing the same system-message bytes as the parent after middleware system-prompt padding.
2. Fork state seeding is intentionally include-list based; only messages are inherited today.
3. CLI `DEEPAGENTS_CLI_FORK_SUBAGENT=1` intentionally makes fork mode an all-subagents mode for CLI-loaded agents.

Verification:

1. Unit coverage includes parent/fork system prompt equality, inherited message seeding, current task-call trimming, parallel task-call trimming, private state exclusion, memory, async subagents, skills, custom system middleware, multiple subagents, no recursive `task` tool, `SystemMessage` content blocks, explicit fork model rejection, compiled fork rejection, output isolation, and CLI env wiring.
2. Live Anthropic test uses `claude-haiku-4-5-20251001` and asserts fork cache reads cover the inherited large message, not just the system prompt.
3. Live OpenAI test uses `gpt-5.4` and asserts the same inherited-message cache behavior through raw `prompt_tokens_details.cached_tokens`.
4. Latest local checks run: `ruff check`, `ty check`, `tests/unit_tests/test_fork_subagents.py`, `tests/unit_tests/test_agent.py`, and the live Anthropic/OpenAI fork cache integration tests.
