### PR TITLE
fix(sdk): preserve image blocks in summarization archive

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -67,7 +67,7 @@ from langchain.agents.middleware.summarization import (
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
 from langchain.tools import ToolRuntime
 from langchain_core.exceptions import ContextOverflowError
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage, get_buffer_string
+from langchain_core.messages import AIMessage, AnyMessage, ChatMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.config import get_config
 from langgraph.types import Command
@@ -89,6 +89,81 @@ if TYPE_CHECKING:
     from deepagents.backends.protocol import BACKEND_TYPES, BackendProtocol
 
 logger = logging.getLogger(__name__)
+
+_ROLE_MAP = {
+    "human": "Human",
+    "ai": "AI",
+    "system": "System",
+    "tool": "Tool",
+    "function": "Function",
+}
+
+
+def _serialize_content_block(block: dict[str, Any]) -> str:
+    """Serialize a single multimodal content block for archival.
+
+    Args:
+        block: A content block dict from a message's `content` list.
+
+    Returns:
+        String representation of the block with image data preserved.
+    """
+    block_type = block.get("type", "")
+    if block_type == "text":
+        return block.get("text", "")
+    if block_type == "image_url":
+        url = block.get("image_url", {}).get("url", "")
+        return f"[image_url: {url}]"
+    if block_type == "image":
+        source_type = block.get("source_type", "")
+        if source_type == "base64":
+            mime = block.get("mime_type", "image/png")
+            data = block.get("data", "")
+            return f"[image/base64 mime={mime} data={data}]"
+        if source_type == "url":
+            return f"[image_url: {block.get('url', '')}]"
+        return f"[image: {block}]"
+    return str(block)
+
+
+def _serialize_messages_for_archive(messages: list[AnyMessage]) -> str:
+    """Serialize messages for archival, preserving image content blocks.
+
+    A multimodal-aware replacement for `get_buffer_string` used when offloading
+    messages to the backend. Unlike `get_buffer_string`, this function preserves
+    image blocks — both base64-encoded data and URL references — so they are
+    not silently dropped from the archival record.
+
+    Args:
+        messages: Messages to serialize.
+
+    Returns:
+        String representation of all messages with image content preserved.
+    """
+    parts: list[str] = []
+    for msg in messages:
+        role = msg.role if isinstance(msg, ChatMessage) else _ROLE_MAP.get(msg.type, msg.type.title())
+        content = msg.content
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = "".join(
+                str(block) if not isinstance(block, dict) else _serialize_content_block(block)
+                for block in content
+            )
+        else:
+            text = str(content)
+
+        message = f"{role}: {text}"
+
+        if isinstance(msg, AIMessage):
+            if msg.tool_calls:
+                message += str(msg.tool_calls)
+            elif "function_call" in msg.additional_kwargs:
+                message += str(msg.additional_kwargs["function_call"])
+
+        parts.append(message)
+    return "\n".join(parts)
 
 
 class CompactConversationSchema(BaseModel):
@@ -761,7 +836,7 @@ A condensed summary follows:
         filtered_messages = self._filter_summary_messages(messages)
 
         timestamp = datetime.now(UTC).isoformat()
-        new_section = f"## Summarized at {timestamp}\n\n{get_buffer_string(filtered_messages)}\n\n"
+        new_section = f"## Summarized at {timestamp}\n\n{_serialize_messages_for_archive(filtered_messages)}\n\n"
 
         # Read existing content (if any) and append.
         # Note: We use download_files() instead of read() because read() returns
@@ -835,7 +910,7 @@ A condensed summary follows:
         filtered_messages = self._filter_summary_messages(messages)
 
         timestamp = datetime.now(UTC).isoformat()
-        new_section = f"## Summarized at {timestamp}\n\n{get_buffer_string(filtered_messages)}\n\n"
+        new_section = f"## Summarized at {timestamp}\n\n{_serialize_messages_for_archive(filtered_messages)}\n\n"
 
         # Read existing content (if any) and append.
         # Note: We use adownload_files() instead of aread() because read() returns

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -13,7 +13,7 @@ from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 
 from deepagents.backends.protocol import BackendProtocol, EditResult, FileDownloadResponse, ReadResult, WriteResult
-from deepagents.middleware.summarization import SummarizationMiddleware
+from deepagents.middleware.summarization import SummarizationMiddleware, _serialize_messages_for_archive
 
 if TYPE_CHECKING:
     from langchain.agents.middleware.types import AgentState
@@ -582,6 +582,79 @@ class TestOffloadingBasic:
         # Check that the offloaded content doesn't include "Previous summary content"
         # (which is the content of the summary message added by include_previous_summary)
         assert "Previous summary content" not in content, "Previous summary message should be filtered from offload"
+
+    def test_offload_preserves_base64_image(self) -> None:
+        """Regression test: `get_buffer_string` silently dropped image blocks from the archive."""
+        image_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII="
+        backend = MockBackend()
+        mock_model = make_mock_model()
+
+        middleware = SummarizationMiddleware(
+            model=mock_model,
+            backend=backend,
+            trigger=("messages", 1),
+            keep=("messages", 1),
+        )
+
+        multimodal_msg = HumanMessage(
+            content=[
+                {"type": "text", "text": "What is in this diagram?"},
+                {
+                    "type": "image",
+                    "source_type": "base64",
+                    "mime_type": "image/png",
+                    "data": image_b64,
+                },
+            ]
+        )
+        messages = [multimodal_msg, HumanMessage(content="Recent message")]
+        state = cast("AgentState[Any]", {"messages": messages})
+        runtime = make_mock_runtime()
+
+        with mock_get_config():
+            call_wrap_model_call(middleware, state, runtime)
+
+        assert len(backend.write_calls) == 1
+        _, content = backend.write_calls[0]
+
+        assert image_b64 in content, "Base64 image data must be preserved in the archive"
+        assert "What is in this diagram?" in content
+
+
+class TestSerializeMessagesForArchive:
+    """Unit tests for the `_serialize_messages_for_archive` helper."""
+
+    def test_base64_image_preserved(self) -> None:
+        """Base64 image data and mime type are included verbatim in the output."""
+        image_b64 = "abc123=="
+        msg = HumanMessage(
+            content=[
+                {"type": "text", "text": "Look at this:"},
+                {
+                    "type": "image",
+                    "source_type": "base64",
+                    "mime_type": "image/jpeg",
+                    "data": image_b64,
+                },
+            ]
+        )
+        result = _serialize_messages_for_archive([msg])
+        assert "Look at this:" in result
+        assert image_b64 in result
+        assert "image/jpeg" in result
+
+    def test_image_url_preserved(self) -> None:
+        """image_url blocks include the URL in the output."""
+        url = "https://cdn.example.com/photo.jpg"
+        msg = HumanMessage(
+            content=[
+                {"type": "text", "text": "What is this?"},
+                {"type": "image_url", "image_url": {"url": url}},
+            ]
+        )
+        result = _serialize_messages_for_archive([msg])
+        assert "What is this?" in result
+        assert url in result
 
 
 class TestSummaryMessageFormat:


### PR DESCRIPTION
Fixes #2873

---

When messages containing images are swept into a summarization event, `get_buffer_string` silently drops all image content blocks before the archive is written to the backend. 

Replaces it with `_serialize_messages_for_archive`, which preserves base64 and `image_url` blocks while keeping the existing `Role: content` format for text and tool calls.

> I used AI assistance to help reproduce and review the fix.