### PR TITLE
feat(sdk,cli): labelled skill sources

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -16,6 +16,18 @@ from deepagents.backends import CompositeBackend, LocalShellBackend
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware import MemoryMiddleware, SkillsMiddleware
 
+# Backwards-compat flag: SDKs before 0.5.4 accept only `list[str]` for
+# `SkillsMiddleware.sources`; newer SDKs expose the `SkillSource` alias
+# that permits `(path, label)` tuples. The `skills` module is already
+# loaded by the `SkillsMiddleware` import above, so the extra lookup
+# here adds no startup cost.
+try:
+    from deepagents.middleware.skills import SkillSource as _SkillSource  # noqa: F401
+except ImportError:
+    _SUPPORTS_SKILL_SOURCE_TUPLES = False
+else:
+    _SUPPORTS_SKILL_SOURCE_TUPLES = True
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
 
@@ -1116,25 +1128,40 @@ def create_cli_agent(
         # built-in -> user .deepagents -> user .agents
         # -> project .deepagents -> project .agents
         # -> user .claude (experimental) -> project .claude (experimental)
-        sources = [str(settings.get_built_in_skills_dir())]
-        sources.extend([str(skills_dir), str(user_agent_skills_dir)])
+        # Labels disambiguate user- vs project-scoped sources that share a
+        # `.../skills` leaf; the middleware would otherwise derive identical
+        # labels from the parent directory name.
+        sources: list[tuple[str, str]] = [
+            (str(settings.get_built_in_skills_dir()), "Built-in"),
+            (str(skills_dir), "User Deepagents"),
+            (str(user_agent_skills_dir), "User Agents"),
+        ]
         if project_skills_dir:
-            sources.append(str(project_skills_dir))
+            sources.append((str(project_skills_dir), "Project Deepagents"))
         if project_agent_skills_dir:
-            sources.append(str(project_agent_skills_dir))
+            sources.append((str(project_agent_skills_dir), "Project Agents"))
 
         # Experimental: Claude Code skill directories
         user_claude_skills_dir = settings.get_user_claude_skills_dir()
         if user_claude_skills_dir.exists():
-            sources.append(str(user_claude_skills_dir))
+            sources.append((str(user_claude_skills_dir), "User Claude"))
         project_claude_skills_dir = settings.get_project_claude_skills_dir()
         if project_claude_skills_dir:
-            sources.append(str(project_claude_skills_dir))
+            sources.append((str(project_claude_skills_dir), "Project Claude"))
+
+        # Backwards-compat: strip labels when the installed SDK is too old
+        # to accept `(path, label)` tuples. Label-based disambiguation
+        # regresses to the pre-alias behavior (user- and project-scoped
+        # `.claude/skills` collapse to the same label), but functionality
+        # is preserved.
+        middleware_sources: Sequence[str | tuple[str, str]] = (
+            sources if _SUPPORTS_SKILL_SOURCE_TUPLES else [path for path, _ in sources]
+        )
 
         agent_middleware.append(
             SkillsMiddleware(
                 backend=FilesystemBackend(),
-                sources=sources,
+                sources=middleware_sources,
             )
         )
 

--- a/libs/cli/deepagents_cli/local_context.py
+++ b/libs/cli/deepagents_cli/local_context.py
@@ -224,7 +224,7 @@ if command -v node >/dev/null 2>&1; then
   NV="$(node --version 2>/dev/null | sed 's/^v//')"
   [ -n "$NV" ] && RT="${RT:+${RT}, }Node ${NV}"
 fi
-[ -n "$RT" ] && echo "**Runtimes**: ${RT}" && echo ""
+[ -n "$RT" ] && echo "**Detected Runtimes**: ${RT}" && echo ""
 """
 
 
@@ -246,7 +246,7 @@ if $IN_GIT; then
       master) MAINS="${MAINS:+${MAINS}, }\`master\`" ;;
     esac
   done
-  [ -n "$MAINS" ] && GT="${GT}, main branch available: ${MAINS}"
+  [ -n "$MAINS" ] && GT="${GT}, ${MAINS} available"
 
   DC=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
   if [ "$DC" -gt 0 ]; then
@@ -301,13 +301,18 @@ if [ -n "$FILES" ]; then
   TOTAL=$(echo "$FILES" | wc -l | tr -d ' ')
   SHOWN_FILES=$(echo "$FILES" | head -20)
   SHOWN=$(echo "$SHOWN_FILES" | wc -l | tr -d ' ')
-  echo "**Files** (${SHOWN} shown):"
+  TOTAL=${TOTAL:-0}
+  SHOWN=${SHOWN:-0}
+  if [ "$SHOWN" -lt "$TOTAL" ]; then
+    echo "**Files** (showing ${SHOWN} of ${TOTAL}):"
+  else
+    echo "**Files** (${TOTAL}):"
+  fi
   echo "$SHOWN_FILES" | while IFS= read -r f; do
     if [ -d "$f" ]; then echo "- ${f}/"
     else echo "- ${f}"
     fi
   done
-  [ "$SHOWN" -lt "$TOTAL" ] && echo "... ($((TOTAL - SHOWN)) more files)"
   echo ""
 fi"""
 
@@ -323,12 +328,19 @@ if command -v tree >/dev/null 2>&1; then
   TREE_EXCL='node_modules|.venv|__pycache__|.pytest_cache'
   TREE_EXCL="${TREE_EXCL}|.git|.mypy_cache|.ruff_cache"
   TREE_EXCL="${TREE_EXCL}|.tox|.coverage|.eggs|dist|build"
-  T=$(tree -L 3 --noreport --dirsfirst \
-    -I "$TREE_EXCL" 2>/dev/null | head -22)
-  if [ -n "$T" ]; then
+  T_FULL=$(tree -L 3 --noreport --dirsfirst \
+    -I "$TREE_EXCL" 2>/dev/null)
+  if [ -n "$T_FULL" ]; then
+    TOTAL_LINES=$(echo "$T_FULL" | wc -l | tr -d ' ')
+    T=$(echo "$T_FULL" | head -22)
+    SHOWN_LINES=$(echo "$T" | wc -l | tr -d ' ')
+    TOTAL_LINES=${TOTAL_LINES:-0}
+    SHOWN_LINES=${SHOWN_LINES:-0}
     echo "**Tree** (3 levels):"
     echo '```text'
     echo "$T"
+    [ "$SHOWN_LINES" -lt "$TOTAL_LINES" ] \
+      && echo "... ($((TOTAL_LINES - SHOWN_LINES)) more lines truncated)"
     echo '```'
     echo ""
   fi

--- a/libs/cli/deepagents_cli/local_context.py
+++ b/libs/cli/deepagents_cli/local_context.py
@@ -328,19 +328,21 @@ if command -v tree >/dev/null 2>&1; then
   TREE_EXCL='node_modules|.venv|__pycache__|.pytest_cache'
   TREE_EXCL="${TREE_EXCL}|.git|.mypy_cache|.ruff_cache"
   TREE_EXCL="${TREE_EXCL}|.tox|.coverage|.eggs|dist|build"
-  T_FULL=$(tree -L 3 --noreport --dirsfirst \
-    -I "$TREE_EXCL" 2>/dev/null)
-  if [ -n "$T_FULL" ]; then
-    TOTAL_LINES=$(echo "$T_FULL" | wc -l | tr -d ' ')
-    T=$(echo "$T_FULL" | head -22)
-    SHOWN_LINES=$(echo "$T" | wc -l | tr -d ' ')
-    TOTAL_LINES=${TOTAL_LINES:-0}
-    SHOWN_LINES=${SHOWN_LINES:-0}
+  T_PREVIEW=$(tree -L 3 --noreport --dirsfirst \
+    -I "$TREE_EXCL" 2>/dev/null | sed -n '1,22p;23{p;q;}')
+  if [ -n "$T_PREVIEW" ]; then
+    PREVIEW_LINES=$(echo "$T_PREVIEW" | wc -l | tr -d ' ')
+    PREVIEW_LINES=${PREVIEW_LINES:-0}
+    T="$T_PREVIEW"
+    TREE_TRUNCATED=false
+    if [ "$PREVIEW_LINES" -gt 22 ]; then
+      T=$(echo "$T_PREVIEW" | head -22)
+      TREE_TRUNCATED=true
+    fi
     echo "**Tree** (3 levels):"
     echo '```text'
     echo "$T"
-    [ "$SHOWN_LINES" -lt "$TOTAL_LINES" ] \
-      && echo "... ($((TOTAL_LINES - SHOWN_LINES)) more lines truncated)"
+    $TREE_TRUNCATED && echo "... (more lines truncated)"
     echo '```'
     echo ""
   fi

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -1066,14 +1066,116 @@ class TestCreateCliAgentSkillsSources:
         assert len(captured_sources) == 1
         sources = captured_sources[0]
         assert sources == [
+            (str(built_in_dir), "Built-in"),
+            (str(skills_dir), "User Deepagents"),
+            (str(user_agent_skills_dir), "User Agents"),
+            (str(project_skills_dir), "Project Deepagents"),
+            (str(project_agent_skills_dir), "Project Agents"),
+            (str(tmp_path / "user-claude-skills"), "User Claude"),
+            (str(tmp_path / "project-claude-skills"), "Project Claude"),
+        ]
+
+        # End-to-end: the captured tuple list should produce distinct
+        # labels when formatted by the real middleware. Guards against
+        # a regression that drops labels back to leaf-only derivation
+        # (which would collapse user- vs project-scoped `.claude/skills`
+        # and `.agents/skills` / `.deepagents/skills` directories).
+        from deepagents.middleware.skills import (
+            SkillsMiddleware as RealSkillsMiddleware,
+        )
+
+        real_middleware = RealSkillsMiddleware(
+            backend=None,  # type: ignore[arg-type]
+            sources=sources,
+        )
+        rendered = real_middleware._format_skills_locations()
+        for expected in (
+            "**Built-in Skills**:",
+            "**User Deepagents Skills**:",
+            "**User Agents Skills**:",
+            "**Project Deepagents Skills**:",
+            "**Project Agents Skills**:",
+            "**User Claude Skills**:",
+            "**Project Claude Skills**:",
+        ):
+            assert expected in rendered, f"missing {expected!r} in:\n{rendered}"
+        assert rendered.rstrip().endswith("(higher priority)")
+
+    def test_skills_sources_fallback_to_bare_paths_on_old_sdk(
+        self, tmp_path: Path
+    ) -> None:
+        """If the installed SDK lacks `SkillSource`, CLI passes bare paths.
+
+        Backwards-compat: SDKs < 0.5.4 only accept `list[str]`. The CLI
+        detects the missing alias at import time and strips labels
+        before handing sources to `SkillsMiddleware`, so the middleware
+        never receives an unsupported tuple.
+        """
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        user_agent_skills_dir = tmp_path / "user-agent-skills"
+        user_agent_skills_dir.mkdir()
+        built_in_dir = Settings.get_built_in_skills_dir()
+
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_user_agent_skills_dir.return_value = user_agent_skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_project_agent_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = built_in_dir
+        mock_settings.get_user_claude_skills_dir.return_value = tmp_path / "nonexistent"
+        mock_settings.get_project_claude_skills_dir.return_value = None
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+
+        captured_sources: list[list[Any]] = []
+
+        class FakeSkillsMiddleware:
+            def __init__(self, **kwargs: Any) -> None:
+                captured_sources.append(kwargs.get("sources", []))
+
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+        with (
+            patch("deepagents_cli.agent._SUPPORTS_SKILL_SOURCE_TUPLES", False),
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware", FakeSkillsMiddleware),
+            patch("deepagents_cli.agent.MemoryMiddleware"),
+            patch("deepagents_cli.agent.create_deep_agent", return_value=mock_agent),
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=True,
+                enable_shell=False,
+            )
+
+        assert len(captured_sources) == 1
+        sources = captured_sources[0]
+        # Fallback stripped all labels; middleware receives bare strings.
+        assert sources == [
             str(built_in_dir),
             str(skills_dir),
             str(user_agent_skills_dir),
-            str(project_skills_dir),
-            str(project_agent_skills_dir),
-            str(tmp_path / "user-claude-skills"),
-            str(tmp_path / "project-claude-skills"),
         ]
+        for source in sources:
+            assert isinstance(source, str), f"expected str, got {type(source)!r}"
 
 
 class TestCreateCliAgentMemorySources:
@@ -1295,8 +1397,10 @@ class TestCreateCliAgentProjectContext:
 
         assert len(captured_sources) == 1
         sources = captured_sources[0]
-        assert str(project_skills_dir) in sources
-        assert str(project_agent_skills_dir) in sources
+        # Sources are (path, label) tuples; assert the project paths are wired.
+        source_paths = [s[0] if isinstance(s, tuple) else s for s in sources]
+        assert str(project_skills_dir) in source_paths
+        assert str(project_agent_skills_dir) in source_paths
         mock_list.assert_called_once_with(
             user_agents_dir=tmp_path / "agents",
             project_agents_dir=project_agents_dir,

--- a/libs/cli/tests/unit_tests/test_local_context.py
+++ b/libs/cli/tests/unit_tests/test_local_context.py
@@ -117,15 +117,15 @@ def _make_summarization_event(cutoff: int) -> dict[str, Any]:
 SAMPLE_CONTEXT = (
     "## Local Context\n\n"
     "**Current Directory**: `/home/user/project`\n\n"
-    "**Git**: Current branch `main`, main branch available: `main`, `master`,"
+    "**Git**: Current branch `main`, `main`, `master` available,"
     " 1 uncommitted change\n\n"
-    "**Runtimes**: Python 3.12.4, Node 20.11.0\n"
+    "**Detected Runtimes**: Python 3.12.4, Node 20.11.0\n"
 )
 
 SAMPLE_CONTEXT_NO_GIT = (
     "## Local Context\n\n"
     "**Current Directory**: `/home/user/project`\n\n"
-    "**Runtimes**: Python 3.12.4\n"
+    "**Detected Runtimes**: Python 3.12.4\n"
 )
 
 
@@ -218,9 +218,7 @@ class TestLocalContextMiddleware:
         assert result is not None
         ctx = result["local_context"]
         assert "**Git**: Current branch `main`" in ctx
-        assert "main branch available:" in ctx
-        assert "`main`" in ctx
-        assert "`master`" in ctx
+        assert "`main`, `master` available" in ctx
         assert "1 uncommitted change" in ctx
 
     def test_before_agent_no_git(self) -> None:
@@ -1018,7 +1016,7 @@ class TestSectionRuntimes:
     def test_runs_and_detects_python(self, tmp_path: Path) -> None:
         out = _run_section(_section_runtimes(), tmp_path)
         # python3 is available in CI and dev; just check format
-        assert "**Runtimes**:" in out
+        assert "**Detected Runtimes**:" in out
         assert "Python " in out
 
 
@@ -1059,7 +1057,7 @@ class TestSectionGit:
     def test_main_branch_listed(self, tmp_path: Path) -> None:
         _git_init_commit(tmp_path, branch="main")
         out = _run_section(_section_git(), tmp_path, with_header=True)
-        assert "main branch available: `main`" in out
+        assert "`main` available" in out
 
     def test_uncommitted_changes_singular(self, tmp_path: Path) -> None:
         _git_init_commit(tmp_path)
@@ -1119,13 +1117,15 @@ class TestSectionFiles:
         out = _run_section(_section_files(), tmp_path)
         assert "- README.md" in out
         assert "- src/" in out
+        # Below the 20-file cap: header shows the total, not a "showing X of Y".
+        assert "**Files** (2):" in out
+        assert "showing" not in out
 
     def test_caps_at_20(self, tmp_path: Path) -> None:
         for i in range(25):
             (tmp_path / f"file{i:02d}.txt").write_text("")
         out = _run_section(_section_files(), tmp_path)
-        assert "(20 shown)" in out
-        assert "5 more files" in out
+        assert "(showing 20 of 25)" in out
 
     def test_excludes_pycache(self, tmp_path: Path) -> None:
         (tmp_path / "__pycache__").mkdir()
@@ -1167,6 +1167,29 @@ class TestSectionTree:
             check=False,
         )
         assert "**Tree**" not in result.stdout
+
+    def test_truncation_indicator_when_tree_exceeds_cap(self, tmp_path: Path) -> None:
+        """Tree output longer than 22 lines emits a truncation notice."""
+        import shutil
+
+        if shutil.which("tree") is None:
+            pytest.skip("tree not installed")
+        # Create enough top-level dirs that `tree -L 3` output exceeds 22 lines.
+        for i in range(30):
+            (tmp_path / f"d{i:02d}").mkdir()
+        out = _run_section(_section_tree(), tmp_path)
+        assert "more lines truncated" in out
+
+    def test_no_truncation_indicator_when_small(self, tmp_path: Path) -> None:
+        """Tree output at or under 22 lines does not emit truncation notice."""
+        import shutil
+
+        if shutil.which("tree") is None:
+            pytest.skip("tree not installed")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("")
+        out = _run_section(_section_tree(), tmp_path)
+        assert "truncated" not in out
 
 
 class TestSectionMakefile:

--- a/libs/cli/tests/unit_tests/test_local_context.py
+++ b/libs/cli/tests/unit_tests/test_local_context.py
@@ -1191,6 +1191,12 @@ class TestSectionTree:
         out = _run_section(_section_tree(), tmp_path)
         assert "truncated" not in out
 
+    def test_uses_early_truncation_instead_of_full_tree_capture(self) -> None:
+        """The shell snippet should stop `tree` after the preview window."""
+        script = _section_tree()
+        assert "T_FULL=$(" not in script
+        assert "sed -n '1,22p;23{p;q;}'" in script
+
 
 class TestSectionMakefile:
     """Tests for _section_makefile."""

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -53,14 +53,22 @@ Parsed from YAML frontmatter per Agent Skills specification:
 
 ## Sources
 
-Sources are simply paths to skill directories in the backend. The source name is
-derived from the last component of the path (e.g., "/skills/user/" -> "user").
+Sources point to skill directories in the backend. Each source is either a bare
+path or a `(path, label)` tuple. With a bare path the label is derived from the
+last path component capitalized (e.g., `/skills/user/` -> `User`), with two
+special cases: `built_in_skills` collapses to `Built-in`, and a literal `skills`
+leaf climbs one level so `~/.claude/skills` renders as `Claude` rather than the
+duplicative `Skills Skills`. Pass an explicit tuple to disambiguate sources
+whose leaf directories would collide (e.g. user- vs project-scoped
+`.claude/skills`).
 
 Example sources:
 ```python
 [
     "/skills/user/",
-    "/skills/project/"
+    "/skills/project/",
+    ("/home/me/.claude/skills", "User Claude"),
+    ("/repo/.claude/skills", "Project Claude"),
 ]
 ```
 
@@ -83,6 +91,7 @@ middleware = SkillsMiddleware(
         "/skills/base/",
         "/skills/user/",
         "/skills/project/",
+        ("/repo/.claude/skills", "Project Claude"),
     ],
 )
 ```
@@ -99,7 +108,7 @@ import yaml
 from langchain.agents.middleware.types import PrivateStateAttr
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Sequence
 
     from langchain_core.runnables import RunnableConfig
     from langgraph.runtime import Runtime
@@ -131,6 +140,79 @@ MAX_SKILL_FILE_SIZE = 10 * 1024 * 1024
 MAX_SKILL_NAME_LENGTH = 64
 MAX_SKILL_DESCRIPTION_LENGTH = 1024
 MAX_SKILL_COMPATIBILITY_LENGTH = 500
+
+SkillSource = str | tuple[str, str]
+"""A skill source: either a bare path or a `(path, label)` pair.
+
+When only a path is given, the label is derived from the final path
+component. Supply a tuple to override the default (e.g. to distinguish
+user-scoped from project-scoped directories that share the same leaf
+name). The label is rendered as `**{label} Skills**` in the system
+prompt; do not include the trailing "Skills" yourself.
+"""
+
+
+def _validate_tuple_source(source: tuple[object, ...]) -> None:
+    """Raise `TypeError` if a tuple source is not a `(str, str)` pair.
+
+    Catches the near-miss shapes at construction time so the traceback
+    points at the caller rather than at a later `IndexError` inside the
+    middleware or a silently-coerced non-string path downstream.
+    """
+    if (
+        len(source) != 2  # noqa: PLR2004  # SkillSource tuple is exactly (path, label)
+        or not isinstance(source[0], str)
+        or not isinstance(source[1], str)
+    ):
+        msg = f"Invalid skill source: expected str or (str, str) tuple, got {source!r}"
+        raise TypeError(msg)
+
+
+def _source_path(source: SkillSource) -> str:
+    """Return just the path component of a source."""
+    if isinstance(source, str):
+        return source
+    _validate_tuple_source(source)
+    return source[0]
+
+
+def _derive_source_label(source: SkillSource) -> str:
+    """Derive the display label for a skill source.
+
+    Tuples carry an explicit label, which is used verbatim. Bare paths
+    fall back to a `.capitalize()` of the final path component (matching
+    historical behavior so pre-existing callers see unchanged prompt
+    output), with two special cases:
+
+    - A leaf of `built_in_skills` collapses to `Built-in`.
+    - A leaf of literal `skills` climbs one level and title-cases the
+      parent with `_`/`-` normalized to spaces, so paths like
+      `~/.claude/skills` render as `Claude` rather than the duplicative
+      `Skills Skills`. If the parent is empty, `/`, or `.`, the climb
+      is skipped and the leaf (`Skills`) is used as-is.
+
+    Root-anchored or empty inputs (`/`, ``) fall back to `Unnamed`; this
+    is a programmer error but is tolerated to avoid crashing prompt
+    rendering.
+    """
+    if isinstance(source, tuple):
+        _validate_tuple_source(source)
+        return source[1]
+
+    parts = PurePosixPath(to_posix_path(source).rstrip("/")).parts
+    if not parts:
+        return "Unnamed"
+
+    leaf = parts[-1]
+    if leaf.lower() == "built_in_skills":
+        return "Built-in"
+
+    if leaf.lower() == "skills" and len(parts) >= 2:  # noqa: PLR2004  # need leaf + parent
+        parent = parts[-2].lstrip(".")
+        if parent and parent not in {"/", "."}:
+            return parent.replace("_", " ").replace("-", " ").title()
+
+    return leaf.capitalize()
 
 
 class SkillMetadata(TypedDict):
@@ -639,24 +721,45 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         ```
 
     Args:
-        backend: Backend instance for file operations
-        sources: List of skill source paths.
+        backend: Backend instance for file operations.
+        sources: List of skill sources.
 
-            Source names are derived from the last path component.
+            Each entry is either a bare path (backwards-compatible) or a
+            `(path, label)` tuple. Bare paths derive a label from the
+            final path component; tuples use the supplied label verbatim.
+
+    Attributes:
+        sources: Paths-only view of sources (`list[str]`). Preserves the
+            historical shape of this attribute for callers that inspect
+            it directly.
+        source_labels: Display labels aligned by index with `sources`.
     """
 
     state_schema = SkillsState
 
-    def __init__(self, *, backend: BACKEND_TYPES, sources: list[str]) -> None:
+    def __init__(self, *, backend: BACKEND_TYPES, sources: Sequence[SkillSource]) -> None:
         """Initialize the skills middleware.
 
         Args:
-            backend: Backend instance (e.g. ``StateBackend()``).
-            sources: List of skill source paths (e.g.,
-                `['/skills/user/', '/skills/project/']`).
+            backend: Backend instance (e.g. `StateBackend()`).
+            sources: List of skill sources.
+
+                Each entry is either a bare path (e.g. `'/skills/user/'`) or
+                a `(path, label)` tuple
+                (e.g. `('/home/me/.claude/skills', 'User Claude')`). Labels
+                are rendered as `**{label} Skills**` in the system prompt
+                (do not include the trailing `Skills` in your label).
+
+        Raises:
+            TypeError: If a tuple entry in `sources` is not exactly a
+                `(str, str)` pair.
         """
         self._backend = backend
-        self.sources = sources
+        # `self.sources` remains paths-only (`list[str]`) to preserve
+        # backwards-compat for callers that inspect it directly; label
+        # information is mirrored on `self.source_labels` at the same index.
+        self.sources: list[str] = [_source_path(s) for s in sources]
+        self.source_labels: list[str] = [_derive_source_label(s) for s in sources]
         self.system_prompt_template = SKILLS_SYSTEM_PROMPT
 
     def _get_backend(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> BackendProtocol:
@@ -691,11 +794,11 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
     def _format_skills_locations(self) -> str:
         """Format skills locations for display in system prompt."""
         locations = []
+        last = len(self.sources) - 1
 
-        for i, source_path in enumerate(self.sources):
-            name = PurePosixPath(to_posix_path(source_path).rstrip("/")).name.capitalize()
-            suffix = " (higher priority)" if i == len(self.sources) - 1 else ""
-            locations.append(f"**{name} Skills**: `{source_path}`{suffix}")
+        for i, (source_path, label) in enumerate(zip(self.sources, self.source_labels, strict=True)):
+            suffix = " (higher priority)" if i == last else ""
+            locations.append(f"**{label} Skills**: `{source_path}`{suffix}")
 
         return "\n".join(locations)
 

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -716,6 +716,10 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
             sources=[
                 "/path/to/skills/user/",
                 "/path/to/skills/project/",
+                # Pass a (path, label) tuple to disambiguate sources whose
+                # leaf directories would otherwise collide
+                ("/home/me/.claude/skills", "User Claude"),
+                ("/repo/.claude/skills", "Project Claude"),
             ],
         )
         ```

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -840,21 +840,23 @@ class TestSkillMetadataFromResponseLogging:
 
 
 @pytest.mark.parametrize(
-    "source_path",
+    ("source_path", "expected_label"),
     [
-        "C:\\Users\\project\\skills\\",
-        "C:\\Users\\project\\skills",
-        "\\\\server\\share\\skills\\",
+        ("C:\\Users\\project\\skills\\", "Project"),
+        ("C:\\Users\\project\\skills", "Project"),
+        ("\\\\server\\share\\skills\\", "Share"),
     ],
     ids=["trailing-backslash", "no-trailing-sep", "unc-path"],
 )
-def test_format_skills_locations_with_windows_path(source_path: str) -> None:
-    r"""Derive the trailing directory name from Windows-style source paths.
+def test_format_skills_locations_with_windows_path(source_path: str, expected_label: str) -> None:
+    r"""Derive a sensible label from Windows-style source paths.
 
     Without backslash normalization, `.name` on the resulting `PurePosixPath`
     returns the raw backslashed string (or the empty string for UNC paths
     where `\\\\server\\share\\skills` has no POSIX-delimited final component),
-    not the intended directory label.
+    not the intended directory label. A leaf of literal `skills` climbs one
+    level so the label reflects the scope (`project`, `share`) rather than
+    collapsing to the generic "Skills Skills" duplicate.
     """
     middleware = SkillsMiddleware(
         backend=None,  # type: ignore[arg-type]
@@ -862,10 +864,148 @@ def test_format_skills_locations_with_windows_path(source_path: str) -> None:
     )
 
     result = middleware._format_skills_locations()
-    # Pin the full marker so either a silently wrong directory name or a
-    # capitalization regression trips the assertion.
-    assert "**Skills Skills**:" in result
+    assert f"**{expected_label} Skills**:" in result
+    assert "**Skills Skills**:" not in result
     assert source_path in result
+
+
+def test_format_skills_locations_builtin_leaf() -> None:
+    """`built_in_skills` collapses to `Built-in Skills` rather than the raw leaf."""
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=["/pkg/deepagents_cli/built_in_skills"],
+    )
+
+    result = middleware._format_skills_locations()
+    assert "**Built-in Skills**:" in result
+
+
+def test_format_skills_locations_skills_leaf_climbs_to_parent() -> None:
+    """A leaf of literal `skills` derives its label from the parent dir."""
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=[
+            "/home/me/.claude/skills",
+            "/home/me/.agents/skills/",
+            "/home/me/.deepagents/skills",
+        ],
+    )
+
+    result = middleware._format_skills_locations()
+    assert "**Claude Skills**:" in result
+    assert "**Agents Skills**:" in result
+    assert "**Deepagents Skills**:" in result
+    assert "**Skills Skills**:" not in result
+
+
+def test_format_skills_locations_explicit_label_tuples() -> None:
+    """`(path, label)` tuples use the supplied label verbatim."""
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=[
+            ("/home/me/.claude/skills", "User Claude"),
+            ("/repo/.claude/skills", "Project Claude"),
+        ],
+    )
+
+    result = middleware._format_skills_locations()
+    assert "**User Claude Skills**: `/home/me/.claude/skills`" in result
+    assert "**Project Claude Skills**: `/repo/.claude/skills`" in result
+    # Higher-priority marker belongs to the last entry.
+    assert result.rstrip().endswith("(higher priority)")
+    assert "Project Claude" in result.split("(higher priority)")[0]
+
+
+@pytest.mark.parametrize(
+    ("source_path", "expected_label"),
+    [
+        ("/skills", "Skills"),
+        ("/skills/", "Skills"),
+        ("skills", "Skills"),
+        ("/foo/my_custom", "My_custom"),
+        ("/foo/my-skills", "My-skills"),
+    ],
+    ids=[
+        "root-anchored-skills",
+        "root-anchored-skills-trailing",
+        "bare-skills",
+        "underscore-leaf-capitalize-fallback",
+        "hyphen-leaf-capitalize-fallback",
+    ],
+)
+def test_format_skills_locations_fallback_capitalize(source_path: str, expected_label: str) -> None:
+    """Bare paths without a special leaf fall back to `.capitalize()`.
+
+    Preserves the historical labelling for existing callers: a leaf like
+    `my_custom` renders as `My_custom` (single-capital) rather than the
+    more aggressive `My Custom` title-casing. Root-anchored and bare
+    `skills` inputs cannot climb and fall back to `Skills`.
+    """
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=[source_path],
+    )
+
+    result = middleware._format_skills_locations()
+    assert f"**{expected_label} Skills**:" in result
+
+
+@pytest.mark.parametrize(
+    "empty_path",
+    ["", "/"],
+    ids=["empty-string", "root-only"],
+)
+def test_format_skills_locations_empty_path_fallback(empty_path: str) -> None:
+    """Empty/`/` inputs fall back to `Unnamed` without crashing render."""
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=[empty_path],
+    )
+
+    result = middleware._format_skills_locations()
+    assert "**Unnamed Skills**:" in result
+
+
+@pytest.mark.parametrize(
+    "bad_source",
+    [
+        ("/only-one-element",),
+        ("/one", "two", "three"),
+        ("/path", 42),
+        (None, "label"),
+    ],
+    ids=["one-tuple", "three-tuple", "non-string-label", "non-string-path"],
+)
+def test_malformed_tuple_source_raises_type_error(bad_source: object) -> None:
+    """Malformed tuple sources raise `TypeError` at construction time.
+
+    Fails close to the caller rather than surfacing later as an
+    `IndexError` in the middleware or a silently-coerced non-string path
+    downstream.
+    """
+    with pytest.raises(TypeError, match=r"expected str or \(str, str\) tuple"):
+        SkillsMiddleware(
+            backend=None,  # type: ignore[arg-type]
+            sources=[bad_source],  # type: ignore[list-item]
+        )
+
+
+def test_sources_attribute_is_paths_only() -> None:
+    """`middleware.sources` exposes paths only; labels live on `source_labels`.
+
+    Backwards-compat: callers that inspected `middleware.sources` before
+    the tuple-form API was added continue to see a plain `list[str]`.
+    """
+    middleware = SkillsMiddleware(
+        backend=None,  # type: ignore[arg-type]
+        sources=[
+            "/skills/user/",
+            ("/home/me/.claude/skills", "User Claude"),
+        ],
+    )
+
+    assert middleware.sources == ["/skills/user/", "/home/me/.claude/skills"]
+    assert middleware.source_labels == ["User", "User Claude"]
 
 
 def test_format_skills_locations_single_registry() -> None:


### PR DESCRIPTION
`SkillsMiddleware` previously rendered each skill directory in the system prompt by capitalizing the leaf folder name. That's fine when leaves are unique, but breaks down for two cases:

- Any two sources whose leaf directories share the same name collide. The CLI hit this in practice when it started layering user-scoped and project-scoped `.claude/skills`, `.agents/skills`, and `.deepagents/skills` directories — every pair rendered as the same `**Skills Skills**:` header with no way to tell them apart.
- A leaf like `built_in_skills` rendered as `**Built_in_skills**:` — the underscore was a giveaway that the leaf-capitalize heuristic had hit a wall.

This PR introduces a `SkillSource` type alias so each entry in `sources` can be either a bare path or a `(path, label)` tuple. Existing callers passing `list[str]` are unaffected. The auto-derivation also got smarter for the bare-path case: a leaf of literal `skills` climbs one level (so a path ending in `.../foo/skills` renders as `Foo`), and `built_in_skills` collapses to `Built-in`.

```python
SkillsMiddleware(sources=[
    "/skills/user/",                                # bare path → auto label
    ("/home/me/.claude/skills", "User Claude"),     # explicit label
    ("/repo/.claude/skills", "Project Claude"),
])
```

The CLI side also picks up some incidental polish to the shell snippets that build the "Local Context" injection: `Runtimes` is now `Detected Runtimes`, the file list shows `(showing N of M)` inline instead of a separate trailer, the tree output gains a `... (N more lines truncated)` notice when capped, and the git line reads `` `main`, `master` available `` rather than the wordier prior phrasing.

BEGIN_COMMIT_OVERRIDE
.
END_COMMIT_OVERRIDE