### PR TITLE
feat(cli): hint `Enter` behavior in `/model` empty state

### DIFF
--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -471,8 +471,29 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._option_widgets = []
 
         if not self._filtered_models:
-            msg = "Loading models…" if not self._loaded else "No matching models"
-            await self._options_container.mount(Static(Content.styled(msg, "dim")))
+            if not self._loaded:
+                empty_content: Content = Content.styled("Loading models…", "dim")
+            else:
+                typed = self._filter_text.strip()
+                if typed and ":" in typed:
+                    empty_content = Content.assemble(
+                        ("No matching models — press ", "dim"),
+                        ("Enter", "bold"),
+                        (" to use ", "dim"),
+                        (typed, "bold"),
+                        (" as a custom provider:model spec", "dim"),
+                    )
+                elif typed:
+                    empty_content = Content.assemble(
+                        ("No matching models — press ", "dim"),
+                        ("Enter", "bold"),
+                        (" to use ", "dim"),
+                        (typed, "bold"),
+                        (" as a custom model spec (no provider prefix)", "dim"),
+                    )
+                else:
+                    empty_content = Content.styled("No matching models", "dim")
+            await self._options_container.mount(Static(empty_content))
             self._update_footer()
             return
 


### PR DESCRIPTION
Expand the `/model` selector's empty-state so users discover that pressing Enter submits their typed text as a custom model spec. The previous bare `"No matching models"` gave no clue that the filter box doubles as a free-form input, which mirrored `action_select()`'s fallback path invisibly.

## Changes
- Replace the single empty-state string in `ModelSelectorScreen._update_display` with three branches keyed off `self._filter_text`: `provider:model` input shows `"press Enter to use <typed> as a custom provider:model spec"`, non-colon input shows the `"(no provider prefix)"` variant, and empty filter keeps the original `"No matching models"`
- Render the hint via `Content.assemble` with `(text, style)` tuples so user-supplied filter text is treated as plain — avoids markup parsing on brackets or `$` characters per the CLI's `Content` conventions
- Loading branch (`Loading models…`) and the behavior of `action_select()` itself are unchanged; the new copy mirrors its existing fallback routing
