### PR TITLE
fix(cli): honor SDK `ProviderProfile` defaults in `create_model`

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1862,36 +1862,52 @@ _OPENROUTER_APP_TITLE = "Deep Agents CLI"
 _OPENROUTER_APP_CATEGORIES: list[str] = ["cli-agent"]
 """Default `app_categories` (maps to `X-OpenRouter-Categories`) for OpenRouter."""
 
+_cli_openrouter_profile_registered = False
+"""Process-wide guard so the CLI OpenRouter profile is registered exactly once."""
 
-def _apply_openrouter_defaults(kwargs: dict[str, Any]) -> None:
-    """Inject default OpenRouter attribution kwargs.
 
-    Sets `app_url`, `app_title`, and `app_categories` via `setdefault` so
-    that user-supplied values in config take precedence. These map to the
-    `HTTP-Referer`, `X-Title`, and `X-OpenRouter-Categories` headers that
-    `ChatOpenRouter` sends for app attribution
-    (see https://openrouter.ai/docs/app-attribution).
+def _cli_openrouter_attribution_kwargs() -> dict[str, Any]:
+    """CLI-specific OpenRouter attribution kwargs.
 
-    Users can override either value provider-wide or per-model in
-    `~/.deepagents/config.toml`:
+    Layered on top of the SDK's built-in factory via profile stacking; these
+    values override the SDK defaults but still sit beneath any caller-supplied
+    `kwargs` (i.e. `config.toml`-resolved values), preserving the precedence
+    documented on `apply_provider_profile`.
 
-    ```toml
-    # Provider-wide
-    [models.providers.openrouter.params]
-    app_url = "https://myapp.com"
-    app_title = "My App"
-
-    # Per-model (shallow-merges on top of provider-wide)
-    [models.providers.openrouter.params."openai/gpt-oss-120b"]
-    app_title = "My App (GPT)"
-    ```
-
-    Args:
-        kwargs: Mutable kwargs dict to update in place.
+    Returns:
+        Mapping of `app_url` and `app_title` to spread into `init_chat_model`.
     """
-    kwargs.setdefault("app_url", _OPENROUTER_APP_URL)
-    kwargs.setdefault("app_title", _OPENROUTER_APP_TITLE)
-    kwargs.setdefault("app_categories", _OPENROUTER_APP_CATEGORIES)
+    return {
+        "app_url": _OPENROUTER_APP_URL,
+        "app_title": _OPENROUTER_APP_TITLE,
+    }
+
+
+def _ensure_cli_openrouter_profile_registered() -> None:
+    """Stack the CLI OpenRouter attribution onto the SDK's built-in profile.
+
+    Stacking (vs. duplicating the inline `_get_provider_kwargs` path) means the
+    SDK's `pre_init` version check fires exactly once and the CLI's app-
+    attribution defaults are composed via the same `apply_provider_profile`
+    path used for every other provider. `register_provider_profile` merges on
+    top of the existing built-in registration: the CLI's `init_kwargs` and
+    factory output win on shared keys, while the built-in's `pre_init` and
+    factory still chain.
+    """
+    global _cli_openrouter_profile_registered  # noqa: PLW0603
+    if _cli_openrouter_profile_registered:
+        return
+
+    from deepagents.profiles.provider import ProviderProfile, register_provider_profile
+
+    register_provider_profile(
+        "openrouter",
+        ProviderProfile(
+            init_kwargs={"app_categories": _OPENROUTER_APP_CATEGORIES},
+            init_kwargs_factory=_cli_openrouter_attribution_kwargs,
+        ),
+    )
+    _cli_openrouter_profile_registered = True
 
 
 def _get_provider_kwargs(
@@ -1934,21 +1950,6 @@ def _get_provider_kwargs(
         api_key = resolve_env_var(api_key_env)
         if api_key:
             result["api_key"] = api_key
-
-    if provider == "openrouter":
-        try:
-            # SDK >= profiles-subpackage layout.
-            from deepagents.profiles.provider._openrouter import (
-                check_openrouter_version,
-            )
-        except ImportError:
-            # Fallback for older SDK versions that hadn't nested provider built-ins.
-            from deepagents.profiles._openrouter import (  # ty: ignore[unresolved-import]
-                check_openrouter_version,  # noqa: PLC2701
-            )
-
-        check_openrouter_version()
-        _apply_openrouter_defaults(result)
 
     return result
 
@@ -2257,12 +2258,36 @@ def create_model(
     # Provider-specific kwargs (with per-model overrides)
     kwargs = _get_provider_kwargs(provider, model_name=model_name)
 
-    # SDK profile defaults sit beneath config.toml; user config still wins.
+    # Compose under existing kwargs: profile < config.toml < --model-params
+    # (applied below). The CLI's OpenRouter profile is stacked on top of the
+    # built-in SDK profile so its `pre_init` (version check) and factory
+    # (app attribution) compose into a single `apply_provider_profile` call.
     if provider:
         from deepagents.profiles.provider import apply_provider_profile
 
+        if provider == "openrouter":
+            _ensure_cli_openrouter_profile_registered()
+
         spec = f"{provider}:{model_name}" if model_name else provider
-        kwargs = apply_provider_profile(spec, kwargs)
+        try:
+            kwargs = apply_provider_profile(spec, kwargs)
+        except ModelConfigError:
+            raise
+        except Exception as exc:
+            # `pre_init` and `init_kwargs_factory` callables registered on a
+            # `ProviderProfile` may raise arbitrary exceptions (e.g. an
+            # `ImportError` from the OpenRouter min-version check). Surface
+            # them as `ModelConfigError` so the CLI's error path renders an
+            # actionable message instead of a raw stack trace.
+            logger.debug(
+                "ProviderProfile resolution for %r failed.", spec, exc_info=True
+            )
+            msg = (
+                f"Failed to apply provider profile for '{spec}': {exc}. "
+                f"Check that the provider package is installed and up to date, "
+                f"or set explicit kwargs via `--model-params`."
+            )
+            raise ModelConfigError(msg) from exc
 
     # CLI --model-params take highest priority
     if extra_kwargs:

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -2257,6 +2257,13 @@ def create_model(
     # Provider-specific kwargs (with per-model overrides)
     kwargs = _get_provider_kwargs(provider, model_name=model_name)
 
+    # SDK profile defaults sit beneath config.toml; user config still wins.
+    if provider:
+        from deepagents.profiles.provider import apply_provider_profile
+
+        spec = f"{provider}:{model_name}" if model_name else provider
+        kwargs = apply_provider_profile(spec, kwargs)
+
     # CLI --model-params take highest priority
     if extra_kwargs:
         kwargs.update(extra_kwargs)

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -1536,44 +1537,91 @@ base_url = "https://wrong-url.com"
         assert kwargs["base_url"] == "https://correct-url.com"
 
 
+def _make_init_chat_model_mock() -> Mock:
+    """Return a `Mock` shaped like `init_chat_model`'s return value.
+
+    Each `TestCreateModel*` test patches `langchain.chat_models.init_chat_model`
+    and inspects `call_args`; the returned model needs `profile = None` so the
+    downstream context-limit/modality extraction in `create_model` is a no-op.
+    """
+    mock_model = Mock()
+    mock_model.profile = None
+    return mock_model
+
+
+@pytest.fixture
+def _isolate_provider_profiles() -> Iterator[None]:
+    """Snapshot/restore SDK `_PROVIDER_PROFILES` and CLI registration sentinel.
+
+    The provider-profile registry is process-global. Tests that register
+    custom profiles (or that exercise the CLI's lazy OpenRouter registration)
+    must not leak state into other tests in the same session.
+    """
+    from deepagents.profiles.provider import provider_profiles
+
+    from deepagents_cli import config as cli_config
+
+    saved_profiles = dict(provider_profiles._PROVIDER_PROFILES)
+    saved_cli_flag = cli_config._cli_openrouter_profile_registered
+    try:
+        yield
+    finally:
+        provider_profiles._PROVIDER_PROFILES.clear()
+        provider_profiles._PROVIDER_PROFILES.update(saved_profiles)
+        cli_config._cli_openrouter_profile_registered = saved_cli_flag
+
+
 class TestOpenRouterVersionCheck:
-    """Tests for OpenRouter version enforcement via the SDK check."""
+    """Tests for OpenRouter version enforcement via the SDK profile."""
 
     def setup_method(self) -> None:
         """Clear model config cache before each test."""
         clear_caches()
 
-    def test_rejects_old_version(self) -> None:
-        """_get_provider_kwargs raises ImportError for old langchain-openrouter."""
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_rejects_old_version(self, mock_init: Mock) -> None:
+        """`create_model` wraps the version `ImportError` in `ModelConfigError`."""
+        mock_init.return_value = _make_init_chat_model_mock()
         with (
             patch(
                 "deepagents.profiles.provider._openrouter.pkg_version",
                 return_value="0.0.1",
             ),
-            pytest.raises(ImportError, match="langchain-openrouter>="),
+            pytest.raises(ModelConfigError, match="langchain-openrouter>="),
         ):
-            _get_provider_kwargs("openrouter")
+            create_model("openrouter:deepseek/deepseek-chat")
 
-    def test_accepts_sufficient_version(self) -> None:
-        """_get_provider_kwargs succeeds when version meets minimum."""
+    @patch("langchain.chat_models.init_chat_model")
+    def test_accepts_sufficient_version(self, mock_init: Mock) -> None:
+        """`create_model` succeeds when version meets minimum."""
         from deepagents.profiles.provider._openrouter import OPENROUTER_MIN_VERSION
 
+        mock_init.return_value = _make_init_chat_model_mock()
         with patch(
             "deepagents.profiles.provider._openrouter.pkg_version",
             return_value=OPENROUTER_MIN_VERSION,
         ):
-            kwargs = _get_provider_kwargs("openrouter")
+            create_model("openrouter:deepseek/deepseek-chat")
 
-        assert "app_url" in kwargs
+        _, call_kwargs = mock_init.call_args
+        assert "app_url" in call_kwargs
 
-    def test_skipped_for_other_providers(self) -> None:
+    @patch("langchain.chat_models.init_chat_model")
+    def test_skipped_for_other_providers(self, mock_init: Mock) -> None:
         """Version check is not invoked for non-openrouter providers."""
+        mock_init.return_value = _make_init_chat_model_mock()
         with patch(
             "deepagents.profiles.provider._openrouter.check_openrouter_version"
-        ) as mock:
-            _get_provider_kwargs("openai")
+        ) as mock_check:
+            create_model("openai:gpt-5.2")
 
-        mock.assert_not_called()
+        mock_check.assert_not_called()
 
 
 class TestOpenRouterHeaders:
@@ -1583,16 +1631,29 @@ class TestOpenRouterHeaders:
         """Clear model config cache before each test."""
         clear_caches()
 
-    def test_injects_attribution_kwargs(self) -> None:
-        """Injects app_url, app_title, and app_categories for openrouter."""
-        kwargs = _get_provider_kwargs("openrouter")
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
 
-        assert kwargs["app_url"] == "https://pypi.org/project/deepagents-cli/"
-        assert kwargs["app_title"] == "Deep Agents CLI"
-        assert kwargs["app_categories"] == ["cli-agent"]
+    @patch("langchain.chat_models.init_chat_model")
+    def test_injects_attribution_kwargs(self, mock_init: Mock) -> None:
+        """`create_model` injects `app_url`, `app_title`, `app_categories`."""
+        mock_init.return_value = _make_init_chat_model_mock()
 
-    def test_per_model_attribution_overrides_defaults(self, tmp_path: Path) -> None:
-        """Per-model app_title overrides built-in default."""
+        create_model("openrouter:deepseek/deepseek-chat")
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs["app_url"] == "https://pypi.org/project/deepagents-cli/"
+        assert call_kwargs["app_title"] == "Deep Agents CLI"
+        assert call_kwargs["app_categories"] == ["cli-agent"]
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_per_model_attribution_overrides_defaults(
+        self, mock_init: Mock, tmp_path: Path
+    ) -> None:
+        """Per-model `app_title` from `config.toml` overrides built-in default."""
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
 [models.providers.openrouter]
@@ -1601,17 +1662,20 @@ models = ["deepseek/deepseek-chat"]
 [models.providers.openrouter.params."deepseek/deepseek-chat"]
 app_title = "My Custom App"
 """)
+        mock_init.return_value = _make_init_chat_model_mock()
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            kwargs = _get_provider_kwargs(
-                "openrouter", model_name="deepseek/deepseek-chat"
-            )
+            create_model("openrouter:deepseek/deepseek-chat")
 
-        assert kwargs["app_title"] == "My Custom App"
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs["app_title"] == "My Custom App"
         # Built-in app_url should still be present
-        assert kwargs["app_url"] == "https://pypi.org/project/deepagents-cli/"
+        assert call_kwargs["app_url"] == "https://pypi.org/project/deepagents-cli/"
 
-    def test_per_model_categories_override(self, tmp_path: Path) -> None:
-        """Per-model app_categories overrides built-in default."""
+    @patch("langchain.chat_models.init_chat_model")
+    def test_per_model_categories_override(
+        self, mock_init: Mock, tmp_path: Path
+    ) -> None:
+        """Per-model `app_categories` from `config.toml` overrides built-in default."""
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
 [models.providers.openrouter]
@@ -1620,27 +1684,33 @@ models = ["deepseek/deepseek-chat"]
 [models.providers.openrouter.params."deepseek/deepseek-chat"]
 app_categories = ["cloud-agent"]
 """)
+        mock_init.return_value = _make_init_chat_model_mock()
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            kwargs = _get_provider_kwargs(
-                "openrouter", model_name="deepseek/deepseek-chat"
-            )
+            create_model("openrouter:deepseek/deepseek-chat")
 
-        assert kwargs["app_categories"] == ["cloud-agent"]
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs["app_categories"] == ["cloud-agent"]
 
-    def test_no_attribution_for_other_providers(self) -> None:
+    @patch("langchain.chat_models.init_chat_model")
+    def test_no_attribution_for_other_providers(self, mock_init: Mock) -> None:
         """Other providers do not get OpenRouter attribution kwargs."""
-        kwargs = _get_provider_kwargs("openai")
-        assert "app_url" not in kwargs
-        assert "app_title" not in kwargs
-        assert "app_categories" not in kwargs
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        create_model("openai:gpt-5.2")
+
+        _, call_kwargs = mock_init.call_args
+        assert "app_url" not in call_kwargs
+        assert "app_title" not in call_kwargs
+        assert "app_categories" not in call_kwargs
 
 
 class TestCreateModelForwardsProviderProfile:
     """Tests that `create_model` forwards profile kwargs to `init_chat_model`.
 
-    Regression coverage for the original PDF bug reported in #2959: env-default
-    and explicit OpenAI selections both need `use_responses_api=True` so file
-    content blocks are routed through the Responses API.
+    Regression coverage for #2959: env-default and explicit OpenAI selections
+    both need `use_responses_api=True` so the CLI's PDF-attachment path (which
+    emits `type: "file"` content blocks) is routed through the Responses API
+    instead of 400'ing against Chat Completions.
     """
 
     def setup_method(self) -> None:
@@ -1660,9 +1730,7 @@ class TestCreateModelForwardsProviderProfile:
     ) -> None:
         """No-spec `create_model()` resolves to OpenAI with `use_responses_api=True`."""
         mock_default.return_value = "openai:gpt-5.2"
-        mock_model = Mock()
-        mock_model.profile = None
-        mock_init.return_value = mock_model
+        mock_init.return_value = _make_init_chat_model_mock()
 
         create_model()
 
@@ -1672,9 +1740,7 @@ class TestCreateModelForwardsProviderProfile:
     @patch("langchain.chat_models.init_chat_model")
     def test_explicit_openai_spec_gets_use_responses_api(self, mock_init: Mock) -> None:
         """Explicit `openai:*` selection also inherits the SDK Responses API default."""
-        mock_model = Mock()
-        mock_model.profile = None
-        mock_init.return_value = mock_model
+        mock_init.return_value = _make_init_chat_model_mock()
 
         create_model("openai:gpt-5.2")
 
@@ -1683,10 +1749,8 @@ class TestCreateModelForwardsProviderProfile:
 
     @patch("langchain.chat_models.init_chat_model")
     def test_model_params_override_profile_default(self, mock_init: Mock) -> None:
-        """`--model-params` (extra_kwargs) wins over profile defaults."""
-        mock_model = Mock()
-        mock_model.profile = None
-        mock_init.return_value = mock_model
+        """`--model-params` (`extra_kwargs`) wins over profile defaults."""
+        mock_init.return_value = _make_init_chat_model_mock()
 
         create_model(
             "openai:gpt-5.2",
@@ -1706,9 +1770,7 @@ class TestCreateModelForwardsProviderProfile:
 [models.providers.openai.params]
 use_responses_api = false
 """)
-        mock_model = Mock()
-        mock_model.profile = None
-        mock_init.return_value = mock_model
+        mock_init.return_value = _make_init_chat_model_mock()
 
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
             create_model("openai:gpt-5.2")
@@ -1718,15 +1780,147 @@ use_responses_api = false
 
     @patch("langchain.chat_models.init_chat_model")
     def test_anthropic_unaffected(self, mock_init: Mock) -> None:
-        """Providers without a `ProviderProfile` are not given a `use_responses_api`."""
-        mock_model = Mock()
-        mock_model.profile = None
-        mock_init.return_value = mock_model
+        """Anthropic profile currently does not set `use_responses_api`."""
+        mock_init.return_value = _make_init_chat_model_mock()
 
         create_model("anthropic:claude-sonnet-4-5")
 
         _, call_kwargs = mock_init.call_args
         assert "use_responses_api" not in call_kwargs
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_exact_model_profile_wins_over_provider_profile(
+        self,
+        mock_init: Mock,
+        _isolate_provider_profiles: None,  # noqa: PT019
+    ) -> None:
+        """Per-model profile registration wins over the provider-wide profile.
+
+        Pins the spec construction in `create_model` (`f"{provider}:{model_name}"`).
+        A regression that drops the model-name suffix would silently fall back
+        to the provider-wide registration and bypass exact-model overrides.
+        """
+        from deepagents.profiles.provider import (
+            ProviderProfile,
+            register_provider_profile,
+        )
+
+        register_provider_profile(
+            "openai:gpt-5.2",
+            ProviderProfile(init_kwargs={"temperature": 0.42}),
+        )
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        create_model("openai:gpt-5.2")
+        _, exact_kwargs = mock_init.call_args
+        assert exact_kwargs.get("temperature") == 0.42
+
+        mock_init.reset_mock()
+        create_model("openai:gpt-4o")
+        _, other_kwargs = mock_init.call_args
+        assert "temperature" not in other_kwargs
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_init_kwargs_factory_output_forwarded(
+        self,
+        mock_init: Mock,
+        _isolate_provider_profiles: None,  # noqa: PT019
+    ) -> None:
+        """`init_kwargs_factory` output reaches `init_chat_model`.
+
+        Direct coverage for the factory branch in `apply_provider_profile` —
+        previously exercised only transitively via OpenRouter.
+        """
+        from deepagents.profiles.provider import (
+            ProviderProfile,
+            register_provider_profile,
+        )
+
+        register_provider_profile(
+            "anthropic",
+            ProviderProfile(init_kwargs_factory=lambda: {"max_tokens": 4096}),
+        )
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        create_model("anthropic:claude-sonnet-4-5")
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs.get("max_tokens") == 4096
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_pre_init_invoked_exactly_once(
+        self,
+        mock_init: Mock,
+        _isolate_provider_profiles: None,  # noqa: PT019
+    ) -> None:
+        """`pre_init` runs once per `create_model` call (not duplicated by CLI path).
+
+        Pins the consolidation: previously the CLI inline-called
+        `check_openrouter_version` *and* the SDK profile's `pre_init` ran the
+        same check, firing it twice. Only the profile path should run it now.
+        """
+        from deepagents.profiles.provider import (
+            ProviderProfile,
+            register_provider_profile,
+        )
+
+        pre_init_calls: list[str] = []
+        register_provider_profile(
+            "anthropic",
+            ProviderProfile(pre_init=lambda spec: pre_init_calls.append(spec)),
+        )
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        create_model("anthropic:claude-sonnet-4-5")
+
+        assert pre_init_calls == ["anthropic:claude-sonnet-4-5"]
+
+    @patch("deepagents.profiles.provider.apply_provider_profile")
+    @patch("langchain.chat_models.init_chat_model")
+    def test_no_provider_skips_profile_lookup(
+        self, mock_init: Mock, mock_apply: Mock
+    ) -> None:
+        """Bare model spec with no detected provider skips profile resolution.
+
+        `detect_provider` returns `None` for unrecognized model names; the
+        `if provider:` guard in `create_model` keeps the profile call out of
+        that path so an empty spec is never sent to `apply_provider_profile`.
+        """
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        create_model("some-unknown-model-name")
+
+        mock_apply.assert_not_called()
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_profile_pre_init_failure_wrapped_in_model_config_error(
+        self,
+        mock_init: Mock,
+        _isolate_provider_profiles: None,  # noqa: PT019
+    ) -> None:
+        """Arbitrary `pre_init` exceptions surface as `ModelConfigError`.
+
+        Without wrapping, a profile's `pre_init` failure bubbles up as a raw
+        traceback to the user; the CLI's error path expects `ModelConfigError`
+        for actionable rendering.
+        """
+        from deepagents.profiles.provider import (
+            ProviderProfile,
+            register_provider_profile,
+        )
+
+        def _broken_pre_init(_spec: str) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        register_provider_profile(
+            "anthropic",
+            ProviderProfile(pre_init=_broken_pre_init),
+        )
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        with pytest.raises(ModelConfigError, match="provider profile"):
+            create_model("anthropic:claude-sonnet-4-5")
 
 
 class TestCreateModelFromClass:

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1635,6 +1635,100 @@ app_categories = ["cloud-agent"]
         assert "app_categories" not in kwargs
 
 
+class TestCreateModelForwardsProviderProfile:
+    """Tests that `create_model` forwards profile kwargs to `init_chat_model`.
+
+    Regression coverage for the original PDF bug reported in #2959: env-default
+    and explicit OpenAI selections both need `use_responses_api=True` so file
+    content blocks are routed through the Responses API.
+    """
+
+    def setup_method(self) -> None:
+        """Clear model config cache before each test."""
+        clear_caches()
+
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.has_provider_credentials", lambda _: True
+        )
+
+    @patch("deepagents_cli.config._get_default_model_spec")
+    @patch("langchain.chat_models.init_chat_model")
+    def test_env_default_openai_gets_use_responses_api(
+        self, mock_init: Mock, mock_default: Mock
+    ) -> None:
+        """No-spec `create_model()` resolves to OpenAI with `use_responses_api=True`."""
+        mock_default.return_value = "openai:gpt-5.2"
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init.return_value = mock_model
+
+        create_model()
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs.get("use_responses_api") is True
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_explicit_openai_spec_gets_use_responses_api(self, mock_init: Mock) -> None:
+        """Explicit `openai:*` selection also inherits the SDK Responses API default."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init.return_value = mock_model
+
+        create_model("openai:gpt-5.2")
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs.get("use_responses_api") is True
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_model_params_override_profile_default(self, mock_init: Mock) -> None:
+        """`--model-params` (extra_kwargs) wins over profile defaults."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init.return_value = mock_model
+
+        create_model(
+            "openai:gpt-5.2",
+            extra_kwargs={"use_responses_api": False},
+        )
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs.get("use_responses_api") is False
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_config_toml_opt_out_wins_over_profile(
+        self, mock_init: Mock, tmp_path: Path
+    ) -> None:
+        """`use_responses_api=false` in `config.toml` opts out of the default."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openai.params]
+use_responses_api = false
+""")
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init.return_value = mock_model
+
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            create_model("openai:gpt-5.2")
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs.get("use_responses_api") is False
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_anthropic_unaffected(self, mock_init: Mock) -> None:
+        """Providers without a `ProviderProfile` are not given a `use_responses_api`."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init.return_value = mock_model
+
+        create_model("anthropic:claude-sonnet-4-5")
+
+        _, call_kwargs = mock_init.call_args
+        assert "use_responses_api" not in call_kwargs
+
+
 class TestCreateModelFromClass:
     """Tests for _create_model_from_class() custom class factory."""
 


### PR DESCRIPTION
Closes #2959.

Stacked on #2892 — should land after that PR.

---

`deepagents-cli` builds chat models through its own pipeline (`create_model` → `_get_provider_kwargs` → `init_chat_model`) that bypasses `resolve_model` and never consults the `ProviderProfile` registry. As a result, the built-in OpenAI profile's `use_responses_api=True` is silently dropped. The CLI's PDF attachment path emits `type: "file"` content blocks; Chat Completions rejects them with `Invalid value: 'file'. Supported values are: 'text', 'refusal', 'image_url', and 'input_audio'`.

This wires `_get_provider_profile` into `create_model` via a new `_apply_provider_profile` helper. After `_get_provider_kwargs` resolves config-driven kwargs, the helper fetches the registered profile (per-model with provider-wide fallback), runs `pre_init`, and `setdefault`-merges `init_kwargs` and `init_kwargs_factory` output beneath any keys already set. Precedence:

1. `--model-params` (highest)
2. `config.toml` provider/model params
3. `ProviderProfile` defaults from the SDK

Net effect: env-default *and* explicit `openai:*` selections both ride the Responses API by default, matching `resolve_model` and the policy already documented in `THREAT_MODEL.md` (opt-out via `[models.providers.openai.params] use_responses_api = false`). Other providers gain coverage automatically as the SDK adds built-in profiles or third parties register their own.

Supersedes #2960. The earlier `is_env_default` heuristic only covered env-default OpenAI; this PR fixes explicit-spec selection too by going through the same SDK contract that governs `resolve_model`.

### Follow-ups (out of scope)

`_get_provider_kwargs`'s inline `check_openrouter_version` and `_apply_openrouter_defaults` calls now run alongside the OpenRouter `ProviderProfile` `pre_init` and `init_kwargs_factory`. The version check is idempotent and the CLI-specific app-attribution defaults still take precedence over the SDK profile's via `setdefault`, so behavior is unchanged. Consolidating CLI OpenRouter handling into a stacked `ProviderProfile` registration is a clean follow-up.