### PR TITLE
feat(sdk): Codex harness profile

### DIFF
--- a/libs/deepagents/deepagents/profiles/_builtin_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_builtin_profiles.py
@@ -30,6 +30,7 @@ from deepagents.profiles.harness import (
     _anthropic_haiku_4_5,
     _anthropic_opus_4_7,
     _anthropic_sonnet_4_6,
+    _openai_codex,
 )
 from deepagents.profiles.harness_profiles import _HARNESS_PROFILES
 from deepagents.profiles.provider import _openai, _openrouter
@@ -134,6 +135,7 @@ def _ensure_builtin_profiles_loaded() -> None:
         _anthropic_opus_4_7.register()
         _anthropic_sonnet_4_6.register()
         _anthropic_haiku_4_5.register()
+        _openai_codex.register()
         _invoke_profile_plugins(_PROVIDER_PROFILE_GROUP)
         _invoke_profile_plugins(_HARNESS_PROFILE_GROUP)
         bootstrap_harness_keys = frozenset(_HARNESS_PROFILES)

--- a/libs/deepagents/deepagents/profiles/harness/_openai_codex.py
+++ b/libs/deepagents/deepagents/profiles/harness/_openai_codex.py
@@ -1,0 +1,68 @@
+"""Built-in OpenAI Codex harness profile.
+
+Registers a `HarnessProfile` for each OpenAI Codex model spec with a
+behavior-shaping `system_prompt_suffix` that aligns Deep Agents'
+runtime defaults with how Codex was trained to operate — autonomous
+senior engineer demeanor, bias to action, parallel tool use, and TODO
+hygiene.
+
+The suffix is appended to whatever `base_system_prompt` is ultimately
+assembled for the agent, so it layers cleanly on top of user- or
+SDK-provided base prompts without fighting them.
+
+Per-model keys (not the `"openai"` prefix) keep the default behavior of
+non-Codex OpenAI models unchanged.
+"""
+
+from deepagents.profiles.harness_profiles import (
+    HarnessProfile,
+    _register_harness_profile_impl,
+)
+
+_CODEX_MODEL_SPECS: tuple[str, ...] = (
+    "openai:gpt-5.1-codex",
+    "openai:gpt-5.2-codex",
+    "openai:gpt-5.3-codex",
+)
+"""Model specs that receive the Codex harness profile.
+
+All three variants share the same trained response style, so a single
+suffix works across the family. Add or remove specs here only when a
+new Codex variant ships with divergent training expectations that
+warrant a different suffix.
+"""
+
+_SYSTEM_PROMPT_SUFFIX: str = """\
+## Codex-Specific Behavior
+
+- You are an autonomous senior engineer. Once given a direction, proactively \
+gather context, plan, implement, and verify without waiting for additional \
+prompts at each step.
+- Persist until the task is fully handled end-to-end within the current turn \
+whenever feasible. Do not stop at analysis or partial fixes; carry changes \
+through implementation, verification, and a clear explanation of outcomes.
+- Bias to action: default to implementing with reasonable assumptions. Do not \
+end your turn with clarifications unless truly blocked.
+- Do not communicate an upfront plan or status preamble before acting. Just act.
+
+## Parallel Tool Use
+
+- Before any tool call, decide ALL files and resources you will need.
+- Batch reads, searches, and other independent operations into parallel tool \
+calls instead of issuing them one at a time.
+- Only make sequential calls when you truly cannot determine the next step \
+without seeing a prior result.
+
+## Plan Hygiene
+
+- Before finishing, reconcile every TODO or plan item created via write_todos. \
+Mark each as done, blocked (with a one-sentence reason), or cancelled. Do not \
+finish with pending items."""
+"""Text appended to the assembled base system prompt."""
+
+
+def register() -> None:
+    """Register the built-in Codex harness profile for each Codex spec."""
+    profile = HarnessProfile(system_prompt_suffix=_SYSTEM_PROMPT_SUFFIX)
+    for spec in _CODEX_MODEL_SPECS:
+        _register_harness_profile_impl(spec, profile)

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -1045,6 +1045,35 @@ class TestBuiltInProfiles:
         assert opus.system_prompt_suffix.startswith(sonnet.system_prompt_suffix)
         assert sonnet.system_prompt_suffix == haiku.system_prompt_suffix
 
+    @pytest.mark.parametrize(
+        "model_key",
+        [
+            "openai:gpt-5.1-codex",
+            "openai:gpt-5.2-codex",
+            "openai:gpt-5.3-codex",
+        ],
+    )
+    def test_codex_models_have_harness_profile(self, model_key: str) -> None:
+        """Each Codex model registers a non-empty Codex harness profile."""
+        profile = _get_harness_profile(model_key)
+        assert profile is not None
+        assert profile.system_prompt_suffix
+        assert "## Codex-Specific Behavior" in profile.system_prompt_suffix
+        assert "## Parallel Tool Use" in profile.system_prompt_suffix
+        assert "## Plan Hygiene" in profile.system_prompt_suffix
+
+    def test_codex_suffix_is_identical_across_models(self) -> None:
+        """All Codex variants share the same suffix from a single profile."""
+        suffixes = {
+            _get_harness_profile(spec).system_prompt_suffix  # type: ignore[union-attr]
+            for spec in (
+                "openai:gpt-5.1-codex",
+                "openai:gpt-5.2-codex",
+                "openai:gpt-5.3-codex",
+            )
+        }
+        assert len(suffixes) == 1
+
 
 class TestProfilePluginLoader:
     """Tests for the `importlib.metadata` entry-point loader."""


### PR DESCRIPTION
Carves the Codex `HarnessProfile` registration off the larger codex PR so it can land independently.

The profile registers a `system_prompt_suffix` against each Codex model spec (`openai:gpt-5.1-codex`, `openai:gpt-5.2-codex`, `openai:gpt-5.3-codex`) to align Deep Agents' runtime defaults with how Codex was trained to operate — autonomous senior engineer demeanor, bias to action, parallel tool use, and TODO hygiene. Per-model keys (rather than the `"openai"` provider key) keep the default behavior of non-Codex OpenAI models unchanged.

Bootstrap registration follows the existing built-in pattern: `_openai_codex.register()` is called from `_ensure_builtin_profiles_loaded` alongside the Anthropic siblings, using `_register_harness_profile_impl` to avoid recursing back into the lazy bootstrap.

### Out of scope

- `_ApplyPatchMiddleware` and the V4A `apply_patch` tool — Codex is trained to emit V4A diffs, but introducing the middleware requires the backend-aware `extra_middleware` factory plumbing that lives further up the stack. That, plus the corresponding tool-specific suffix sections, will land in follow-up work.
- Other tool-specific guidance (e.g. `shell_command` vs. `execute` aliasing) — same rationale.
