### PR TITLE
fix(sdk): prevent premature cancellation of long-running tool calls

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -5,6 +5,7 @@ from deepagents.graph import create_deep_agent
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.permissions import FilesystemPermission
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 
@@ -15,6 +16,7 @@ __all__ = [
     "FilesystemMiddleware",
     "FilesystemPermission",
     "MemoryMiddleware",
+    "PatchToolCallsMiddleware",
     "SubAgent",
     "SubAgentMiddleware",
     "__version__",

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -50,6 +50,7 @@ Use a **plain tool** when:
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.memory import MemoryMiddleware
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.permissions import FilesystemPermission
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
@@ -66,6 +67,7 @@ __all__ = [
     "FilesystemMiddleware",
     "FilesystemPermission",
     "MemoryMiddleware",
+    "PatchToolCallsMiddleware",
     "SkillsMiddleware",
     "SubAgent",
     "SubAgentMiddleware",

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,4 +1,27 @@
-"""Middleware to patch dangling tool calls in the messages history."""
+"""Middleware to patch dangling tool calls in the messages history.
+
+This middleware serves two purposes:
+
+1. **Dangling call patching**: When a tool call is in the message history with no
+   corresponding ``ToolMessage`` (because the agent loop was interrupted mid-flight),
+   it injects a synthetic cancellation ``ToolMessage`` so the LLM receives a coherent
+   conversation history on the next turn.
+
+2. **MCP transport protection**: As noted by m13v on issue #2471, slow tools like
+   ``playwright_browser_navigate`` (cold Chromium start, 5-15 s) are vulnerable to
+   ``ClosedResourceError`` when the MCP stdio transport is torn down before the
+   subprocess finishes its response. Two mitigations are applied here:
+
+   - **Sequential execution** (via a per-instance semaphore): prevents concurrent MCP
+     calls over the same stdio pipe from multiplexing badly, which is the root cause of
+     transport teardowns under load.
+
+   - **Configurable tool timeout** (via ``asyncio.wait_for``): gives the agent-level
+     tool executor a wall-clock timeout that is independent of ``PLAYWRIGHT_TIMEOUT``
+     (which only covers the Playwright side, not the MCP client read timeout). When the
+     timeout fires the ``asyncio.CancelledError`` is re-raised so the ``finally`` block
+     cleans up ``_in_flight`` correctly before the next ``before_agent`` hook runs.
+"""
 
 import asyncio
 import logging
@@ -14,14 +37,50 @@ from langgraph.types import Command, Overwrite
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_TOOL_TIMEOUT: float = 120.0
+"""Default agent-level tool execution timeout in seconds.
+
+Set to 120 s (2 min) to accommodate slow tools like ``playwright_browser_navigate``
+(cold Chromium spawn + network) which can take 5-15 s on first call, leaving plenty
+of headroom while still preventing indefinite hangs.
+
+Override via ``PatchToolCallsMiddleware(tool_timeout=...)``.
+"""
+
 
 class PatchToolCallsMiddleware(AgentMiddleware):
-    """Middleware to patch dangling tool calls in the messages history."""
+    """Middleware to patch dangling tool calls and protect MCP stdio transports.
 
-    def __init__(self) -> None:
-        """Initialize the middleware."""
+    Args:
+        sequential: If ``True`` (default), a per-instance semaphore serialises async
+            tool calls so that concurrent MCP calls over the same stdio pipe do not
+            multiplex. Pass ``False`` only if your tools are known to be safe to run
+            concurrently (e.g. pure-HTTP tools with no shared transport).
+        tool_timeout: Wall-clock timeout in seconds for each individual async tool
+            call. Defaults to ``120.0``. Set to ``None`` to disable. This timeout
+            covers the full MCP round-trip, unlike ``PLAYWRIGHT_TIMEOUT`` which only
+            covers the Playwright side.
+    """
+
+    def __init__(
+        self,
+        *,
+        sequential: bool = True,
+        tool_timeout: float | None = _DEFAULT_TOOL_TIMEOUT,
+    ) -> None:
+        """Initialize the middleware.
+
+        Args:
+            sequential: Serialise async tool calls via a semaphore to prevent
+                concurrent MCP stdio multiplexing issues.
+            tool_timeout: Per-tool wall-clock timeout (seconds). ``None`` disables.
+        """
         super().__init__()
         self._in_flight: set[tuple[str | None, str]] = set()
+        self._sequential = sequential
+        self._tool_timeout = tool_timeout
+        # Semaphore(1) gives us a mutex for sequential execution.
+        self._semaphore: asyncio.Semaphore | None = asyncio.Semaphore(1) if sequential else None
 
     def _get_thread_id(self) -> str | None:
         """Get the current thread ID from langgraph config.
@@ -39,7 +98,15 @@ class PatchToolCallsMiddleware(AgentMiddleware):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
     ) -> ToolMessage | Command[Any]:
-        """Wrap the tool call to track its in-flight execution."""
+        """Wrap the tool call to track its in-flight execution (sync path).
+
+        Args:
+            request: The tool call request to process.
+            handler: The next handler in the middleware chain.
+
+        Returns:
+            The ``ToolMessage`` or ``Command`` produced by the handler.
+        """
         tool_call_id = request.tool_call.get("id")
         thread_id = self._get_thread_id()
         if tool_call_id:
@@ -56,24 +123,103 @@ class PatchToolCallsMiddleware(AgentMiddleware):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
-        """Wrap the tool call to track its in-flight execution."""
+        """Wrap the tool call to track in-flight execution (async path).
+
+        Applies two MCP transport protections when enabled:
+
+        - **Sequential execution**: acquires a semaphore before calling the handler so
+          that concurrent calls over the same stdio pipe are serialised.
+        - **Tool timeout**: wraps the handler in ``asyncio.wait_for`` so a wall-clock
+          deadline is enforced independently of ``PLAYWRIGHT_TIMEOUT``.
+
+        Args:
+            request: The tool call request to process.
+            handler: The async next handler in the middleware chain.
+
+        Returns:
+            The ``ToolMessage`` or ``Command`` produced by the handler.
+
+        Raises:
+            asyncio.CancelledError: If the tool is cancelled (e.g. timeout or upstream
+                task cancellation). The ``_in_flight`` entry is always cleaned up in the
+                ``finally`` block before re-raising so ``abefore_agent`` sees a
+                consistent state.
+        """
         tool_call_id = request.tool_call.get("id")
         thread_id = self._get_thread_id()
+        tool_name = request.tool_call.get("name", "<unknown>")
         if tool_call_id:
             self._in_flight.add((thread_id, tool_call_id))
 
         try:
-            return await handler(request)
+            if self._semaphore is not None:
+                async with self._semaphore:
+                    logger.debug(
+                        "PatchToolCallsMiddleware: acquired semaphore for tool %s (thread=%s)",
+                        tool_name,
+                        thread_id,
+                    )
+                    return await self._invoke_with_timeout(handler, request, tool_name)
+            return await self._invoke_with_timeout(handler, request, tool_name)
         finally:
             if tool_call_id:
                 self._in_flight.discard((thread_id, tool_call_id))
 
+    async def _invoke_with_timeout(
+        self,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+        request: ToolCallRequest,
+        tool_name: str,
+    ) -> ToolMessage | Command[Any]:
+        """Invoke the handler with an optional wall-clock timeout.
+
+        Args:
+            handler: The async handler to call.
+            request: The tool call request.
+            tool_name: Name of the tool (for logging only).
+
+        Returns:
+            The ``ToolMessage`` or ``Command`` from the handler.
+
+        Raises:
+            asyncio.CancelledError: If the timeout fires or the task is cancelled.
+        """
+        if self._tool_timeout is None:
+            return await handler(request)
+
+        try:
+            return await asyncio.wait_for(handler(request), timeout=self._tool_timeout)
+        except TimeoutError:
+            msg = f"tool {tool_name!r} exceeded timeout of {self._tool_timeout:.1f} s"
+            logger.warning(
+                "PatchToolCallsMiddleware: tool %s timed out after %.1f s — cancelling",
+                tool_name,
+                self._tool_timeout,
+            )
+            raise asyncio.CancelledError(msg) from None
+
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Before the agent runs, handle dangling tool calls from any AIMessage."""
+        """Before the agent runs, handle dangling tool calls from any AIMessage.
+
+        Args:
+            state: The current agent state.
+            runtime: The agent runtime.
+
+        Returns:
+            A state update dictionary with patched messages, or None if no patching needed.
+        """
         return self._process_state(state)
 
     async def abefore_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
-        """Async hook before agent runs. Waits for in-flight tools to complete cancellation."""
+        """Async hook before agent runs. Waits for in-flight tools to complete cancellation.
+
+        Args:
+            state: The current agent state.
+            runtime: The agent runtime.
+
+        Returns:
+            A state update dictionary with patched messages, or None if no patching needed.
+        """
         thread_id = self._get_thread_id()
         in_flight_for_thread = {tid_tcid[1] for tid_tcid in self._in_flight if tid_tcid[0] == thread_id}
 
@@ -125,7 +271,11 @@ class PatchToolCallsMiddleware(AgentMiddleware):
         if not dangling_found:
             return None
 
-        logger.info("PatchToolCallsMiddleware: Found dangling tool calls for thread %s. Injecting cancellation ToolMessage.", thread_id)
+        logger.info(
+            "PatchToolCallsMiddleware: Found dangling tool calls for thread %s. "
+            "Injecting cancellation ToolMessage.",
+            thread_id,
+        )
 
         patched_messages = []
         for msg in messages:

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -1,44 +1,115 @@
 """Middleware to patch dangling tool calls in the messages history."""
 
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
-from langgraph.types import Overwrite
+from langgraph.types import Command, Overwrite
+
+logger = logging.getLogger(__name__)
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
     """Middleware to patch dangling tool calls in the messages history."""
 
+    def __init__(self) -> None:
+        """Initialize the middleware."""
+        super().__init__()
+        self._in_flight: set[str] = set()
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Wrap the tool call to track its in-flight execution."""
+        tool_call_id = request.tool_call.get("id")
+        if tool_call_id:
+            self._in_flight.add(tool_call_id)
+
+        try:
+            return handler(request)
+        finally:
+            if tool_call_id:
+                self._in_flight.discard(tool_call_id)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Wrap the tool call to track its in-flight execution."""
+        tool_call_id = request.tool_call.get("id")
+        if tool_call_id:
+            self._in_flight.add(tool_call_id)
+
+        try:
+            return await handler(request)
+        finally:
+            if tool_call_id:
+                self._in_flight.discard(tool_call_id)
+
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
         """Before the agent runs, handle dangling tool calls from any AIMessage."""
+        return self._process_state(state)
+
+    async def abefore_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Async hook before agent runs. Waits for in-flight tools to complete cancellation."""
+        if self._in_flight:
+            logger.info(
+                "PatchToolCallsMiddleware: Holding before_agent to allow %d in-flight tool calls to complete or cancel.", len(self._in_flight)
+            )
+            # Wait up to a short period for tasks to exit their finally blocks
+            for _ in range(20):
+                if not self._in_flight:
+                    break
+                await asyncio.sleep(0.05)
+            if self._in_flight:
+                logger.warning("PatchToolCallsMiddleware: Some tool calls remain in-flight after waiting: %s", self._in_flight)
+
+        return self._process_state(state)
+
+    def _process_state(self, state: AgentState) -> dict[str, Any] | None:
+        """Core logic to handle dangling tool calls."""
         messages = state["messages"]
         if not messages:
             return None
 
-        answered_ids = {msg.tool_call_id for msg in messages if msg.type == "tool"}  # ty: ignore[unresolved-attribute]
+        answered_ids = {msg.tool_call_id for msg in messages if isinstance(msg, ToolMessage)}
 
-        if not any(
-            tool_call["id"] not in answered_ids for msg in messages if isinstance(msg, AIMessage) and msg.tool_calls for tool_call in msg.tool_calls
-        ):
+        dangling_found = any(
+            tool_call["id"] not in answered_ids and tool_call["id"] not in self._in_flight
+            for msg in messages
+            if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None)
+            for tool_call in msg.tool_calls
+        )
+
+        if not dangling_found:
             return None
+
+        logger.info("PatchToolCallsMiddleware: Found dangling tool calls. Injecting cancellation ToolMessage.")
 
         patched_messages = []
         for msg in messages:
             patched_messages.append(msg)
-            if isinstance(msg, AIMessage) and msg.tool_calls:
-                patched_messages.extend(
-                    ToolMessage(
-                        content=(
-                            f"Tool call {tool_call['name']} with id {tool_call['id']} was "
-                            "cancelled - another message came in before it could be completed."
-                        ),
-                        name=tool_call["name"],
-                        tool_call_id=tool_call["id"],
-                    )
-                    for tool_call in msg.tool_calls
-                    if tool_call["id"] not in answered_ids
-                )
+            if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+                for tool_call in msg.tool_calls:
+                    if tool_call["id"] not in answered_ids and tool_call["id"] not in self._in_flight:
+                        logger.info("PatchToolCallsMiddleware: Cancelling tool call %s (%s)", tool_call["name"], tool_call["id"])
+                        patched_messages.append(
+                            ToolMessage(
+                                content=(
+                                    f"Tool call {tool_call['name']} with id {tool_call['id']} was "
+                                    "cancelled - another message came in before it could be completed."
+                                ),
+                                name=tool_call["name"],
+                                tool_call_id=tool_call["id"],
+                            )
+                        )
 
         return {"messages": Overwrite(patched_messages)}

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.config import get_config
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command, Overwrite
@@ -20,7 +21,18 @@ class PatchToolCallsMiddleware(AgentMiddleware):
     def __init__(self) -> None:
         """Initialize the middleware."""
         super().__init__()
-        self._in_flight: set[str] = set()
+        self._in_flight: set[tuple[str | None, str]] = set()
+
+    def _get_thread_id(self) -> str | None:
+        """Get the current thread ID from langgraph config.
+
+        Returns:
+            The thread ID if in a runnable context, else None.
+        """
+        try:
+            return get_config().get("configurable", {}).get("thread_id")
+        except RuntimeError:
+            return None
 
     def wrap_tool_call(
         self,
@@ -29,14 +41,15 @@ class PatchToolCallsMiddleware(AgentMiddleware):
     ) -> ToolMessage | Command[Any]:
         """Wrap the tool call to track its in-flight execution."""
         tool_call_id = request.tool_call.get("id")
+        thread_id = self._get_thread_id()
         if tool_call_id:
-            self._in_flight.add(tool_call_id)
+            self._in_flight.add((thread_id, tool_call_id))
 
         try:
             return handler(request)
         finally:
             if tool_call_id:
-                self._in_flight.discard(tool_call_id)
+                self._in_flight.discard((thread_id, tool_call_id))
 
     async def awrap_tool_call(
         self,
@@ -45,14 +58,15 @@ class PatchToolCallsMiddleware(AgentMiddleware):
     ) -> ToolMessage | Command[Any]:
         """Wrap the tool call to track its in-flight execution."""
         tool_call_id = request.tool_call.get("id")
+        thread_id = self._get_thread_id()
         if tool_call_id:
-            self._in_flight.add(tool_call_id)
+            self._in_flight.add((thread_id, tool_call_id))
 
         try:
             return await handler(request)
         finally:
             if tool_call_id:
-                self._in_flight.discard(tool_call_id)
+                self._in_flight.discard((thread_id, tool_call_id))
 
     def before_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
         """Before the agent runs, handle dangling tool calls from any AIMessage."""
@@ -60,30 +74,49 @@ class PatchToolCallsMiddleware(AgentMiddleware):
 
     async def abefore_agent(self, state: AgentState, runtime: Runtime[Any]) -> dict[str, Any] | None:  # noqa: ARG002
         """Async hook before agent runs. Waits for in-flight tools to complete cancellation."""
-        if self._in_flight:
+        thread_id = self._get_thread_id()
+        in_flight_for_thread = {tid_tcid[1] for tid_tcid in self._in_flight if tid_tcid[0] == thread_id}
+
+        if in_flight_for_thread:
             logger.info(
-                "PatchToolCallsMiddleware: Holding before_agent to allow %d in-flight tool calls to complete or cancel.", len(self._in_flight)
+                "PatchToolCallsMiddleware: Holding before_agent to allow %d in-flight tool calls (thread=%s) to complete or cancel.",
+                len(in_flight_for_thread),
+                thread_id,
             )
             # Wait up to a short period for tasks to exit their finally blocks
             for _ in range(20):
-                if not self._in_flight:
+                in_flight_for_thread = {tid_tcid[1] for tid_tcid in self._in_flight if tid_tcid[0] == thread_id}
+                if not in_flight_for_thread:
                     break
                 await asyncio.sleep(0.05)
-            if self._in_flight:
-                logger.warning("PatchToolCallsMiddleware: Some tool calls remain in-flight after waiting: %s", self._in_flight)
+            if in_flight_for_thread:
+                logger.warning(
+                    "PatchToolCallsMiddleware: Some tool calls (thread=%s) remain in-flight after waiting: %s",
+                    thread_id,
+                    in_flight_for_thread,
+                )
 
-        return self._process_state(state)
+        return self._process_state(state, thread_id)
 
-    def _process_state(self, state: AgentState) -> dict[str, Any] | None:
-        """Core logic to handle dangling tool calls."""
+    def _process_state(self, state: AgentState, thread_id: str | None = None) -> dict[str, Any] | None:
+        """Core logic to handle dangling tool calls.
+
+        Args:
+            state: The current agent state containing messages.
+            thread_id: Optional thread ID to isolate tool tracking.
+
+        Returns:
+            A state update dictionary with patched messages, or None if no patching needed.
+        """
         messages = state["messages"]
         if not messages:
             return None
 
+        in_flight_for_thread = {tid_tcid[1] for tid_tcid in self._in_flight if tid_tcid[0] == thread_id}
         answered_ids = {msg.tool_call_id for msg in messages if isinstance(msg, ToolMessage)}
 
         dangling_found = any(
-            tool_call["id"] not in answered_ids and tool_call["id"] not in self._in_flight
+            tool_call["id"] not in answered_ids and tool_call["id"] not in in_flight_for_thread
             for msg in messages
             if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None)
             for tool_call in msg.tool_calls
@@ -92,15 +125,20 @@ class PatchToolCallsMiddleware(AgentMiddleware):
         if not dangling_found:
             return None
 
-        logger.info("PatchToolCallsMiddleware: Found dangling tool calls. Injecting cancellation ToolMessage.")
+        logger.info("PatchToolCallsMiddleware: Found dangling tool calls for thread %s. Injecting cancellation ToolMessage.", thread_id)
 
         patched_messages = []
         for msg in messages:
             patched_messages.append(msg)
             if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
                 for tool_call in msg.tool_calls:
-                    if tool_call["id"] not in answered_ids and tool_call["id"] not in self._in_flight:
-                        logger.info("PatchToolCallsMiddleware: Cancelling tool call %s (%s)", tool_call["name"], tool_call["id"])
+                    if tool_call["id"] not in answered_ids and tool_call["id"] not in in_flight_for_thread:
+                        logger.info(
+                            "PatchToolCallsMiddleware: Cancelling tool call %s (%s) for thread %s",
+                            tool_call["name"],
+                            tool_call["id"],
+                            thread_id,
+                        )
                         patched_messages.append(
                             ToolMessage(
                                 content=(

--- a/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
@@ -103,7 +103,7 @@ class TestInFlightProtection:
 
     def test_in_flight_call_is_not_cancelled(self) -> None:
         mw = PatchToolCallsMiddleware()
-        mw._in_flight.add("tc-1")
+        mw._in_flight.add((None, "tc-1"))
         ai_msg = _ai_with_tool_call("tc-1")
         state = _state([ai_msg])
 
@@ -178,11 +178,11 @@ class TestAbforeAgentWaiting:
     async def test_abefore_agent_waits_for_in_flight_to_clear(self) -> None:
         """If in-flight clears asynchronously, abefore_agent should not cancel it."""
         mw = PatchToolCallsMiddleware()
-        mw._in_flight.add("tc-1")
+        mw._in_flight.add((None, "tc-1"))
 
         async def _clear_after_delay() -> None:
             await asyncio.sleep(0.02)
-            mw._in_flight.discard("tc-1")
+            mw._in_flight.discard((None, "tc-1"))
 
         _background_tasks = set()
         task = asyncio.create_task(_clear_after_delay())
@@ -202,7 +202,7 @@ class TestAbforeAgentWaiting:
         The in-flight ID is not cancelled because we cannot verify the tool truly abandoned.
         """
         mw = PatchToolCallsMiddleware()
-        mw._in_flight.add("tc-stuck")
+        mw._in_flight.add((None, "tc-stuck"))
 
         ai_msg = _ai_with_tool_call("tc-stuck")
         # No corresponding ToolMessage → dangling, but still in-flight
@@ -211,3 +211,25 @@ class TestAbforeAgentWaiting:
         result = await mw.abefore_agent(state, _make_runtime())
         # tc-stuck is still in _in_flight, so it is NOT cancelled (protected)
         assert result is None
+
+
+class TestThreadIsolation:
+    """Tools in one thread should not affect or block another thread."""
+
+    @pytest.mark.asyncio
+    async def test_isolation_between_threads(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mw = PatchToolCallsMiddleware()
+
+        # Mock thread 1
+        monkeypatch.setattr(_mod, "get_config", lambda: {"configurable": {"thread_id": "thread-1"}})
+        mw._in_flight.add(("thread-1", "tc-1"))
+
+        # In thread 2, tc-1 should NOT be seen as in-flight
+        monkeypatch.setattr(_mod, "get_config", lambda: {"configurable": {"thread_id": "thread-2"}})
+        state = _state([_ai_with_tool_call("tc-1")])
+
+        # It should be cancelled because thread-2 doesn't own tc-1
+        result = await mw.abefore_agent(state, _make_runtime())
+        assert result is not None
+        messages = result["messages"].value
+        assert any(isinstance(m, ToolMessage) and m.tool_call_id == "tc-1" for m in messages)

--- a/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
@@ -1,0 +1,213 @@
+"""Unit tests for PatchToolCallsMiddleware."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+# Import directly from the module file to avoid deepagents/__init__.py
+# which eagerly imports graph.py → langchain_anthropic (not installed in test env)
+_mod_path = Path(__file__).parent.parent.parent.parent / "deepagents" / "middleware" / "patch_tool_calls.py"
+_spec = importlib.util.spec_from_file_location("patch_tool_calls", _mod_path)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+PatchToolCallsMiddleware = _mod.PatchToolCallsMiddleware
+
+
+def _make_runtime() -> MagicMock:
+    return MagicMock()
+
+
+def _state(messages: list) -> dict:
+    return {"messages": messages}
+
+
+def _ai_with_tool_call(tool_id: str = "tc-1", name: str = "my_tool") -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"id": tool_id, "name": name, "args": {}}],
+    )
+
+
+def _tool_message(tool_id: str = "tc-1", name: str = "my_tool") -> ToolMessage:
+    return ToolMessage(content="result", name=name, tool_call_id=tool_id)
+
+
+class TestNoDangling:
+    """No patching needed when all tool calls have been answered."""
+
+    def test_empty_messages_returns_none(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        result = mw.before_agent(_state([]), _make_runtime())
+        assert result is None
+
+    def test_no_tool_calls_returns_none(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        state = _state([HumanMessage(content="hi"), AIMessage(content="hello")])
+        assert mw.before_agent(state, _make_runtime()) is None
+
+    def test_answered_tool_call_returns_none(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        state = _state([_ai_with_tool_call("tc-1"), _tool_message("tc-1")])
+        assert mw.before_agent(state, _make_runtime()) is None
+
+
+class TestDanglingCancellation:
+    """Dangling tool calls should be patched with a cancellation ToolMessage."""
+
+    def test_dangling_call_gets_cancellation(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        ai_msg = _ai_with_tool_call("tc-1", "playwright_browser_navigate")
+        state = _state([ai_msg])
+
+        result = mw.before_agent(state, _make_runtime())
+
+        assert result is not None
+        messages = result["messages"].value
+        assert len(messages) == 2
+        cancel_msg = messages[1]
+        assert isinstance(cancel_msg, ToolMessage)
+        assert cancel_msg.tool_call_id == "tc-1"
+        assert "cancelled" in cancel_msg.content
+
+    def test_only_unanswered_calls_are_cancelled(self) -> None:
+        """If one call is answered and one is not, only the unanswered is patched."""
+        mw = PatchToolCallsMiddleware()
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "tc-1", "name": "tool_a", "args": {}},
+                {"id": "tc-2", "name": "tool_b", "args": {}},
+            ],
+        )
+        tool_answer = _tool_message("tc-1", "tool_a")
+        state = _state([ai_msg, tool_answer])
+
+        result = mw.before_agent(state, _make_runtime())
+
+        assert result is not None
+        messages = result["messages"].value
+        # ai_msg + cancel for tc-2 (inserted right after AIMessage) + tool_answer
+        assert len(messages) == 3
+        cancel_msg = messages[1]
+        assert cancel_msg.tool_call_id == "tc-2"
+
+
+class TestInFlightProtection:
+    """Tool calls registered as in-flight must not be cancelled."""
+
+    def test_in_flight_call_is_not_cancelled(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        mw._in_flight.add("tc-1")
+        ai_msg = _ai_with_tool_call("tc-1")
+        state = _state([ai_msg])
+
+        result = mw.before_agent(state, _make_runtime())
+        assert result is None
+
+    def test_in_flight_cleared_after_sync_wrap(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = MagicMock(return_value=_tool_message("tc-1"))
+
+        mw.wrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    def test_in_flight_cleared_on_sync_exception(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = MagicMock(side_effect=RuntimeError("tool failed"))
+
+        with pytest.raises(RuntimeError):
+            mw.wrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    async def test_in_flight_cleared_after_async_wrap(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = AsyncMock(return_value=_tool_message("tc-1"))
+
+        await mw.awrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    async def test_in_flight_cleared_on_async_exception(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-1"}
+        handler = AsyncMock(side_effect=RuntimeError("async tool failed"))
+
+        with pytest.raises(RuntimeError):
+            await mw.awrap_tool_call(request, handler)
+
+        assert "tc-1" not in mw._in_flight
+
+    async def test_in_flight_cleared_on_cancellation(self) -> None:
+        """Simulates asyncio.CancelledError (e.g. Playwright timeout)."""
+        mw = PatchToolCallsMiddleware()
+        request = MagicMock()
+        request.tool_call = {"id": "tc-playwright"}
+        handler = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await mw.awrap_tool_call(request, handler)
+
+        assert "tc-playwright" not in mw._in_flight
+
+
+class TestAbforeAgentWaiting:
+    """abefore_agent must wait for in-flight tools to clear before proceeding."""
+
+    async def test_abefore_agent_no_in_flight_returns_immediately(self) -> None:
+        mw = PatchToolCallsMiddleware()
+        state = _state([_ai_with_tool_call("tc-1")])
+        result = await mw.abefore_agent(state, _make_runtime())
+        # No in-flight, so the dangling call should be cancelled normally
+        assert result is not None
+
+    async def test_abefore_agent_waits_for_in_flight_to_clear(self) -> None:
+        """If in-flight clears asynchronously, abefore_agent should not cancel it."""
+        mw = PatchToolCallsMiddleware()
+        mw._in_flight.add("tc-1")
+
+        async def _clear_after_delay() -> None:
+            await asyncio.sleep(0.02)
+            mw._in_flight.discard("tc-1")
+
+        _background_tasks = set()
+        task = asyncio.create_task(_clear_after_delay())
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+        ai_msg = _ai_with_tool_call("tc-1")
+        state = _state([ai_msg, _tool_message("tc-1")])
+
+        result = await mw.abefore_agent(state, _make_runtime())
+        # tc-1 was answered so no dangling once in-flight is cleared
+        assert result is None
+
+    async def test_abefore_agent_cancels_if_still_in_flight_after_timeout(self) -> None:
+        """If tool stays in-flight past the wait window, the in-flight ID is still protected.
+
+        The in-flight ID is not cancelled because we cannot verify the tool truly abandoned.
+        """
+        mw = PatchToolCallsMiddleware()
+        mw._in_flight.add("tc-stuck")
+
+        ai_msg = _ai_with_tool_call("tc-stuck")
+        # No corresponding ToolMessage → dangling, but still in-flight
+        state = _state([ai_msg])
+
+        result = await mw.abefore_agent(state, _make_runtime())
+        # tc-stuck is still in _in_flight, so it is NOT cancelled (protected)
+        assert result is None

--- a/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_patch_tool_calls.py
@@ -113,56 +113,56 @@ class TestInFlightProtection:
     def test_in_flight_cleared_after_sync_wrap(self) -> None:
         mw = PatchToolCallsMiddleware()
         request = MagicMock()
-        request.tool_call = {"id": "tc-1"}
+        request.tool_call = {"id": "tc-1", "name": "my_tool"}
         handler = MagicMock(return_value=_tool_message("tc-1"))
 
         mw.wrap_tool_call(request, handler)
 
-        assert "tc-1" not in mw._in_flight
+        assert not any(tcid == "tc-1" for _, tcid in mw._in_flight)
 
     def test_in_flight_cleared_on_sync_exception(self) -> None:
         mw = PatchToolCallsMiddleware()
         request = MagicMock()
-        request.tool_call = {"id": "tc-1"}
+        request.tool_call = {"id": "tc-1", "name": "my_tool"}
         handler = MagicMock(side_effect=RuntimeError("tool failed"))
 
         with pytest.raises(RuntimeError):
             mw.wrap_tool_call(request, handler)
 
-        assert "tc-1" not in mw._in_flight
+        assert not any(tcid == "tc-1" for _, tcid in mw._in_flight)
 
     async def test_in_flight_cleared_after_async_wrap(self) -> None:
         mw = PatchToolCallsMiddleware()
         request = MagicMock()
-        request.tool_call = {"id": "tc-1"}
+        request.tool_call = {"id": "tc-1", "name": "my_tool"}
         handler = AsyncMock(return_value=_tool_message("tc-1"))
 
         await mw.awrap_tool_call(request, handler)
 
-        assert "tc-1" not in mw._in_flight
+        assert not any(tcid == "tc-1" for _, tcid in mw._in_flight)
 
     async def test_in_flight_cleared_on_async_exception(self) -> None:
         mw = PatchToolCallsMiddleware()
         request = MagicMock()
-        request.tool_call = {"id": "tc-1"}
+        request.tool_call = {"id": "tc-1", "name": "my_tool"}
         handler = AsyncMock(side_effect=RuntimeError("async tool failed"))
 
         with pytest.raises(RuntimeError):
             await mw.awrap_tool_call(request, handler)
 
-        assert "tc-1" not in mw._in_flight
+        assert not any(tcid == "tc-1" for _, tcid in mw._in_flight)
 
     async def test_in_flight_cleared_on_cancellation(self) -> None:
         """Simulates asyncio.CancelledError (e.g. Playwright timeout)."""
         mw = PatchToolCallsMiddleware()
         request = MagicMock()
-        request.tool_call = {"id": "tc-playwright"}
+        request.tool_call = {"id": "tc-playwright", "name": "playwright_browser_navigate"}
         handler = AsyncMock(side_effect=asyncio.CancelledError())
 
         with pytest.raises(asyncio.CancelledError):
             await mw.awrap_tool_call(request, handler)
 
-        assert "tc-playwright" not in mw._in_flight
+        assert not any(tcid == "tc-playwright" for _, tcid in mw._in_flight)
 
 
 class TestAbforeAgentWaiting:
@@ -216,12 +216,10 @@ class TestAbforeAgentWaiting:
 class TestThreadIsolation:
     """Tools in one thread should not affect or block another thread."""
 
-    @pytest.mark.asyncio
     async def test_isolation_between_threads(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mw = PatchToolCallsMiddleware()
 
-        # Mock thread 1
-        monkeypatch.setattr(_mod, "get_config", lambda: {"configurable": {"thread_id": "thread-1"}})
+        # Mock thread 1 has tc-1 in flight
         mw._in_flight.add(("thread-1", "tc-1"))
 
         # In thread 2, tc-1 should NOT be seen as in-flight
@@ -233,3 +231,88 @@ class TestThreadIsolation:
         assert result is not None
         messages = result["messages"].value
         assert any(isinstance(m, ToolMessage) and m.tool_call_id == "tc-1" for m in messages)
+
+
+class TestSequentialExecution:
+    """Sequential semaphore must serialise async tool calls."""
+
+    async def test_sequential_tools_run_one_at_a_time(self) -> None:
+        """Two concurrent async tool calls must not overlap when sequential=True."""
+        mw = PatchToolCallsMiddleware(sequential=True)
+        order: list[str] = []
+
+        async def slow_handler(request: MagicMock) -> ToolMessage:
+            order.append("start-" + request.tool_call["id"])
+            await asyncio.sleep(0.05)
+            order.append("end-" + request.tool_call["id"])
+            return _tool_message(request.tool_call["id"])
+
+        req1 = MagicMock()
+        req1.tool_call = {"id": "tc-1", "name": "tool_a"}
+        req2 = MagicMock()
+        req2.tool_call = {"id": "tc-2", "name": "tool_a"}
+
+        await asyncio.gather(
+            mw.awrap_tool_call(req1, slow_handler),
+            mw.awrap_tool_call(req2, slow_handler),
+        )
+
+        # If sequential, we expect: start-1, end-1, start-2, end-2 (no overlap)
+        assert order.index("end-tc-1") < order.index("start-tc-2") or order.index("end-tc-2") < order.index("start-tc-1")
+
+    async def test_concurrent_tools_can_overlap_when_disabled(self) -> None:
+        """When sequential=False, two async calls can overlap."""
+        mw = PatchToolCallsMiddleware(sequential=False)
+        started: list[str] = []
+
+        async def slow_handler(request: MagicMock) -> ToolMessage:
+            started.append(request.tool_call["id"])
+            await asyncio.sleep(0.05)
+            return _tool_message(request.tool_call["id"])
+
+        req1 = MagicMock()
+        req1.tool_call = {"id": "tc-1", "name": "tool_a"}
+        req2 = MagicMock()
+        req2.tool_call = {"id": "tc-2", "name": "tool_a"}
+
+        await asyncio.gather(
+            mw.awrap_tool_call(req1, slow_handler),
+            mw.awrap_tool_call(req2, slow_handler),
+        )
+
+        # Both should have started (concurrently)
+        assert set(started) == {"tc-1", "tc-2"}
+
+
+class TestToolTimeout:
+    """Tool timeout must fire a CancelledError and clean up in-flight state."""
+
+    async def test_timeout_raises_cancelled_error(self) -> None:
+        """A tool that exceeds the timeout should raise CancelledError."""
+        mw = PatchToolCallsMiddleware(sequential=False, tool_timeout=0.05)
+
+        async def slow_handler(request: MagicMock) -> ToolMessage:
+            await asyncio.sleep(10)  # longer than timeout
+            return _tool_message(request.tool_call["id"])
+
+        req = MagicMock()
+        req.tool_call = {"id": "tc-timeout", "name": "playwright_browser_navigate"}
+
+        with pytest.raises(asyncio.CancelledError):
+            await mw.awrap_tool_call(req, slow_handler)
+
+        # _in_flight must be clean after timeout
+        assert not any(tcid == "tc-timeout" for _, tcid in mw._in_flight)
+
+    async def test_no_timeout_when_disabled(self) -> None:
+        """When tool_timeout=None, slow tools complete without interruption."""
+        mw = PatchToolCallsMiddleware(sequential=False, tool_timeout=None)
+
+        async def slow_handler(request: MagicMock) -> ToolMessage:
+            await asyncio.sleep(0.01)
+            return _tool_message(request.tool_call["id"])
+
+        req = MagicMock()
+        req.tool_call = {"id": "tc-1", "name": "my_tool"}
+        result = await mw.awrap_tool_call(req, slow_handler)
+        assert isinstance(result, ToolMessage)


### PR DESCRIPTION
Fixes #2471

## Root cause (per m13v's analysis)
Slow MCP tools like `playwright_browser_navigate` (cold Chromium spawn, 5-15s) are 
vulnerable to `ClosedResourceError` when the stdio transport is torn down mid-request.

## Changes
- `sequential=True` (default): serialises async tool calls via `asyncio.Semaphore` 
  so concurrent calls over the same stdio pipe don't multiplex badly
- `tool_timeout=120.0` (default): agent-level wall-clock timeout via `asyncio.wait_for`, 
  independent of `PLAYWRIGHT_TIMEOUT` which only covers the Playwright side
- Thread-aware `_in_flight` tracking prevents false "cancelled" messages
- 19 unit tests all passing
