### PR TITLE
feat(sdk): tool aliasing

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -29,6 +29,7 @@ from deepagents._models import get_model_identifier, get_model_provider, resolve
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
+from deepagents.middleware._tool_aliasing import _ToolAliasingMiddleware
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -584,7 +585,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 non-Anthropic models)
             - `MemoryMiddleware` (if `memory` is provided)
             - `HumanInTheLoopMiddleware` (if `interrupt_on` is provided)
-            - `_PermissionMiddleware` (if permission rules are present, always last)
+            - `_PermissionMiddleware` (if permission rules are present, last
+                name-aware middleware so its rules match canonical tool names)
+            - `_ToolAliasingMiddleware` (if profile has `tool_aliases`,
+                innermost so tool name translation happens only at the model
+                boundary)
 
             After assembly, any entries in the profile's
             `excluded_middleware` are filtered from the final stack. Class
@@ -648,8 +653,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             Subagents inherit these rules unless they specify their own
             `permissions` field, which replaces the parent's rules entirely.
 
-            `_PermissionMiddleware` is appended last in the stack so it sees
-            all tools (including those injected by other middleware).
+            `_PermissionMiddleware` is the last name-aware middleware in the
+            stack so it sees the full tool set with canonical names. If the
+            active harness profile defines `tool_aliases`, the
+            name-translating middleware is appended after it as the
+            innermost transform.
         backend: Optional backend for file storage and execution.
 
             Pass a `Backend` instance (e.g. `StateBackend()`).
@@ -792,6 +800,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
             if subagent_permissions:
                 subagent_middleware.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
+            # Aliasing is the innermost name-aware middleware: keeps every
+            # other layer on canonical names while the model sees its
+            # trained vocabulary.
+            if _subagent_profile.tool_aliases:
+                subagent_middleware.append(_ToolAliasingMiddleware(aliases=dict(_subagent_profile.tool_aliases)))
 
             _subagent_matched_classes: set[type[AgentMiddleware[Any, Any, Any]]] = set()
             _subagent_matched_names: set[str] = set()
@@ -852,9 +865,13 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # Prompt caching is unconditional: "ignore" silently skips non-Anthropic models
         gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
-        # Permissions must be last so they see all tools from prior middleware
+        # Permissions is the last name-aware middleware so its rules match
+        # canonical tool names; aliasing is appended after it to translate
+        # names canonical <-> alias only at the model boundary.
         if permissions:
             gp_middleware.append(_PermissionMiddleware(rules=permissions, backend=backend))
+        if _profile.tool_aliases:
+            gp_middleware.append(_ToolAliasingMiddleware(aliases=dict(_profile.tool_aliases)))
 
         gp_middleware = _apply_excluded_middleware(
             gp_middleware,
@@ -932,9 +949,16 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         )
     if interrupt_on is not None:
         deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
-    # _PermissionMiddleware must be last so it sees all tools from prior middleware
+    # `_PermissionMiddleware` is the last name-aware middleware: it sees the
+    # full tool set with canonical names so user-supplied permission rules
+    # (keyed on canonical names) match. Aliasing is appended after it as the
+    # innermost transform, renaming canonical -> alias on the way out and
+    # alias -> canonical on the way back, so the model sees its trained
+    # vocabulary while every other middleware stays on canonical names.
     if permissions:
         deepagent_middleware.append(_PermissionMiddleware(rules=permissions, backend=backend))
+    if _profile.tool_aliases:
+        deepagent_middleware.append(_ToolAliasingMiddleware(aliases=dict(_profile.tool_aliases)))
 
     deepagent_middleware = _apply_excluded_middleware(
         deepagent_middleware,

--- a/libs/deepagents/deepagents/middleware/_tool_aliasing.py
+++ b/libs/deepagents/deepagents/middleware/_tool_aliasing.py
@@ -1,0 +1,360 @@
+"""Middleware for renaming tools at the model boundary.
+
+Translates tool names at the model boundary so the model sees its
+training vocabulary while the rest of the Deep Agents stack (routing,
+permissions, HITL, logging, tests) stays on canonical names.
+
+## Outbound (canonical -> alias)
+
+Rewrites, in order:
+
+1. `request.tools` — the current tool catalog (`execute` -> `shell_command`).
+2. `AIMessage.tool_calls` and `AIMessage.invalid_tool_calls` in
+    `request.messages` — past tool calls in conversation history.
+3. `ToolMessage.name` in `request.messages` — tool result messages from
+    prior turns.
+
+Steps 2 and 3 are what give the model a consistent vocabulary across
+turns. If only the tool catalog were renamed and history left on
+canonical names, the model would see an unfamiliar name for the tool it
+supposedly called last turn — the very distribution mismatch this
+middleware exists to avoid.
+
+## Inbound (alias -> canonical)
+
+Rewrites tool-call names on the response (`AIMessage` directly,
+`ModelResponse.result`, or `ExtendedModelResponse.model_response.result`)
+so downstream tool routing and state persistence only ever observe
+canonical names.
+
+## Positioning
+
+This middleware MUST be the innermost name-aware entry in the stack —
+placed after every other name-aware middleware (tool exclusion, HITL,
+permissions). Any entry before aliasing sees canonical names, which
+matches the names users specify in tool exclusion, HITL `interrupt_on`
+rules, and permission configs. Any entry after aliasing must be
+name-agnostic (e.g. `AnthropicPromptCachingMiddleware` adds only
+positional cache markers and is unaffected by rename order).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, cast
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+
+from deepagents.middleware._tool_exclusion import _tool_name
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Mapping
+
+    from langchain.agents.middleware.types import (
+        ExtendedModelResponse,
+        ModelRequest,
+        ModelResponse,
+        ResponseT,
+    )
+    from langchain_core.tools import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_tool_aliases(aliases: Mapping[str, str]) -> None:
+    """Validate that an alias map is safe to round-trip.
+
+    Two invariants are enforced:
+
+    1. **Injective values.** Two canonical names mapping to the same alias
+        would make the reverse map drop an entry, so a round-tripped tool
+        call could resolve to the wrong canonical tool.
+    2. **Disjoint keys and values.** A canonical name that also appears as
+        an alias for a different tool would make the model's catalog
+        contain a name that is simultaneously a canonical identifier
+        elsewhere in the system, rendering round-tripping ambiguous.
+
+    Args:
+        aliases: Mapping from canonical tool name to model-facing alias.
+
+    Raises:
+        TypeError: If `aliases` is not a mapping or contains non-string
+            keys or values.
+        ValueError: If either invariant is violated. Empty maps pass.
+    """
+    if not aliases:
+        return
+
+    for key, value in aliases.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            msg = f"`tool_aliases` keys and values must be strings, got {type(key).__name__} -> {type(value).__name__}"
+            raise TypeError(msg)
+        if not key or not value:
+            msg = f"`tool_aliases` keys and values must be non-empty strings, got {key!r} -> {value!r}"
+            raise ValueError(msg)
+
+    value_counts = Counter(aliases.values())
+    duplicates = sorted(v for v, count in value_counts.items() if count > 1)
+    if duplicates:
+        msg = (
+            "`tool_aliases` values must be unique so the reverse map is "
+            f"well-defined. Duplicate alias targets: {duplicates}. "
+            f"Aliases: {dict(aliases)}"
+        )
+        raise ValueError(msg)
+
+    collisions = sorted(set(aliases.keys()) & set(aliases.values()))
+    if collisions:
+        msg = (
+            "`tool_aliases` keys and values must be disjoint — a name cannot be "
+            "both a canonical tool and an alias for a different tool. "
+            f"Collisions: {collisions}. Aliases: {dict(aliases)}"
+        )
+        raise ValueError(msg)
+
+
+def _rename_tool(
+    tool: BaseTool | dict[str, Any] | object,
+    new_name: str,
+) -> BaseTool | dict[str, Any] | object:
+    """Return a copy of `tool` with its name replaced.
+
+    `BaseTool` instances are copied via `model_copy`; dict tools get a
+    shallow `dict.copy()`; other shapes (plain callables, unusual custom
+    tool classes without `model_copy`) cannot be renamed and are returned
+    unchanged with a warning — the model will see the tool under its
+    original name, which defeats the point of aliasing for that entry.
+    """
+    if isinstance(tool, dict):
+        copied = cast("dict[str, Any]", tool).copy()
+        copied["name"] = new_name
+        return copied
+    model_copy = getattr(tool, "model_copy", None)
+    if model_copy is not None:
+        return model_copy(update={"name": new_name})
+    logger.warning(
+        "Tool %r matched alias target %r but cannot be renamed (no "
+        "`model_copy` support and not a dict). Model will see the original "
+        "name; this may degrade performance on models trained on the alias.",
+        getattr(tool, "name", tool),
+        new_name,
+    )
+    return tool
+
+
+def _rewrite_ai_message_tool_calls(
+    message: AIMessage,
+    aliases: Mapping[str, str],
+) -> AIMessage:
+    """Rewrite tool-call names in `message` per `aliases`, returning a copy.
+
+    Returns `message` unchanged (same object identity) when no tool calls
+    match the alias map, so callers can use `is` to detect no-ops.
+    """
+    if not message.tool_calls and not message.invalid_tool_calls:
+        return message
+
+    changed = False
+    rewritten: list[dict[str, Any]] = []
+    for tc in message.tool_calls:
+        if tc["name"] in aliases:
+            rewritten.append({**tc, "name": aliases[tc["name"]]})
+            changed = True
+        else:
+            rewritten.append(cast("dict[str, Any]", tc))
+
+    rewritten_invalid: list[dict[str, Any]] = []
+    for tc in message.invalid_tool_calls:
+        if tc["name"] in aliases:
+            rewritten_invalid.append({**tc, "name": aliases[tc["name"]]})
+            changed = True
+        else:
+            rewritten_invalid.append(cast("dict[str, Any]", tc))
+
+    if not changed:
+        return message
+
+    return message.model_copy(
+        update={"tool_calls": rewritten, "invalid_tool_calls": rewritten_invalid},
+    )
+
+
+def _rewrite_tool_message_name(
+    message: ToolMessage,
+    aliases: Mapping[str, str],
+) -> ToolMessage:
+    """Rewrite `ToolMessage.name` per `aliases`, returning a copy.
+
+    Returns `message` unchanged (same object identity) when the name is
+    absent or not in the alias map.
+    """
+    name = message.name
+    if name is None or name not in aliases:
+        return message
+    return message.model_copy(update={"name": aliases[name]})
+
+
+def _rewrite_message_list(
+    messages: list[BaseMessage],
+    aliases: Mapping[str, str],
+) -> tuple[list[BaseMessage], bool]:
+    """Rewrite tool-related names across a list of messages.
+
+    Rewrites both `AIMessage.tool_calls` (and `invalid_tool_calls`) and
+    `ToolMessage.name` via `aliases`. Other message types pass through
+    unchanged.
+
+    Returns the (possibly new) list and whether any change was made. When
+    nothing changed the returned list still contains the original message
+    objects, so callers can skip `request.override` entirely on the
+    `changed=False` path.
+    """
+    changed = False
+    result: list[BaseMessage] = []
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            rewritten: BaseMessage = _rewrite_ai_message_tool_calls(msg, aliases)
+        elif isinstance(msg, ToolMessage):
+            rewritten = _rewrite_tool_message_name(msg, aliases)
+        else:
+            result.append(msg)
+            continue
+        if rewritten is not msg:
+            changed = True
+        result.append(rewritten)
+    return result, changed
+
+
+def _rewrite_response_tool_names(
+    response: object,
+    aliases: Mapping[str, str],
+) -> object:
+    """Rewrite tool-call names in a model response using `aliases`.
+
+    Handles:
+
+    - `AIMessage` directly (bare message response).
+    - `ModelResponse` (has `.result: list[BaseMessage]`).
+    - `ExtendedModelResponse` (wraps a `ModelResponse` in `.model_response`).
+
+    Other response shapes are returned unchanged.
+    """
+    if isinstance(response, AIMessage):
+        return _rewrite_ai_message_tool_calls(response, aliases)
+
+    result_msgs = getattr(response, "result", None)
+    if isinstance(result_msgs, list):
+        new_msgs, changed = _rewrite_message_list(result_msgs, aliases)
+        if changed:
+            return replace(cast("Any", response), result=new_msgs)
+        return response
+
+    inner = getattr(response, "model_response", None)
+    if inner is not None:
+        inner_msgs = getattr(inner, "result", None)
+        if isinstance(inner_msgs, list):
+            new_msgs, changed = _rewrite_message_list(inner_msgs, aliases)
+            if changed:
+                return replace(
+                    cast("Any", response),
+                    model_response=replace(cast("Any", inner), result=new_msgs),
+                )
+        return response
+
+    return response
+
+
+class _ToolAliasingMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Rename tools at the model boundary for better model-distribution fit.
+
+    Must be positioned as the innermost name-aware middleware in the
+    stack so that tool exclusion, HITL rules, and permission configs
+    keyed on canonical tool names continue to match. The translation is
+    symmetric: outbound, both the tool catalog and any past tool calls /
+    tool messages in `request.messages` are rewritten canonical -> alias;
+    inbound, tool-call names on the response are reverted alias ->
+    canonical.
+
+    Args:
+        aliases: Mapping of canonical tool name to model-facing alias
+            (e.g. `{"execute": "shell_command"}`).
+
+    Raises:
+        TypeError: If `aliases` contains non-string keys or values.
+        ValueError: If `aliases` has duplicate values or keys/values
+            overlap. See `_validate_tool_aliases`.
+    """
+
+    def __init__(self, *, aliases: Mapping[str, str]) -> None:
+        _validate_tool_aliases(aliases)
+        self._forward: dict[str, str] = dict(aliases)
+        self._reverse: dict[str, str] = {v: k for k, v in aliases.items()}
+
+    def _apply_outbound(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        """Translate tool catalog and message history canonical -> alias.
+
+        Returns the original request unchanged (same identity) when the
+        alias map is empty or no tool/message actually needed renaming,
+        so downstream cache keys keyed on request identity remain stable
+        when aliasing is a no-op.
+        """
+        if not self._forward:
+            return request
+
+        renamed_tools: list[Any] = []
+        tools_changed = False
+        for tool in request.tools:
+            name = _tool_name(tool)
+            if name is not None and name in self._forward:
+                renamed_tools.append(_rename_tool(tool, self._forward[name]))
+                tools_changed = True
+            else:
+                renamed_tools.append(tool)
+
+        new_messages, messages_changed = _rewrite_message_list(list(request.messages), self._forward)
+
+        if not tools_changed and not messages_changed:
+            return request
+
+        overrides: dict[str, Any] = {}
+        if tools_changed:
+            overrides["tools"] = renamed_tools
+        if messages_changed:
+            overrides["messages"] = new_messages
+        return request.override(**overrides)
+
+    def _apply_inbound(
+        self,
+        response: ModelResponse[Any] | AIMessage | ExtendedModelResponse[Any],
+    ) -> ModelResponse[Any] | AIMessage | ExtendedModelResponse[Any]:
+        """Translate response tool-call names alias -> canonical."""
+        if not self._reverse:
+            return response
+        return cast(
+            "ModelResponse[Any] | AIMessage | ExtendedModelResponse[Any]",
+            _rewrite_response_tool_names(response, self._reverse),
+        )
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Rename outbound request, revert inbound response tool-call names."""
+        response = handler(self._apply_outbound(request))
+        return cast("ModelResponse[Any]", self._apply_inbound(response))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
+        """Async variant of `wrap_model_call`."""
+        response = await handler(self._apply_outbound(request))
+        return cast(
+            "ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]",
+            self._apply_inbound(response),
+        )

--- a/libs/deepagents/deepagents/profiles/harness/_codex.py
+++ b/libs/deepagents/deepagents/profiles/harness/_codex.py
@@ -5,12 +5,17 @@ Registers a `HarnessProfile` for each OpenAI Codex model spec with:
 * a behavior-shaping `system_prompt_suffix` that aligns Deep Agents'
   runtime defaults with how Codex was trained to operate — autonomous
   senior engineer demeanor, bias to action, parallel tool use, and TODO
-  hygiene; and
+  hygiene;
 * a backend-aware `extra_middleware` factory that contributes an
   `_ApplyPatchMiddleware` so the agent can apply V4A diffs through the
   same filesystem backend `FilesystemMiddleware` uses. Codex models are
   trained to emit V4A `apply_patch` invocations; without the middleware
-  they underperform on file-editing tasks.
+  they underperform on file-editing tasks; and
+* `tool_aliases` that present Deep Agents' canonical tool names under
+  the names Codex was trained on (`shell_command`, `ls`). Aliasing is
+  applied by `_ToolAliasingMiddleware` as the innermost name-aware
+  transform, so routing, exclusion, HITL, and permissions all continue
+  to operate on canonical names.
 
 The suffix is appended to whatever `base_system_prompt` is ultimately
 assembled for the agent, so it layers cleanly on top of user- or
@@ -27,6 +32,7 @@ install-time metadata to activate.
 
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from deepagents.middleware._apply_patch import _ApplyPatchMiddleware
@@ -36,7 +42,7 @@ from deepagents.profiles.harness_profiles import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from langchain.agents.middleware.types import AgentMiddleware
 
@@ -95,6 +101,29 @@ follow-up work that introduces those capabilities to the harness.
 """
 
 
+_CODEX_TOOL_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "execute": "shell_command",
+        "list_dir": "ls",
+    }
+)
+"""Canonical Deep Agents tool name -> Codex-trained alias.
+
+Codex's training distribution heavily features `shell_command` (for shell
+execution) and `ls` (for directory listing). Presenting Deep Agents' more
+generic canonical names — `execute` and `list_dir` — to Codex measurably
+degrades tool-selection accuracy and per-call argument quality on those
+tools. The aliasing layer renames them at the model boundary only; every
+other layer of the runtime continues to use canonical names.
+
+The map is frozen via `MappingProxyType` to prevent accidental mutation
+through a shared reference after profile registration. New entries
+should only be added when there is concrete evidence (eval delta, OpenAI
+prompting guidance) that another canonical tool name diverges from
+Codex's trained vocabulary.
+"""
+
+
 def _apply_patch_factory(backend: BACKEND_TYPES) -> Sequence[AgentMiddleware[Any, Any, Any]]:
     """Contribute `_ApplyPatchMiddleware` bound to the agent's backend.
 
@@ -112,6 +141,7 @@ def register() -> None:
     """Register the built-in Codex harness profile for each Codex spec."""
     profile = HarnessProfile(
         system_prompt_suffix=_CODEX_SYSTEM_PROMPT_SUFFIX,
+        tool_aliases=_CODEX_TOOL_ALIASES,
         extra_middleware=_apply_patch_factory,
     )
     for spec in _CODEX_MODEL_SPECS:

--- a/libs/deepagents/deepagents/profiles/harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/harness_profiles.py
@@ -27,6 +27,7 @@ from importlib import import_module
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
 
+from deepagents.middleware._tool_aliasing import _validate_tool_aliases
 from deepagents.profiles._keys import validate_profile_key
 
 if TYPE_CHECKING:
@@ -213,6 +214,23 @@ class HarnessProfileConfig:
     `from_dict`.
     """
 
+    tool_aliases: Mapping[str, str] = field(default_factory=dict)
+    """Canonical -> model-facing tool name aliases.
+
+    Rewrites a tool's name between canonical Deep Agents identifiers and the
+    vocabulary a model was trained on (e.g. `{"execute": "shell_command"}`
+    for OpenAI Codex). The model sees aliased names on its tool catalog and
+    in conversation history; the rest of the Deep Agents stack — routing,
+    tool exclusion, HITL rules, permissions, tests — continues to use
+    canonical names.
+
+    Keys are canonical tool names; values are the names the model should
+    see. The map MUST be injective (unique values) and keys/values MUST be
+    disjoint so the alias table round-trips unambiguously. Violations raise
+    `ValueError` at construction. When two profiles merge (e.g. provider
+    plus exact-model), the combined map is re-validated.
+    """
+
     general_purpose_subagent: GeneralPurposeSubagentProfile | None = None
     """Edits for the auto-added `general-purpose` subagent."""
 
@@ -224,6 +242,13 @@ class HarnessProfileConfig:
                 "tool_description_overrides",
                 MappingProxyType(dict(self.tool_description_overrides)),
             )
+        if not isinstance(self.tool_aliases, MappingProxyType):
+            object.__setattr__(
+                self,
+                "tool_aliases",
+                MappingProxyType(dict(self.tool_aliases)),
+            )
+        _validate_tool_aliases(self.tool_aliases)
         for entry in self.excluded_middleware:
             _validate_config_middleware_string(entry, "excluded_middleware")
 
@@ -255,6 +280,11 @@ class HarnessProfileConfig:
             out["excluded_tools"] = sorted(self.excluded_tools)
         if self.excluded_middleware:
             out["excluded_middleware"] = sorted(self.excluded_middleware)
+        if self.tool_aliases:
+            out["tool_aliases"] = _coerce_str_mapping(
+                dict(self.tool_aliases),
+                "tool_aliases",
+            )
         if self.general_purpose_subagent is not None:
             # Emit the key even when the sub-profile has no fields set so
             # `from_dict(to_dict(c))` preserves the "explicit empty sub-profile"
@@ -295,6 +325,7 @@ class HarnessProfileConfig:
             tool_description_overrides=_coerce_str_mapping(data.get("tool_description_overrides"), "tool_description_overrides"),
             excluded_tools=_coerce_frozen_strset(data.get("excluded_tools"), "excluded_tools"),
             excluded_middleware=_coerce_frozen_strset(data.get("excluded_middleware"), "excluded_middleware"),
+            tool_aliases=_coerce_str_mapping(data.get("tool_aliases"), "tool_aliases"),
             general_purpose_subagent=_coerce_general_purpose_subagent(data.get("general_purpose_subagent")),
         )
 
@@ -320,6 +351,7 @@ class HarnessProfileConfig:
             tool_description_overrides=self.tool_description_overrides,
             excluded_tools=self.excluded_tools,
             excluded_middleware=frozenset(_resolve_config_excluded_middleware_entry(entry) for entry in self.excluded_middleware),
+            tool_aliases=self.tool_aliases,
             general_purpose_subagent=self.general_purpose_subagent,
         )
 
@@ -342,8 +374,8 @@ class HarnessProfileConfig:
                 non-empty `extra_middleware`, or if a class-form
                 `excluded_middleware` entry cannot be expressed as an import
                 ref.
-            TypeError: If `tool_description_overrides` contains a non-string
-                key or value.
+            TypeError: If `tool_description_overrides` or `tool_aliases`
+                contains a non-string key or value.
         """
         extra = profile.extra_middleware
         if callable(extra) or (isinstance(extra, tuple) and extra):
@@ -363,6 +395,10 @@ class HarnessProfileConfig:
             ),
             excluded_tools=profile.excluded_tools,
             excluded_middleware=frozenset(_serialize_runtime_excluded_middleware_entry(entry) for entry in profile.excluded_middleware),
+            tool_aliases=_coerce_str_mapping(
+                dict(profile.tool_aliases),
+                "tool_aliases",
+            ),
             general_purpose_subagent=profile.general_purpose_subagent,
         )
 
@@ -514,6 +550,29 @@ class HarnessProfile:
             rejected as likely typos or stale profiles.
     """
 
+    tool_aliases: Mapping[str, str] = field(default_factory=dict)
+    """Canonical -> model-facing tool name aliases.
+
+    Rewrites tool names between canonical Deep Agents identifiers and the
+    vocabulary a model was trained on (e.g. `{"execute": "shell_command"}`
+    for OpenAI Codex). Applied by a late-stack middleware positioned after
+    tool exclusion, HITL, and permissions so the model sees aliased names
+    on its tool catalog and in conversation history, while the rest of the
+    Deep Agents stack — routing, tool exclusion, HITL rules, permissions,
+    tests — continues to use canonical names.
+
+    Keys are canonical tool names; values are the names the model should
+    see. The map MUST be injective (unique values) and keys/values MUST be
+    disjoint so the alias table round-trips unambiguously. Violations raise
+    `ValueError` at construction. When two profiles merge (e.g. provider
+    plus exact-model), the combined map is re-validated.
+
+    Tools whose canonical name does not appear as a key pass through
+    unchanged. Tools whose internal shape cannot be copied (neither a dict
+    nor a Pydantic `BaseTool`-like with `model_copy`) are logged and
+    skipped; see `_ToolAliasingMiddleware` for details.
+    """
+
     extra_middleware: _MiddlewareSpec = ()
     """Middleware appended to every runtime middleware stack.
 
@@ -589,6 +648,13 @@ class HarnessProfile:
                 "tool_description_overrides",
                 MappingProxyType(dict(self.tool_description_overrides)),
             )
+        if not isinstance(self.tool_aliases, MappingProxyType):
+            object.__setattr__(
+                self,
+                "tool_aliases",
+                MappingProxyType(dict(self.tool_aliases)),
+            )
+        _validate_tool_aliases(self.tool_aliases)
         extra = self.extra_middleware
         if not callable(extra) and not isinstance(extra, tuple):
             object.__setattr__(self, "extra_middleware", tuple(extra))
@@ -1132,6 +1198,13 @@ def _merge_profiles(base: HarnessProfile, override: HarnessProfile) -> HarnessPr
     example, `{SummarizationMiddleware}` plus `{AnthropicPromptCachingMiddleware}`
     becomes both classes in the merged profile.
 
+    `tool_aliases` maps merge with the override winning per key, then the
+    combined map is re-validated. The injective and disjoint-keys/values
+    invariants hold for each profile individually; merging two
+    individually-valid maps can still produce a conflicting composite (e.g.
+    `{"execute": "shell_command"}` + `{"shell_command": "foo"}`), so the
+    re-check fails fast at resolution time rather than at runtime.
+
     Middleware sequences are merged by type (see `_merge_middleware`). For
     example, if both profiles provide a middleware of the same class, the
     override instance replaces the base instance in the same position, while
@@ -1160,6 +1233,7 @@ def _merge_profiles(base: HarnessProfile, override: HarnessProfile) -> HarnessPr
         },
         excluded_tools=base.excluded_tools | override.excluded_tools,
         excluded_middleware=base.excluded_middleware | override.excluded_middleware,
+        tool_aliases={**base.tool_aliases, **override.tool_aliases},
         extra_middleware=_merge_middleware(base.extra_middleware, override.extra_middleware),
         general_purpose_subagent=_merge_general_purpose_subagent_profiles(
             base.general_purpose_subagent,

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_aliasing.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_aliasing.py
@@ -1,0 +1,531 @@
+"""Unit tests for `_ToolAliasingMiddleware`."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from langchain.agents.middleware.types import ExtendedModelResponse, ModelResponse
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.tools import StructuredTool
+
+from deepagents.middleware._tool_aliasing import (
+    _rename_tool,
+    _rewrite_ai_message_tool_calls,
+    _rewrite_response_tool_names,
+    _rewrite_tool_message_name,
+    _ToolAliasingMiddleware,
+    _validate_tool_aliases,
+)
+
+
+@dataclass
+class FakeRequest:
+    """Minimal stand-in for `ModelRequest` in middleware tests.
+
+    Matches just enough of the real interface (`tools`, `messages`,
+    `override`) for the aliasing middleware to exercise its full code
+    path.
+    """
+
+    tools: list[Any] = field(default_factory=list)
+    messages: list[BaseMessage] = field(default_factory=list)
+
+    def override(self, **kwargs: Any) -> FakeRequest:
+        return FakeRequest(
+            tools=kwargs.get("tools", self.tools),
+            messages=kwargs.get("messages", self.messages),
+        )
+
+
+class TestRenameTool:
+    """Tests for `_rename_tool` helper."""
+
+    def test_rename_dict_tool(self) -> None:
+        tool: dict[str, Any] = {"name": "execute", "description": "Run a command"}
+        result = _rename_tool(tool, "shell_command")
+        assert result["name"] == "shell_command"
+        assert result["description"] == "Run a command"
+        assert tool["name"] == "execute"
+
+    def test_rename_basetool(self) -> None:
+        def sample(text: str) -> str:
+            return text
+
+        tool = StructuredTool.from_function(func=sample, name="execute", description="Run a command")
+        result = _rename_tool(tool, "shell_command")
+        assert result.name == "shell_command"
+        assert result.description == "Run a command"
+        assert tool.name == "execute"
+
+    def test_rename_plain_callable_is_noop(self) -> None:
+        def my_func() -> None:
+            pass
+
+        result = _rename_tool(my_func, "new_name")
+        assert result is my_func
+
+
+class TestRewriteAIMessageToolCalls:
+    """Tests for `_rewrite_ai_message_tool_calls`."""
+
+    def test_rewrites_matching_tool_calls(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "ls"}, "id": "1", "type": "tool_call"},
+                {"name": "read_file", "args": {"path": "/a"}, "id": "2", "type": "tool_call"},
+            ],
+        )
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result.tool_calls[0]["name"] == "execute"
+        assert result.tool_calls[1]["name"] == "read_file"
+        assert msg.tool_calls[0]["name"] == "shell_command"
+
+    def test_no_match_returns_original(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "read_file", "args": {"path": "/a"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result is msg
+
+    def test_empty_tool_calls_returns_original(self) -> None:
+        msg = AIMessage(content="hello")
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result is msg
+
+    def test_rewrites_invalid_tool_calls(self) -> None:
+        msg = AIMessage(
+            content="",
+            invalid_tool_calls=[
+                {"name": "shell_command", "args": "bad", "id": "1", "error": "parse error"},
+            ],
+        )
+        aliases = {"shell_command": "execute"}
+        result = _rewrite_ai_message_tool_calls(msg, aliases)
+        assert result.invalid_tool_calls[0]["name"] == "execute"
+
+
+class TestRewriteResponseToolNames:
+    """Tests for `_rewrite_response_tool_names` with various response shapes."""
+
+    def test_ai_message(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        result = _rewrite_response_tool_names(msg, {"list_dir": "ls"})
+        assert isinstance(result, AIMessage)
+        assert result.tool_calls[0]["name"] == "ls"
+
+    def test_model_response(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+                {"name": "read_file", "args": {"path": "/a"}, "id": "2", "type": "tool_call"},
+            ],
+        )
+        resp = ModelResponse(result=[msg])
+        result = _rewrite_response_tool_names(resp, {"list_dir": "ls"})
+        assert isinstance(result, ModelResponse)
+        rewritten_msg = result.result[0]
+        assert isinstance(rewritten_msg, AIMessage)
+        assert rewritten_msg.tool_calls[0]["name"] == "ls"
+        assert rewritten_msg.tool_calls[1]["name"] == "read_file"
+
+    def test_model_response_no_match(self) -> None:
+        msg = AIMessage(content="hello")
+        resp = ModelResponse(result=[msg])
+        result = _rewrite_response_tool_names(resp, {"x": "y"})
+        assert result is resp
+
+    def test_extended_model_response(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"cmd": "ls"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        inner = ModelResponse(result=[msg])
+        resp = ExtendedModelResponse(model_response=inner)
+        result = _rewrite_response_tool_names(resp, {"shell_command": "execute"})
+        assert isinstance(result, ExtendedModelResponse)
+        rewritten_msg = result.model_response.result[0]
+        assert isinstance(rewritten_msg, AIMessage)
+        assert rewritten_msg.tool_calls[0]["name"] == "execute"
+
+    def test_unknown_type_returned_unchanged(self) -> None:
+        obj = {"not": "a message"}
+        result = _rewrite_response_tool_names(obj, {"x": "y"})
+        assert result is obj
+
+
+class TestToolAliasingMiddleware:
+    """Tests for the full middleware round-trip."""
+
+    def test_roundtrip_sync_bare_ai_message(self) -> None:
+        """Handler returns a bare `AIMessage` (legacy path)."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command", "ls": "list_dir"})
+
+        tool_dict: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        ls_tool: dict[str, Any] = {"name": "ls", "description": "List files"}
+        other: dict[str, Any] = {"name": "read_file", "description": "Read a file"}
+
+        model_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "git status"}, "id": "1", "type": "tool_call"},
+                {"name": "list_dir", "args": {"path": "/"}, "id": "2", "type": "tool_call"},
+                {"name": "read_file", "args": {"path": "/a.py"}, "id": "3", "type": "tool_call"},
+            ],
+        )
+
+        captured_request: dict[str, Any] = {}
+
+        def handler(request: FakeRequest) -> AIMessage:
+            captured_request["tools"] = request.tools
+            return model_response
+
+        request = FakeRequest(tools=[tool_dict, ls_tool, other])
+        response = mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        tool_names_sent = [t["name"] for t in captured_request["tools"]]
+        assert tool_names_sent == ["shell_command", "list_dir", "read_file"]
+
+        assert isinstance(response, AIMessage)
+        assert response.tool_calls[0]["name"] == "execute"
+        assert response.tool_calls[1]["name"] == "ls"
+        assert response.tool_calls[2]["name"] == "read_file"
+
+    def test_roundtrip_sync_model_response(self) -> None:
+        """Handler returns a `ModelResponse` (realistic path)."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command", "ls": "list_dir"})
+
+        tool_dict: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        ls_tool: dict[str, Any] = {"name": "ls", "description": "List files"}
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "git status"}, "id": "1", "type": "tool_call"},
+                {"name": "list_dir", "args": {"path": "/"}, "id": "2", "type": "tool_call"},
+            ],
+        )
+
+        captured_request: dict[str, Any] = {}
+
+        def handler(request: FakeRequest) -> ModelResponse[Any]:
+            captured_request["tools"] = request.tools
+            return ModelResponse(result=[ai_msg])
+
+        request = FakeRequest(tools=[tool_dict, ls_tool])
+        response = mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        tool_names_sent = [t["name"] for t in captured_request["tools"]]
+        assert tool_names_sent == ["shell_command", "list_dir"]
+
+        assert isinstance(response, ModelResponse)
+        rewritten = response.result[0]
+        assert isinstance(rewritten, AIMessage)
+        assert rewritten.tool_calls[0]["name"] == "execute"
+        assert rewritten.tool_calls[1]["name"] == "ls"
+
+    def test_empty_aliases_is_noop(self) -> None:
+        mw = _ToolAliasingMiddleware(aliases={})
+
+        tool: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        model_response = AIMessage(content="ok")
+
+        request = FakeRequest(tools=[tool])
+        response = mw.wrap_model_call(request, lambda _r: model_response)  # type: ignore[arg-type]
+
+        assert response is model_response
+
+    def test_no_rename_preserves_request_identity(self) -> None:
+        """If nothing matches the alias map, pass the original request through.
+
+        Lets downstream middleware / cache keys that hold onto request
+        object identity continue to observe the same reference.
+        """
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        request = FakeRequest(
+            tools=[{"name": "read_file", "description": "Read"}],
+            messages=[HumanMessage(content="hi")],
+        )
+
+        captured: dict[str, Any] = {}
+
+        def handler(received: FakeRequest) -> AIMessage:
+            captured["request"] = received
+            return AIMessage(content="ok")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+        assert captured["request"] is request
+
+    async def test_roundtrip_async_bare_ai_message(self) -> None:
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        tool: dict[str, Any] = {"name": "execute", "description": "Run cmd"}
+        model_response = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "shell_command", "args": {"command": "ls"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def handler(request: FakeRequest) -> AIMessage:
+            captured["tools"] = request.tools
+            return model_response
+
+        request = FakeRequest(tools=[tool])
+        response = await mw.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        assert captured["tools"][0]["name"] == "shell_command"
+        assert isinstance(response, AIMessage)
+        assert response.tool_calls[0]["name"] == "execute"
+
+    async def test_roundtrip_async_model_response(self) -> None:
+        """Async handler returns a `ModelResponse` (realistic path)."""
+        mw = _ToolAliasingMiddleware(aliases={"ls": "list_dir"})
+
+        tool: dict[str, Any] = {"name": "ls", "description": "List files"}
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def handler(request: FakeRequest) -> ModelResponse[Any]:
+            captured["tools"] = request.tools
+            return ModelResponse(result=[ai_msg])
+
+        request = FakeRequest(tools=[tool])
+        response = await mw.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        assert captured["tools"][0]["name"] == "list_dir"
+        assert isinstance(response, ModelResponse)
+        rewritten = response.result[0]
+        assert isinstance(rewritten, AIMessage)
+        assert rewritten.tool_calls[0]["name"] == "ls"
+
+
+class TestValidateToolAliases:
+    """Tests for alias-map validation."""
+
+    def test_empty_passes(self) -> None:
+        _validate_tool_aliases({})
+
+    def test_simple_valid_mapping_passes(self) -> None:
+        _validate_tool_aliases({"execute": "shell_command", "list_dir": "ls"})
+
+    def test_duplicate_values_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            _validate_tool_aliases({"a": "x", "b": "x"})
+
+    def test_key_value_collision_rejected(self) -> None:
+        """`b` appears as both a canonical name and as an alias for `a`."""
+        with pytest.raises(ValueError, match="must be disjoint"):
+            _validate_tool_aliases({"a": "b", "b": "c"})
+
+    def test_non_string_key_rejected(self) -> None:
+        with pytest.raises(TypeError, match="must be strings"):
+            _validate_tool_aliases({1: "x"})  # type: ignore[dict-item]
+
+    def test_non_string_value_rejected(self) -> None:
+        with pytest.raises(TypeError, match="must be strings"):
+            _validate_tool_aliases({"a": 1})  # type: ignore[dict-item]
+
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_tool_aliases({"": "x"})
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_tool_aliases({"a": ""})
+
+    def test_constructor_rejects_invalid_aliases(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            _ToolAliasingMiddleware(aliases={"a": "x", "b": "x"})
+
+
+class TestRewriteToolMessageName:
+    """Tests for `_rewrite_tool_message_name`."""
+
+    def test_rewrites_matching_name(self) -> None:
+        msg = ToolMessage(content="ok", tool_call_id="1", name="execute")
+        result = _rewrite_tool_message_name(msg, {"execute": "shell_command"})
+        assert result.name == "shell_command"
+        assert result.tool_call_id == "1"
+        assert result.content == "ok"
+        assert msg.name == "execute"
+
+    def test_no_match_returns_original(self) -> None:
+        msg = ToolMessage(content="ok", tool_call_id="1", name="read_file")
+        result = _rewrite_tool_message_name(msg, {"execute": "shell_command"})
+        assert result is msg
+
+    def test_missing_name_returns_original(self) -> None:
+        msg = ToolMessage(content="ok", tool_call_id="1")
+        result = _rewrite_tool_message_name(msg, {"execute": "shell_command"})
+        assert result is msg
+
+
+class TestHistoryRewriteOutbound:
+    """Outbound canonical -> alias rewriting of `request.messages`.
+
+    This is the correctness-critical piece: without it, turn N+1 ships
+    aliased tools to the model but canonical names in past-turn tool
+    calls, so the model sees two names for the same tool.
+    """
+
+    def test_history_tool_calls_rewritten_on_outbound(self) -> None:
+        """Canonical names in `AIMessage.tool_calls` become aliases for the model."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        past_ai = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "execute", "args": {"command": "ls"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        past_tool = ToolMessage(content="file.py", tool_call_id="1", name="execute")
+
+        request = FakeRequest(
+            tools=[{"name": "execute", "description": "Run cmd"}],
+            messages=[HumanMessage(content="run ls"), past_ai, past_tool],
+        )
+
+        captured: dict[str, Any] = {}
+
+        def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            captured["tools"] = req.tools
+            return AIMessage(content="done")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        assert captured["tools"][0]["name"] == "shell_command"
+        sent_ai = captured["messages"][1]
+        assert isinstance(sent_ai, AIMessage)
+        assert sent_ai.tool_calls[0]["name"] == "shell_command"
+        sent_tool = captured["messages"][2]
+        assert isinstance(sent_tool, ToolMessage)
+        assert sent_tool.name == "shell_command"
+
+        assert past_ai.tool_calls[0]["name"] == "execute"
+        assert past_tool.name == "execute"
+
+    def test_history_with_invalid_tool_calls(self) -> None:
+        """Invalid (malformed-args) past tool calls are also renamed."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        past_ai = AIMessage(
+            content="",
+            invalid_tool_calls=[
+                {"name": "execute", "args": "bad-json", "id": "1", "error": "parse"},
+            ],
+        )
+        request = FakeRequest(tools=[], messages=[past_ai])
+
+        captured: dict[str, Any] = {}
+
+        def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            return AIMessage(content="ok")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        sent = captured["messages"][0]
+        assert isinstance(sent, AIMessage)
+        assert sent.invalid_tool_calls[0]["name"] == "shell_command"
+
+    def test_no_history_rename_preserves_other_messages(self) -> None:
+        """`HumanMessage`s and unrelated `AIMessage`s pass through untouched."""
+        mw = _ToolAliasingMiddleware(aliases={"execute": "shell_command"})
+
+        human = HumanMessage(content="hi")
+        bare_ai = AIMessage(content="hello")
+        request = FakeRequest(tools=[], messages=[human, bare_ai])
+
+        captured: dict[str, Any] = {}
+
+        def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            return AIMessage(content="ok")
+
+        mw.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        assert captured["messages"][0] is human
+        assert captured["messages"][1] is bare_ai
+
+    async def test_history_rewrite_async(self) -> None:
+        """Async path rewrites history identically."""
+        mw = _ToolAliasingMiddleware(aliases={"list_dir": "ls"})
+
+        past_ai = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "list_dir", "args": {"path": "/"}, "id": "1", "type": "tool_call"},
+            ],
+        )
+        request = FakeRequest(tools=[], messages=[past_ai])
+
+        captured: dict[str, Any] = {}
+
+        async def handler(req: FakeRequest) -> AIMessage:
+            captured["messages"] = req.messages
+            return AIMessage(content="ok")
+
+        await mw.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+        sent = captured["messages"][0]
+        assert isinstance(sent, AIMessage)
+        assert sent.tool_calls[0]["name"] == "ls"
+
+
+class TestRenameToolWarning:
+    """`_rename_tool` warns when a tool cannot be renamed."""
+
+    def test_warns_on_unrenameable_tool(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Plain object with no `model_copy` and not a dict triggers the warning."""
+
+        class WeirdTool:
+            name = "execute"
+
+        weird = WeirdTool()
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware._tool_aliasing"):
+            result = _rename_tool(weird, "shell_command")
+
+        assert result is weird
+        assert any("cannot be renamed" in record.message for record in caplog.records), (
+            f"Expected warning not logged. Got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_no_warning_on_dict_tool(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware._tool_aliasing"):
+            _rename_tool({"name": "execute"}, "shell_command")
+        assert not any("cannot be renamed" in r.message for r in caplog.records)
+
+    def test_no_warning_on_basetool(self, caplog: pytest.LogCaptureFixture) -> None:
+        def sample(text: str) -> str:
+            return text
+
+        tool = StructuredTool.from_function(func=sample, name="execute", description="Run cmd")
+        with caplog.at_level(logging.WARNING, logger="deepagents.middleware._tool_aliasing"):
+            _rename_tool(tool, "shell_command")
+        assert not any("cannot be renamed" in r.message for r in caplog.records)

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -24,10 +24,11 @@ from deepagents.graph import (
     _tool_name,
     create_deep_agent,
 )
+from deepagents.middleware._tool_aliasing import _ToolAliasingMiddleware
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
-from deepagents.middleware.permissions import _PermissionMiddleware
+from deepagents.middleware.permissions import FilesystemPermission, _PermissionMiddleware
 from deepagents.middleware.subagents import SubAgentMiddleware
 from deepagents.middleware.summarization import _DeepAgentsSummarizationMiddleware
 from deepagents.profiles import GeneralPurposeSubagentProfile, HarnessProfile, register_harness_profile
@@ -678,6 +679,128 @@ class TestToolExclusionWiring:
             exclusion_mws = [m for m in mw_stack if isinstance(m, _ToolExclusionMiddleware)]
             assert len(exclusion_mws) == 1
             assert "my_tool" in exclusion_mws[0]._excluded
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+
+class TestToolAliasingMiddlewareWiring:
+    """Tests that `tool_aliases` on a profile wires `_ToolAliasingMiddleware` correctly."""
+
+    def test_aliasing_middleware_added_when_profile_has_aliases(self) -> None:
+        """`_ToolAliasingMiddleware` is appended to the main stack with the configured map."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "aliasprov",
+                HarnessProfile(tool_aliases={"execute": "shell_command", "list_dir": "ls"}),
+            )
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+            ):
+                create_deep_agent(model="aliasprov:some-model")
+
+            mw_stack = mock_create.call_args.kwargs["middleware"]
+            aliasing_mws = [m for m in mw_stack if isinstance(m, _ToolAliasingMiddleware)]
+            assert len(aliasing_mws) == 1
+            assert aliasing_mws[0]._forward == {"execute": "shell_command", "list_dir": "ls"}
+            assert aliasing_mws[0]._reverse == {"shell_command": "execute", "ls": "list_dir"}
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_no_aliasing_middleware_when_aliases_empty(self) -> None:
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "noaliasprov",
+                HarnessProfile(system_prompt_suffix="present"),
+            )
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+            ):
+                create_deep_agent(model="noaliasprov:some-model")
+
+            mw_stack = mock_create.call_args.kwargs["middleware"]
+            aliasing_mws = [m for m in mw_stack if isinstance(m, _ToolAliasingMiddleware)]
+            assert len(aliasing_mws) == 0
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_aliasing_is_innermost_after_permissions(self) -> None:
+        """Aliasing must come after `_PermissionMiddleware` so permissions see canonical names.
+
+        The middleware stack runs outermost to innermost on outbound and the
+        reverse on inbound. Aliasing renames at the model boundary; every
+        prior name-aware middleware (tool exclusion, HITL, permissions) must
+        observe canonical tool names. Permissions has the strongest
+        ordering constraint of those (security guarantee), so this test
+        pins down the relative order explicitly.
+        """
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "aliasprov",
+                HarnessProfile(tool_aliases={"execute": "shell_command"}),
+            )
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+            ):
+                create_deep_agent(
+                    model="aliasprov:some-model",
+                    permissions=[FilesystemPermission(operations=["read"], paths=["/**"])],
+                )
+
+            mw_stack = mock_create.call_args.kwargs["middleware"]
+            classes = [type(m) for m in mw_stack]
+            perm_idx = classes.index(_PermissionMiddleware)
+            alias_idx = classes.index(_ToolAliasingMiddleware)
+            assert alias_idx > perm_idx
+            assert alias_idx == len(classes) - 1, "aliasing must be the last (innermost) middleware"
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_aliasing_wired_into_general_purpose_subagent_stack(self) -> None:
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "aliasprov",
+                HarnessProfile(tool_aliases={"execute": "shell_command"}),
+            )
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.create_agent", return_value=fake_agent),
+            ):
+                create_deep_agent(model="aliasprov:some-model")
+
+            subagents = mock_subagents.call_args.kwargs["subagents"]
+            general_purpose = next(spec for spec in subagents if spec["name"] == "general-purpose")
+            gp_mw = general_purpose["middleware"]
+            aliasing_mws = [m for m in gp_mw if isinstance(m, _ToolAliasingMiddleware)]
+            assert len(aliasing_mws) == 1
+            assert aliasing_mws[0]._forward == {"execute": "shell_command"}
         finally:
             _HARNESS_PROFILES.clear()
             _HARNESS_PROFILES.update(original)
@@ -1644,6 +1767,58 @@ class TestSubagentLevelToolExclusionAndOverrides:
             exclusions = [m for m in worker["middleware"] if isinstance(m, _ToolExclusionMiddleware)]
             assert len(exclusions) == 1
             assert exclusions[0]._excluded == frozenset({"child_only"})
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+    def test_subagent_tool_aliases_not_leaked_from_parent(self) -> None:
+        """A subagent's profile `tool_aliases` must reach the subagent's stack, not inherit the parent's."""
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "parentalias",
+                HarnessProfile(tool_aliases={"execute": "parent_alias"}),
+            )
+            register_harness_profile(
+                "subalias",
+                HarnessProfile(tool_aliases={"execute": "child_alias"}),
+            )
+
+            parent_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            subagent_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+
+            def fake_resolve(spec: str | BaseChatModel) -> BaseChatModel:
+                if isinstance(spec, BaseChatModel):
+                    return spec
+                if spec.startswith("subalias"):
+                    return subagent_model
+                return parent_model
+
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+
+            with (
+                patch("deepagents.graph.resolve_model", side_effect=fake_resolve),
+                patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+                patch("deepagents.graph.create_agent", return_value=fake_agent),
+            ):
+                create_deep_agent(
+                    model="parentalias:main-model",
+                    subagents=[
+                        {
+                            "name": "worker",
+                            "description": "Worker.",
+                            "system_prompt": "Do work.",
+                            "model": "subalias:worker-model",
+                        }
+                    ],
+                )
+
+            sub_specs = mock_subagents.call_args.kwargs["subagents"]
+            worker = next(s for s in sub_specs if s.get("name") == "worker")
+            aliasing = [m for m in worker["middleware"] if isinstance(m, _ToolAliasingMiddleware)]
+            assert len(aliasing) == 1
+            assert aliasing[0]._forward == {"execute": "child_alias"}
         finally:
             _HARNESS_PROFILES.clear()
             _HARNESS_PROFILES.update(original)

--- a/libs/deepagents/tests/unit_tests/test_harness_profiles.py
+++ b/libs/deepagents/tests/unit_tests/test_harness_profiles.py
@@ -11,6 +11,8 @@ from deepagents import (
     HarnessProfileConfig,
 )
 from deepagents.middleware.summarization import _DeepAgentsSummarizationMiddleware
+from deepagents.profiles.harness._codex import _CODEX_MODEL_SPECS
+from deepagents.profiles.harness_profiles import _get_harness_profile, _merge_profiles
 
 
 class TestGeneralPurposeSubagentProfileSerde:
@@ -364,6 +366,7 @@ class TestHarnessProfileConfigYamlRoundTrip:
             tool_description_overrides={"ls": "List files."},
             excluded_tools=frozenset({"execute"}),
             excluded_middleware=frozenset({"SummarizationMiddleware"}),
+            tool_aliases={"execute": "shell_command", "list_dir": "ls"},
             general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False),
         )
         serialized = yaml.safe_dump(config.to_dict())
@@ -379,3 +382,131 @@ class TestHarnessProfileConfigYamlRoundTrip:
         )
         output = yaml.safe_dump(config.to_dict())
         assert "!!" not in output
+
+
+class TestToolAliases:
+    """Construction, validation, merge, and serde for `tool_aliases`."""
+
+    def test_default_is_empty(self) -> None:
+        assert dict(HarnessProfile().tool_aliases) == {}
+        assert dict(HarnessProfileConfig().tool_aliases) == {}
+
+    def test_valid_aliases_construct(self) -> None:
+        aliases = {"execute": "shell_command", "list_dir": "ls"}
+        profile = HarnessProfile(tool_aliases=aliases)
+        config = HarnessProfileConfig(tool_aliases=aliases)
+        assert dict(profile.tool_aliases) == aliases
+        assert dict(config.tool_aliases) == aliases
+
+    def test_duplicate_alias_values_rejected_at_construction(self) -> None:
+        """Two canonical names cannot share an alias — reverse map would be lossy."""
+        with pytest.raises(ValueError, match="must be unique"):
+            HarnessProfile(tool_aliases={"a": "x", "b": "x"})
+        with pytest.raises(ValueError, match="must be unique"):
+            HarnessProfileConfig(tool_aliases={"a": "x", "b": "x"})
+
+    def test_key_value_collision_rejected_at_construction(self) -> None:
+        """A name cannot be both canonical and an alias for a different tool."""
+        with pytest.raises(ValueError, match="must be disjoint"):
+            HarnessProfile(tool_aliases={"a": "b", "b": "c"})
+        with pytest.raises(ValueError, match="must be disjoint"):
+            HarnessProfileConfig(tool_aliases={"a": "b", "b": "c"})
+
+    def test_tool_aliases_round_trip_through_config(self) -> None:
+        config = HarnessProfileConfig(tool_aliases={"execute": "shell_command", "list_dir": "ls"})
+        data = config.to_dict()
+        assert data["tool_aliases"] == {"execute": "shell_command", "list_dir": "ls"}
+        assert isinstance(data["tool_aliases"], dict)
+        assert HarnessProfileConfig.from_dict(data) == config
+
+    def test_to_dict_omits_empty_tool_aliases(self) -> None:
+        config = HarnessProfileConfig(tool_aliases={})
+        assert "tool_aliases" not in config.to_dict()
+
+    def test_construction_rejects_non_string_alias_types(self) -> None:
+        """Non-string keys/values raise at construction (fail-fast).
+
+        This is stricter than `tool_description_overrides`, which validates
+        only at `to_dict` time. Aliasing's invariants are non-trivial
+        (injective values, disjoint keys/values) and the runtime middleware
+        needs them to hold for round-tripping to be unambiguous, so the
+        check moves up to construction where it surfaces immediately.
+        """
+        with pytest.raises(TypeError, match="tool_aliases"):
+            HarnessProfileConfig(
+                tool_aliases={"a": 1}  # ty: ignore[invalid-argument-type]  # test fixture types
+            )
+
+    def test_from_dict_rejects_non_string_alias(self) -> None:
+        with pytest.raises(TypeError, match="tool_aliases"):
+            HarnessProfileConfig.from_dict({"tool_aliases": {"execute": 1}})
+
+    def test_from_dict_rejects_invalid_alias_map(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            HarnessProfileConfig.from_dict({"tool_aliases": {"a": "x", "b": "x"}})
+
+    def test_to_harness_profile_passes_through_aliases(self) -> None:
+        config = HarnessProfileConfig(tool_aliases={"execute": "shell_command"})
+        runtime = config.to_harness_profile()
+        assert dict(runtime.tool_aliases) == {"execute": "shell_command"}
+
+    def test_from_harness_profile_passes_through_aliases(self) -> None:
+        runtime = HarnessProfile(tool_aliases={"execute": "shell_command"})
+        config = HarnessProfileConfig.from_harness_profile(runtime)
+        assert dict(config.tool_aliases) == {"execute": "shell_command"}
+
+    def test_tool_aliases_frozen_after_construction(self) -> None:
+        """The internal mapping is read-only so registered profiles can't be mutated."""
+        source = {"execute": "shell_command"}
+        profile = HarnessProfile(tool_aliases=source)
+        with pytest.raises(TypeError):
+            profile.tool_aliases["execute"] = "something_else"  # type: ignore[index]
+        source["execute"] = "mutated_externally"
+        assert profile.tool_aliases["execute"] == "shell_command"
+
+
+class TestToolAliasesMerge:
+    """`_merge_profiles` semantics for `tool_aliases`."""
+
+    def test_disjoint_maps_union(self) -> None:
+        base = HarnessProfile(tool_aliases={"execute": "shell_command"})
+        override = HarnessProfile(tool_aliases={"list_dir": "ls"})
+        merged = _merge_profiles(base, override)
+        assert dict(merged.tool_aliases) == {
+            "execute": "shell_command",
+            "list_dir": "ls",
+        }
+
+    def test_override_wins_per_key(self) -> None:
+        base = HarnessProfile(tool_aliases={"execute": "shell_command"})
+        override = HarnessProfile(tool_aliases={"execute": "run_command"})
+        merged = _merge_profiles(base, override)
+        assert merged.tool_aliases["execute"] == "run_command"
+
+    def test_individually_valid_maps_can_combine_into_invalid_composite(self) -> None:
+        """Cross-profile collision is caught when the merged profile is constructed."""
+        base = HarnessProfile(tool_aliases={"execute": "shell_command"})
+        override = HarnessProfile(tool_aliases={"shell_command": "foo"})
+        with pytest.raises(ValueError, match="must be disjoint"):
+            _merge_profiles(base, override)
+
+
+class TestCodexToolAliases:
+    """Codex harness profile registers the expected aliases."""
+
+    def test_codex_profile_has_expected_aliases(self) -> None:
+        profile = _get_harness_profile("openai:gpt-5.1-codex")
+        assert profile is not None
+        assert dict(profile.tool_aliases) == {
+            "execute": "shell_command",
+            "list_dir": "ls",
+        }
+
+    def test_all_codex_specs_share_aliases(self) -> None:
+        for spec in _CODEX_MODEL_SPECS:
+            profile = _get_harness_profile(spec)
+            assert profile is not None
+            assert dict(profile.tool_aliases) == {
+                "execute": "shell_command",
+                "list_dir": "ls",
+            }


### PR DESCRIPTION
Adds a declarative `tool_aliases` field to `HarnessProfile` / `HarnessProfileConfig` and a corresponding `_ToolAliasingMiddleware` that renames tools at the model boundary. The Codex harness profile uses it to present `execute` as `shell_command` and `list_dir` as `ls` — the names Codex was trained on — without changing what the rest of the runtime calls those tools.

## Why

OpenAI's Codex prompting guide is explicit that Codex underperforms when its tool catalog uses names outside its training distribution. Deep Agents' canonical names (`execute`, `list_dir`) diverge from Codex's trained vocabulary (`shell_command`, `ls`), and evals show measurable tool-selection regressions when the canonical names go through unmodified.

Renaming the tools globally is not an option — `execute` and `list_dir` are the names users specify in `excluded_tools`, `interrupt_on`, permission rules, tests, and SDK docs. The mismatch is purely a distribution concern at the model boundary, so the fix should also live at the model boundary.

## Why a declarative field instead of `extra_middleware`

The first sketch of this work (in an earlier branch) contributed `_ToolAliasingMiddleware` through the existing `extra_middleware` factory. That works for the happy path but places aliasing too early in the stack: `_ToolExclusionMiddleware`, `HumanInTheLoopMiddleware`, and `_PermissionMiddleware` all see aliased names while users specify canonical names in their configs. The failure mode is silent — an `interrupt_on={"execute": True}` rule on a Codex agent simply never triggers — so it would only surface once someone wrote that config and wondered why it was ignored.

Promoting `tool_aliases` to a first-class field on `HarnessProfile` (parallel to `tool_description_overrides` and `excluded_tools`) lets the SDK position the middleware itself, *after* every other name-aware layer. Permission rules, HITL, and tool exclusion all keep operating on canonical names; only the model sees aliased names. The field also serializes through `HarnessProfileConfig` for free, so YAML/JSON-driven profiles get aliasing with no extra serde code.

## Behavior

`_ToolAliasingMiddleware` translates symmetrically:

- **Outbound** (canonical → alias): rewrites the tool catalog, plus any `tool_calls`, `invalid_tool_calls`, and `ToolMessage.name` entries in conversation history. Rewriting history matters — without it, turn N+1 ships aliased tools to the model alongside canonical names from past tool calls, and the model sees two names for the same tool.
- **Inbound** (alias → canonical): rewrites tool-call names on the response so downstream routing and state persistence only ever observe canonical names.

The alias map is validated at profile construction (injective values, disjoint keys/values) and re-validated on profile merge so a provider-level + exact-model-level combination that produces a conflicting composite fails at registration rather than at runtime.
