### PR TITLE
fix(evals): don't mask pytest exit 1 when no tests ran

### DIFF
--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -345,7 +345,16 @@ def _collect_experiment_links() -> list[dict[str, str]]:
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     _ = exitstatus
-    if session.exitstatus == 1:
+    # Test failures alone shouldn't fail the CI step — aggregation/reporting
+    # steps need to run even when some evals regress. But if no tests ran, the
+    # session is either misconfigured (e.g. unknown `--eval-category` value) or
+    # crashed before collection; preserve the non-zero exit so the step fails
+    # loudly instead of silently producing an empty report. `_RESULTS["total"]`
+    # is incremented only on the `call` phase, so marked-skip runs (setup-only
+    # reports) also leave `total == 0` and are treated as "no tests ran".
+    # Non-1 exit codes (interrupt, internal error, usage error, no-tests-
+    # collected) are never rewritten.
+    if session.exitstatus == 1 and _RESULTS["total"] > 0:
         session.exitstatus = 0
 
     if not _EXPERIMENT_LINKS:

--- a/libs/evals/tests/unit_tests/test_pytest_reporter.py
+++ b/libs/evals/tests/unit_tests/test_pytest_reporter.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from _pytest.outcomes import Exit
 
 import tests.evals.pytest_reporter as reporter
+
+if TYPE_CHECKING:
+    from _pytest.mark.structures import Mark
 
 
 @dataclass
@@ -16,6 +24,20 @@ class _FakeReport:
     outcome: str
     duration: float
     longreprtext: str = ""
+
+
+@dataclass
+class _FakeSession:
+    """Minimal stand-in for `pytest.Session` for `sessionfinish` tests."""
+
+    exitstatus: int
+    config: Any = field(
+        default_factory=lambda: SimpleNamespace(
+            getoption=lambda *_args, **_kw: None,
+            _inicache={},
+            pluginmanager=SimpleNamespace(getplugin=lambda _name: None),
+        )
+    )
 
 
 class TestFailuresCapture:
@@ -123,3 +145,140 @@ class TestFailuresCapture:
         msg = reporter._FAILURES[0]["failure_message"]
         assert msg.endswith("... [truncated]")
         assert len(msg) < len(long_msg)
+
+
+class TestSessionExitStatus:
+    """Verify that pytest_sessionfinish preserves exit 1 when no tests ran."""
+
+    def setup_method(self):
+        reporter._FAILURES.clear()
+        reporter._RESULTS.update(passed=0, failed=0, skipped=0, total=0)
+        reporter._DURATIONS_S.clear()
+        reporter._EFFICIENCY_RESULTS.clear()
+        reporter._NODEID_TO_CATEGORY.clear()
+        reporter._CATEGORY_RESULTS.clear()
+        reporter._EXPERIMENT_LINKS.clear()
+
+    def test_exit_1_swallowed_when_tests_ran(self):
+        reporter._RESULTS.update(passed=2, failed=1, total=3)
+        session = _FakeSession(exitstatus=1)
+        reporter.pytest_sessionfinish(session, 1)  # type: ignore[arg-type]
+        assert session.exitstatus == 0
+
+    def test_exit_1_preserved_when_no_tests_ran(self):
+        session = _FakeSession(exitstatus=1)
+        reporter.pytest_sessionfinish(session, 1)  # type: ignore[arg-type]
+        assert session.exitstatus == 1
+
+    def test_exit_0_unchanged(self):
+        reporter._RESULTS.update(passed=3, total=3)
+        session = _FakeSession(exitstatus=0)
+        reporter.pytest_sessionfinish(session, 0)  # type: ignore[arg-type]
+        assert session.exitstatus == 0
+
+    def test_exit_1_preserved_when_only_marked_skips(self):
+        """Marked-skip tests (`@pytest.mark.skip`) emit only a `setup` phase
+        report — pytest_runtest_logreport returns early and total stays 0. If
+        an external exit 1 were to fire in this state, the reporter must not
+        mask it.
+        """
+        report = _FakeReport(
+            nodeid="tests/evals/test_x.py::test_y",
+            when="setup",
+            outcome="skipped",
+            duration=0.0,
+        )
+        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        assert reporter._RESULTS["total"] == 0
+
+        session = _FakeSession(exitstatus=1)
+        reporter.pytest_sessionfinish(session, 1)  # type: ignore[arg-type]
+        assert session.exitstatus == 1
+
+    @pytest.mark.parametrize("exitstatus", [2, 3, 4, 5])
+    def test_non_1_exitstatus_unchanged(self, exitstatus: int):
+        """Pytest exit codes 2 (interrupt), 3 (internal), 4 (usage), 5 (no
+        tests collected) must pass through regardless of whether tests ran.
+        """
+        reporter._RESULTS.update(passed=3, total=3)
+        session = _FakeSession(exitstatus=exitstatus)
+        reporter.pytest_sessionfinish(session, exitstatus)  # type: ignore[arg-type]
+        assert session.exitstatus == exitstatus
+
+
+class _FakeItem:
+    """Minimal stand-in for `pytest.Item` carrying a single `eval_category` mark."""
+
+    def __init__(self, category: str) -> None:
+        self._mark = pytest.mark.eval_category(category).mark
+
+    def get_closest_marker(self, name: str) -> Mark | None:
+        return self._mark if self._mark.name == name else None
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnknownMarkWarning")
+class TestFilterByMarker:
+    """Integration check: unknown `--eval-category` values call `pytest.exit`.
+
+    Pairs with TestSessionExitStatus to cover the full failure path — the
+    filter raises `Exit(returncode=1)`, and the reporter preserves it.
+    The `eval_category` mark is registered in the eval conftest, not here.
+    """
+
+    @staticmethod
+    def _make_config(values: list[str]) -> SimpleNamespace:
+        deselected: list[object] = []
+        return SimpleNamespace(
+            getoption=lambda _option: values,
+            hook=SimpleNamespace(pytest_deselected=lambda items: deselected.extend(items)),
+        )
+
+    def test_unknown_value_exits_with_code_1(self):
+        from tests.evals.conftest import _filter_by_marker
+
+        items = [_FakeItem("valid_cat")]
+        config = self._make_config(["unknown_cat"])
+
+        with pytest.raises(Exit) as exc_info:
+            _filter_by_marker(
+                config,  # ty: ignore[invalid-argument-type]
+                items,  # ty: ignore[invalid-argument-type]
+                option="--eval-category",
+                marker_name="eval_category",
+            )
+
+        assert exc_info.value.returncode == 1
+        msg = str(exc_info.value)
+        assert "unknown_cat" in msg
+        assert "valid_cat" in msg
+
+    def test_known_value_does_not_exit(self):
+        from tests.evals.conftest import _filter_by_marker
+
+        items = [_FakeItem("valid_cat"), _FakeItem("other_cat")]
+        config = self._make_config(["valid_cat"])
+
+        _filter_by_marker(
+            config,  # ty: ignore[invalid-argument-type]
+            items,  # ty: ignore[invalid-argument-type]
+            option="--eval-category",
+            marker_name="eval_category",
+        )
+        assert len(items) == 1
+        mark = items[0].get_closest_marker("eval_category")
+        assert mark is not None
+        assert mark.args == ("valid_cat",)
+
+    def test_empty_option_is_noop(self):
+        from tests.evals.conftest import _filter_by_marker
+
+        items = [_FakeItem("valid_cat")]
+        config = self._make_config([])
+
+        _filter_by_marker(
+            config,  # ty: ignore[invalid-argument-type]
+            items,  # ty: ignore[invalid-argument-type]
+            option="--eval-category",
+            marker_name="eval_category",
+        )
+        assert len(items) == 1


### PR DESCRIPTION
Stop the evals CI step from silently passing when pytest aborts with no tests run. The reporter's `pytest_sessionfinish` unconditionally rewrote `session.exitstatus == 1 -> 0` so aggregation steps could run after ordinary test failures — but that also masked `pytest.exit(returncode=1)` fired from `conftest.py`, e.g. when an invalid `--eval-category` value (`file_operation` vs `file_operations`) made it into a workflow dispatch.