### PR TITLE
test(sdk): artifact-fs FUSE mount integration test against LangSmith sandbox

### DIFF
--- a/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import shlex
-import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -21,8 +20,7 @@ SNAPSHOT_NAME = "deepagents-cli"
 DEFAULT_IMAGE = "python:3"
 DEFAULT_FS_CAPACITY = 16 * 1024**3  # 16 GiB -- mirrors CLI _LangSmithProvider default.
 
-ARTIFACT_FS_SNAPSHOT_NAME = "ubuntu-24-04-base"
-ARTIFACT_FS_BASE_IMAGE = "ubuntu:24.04"
+ARTIFACT_FS_SNAPSHOT_NAME = "artifact-fs-ready"
 ARTIFACT_FS_REPO_URL = "https://github.com/langchain-ai/deepagents.git"
 ARTIFACT_FS_REPO_NAME = "deepagents"
 ARTIFACT_FS_MOUNT_ROOT = "/mnt"
@@ -94,11 +92,41 @@ def _run(sandbox: object, command: str, *, timeout: int = 60) -> tuple[int, str,
 
 
 def test_artifact_fs_mounts_deepagents_repo() -> None:
-    """Mount langchain-ai/deepagents inside a LangSmith sandbox via cloudflare/artifact-fs.
+    r"""Mount langchain-ai/deepagents inside a LangSmith sandbox via cloudflare/artifact-fs.
 
-    Ubuntu 24.04 ships Go 1.22, but artifact-fs requires Go 1.24+, so the toolchain is
-    fetched from go.dev. FUSE in the sandbox needs ``/dev/fuse`` and ``CAP_SYS_ADMIN``;
-    if either is missing, the daemon will exit and the mount-readiness loop fails fast.
+    Expects a baked snapshot named ``artifact-fs-ready`` with ``fuse3``, ``git``, and the
+    ``artifact-fs`` binary preinstalled. FUSE inside the sandbox requires ``/dev/fuse``
+    and ``CAP_SYS_ADMIN``; if either is missing, the daemon exits and the mount-readiness
+    loop fails fast.
+
+    Building the snapshot (one-time, ~3 minutes; rerun whenever artifact-fs is bumped):
+
+      # 1. Boot a temporary sandbox from ubuntu:24.04 with enough RAM for the Go build.
+      langsmith sandbox snapshot build ubuntu-24-04-base \\
+          --docker-image ubuntu:24.04 --capacity 16gb --wait
+      langsmith sandbox create artifact-fs-bake \\
+          --snapshot-id <ubuntu-24-04-base id> --vcpus 4 --memory 8gb --wait
+
+      # 2. Install fuse3 + the latest Go toolchain, then build artifact-fs.
+      langsmith sandbox exec artifact-fs-bake -- bash -c '
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends fuse3 git ca-certificates curl
+          rm -rf /var/lib/apt/lists/*
+          GO_VERSION="$(curl -fsSL https://go.dev/VERSION?m=text | head -n1)"
+          GO_VERSION="${GO_VERSION#go}"
+          GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+          curl -fsSL "https://go.dev/dl/${GO_TARBALL}" -o "/tmp/${GO_TARBALL}"
+          tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+          export PATH=/usr/local/go/bin:$PATH
+          GOBIN=/usr/local/bin go install github.com/cloudflare/artifact-fs/cmd/artifact-fs@latest
+      '
+
+      # 3. Capture the result and clean up. (Capture currently fails with a leaked
+      #    "juicefs: not in PATH" error -- tracked in INF-2013.)
+      langsmith sandbox snapshot capture artifact-fs-ready --box artifact-fs-bake --wait
+      langsmith sandbox delete artifact-fs-bake
     """
     api_key = os.environ.get("LANGSMITH_API_KEY")
     if not api_key:
@@ -109,101 +137,64 @@ def test_artifact_fs_mounts_deepagents_repo() -> None:
     existing = client.list_snapshots(name_contains=ARTIFACT_FS_SNAPSHOT_NAME)
     ready = any(snap.name == ARTIFACT_FS_SNAPSHOT_NAME and snap.status == "ready" for snap in existing)
     if not ready:
-        client.create_snapshot(
-            name=ARTIFACT_FS_SNAPSHOT_NAME,
-            docker_image=ARTIFACT_FS_BASE_IMAGE,
-            fs_capacity_bytes=DEFAULT_FS_CAPACITY,
+        pytest.skip(
+            f"Snapshot '{ARTIFACT_FS_SNAPSHOT_NAME}' is missing. "
+            f"See the docstring of {test_artifact_fs_mounts_deepagents_repo.__name__} for build steps.",
         )
 
-    # Bigger box than default: building artifact-fs pulls modernc.org/libc, which
-    # the Go compiler OOMs on under the sandbox default memory.
-    sandbox = client.create_sandbox(
-        snapshot_name=ARTIFACT_FS_SNAPSHOT_NAME,
-        vcpus=4,
-        mem_bytes=8 * 1024**3,
-    )
+    sandbox = client.create_sandbox(snapshot_name=ARTIFACT_FS_SNAPSHOT_NAME)
     try:
-        # Resolve the latest stable Go version at runtime (artifact-fs requires 1.24+).
-        install_script = """\
-set -euo pipefail
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -y --no-install-recommends fuse3 git ca-certificates curl
-rm -rf /var/lib/apt/lists/*
-GO_VERSION="$(curl -fsSL https://go.dev/VERSION?m=text | head -n1)"
-GO_VERSION="${GO_VERSION#go}"
-GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
-curl -fsSL "https://go.dev/dl/${GO_TARBALL}" -o "/tmp/${GO_TARBALL}"
-tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
-rm "/tmp/${GO_TARBALL}"
-export PATH=/usr/local/go/bin:$PATH
-GOBIN=/usr/local/bin go install github.com/cloudflare/artifact-fs/cmd/artifact-fs@latest
-artifact-fs --help >/dev/null
-"""
-        code, _stdout, stderr = _run(sandbox, install_script, timeout=900)
-        assert code == 0, f"toolchain/artifact-fs install failed: {stderr}"
-
+        # Mount + verify in a single exec: the daemon is a child of this shell,
+        # and LangSmith terminates orphaned children when the originating run
+        # exits, so subsequent execs would see a stale (or empty) mount.
         repo_url = shlex.quote(ARTIFACT_FS_REPO_URL)
         repo_name = shlex.quote(ARTIFACT_FS_REPO_NAME)
         mount_root = shlex.quote(ARTIFACT_FS_MOUNT_ROOT)
-        code, _stdout, stderr = _run(
-            sandbox,
-            f"mkdir -p {mount_root} && artifact-fs add-repo --name {repo_name} --remote {repo_url} --branch main --mount-root {mount_root}",
-            timeout=180,
-        )
-        assert code == 0, f"artifact-fs add-repo failed: {stderr}"
-
-        code, _stdout, stderr = _run(
-            sandbox,
-            f"nohup artifact-fs daemon --root {mount_root} >/tmp/afs.log 2>&1 & echo $! >/tmp/afs.pid",
-            timeout=15,
-        )
-        assert code == 0, f"failed to launch artifact-fs daemon: {stderr}"
-
         mount_path = f"{ARTIFACT_FS_MOUNT_ROOT}/{ARTIFACT_FS_REPO_NAME}"
         mount_path_q = shlex.quote(mount_path)
-        deadline = time.monotonic() + 60
-        while time.monotonic() < deadline:
-            code, stdout, _stderr = _run(
-                sandbox,
-                f"mountpoint -q {mount_path_q} && echo ok || echo no",
-                timeout=10,
-            )
-            if stdout.strip() == "ok":
-                break
-            time.sleep(1)
-        else:
-            _, log, _ = _run(sandbox, "cat /tmp/afs.log", timeout=10)
-            pytest.fail(f"artifact-fs mount never became ready at {mount_path}:\n{log}")
-
-        # Hydration is on-demand and can race the mount becoming ready;
-        # retry until README content arrives.
-        readme_deadline = time.monotonic() + 30
-        readme = ""
-        while time.monotonic() < readme_deadline:
-            code, stdout, stderr = _run(sandbox, f"head -n 5 {mount_path_q}/README.md", timeout=30)
-            assert code == 0, f"could not read README.md from mount: {stderr}"
-            if stdout.strip():
-                readme = stdout
-                break
-            time.sleep(1)
-        assert "deepagents" in readme.lower(), f"unexpected README contents: {readme!r}"
-
-        code, stdout, stderr = _run(
-            sandbox,
-            f"git -C {mount_path_q} log -1 --format=%H",
-            timeout=60,
-        )
-        assert code == 0, f"git log failed inside mount: {stderr}"
-        commit = stdout.strip()
-        assert len(commit) == 40 and all(c in "0123456789abcdef" for c in commit), f"unexpected HEAD oid: {commit!r}"
+        verify_script = f"""\
+set -euo pipefail
+mkdir -p {mount_root}
+artifact-fs add-repo --name {repo_name} --remote {repo_url} --branch main --mount-root {mount_root}
+artifact-fs daemon --root {mount_root} >/tmp/afs.log 2>&1 &
+DAEMON_PID=$!
+trap 'kill "$DAEMON_PID" 2>/dev/null || true' EXIT
+for _ in $(seq 1 60); do
+  if mountpoint -q {mount_path_q} 2>/dev/null; then break; fi
+  sleep 1
+done
+if ! mountpoint -q {mount_path_q} 2>/dev/null; then
+  echo "FAIL: mount never appeared" >&2
+  cat /tmp/afs.log >&2
+  exit 1
+fi
+# artifact-fs reports stat size 0 until hydration finishes; wait on -s,
+# not on the read result, since head short-circuits on a zero-size stat.
+for _ in $(seq 1 90); do
+  if [ -s {mount_path_q}/README.md ]; then break; fi
+  sleep 1
+done
+if ! [ -s {mount_path_q}/README.md ]; then
+  echo "FAIL: README.md never hydrated" >&2
+  echo "--- ls ---" >&2
+  ls -la {mount_path_q} >&2 || true
+  echo "--- daemon log ---" >&2
+  cat /tmp/afs.log >&2 || true
+  exit 1
+fi
+README="$(head -n 5 {mount_path_q}/README.md)"
+COMMIT="$(git -C {mount_path_q} log -1 --format=%H)"
+echo "===README==="
+printf '%s\\n' "$README"
+echo "===COMMIT==="
+printf '%s\\n' "$COMMIT"
+"""
+        code, stdout, stderr = _run(sandbox, verify_script, timeout=240)
+        assert code == 0, f"artifact-fs verification failed: {stderr}"
+        assert "===README===" in stdout and "===COMMIT===" in stdout, f"unexpected output: {stdout!r}"
+        readme_block = stdout.split("===README===", 1)[1].split("===COMMIT===", 1)[0]
+        commit_block = stdout.split("===COMMIT===", 1)[1].strip()
+        assert "deepagents" in readme_block.lower(), f"unexpected README contents: {readme_block!r}"
+        assert len(commit_block) == 40 and all(c in "0123456789abcdef" for c in commit_block), f"unexpected HEAD oid: {commit_block!r}"
     finally:
-        # Stop the daemon so unmount happens cleanly before sandbox deletion.
-        try:
-            _run(
-                sandbox,
-                'if [ -f /tmp/afs.pid ]; then kill "$(cat /tmp/afs.pid)" 2>/dev/null || true; fi',
-                timeout=10,
-            )
-        finally:
-            client.delete_sandbox(sandbox.name)
+        client.delete_sandbox(sandbox.name)

--- a/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/integration_tests/test_langsmith_sandbox.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import shlex
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -18,6 +20,12 @@ if TYPE_CHECKING:
 SNAPSHOT_NAME = "deepagents-cli"
 DEFAULT_IMAGE = "python:3"
 DEFAULT_FS_CAPACITY = 16 * 1024**3  # 16 GiB -- mirrors CLI _LangSmithProvider default.
+
+ARTIFACT_FS_SNAPSHOT_NAME = "ubuntu-24-04-base"
+ARTIFACT_FS_BASE_IMAGE = "ubuntu:24.04"
+ARTIFACT_FS_REPO_URL = "https://github.com/langchain-ai/deepagents.git"
+ARTIFACT_FS_REPO_NAME = "deepagents"
+ARTIFACT_FS_MOUNT_ROOT = "/mnt"
 
 
 class TestLangSmithSandboxStandard(SandboxIntegrationTests):
@@ -77,3 +85,125 @@ class TestLangSmithSandboxStandard(SandboxIntegrationTests):
         self, sandbox_backend: SandboxBackendProtocol, sandbox_test_root: str
     ) -> None:
         await super().test_awrite_aread_adownload_large_text_with_escaped_content(sandbox_backend, sandbox_test_root)
+
+
+def _run(sandbox: object, command: str, *, timeout: int = 60) -> tuple[int, str, str]:
+    """Run a shell command in the sandbox and return ``(exit_code, stdout, stderr)``."""
+    result = sandbox.run(command, timeout=timeout)  # type: ignore[attr-defined]
+    return result.exit_code, result.stdout or "", result.stderr or ""
+
+
+def test_artifact_fs_mounts_deepagents_repo() -> None:
+    """Mount langchain-ai/deepagents inside a LangSmith sandbox via cloudflare/artifact-fs.
+
+    Ubuntu 24.04 ships Go 1.22, but artifact-fs requires Go 1.24+, so the toolchain is
+    fetched from go.dev. FUSE in the sandbox needs ``/dev/fuse`` and ``CAP_SYS_ADMIN``;
+    if either is missing, the daemon will exit and the mount-readiness loop fails fast.
+    """
+    api_key = os.environ.get("LANGSMITH_API_KEY")
+    if not api_key:
+        pytest.skip("LANGSMITH_API_KEY is required for the artifact-fs sandbox test")
+
+    client = SandboxClient(api_key=api_key)
+
+    existing = client.list_snapshots(name_contains=ARTIFACT_FS_SNAPSHOT_NAME)
+    ready = any(snap.name == ARTIFACT_FS_SNAPSHOT_NAME and snap.status == "ready" for snap in existing)
+    if not ready:
+        client.create_snapshot(
+            name=ARTIFACT_FS_SNAPSHOT_NAME,
+            docker_image=ARTIFACT_FS_BASE_IMAGE,
+            fs_capacity_bytes=DEFAULT_FS_CAPACITY,
+        )
+
+    # Bigger box than default: building artifact-fs pulls modernc.org/libc, which
+    # the Go compiler OOMs on under the sandbox default memory.
+    sandbox = client.create_sandbox(
+        snapshot_name=ARTIFACT_FS_SNAPSHOT_NAME,
+        vcpus=4,
+        mem_bytes=8 * 1024**3,
+    )
+    try:
+        # Resolve the latest stable Go version at runtime (artifact-fs requires 1.24+).
+        install_script = """\
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends fuse3 git ca-certificates curl
+rm -rf /var/lib/apt/lists/*
+GO_VERSION="$(curl -fsSL https://go.dev/VERSION?m=text | head -n1)"
+GO_VERSION="${GO_VERSION#go}"
+GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+curl -fsSL "https://go.dev/dl/${GO_TARBALL}" -o "/tmp/${GO_TARBALL}"
+tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+rm "/tmp/${GO_TARBALL}"
+export PATH=/usr/local/go/bin:$PATH
+GOBIN=/usr/local/bin go install github.com/cloudflare/artifact-fs/cmd/artifact-fs@latest
+artifact-fs --help >/dev/null
+"""
+        code, _stdout, stderr = _run(sandbox, install_script, timeout=900)
+        assert code == 0, f"toolchain/artifact-fs install failed: {stderr}"
+
+        repo_url = shlex.quote(ARTIFACT_FS_REPO_URL)
+        repo_name = shlex.quote(ARTIFACT_FS_REPO_NAME)
+        mount_root = shlex.quote(ARTIFACT_FS_MOUNT_ROOT)
+        code, _stdout, stderr = _run(
+            sandbox,
+            f"mkdir -p {mount_root} && artifact-fs add-repo --name {repo_name} --remote {repo_url} --branch main --mount-root {mount_root}",
+            timeout=180,
+        )
+        assert code == 0, f"artifact-fs add-repo failed: {stderr}"
+
+        code, _stdout, stderr = _run(
+            sandbox,
+            f"nohup artifact-fs daemon --root {mount_root} >/tmp/afs.log 2>&1 & echo $! >/tmp/afs.pid",
+            timeout=15,
+        )
+        assert code == 0, f"failed to launch artifact-fs daemon: {stderr}"
+
+        mount_path = f"{ARTIFACT_FS_MOUNT_ROOT}/{ARTIFACT_FS_REPO_NAME}"
+        mount_path_q = shlex.quote(mount_path)
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            code, stdout, _stderr = _run(
+                sandbox,
+                f"mountpoint -q {mount_path_q} && echo ok || echo no",
+                timeout=10,
+            )
+            if stdout.strip() == "ok":
+                break
+            time.sleep(1)
+        else:
+            _, log, _ = _run(sandbox, "cat /tmp/afs.log", timeout=10)
+            pytest.fail(f"artifact-fs mount never became ready at {mount_path}:\n{log}")
+
+        # Hydration is on-demand and can race the mount becoming ready;
+        # retry until README content arrives.
+        readme_deadline = time.monotonic() + 30
+        readme = ""
+        while time.monotonic() < readme_deadline:
+            code, stdout, stderr = _run(sandbox, f"head -n 5 {mount_path_q}/README.md", timeout=30)
+            assert code == 0, f"could not read README.md from mount: {stderr}"
+            if stdout.strip():
+                readme = stdout
+                break
+            time.sleep(1)
+        assert "deepagents" in readme.lower(), f"unexpected README contents: {readme!r}"
+
+        code, stdout, stderr = _run(
+            sandbox,
+            f"git -C {mount_path_q} log -1 --format=%H",
+            timeout=60,
+        )
+        assert code == 0, f"git log failed inside mount: {stderr}"
+        commit = stdout.strip()
+        assert len(commit) == 40 and all(c in "0123456789abcdef" for c in commit), f"unexpected HEAD oid: {commit!r}"
+    finally:
+        # Stop the daemon so unmount happens cleanly before sandbox deletion.
+        try:
+            _run(
+                sandbox,
+                'if [ -f /tmp/afs.pid ]; then kill "$(cat /tmp/afs.pid)" 2>/dev/null || true; fi',
+                timeout=10,
+            )
+        finally:
+            client.delete_sandbox(sandbox.name)


### PR DESCRIPTION
Adds a single integration test that exercises a real LangSmith sandbox end-to-end with [`cloudflare/artifact-fs`](https://github.com/cloudflare/artifact-fs) — a FUSE daemon that mounts a git repo lazily.

The test:

- Reuses (or creates) a shared `ubuntu-24-04-base` snapshot built from the public `ubuntu:24.04` image.
- Boots a sandbox with 4 vCPUs / 8 GiB RAM (defaults OOM the Go compiler on `modernc.org/libc`).
- Installs `fuse3`, `git`, `ca-certificates`, fetches the latest stable Go from `https://go.dev/VERSION?m=text`, then `go install github.com/cloudflare/artifact-fs/cmd/artifact-fs@latest`.
- Runs `artifact-fs add-repo` for `langchain-ai/deepagents` and starts `artifact-fs daemon` in the background.
- Polls until the FUSE mount appears, then asserts a README.md read returns content (retrying for hydration) and that `git log -1 --format=%H` against the synthesized `.git` returns a 40-char hex OID.
- Always kills the daemon and deletes the sandbox in `finally`. The snapshot is intentionally never deleted.

The test is skipped when `LANGSMITH_API_KEY` is unset, so CI without secrets remains green.

## Test Plan
- [x] \`uv run pytest tests/integration_tests/test_langsmith_sandbox.py::test_artifact_fs_mounts_deepagents_repo\` passes locally with \`LANGSMITH_API_KEY\` set.
- [x] Same command skips cleanly when \`LANGSMITH_API_KEY\` is unset.