### PR TITLE
feat(cli): Create agents in hub on deploy instead of on invoke

### DIFF
--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from deepagents_cli.deploy.config import DeployConfig
+
 
 def setup_deploy_parsers(
     subparsers: Any,  # noqa: ANN401
@@ -386,7 +388,7 @@ def _dev(
         shutil.rmtree(build_dir, ignore_errors=True)
 
 
-def _seed_hub_repo(config: Any, build_dir: Path) -> None:
+def _seed_hub_repo(config: DeployConfig, build_dir: Path) -> None:
     """Eagerly create the LangSmith Hub agent repo at bundle time.
 
     Mirrors the per-(process, assistant_id) seeding that the generated
@@ -449,7 +451,7 @@ def _seed_hub_repo(config: Any, build_dir: Path) -> None:
         if backend.has_prior_commits():
             print(f"Hub repo {identifier} already exists — skipping seed.")
             return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         print(f"Error: failed to inspect hub repo {identifier}: {exc}")
         raise SystemExit(1) from None
 
@@ -460,7 +462,7 @@ def _seed_hub_repo(config: Any, build_dir: Path) -> None:
     print(f"Creating hub repo {identifier} with {len(batch)} file(s)...")
     try:
         responses = backend.upload_files(batch)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         print(f"Error: hub seed failed for {identifier}: {exc}")
         raise SystemExit(1) from None
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -277,6 +277,8 @@ def _deploy(
             print(f"Inspect the build directory: {build_dir}")
             return
 
+        _seed_hub_repo(config, build_dir)
+
         # Deploy via langgraph CLI.
         _run_langgraph_deploy(build_dir, name=config.agent.name)
     finally:
@@ -347,6 +349,8 @@ def _dev(
         bundle(config, project_root, build_dir)
         print_bundle_summary(config, build_dir)
 
+        _seed_hub_repo(config, build_dir)
+
         if shutil.which("langgraph") is None:
             print(
                 "Error: `langgraph` CLI not found. Install it with:\n"
@@ -380,6 +384,94 @@ def _dev(
             raise SystemExit(result.returncode)
     finally:
         shutil.rmtree(build_dir, ignore_errors=True)
+
+
+def _seed_hub_repo(config: Any, build_dir: Path) -> None:
+    """Eagerly create the LangSmith Hub agent repo at bundle time.
+
+    Mirrors the per-(process, assistant_id) seeding that the generated
+    `deploy_graph.py` performs on first invocation, but runs it from the
+    CLI so the repo exists in LangSmith Hub the moment `deepagents deploy`
+    (or `deepagents dev`) returns from bundling. The runtime seed path
+    stays in place as a defensive no-op: it short-circuits via
+    `has_prior_commits()` once this seed has run.
+
+    Per-user hub repos (`{identifier}-user-{slug}`) are intentionally
+    *not* seeded here — user identities aren't known until authenticated
+    requests arrive at runtime.
+
+    Args:
+        config: Loaded `DeployConfig`. Only invoked for hub-backed deploys;
+            no-op otherwise.
+        build_dir: Directory containing `_seed.json` written by `bundle()`.
+
+    Raises:
+        SystemExit: If the hub commit fails or returns per-file errors —
+            fail fast at bundle time rather than at first invocation.
+    """
+    import json
+
+    from deepagents_cli.deploy.context_hub import ContextHubBackend
+
+    if config.memories.backend != "hub":
+        return
+
+    seed_path = build_dir / "_seed.json"
+    try:
+        seed = json.loads(seed_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error: failed to read {seed_path.name} for hub seed: {exc}")
+        raise SystemExit(1) from None
+
+    # Hub-repo layout matches what the runtime ends up writing: when the
+    # generated graph calls `CompositeBackend.aupload_files` with paths
+    # like `/memories/AGENTS.md`, the composite strips the `/memories/`
+    # route prefix before delegating to `ContextHubBackend`. We call the
+    # hub backend directly here, so emit the post-strip paths directly.
+    batch: list[tuple[str, bytes]] = []
+    for path, content in seed.get("memories", {}).items():
+        batch.append((path.lstrip("/"), content.encode("utf-8")))
+    for path, content in seed.get("skills", {}).items():
+        batch.append((f"skills/{path.lstrip('/')}", content.encode("utf-8")))
+    for sa_name, sa_data in seed.get("subagents", {}).items():
+        sa_prefix = f"subagents/{sa_name}/"
+        for path, content in sa_data.get("memories", {}).items():
+            batch.append((f"{sa_prefix}{path.lstrip('/')}", content.encode("utf-8")))
+        for path, content in sa_data.get("skills", {}).items():
+            batch.append(
+                (f"{sa_prefix}skills/{path.lstrip('/')}", content.encode("utf-8"))
+            )
+
+    identifier = config.memories.identifier or f"-/{config.agent.name}"
+    backend = ContextHubBackend(identifier=identifier)
+
+    try:
+        if backend.has_prior_commits():
+            print(f"Hub repo {identifier} already exists — skipping seed.")
+            return
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error: failed to inspect hub repo {identifier}: {exc}")
+        raise SystemExit(1) from None
+
+    if not batch:
+        print(f"Hub repo {identifier}: nothing to seed.")
+        return
+
+    print(f"Creating hub repo {identifier} with {len(batch)} file(s)...")
+    try:
+        responses = backend.upload_files(batch)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error: hub seed failed for {identifier}: {exc}")
+        raise SystemExit(1) from None
+
+    failures = [r for r in responses if r.error is not None]
+    if failures:
+        print(f"Error: hub seed had {len(failures)} failed file(s):")
+        for resp in failures:
+            print(f"  - {resp.path}: {resp.error}")
+        raise SystemExit(1)
+
+    print(f"Hub repo {identifier} created.")
 
 
 def _run_langgraph_deploy(build_dir: Path, *, name: str) -> None:

--- a/libs/cli/tests/integration_tests/test_deploy_hub.py
+++ b/libs/cli/tests/integration_tests/test_deploy_hub.py
@@ -147,6 +147,34 @@ def test_hub_bundle_seeds_through_composite(
     assert "Deploy hub integration test" in read.file_data["content"]
 
 
+def test_seed_hub_repo_creates_repo_before_invocation(
+    tmp_path: Path, hub_identifier: str
+) -> None:
+    """`_seed_hub_repo` must create the hub repo at deploy time, not first run.
+
+    Bundles a minimal hub-backed project, runs the CLI seed helper directly,
+    and asserts the agent repo exists in LangSmith Hub — proving the agent
+    is created before any graph invocation.
+    """
+    from langsmith import Client
+
+    from deepagents_cli.deploy.commands import _seed_hub_repo
+
+    project = tmp_path / "project"
+    _scaffold_project(project)
+    build = tmp_path / "build"
+    config = DeployConfig(
+        agent=AgentConfig(name="deploy-hub-test"),
+        memories=MemoriesConfig(backend="hub", identifier=hub_identifier),
+    )
+    bundle(config, project, build)
+
+    _seed_hub_repo(config, build)
+
+    pulled = Client().pull_agent(hub_identifier)
+    assert "AGENTS.md" in pulled.files
+
+
 def test_store_bundle_omits_vendored_hub(tmp_path: Path) -> None:
     """Regression: default store mode must not ship the hub module."""
     project = tmp_path / "project"

--- a/libs/cli/tests/unit_tests/deploy/test_config.py
+++ b/libs/cli/tests/unit_tests/deploy/test_config.py
@@ -138,7 +138,6 @@ class TestMemoriesConfig:
         cfg = MemoriesConfig(backend="store")
         assert cfg.backend == "store"
 
-
     def test_hub_backend(self) -> None:
         cfg = MemoriesConfig(backend="hub", identifier="-/my-agent")
         assert cfg.backend == "hub"
@@ -355,7 +354,6 @@ class TestParseConfig:
         )
         assert cfg.memories.backend == "hub"
         assert cfg.memories.identifier == "-/my-agent"
-
 
     def test_memories_invalid_backend_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown memories backend"):


### PR DESCRIPTION
Fixes #

---

Running deepagents deploy now immediately pushes the agent to context hub instead of waiting until the first invocation. There is still a fallback to pushing on invoke to handle the case when an agent is deployed and then removed from the ui without being redeployed

4. How did you verify your code works?
- run deepagents deploy and verify context hub ui shows new agent
- test_seed_hub_repo_creates_repo_before_invocation