### PR TITLE
fix(examples): correct grammatical error in research_agent notebook

### DIFF
--- a/examples/deep_research/research_agent.ipynb
+++ b/examples/deep_research/research_agent.ipynb
@@ -280,7 +280,7 @@
     "\n",
     "You can specify [custom subagents](https://github.com/langchain-ai/deepagents?tab=readme-ov-file#subagents) as a means of context isolation. \n",
     "\n",
-    "Here's well define a sub-agent that can search the web for information. "
+    "Here we define a sub-agent that can search the web for information."
    ]
   },
   {
@@ -604,7 +604,7 @@
     "from langchain.chat_models import init_chat_model\n",
     "from langchain_google_genai import ChatGoogleGenerativeAI\n",
     "\n",
-    "# Model Gemini 3 \n",
+    "# Model Gemini 3\n",
     "model = ChatGoogleGenerativeAI(model=\"gemini-3-pro-preview\")\n",
     "\n",
     "# Model Claude 4.5\n",
@@ -613,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "62da8411",
    "metadata": {},
    "outputs": [
@@ -632,18 +632,18 @@
     "# Create the agent\n",
     "agent = create_deep_agent(\n",
     "      model=model,\n",
-    "      tools=tools, \n",
+    "      tools=tools,\n",
     "      system_prompt=INSTRUCTIONS,\n",
     "      subagents=[research_sub_agent],\n",
     "  )\n",
-    "  \n",
+    "\n",
     "# Show the agent\n",
     "display(Image(agent.get_graph().draw_mermaid_png()))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "613634c2",
    "metadata": {},
    "outputs": [
@@ -1767,14 +1767,14 @@
     "                \"content\": \"research context engineering approaches used to build AI agents\",\n",
     "            }\n",
     "        ],\n",
-    "    }, \n",
+    "    },\n",
     ")\n",
     "format_messages(result[\"messages\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "188b5ab5",
    "metadata": {},
    "outputs": [
@@ -2005,7 +2005,7 @@
     "\n",
     "# Convert a specific file to string\n",
     "file_content = file_data_to_string(result[\"files\"]['/final_report.md'])\n",
-    "show_prompt(file_content) "
+    "show_prompt(file_content)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #2944

Corrects a grammatical error in [`examples/deep_research/research_agent.ipynb`](examples/deep_research/research_agent.ipynb) notebook, changing "Here's well define a sub-agent..." to "Here we define a sub-agent..." for better readability.

## Social handles
LinkedIn: https://www.linkedin.com/in/yashtechi/