### PR TITLE
feat(repl): enable sync invocation for PTC

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -67,7 +67,11 @@ def filter_tools_for_ptc(
     """
     if config is False:
         return []
-    if isinstance(config, list) and config and any(isinstance(t, BaseTool) for t in config):
+    if (
+        isinstance(config, list)
+        and config
+        and any(isinstance(t, BaseTool) for t in config)
+    ):
         if any(not isinstance(t, BaseTool) for t in config):
             msg = "ptc list must be all str or all BaseTool, not mixed"
             raise TypeError(msg)

--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -67,11 +67,7 @@ def filter_tools_for_ptc(
     """
     if config is False:
         return []
-    if (
-        isinstance(config, list)
-        and config
-        and any(isinstance(t, BaseTool) for t in config)
-    ):
+    if isinstance(config, list) and config and any(isinstance(t, BaseTool) for t in config):
         if any(not isinstance(t, BaseTool) for t in config):
             msg = "ptc list must be all str or all BaseTool, not mixed"
             raise TypeError(msg)

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -329,12 +329,6 @@ class _ThreadREPL:
         self._capture_console = capture_console
         self._console = _ConsoleBuffer()
         self._ctx: Context | None = None
-        # Single asyncio.Lock serialises ctx access on the worker loop —
-        # both sync and async entry points funnel through the worker, so
-        # we no longer need a separate threading.Lock. QuickJS raises
-        # ``ConcurrentEvalError`` on overlapping evals; this lock queues
-        # them instead.
-        self._async_lock = asyncio.Lock()
         # PTC state. ``_registered_tools`` tracks which camel-case names
         # have already had their host-function bridge installed on the
         # QuickJS context. Host functions cannot be un-registered, so we
@@ -501,21 +495,13 @@ class _ThreadREPL:
         self._runtime.install(scope)
 
     async def _aeval_async(self, code: str) -> EvalOutcome:
-        # Hold the lock around the whole eval_async call so concurrent
-        # tool calls queue rather than racing into ConcurrentEvalError.
-        async with self._async_lock:
-            return await self._eval_async_locked(code)
+        """Uses ``ctx.eval_async`` directly.
 
-    async def _eval_async_locked(self, code: str) -> EvalOutcome:
-        """v0.2 async path. Uses ``ctx.eval_async`` directly.
-
-        Differences from the sync path the model should know about:
-        - Top-level ``await`` works; Promises settle before returning.
-        - ``timeout=`` is per-call (fresh budget each invocation) instead
-          of cumulative across a Context's lifetime.
-        - ``asyncio.CancelledError`` propagates out if JS doesn't absorb
-          the ``HostCancellationError``. We let it through untouched so
-          LangGraph's cancellation semantics work end-to-end.
+        Overlapping evals on the same context surface as
+        ``ConcurrentEvalError`` (recorded in ``EvalOutcome.error_type``).
+        We intentionally do not queue: a model dispatching overlapping
+        evals against shared state is almost always a prompting bug,
+        and a loud failure is a better signal than silent serialisation.
         """
         outcome = EvalOutcome()
         try:

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -13,6 +13,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
 from quickjs_rs import (
     UNDEFINED,
     ConcurrentEvalError,
@@ -25,13 +27,11 @@ from quickjs_rs import (
     MemoryLimitError,
     ModuleScope,
     Runtime,
+    ThreadWorker,
 )
 from quickjs_rs import (
     TimeoutError as QJSTimeoutError,
 )
-
-from langchain_core.messages import ToolMessage
-from langgraph.types import Command
 
 from langchain_quickjs._ptc import to_camel_case
 from langchain_quickjs._skills import LoadedSkill, SkillLoadError, aload_skill
@@ -303,90 +303,6 @@ def _inject_tool_args_for_ptc(
     return enriched
 
 
-class _QuickjsWorker:
-    """Dedicated OS thread with its own asyncio event loop.
-
-    ``quickjs_rs.Runtime`` and ``quickjs_rs.Context`` are ``!Send`` — they
-    panic if used from a thread other than the one that created them.
-    This worker owns that thread; all Runtime/Context operations are
-    dispatched here via ``run_sync`` (blocks caller) or ``run_async``
-    (returns an awaitable tied to the caller's loop).
-    """
-
-    def __init__(self) -> None:
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._thread: threading.Thread | None = None
-        self._ready = threading.Event()
-        self._start_lock = threading.Lock()
-
-    def _ensure_started(self) -> None:
-        if self._loop is not None:
-            return
-        with self._start_lock:
-            if self._loop is not None:
-                return
-
-            def _runner() -> None:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                self._loop = loop
-                self._ready.set()
-                try:
-                    loop.run_forever()
-                finally:
-                    try:
-                        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
-                        for t in pending:
-                            t.cancel()
-                        if pending:
-                            loop.run_until_complete(
-                                asyncio.gather(*pending, return_exceptions=True)
-                            )
-                    except Exception:  # noqa: BLE001 — shutdown is best-effort
-                        pass
-                    loop.close()
-
-            self._thread = threading.Thread(
-                target=_runner, name="quickjs-worker", daemon=True
-            )
-            self._thread.start()
-            self._ready.wait()
-
-    def run_sync(self, coro: Any) -> Any:
-        """Submit ``coro`` to the worker loop and block until it completes."""
-        self._ensure_started()
-        assert self._loop is not None
-        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
-
-    def run_async(self, coro: Any) -> asyncio.Future[Any]:
-        """Submit ``coro`` to the worker loop; return a future on the caller's loop."""
-        self._ensure_started()
-        assert self._loop is not None
-        return asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coro, self._loop))
-
-    def close(self) -> None:
-        if self._loop is None or self._thread is None:
-            return
-        # Force a gc pass on the worker thread so any unreachable
-        # QjsHandle / Context objects get finalized here, where the
-        # owning thread still exists. Without this, a later gc on any
-        # other thread (e.g. pytest's gc_collect_harder at session end)
-        # would hit the !Send drop check and raise.
-        async def _gc() -> None:
-            import gc  # noqa: PLC0415 — deliberate: runs inside the worker loop
-
-            gc.collect()
-
-        try:
-            asyncio.run_coroutine_threadsafe(_gc(), self._loop).result(timeout=1.0)
-        except Exception:  # noqa: BLE001 — best-effort, don't block shutdown
-            pass
-        self._loop.call_soon_threadsafe(self._loop.stop)
-        self._thread.join(timeout=5.0)
-        self._loop = None
-        self._thread = None
-
-
 class _ThreadREPL:
     """One QuickJS context + console buffer, per LangGraph thread.
 
@@ -397,7 +313,7 @@ class _ThreadREPL:
 
     def __init__(
         self,
-        worker: _QuickjsWorker,
+        worker: ThreadWorker,
         runtime: Runtime,
         *,
         timeout: float,
@@ -582,7 +498,7 @@ class _ThreadREPL:
         await self._worker.run_async(self._ainstall_module_scope(scope))
 
     async def _ainstall_module_scope(self, scope: ModuleScope) -> None:
-        self._ctx.install(scope)
+        self._runtime.install(scope)
 
     async def _aeval_async(self, code: str) -> EvalOutcome:
         # Hold the lock around the whole eval_async call so concurrent
@@ -693,13 +609,13 @@ class _Registry:
     memory_limit: int
     timeout: float
     capture_console: bool
-    _worker: _QuickjsWorker = field(default_factory=_QuickjsWorker)
+    _worker: ThreadWorker = field(default_factory=ThreadWorker)
     _runtime: Runtime | None = None
     _repls: dict[str, _ThreadREPL] = field(default_factory=dict)
     _init_lock: threading.Lock = field(default_factory=threading.Lock)
     # Per-Runtime skill install cache. `ModuleScope` storage is per-
     # Runtime in quickjs-rs v0.4 (see src/runtime.rs:132-146), and
-    # ``ctx.install`` is additive — re-install of a bare specifier
+    # ``runtime.install`` is additive — re-install of a bare specifier
     # after first import is a silent no-op. So we only need to install
     # each skill *once* per Runtime, even if multiple threads reference
     # it. Successes go under ``loaded``; failures are cached too so a

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -303,39 +303,122 @@ def _inject_tool_args_for_ptc(
     return enriched
 
 
+class _QuickjsWorker:
+    """Dedicated OS thread with its own asyncio event loop.
+
+    ``quickjs_rs.Runtime`` and ``quickjs_rs.Context`` are ``!Send`` — they
+    panic if used from a thread other than the one that created them.
+    This worker owns that thread; all Runtime/Context operations are
+    dispatched here via ``run_sync`` (blocks caller) or ``run_async``
+    (returns an awaitable tied to the caller's loop).
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._start_lock = threading.Lock()
+
+    def _ensure_started(self) -> None:
+        if self._loop is not None:
+            return
+        with self._start_lock:
+            if self._loop is not None:
+                return
+
+            def _runner() -> None:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                self._loop = loop
+                self._ready.set()
+                try:
+                    loop.run_forever()
+                finally:
+                    try:
+                        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+                        for t in pending:
+                            t.cancel()
+                        if pending:
+                            loop.run_until_complete(
+                                asyncio.gather(*pending, return_exceptions=True)
+                            )
+                    except Exception:  # noqa: BLE001 — shutdown is best-effort
+                        pass
+                    loop.close()
+
+            self._thread = threading.Thread(
+                target=_runner, name="quickjs-worker", daemon=True
+            )
+            self._thread.start()
+            self._ready.wait()
+
+    def run_sync(self, coro: Any) -> Any:
+        """Submit ``coro`` to the worker loop and block until it completes."""
+        self._ensure_started()
+        assert self._loop is not None
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    def run_async(self, coro: Any) -> asyncio.Future[Any]:
+        """Submit ``coro`` to the worker loop; return a future on the caller's loop."""
+        self._ensure_started()
+        assert self._loop is not None
+        return asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coro, self._loop))
+
+    def close(self) -> None:
+        if self._loop is None or self._thread is None:
+            return
+        # Force a gc pass on the worker thread so any unreachable
+        # QjsHandle / Context objects get finalized here, where the
+        # owning thread still exists. Without this, a later gc on any
+        # other thread (e.g. pytest's gc_collect_harder at session end)
+        # would hit the !Send drop check and raise.
+        async def _gc() -> None:
+            import gc  # noqa: PLC0415 — deliberate: runs inside the worker loop
+
+            gc.collect()
+
+        try:
+            asyncio.run_coroutine_threadsafe(_gc(), self._loop).result(timeout=1.0)
+        except Exception:  # noqa: BLE001 — best-effort, don't block shutdown
+            pass
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5.0)
+        self._loop = None
+        self._thread = None
+
+
 class _ThreadREPL:
-    """One QuickJS context + console buffer + lock, per LangGraph thread."""
+    """One QuickJS context + console buffer, per LangGraph thread.
+
+    All ``ctx.*`` operations are marshalled onto the worker's dedicated
+    thread because ``quickjs_rs`` objects are ``!Send``. The public
+    methods are safe to call from any thread/loop.
+    """
 
     def __init__(
         self,
+        worker: _QuickjsWorker,
         runtime: Runtime,
         *,
         timeout: float,
         capture_console: bool,
     ) -> None:
+        self._worker = worker
+        self._runtime = runtime
         # The Context-level ``timeout`` is used as the cumulative budget
         # for sync evals. Async evals pass ``timeout=`` per call so each
         # call gets a fresh budget — matches what a REPL user expects,
         # and what we describe in the system prompt.
-        self._ctx: Context = runtime.new_context(timeout=timeout)
         self._per_call_timeout = timeout
+        self._capture_console = capture_console
         self._console = _ConsoleBuffer()
-        # Two locks because async and sync entry points both exist:
-        #   - ``_async_lock`` serializes queued concurrent async calls on
-        #     the same context. QuickJS raises ``ConcurrentEvalError``
-        #     rather than queueing; we prefer to queue, so hold a lock
-        #     around ``ctx.eval_async`` to guarantee only one is in
-        #     flight at a time.
-        #   - ``_sync_lock`` exists for the same reason on the sync path,
-        #     which will usually be used from a worker thread.
-        # A call from the sync path *can* race a call from the async
-        # path. Contexts aren't reentrant; we rely on the natural
-        # ordering of "the agent's tool handler picks one path or the
-        # other per call" and don't try to coordinate across both
-        # locks. If that assumption breaks, add a single threading.Lock
-        # that both paths acquire.
+        self._ctx: Context | None = None
+        # Single asyncio.Lock serialises ctx access on the worker loop —
+        # both sync and async entry points funnel through the worker, so
+        # we no longer need a separate threading.Lock. QuickJS raises
+        # ``ConcurrentEvalError`` on overlapping evals; this lock queues
+        # them instead.
         self._async_lock = asyncio.Lock()
-        self._sync_lock = threading.Lock()
         # PTC state. ``_registered_tools`` tracks which camel-case names
         # have already had their host-function bridge installed on the
         # QuickJS context. Host functions cannot be un-registered, so we
@@ -355,7 +438,14 @@ class _ThreadREPL:
         # graph state, store, context, etc. Set via ``set_outer_runtime``
         # from the middleware's tool handler immediately before eval.
         self._outer_runtime: ToolRuntime | None = None
-        if capture_console:
+        # Context creation + console install must happen on the worker
+        # thread. Block caller here so the REPL is ready to use when
+        # __init__ returns.
+        worker.run_sync(self._ainit())
+
+    async def _ainit(self) -> None:
+        self._ctx = self._runtime.new_context(timeout=self._per_call_timeout)
+        if self._capture_console:
             self._install_console()
 
     def _install_console(self) -> None:
@@ -398,6 +488,9 @@ class _ThreadREPL:
         set changes. Hot path cost when nothing changes: one frozenset
         equality check.
         """
+        self._worker.run_sync(self._ainstall_tools(tools))
+
+    async def _ainstall_tools(self, tools: Sequence[BaseTool]) -> None:
         ctx = self._ctx
         name_to_tool: dict[str, BaseTool] = {to_camel_case(t.name): t for t in tools}
         target_names = frozenset(name_to_tool)
@@ -475,38 +568,27 @@ class _ThreadREPL:
         self._ctx.register(f"__tools_{camel}", _bridge, is_async=True)
 
     def eval_sync(self, code: str) -> EvalOutcome:
-        with self._sync_lock:
-            return self._eval_sync_locked(code)
+        # Both sync and async entry points funnel through ctx.eval_async on
+        # the worker loop. Sync ctx.eval can't dispatch async host functions
+        # (PTC bridges are is_async=True), so routing sync callers through
+        # the async path is required for PTC to work under sync invocation.
+        return self._worker.run_sync(self._aeval_async(code))
 
     async def eval_async(self, code: str) -> EvalOutcome:
+        return await self._worker.run_async(self._aeval_async(code))
+
+    async def ainstall_module_scope(self, scope: ModuleScope) -> None:
+        """Install a ``ModuleScope`` on the context from the caller's loop."""
+        await self._worker.run_async(self._ainstall_module_scope(scope))
+
+    async def _ainstall_module_scope(self, scope: ModuleScope) -> None:
+        self._ctx.install(scope)
+
+    async def _aeval_async(self, code: str) -> EvalOutcome:
         # Hold the lock around the whole eval_async call so concurrent
         # tool calls queue rather than racing into ConcurrentEvalError.
         async with self._async_lock:
             return await self._eval_async_locked(code)
-
-    def _eval_sync_locked(self, code: str) -> EvalOutcome:
-        outcome = EvalOutcome()
-        try:
-            value = self._ctx.eval(code)
-            outcome.result = _stringify(value)
-        except MarshalError:
-            outcome.result_kind = "handle"
-            outcome.result = self._describe_via_handle_sync(code)
-        except QJSTimeoutError as e:
-            outcome.error_type = "Timeout"
-            outcome.error_message = str(e)
-        except JSError as e:
-            self._record_js_error(outcome, e)
-        except ConcurrentEvalError as e:
-            # Shouldn't happen given the locks, but map it defensively so
-            # it's a clean tool error rather than a propagated exception.
-            outcome.error_type = "ConcurrentEval"
-            outcome.error_message = str(e)
-        except MemoryLimitError as e:
-            outcome.error_type = "OutOfMemory"
-            outcome.error_message = str(e)
-        outcome.stdout = self._console.drain()
-        return outcome
 
     async def _eval_async_locked(self, code: str) -> EvalOutcome:
         """v0.2 async path. Uses ``ctx.eval_async`` directly.
@@ -565,16 +647,6 @@ class _ThreadREPL:
         outcome.error_message = e.message
         outcome.error_stack = e.stack
 
-    def _describe_via_handle_sync(self, code: str) -> str:
-        try:
-            handle = self._ctx.eval_handle(code)
-        except Exception:  # noqa: BLE001 — describe-only path; swallow to placeholder
-            return _HANDLE_PLACEHOLDER
-        try:
-            return _format_handle(handle)
-        finally:
-            handle.dispose()
-
     async def _describe_via_handle_async(self, code: str) -> str:
         try:
             handle = await self._ctx.eval_handle_async(
@@ -588,7 +660,12 @@ class _ThreadREPL:
             handle.dispose()
 
     def close(self) -> None:
-        self._ctx.close()
+        self._worker.run_sync(self._aclose())
+
+    async def _aclose(self) -> None:
+        if self._ctx is not None:
+            self._ctx.close()
+            self._ctx = None
 
 
 @dataclass
@@ -616,6 +693,7 @@ class _Registry:
     memory_limit: int
     timeout: float
     capture_console: bool
+    _worker: _QuickjsWorker = field(default_factory=_QuickjsWorker)
     _runtime: Runtime | None = None
     _repls: dict[str, _ThreadREPL] = field(default_factory=dict)
     _init_lock: threading.Lock = field(default_factory=threading.Lock)
@@ -633,17 +711,19 @@ class _Registry:
         # Double-checked lock on the runtime; then a bare check on the per-
         # thread entry because contexts are cheap and we'd rather create a
         # throwaway on a race than serialize every eval through a global
-        # lock.
+        # lock. Runtime + Context are !Send so creation is dispatched onto
+        # the worker thread.
         if self._runtime is None:
             with self._init_lock:
                 if self._runtime is None:
-                    self._runtime = Runtime(memory_limit=self.memory_limit)
+                    self._runtime = self._worker.run_sync(self._acreate_runtime())
         repl = self._repls.get(thread_id)
         if repl is None:
             with self._init_lock:
                 repl = self._repls.get(thread_id)
                 if repl is None:
                     repl = _ThreadREPL(
+                        self._worker,
                         self._runtime,
                         timeout=self.timeout,
                         capture_console=self.capture_console,
@@ -651,12 +731,15 @@ class _Registry:
                     self._repls[thread_id] = repl
         return repl
 
+    async def _acreate_runtime(self) -> Runtime:
+        return Runtime(memory_limit=self.memory_limit)
+
     async def aensure_skills_installed(
         self,
         referenced: frozenset[str],
         metadata: dict[str, SkillMetadata],
         backend: BackendProtocol,
-        ctx: Context,
+        repl: _ThreadREPL,
     ) -> list[SkillLoadError]:
         """Install any referenced skills not yet on this Runtime.
 
@@ -698,7 +781,9 @@ class _Registry:
                 # previously-installed scope for a different specifier
                 # is untouched. Re-install of the same specifier after
                 # first import is a silent no-op (spec §5).
-                ctx.install(ModuleScope({loaded.specifier: loaded.scope}))
+                await repl.ainstall_module_scope(
+                    ModuleScope({loaded.specifier: loaded.scope})
+                )
                 self._skill_installs[name] = _SkillInstall(loaded=loaded)
         return errors
 
@@ -709,8 +794,13 @@ class _Registry:
         self._repls.clear()
         self._skill_installs.clear()
         if self._runtime is not None:
-            self._runtime.close()
+            self._worker.run_sync(self._aclose_runtime())
             self._runtime = None
+        self._worker.close()
+
+    async def _aclose_runtime(self) -> None:
+        if self._runtime is not None:
+            self._runtime.close()
 
 
 def format_outcome(

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -298,7 +298,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             referenced,
             metadata,
             self._skills_backend,
-            repl._ctx,
+            repl,
         )
         if not errors:
             return None

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -1,0 +1,101 @@
+"""End-to-end tests for ``REPLMiddleware`` with a fake LLM.
+
+Regression gate for the sync tool handler: before the worker-thread
+refactor, sync ``invoke`` ran ``ctx.eval``, which cannot dispatch async
+host functions (PTC bridges are ``is_async=True``). Any eval that
+referenced ``tools.*`` surfaced as:
+
+    <error type="ConcurrentEval">sync ctx.eval dispatched a registered
+    async host function; use ctx.eval_async for code that awaits async
+    host calls</error>
+
+We reproduce the exact production snippet on both the sync and async
+handlers and assert it no longer errors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from deepagents import create_deep_agent
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from pydantic import Field
+
+from langchain_quickjs import REPLMiddleware
+
+# The exact snippet a model produced in production when this regressed.
+_EVAL_CODE = "var result = tools.listUserIds({}); result;"
+
+
+class _FakeChatModel(GenericFakeChatModel):
+    """GenericFakeChatModel whose bind_tools returns self.
+
+    Without the override, ``create_deep_agent``'s bind_tools call replaces
+    the model with a RunnableBinding whose ``_generate`` no longer reads
+    from our pre-scripted iterator.
+    """
+
+    messages: Iterator[AIMessage | str] = Field(exclude=True)
+
+    def bind_tools(self, tools: Sequence[Any], **_: Any) -> "_FakeChatModel":
+        return self
+
+
+@tool
+def list_user_ids() -> list[int]:
+    """List user IDs."""
+    return [1, 21, 35, 41, 42, 43]
+
+
+def _script() -> Iterator[AIMessage]:
+    return iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "eval",
+                        "args": {"code": _EVAL_CODE},
+                        "id": "call_1",
+                        "type": "tool_call",
+                    },
+                ],
+            ),
+            AIMessage(content="Done."),
+        ]
+    )
+
+
+def _make_agent() -> Any:
+    return create_deep_agent(
+        model=_FakeChatModel(messages=_script()),
+        middleware=[REPLMiddleware(ptc=[list_user_ids])],
+    )
+
+
+def _eval_tool_message(result: dict) -> ToolMessage:
+    messages = [
+        m for m in result["messages"] if isinstance(m, ToolMessage) and m.name == "eval"
+    ]
+    assert messages, "expected at least one eval ToolMessage"
+    return messages[-1]
+
+
+def _assert_no_error(content: str) -> None:
+    assert "ConcurrentEval" not in content, content
+    assert "<error" not in content, content
+
+
+def test_sync_ptc_eval_through_repl() -> None:
+    """``invoke`` path: the observed production snippet must not error."""
+    result = _make_agent().invoke({"messages": [HumanMessage(content="go")]})
+    _assert_no_error(_eval_tool_message(result).content)
+
+
+async def test_async_ptc_eval_through_repl() -> None:
+    """``ainvoke`` path: same guard on the async handler."""
+    result = await _make_agent().ainvoke({"messages": [HumanMessage(content="go")]})
+    _assert_no_error(_eval_tool_message(result).content)

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -17,7 +17,7 @@ from langchain_quickjs._ptc import (
     render_ptc_prompt,
     to_camel_case,
 )
-from langchain_quickjs._repl import _ThreadREPL
+from langchain_quickjs._repl import _QuickjsWorker, _ThreadREPL
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,17 +67,33 @@ def _echo_tool(name: str = "echo") -> BaseTool:
 
 
 @pytest.fixture
-def runtime() -> Runtime:
-    rt = Runtime()
+def worker() -> _QuickjsWorker:
+    w = _QuickjsWorker()
     try:
-        yield rt
+        yield w
     finally:
-        rt.close()
+        w.close()
 
 
 @pytest.fixture
-def repl(runtime: Runtime) -> _ThreadREPL:
-    return _ThreadREPL(runtime, timeout=5.0, capture_console=True)
+def runtime(worker: _QuickjsWorker) -> Runtime:
+    async def _make() -> Runtime:
+        return Runtime()
+
+    rt = worker.run_sync(_make())
+    try:
+        yield rt
+    finally:
+
+        async def _close() -> None:
+            rt.close()
+
+        worker.run_sync(_close())
+
+
+@pytest.fixture
+def repl(worker: _QuickjsWorker, runtime: Runtime) -> _ThreadREPL:
+    return _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel, Field
-from quickjs_rs import Runtime
+from quickjs_rs import Runtime, ThreadWorker
 
 from langchain_quickjs import REPLMiddleware
 from langchain_quickjs._ptc import (
@@ -17,7 +17,7 @@ from langchain_quickjs._ptc import (
     render_ptc_prompt,
     to_camel_case,
 )
-from langchain_quickjs._repl import _QuickjsWorker, _ThreadREPL
+from langchain_quickjs._repl import _ThreadREPL
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,8 +67,8 @@ def _echo_tool(name: str = "echo") -> BaseTool:
 
 
 @pytest.fixture
-def worker() -> _QuickjsWorker:
-    w = _QuickjsWorker()
+def worker() -> ThreadWorker:
+    w = ThreadWorker()
     try:
         yield w
     finally:
@@ -76,7 +76,7 @@ def worker() -> _QuickjsWorker:
 
 
 @pytest.fixture
-def runtime(worker: _QuickjsWorker) -> Runtime:
+def runtime(worker: ThreadWorker) -> Runtime:
     async def _make() -> Runtime:
         return Runtime()
 
@@ -92,7 +92,7 @@ def runtime(worker: _QuickjsWorker) -> Runtime:
 
 
 @pytest.fixture
-def repl(worker: _QuickjsWorker, runtime: Runtime) -> _ThreadREPL:
+def repl(worker: ThreadWorker, runtime: Runtime) -> _ThreadREPL:
     return _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
 
 

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -11,7 +11,7 @@ from langchain_core.messages import SystemMessage
 from quickjs_rs import Runtime
 
 from langchain_quickjs import REPLMiddleware
-from langchain_quickjs._repl import _Registry, _ThreadREPL, format_outcome
+from langchain_quickjs._repl import _QuickjsWorker, _Registry, _ThreadREPL, format_outcome
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -19,18 +19,35 @@ from langchain_quickjs._repl import _Registry, _ThreadREPL, format_outcome
 
 
 @pytest.fixture
-def runtime() -> Runtime:
-    """A fresh QuickJS Runtime for tests that drive _ThreadREPL directly."""
-    rt = Runtime()
+def worker() -> _QuickjsWorker:
+    w = _QuickjsWorker()
     try:
-        yield rt
+        yield w
     finally:
-        rt.close()
+        w.close()
 
 
 @pytest.fixture
-def repl(runtime: Runtime) -> _ThreadREPL:
-    return _ThreadREPL(runtime, timeout=5.0, capture_console=True)
+def runtime(worker: _QuickjsWorker) -> Runtime:
+    """A fresh QuickJS Runtime for tests that drive _ThreadREPL directly."""
+
+    async def _make() -> Runtime:
+        return Runtime()
+
+    rt = worker.run_sync(_make())
+    try:
+        yield rt
+    finally:
+
+        async def _close() -> None:
+            rt.close()
+
+        worker.run_sync(_close())
+
+
+@pytest.fixture
+def repl(worker: _QuickjsWorker, runtime: Runtime) -> _ThreadREPL:
+    return _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
 
 
 # ---------------------------------------------------------------------------
@@ -133,9 +150,9 @@ def test_state_persists_across_evals(repl: _ThreadREPL) -> None:
     assert second.result == "42"
 
 
-def test_threads_are_isolated(runtime: Runtime) -> None:
-    a = _ThreadREPL(runtime, timeout=5.0, capture_console=True)
-    b = _ThreadREPL(runtime, timeout=5.0, capture_console=True)
+def test_threads_are_isolated(worker: _QuickjsWorker, runtime: Runtime) -> None:
+    a = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
+    b = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
     a.eval_sync("let shared = 'from_a'")
     outcome = b.eval_sync("typeof shared")
     # QuickJS returns "undefined" for missing globals — an isolated context
@@ -162,8 +179,8 @@ def test_syntax_error_surfaces(repl: _ThreadREPL) -> None:
     assert outcome.error_type == "SyntaxError"
 
 
-def test_timeout(runtime: Runtime) -> None:
-    tight = _ThreadREPL(runtime, timeout=0.1, capture_console=True)
+def test_timeout(worker: _QuickjsWorker, runtime: Runtime) -> None:
+    tight = _ThreadREPL(worker, runtime, timeout=0.1, capture_console=True)
     outcome = tight.eval_sync("while(true){}")
     assert outcome.error_type == "Timeout"
 
@@ -183,8 +200,8 @@ def test_console_log_is_captured(repl: _ThreadREPL) -> None:
     assert "<result>2</result>" in formatted
 
 
-def test_console_can_be_disabled(runtime: Runtime) -> None:
-    quiet = _ThreadREPL(runtime, timeout=5.0, capture_console=False)
+def test_console_can_be_disabled(worker: _QuickjsWorker, runtime: Runtime) -> None:
+    quiet = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=False)
     outcome = quiet.eval_sync("typeof console")
     # With the bridge off, the global is absent.
     assert outcome.result == "undefined"

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -8,10 +8,10 @@ import pytest
 from langchain.agents import create_agent
 from langchain.agents.middleware.types import ModelRequest
 from langchain_core.messages import SystemMessage
-from quickjs_rs import Runtime
+from quickjs_rs import Runtime, ThreadWorker
 
 from langchain_quickjs import REPLMiddleware
-from langchain_quickjs._repl import _QuickjsWorker, _Registry, _ThreadREPL, format_outcome
+from langchain_quickjs._repl import _Registry, _ThreadREPL, format_outcome
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -19,8 +19,8 @@ from langchain_quickjs._repl import _QuickjsWorker, _Registry, _ThreadREPL, form
 
 
 @pytest.fixture
-def worker() -> _QuickjsWorker:
-    w = _QuickjsWorker()
+def worker() -> ThreadWorker:
+    w = ThreadWorker()
     try:
         yield w
     finally:
@@ -28,7 +28,7 @@ def worker() -> _QuickjsWorker:
 
 
 @pytest.fixture
-def runtime(worker: _QuickjsWorker) -> Runtime:
+def runtime(worker: ThreadWorker) -> Runtime:
     """A fresh QuickJS Runtime for tests that drive _ThreadREPL directly."""
 
     async def _make() -> Runtime:
@@ -46,7 +46,7 @@ def runtime(worker: _QuickjsWorker) -> Runtime:
 
 
 @pytest.fixture
-def repl(worker: _QuickjsWorker, runtime: Runtime) -> _ThreadREPL:
+def repl(worker: ThreadWorker, runtime: Runtime) -> _ThreadREPL:
     return _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
 
 
@@ -150,7 +150,7 @@ def test_state_persists_across_evals(repl: _ThreadREPL) -> None:
     assert second.result == "42"
 
 
-def test_threads_are_isolated(worker: _QuickjsWorker, runtime: Runtime) -> None:
+def test_threads_are_isolated(worker: ThreadWorker, runtime: Runtime) -> None:
     a = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
     b = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
     a.eval_sync("let shared = 'from_a'")
@@ -179,7 +179,7 @@ def test_syntax_error_surfaces(repl: _ThreadREPL) -> None:
     assert outcome.error_type == "SyntaxError"
 
 
-def test_timeout(worker: _QuickjsWorker, runtime: Runtime) -> None:
+def test_timeout(worker: ThreadWorker, runtime: Runtime) -> None:
     tight = _ThreadREPL(worker, runtime, timeout=0.1, capture_console=True)
     outcome = tight.eval_sync("while(true){}")
     assert outcome.error_type == "Timeout"
@@ -200,7 +200,7 @@ def test_console_log_is_captured(repl: _ThreadREPL) -> None:
     assert "<result>2</result>" in formatted
 
 
-def test_console_can_be_disabled(worker: _QuickjsWorker, runtime: Runtime) -> None:
+def test_console_can_be_disabled(worker: ThreadWorker, runtime: Runtime) -> None:
     quiet = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=False)
     outcome = quiet.eval_sync("typeof console")
     # With the bridge off, the global is absent.

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.agents import create_agent
 from langchain.agents.middleware.types import ModelRequest
 from langchain_core.messages import SystemMessage
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel
 from quickjs_rs import Runtime, ThreadWorker
 
 from langchain_quickjs import REPLMiddleware
@@ -314,22 +318,36 @@ async def test_async_deadlock_detection(repl: _ThreadREPL) -> None:
     assert outcome.error_type == "Deadlock"
 
 
-async def test_async_concurrent_calls_serialize(repl: _ThreadREPL) -> None:
-    """Two concurrent eval_async on the same thread should queue, not raise.
+async def test_async_concurrent_calls_surface_error(repl: _ThreadREPL) -> None:
+    """Overlapping async evals on the same context surface as
+    ``ConcurrentEvalError`` rather than silently serialising.
 
-    If the internal lock is removed this test will flakily raise
-    ``ConcurrentEvalError`` rather than returning two clean outcomes.
+    A model issuing overlapping evals against shared state is almost
+    always a prompting bug; a loud failure is a better signal than
+    silent queueing. The slow tool forces a yield so the two evals
+    actually overlap (pure sync code takes the non-promise fast path).
     """
-    import asyncio as _asyncio
 
-    a, b = await _asyncio.gather(
-        repl.eval_async("1 + 1"),
-        repl.eval_async("2 + 2"),
+    class _NoArgs(BaseModel):
+        pass
+
+    async def _slow(**_: Any) -> str:
+        await asyncio.sleep(0.05)
+        return "ok"
+
+    slow_tool = StructuredTool.from_function(
+        name="slow",
+        description="Sleeps briefly.",
+        coroutine=_slow,
+        args_schema=_NoArgs,
     )
-    assert a.result == "2"
-    assert b.result == "4"
-    assert a.error_type is None
-    assert b.error_type is None
+    repl.install_tools([slow_tool])
+
+    a, b = await asyncio.gather(
+        repl.eval_async("await tools.slow({})"),
+        repl.eval_async("await tools.slow({})"),
+    )
+    assert "ConcurrentEval" in {a.error_type, b.error_type}, (a, b)
 
 
 def test_sync_path_still_works(repl: _ThreadREPL) -> None:

--- a/libs/partners/quickjs/tests/unit_tests/test_skills.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_skills.py
@@ -353,8 +353,8 @@ def test_loaded_scope_installs_on_context(tmp_path: Path) -> None:
     meta = _metadata("hello", path=f"{skill_dir}/SKILL.md", module="index.js")
     loaded = load_skill(meta, backend)
 
-    with Runtime() as rt, rt.new_context() as ctx:
-        ctx.install(ModuleScope({loaded.specifier: loaded.scope}))
+    with Runtime() as rt, rt.new_context():
+        rt.install(ModuleScope({loaded.specifier: loaded.scope}))
 
 
 __all__: list[Any] = []

--- a/libs/partners/quickjs/tests/unit_tests/test_skills_integration.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_skills_integration.py
@@ -65,7 +65,7 @@ async def test_dynamic_import_roundtrip(registry: _Registry, tmp_path: Path) -> 
 
     repl = registry.get("t1")
     errors = await registry.aensure_skills_installed(
-        frozenset({"slugify"}), {"slugify": meta}, backend, repl._ctx
+        frozenset({"slugify"}), {"slugify": meta}, backend, repl
     )
     assert errors == []
 
@@ -96,7 +96,7 @@ async def test_dynamic_import_of_ts_skill_strips_types(
 
     repl = registry.get("t1")
     errors = await registry.aensure_skills_installed(
-        frozenset({"ts-skill"}), {"ts-skill": meta}, backend, repl._ctx
+        frozenset({"ts-skill"}), {"ts-skill": meta}, backend, repl
     )
     assert errors == []
 
@@ -128,7 +128,7 @@ async def test_multi_file_skill_relative_import(
 
     repl = registry.get("t1")
     errors = await registry.aensure_skills_installed(
-        frozenset({"multi"}), {"multi": meta}, backend, repl._ctx
+        frozenset({"multi"}), {"multi": meta}, backend, repl
     )
     assert errors == []
 
@@ -157,14 +157,14 @@ async def test_install_cache_avoids_second_fetch(
 
     repl = registry.get("t1")
     await registry.aensure_skills_installed(
-        frozenset({"cached"}), {"cached": meta}, backend, repl._ctx
+        frozenset({"cached"}), {"cached": meta}, backend, repl
     )
     assert "cached" in registry._skill_installs
     first_loaded = registry._skill_installs["cached"].loaded
 
     # Second pass — no backend I/O, no new install.
     await registry.aensure_skills_installed(
-        frozenset({"cached"}), {"cached": meta}, backend, repl._ctx
+        frozenset({"cached"}), {"cached": meta}, backend, repl
     )
     assert registry._skill_installs["cached"].loaded is first_loaded
 
@@ -187,7 +187,7 @@ async def test_installed_skill_visible_from_second_thread(
 
     repl_a = registry.get("thread-a")
     await registry.aensure_skills_installed(
-        frozenset({"shared"}), {"shared": meta}, backend, repl_a._ctx
+        frozenset({"shared"}), {"shared": meta}, backend, repl_a
     )
 
     # Thread B — no new install call — can still import.
@@ -208,7 +208,7 @@ async def test_unavailable_skill_returns_error(
     repl = registry.get("t1")
 
     errors = await registry.aensure_skills_installed(
-        frozenset({"nope"}), {}, backend, repl._ctx
+        frozenset({"nope"}), {}, backend, repl
     )
     assert len(errors) == 1
     assert "nope" in str(errors[0])
@@ -232,7 +232,7 @@ async def test_broken_skill_failure_is_cached(
 
     repl = registry.get("t1")
     errors1 = await registry.aensure_skills_installed(
-        frozenset({"broken"}), {"broken": meta}, backend, repl._ctx
+        frozenset({"broken"}), {"broken": meta}, backend, repl
     )
     assert len(errors1) == 1
     assert isinstance(errors1[0], SkillScopeInvalid)
@@ -241,7 +241,7 @@ async def test_broken_skill_failure_is_cached(
     # backend load. We can't directly assert "no I/O happened", but we
     # can confirm the cache entry is populated.
     errors2 = await registry.aensure_skills_installed(
-        frozenset({"broken"}), {"broken": meta}, backend, repl._ctx
+        frozenset({"broken"}), {"broken": meta}, backend, repl
     )
     assert len(errors2) == 1
     cached = registry._skill_installs["broken"]
@@ -256,7 +256,7 @@ async def test_unknown_specifier_rejects_at_import(
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
     # Empty: no skills installed.
     await registry.aensure_skills_installed(
-        frozenset(), {}, backend, registry.get("t1")._ctx
+        frozenset(), {}, backend, registry.get("t1")
     )
     repl = registry.get("t1")
     outcome = await repl.eval_async('await import("@/skills/nonexistent")')


### PR DESCRIPTION
Alternative to https://github.com/langchain-ai/deepagents/pull/2914. Relies on ThreadWorker upstream in quickjs-rs.

Also bubbles up ConcurrentEvalError when model makes parallel calls to `eval` instead of silently queueing them.