### PR TITLE
fix(quickjs): propagate PTC Command updates through eval

### DIFF
--- a/examples/repl_swarm/uv.lock
+++ b/examples/repl_swarm/uv.lock
@@ -298,7 +298,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
-    { name = "langsmith", specifier = ">=0.3.0" },
+    { name = "langsmith", specifier = ">=0.7.35" },
     { name = "wcmatch" },
 ]
 
@@ -574,10 +574,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -586,9 +587,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -607,6 +608,18 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/51/1157009b6f94e6e58be58fa8b620187d657909a8b36a6bf5b0c52a2711f6/langchain_protocol-0.0.12.tar.gz", hash = "sha256:5e14c434290a705c9510fdb1a83ecf7561a5e6e0dfd053930ade80dba069269f", size = 6408, upload-time = "2026-04-25T01:05:01.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/82/3431e3061c917439589fa88a6b23c9bc0e154cba0f05d2e895a68c76ff74/langchain_protocol-0.0.12-py3-none-any.whl", hash = "sha256:402b61f42d4139692528cf37226c367bb6efc8ff8165b29380accb0abfece7b2", size = 6639, upload-time = "2026-04-25T01:05:00.487Z" },
+]
+
+[[package]]
 name = "langchain-quickjs"
 version = "0.1.0"
 source = { editable = "../../libs/partners/quickjs" }
@@ -614,6 +627,7 @@ dependencies = [
     { name = "deepagents" },
     { name = "langchain" },
     { name = "langchain-core" },
+    { name = "langgraph" },
     { name = "quickjs-rs" },
 ]
 
@@ -621,8 +635,9 @@ dependencies = [
 requires-dist = [
     { name = "deepagents", editable = "../../libs/deepagents" },
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
-    { name = "quickjs-rs", editable = "../../../quickjs-wasm" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
+    { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
+    { name = "quickjs-rs" },
 ]
 
 [package.metadata.requires-dev]
@@ -642,7 +657,7 @@ test = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.8"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -652,9 +667,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/02/196eff4f673fd461f8780930c3bfa7f27d6533a48e4f1104d544e843b093/langgraph-1.1.8.tar.gz", hash = "sha256:a97b8248129f2e007b81eef8277009ad1e1280b75fa2175889ab5aff5dcc4578", size = 560389, upload-time = "2026-04-17T19:45:50.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/38/c72e795f6f8fd05a8e7c3be32c04ea8534294decc6785f3b04e0ce932e8a/langgraph-1.1.8-py3-none-any.whl", hash = "sha256:3278c7e335da25eac3327bb474c502d4cab94ae6dcc685fbf93be2bbf7664cd5", size = 173678, upload-time = "2026-04-17T19:45:48.991Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -672,15 +687,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.10"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", size = 169769, upload-time = "2026-04-17T17:59:45.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", size = 36086, upload-time = "2026-04-17T17:59:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]
@@ -698,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.32"
+version = "0.7.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -711,9 +726,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/38/092f99a3326f0f6bb6ea62f388b16611d9cb619869ed7b0f3dae6c21c331/langsmith-0.7.37.tar.gz", hash = "sha256:e15ab27f5febbcfbaec4e6fa74ab71f0284f4c5965249cc732fe9344844290cb", size = 4433170, upload-time = "2026-04-26T21:36:41.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/fa99559d23ec9a39e1153f317a5ec99e7b967aec08b5faac04f8da603dd3/langsmith-0.7.37-py3-none-any.whl", hash = "sha256:64fc5fbf223fcdcc6ee44b08a5df4b2ab8a55e4d968e850c86b6b69fe0c258e3", size = 385948, upload-time = "2026-04-26T21:36:39.09Z" },
 ]
 
 [[package]]
@@ -1045,19 +1060,26 @@ wheels = [
 
 [[package]]
 name = "quickjs-rs"
-version = "0.3.0.dev0"
-source = { editable = "../../../quickjs-wasm" }
-
-[package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-codspeed", marker = "extra == 'bench'", specifier = ">=3.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'" },
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/33/024e9ea32bf1bee8dc60049dc37fcbdb07e838bc661ac74020f10ba18da1/quickjs_rs-0.1.0.tar.gz", hash = "sha256:2e0a85c785d86d4d57d475f91d2538417518fd225ae7911f54d8d021f303838d", size = 138266, upload-time = "2026-04-27T20:27:27.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/dc/fb9f1f6850b34d5f3e6bb6bf0a14d6e6888ec25306cf33768fe58fdde66b/quickjs_rs-0.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5618b9a105a4a648c07a3cda7a142b0cc49d9b00b8ad58b1903506459fb55c33", size = 1020758, upload-time = "2026-04-27T20:27:03.716Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/443e214f376ee1fdba076f4b87cc461a3ae07e740dd116d2bbd8fb689e9b/quickjs_rs-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5d86fcec48571edec725bfddddf8061acd68535086e4651d83c2cfa841855d15", size = 963264, upload-time = "2026-04-27T20:27:05.398Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/7f579033fac462058b9aa6c9f2f7e5ab560ea7da2c89bebe2f1e79dd29af/quickjs_rs-0.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0780ad58741a377482ba14c700292604a6ea93376431a967b9bab7e019d279c", size = 982681, upload-time = "2026-04-27T20:27:06.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7f/41738e22a54f685a05626cd0c8b8e397bd78b19fda74adedbd436b63765e/quickjs_rs-0.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff684c3f90f032b1e8449a3d8025f32470bfc5059f76c9292d68a755822bc3bc", size = 1050439, upload-time = "2026-04-27T20:27:08.509Z" },
+    { url = "https://files.pythonhosted.org/packages/56/82/45be566762c17dafbb782fdd1906790b4bccb2d63604fb3d98cd8eb82366/quickjs_rs-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:947fa051c99635da4a2151b17637550f48a0ddf0a7de639ab4d27d6d352eae59", size = 969395, upload-time = "2026-04-27T20:27:09.881Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/82/044a06f5d97c9bfe5807ce35cda10864c09446aaf363b0e68de35e9aeeea/quickjs_rs-0.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4a55fe742ca348f30ace35d9d76725536d6d013eeeddea9f97b2cc20710cf4e5", size = 1020976, upload-time = "2026-04-27T20:27:11.995Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a6/f2352f13c640a96ed750ff3e64808f219c4dc18ff8f10c03aafd670cca38/quickjs_rs-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d973810a8f4ed6d119cb226867d47caa7f9c4073309a25bb14116c6d3b6d04b", size = 964102, upload-time = "2026-04-27T20:27:13.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/33/65261b05be1c7669aad8ad1dac2cff389dbc4a46f19be5dc1656fc2febae/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:685a77c7c04ea2dc51fa0e53b65477c7906a48d809acef8d9a4b65330925a7ab", size = 982409, upload-time = "2026-04-27T20:27:14.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f0/056e1537de49bce75073019d963bfcc705114ef2dfebb5327da712f73937/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02f2fffe796c4a45909208b06c7781135ad77ba78c7d27e0d46bcbc44b530387", size = 1049531, upload-time = "2026-04-27T20:27:16.328Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/93d5b315db29075881630c6748c3c4838084291ad41e5ce3061d71cae310/quickjs_rs-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:71b0dddd27053cb270ddab537718b6e132b35f84d20368559d83b06293da17ac", size = 967263, upload-time = "2026-04-27T20:27:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e1/11a2a78f8ba7c28279e2e8a058c4a38952547d07cfde2a8368cf05908522/quickjs_rs-0.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8e34472e522064f0db46fa7f92c14baeabbe9b158071145868c814699490a28f", size = 1021769, upload-time = "2026-04-27T20:27:19.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a1/5052454cbef8bfc643e96b9d1d137f1928f0bf48e960bf0b77a3c333702d/quickjs_rs-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4d10697b3953b4e7d599ca6cf4c2b9a9510bc1eba368932e6bd0bb410e9951cf", size = 964415, upload-time = "2026-04-27T20:27:20.929Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d5/4c50ad704ab58082d3d13a1eeeb774f4a7eb88b4e634590eda057153e9aa/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35f1702417fb43049d18fa8bc7a01f3c9b7f651f758c32808368ce61aa58b8dd", size = 982720, upload-time = "2026-04-27T20:27:23.078Z" },
+    { url = "https://files.pythonhosted.org/packages/08/98/49ad0065ac927cdca16f289ca5fc819b67ee2eed5dec4febe6751b4a9c46/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6180aaaf7d64618c92845100dee9cba845c6ffcb73e8b4328ff02abbe8b639ac", size = 1049847, upload-time = "2026-04-27T20:27:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/65/1707487f5437b94ebcf1d69983673f8dce74aaefb44a7c560e2019b0159e/quickjs_rs-0.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:6d16ea5d366bb2885f426f9cb37ea68e668409a940fea85b1015b3c58612a346", size = 967729, upload-time = "2026-04-27T20:27:26.16Z" },
 ]
-provides-extras = ["dev", "bench"]
 
 [[package]]
 name = "repl-swarm-example"

--- a/examples/rlm_agent/uv.lock
+++ b/examples/rlm_agent/uv.lock
@@ -298,7 +298,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.1,<5.0.0" },
-    { name = "langsmith", specifier = ">=0.3.0" },
+    { name = "langsmith", specifier = ">=0.7.35" },
     { name = "wcmatch" },
 ]
 
@@ -574,10 +574,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -586,9 +587,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -607,6 +608,18 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/51/1157009b6f94e6e58be58fa8b620187d657909a8b36a6bf5b0c52a2711f6/langchain_protocol-0.0.12.tar.gz", hash = "sha256:5e14c434290a705c9510fdb1a83ecf7561a5e6e0dfd053930ade80dba069269f", size = 6408, upload-time = "2026-04-25T01:05:01.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/82/3431e3061c917439589fa88a6b23c9bc0e154cba0f05d2e895a68c76ff74/langchain_protocol-0.0.12-py3-none-any.whl", hash = "sha256:402b61f42d4139692528cf37226c367bb6efc8ff8165b29380accb0abfece7b2", size = 6639, upload-time = "2026-04-25T01:05:00.487Z" },
+]
+
+[[package]]
 name = "langchain-quickjs"
 version = "0.1.0"
 source = { editable = "../../libs/partners/quickjs" }
@@ -614,6 +627,7 @@ dependencies = [
     { name = "deepagents" },
     { name = "langchain" },
     { name = "langchain-core" },
+    { name = "langgraph" },
     { name = "quickjs-rs" },
 ]
 
@@ -621,8 +635,9 @@ dependencies = [
 requires-dist = [
     { name = "deepagents", editable = "../../libs/deepagents" },
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
-    { name = "quickjs-rs", editable = "../../../quickjs-wasm" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
+    { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
+    { name = "quickjs-rs" },
 ]
 
 [package.metadata.requires-dev]
@@ -642,7 +657,7 @@ test = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.9"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -652,9 +667,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/d5/9d9c65d5500a1ca7ea63d6d65aecfb248037018a74d7d4ef52e276bb4e4b/langgraph-1.1.9.tar.gz", hash = "sha256:bc5a49d5a5e71fda1f9c53c06c62f4caec9a95545b739d130a58b6ab3269e274", size = 560717, upload-time = "2026-04-21T13:43:06.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/58/0380420e66619d12c992c1f8cfda0c7a04e8f0fe8a84752245b9e7b1cba7/langgraph-1.1.9-py3-none-any.whl", hash = "sha256:7db13ceecde4ea643df6c097dcc9e534895dcd9fcc6500eeff2f2cde0fab16b2", size = 173744, upload-time = "2026-04-21T13:43:05.513Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -672,15 +687,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.10"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", size = 169769, upload-time = "2026-04-17T17:59:45.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", size = 36086, upload-time = "2026-04-17T17:59:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]
@@ -698,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.33"
+version = "0.7.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -711,9 +726,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/75/1ee27b3510bf5b1b569b9695c9466c256caab45885bd569c0c67720236ad/langsmith-0.7.33.tar.gz", hash = "sha256:fa2d81ad6e8374a81fda9291894f6fcae714e55fbf11a0b07578e3cd4b1ea384", size = 1186298, upload-time = "2026-04-20T16:17:54.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/38/092f99a3326f0f6bb6ea62f388b16611d9cb619869ed7b0f3dae6c21c331/langsmith-0.7.37.tar.gz", hash = "sha256:e15ab27f5febbcfbaec4e6fa74ab71f0284f4c5965249cc732fe9344844290cb", size = 4433170, upload-time = "2026-04-26T21:36:41.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/76/53033db34ffccd25d62c32b23b9468f7228b455da6976e1c420ae31555c4/langsmith-0.7.33-py3-none-any.whl", hash = "sha256:5b535b991d52d3b664ebb8dc6f95afcf8d0acb42e062ac45a54a6a4820139f20", size = 378981, upload-time = "2026-04-20T16:17:52.503Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/fa99559d23ec9a39e1153f317a5ec99e7b967aec08b5faac04f8da603dd3/langsmith-0.7.37-py3-none-any.whl", hash = "sha256:64fc5fbf223fcdcc6ee44b08a5df4b2ab8a55e4d968e850c86b6b69fe0c258e3", size = 385948, upload-time = "2026-04-26T21:36:39.09Z" },
 ]
 
 [[package]]
@@ -1045,19 +1060,26 @@ wheels = [
 
 [[package]]
 name = "quickjs-rs"
-version = "0.3.0.dev0"
-source = { editable = "../../../quickjs-wasm" }
-
-[package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-codspeed", marker = "extra == 'bench'", specifier = ">=3.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'" },
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/33/024e9ea32bf1bee8dc60049dc37fcbdb07e838bc661ac74020f10ba18da1/quickjs_rs-0.1.0.tar.gz", hash = "sha256:2e0a85c785d86d4d57d475f91d2538417518fd225ae7911f54d8d021f303838d", size = 138266, upload-time = "2026-04-27T20:27:27.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/dc/fb9f1f6850b34d5f3e6bb6bf0a14d6e6888ec25306cf33768fe58fdde66b/quickjs_rs-0.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5618b9a105a4a648c07a3cda7a142b0cc49d9b00b8ad58b1903506459fb55c33", size = 1020758, upload-time = "2026-04-27T20:27:03.716Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/443e214f376ee1fdba076f4b87cc461a3ae07e740dd116d2bbd8fb689e9b/quickjs_rs-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5d86fcec48571edec725bfddddf8061acd68535086e4651d83c2cfa841855d15", size = 963264, upload-time = "2026-04-27T20:27:05.398Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/7f579033fac462058b9aa6c9f2f7e5ab560ea7da2c89bebe2f1e79dd29af/quickjs_rs-0.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0780ad58741a377482ba14c700292604a6ea93376431a967b9bab7e019d279c", size = 982681, upload-time = "2026-04-27T20:27:06.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7f/41738e22a54f685a05626cd0c8b8e397bd78b19fda74adedbd436b63765e/quickjs_rs-0.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff684c3f90f032b1e8449a3d8025f32470bfc5059f76c9292d68a755822bc3bc", size = 1050439, upload-time = "2026-04-27T20:27:08.509Z" },
+    { url = "https://files.pythonhosted.org/packages/56/82/45be566762c17dafbb782fdd1906790b4bccb2d63604fb3d98cd8eb82366/quickjs_rs-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:947fa051c99635da4a2151b17637550f48a0ddf0a7de639ab4d27d6d352eae59", size = 969395, upload-time = "2026-04-27T20:27:09.881Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/82/044a06f5d97c9bfe5807ce35cda10864c09446aaf363b0e68de35e9aeeea/quickjs_rs-0.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4a55fe742ca348f30ace35d9d76725536d6d013eeeddea9f97b2cc20710cf4e5", size = 1020976, upload-time = "2026-04-27T20:27:11.995Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a6/f2352f13c640a96ed750ff3e64808f219c4dc18ff8f10c03aafd670cca38/quickjs_rs-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d973810a8f4ed6d119cb226867d47caa7f9c4073309a25bb14116c6d3b6d04b", size = 964102, upload-time = "2026-04-27T20:27:13.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/33/65261b05be1c7669aad8ad1dac2cff389dbc4a46f19be5dc1656fc2febae/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:685a77c7c04ea2dc51fa0e53b65477c7906a48d809acef8d9a4b65330925a7ab", size = 982409, upload-time = "2026-04-27T20:27:14.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f0/056e1537de49bce75073019d963bfcc705114ef2dfebb5327da712f73937/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02f2fffe796c4a45909208b06c7781135ad77ba78c7d27e0d46bcbc44b530387", size = 1049531, upload-time = "2026-04-27T20:27:16.328Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/93d5b315db29075881630c6748c3c4838084291ad41e5ce3061d71cae310/quickjs_rs-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:71b0dddd27053cb270ddab537718b6e132b35f84d20368559d83b06293da17ac", size = 967263, upload-time = "2026-04-27T20:27:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e1/11a2a78f8ba7c28279e2e8a058c4a38952547d07cfde2a8368cf05908522/quickjs_rs-0.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8e34472e522064f0db46fa7f92c14baeabbe9b158071145868c814699490a28f", size = 1021769, upload-time = "2026-04-27T20:27:19.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a1/5052454cbef8bfc643e96b9d1d137f1928f0bf48e960bf0b77a3c333702d/quickjs_rs-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4d10697b3953b4e7d599ca6cf4c2b9a9510bc1eba368932e6bd0bb410e9951cf", size = 964415, upload-time = "2026-04-27T20:27:20.929Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d5/4c50ad704ab58082d3d13a1eeeb774f4a7eb88b4e634590eda057153e9aa/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35f1702417fb43049d18fa8bc7a01f3c9b7f651f758c32808368ce61aa58b8dd", size = 982720, upload-time = "2026-04-27T20:27:23.078Z" },
+    { url = "https://files.pythonhosted.org/packages/08/98/49ad0065ac927cdca16f289ca5fc819b67ee2eed5dec4febe6751b4a9c46/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6180aaaf7d64618c92845100dee9cba845c6ffcb73e8b4328ff02abbe8b639ac", size = 1049847, upload-time = "2026-04-27T20:27:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/65/1707487f5437b94ebcf1d69983673f8dce74aaefb44a7c560e2019b0159e/quickjs_rs-0.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:6d16ea5d366bb2885f426f9cb37ea68e668409a940fea85b1015b3c58612a346", size = 967729, upload-time = "2026-04-27T20:27:26.16Z" },
 ]
-provides-extras = ["dev", "bench"]
 
 [[package]]
 name = "repl-swarm-example"

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -438,7 +438,7 @@ def _parse_skill_metadata(  # noqa: C901
 
     module_path = _validate_module_path(frontmatter_data.get("module"), skill_path)
 
-    result = SkillMetadata( 
+    result = SkillMetadata(
         name=str(name),
         description=description_str,
         path=skill_path,

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
@@ -62,7 +62,6 @@ async def test_alist_skills_from_backend_single_skill(tmp_path: Path) -> None:
             "license": None,
             "compatibility": None,
             "allowed_tools": [],
-            "module": None,
         }
     ]
 
@@ -152,7 +151,6 @@ async def test_alist_skills_from_backend_missing_skill_md(tmp_path: Path) -> Non
             "license": None,
             "compatibility": None,
             "allowed_tools": [],
-            "module": None,
         }
     ]
 
@@ -193,7 +191,6 @@ Content
             "license": None,
             "compatibility": None,
             "allowed_tools": [],
-            "module": None,
         }
     ]
 
@@ -280,7 +277,6 @@ async def test_abefore_agent_skill_override(tmp_path: Path) -> None:
         "license": None,
         "compatibility": None,
         "allowed_tools": [],
-        "module": None,
     }
 
 

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -2407,10 +2407,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0a3"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -2419,9 +2420,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/3b/c4f9466f2ca7d56bde381ee26e78272b3eff65255ddc3954e3c4f99ca6d5/langchain_core-1.3.0a3.tar.gz", hash = "sha256:d27d9e43060850159a84c3913ba71bfcdd5807d52a4794c6ee719116510a5f04", size = 860836, upload-time = "2026-04-16T19:40:36.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/ed/e58ff8229b18a9c5cfbeb531d463b5193bb643ddfa97cf42f2c11c06d4db/langchain_core-1.3.0a3-py3-none-any.whl", hash = "sha256:f819afed6c2c48fc70dadf7f968f03f224307820e6965a885a357412090c9241", size = 515161, upload-time = "2026-04-16T19:40:35.493Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -2567,18 +2568,36 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/51/1157009b6f94e6e58be58fa8b620187d657909a8b36a6bf5b0c52a2711f6/langchain_protocol-0.0.12.tar.gz", hash = "sha256:5e14c434290a705c9510fdb1a83ecf7561a5e6e0dfd053930ade80dba069269f", size = 6408, upload-time = "2026-04-25T01:05:01.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/82/3431e3061c917439589fa88a6b23c9bc0e154cba0f05d2e895a68c76ff74/langchain_protocol-0.0.12-py3-none-any.whl", hash = "sha256:402b61f42d4139692528cf37226c367bb6efc8ff8165b29380accb0abfece7b2", size = 6639, upload-time = "2026-04-25T01:05:00.487Z" },
+]
+
+[[package]]
 name = "langchain-quickjs"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "../partners/quickjs" }
 dependencies = [
     { name = "deepagents" },
-    { name = "quickjs" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "quickjs-rs" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "deepagents", editable = "../deepagents" },
-    { name = "quickjs", specifier = ">=1.19.4,<2" },
+    { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
+    { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
+    { name = "quickjs-rs" },
 ]
 
 [package.metadata.requires-dev]
@@ -2640,7 +2659,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.6"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2650,9 +2669,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -2743,15 +2762,15 @@ inmem = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]
@@ -4472,15 +4491,21 @@ wheels = [
 ]
 
 [[package]]
-name = "quickjs"
-version = "1.19.4"
+name = "quickjs-rs"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/a7/8fac2e213db8108d8108e9f1ee8d6c2abfcbe943238b0960585c26666862/quickjs-1.19.4.tar.gz", hash = "sha256:1205953abc24ff757f4a795304d5d61e4bf1e555c9ef6ec96a132d4b95535484", size = 456179, upload-time = "2023-11-19T10:06:39.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/33/024e9ea32bf1bee8dc60049dc37fcbdb07e838bc661ac74020f10ba18da1/quickjs_rs-0.1.0.tar.gz", hash = "sha256:2e0a85c785d86d4d57d475f91d2538417518fd225ae7911f54d8d021f303838d", size = 138266, upload-time = "2026-04-27T20:27:27.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/4f/df90bde103703cd052fd76ad7bddfcb9a4f908ab6c940ad05fdb3997e173/quickjs-1.19.4-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1bc38a840144a54e90668fb1f99441148429ab1d1b1355ecafbbe656eaeff788", size = 1004472, upload-time = "2023-11-19T10:06:17.453Z" },
-    { url = "https://files.pythonhosted.org/packages/26/59/1689a6f59f26d8f68c082dc6dfbbb38d9b7eaa3e243a775f8be2c876b561/quickjs-1.19.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:45d0e68570425d8322c48fb8989865df9b8c3e3ad3a01726151e0451d3c637eb", size = 2179639, upload-time = "2023-11-19T10:06:21.064Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/cd/8fd683236b976487bbd4c99e24334b25fc0542367164f2348bca08572490/quickjs-1.19.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac4b6d40b90553e9b135b35b3eaca264d10cdf92bfafce36ed9fb9acfdc5b420", size = 2173664, upload-time = "2023-11-19T10:06:22.931Z" },
-    { url = "https://files.pythonhosted.org/packages/be/10/58064fe6beeb72c122f2ecb4729cf437055d89891d29cc2cd20ed88c1d66/quickjs-1.19.4-cp312-cp312-win_amd64.whl", hash = "sha256:3ebe018eaef1957a21264b98877c6217d7bfc4e28cbc5d87e75f879e1f45fc85", size = 382359, upload-time = "2023-11-19T10:06:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/82/044a06f5d97c9bfe5807ce35cda10864c09446aaf363b0e68de35e9aeeea/quickjs_rs-0.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4a55fe742ca348f30ace35d9d76725536d6d013eeeddea9f97b2cc20710cf4e5", size = 1020976, upload-time = "2026-04-27T20:27:11.995Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a6/f2352f13c640a96ed750ff3e64808f219c4dc18ff8f10c03aafd670cca38/quickjs_rs-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d973810a8f4ed6d119cb226867d47caa7f9c4073309a25bb14116c6d3b6d04b", size = 964102, upload-time = "2026-04-27T20:27:13.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/33/65261b05be1c7669aad8ad1dac2cff389dbc4a46f19be5dc1656fc2febae/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:685a77c7c04ea2dc51fa0e53b65477c7906a48d809acef8d9a4b65330925a7ab", size = 982409, upload-time = "2026-04-27T20:27:14.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f0/056e1537de49bce75073019d963bfcc705114ef2dfebb5327da712f73937/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02f2fffe796c4a45909208b06c7781135ad77ba78c7d27e0d46bcbc44b530387", size = 1049531, upload-time = "2026-04-27T20:27:16.328Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/93d5b315db29075881630c6748c3c4838084291ad41e5ce3061d71cae310/quickjs_rs-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:71b0dddd27053cb270ddab537718b6e132b35f84d20368559d83b06293da17ac", size = 967263, upload-time = "2026-04-27T20:27:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e1/11a2a78f8ba7c28279e2e8a058c4a38952547d07cfde2a8368cf05908522/quickjs_rs-0.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8e34472e522064f0db46fa7f92c14baeabbe9b158071145868c814699490a28f", size = 1021769, upload-time = "2026-04-27T20:27:19.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a1/5052454cbef8bfc643e96b9d1d137f1928f0bf48e960bf0b77a3c333702d/quickjs_rs-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4d10697b3953b4e7d599ca6cf4c2b9a9510bc1eba368932e6bd0bb410e9951cf", size = 964415, upload-time = "2026-04-27T20:27:20.929Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d5/4c50ad704ab58082d3d13a1eeeb774f4a7eb88b4e634590eda057153e9aa/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35f1702417fb43049d18fa8bc7a01f3c9b7f651f758c32808368ce61aa58b8dd", size = 982720, upload-time = "2026-04-27T20:27:23.078Z" },
+    { url = "https://files.pythonhosted.org/packages/08/98/49ad0065ac927cdca16f289ca5fc819b67ee2eed5dec4febe6751b4a9c46/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6180aaaf7d64618c92845100dee9cba845c6ffcb73e8b4328ff02abbe8b639ac", size = 1049847, upload-time = "2026-04-27T20:27:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/65/1707487f5437b94ebcf1d69983673f8dce74aaefb44a7c560e2019b0159e/quickjs_rs-0.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:6d16ea5d366bb2885f426f9cb37ea68e668409a940fea85b1015b3c58612a346", size = 967729, upload-time = "2026-04-27T20:27:26.16Z" },
 ]
 
 [[package]]

--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -78,11 +78,7 @@ def filter_tools_for_ptc(
             raise TypeError(msg)
         selected = [
             *explicit_tools,
-            *[
-                t
-                for t in tools
-                if t.name != self_tool_name and t.name in allow_names
-            ],
+            *[t for t in tools if t.name != self_tool_name and t.name in allow_names],
         ]
         deduped: list[BaseTool] = []
         seen_names: set[str] = set()

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -301,24 +301,17 @@ def _inject_tool_args_for_ptc(
     # Build a ToolRuntime matching the outer one but with a fresh
     # tool_call_id. ``type(outer_runtime)`` rather than a literal import
     # so the shape stays in lockstep with whatever langgraph ships.
-    runtime_kwargs: dict[str, Any] = {
-        "state": outer_runtime.state,
-        "tool_call_id": tool_call_id,
-        "config": outer_runtime.config,
-        "context": outer_runtime.context,
-        "store": outer_runtime.store,
-        "stream_writer": outer_runtime.stream_writer,
-        "execution_info": getattr(outer_runtime, "execution_info", None),
-        "server_info": getattr(outer_runtime, "server_info", None),
-    }
-    if hasattr(outer_runtime, "tools"):
-        runtime_kwargs["tools"] = outer_runtime.tools
-    try:
-        derived = type(outer_runtime)(**runtime_kwargs)
-    except TypeError:
-        # Older ToolRuntime signatures don't include ``tools``.
-        runtime_kwargs.pop("tools", None)
-        derived = type(outer_runtime)(**runtime_kwargs)
+    derived = type(outer_runtime)(
+        state=outer_runtime.state,
+        tool_call_id=tool_call_id,
+        config=outer_runtime.config,
+        context=outer_runtime.context,
+        store=outer_runtime.store,
+        stream_writer=outer_runtime.stream_writer,
+        tools=outer_runtime.tools,
+        execution_info=getattr(outer_runtime, "execution_info", None),
+        server_info=getattr(outer_runtime, "server_info", None),
+    )
 
     enriched = dict(payload)
     if injected.runtime:

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -71,7 +71,7 @@ class EvalOutcome:
     error_type: str | None = None
     error_message: str = ""
     error_stack: str | None = None
-    command_updates: list[Command] = field(default_factory=list)
+    commands: list[Command] = field(default_factory=list)
 
 
 class _ConsoleBuffer:
@@ -599,7 +599,7 @@ class _ThreadREPL:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
         finally:
-            outcome.command_updates.extend(self._ptc_command_buffer)
+            outcome.commands.extend(self._ptc_command_buffer)
             self._ptc_command_buffer.clear()
             outcome.stdout = self._console.drain()
         return outcome

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -71,6 +71,7 @@ class EvalOutcome:
     error_type: str | None = None
     error_message: str = ""
     error_stack: str | None = None
+    command_updates: list[Command] = field(default_factory=list)
 
 
 class _ConsoleBuffer:
@@ -234,6 +235,15 @@ def _coerce_tool_output(value: Any) -> str:
         return str(value)
 
 
+def _extract_commands(value: Any) -> list[Command]:
+    """Collect LangGraph ``Command`` values from a tool return payload."""
+    if isinstance(value, Command):
+        return [value]
+    if isinstance(value, list):
+        return [entry for entry in value if isinstance(entry, Command)]
+    return []
+
+
 def _synth_tool_call_id(tool_name: str) -> str:
     """Mint a synthetic tool_call_id for a PTC-driven tool invocation.
 
@@ -275,16 +285,24 @@ def _inject_tool_args_for_ptc(
     # Build a ToolRuntime matching the outer one but with a fresh
     # tool_call_id. ``type(outer_runtime)`` rather than a literal import
     # so the shape stays in lockstep with whatever langgraph ships.
-    derived = type(outer_runtime)(
-        state=outer_runtime.state,
-        tool_call_id=tool_call_id,
-        config=outer_runtime.config,
-        context=outer_runtime.context,
-        store=outer_runtime.store,
-        stream_writer=outer_runtime.stream_writer,
-        execution_info=getattr(outer_runtime, "execution_info", None),
-        server_info=getattr(outer_runtime, "server_info", None),
-    )
+    runtime_kwargs: dict[str, Any] = {
+        "state": outer_runtime.state,
+        "tool_call_id": tool_call_id,
+        "config": outer_runtime.config,
+        "context": outer_runtime.context,
+        "store": outer_runtime.store,
+        "stream_writer": outer_runtime.stream_writer,
+        "execution_info": getattr(outer_runtime, "execution_info", None),
+        "server_info": getattr(outer_runtime, "server_info", None),
+    }
+    if hasattr(outer_runtime, "tools"):
+        runtime_kwargs["tools"] = outer_runtime.tools
+    try:
+        derived = type(outer_runtime)(**runtime_kwargs)
+    except TypeError:
+        # Older ToolRuntime signatures don't include ``tools``.
+        runtime_kwargs.pop("tools", None)
+        derived = type(outer_runtime)(**runtime_kwargs)
 
     enriched = dict(payload)
     if injected.runtime:
@@ -378,6 +396,9 @@ class _ThreadREPL:
         # graph state, store, context, etc. Set via ``set_outer_runtime``
         # from the middleware's tool handler immediately before eval.
         self._outer_runtime: ToolRuntime | None = None
+        # ``Command`` values emitted by PTC-invoked tools during the
+        # currently-running eval call. Drained into ``EvalOutcome``.
+        self._ptc_command_buffer: list[Command] = []
         # Context creation + console install must happen on the worker
         # thread. Block caller here so the REPL is ready to use when
         # __init__ returns.
@@ -511,6 +532,7 @@ class _ThreadREPL:
             result = await tool.ainvoke(
                 {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
             )
+            self._ptc_command_buffer.extend(_extract_commands(result))
             return _coerce_tool_output(result)
 
         bridge_symbol = _bridge_symbol_name(camel)
@@ -545,6 +567,7 @@ class _ThreadREPL:
         """
         ctx = cast("Context", self._ctx)
         outcome = EvalOutcome()
+        self._ptc_command_buffer.clear()
         try:
             value = await ctx.eval_async(code, timeout=self._per_call_timeout)
             outcome.result = _stringify(value)
@@ -575,7 +598,10 @@ class _ThreadREPL:
         except MemoryLimitError as e:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
-        outcome.stdout = self._console.drain()
+        finally:
+            outcome.command_updates.extend(self._ptc_command_buffer)
+            self._ptc_command_buffer.clear()
+            outcome.stdout = self._console.drain()
         return outcome
 
     def _record_js_error(self, outcome: EvalOutcome, e: JSError) -> None:

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -192,7 +192,7 @@ def _normalize_tool_input(raw: Any) -> dict[str, Any]:
 def _coerce_tool_output(value: Any) -> str:
     """Tools return arbitrary Python; JS-side users expect a string.
 
-    Handles three shapes:
+    Handles four shapes:
 
     - ``str`` — pass through unchanged.
     - ``langgraph.types.Command`` — the shape ``task`` / subagent tools
@@ -208,31 +208,47 @@ def _coerce_tool_output(value: Any) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, Command):
-        update = value.update
-        if isinstance(update, dict):
-            messages = update.get("messages")
-            if messages:
-                last = messages[-1]
-                content = getattr(last, "content", None)
-                if isinstance(content, str):
-                    return content
-        # No extractable message — stringify the update for debuggability.
-        return str(update)
+        return _coerce_command_output(value)
     # When we invoke with a ToolCall-shaped input, BaseTool wraps the
     # return value in a ToolMessage. Unwrap its content so the JS side
     # sees the raw tool output, not a Python repr of the envelope.
     if isinstance(value, ToolMessage):
-        content = value.content
-        if isinstance(content, str):
-            return content
-        try:
-            return json.dumps(content, default=str)
-        except (TypeError, ValueError):
-            return str(content)
+        return _coerce_tool_message_output(value)
+    if isinstance(value, list):
+        # Some tools return a mixed ``list[Command | ToolMessage]``.
+        # Mirror parent-agent behavior by surfacing the last message-like
+        # entry as the JS-visible value.
+        for entry in reversed(value):
+            if isinstance(entry, ToolMessage):
+                return _coerce_tool_message_output(entry)
+            if isinstance(entry, Command):
+                return _coerce_command_output(entry)
+    return _coerce_message_content(value)
+
+
+def _coerce_message_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
     try:
-        return json.dumps(value, default=str)
+        return json.dumps(content, default=str)
     except (TypeError, ValueError):
-        return str(value)
+        return str(content)
+
+
+def _coerce_tool_message_output(message: ToolMessage) -> str:
+    return _coerce_message_content(message.content)
+
+
+def _coerce_command_output(command: Command) -> str:
+    update = command.update
+    if isinstance(update, dict):
+        messages = update.get("messages")
+        if isinstance(messages, list):
+            for entry in reversed(messages):
+                content = getattr(entry, "content", None)
+                if content is not None:
+                    return _coerce_message_content(content)
+    return str(update)
 
 
 def _extract_commands(value: Any) -> list[Command]:

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -216,8 +216,8 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 tool_call_id=tool_call_id,
                 name=tool_name,
             )
-            if outcome.command_updates:
-                return [*outcome.command_updates, message]
+            if outcome.commands:
+                return [*outcome.commands, message]
             return message
 
         code_doc = (
@@ -271,8 +271,8 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 tool_call_id=runtime.tool_call_id,
                 name=tool_name,
             )
-            if outcome.command_updates:
-                return [*outcome.command_updates, message]
+            if outcome.commands:
+                return [*outcome.commands, message]
             return message
 
         return StructuredTool.from_function(

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -22,6 +22,7 @@ from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 from langgraph.config import get_config
+from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ _DEFAULT_MEMORY_LIMIT = 64 * 1024 * 1024
 _DEFAULT_TIMEOUT = 5.0
 _DEFAULT_MAX_RESULT_CHARS = 4_000
 _DEFAULT_TOOL_NAME = "eval"
+_EvalToolResult = ToolMessage | list[Command | ToolMessage]
 
 _SYSTEM_PROMPT_TEMPLATE = (
     "An `{tool_name}` tool is available. It runs JavaScript in a persistent "
@@ -205,11 +207,18 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         fallback_id = self._fallback_thread_id
         middleware = self
 
-        def _run(outcome_fn: Any, code: str, tool_call_id: str | None) -> ToolMessage:
-            content = format_outcome(outcome_fn(code), max_result_chars=max_chars)
-            return ToolMessage(
-                content=content, tool_call_id=tool_call_id, name=tool_name
+        def _run(
+            outcome_fn: Any, code: str, tool_call_id: str | None
+        ) -> _EvalToolResult:
+            outcome = outcome_fn(code)
+            message = ToolMessage(
+                content=format_outcome(outcome, max_result_chars=max_chars),
+                tool_call_id=tool_call_id,
+                name=tool_name,
             )
+            if outcome.command_updates:
+                return [*outcome.command_updates, message]
+            return message
 
         code_doc = (
             "JavaScript expression or statement(s) to evaluate in the persistent REPL."
@@ -218,7 +227,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         def sync_eval(
             runtime: ToolRuntime[None, Any],
             code: Annotated[str, code_doc],
-        ) -> ToolMessage:
+        ) -> _EvalToolResult:
             repl = registry.get(_resolve_thread_id(fallback_id))
             # The sync path doesn't support PTC (host-fn bridges are
             # async); set_outer_runtime is a no-op here.
@@ -231,7 +240,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         async def async_eval(
             runtime: ToolRuntime[None, Any],
             code: Annotated[str, code_doc],
-        ) -> ToolMessage:
+        ) -> _EvalToolResult:
             repl = registry.get(_resolve_thread_id(fallback_id))
             # Install any referenced skills before eval. If install
             # fails (bad skill, unknown name, backend error) we short-
@@ -254,15 +263,17 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             # would otherwise retain a reference past the call.
             repl.set_outer_runtime(runtime)
             try:
-                content = format_outcome(
-                    await repl.eval_async(code),
-                    max_result_chars=max_chars,
-                )
+                outcome = await repl.eval_async(code)
             finally:
                 repl.set_outer_runtime(None)
-            return ToolMessage(
-                content=content, tool_call_id=runtime.tool_call_id, name=tool_name
+            message = ToolMessage(
+                content=format_outcome(outcome, max_result_chars=max_chars),
+                tool_call_id=runtime.tool_call_id,
+                name=tool_name,
             )
+            if outcome.command_updates:
+                return [*outcome.command_updates, message]
+            return message
 
         return StructuredTool.from_function(
             name=tool_name,

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "deepagents",
     "quickjs-rs",
     "langchain>=1.2.15,<2.0.0",
-    "langchain-core>=1.2.27,<2.0.0",
+    "langchain-core>=1.3.1,<2.0.0",
+    "langgraph>=1.1.10,<2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -53,16 +53,8 @@ test = [
     "build",
 ]
 
-# TODO(packaging): before publishing to PyPI, remove the [tool.uv.sources] block
-# below and replace it with version pins. The local path assumption only holds
-# in the monorepo-style sibling layout used during development.
-#
-# Note: the upstream repo directory is still named ``quickjs-wasm`` even
-# though the package was renamed ``quickjs-rs`` in 0.3 (the path is the
-# repo on disk, the package name is what pip/uv installs).
 [tool.uv.sources]
 deepagents = { path = "../../deepagents", editable = true }
-quickjs-rs = { path = "../../../../quickjs-wasm", editable = true }
 
 [tool.uv]
 constraint-dependencies = ["urllib3>=2.6.3"]

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -283,7 +283,7 @@ async def test_command_tool_updates_are_collected_from_single_eval(
     )
     assert outcome.error_type is None, outcome.error_message
     assert outcome.result == "done"
-    assert [cmd.update.get("ptc_values") for cmd in outcome.command_updates] == [
+    assert [cmd.update.get("ptc_values") for cmd in outcome.commands] == [
         [1],
         [2],
     ]
@@ -292,9 +292,9 @@ async def test_command_tool_updates_are_collected_from_single_eval(
 async def test_command_buffer_is_scoped_to_one_eval(repl: _ThreadREPL) -> None:
     repl.install_tools([_command_tool()])
     first = await repl.eval_async("await tools.emitCommand({value: 7})")
-    assert len(first.command_updates) == 1
+    assert len(first.commands) == 1
     second = await repl.eval_async("1 + 1")
-    assert second.command_updates == []
+    assert second.commands == []
 async def test_tool_failure_surfaces_as_js_error(repl: _ThreadREPL) -> None:
     def _boom(**_: object) -> str:
         msg = "tool exploded"

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -358,6 +358,8 @@ async def test_command_buffer_is_scoped_to_one_eval(repl: _ThreadREPL) -> None:
     assert len(first.commands) == 1
     second = await repl.eval_async("1 + 1")
     assert second.commands == []
+
+
 async def test_toolmessage_list_uses_last_message_content(repl: _ThreadREPL) -> None:
     repl.install_tools([_tool_message_list_tool()])
     outcome = await repl.eval_async("await tools.emitMessages({value: 9})")
@@ -375,6 +377,8 @@ async def test_mixed_list_collects_commands_and_uses_tail_message(
     assert outcome.result == "from-list-tail=11"
     assert len(outcome.commands) == 1
     assert outcome.commands[0].update.get("ptc_values") == [11]
+
+
 async def test_tool_failure_surfaces_as_js_error(repl: _ThreadREPL) -> None:
     def _boom(**_: object) -> str:
         msg = "tool exploded"

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import json
 
 import pytest
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import BaseTool, StructuredTool
+from langgraph.types import Command
 from pydantic import BaseModel, Field
 from quickjs_rs import Runtime, ThreadWorker
 
@@ -63,6 +65,34 @@ def _echo_tool(name: str = "echo") -> BaseTool:
     return StructuredTool.from_function(
         name=name,
         description=f"Echo back its input ({name}).",
+        func=_fn,
+        args_schema=_In,
+    )
+
+
+def _command_tool(name: str = "emit_command") -> BaseTool:
+    """A tool that returns a LangGraph ``Command`` update."""
+
+    class _In(BaseModel):
+        value: int = Field(description="Integer marker to emit")
+
+    def _fn(value: int) -> Command:
+        return Command(
+            update={
+                "ptc_values": [value],
+                "messages": [
+                    ToolMessage(
+                        content=f"value={value}",
+                        tool_call_id=f"ptc_call_{value}",
+                        name=name,
+                    )
+                ],
+            }
+        )
+
+    return StructuredTool.from_function(
+        name=name,
+        description="Return a Command update carrying the input value.",
         func=_fn,
         args_schema=_In,
     )
@@ -242,7 +272,29 @@ async def test_promise_all_runs_tools_concurrently(repl: _ThreadREPL) -> None:
     assert {c["name"] for c in calls} == {"a", "b"}
 
 
-@pytest.mark.xfail
+async def test_command_tool_updates_are_collected_from_single_eval(
+    repl: _ThreadREPL,
+) -> None:
+    repl.install_tools([_command_tool()])
+    outcome = await repl.eval_async(
+        "await tools.emitCommand({value: 1});\n"
+        "await tools.emitCommand({value: 2});\n"
+        "'done'"
+    )
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result == "done"
+    assert [cmd.update.get("ptc_values") for cmd in outcome.command_updates] == [
+        [1],
+        [2],
+    ]
+
+
+async def test_command_buffer_is_scoped_to_one_eval(repl: _ThreadREPL) -> None:
+    repl.install_tools([_command_tool()])
+    first = await repl.eval_async("await tools.emitCommand({value: 7})")
+    assert len(first.command_updates) == 1
+    second = await repl.eval_async("1 + 1")
+    assert second.command_updates == []
 async def test_tool_failure_surfaces_as_js_error(repl: _ThreadREPL) -> None:
     def _boom(**_: object) -> str:
         msg = "tool exploded"
@@ -379,13 +431,51 @@ async def test_ptc_install_and_eval_resolve_to_same_repl() -> None:
     assert outcome.result == "function"
 
 
-def test_middleware_rejects_boolean_ptc_config() -> None:
-    with pytest.raises(TypeError, match="Boolean `ptc` is no longer supported"):
-        REPLMiddleware(ptc=True)  # type: ignore[arg-type]
-    with pytest.raises(TypeError, match="Boolean `ptc` is no longer supported"):
-        REPLMiddleware(ptc=False)  # type: ignore[arg-type]
+async def test_middleware_eval_tool_returns_commands_plus_tool_message() -> None:
+    from types import SimpleNamespace
+
+    from langchain.tools import ToolRuntime
+
+    command_tool = _command_tool()
+    mw = REPLMiddleware(ptc=[command_tool])
+    tool = mw.tools[0]
+    mw._prepare_for_call(SimpleNamespace(tools=[command_tool, tool]))
+    runtime = ToolRuntime(
+        state={},
+        context={},
+        config={},
+        stream_writer=lambda _chunk: None,
+        tools=[tool],
+        tool_call_id="outer_eval_call",
+        store=None,
+    )
+    assert tool.coroutine is not None
+    result = await tool.coroutine(
+        runtime=runtime,
+        code="await tools.emitCommand({value: 5})",
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert isinstance(result[0], Command)
+    assert result[0].update.get("ptc_values") == [5]
+    assert isinstance(result[1], ToolMessage)
+    assert result[1].name == "eval"
 
 
-def test_middleware_rejects_dict_ptc_config() -> None:
-    with pytest.raises(TypeError, match="Dict `ptc` configs are no longer supported"):
-        REPLMiddleware(ptc={"include": ["greet"]})  # type: ignore[arg-type]
+def test_middleware_rejects_boolean_ptc_config_during_prepare() -> None:
+    from types import SimpleNamespace
+
+    mw = REPLMiddleware(ptc=True)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
+        mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))
+    mw = REPLMiddleware(ptc=False)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
+        mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))
+
+
+def test_middleware_rejects_dict_ptc_config_during_prepare() -> None:
+    from types import SimpleNamespace
+
+    mw = REPLMiddleware(ptc={"include": ["greet"]})  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
+        mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -98,6 +98,69 @@ def _command_tool(name: str = "emit_command") -> BaseTool:
     )
 
 
+def _tool_message_list_tool(name: str = "emit_messages") -> BaseTool:
+    """A tool that returns a list of ``ToolMessage`` values."""
+
+    class _In(BaseModel):
+        value: int = Field(description="Integer marker to emit")
+
+    def _fn(value: int) -> list[ToolMessage]:
+        return [
+            ToolMessage(
+                content=f"first={value}",
+                tool_call_id=f"ptc_call_{value}_first",
+                name=name,
+            ),
+            ToolMessage(
+                content=f"second={value}",
+                tool_call_id=f"ptc_call_{value}_second",
+                name=name,
+            ),
+        ]
+
+    return StructuredTool.from_function(
+        name=name,
+        description="Return a list of ToolMessage values.",
+        func=_fn,
+        args_schema=_In,
+    )
+
+
+def _mixed_list_tool(name: str = "emit_mixed") -> BaseTool:
+    """A tool that returns a mixed list of ``Command`` and ``ToolMessage``."""
+
+    class _In(BaseModel):
+        value: int = Field(description="Integer marker to emit")
+
+    def _fn(value: int) -> list[Command | ToolMessage]:
+        return [
+            Command(
+                update={
+                    "ptc_values": [value],
+                    "messages": [
+                        ToolMessage(
+                            content=f"from-command={value}",
+                            tool_call_id=f"ptc_call_{value}_command",
+                            name=name,
+                        )
+                    ],
+                }
+            ),
+            ToolMessage(
+                content=f"from-list-tail={value}",
+                tool_call_id=f"ptc_call_{value}_tail",
+                name=name,
+            ),
+        ]
+
+    return StructuredTool.from_function(
+        name=name,
+        description="Return a mixed list of Command and ToolMessage values.",
+        func=_fn,
+        args_schema=_In,
+    )
+
+
 @pytest.fixture
 def worker() -> ThreadWorker:
     w = ThreadWorker()
@@ -295,6 +358,23 @@ async def test_command_buffer_is_scoped_to_one_eval(repl: _ThreadREPL) -> None:
     assert len(first.commands) == 1
     second = await repl.eval_async("1 + 1")
     assert second.commands == []
+async def test_toolmessage_list_uses_last_message_content(repl: _ThreadREPL) -> None:
+    repl.install_tools([_tool_message_list_tool()])
+    outcome = await repl.eval_async("await tools.emitMessages({value: 9})")
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result == "second=9"
+    assert outcome.commands == []
+
+
+async def test_mixed_list_collects_commands_and_uses_tail_message(
+    repl: _ThreadREPL,
+) -> None:
+    repl.install_tools([_mixed_list_tool()])
+    outcome = await repl.eval_async("await tools.emitMixed({value: 11})")
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result == "from-list-tail=11"
+    assert len(outcome.commands) == 1
+    assert outcome.commands[0].update.get("ptc_values") == [11]
 async def test_tool_failure_surfaces_as_js_error(repl: _ThreadREPL) -> None:
     def _boom(**_: object) -> str:
         msg = "tool exploded"

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -905,7 +905,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
     { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
-    { name = "quickjs-rs", editable = "../../../../quickjs-wasm" },
+    { name = "quickjs-rs" },
 ]
 
 [package.metadata.requires-dev]
@@ -1520,20 +1520,26 @@ wheels = [
 
 [[package]]
 name = "quickjs-rs"
-version = "0.3.0.dev0"
-source = { editable = "../../../../quickjs-wasm" }
-
-[package.metadata]
-requires-dist = [
-    { name = "matplotlib", marker = "extra == 'bench'", specifier = ">=3.8" },
-    { name = "mypy", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-codspeed", marker = "extra == 'bench'", specifier = ">=4.3.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'" },
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/33/024e9ea32bf1bee8dc60049dc37fcbdb07e838bc661ac74020f10ba18da1/quickjs_rs-0.1.0.tar.gz", hash = "sha256:2e0a85c785d86d4d57d475f91d2538417518fd225ae7911f54d8d021f303838d", size = 138266, upload-time = "2026-04-27T20:27:27.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/dc/fb9f1f6850b34d5f3e6bb6bf0a14d6e6888ec25306cf33768fe58fdde66b/quickjs_rs-0.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5618b9a105a4a648c07a3cda7a142b0cc49d9b00b8ad58b1903506459fb55c33", size = 1020758, upload-time = "2026-04-27T20:27:03.716Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/443e214f376ee1fdba076f4b87cc461a3ae07e740dd116d2bbd8fb689e9b/quickjs_rs-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5d86fcec48571edec725bfddddf8061acd68535086e4651d83c2cfa841855d15", size = 963264, upload-time = "2026-04-27T20:27:05.398Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/7f579033fac462058b9aa6c9f2f7e5ab560ea7da2c89bebe2f1e79dd29af/quickjs_rs-0.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0780ad58741a377482ba14c700292604a6ea93376431a967b9bab7e019d279c", size = 982681, upload-time = "2026-04-27T20:27:06.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7f/41738e22a54f685a05626cd0c8b8e397bd78b19fda74adedbd436b63765e/quickjs_rs-0.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff684c3f90f032b1e8449a3d8025f32470bfc5059f76c9292d68a755822bc3bc", size = 1050439, upload-time = "2026-04-27T20:27:08.509Z" },
+    { url = "https://files.pythonhosted.org/packages/56/82/45be566762c17dafbb782fdd1906790b4bccb2d63604fb3d98cd8eb82366/quickjs_rs-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:947fa051c99635da4a2151b17637550f48a0ddf0a7de639ab4d27d6d352eae59", size = 969395, upload-time = "2026-04-27T20:27:09.881Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/82/044a06f5d97c9bfe5807ce35cda10864c09446aaf363b0e68de35e9aeeea/quickjs_rs-0.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4a55fe742ca348f30ace35d9d76725536d6d013eeeddea9f97b2cc20710cf4e5", size = 1020976, upload-time = "2026-04-27T20:27:11.995Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a6/f2352f13c640a96ed750ff3e64808f219c4dc18ff8f10c03aafd670cca38/quickjs_rs-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d973810a8f4ed6d119cb226867d47caa7f9c4073309a25bb14116c6d3b6d04b", size = 964102, upload-time = "2026-04-27T20:27:13.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/33/65261b05be1c7669aad8ad1dac2cff389dbc4a46f19be5dc1656fc2febae/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:685a77c7c04ea2dc51fa0e53b65477c7906a48d809acef8d9a4b65330925a7ab", size = 982409, upload-time = "2026-04-27T20:27:14.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f0/056e1537de49bce75073019d963bfcc705114ef2dfebb5327da712f73937/quickjs_rs-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02f2fffe796c4a45909208b06c7781135ad77ba78c7d27e0d46bcbc44b530387", size = 1049531, upload-time = "2026-04-27T20:27:16.328Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/93d5b315db29075881630c6748c3c4838084291ad41e5ce3061d71cae310/quickjs_rs-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:71b0dddd27053cb270ddab537718b6e132b35f84d20368559d83b06293da17ac", size = 967263, upload-time = "2026-04-27T20:27:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e1/11a2a78f8ba7c28279e2e8a058c4a38952547d07cfde2a8368cf05908522/quickjs_rs-0.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8e34472e522064f0db46fa7f92c14baeabbe9b158071145868c814699490a28f", size = 1021769, upload-time = "2026-04-27T20:27:19.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a1/5052454cbef8bfc643e96b9d1d137f1928f0bf48e960bf0b77a3c333702d/quickjs_rs-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4d10697b3953b4e7d599ca6cf4c2b9a9510bc1eba368932e6bd0bb410e9951cf", size = 964415, upload-time = "2026-04-27T20:27:20.929Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d5/4c50ad704ab58082d3d13a1eeeb774f4a7eb88b4e634590eda057153e9aa/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35f1702417fb43049d18fa8bc7a01f3c9b7f651f758c32808368ce61aa58b8dd", size = 982720, upload-time = "2026-04-27T20:27:23.078Z" },
+    { url = "https://files.pythonhosted.org/packages/08/98/49ad0065ac927cdca16f289ca5fc819b67ee2eed5dec4febe6751b4a9c46/quickjs_rs-0.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6180aaaf7d64618c92845100dee9cba845c6ffcb73e8b4328ff02abbe8b639ac", size = 1049847, upload-time = "2026-04-27T20:27:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/65/1707487f5437b94ebcf1d69983673f8dce74aaefb44a7c560e2019b0159e/quickjs_rs-0.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:6d16ea5d366bb2885f426f9cb37ea68e668409a940fea85b1015b3c58612a346", size = 967729, upload-time = "2026-04-27T20:27:26.16Z" },
 ]
-provides-extras = ["dev", "bench"]
 
 [[package]]
 name = "readme-renderer"

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -827,10 +827,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.30"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -839,9 +840,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/f149313d1536de8fe45619d460a12308b5a87947a37d4958024d79b011b0/langchain_core-1.2.30.tar.gz", hash = "sha256:ee6c6b3476215c4be438231bab7003d880359230b9fdf1f65e0ffa1bde8a58e0", size = 850262, upload-time = "2026-04-15T20:37:13.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/46/e988e9f024e762750f9f53878316980bdaea2ab1f19600df01a7c39eda89/langchain_core-1.2.30-py3-none-any.whl", hash = "sha256:26fa50894449b29b31b3712fa4975db679d26abe8241a966ea2c5978b68d8394", size = 513005, upload-time = "2026-04-15T20:37:12.396Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -860,6 +861,18 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/51/1157009b6f94e6e58be58fa8b620187d657909a8b36a6bf5b0c52a2711f6/langchain_protocol-0.0.12.tar.gz", hash = "sha256:5e14c434290a705c9510fdb1a83ecf7561a5e6e0dfd053930ade80dba069269f", size = 6408, upload-time = "2026-04-25T01:05:01.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/82/3431e3061c917439589fa88a6b23c9bc0e154cba0f05d2e895a68c76ff74/langchain_protocol-0.0.12-py3-none-any.whl", hash = "sha256:402b61f42d4139692528cf37226c367bb6efc8ff8165b29380accb0abfece7b2", size = 6639, upload-time = "2026-04-25T01:05:00.487Z" },
+]
+
+[[package]]
 name = "langchain-quickjs"
 version = "0.1.0"
 source = { editable = "." }
@@ -867,6 +880,7 @@ dependencies = [
     { name = "deepagents" },
     { name = "langchain" },
     { name = "langchain-core" },
+    { name = "langgraph" },
     { name = "quickjs-rs" },
 ]
 
@@ -889,7 +903,8 @@ test = [
 requires-dist = [
     { name = "deepagents", editable = "../../deepagents" },
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.2.27,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
+    { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
     { name = "quickjs-rs", editable = "../../../../quickjs-wasm" },
 ]
 
@@ -910,7 +925,7 @@ test = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.6"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -920,9 +935,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -940,15 +955,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enables tool updates flow correctly through quickjs eval

## Changes

- QuickJS PTC command propagation fix:
  - collect `Command` objects returned by PTC-invoked tools during a single eval
  - return eval output as `[...commands, ToolMessage]` when commands are present so LangGraph state updates are preserved
  - clear command buffers between eval calls to avoid cross-call leakage

- Runtime compatibility and dependencies:
  - make PTC runtime injection tolerant of `ToolRuntime` variants that do or do not include a `tools` field
  - bump quickjs package constraints to `langchain-core>=1.3.1` and add `langgraph>=1.1.10` (with lockfile updates)

- Test/lint follow-ups:
  - add/adjust quickjs tests for command collection, eval return shape, and invalid `ptc` config handling
  - update async deepagents skills tests to match optional `module` metadata behavior
  - apply formatting-only lint fixes in quickjs/deepagents touched files
