### PR TITLE
fix(sdk): HTML-decode execute tool command before shell execution

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -4,6 +4,7 @@
 import asyncio
 import concurrent.futures
 import contextvars
+import html
 import mimetypes
 import uuid
 import warnings
@@ -1069,6 +1070,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 if timeout > self._max_execute_timeout:
                     return f"Error: timeout {timeout}s exceeds maximum allowed ({self._max_execute_timeout}s)."
 
+            command = html.unescape(command)
+
             resolved_backend = self._get_backend(runtime)
 
             # Runtime check - fail gracefully if not supported
@@ -1124,6 +1127,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     return f"Error: timeout must be non-negative, got {timeout}."
                 if timeout > self._max_execute_timeout:
                     return f"Error: timeout {timeout}s exceeds maximum allowed ({self._max_execute_timeout}s)."
+
+            command = html.unescape(command)
 
             resolved_backend = self._get_backend(runtime)
 


### PR DESCRIPTION
Closes #2956

---

## Problem

Some LLMs (like Grok) return HTML-encoded characters in tool call arguments. For example, `&&` becomes `&amp;&amp;`, causing shell commands like `cd /tmp &amp;&amp; uv add playwright` to fail because the shell interprets `&amp;&amp;` as literal text instead of a command separator.

## Changes

- **File**: `libs/deepagents/deepagents/backends/shell.py`
- Added `import html` among stdlib imports
- Added `command = html.unescape(command)` in `sync_execute` after timeout validation (line ~1072)
- Added `command = html.unescape(command)` in `async_execute` after timeout validation (line ~1130)