### PR TITLE
feat(cli): opt-in hub-backed /memories/ via [memories] config

### DIFF
--- a/libs/cli/deepagents_cli/deploy/bundler.py
+++ b/libs/cli/deepagents_cli/deploy/bundler.py
@@ -127,6 +127,15 @@ def bundle(
     )
     logger.info("Generated deploy_graph.py")
 
+    # 5b. Vendor ContextHubBackend alongside the graph when hub-backed. The
+    # deployed bundle cannot import `deepagents_cli` (it is a dev-time CLI,
+    # not a cloud runtime dependency), so we ship a copy of the module and
+    # the generated graph imports it locally.
+    if config.memories.backend == "hub":
+        src = Path(__file__).parent / "context_hub.py"
+        shutil.copy2(src, build_dir / "_context_hub.py")
+        logger.info("Vendored %s → _context_hub.py", src.name)
+
     # 6. Generate auth.py if [auth] is configured.
     auth_present = config.auth is not None
     if config.auth is not None:
@@ -288,6 +297,8 @@ def _render_deploy_graph(
         sync_subagents_block = ""
         sync_subagents_load_call = "pass  # no sync subagents"
 
+    memories_hub_identifier = config.memories.identifier or f"-/{config.agent.name}"
+
     return DEPLOY_GRAPH_TEMPLATE.format(
         model=config.agent.model,
         sandbox_snapshot=config.sandbox.template,
@@ -300,6 +311,8 @@ def _render_deploy_graph(
         has_user_memories=has_user_memories,
         sync_subagents_block=sync_subagents_block,
         sync_subagents_load_call=sync_subagents_load_call,
+        memories_backend=config.memories.backend,
+        memories_hub_identifier=memories_hub_identifier,
     )
 
 
@@ -367,6 +380,12 @@ def _render_pyproject(
         if auth_pkg:
             deps.append(auth_pkg)
 
+    # ContextHubBackend uses AgentContext/FileEntry from langsmith 0.7.35+.
+    # deepagents floors langsmith at a lower version, so pin explicitly when
+    # the deployed graph needs the hub APIs.
+    if config.memories.backend == "hub":
+        deps.append("langsmith>=0.7.35")
+
     extra_deps_lines = "".join(f'    "{dep}",\n' for dep in deps)
 
     return PYPROJECT_TEMPLATE.format(
@@ -424,6 +443,12 @@ def print_bundle_summary(config: DeployConfig, build_dir: Path) -> None:
             print(f"    {name} \u2014 {desc}")
 
     print(f"\n  Sandbox: {config.sandbox.provider}")
+    memories_backend = config.memories.backend
+    if memories_backend == "hub":
+        hub_identifier = config.memories.identifier or f"-/{config.agent.name}"
+        print(f"  Memories: hub ({hub_identifier})")
+    else:
+        print(f"  Memories: {memories_backend}")
     print(f"\n  Build directory: {build_dir}")
     generated = sorted(f.name for f in build_dir.iterdir() if f.is_file())
     print(f"  Generated files: {', '.join(generated)}")

--- a/libs/cli/deepagents_cli/deploy/config.py
+++ b/libs/cli/deepagents_cli/deploy/config.py
@@ -42,6 +42,11 @@ AuthProvider = Literal["supabase", "clerk"]
 VALID_AUTH_PROVIDERS: frozenset[str] = frozenset(get_args(AuthProvider))
 """Valid auth providers for deploy."""
 
+MemoriesBackend = Literal["store", "hub"]
+"""Valid backing store for the `/memories/` namespace."""
+
+VALID_MEMORIES_BACKENDS: frozenset[str] = frozenset(get_args(MemoriesBackend))
+
 DEFAULT_CONFIG_FILENAME = "deepagents.toml"
 
 # Canonical filenames inside the project root.
@@ -129,6 +134,23 @@ class AuthConfig:
 
 
 @dataclass(frozen=True)
+class MemoriesConfig:
+    """`[memories]` section — backing store for `/memories/`.
+
+    `backend = "store"` (default) routes `/memories/` through a
+    `StoreBackend` against the LangGraph runtime store. `backend = "hub"`
+    routes it through a `ContextHubBackend` bound to a LangSmith Hub
+    agent repo, giving persistent, git-like storage.
+
+    `identifier` overrides the Hub agent repo. When omitted, it defaults
+    to `-/{agent.name}` at bundle time.
+    """
+
+    backend: MemoriesBackend = "store"
+    identifier: str = ""
+
+
+@dataclass(frozen=True)
 class DeployConfig:
     """Top-level deploy configuration parsed from `deepagents.toml`."""
 
@@ -138,6 +160,8 @@ class DeployConfig:
     sandbox: SandboxConfig = field(default_factory=SandboxConfig)
     """Parsed `[sandbox]` section — provider, snapshot name, image, scope."""
     auth: AuthConfig | None = None
+    memories: MemoriesConfig = field(default_factory=MemoriesConfig)
+    """Parsed `[memories]` section — backing store for `/memories/`."""
 
     def validate(self, project_root: Path) -> list[str]:
         """Validate config against the filesystem.
@@ -183,6 +207,15 @@ class DeployConfig:
                 f"Unknown sandbox scope: {self.sandbox.scope}. "
                 f"Valid: {', '.join(sorted(VALID_SANDBOX_SCOPES))}"
             )
+
+        if self.memories.backend not in VALID_MEMORIES_BACKENDS:
+            errors.append(
+                f"Unknown memories backend: {self.memories.backend}. "
+                f"Valid: {', '.join(sorted(VALID_MEMORIES_BACKENDS))}"
+            )
+
+        if self.memories.backend == "hub":
+            errors.extend(_validate_hub_credentials())
 
         # Validate credentials for model provider.
         errors.extend(_validate_model_credentials(self.agent.model))
@@ -363,10 +396,11 @@ def load_config(config_path: Path) -> DeployConfig:
     return _parse_config(data)
 
 
-_ALLOWED_SECTIONS = frozenset({"agent", "sandbox", "auth"})
+_ALLOWED_SECTIONS = frozenset({"agent", "sandbox", "auth", "memories"})
 _ALLOWED_AGENT_KEYS = frozenset({"name", "description", "model"})
 _ALLOWED_SANDBOX_KEYS = frozenset({"provider", "template", "image", "scope"})
 _ALLOWED_AUTH_KEYS = frozenset({"provider"})
+_ALLOWED_MEMORIES_KEYS = frozenset({"backend", "identifier"})
 
 
 def _parse_config(data: dict[str, Any]) -> DeployConfig:
@@ -442,7 +476,36 @@ def _parse_config(data: dict[str, Any]) -> DeployConfig:
 
         auth = AuthConfig(provider=auth_provider)
 
-    return DeployConfig(agent=agent, sandbox=sandbox, auth=auth)
+    memories = MemoriesConfig()
+    memories_data = data.get("memories")
+    if memories_data is not None:
+        unknown_memories = set(memories_data.keys()) - _ALLOWED_MEMORIES_KEYS
+        if unknown_memories:
+            msg = (
+                f"Unknown key(s) in [memories]: {sorted(unknown_memories)}. "
+                f"Allowed: {sorted(_ALLOWED_MEMORIES_KEYS)}"
+            )
+            raise ValueError(msg)
+
+        backend = memories_data.get("backend", "store")
+        if backend not in VALID_MEMORIES_BACKENDS:
+            msg = (
+                f"Unknown memories backend: {backend}. "
+                f"Valid: {', '.join(sorted(VALID_MEMORIES_BACKENDS))}"
+            )
+            raise ValueError(msg)
+
+        identifier = memories_data.get("identifier", "")
+        if identifier and "/" not in identifier:
+            msg = (
+                f"[memories].identifier must be in 'owner/name' form "
+                f"(or '-/name' for the caller's tenant); got {identifier!r}"
+            )
+            raise ValueError(msg)
+
+        memories = MemoriesConfig(backend=backend, identifier=identifier)
+
+    return DeployConfig(agent=agent, sandbox=sandbox, auth=auth, memories=memories)
 
 
 _MODEL_PROVIDER_ENV: dict[str, str] = {
@@ -530,6 +593,19 @@ def _validate_auth_credentials(provider: str) -> list[str]:
     ]
 
 
+def _validate_hub_credentials() -> list[str]:
+    """Check that a LangSmith key is set when `[memories].backend = 'hub'`."""
+    if os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGCHAIN_API_KEY"):
+        return []
+    return [
+        (
+            "Memories backend 'hub' requires a LangSmith key: "
+            "set LANGSMITH_API_KEY (or LANGCHAIN_API_KEY) in your .env "
+            "file or environment."
+        ),
+    ]
+
+
 def find_config(start_path: Path | None = None) -> Path | None:
     """Find `deepagents.toml` in *start_path* (or cwd if not given).
 
@@ -559,6 +635,12 @@ model = "anthropic:claude-sonnet-4-6"
 # [auth] is optional. Add to enable user authentication.
 # [auth]
 # provider = "supabase"   # supabase | clerk
+
+# [memories] is optional. Defaults to the LangGraph runtime store.
+# Set backend = "hub" to persist /memories/ in a LangSmith Hub agent repo.
+# [memories]
+# backend = "hub"          # store | hub
+# identifier = "-/my-agent"  # optional override; defaults to `-/{agent.name}`
 """
 
 

--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -560,6 +560,13 @@ USER_PREFIX = "/memories/user/"
 
 HAS_USER_MEMORIES = {has_user_memories!r}
 
+# `/memories/` backing store. "store" routes through the LangGraph runtime
+# store (in-memory for `langgraph dev`, Postgres on the platform). "hub"
+# persists into a LangSmith Hub agent repo via ContextHubBackend — a single
+# hub repo for the agent, plus a per-user repo when user memories are on.
+MEMORIES_BACKEND = {memories_backend!r}
+MEMORIES_HUB_IDENTIFIER = {memories_hub_identifier!r}
+
 # What to seed into the store on first run.
 SEED_PATH = Path(__file__).parent / "_seed.json"
 
@@ -665,8 +672,28 @@ def _load_seed() -> dict:
 # Per-(process, assistant_id) gate.
 _SEEDED_ASSISTANTS: set[str] = set()
 
+# Per-(process, assistant_id) gate for hub seeding.
+_SEEDED_HUB_ASSISTANTS: set[str] = set()
+
 # Per-(process, assistant_id, user_id) gate for user memories.
 _SEEDED_USERS: set[tuple[str, str]] = set()
+
+# Per-(process, assistant_id, user_id) gate for per-user hub seeding.
+_SEEDED_HUB_USERS: set[tuple[str, str]] = set()
+
+
+_USER_ID_SAFE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+
+
+def _sanitize_user_id(user_id: str) -> str:
+    """Translate a user identity into a hub-repo-name-safe slug.
+
+    Replaces any non `[A-Za-z0-9_-]` character with `-` and truncates to 40
+    chars so callers with long identities (emails, provider-prefixed IDs,
+    long UUIDs) still get a workable repo name.
+    """
+    slug = "".join(c if c in _USER_ID_SAFE_CHARS else "-" for c in user_id)
+    return slug[:40]
 
 
 async def _seed_store_if_needed(store, assistant_id: str) -> None:
@@ -729,6 +756,67 @@ async def _seed_user_memories_if_needed(
     )
 
 
+async def _write_if_missing(backend, path: str, content: str) -> None:
+    """Write ``content`` to ``path`` only when the file does not exist yet."""
+    existing = await backend.aread(path)
+    if existing.error is None:
+        return
+    result = await backend.awrite(path, content)
+    if result.error is not None:
+        logger.warning("Hub seed write failed for %s: %s", path, result.error)
+
+
+async def _seed_hub_if_needed(backend, assistant_id: str) -> None:
+    """Seed AGENTS.md, skills, and subagent content into the hub repo."""
+    if assistant_id in _SEEDED_HUB_ASSISTANTS:
+        return
+    _SEEDED_HUB_ASSISTANTS.add(assistant_id)
+
+    seed = _load_seed()
+
+    for path, content in seed.get("memories", {{}}).items():
+        full_path = f"{{MEMORIES_PREFIX}}{{path.lstrip('/')}}"
+        await _write_if_missing(backend, full_path, content)
+    for path, content in seed.get("skills", {{}}).items():
+        full_path = f"{{SKILLS_PREFIX}}{{path.lstrip('/')}}"
+        await _write_if_missing(backend, full_path, content)
+
+    for sa_name, sa_data in seed.get("subagents", {{}}).items():
+        sa_prefix = f"{{MEMORIES_PREFIX}}subagents/{{sa_name}}/"
+        for path, content in sa_data.get("memories", {{}}).items():
+            full_path = f"{{sa_prefix}}{{path.lstrip('/')}}"
+            await _write_if_missing(backend, full_path, content)
+        for path, content in sa_data.get("skills", {{}}).items():
+            await _write_if_missing(
+                backend, f"{{sa_prefix}}skills/{{path.lstrip('/')}}", content
+            )
+
+
+async def _seed_user_hub_if_needed(
+    backend, assistant_id: str, user_id: str,
+) -> None:
+    """Seed user memory templates into the per-user hub repo."""
+    key = (assistant_id, user_id)
+    if key in _SEEDED_HUB_USERS:
+        return
+    _SEEDED_HUB_USERS.add(key)
+
+    seed = _load_seed()
+    user_memories = seed.get("user_memories", {{}})
+    if not user_memories:
+        return
+
+    for path, content in user_memories.items():
+        await _write_if_missing(
+            backend, f"{{USER_PREFIX}}{{path.lstrip('/')}}", content
+        )
+    logger.info(
+        "Seeded %d user memory template(s) into hub for user %s",
+        len(user_memories),
+        user_id,
+    )
+
+
 {sandbox_block}
 
 {mcp_tools_block}
@@ -765,7 +853,7 @@ def _make_user_namespace_factory(assistant_id: str):
 SANDBOX_SCOPE = {sandbox_scope!r}
 
 
-def _build_backend_factory(assistant_id: str):
+def _build_backend_factory(assistant_id: str, user_id: str | None = None):
     """Return a backend factory that builds the composite per invocation."""
     def _factory(ctx):  # noqa: ARG001
         from langgraph.config import get_config
@@ -777,27 +865,43 @@ def _build_backend_factory(assistant_id: str):
             cache_key = f"thread:{{thread_id}}"
         sandbox_backend = _get_or_create_sandbox(cache_key)
 
-        routes = {{
-            MEMORIES_PREFIX: StoreBackend(
-                namespace=_make_namespace_factory(assistant_id),
-            ),
-            SKILLS_PREFIX: StoreBackend(
-                namespace=_make_namespace_factory(assistant_id),
-            ),
-        }}
+        if MEMORIES_BACKEND == "hub":
+            # Vendored alongside the generated graph by the bundler.
+            from _context_hub import ContextHubBackend
 
-        if HAS_USER_MEMORIES:
-            routes[USER_PREFIX] = StoreBackend(
-                namespace=_make_user_namespace_factory(assistant_id),
-            )
+            routes = {{
+                MEMORIES_PREFIX: ContextHubBackend(identifier=MEMORIES_HUB_IDENTIFIER),
+            }}
+            if HAS_USER_MEMORIES and user_id:
+                user_hub_identifier = (
+                    f"{{MEMORIES_HUB_IDENTIFIER}}-user-{{_sanitize_user_id(user_id)}}"
+                )
+                routes[USER_PREFIX] = ContextHubBackend(identifier=user_hub_identifier)
+        else:
+            routes = {{
+                MEMORIES_PREFIX: StoreBackend(
+                    namespace=_make_namespace_factory(assistant_id),
+                ),
+                SKILLS_PREFIX: StoreBackend(
+                    namespace=_make_namespace_factory(assistant_id),
+                ),
+            }}
+            if HAS_USER_MEMORIES:
+                routes[USER_PREFIX] = StoreBackend(
+                    namespace=_make_user_namespace_factory(assistant_id),
+                )
 
-        # Add subagent store routes for seeded sync subagents.
-        seed = _load_seed()
-        for sa_name in seed.get("subagents", {{}}):
-            sa_prefix = f"{{MEMORIES_PREFIX}}subagents/{{sa_name}}/"
-            routes[sa_prefix] = StoreBackend(
-                namespace=_make_namespace_factory(assistant_id, "subagents", sa_name),
-            )
+            # Subagent store routes only apply in store mode. In hub mode,
+            # subagent content lives under /memories/subagents/... in the
+            # agent's hub repo and is reached via the single /memories/ mount.
+            seed = _load_seed()
+            for sa_name in seed.get("subagents", {{}}):
+                sa_prefix = f"{{MEMORIES_PREFIX}}subagents/{{sa_name}}/"
+                routes[sa_prefix] = StoreBackend(
+                    namespace=_make_namespace_factory(
+                        assistant_id, "subagents", sa_name
+                    ),
+                )
 
         return CompositeBackend(
             default=sandbox_backend,
@@ -830,10 +934,6 @@ async def make_graph(config: RunnableConfig, runtime: "ServerRuntime"):
             "(runtime.user.identity is empty). User memory features "
             "will be skipped for this invocation."
         )
-    if store is not None:
-        await _seed_store_if_needed(store, assistant_id)
-        if HAS_USER_MEMORIES and user_id:
-            await _seed_user_memories_if_needed(store, assistant_id, user_id)
 
     tools: list = []
     {mcp_tools_load_call}
@@ -842,7 +942,18 @@ async def make_graph(config: RunnableConfig, runtime: "ServerRuntime"):
     all_subagents: list = []
     {sync_subagents_load_call}
 
-    backend_factory = _build_backend_factory(assistant_id)
+    backend_factory = _build_backend_factory(assistant_id, user_id)
+
+    if MEMORIES_BACKEND == "hub":
+        # Seed via the composite so writes land in the hub repo(s).
+        _seed_backend = backend_factory(None)
+        await _seed_hub_if_needed(_seed_backend, assistant_id)
+        if HAS_USER_MEMORIES and user_id:
+            await _seed_user_hub_if_needed(_seed_backend, assistant_id, user_id)
+    elif store is not None:
+        await _seed_store_if_needed(store, assistant_id)
+        if HAS_USER_MEMORIES and user_id:
+            await _seed_user_memories_if_needed(store, assistant_id, user_id)
 
     # Preload AGENTS.md + user memory into the agent's context.
     memory_sources = [f"{{MEMORIES_PREFIX}}AGENTS.md"]

--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -756,46 +756,72 @@ async def _seed_user_memories_if_needed(
     )
 
 
-async def _write_if_missing(backend, path: str, content: str) -> None:
-    """Write ``content`` to ``path`` only when the file does not exist yet."""
-    existing = await backend.aread(path)
-    if existing.error is None:
-        return
-    result = await backend.awrite(path, content)
-    if result.error is not None:
-        logger.warning("Hub seed write failed for %s: %s", path, result.error)
+def _hub_route_or_none(backend, prefix: str):
+    """Return the ContextHubBackend behind ``prefix`` on the composite, or None."""
+    routes = getattr(backend, "routes", None)
+    if routes is None:
+        return None
+    return routes.get(prefix)
+
+
+def _log_seed_errors(responses, scope: str) -> None:
+    """Surface upload errors at warn level; the deploy continues either way."""
+    failures = [r for r in responses if r.error is not None]
+    if failures:
+        logger.warning(
+            "Hub seed had %d failed file(s) in %s: %s",
+            len(failures),
+            scope,
+            [(r.path, r.error) for r in failures],
+        )
 
 
 async def _seed_hub_if_needed(backend, assistant_id: str) -> None:
-    """Seed AGENTS.md, skills, and subagent content into the hub repo."""
+    """Seed the agent hub repo on first deploy as a single multi-file commit.
+
+    Skips entirely once the repo has any prior commits, so user edits/deletes
+    in the LangSmith UI are never silently undone on redeploy or restart.
+    """
     if assistant_id in _SEEDED_HUB_ASSISTANTS:
         return
     _SEEDED_HUB_ASSISTANTS.add(assistant_id)
 
-    seed = _load_seed()
+    hub = _hub_route_or_none(backend, MEMORIES_PREFIX)
+    if hub is not None and hub.has_prior_commits():
+        return
 
+    seed = _load_seed()
+    batch: list[tuple[str, bytes]] = []
     for path, content in seed.get("memories", {{}}).items():
         full_path = f"{{MEMORIES_PREFIX}}{{path.lstrip('/')}}"
-        await _write_if_missing(backend, full_path, content)
+        batch.append((full_path, content.encode("utf-8")))
     for path, content in seed.get("skills", {{}}).items():
         full_path = f"{{SKILLS_PREFIX}}{{path.lstrip('/')}}"
-        await _write_if_missing(backend, full_path, content)
-
+        batch.append((full_path, content.encode("utf-8")))
     for sa_name, sa_data in seed.get("subagents", {{}}).items():
         sa_prefix = f"{{MEMORIES_PREFIX}}subagents/{{sa_name}}/"
         for path, content in sa_data.get("memories", {{}}).items():
             full_path = f"{{sa_prefix}}{{path.lstrip('/')}}"
-            await _write_if_missing(backend, full_path, content)
+            batch.append((full_path, content.encode("utf-8")))
         for path, content in sa_data.get("skills", {{}}).items():
-            await _write_if_missing(
-                backend, f"{{sa_prefix}}skills/{{path.lstrip('/')}}", content
-            )
+            full_path = f"{{sa_prefix}}skills/{{path.lstrip('/')}}"
+            batch.append((full_path, content.encode("utf-8")))
+
+    if not batch:
+        return
+    responses = await backend.aupload_files(batch)
+    _log_seed_errors(responses, scope=f"agent={{assistant_id}}")
 
 
 async def _seed_user_hub_if_needed(
     backend, assistant_id: str, user_id: str,
 ) -> None:
-    """Seed user memory templates into the per-user hub repo."""
+    """Seed user memory templates into the per-user hub repo on first use.
+
+    Same first-deploy gate as :func:`_seed_hub_if_needed`: once the user's
+    repo has any commits, subsequent invocations skip seeding so the user's
+    own changes (including deletes) survive across runs.
+    """
     key = (assistant_id, user_id)
     if key in _SEEDED_HUB_USERS:
         return
@@ -806,10 +832,16 @@ async def _seed_user_hub_if_needed(
     if not user_memories:
         return
 
-    for path, content in user_memories.items():
-        await _write_if_missing(
-            backend, f"{{USER_PREFIX}}{{path.lstrip('/')}}", content
-        )
+    user_hub = _hub_route_or_none(backend, USER_PREFIX)
+    if user_hub is not None and user_hub.has_prior_commits():
+        return
+
+    batch = [
+        (f"{{USER_PREFIX}}{{path.lstrip('/')}}", content.encode("utf-8"))
+        for path, content in user_memories.items()
+    ]
+    responses = await backend.aupload_files(batch)
+    _log_seed_errors(responses, scope=f"user={{user_id}}")
     logger.info(
         "Seeded %d user memory template(s) into hub for user %s",
         len(user_memories),

--- a/libs/cli/tests/integration_tests/test_deploy_hub.py
+++ b/libs/cli/tests/integration_tests/test_deploy_hub.py
@@ -1,0 +1,163 @@
+"""Integration tests for the hub-backed `deepagents deploy` bundle.
+
+These tests scaffold a tiny project, bundle it with
+``[memories].backend = "hub"``, load the vendored ContextHubBackend from
+the bundle directory, and exercise the seed flow against a real LangSmith
+Hub. Each test provisions a unique throwaway agent repo and deletes it on
+teardown so the suite is safe to run against a real tenant.
+
+Skipped unless ``LANGSMITH_API_KEY`` is set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import logging
+import os
+import sys
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_cli.deploy.bundler import bundle
+from deepagents_cli.deploy.config import (
+    AGENTS_MD_FILENAME,
+    SKILLS_DIRNAME,
+    AgentConfig,
+    DeployConfig,
+    MemoriesConfig,
+)
+
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Iterator
+    from pathlib import Path
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("LANGSMITH_API_KEY"),
+    reason="LANGSMITH_API_KEY not set; skipping hub deploy integration tests.",
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def hub_identifier() -> Iterator[str]:
+    """Unique throwaway agent-repo handle; deleted on teardown."""
+    ident = f"-/deepagents-deploy-test-{uuid.uuid4().hex[:12]}"
+    yield ident
+
+    try:
+        from langsmith import Client
+
+        Client().delete_agent(ident)
+    except Exception:
+        logger.warning("Failed to delete test repo %r", ident, exc_info=True)
+
+
+def _scaffold_project(project: Path) -> None:
+    """Drop a minimal AGENTS.md + one skill into *project*."""
+    project.mkdir(parents=True, exist_ok=True)
+    (project / AGENTS_MD_FILENAME).write_text(
+        "# Deploy hub integration test\n\nThis agent exists to validate "
+        "the hub-backed bundle.\n",
+        encoding="utf-8",
+    )
+    skill_dir = project / SKILLS_DIRNAME / "echo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: echo\ndescription: Echo the user input.\n---\n"
+        "# Echo\n\nReturn the user input verbatim.\n",
+        encoding="utf-8",
+    )
+
+
+def _load_vendored_hub_backend(build_dir: Path) -> types.ModuleType:
+    """Import the bundle's vendored ContextHubBackend module."""
+    sys.path.insert(0, str(build_dir))
+    try:
+        # Fresh import so we pick up the copy in this specific build dir.
+        if "_context_hub" in sys.modules:
+            del sys.modules["_context_hub"]
+        return importlib.import_module("_context_hub")
+    finally:
+        sys.path.remove(str(build_dir))
+
+
+def test_hub_bundle_seeds_through_composite(
+    tmp_path: Path, hub_identifier: str
+) -> None:
+    """End-to-end: bundle a hub-backed project and seed it into a real repo."""
+    from deepagents.backends.composite import CompositeBackend
+    from deepagents.backends.state import StateBackend
+    from langsmith import Client
+
+    project = tmp_path / "project"
+    _scaffold_project(project)
+
+    build = tmp_path / "build"
+    config = DeployConfig(
+        agent=AgentConfig(name="deploy-hub-test"),
+        memories=MemoriesConfig(backend="hub", identifier=hub_identifier),
+    )
+    bundle(config, project, build)
+
+    # Bundle-level assertions: the vendored module and the hub wiring land.
+    assert (build / "_context_hub.py").exists()
+    graph_src = (build / "deploy_graph.py").read_text(encoding="utf-8")
+    assert f"MEMORIES_HUB_IDENTIFIER = '{hub_identifier}'" in graph_src
+    assert "from _context_hub import ContextHubBackend" in graph_src
+
+    # Build a composite matching the one the generated graph builds, and
+    # exercise the seed path end-to-end against a real hub.
+    ctx_hub_mod = _load_vendored_hub_backend(build)
+    hub_backend = ctx_hub_mod.ContextHubBackend(identifier=hub_identifier)
+    composite = CompositeBackend(
+        default=StateBackend(),
+        routes={"/memories/": hub_backend},
+    )
+    seed = json.loads((build / "_seed.json").read_text(encoding="utf-8"))
+
+    async def _run() -> None:
+        for path, content in seed.get("memories", {}).items():
+            result = await composite.awrite(f"/memories/{path.lstrip('/')}", content)
+            assert result.error is None, result.error
+        for path, content in seed.get("skills", {}).items():
+            result = await composite.awrite(
+                f"/memories/skills/{path.lstrip('/')}", content
+            )
+            assert result.error is None, result.error
+
+    asyncio.run(_run())
+
+    # Fresh client pull verifies writes reached the hub (not just cache).
+    pulled = Client().pull_agent(hub_identifier)
+    pulled_paths = set(pulled.files.keys())
+    assert "AGENTS.md" in pulled_paths
+    assert "skills/echo/SKILL.md" in pulled_paths
+
+    # Reads through a brand-new backend should round-trip the seeded content.
+    fresh_backend = ctx_hub_mod.ContextHubBackend(identifier=hub_identifier)
+    read = fresh_backend.read("/AGENTS.md")
+    assert read.error is None
+    assert read.file_data is not None
+    assert "Deploy hub integration test" in read.file_data["content"]
+
+
+def test_store_bundle_omits_vendored_hub(tmp_path: Path) -> None:
+    """Regression: default store mode must not ship the hub module."""
+    project = tmp_path / "project"
+    _scaffold_project(project)
+    build = tmp_path / "build"
+    bundle(
+        DeployConfig(agent=AgentConfig(name="store-only")),
+        project,
+        build,
+    )
+    # The vendored module is only shipped in hub mode.
+    assert not (build / "_context_hub.py").exists()
+    graph_src = (build / "deploy_graph.py").read_text(encoding="utf-8")
+    assert "MEMORIES_BACKEND = 'store'" in graph_src

--- a/libs/cli/tests/unit_tests/deploy/test_bundler.py
+++ b/libs/cli/tests/unit_tests/deploy/test_bundler.py
@@ -26,6 +26,7 @@ from deepagents_cli.deploy.config import (
     AgentConfig,
     AuthConfig,
     DeployConfig,
+    MemoriesConfig,
     SandboxConfig,
 )
 
@@ -307,6 +308,29 @@ class TestRenderDeployGraph:
         assert "AGENTS.md" in result
         assert 'mode="deny"' in result
 
+    def test_default_memories_backend_is_store(self) -> None:
+        result = _render_deploy_graph(_minimal_config(), mcp_present=False)
+        assert "MEMORIES_BACKEND = 'store'" in result
+
+    def test_hub_backend_wires_context_hub_route(self) -> None:
+        config = DeployConfig(
+            agent=AgentConfig(name="hubtest"),
+            memories=MemoriesConfig(backend="hub"),
+        )
+        result = _render_deploy_graph(config, mcp_present=False)
+        assert "MEMORIES_BACKEND = 'hub'" in result
+        assert "MEMORIES_HUB_IDENTIFIER = '-/hubtest'" in result
+        assert "from _context_hub import ContextHubBackend" in result
+        assert "_seed_hub_if_needed" in result
+
+    def test_hub_backend_honors_identifier_override(self) -> None:
+        config = DeployConfig(
+            agent=AgentConfig(name="hubtest"),
+            memories=MemoriesConfig(backend="hub", identifier="org-ns/custom"),
+        )
+        result = _render_deploy_graph(config, mcp_present=False)
+        assert "MEMORIES_HUB_IDENTIFIER = 'org-ns/custom'" in result
+
 
 class TestBundle:
     def test_produces_expected_files(self, tmp_path: Path) -> None:
@@ -355,6 +379,40 @@ class TestBundle:
         )
         with pytest.raises(ValueError, match="Unknown sandbox provider"):
             bundle(config, project, build)
+
+    def test_hub_bundle_vendors_context_hub(self, tmp_path: Path) -> None:
+        project = _minimal_project(tmp_path / "project")
+        build = tmp_path / "build"
+        config = DeployConfig(
+            agent=AgentConfig(name="hubtest"),
+            memories=MemoriesConfig(backend="hub"),
+        )
+        bundle(config, project, build)
+        vendored = build / "_context_hub.py"
+        assert vendored.exists()
+        # The vendored file must contain the class the graph imports.
+        assert "class ContextHubBackend" in vendored.read_text(encoding="utf-8")
+        # Generated graph should syntactically compile.
+        graph_py = (build / "deploy_graph.py").read_text(encoding="utf-8")
+        compile(graph_py, "<hub_deploy_graph>", "exec")
+
+    def test_store_bundle_does_not_vendor_context_hub(self, tmp_path: Path) -> None:
+        project = _minimal_project(tmp_path / "project")
+        build = tmp_path / "build"
+        config = _minimal_config()
+        bundle(config, project, build)
+        assert not (build / "_context_hub.py").exists()
+
+    def test_hub_bundle_adds_langsmith_dep(self, tmp_path: Path) -> None:
+        project = _minimal_project(tmp_path / "project")
+        build = tmp_path / "build"
+        config = DeployConfig(
+            agent=AgentConfig(name="hubtest"),
+            memories=MemoriesConfig(backend="hub"),
+        )
+        bundle(config, project, build)
+        pyproject = (build / "pyproject.toml").read_text(encoding="utf-8")
+        assert "langsmith>=0.7.35" in pyproject
 
     def test_bundle_with_subagents(self, tmp_path: Path) -> None:
         """Full bundle with sync subagents produces valid artifacts."""

--- a/libs/cli/tests/unit_tests/deploy/test_config.py
+++ b/libs/cli/tests/unit_tests/deploy/test_config.py
@@ -14,15 +14,18 @@ from deepagents_cli.deploy.config import (
     SKILLS_DIRNAME,
     SUBAGENTS_DIRNAME,
     VALID_AUTH_PROVIDERS,
+    VALID_MEMORIES_BACKENDS,
     VALID_SANDBOX_PROVIDERS,
     AgentConfig,
     AuthConfig,
     DeployConfig,
+    MemoriesConfig,
     SandboxConfig,
     SubAgentConfig,
     SubAgentProject,
     _parse_config,
     _validate_auth_credentials,
+    _validate_hub_credentials,
     _validate_mcp_for_deploy,
     _validate_model_credentials,
     _validate_sandbox_credentials,
@@ -121,6 +124,31 @@ class TestAuthConfig:
 
 
 # ---------------------------------------------------------------------------
+# MemoriesConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMemoriesConfig:
+    def test_defaults(self) -> None:
+        cfg = MemoriesConfig()
+        assert cfg.backend == "store"
+        assert cfg.identifier == ""
+
+    def test_hub_backend(self) -> None:
+        cfg = MemoriesConfig(backend="hub", identifier="-/my-agent")
+        assert cfg.backend == "hub"
+        assert cfg.identifier == "-/my-agent"
+
+    def test_frozen(self) -> None:
+        cfg = MemoriesConfig()
+        with pytest.raises(AttributeError):
+            cfg.backend = "hub"  # type: ignore[misc]
+
+    def test_valid_backends(self) -> None:
+        assert frozenset({"store", "hub"}) == VALID_MEMORIES_BACKENDS
+
+
+# ---------------------------------------------------------------------------
 # DeployConfig
 # ---------------------------------------------------------------------------
 
@@ -169,6 +197,32 @@ class TestDeployConfig:
         )
         errors = cfg.validate(tmp_path)
         assert any("SUPABASE_URL" in e for e in errors)
+
+    def test_validate_hub_missing_langsmith_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# Agent", encoding="utf-8")
+        monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+        monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+        cfg = DeployConfig(
+            agent=AgentConfig(name="x"),
+            memories=MemoriesConfig(backend="hub"),
+        )
+        errors = cfg.validate(tmp_path)
+        assert any("LANGSMITH_API_KEY" in e for e in errors)
+
+    def test_validate_hub_with_langchain_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# Agent", encoding="utf-8")
+        monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+        monkeypatch.setenv("LANGCHAIN_API_KEY", "anything")
+        cfg = DeployConfig(
+            agent=AgentConfig(name="x"),
+            memories=MemoriesConfig(backend="hub"),
+        )
+        errors = cfg.validate(tmp_path)
+        assert not any("LANGSMITH_API_KEY" in e for e in errors)
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +318,46 @@ class TestParseConfig:
         with pytest.raises(ValueError, match=r"Unknown key.*\[auth\]"):
             _parse_config(
                 {"agent": {"name": "x"}, "auth": {"provider": "supabase", "extra": 1}}
+            )
+
+    def test_memories_section_optional(self) -> None:
+        cfg = _parse_config({"agent": {"name": "x"}})
+        assert cfg.memories == MemoriesConfig()
+
+    def test_memories_section_parsed(self) -> None:
+        data = {
+            "agent": {"name": "x"},
+            "memories": {"backend": "hub", "identifier": "-/my-agent"},
+        }
+        cfg = _parse_config(data)
+        assert cfg.memories.backend == "hub"
+        assert cfg.memories.identifier == "-/my-agent"
+
+    def test_memories_backend_only(self) -> None:
+        cfg = _parse_config({"agent": {"name": "x"}, "memories": {"backend": "hub"}})
+        assert cfg.memories.backend == "hub"
+        assert cfg.memories.identifier == ""
+
+    def test_memories_invalid_backend_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown memories backend"):
+            _parse_config({"agent": {"name": "x"}, "memories": {"backend": "redis"}})
+
+    def test_memories_unknown_key_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"Unknown key.*\[memories\]"):
+            _parse_config(
+                {
+                    "agent": {"name": "x"},
+                    "memories": {"backend": "hub", "extra": 1},
+                }
+            )
+
+    def test_memories_identifier_without_slash_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"owner/name"):
+            _parse_config(
+                {
+                    "agent": {"name": "x"},
+                    "memories": {"backend": "hub", "identifier": "my-agent"},
+                }
             )
 
 


### PR DESCRIPTION
## Summary

- Stacks on #2923 — adds CLI wiring for the hub-backed `/memories/` route.
- New `[memories]` section in `deepagents.toml`: `backend = "store" | "hub"` (default `store`) + optional `identifier` override.
- Hub mode routes `/memories/` (and per-user `/memories/user/`) through `ContextHubBackend(identifier=f"-/{agent.name}")`, with per-user repos at `-/{agent.name}-user-{sanitized(user_id)}`.
- Seed helpers write through the composite backend so `AGENTS.md` + skills actually reach the hub repo (prior `store.aput` path bypassed hub routing).
- Bundler vendors `context_hub.py → _context_hub.py` and pins `langsmith>=0.7.35` only in hub mode, so the deployed bundle does not need `deepagents-cli` as a runtime dep.
- Unit tests for config parsing + both-mode bundle output, plus a committed integration test that bundles a hub project and round-trips seed writes against a real LangSmith Hub.

Slack thread addressed:
- Opt-in backend toggle ✅
- Per-user hub repo (Harrison's "just its own repo" call) ✅
- Skills-repos design (cc Brace) — correctly out of scope.

Not included in this PR (follow-up):
- `/scratchpad` routing per the Context-Hub-x-DAD design doc (adds a `/scratchpad → StateBackend` route and differentiates per-agent vs per-thread sandbox modes).
- Flipping the default from `store` to `hub`.

## Test plan

- [x] `make test TEST_FILE=tests/unit_tests/deploy/` — 204 passing
- [x] `make integration_test TEST_FILE=tests/integration_tests/test_deploy_hub.py` — 2 passing (scaffolds → bundles → seeds real hub)
- [x] Local E2E: `deepagents init` → edit toml to hub mode with ai-sdr AGENTS.md + skill → `deepagents dev` → agent reads via hub + writes persist (verified via `Client.pull_agent`)