### PR TITLE
fix(sdk): add prompt_caching param to create_deep_agent for LiteLLM/p…

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -234,6 +234,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
+    prompt_caching: bool = True,
 ) -> CompiledStateGraph[AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]]:  # ty: ignore[invalid-type-arguments]  # ty can't verify generic TypedDicts satisfy StateLike bound
     """Create a deep agent.
 
@@ -405,6 +406,12 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         cache: The cache to use for the agent.
 
             Passed through to [`create_agent`][langchain.agents.create_agent].
+        prompt_caching: Whether to enable Anthropic prompt caching.
+
+            Set to `False` when routing `ChatAnthropic` through a proxy (e.g.
+            LiteLLM / Databricks) that does not support the `cache_control`
+            field. When `False`, `AnthropicPromptCachingMiddleware` is omitted
+            and `MemoryMiddleware` will not inject `cache_control` breakpoints.
 
     Returns:
         A configured deep agent.
@@ -458,8 +465,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # Strip excluded tools after all tool-injecting middleware has run
     if _profile.excluded_tools:
         gp_middleware.append(_ToolExclusionMiddleware(excluded=_profile.excluded_tools))
-    # Prompt caching is unconditional: "ignore" silently skips non-Anthropic models
-    gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+    if prompt_caching:
+        gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
     # Permissions must be last so they see all tools from prior middleware
     if permissions:
@@ -516,8 +523,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             if _subagent_profile.excluded_tools:
                 subagent_middleware.append(_ToolExclusionMiddleware(excluded=_subagent_profile.excluded_tools))
 
-            # Prompt caching
-            subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+            if prompt_caching:
+                subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
             if subagent_permissions:
                 subagent_middleware.append(_PermissionMiddleware(rules=subagent_permissions, backend=backend))
 
@@ -587,8 +594,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     deepagent_middleware.extend(_resolve_extra_middleware(_profile))
     if _profile.excluded_tools:
         deepagent_middleware.append(_ToolExclusionMiddleware(excluded=_profile.excluded_tools))
-    # Unconditional prompt caching (see general-purpose subagent comment).
-    deepagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+    if prompt_caching:
+        deepagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
     if memory is not None:
         # MemoryMiddleware applies the cache_control breakpoint only when the
         # request model is Anthropic, making it safe to enable unconditionally.
@@ -596,7 +603,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             MemoryMiddleware(
                 backend=backend,
                 sources=memory,
-                add_cache_control=True,
+                add_cache_control=prompt_caching,
             )
         )
     if interrupt_on is not None:

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -6,6 +6,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.tools import BaseTool, StructuredTool
@@ -20,6 +21,7 @@ from deepagents.graph import (
     create_deep_agent,
 )
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
+from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.profiles import _HARNESS_PROFILES, _get_harness_profile, _HarnessProfile, _register_harness_profile
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
@@ -588,3 +590,74 @@ class TestModelNoneDeprecationWarning:
 
         deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning) and "model=None" in str(w.message)]
         assert len(deprecations) == 0
+
+
+_PATCH_COMMON = [
+    ("deepagents.graph.FilesystemMiddleware", {"side_effect": [MagicMock(), MagicMock()]}),
+    ("deepagents.graph.SubAgentMiddleware", {"return_value": MagicMock()}),
+    ("deepagents.graph.TodoListMiddleware", {"return_value": MagicMock()}),
+    ("deepagents.graph.PatchToolCallsMiddleware", {"return_value": MagicMock()}),
+    ("deepagents.graph.create_summarization_middleware", {"return_value": MagicMock()}),
+]
+
+
+def _run_create_deep_agent(**kwargs: Any) -> list[Any]:
+    """Call create_deep_agent with common patches and return the main middleware stack."""
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+    fake_agent = MagicMock()
+    fake_agent.with_config.return_value = "compiled-agent"
+
+    patches = [patch(target, **kw) for target, kw in _PATCH_COMMON]
+    patches.append(patch("deepagents.graph.create_agent", return_value=fake_agent))
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5] as mock_create:
+        create_deep_agent(model=fake_model, **kwargs)
+
+    return mock_create.call_args.kwargs["middleware"]
+
+
+class TestPromptCaching:
+    """Tests for the prompt_caching parameter on create_deep_agent (issue #2881)."""
+
+    def _build_middleware(self, **kwargs: Any) -> list[Any]:
+        fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+
+        with (
+            patch("deepagents.graph.FilesystemMiddleware", side_effect=[MagicMock(), MagicMock()]),
+            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()),
+            patch("deepagents.graph.TodoListMiddleware", return_value=MagicMock()),
+            patch("deepagents.graph.PatchToolCallsMiddleware", return_value=MagicMock()),
+            patch("deepagents.graph.create_summarization_middleware", return_value=MagicMock()),
+            patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+        ):
+            create_deep_agent(model=fake_model, **kwargs)
+
+        return mock_create.call_args.kwargs["middleware"]
+
+    def test_prompt_caching_true_by_default_includes_caching_middleware(self) -> None:
+        """AnthropicPromptCachingMiddleware is in the stack when prompt_caching=True (default)."""
+        stack = self._build_middleware()
+        caching_mws = [m for m in stack if isinstance(m, AnthropicPromptCachingMiddleware)]
+        assert len(caching_mws) == 1
+
+    def test_prompt_caching_false_excludes_caching_middleware(self) -> None:
+        """AnthropicPromptCachingMiddleware is absent when prompt_caching=False (fix for #2881)."""
+        stack = self._build_middleware(prompt_caching=False)
+        caching_mws = [m for m in stack if isinstance(m, AnthropicPromptCachingMiddleware)]
+        assert len(caching_mws) == 0
+
+    def test_prompt_caching_true_memory_middleware_has_add_cache_control_true(self) -> None:
+        """MemoryMiddleware._add_cache_control is True when prompt_caching=True."""
+        stack = self._build_middleware(memory=["some/path"])
+        memory_mws = [m for m in stack if isinstance(m, MemoryMiddleware)]
+        assert len(memory_mws) == 1
+        assert memory_mws[0]._add_cache_control is True
+
+    def test_prompt_caching_false_memory_middleware_has_add_cache_control_false(self) -> None:
+        """MemoryMiddleware._add_cache_control is False when prompt_caching=False (fix for #2881)."""
+        stack = self._build_middleware(memory=["some/path"], prompt_caching=False)
+        memory_mws = [m for m in stack if isinstance(m, MemoryMiddleware)]
+        assert len(memory_mws) == 1
+        assert memory_mws[0]._add_cache_control is False


### PR DESCRIPTION
Fixes #2881

When ChatAnthropic is routed through a LiteLLM/Databricks proxy (e.g. via ANTHROPIC_BASE_URL), deepagents unconditionally injects cache_control fields into message blocks. The proxy rejects this field because Databricks implements the Anthropic API shape but not prompt caching infrastructure, and its strict schema validation raises: 
`anthropic.BadRequestError: cache_control: Extra inputs are not permitted `

The root cause is that AnthropicPromptCachingMiddleware and MemoryMiddleware both gate on isinstance(model, ChatAnthropic), which is True even when the model is pointed at a non-Anthropic backend. 


**Solution** 
Add a prompt_caching: bool = True parameter to create_deep_agent. When set to False: 
- AnthropicPromptCachingMiddleware is omitted from the main agent and all inline subagent middleware stacks
- MemoryMiddleware skips cache_control injection on system message blocks 

Default is True so existing behaviour is unchanged. 

`agent = create_deep_agent( 
    model=ChatAnthropic(model="claude-sonnet-4-6"), 
    system_prompt="...",
    prompt_caching=False, # set when routing through a proxy that rejects cache_control 
) `

Changes
- deepagents/graph.py — prompt_caching: bool = True parameter with docstring 
- tests/unit_tests/test_graph.py — 4 unit tests covering default-on, opt-out, and MemoryMiddleware wiring for both cases

## Social handles 
LinkedIn: https://www.linkedin.com/in/ninaadrrao/
