### PR TITLE
fix(ci): ignore cancelled jobs in `ci_success` aggregator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,11 +325,12 @@ jobs:
           results='${{ toJSON(needs.*.result) }}'
           echo "Job results: $results"
 
-          # Check for failures or cancellations
-          if echo "$results" | grep -qE '"failure"|"cancelled"'; then
-            echo "Some jobs failed or were cancelled"
+          # Fail only on real failures. Cancellations are usually benign
+          # (concurrency preemption when a newer commit supersedes this run).
+          if echo "$results" | grep -q '"failure"'; then
+            echo "Some jobs failed"
             exit 1
           fi
 
-          echo "All required checks passed (skipped jobs are OK)"
+          echo "All required checks passed (skipped/cancelled jobs are OK)"
           exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,17 +320,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "🎉 All Checks Passed"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Get all job results (excluding 'changes' which always succeeds)
           results='${{ toJSON(needs.*.result) }}'
           echo "Job results: $results"
 
-          # Fail only on real failures. Cancellations are usually benign
-          # (concurrency preemption when a newer commit supersedes this run).
           if echo "$results" | grep -q '"failure"'; then
             echo "Some jobs failed"
             exit 1
           fi
 
-          echo "All required checks passed (skipped/cancelled jobs are OK)"
+          # On main pushes, concurrency preemption routinely cancels
+          # in-flight jobs when a newer commit arrives — the next run will
+          # validate the latest state, so don't flag those as failures.
+          # On PRs and merge_group runs, a cancellation is almost always a
+          # human action or a real problem, so keep the gate strict.
+          if [ "$EVENT_NAME" != "push" ]; then
+            if echo "$results" | grep -q '"cancelled"'; then
+              echo "Some jobs were cancelled (not allowed on $EVENT_NAME runs)"
+              exit 1
+            fi
+          fi
+
+          echo "All required checks passed (skipped jobs are OK)"
           exit 0


### PR DESCRIPTION
Stop treating concurrency-cancelled jobs as CI failures on `main`. When a newer commit preempts an in-flight run, cancelled jobs would previously trip the aggregate `CI Success` gate and mark the older run red — even though nothing was actually broken (recent example: the CodSpeed `cli` benchmark on run [24858827683](https://github.com/langchain-ai/deepagents/actions/runs/24858827683)).

The relaxation is scoped to `push` events. On `pull_request` and `merge_group` runs, a cancellation is almost always a human action or a real problem, so the gate stays strict — preserves merge queue safety and keeps PR signal honest.