### PR TITLE
feat(cli): expand/collapse all tools in MCP viewer (refs #1703)

### DIFF
--- a/libs/cli/deepagents_cli/widgets/mcp_viewer.py
+++ b/libs/cli/deepagents_cli/widgets/mcp_viewer.py
@@ -101,8 +101,18 @@ class MCPToolItem(Static):
 
     def toggle_expand(self) -> None:
         """Toggle between collapsed and expanded view."""
-        self._expanded = not self._expanded
-        if self._expanded:
+        self.set_expanded(not self._expanded)
+
+    def set_expanded(self, expanded: bool) -> None:
+        """Set expansion state explicitly.
+
+        Args:
+            expanded: True for expanded (multi-line), False for collapsed.
+        """
+        if expanded == self._expanded:
+            return
+        self._expanded = expanded
+        if expanded:
             label = self._format_expanded(self.tool_name, self.tool_description)
             self.styles.height = "auto"
         else:
@@ -147,6 +157,7 @@ class MCPViewerScreen(ModalScreen[None]):
         Binding("down", "move_down", "Down", show=False, priority=True),
         Binding("j", "move_down", "Down", show=False, priority=True),
         Binding("enter", "toggle_expand", "Expand", show=False, priority=True),
+        Binding("a", "toggle_all", "Toggle all", show=False, priority=True),
         Binding("pageup", "page_up", "Page up", show=False, priority=True),
         Binding("pagedown", "page_down", "Page down", show=False, priority=True),
         Binding("escape", "cancel", "Close", show=False, priority=True),
@@ -295,6 +306,7 @@ class MCPViewerScreen(ModalScreen[None]):
             help_text = (
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
                 f" {glyphs.bullet} Enter expand/collapse"
+                f" {glyphs.bullet} a expand/collapse all"
                 f" {glyphs.bullet} Esc close"
             )
             yield Static(help_text, classes="mcp-viewer-help")
@@ -346,6 +358,20 @@ class MCPViewerScreen(ModalScreen[None]):
         """Toggle expand/collapse on the selected tool."""
         if self._tool_widgets:
             self._tool_widgets[self._selected_index].toggle_expand()
+
+    def action_toggle_all(self) -> None:
+        """Expand or collapse every tool at once.
+
+        If any tool is collapsed, expand all; otherwise collapse all.
+        Useful when scanning a long list of tools and quickly toggling
+        between overview and detailed views.
+        """
+        if not self._tool_widgets:
+            return
+        any_collapsed = any(not w._expanded for w in self._tool_widgets)
+        target = any_collapsed
+        for widget in self._tool_widgets:
+            widget.set_expanded(target)
 
     def action_page_up(self) -> None:
         """Scroll up by one page."""

--- a/libs/cli/tests/unit_tests/test_mcp_viewer.py
+++ b/libs/cli/tests/unit_tests/test_mcp_viewer.py
@@ -187,3 +187,55 @@ class TestMCPViewerScreen:
             await pilot.click(MCPToolItem)
             await pilot.pause()
             assert widget._expanded
+
+    async def test_toggle_all_expands_then_collapses(self) -> None:
+        """Pressing `a` expands every tool, pressing again collapses all."""
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPViewerScreen(server_info=_sample_info())
+            app.push_screen(screen)
+            await pilot.pause()
+
+            assert all(not w._expanded for w in screen._tool_widgets)
+
+            # First press expands every tool
+            await pilot.press("a")
+            await pilot.pause()
+            assert all(w._expanded for w in screen._tool_widgets)
+
+            # Second press collapses every tool
+            await pilot.press("a")
+            await pilot.pause()
+            assert all(not w._expanded for w in screen._tool_widgets)
+
+    async def test_toggle_all_with_partial_state(self) -> None:
+        """If any tool is collapsed, `a` expands all; otherwise collapses all."""
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPViewerScreen(server_info=_sample_info())
+            app.push_screen(screen)
+            await pilot.pause()
+
+            # Expand only the first tool
+            screen._tool_widgets[0].set_expanded(True)
+            await pilot.pause()
+            assert screen._tool_widgets[0]._expanded
+            assert not screen._tool_widgets[1]._expanded
+
+            # `a` should expand the rest (because some are still collapsed)
+            await pilot.press("a")
+            await pilot.pause()
+            assert all(w._expanded for w in screen._tool_widgets)
+
+    async def test_toggle_all_no_op_when_empty(self) -> None:
+        """Pressing `a` with no tools is a no-op."""
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPViewerScreen(server_info=[])
+            app.push_screen(screen)
+            await pilot.pause()
+
+            # Should not raise
+            await pilot.press("a")
+            await pilot.pause()
+            assert screen._tool_widgets == []


### PR DESCRIPTION
## Summary
Refs #1703. Modest, additive UX polish to the `/mcp` viewer: an `a` keybinding that toggles expand/collapse on all tools at once.

## Why this scope
Issue #1703 is assigned to @peterkolcza with an active XL rework PR (#2906) already open. Picked something small and orthogonal so the rework can keep or drop it trivially.

## Files changed
- `libs/cli/deepagents_cli/widgets/mcp_viewer.py` — `MCPToolItem.set_expanded()` helper, `action_toggle_all` on the screen, new `Binding("a", ...)`, updated footer help text
- `libs/cli/tests/unit_tests/test_mcp_viewer.py` — 3 new tests: full-list toggle, partial-state-expands-rest, empty-list no-op

## Test plan
- `ruff format` clean, `ruff check` clean, `ty check` clean
- pytest: 10/10 pass on `test_mcp_viewer.py` (7 existing + 3 new), 2/2 pass on `test_app.py -k mcp`

Change is ~30 LOC source, additive (no existing binding/behavior altered). Risk of conflict with the rework PR is low.
