### PR TITLE
refactor(sdk,evals): migrate deprecations to `langchain_core` helpers

### DIFF
--- a/libs/deepagents/deepagents/_api/__init__.py
+++ b/libs/deepagents/deepagents/_api/__init__.py
@@ -1,0 +1,5 @@
+"""Internal helpers for `deepagents`.
+
+Modules under this package are private. Their API is allowed to change between
+minor releases without deprecation.
+"""

--- a/libs/deepagents/deepagents/_api/deprecation.py
+++ b/libs/deepagents/deepagents/_api/deprecation.py
@@ -1,0 +1,57 @@
+"""Adapter for `langchain_core`'s private deprecation helpers.
+
+Centralizes the import surface so an upstream rename or move is a one-file
+change. The underlying module (`langchain_core._api.deprecation`) declares
+itself "for internal use only", so consolidating the dependency here also
+contains the blast radius if upstream changes.
+
+Re-exports:
+- `deprecated`: decorator for callables, classes, and properties.
+- `warn_deprecated`: helper for parameter/value-level deprecations where the
+    callable itself isn't being deprecated.
+- `suppress_langchain_deprecation_warning`: context manager that silences
+    emissions from this module's helpers (use sparingly — it is type-wide).
+- `LangChainDeprecationWarning`: warning class emitted by the helpers above
+    (subclass of `DeprecationWarning`).
+"""
+
+from langchain_core._api.deprecation import (
+    LangChainDeprecationWarning,
+    deprecated,
+    suppress_langchain_deprecation_warning,
+    warn_deprecated,
+)
+
+__all__ = [
+    "LangChainDeprecationWarning",
+    "deprecated",
+    "reset_deprecation_dedupe",
+    "suppress_langchain_deprecation_warning",
+    "warn_deprecated",
+]
+
+
+def reset_deprecation_dedupe(*targets: object) -> None:
+    """Reset the `@deprecated` decorator's dedupe flag for testing.
+
+    The langchain_core `@deprecated` decorator emits each warning at most once
+    per process via a closure-bound `warned` flag. Tests that assert per-call
+    emission must reset that flag between cases — otherwise the assertions
+    become reorder-sensitive (notably under `pytest -n auto`).
+
+    Accepts decorated functions, methods, and `property` objects (in which
+    case the `fget` closure is reset).
+
+    Args:
+        *targets: Decorated callables (or properties wrapping them) to reset.
+    """
+    for target in targets:
+        fn = target.fget if isinstance(target, property) else target
+        closure = getattr(fn, "__closure__", None) or ()
+        for cell in closure:
+            try:
+                value = cell.cell_contents
+            except ValueError:  # empty cell
+                continue
+            if isinstance(value, bool):
+                cell.cell_contents = False

--- a/libs/deepagents/deepagents/_api/deprecation.py
+++ b/libs/deepagents/deepagents/_api/deprecation.py
@@ -1,9 +1,7 @@
 """Adapter for `langchain_core`'s private deprecation helpers.
 
 Centralizes the import surface so an upstream rename or move is a one-file
-change. The underlying module (`langchain_core._api.deprecation`) declares
-itself "for internal use only", so consolidating the dependency here also
-contains the blast radius if upstream changes.
+change.
 
 Re-exports:
 - `deprecated`: decorator for callables, classes, and properties.

--- a/libs/deepagents/deepagents/_api/deprecation.py
+++ b/libs/deepagents/deepagents/_api/deprecation.py
@@ -6,18 +6,25 @@ change.
 Re-exports:
 - `deprecated`: decorator for callables, classes, and properties.
 - `warn_deprecated`: helper for parameter/value-level deprecations where the
-    callable itself isn't being deprecated.
+    callable itself isn't being deprecated. Wraps the upstream helper to
+    accept a `stacklevel` argument (the upstream version hardcodes
+    `stacklevel=4`, which mis-attributes warnings emitted directly from a
+    deprecated method body).
 - `suppress_langchain_deprecation_warning`: context manager that silences
     emissions from this module's helpers (use sparingly — it is type-wide).
 - `LangChainDeprecationWarning`: warning class emitted by the helpers above
     (subclass of `DeprecationWarning`).
 """
 
+from __future__ import annotations
+
+import warnings
+
 from langchain_core._api.deprecation import (
     LangChainDeprecationWarning,
     deprecated,
     suppress_langchain_deprecation_warning,
-    warn_deprecated,
+    warn_deprecated as _lc_warn_deprecated,
 )
 
 __all__ = [
@@ -29,6 +36,67 @@ __all__ = [
 ]
 
 
+def warn_deprecated(
+    since: str,
+    *,
+    message: str = "",
+    name: str = "",
+    alternative: str = "",
+    alternative_import: str = "",
+    pending: bool = False,
+    obj_type: str = "",
+    addendum: str = "",
+    removal: str = "",
+    package: str = "",
+    stacklevel: int = 2,
+) -> None:
+    """Emit a deprecation warning with caller-controlled stack attribution.
+
+    `langchain_core.warn_deprecated` formats a standard message but hardcodes
+    `stacklevel=4` in its internal `warnings.warn` call. That value targets a
+    decorator-wrapped frame layout; when called directly from a deprecated
+    method's body the warning is attributed one frame too high (above the
+    user's call site). This wrapper captures the formatted upstream warning
+    and re-emits it with an explicit `stacklevel`, so the warning points at
+    the user's call site.
+
+    Args:
+        since: Release at which this API became deprecated.
+        message: Override the default deprecation message. See upstream
+            `langchain_core.warn_deprecated` for supported format specifiers.
+        name: Name of the deprecated object.
+        alternative: Alternative API the user may use instead.
+        alternative_import: Alternative import path the user may use instead.
+        pending: If `True`, uses a `PendingDeprecationWarning` instead of a
+            `DeprecationWarning`. Cannot be combined with `removal`.
+        obj_type: Object type label (e.g., `"function"`, `"class"`).
+        addendum: Additional text appended to the final message.
+        removal: Expected removal version. Cannot be combined with `pending`.
+        package: Package name attribution for the deprecation message.
+        stacklevel: Frames above this call to attribute the warning to,
+            using the same convention as `warnings.warn` (`1` = this call,
+            `2` = the caller of the method body that invoked us, etc.).
+    """
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        _lc_warn_deprecated(
+            since,
+            message=message,
+            name=name,
+            alternative=alternative,
+            alternative_import=alternative_import,
+            pending=pending,
+            obj_type=obj_type,
+            addendum=addendum,
+            removal=removal,
+            package=package,
+        )
+    if not captured:
+        return
+    record = captured[0]
+    warnings.warn(record.message, category=record.category, stacklevel=stacklevel + 1)
+
+
 def reset_deprecation_dedupe(*targets: object) -> None:
     """Reset the `@deprecated` decorator's dedupe flag for testing.
 
@@ -38,18 +106,26 @@ def reset_deprecation_dedupe(*targets: object) -> None:
     become reorder-sensitive (notably under `pytest -n auto`).
 
     Accepts decorated functions, methods, and `property` objects (in which
-    case the `fget` closure is reset).
+    case the `fget` closure is reset). Targets without the expected `warned`
+    freevar are silently skipped, so passing non-decorated callables is safe.
 
     Args:
         *targets: Decorated callables (or properties wrapping them) to reset.
     """
     for target in targets:
         fn = target.fget if isinstance(target, property) else target
-        closure = getattr(fn, "__closure__", None) or ()
-        for cell in closure:
-            try:
-                value = cell.cell_contents
-            except ValueError:  # empty cell
-                continue
-            if isinstance(value, bool):
-                cell.cell_contents = False
+        code = getattr(fn, "__code__", None)
+        closure = getattr(fn, "__closure__", None)
+        if code is None or closure is None:
+            continue
+        try:
+            index = code.co_freevars.index("warned")
+        except ValueError:
+            continue
+        cell = closure[index]
+        try:
+            current = cell.cell_contents
+        except ValueError:  # empty cell
+            continue
+        if isinstance(current, bool):
+            cell.cell_contents = False

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -10,8 +10,8 @@ from datetime import datetime
 from pathlib import Path
 
 import wcmatch.glob as wcglob
-from langchain_core._api.deprecation import warn_deprecated
 
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
     FILE_NOT_FOUND,
     INVALID_PATH,
@@ -133,14 +133,15 @@ class FilesystemBackend(BackendProtocol):
                 since="0.5.0",
                 removal="0.6.0",
                 message=(
-                    "`FilesystemBackend` `virtual_mode` default will change; "
-                    "please specify `virtual_mode` explicitly. Note: "
-                    "`virtual_mode` is for virtual path semantics (e.g., "
-                    "`CompositeBackend` routing) and optional path-based "
-                    "guardrails; it does not provide sandboxing or process "
-                    "isolation. Security note: leaving `virtual_mode=False` "
-                    "allows absolute paths and `'..'` to bypass `root_dir`. "
-                    "Consult the API reference for details."
+                    "`FilesystemBackend` `virtual_mode` default will change "
+                    "in deepagents==0.6.0; please specify `virtual_mode` "
+                    "explicitly. Note: `virtual_mode` is for virtual path "
+                    "semantics (e.g., `CompositeBackend` routing) and "
+                    "optional path-based guardrails; it does not provide "
+                    "sandboxing or process isolation. Security note: leaving "
+                    "`virtual_mode=False` allows absolute paths and `'..'` "
+                    "to bypass `root_dir`. Consult the API reference for "
+                    "details."
                 ),
                 package="deepagents",
             )

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -6,11 +6,11 @@ import logging
 import os
 import re
 import subprocess
-import warnings
 from datetime import datetime
 from pathlib import Path
 
 import wcmatch.glob as wcglob
+from langchain_core._api.deprecation import warn_deprecated
 
 from deepagents.backends.protocol import (
     FILE_NOT_FOUND,
@@ -129,15 +129,20 @@ class FilesystemBackend(BackendProtocol):
         """
         self.cwd = Path(root_dir).resolve() if root_dir else Path.cwd()
         if virtual_mode is None:
-            warnings.warn(
-                "FilesystemBackend virtual_mode default will change in deepagents 0.5.0; "
-                "please specify virtual_mode explicitly. "
-                "Note: virtual_mode is for virtual path semantics (e.g., CompositeBackend routing) and optional path-based guardrails; "
-                "it does not provide sandboxing or process isolation. "
-                "Security note: leaving virtual_mode=False allows absolute paths and '..' to bypass root_dir. "
-                "Consult the API reference for details.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=(
+                    "`FilesystemBackend` `virtual_mode` default will change; "
+                    "please specify `virtual_mode` explicitly. Note: "
+                    "`virtual_mode` is for virtual path semantics (e.g., "
+                    "`CompositeBackend` routing) and optional path-based "
+                    "guardrails; it does not provide sandboxing or process "
+                    "isolation. Security note: leaving `virtual_mode=False` "
+                    "allows absolute paths and `'..'` to bypass `root_dir`. "
+                    "Consult the API reference for details."
+                ),
+                package="deepagents",
             )
             virtual_mode = False
         self.virtual_mode = virtual_mode

--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -12,8 +12,7 @@ import subprocess
 import uuid
 from typing import TYPE_CHECKING
 
-from langchain_core._api.deprecation import warn_deprecated
-
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
 
@@ -171,16 +170,16 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 since="0.5.0",
                 removal="0.6.0",
                 message=(
-                    "`LocalShellBackend` `virtual_mode` default will change; "
-                    "please specify `virtual_mode` explicitly. Note: "
-                    "`virtual_mode` is for virtual path semantics (e.g., "
-                    "`CompositeBackend` routing) and optional path-based "
-                    "guardrails; it does not provide sandboxing or process "
-                    "isolation. Security note: leaving `virtual_mode=False` "
-                    "allows absolute paths and `'..'` to bypass `root_dir`, "
-                    "and `LocalShellBackend` provides no sandboxing (execute "
-                    "runs commands on the host; `virtual_mode` does not "
-                    "restrict shell execution). See "
+                    "`LocalShellBackend` `virtual_mode` default will change "
+                    "in deepagents==0.6.0; please specify `virtual_mode` "
+                    "explicitly. Note: `virtual_mode` is for virtual path "
+                    "semantics (e.g., `CompositeBackend` routing) and "
+                    "optional path-based guardrails; it does not provide "
+                    "sandboxing or process isolation. Security note: leaving "
+                    "`virtual_mode=False` allows absolute paths and `'..'` "
+                    "to bypass `root_dir`, and `LocalShellBackend` provides "
+                    "no sandboxing (`execute()` runs commands on the host; "
+                    "`virtual_mode` does not restrict shell execution). See "
                     "https://reference.langchain.com/python/deepagents/ for "
                     "usage guidelines."
                 ),

--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import os
 import subprocess
 import uuid
-import warnings
 from typing import TYPE_CHECKING
+
+from langchain_core._api.deprecation import warn_deprecated
 
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
@@ -166,16 +167,24 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             raise ValueError(msg)
 
         if virtual_mode is None:
-            warnings.warn(
-                "LocalShellBackend virtual_mode default will change in deepagents 0.5.0; "
-                "please specify virtual_mode explicitly. "
-                "Note: virtual_mode is for virtual path semantics (e.g., CompositeBackend routing) and optional path-based guardrails; "
-                "it does not provide sandboxing or process isolation. "
-                "Security note: leaving virtual_mode=False allows absolute paths and '..' to bypass root_dir, "
-                "and LocalShellBackend provides no sandboxing (execute runs commands on the host; virtual_mode does not restrict shell execution). "
-                "See https://reference.langchain.com/python/deepagents/ for usage guidelines.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=(
+                    "`LocalShellBackend` `virtual_mode` default will change; "
+                    "please specify `virtual_mode` explicitly. Note: "
+                    "`virtual_mode` is for virtual path semantics (e.g., "
+                    "`CompositeBackend` routing) and optional path-based "
+                    "guardrails; it does not provide sandboxing or process "
+                    "isolation. Security note: leaving `virtual_mode=False` "
+                    "allows absolute paths and `'..'` to bypass `root_dir`, "
+                    "and `LocalShellBackend` provides no sandboxing (execute "
+                    "runs commands on the host; `virtual_mode` does not "
+                    "restrict shell execution). See "
+                    "https://reference.langchain.com/python/deepagents/ for "
+                    "usage guidelines."
+                ),
+                package="deepagents",
             )
             virtual_mode = False
 

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -9,13 +9,13 @@ import abc
 import asyncio
 import inspect
 import logging
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Final, Literal, NotRequired, TypeAlias
 
 from langchain.tools import ToolRuntime
+from langchain_core._api.deprecation import deprecated, warn_deprecated
 from typing_extensions import TypedDict
 
 FileFormat = Literal["v1", "v2"]
@@ -196,10 +196,12 @@ def _normalize_files_update(
     if isinstance(files_update, _Unset):
         return None
 
-    warnings.warn(
-        "`files_update` is deprecated and will be removed in v0.7. State updates are now handled internally by the backend.",
-        DeprecationWarning,
-        stacklevel=3,
+    warn_deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        name="files_update",
+        addendum="State updates are now handled internally by the backend.",
+        package="deepagents",
     )
     return files_update
 
@@ -337,10 +339,11 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             LsResult with directory entries or error.
         """
         if type(self).ls_info is not BackendProtocol.ls_info:
-            warnings.warn(
-                "`ls_info` is deprecated and will be removed in v0.7; rename to `ls` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message="`ls_info` is deprecated; rename to `ls` instead.",
+                package="deepagents",
             )
             return LsResult(entries=self.ls_info(path))
 
@@ -422,10 +425,11 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             `GrepResult` with matches or error.
         """
         if type(self).grep_raw is not BackendProtocol.grep_raw:
-            warnings.warn(
-                "`grep_raw` is deprecated and will be removed in v0.7; rename to `grep` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message="`grep_raw` is deprecated; rename to `grep` instead.",
+                package="deepagents",
             )
             result = self.grep_raw(pattern, path, glob)
             if isinstance(result, str):
@@ -466,10 +470,11 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             GlobResult with matching files or error.
         """
         if type(self).glob_info is not BackendProtocol.glob_info:
-            warnings.warn(
-                "`glob_info` is deprecated and will be removed in v0.7; rename to `glob` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message="`glob_info` is deprecated; rename to `glob` instead.",
+                package="deepagents",
             )
             return GlobResult(matches=self.glob_info(pattern, path))
 
@@ -598,117 +603,93 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     # -- deprecated methods --------------------------------------------------
 
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        alternative="ls",
+        package="deepagents",
+    )
     def ls_info(self, path: str) -> list["FileInfo"]:
-        """List all files in a directory with metadata.
-
-        !!! warning "Deprecated"
-
-            Use `ls` instead.
-        """
-        warnings.warn(
-            "`ls_info` is deprecated and will be removed in v0.7; use `ls` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """List all files in a directory with metadata."""
         result = self.ls(path)
         if result.error is not None:
             msg = "This behavior is only available via the new `ls` API."
             raise NotImplementedError(msg)
         return result.entries or []
 
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        alternative="als",
+        package="deepagents",
+    )
     async def als_info(self, path: str) -> list["FileInfo"]:
-        """Async version of `ls_info`.
-
-        !!! warning "Deprecated"
-
-            Use `als` instead.
-        """
-        warnings.warn(
-            "`als_info` is deprecated and will be removed in v0.7; use `als` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Async version of `ls_info`."""
         result = await self.als(path)
         if result.error is not None:
             msg = "This behavior is only available via the new `als` API."
             raise NotImplementedError(msg)
         return result.entries or []
 
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        alternative="glob",
+        package="deepagents",
+    )
     def glob_info(self, pattern: str, path: str = "/") -> list["FileInfo"]:
-        """Find files matching a glob pattern.
-
-        !!! warning "Deprecated"
-
-            Use `glob` instead.
-        """
-        warnings.warn(
-            "`glob_info` is deprecated and will be removed in v0.7; use `glob` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Find files matching a glob pattern."""
         result = self.glob(pattern, path)
         if result.error is not None:
             msg = "This behavior is only available via the new `glob` API."
             raise NotImplementedError(msg)
         return result.matches or []
 
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        alternative="aglob",
+        package="deepagents",
+    )
     async def aglob_info(self, pattern: str, path: str = "/") -> list["FileInfo"]:
-        """Async version of `glob_info`.
-
-        !!! warning "Deprecated"
-
-            Use `aglob` instead.
-        """
-        warnings.warn(
-            "`aglob_info` is deprecated and will be removed in v0.7; use `aglob` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Async version of `glob_info`."""
         result = await self.aglob(pattern, path)
         if result.error is not None:
             msg = "This behavior is only available via the new `aglob` API."
             raise NotImplementedError(msg)
         return result.matches or []
 
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        alternative="grep",
+        package="deepagents",
+    )
     def grep_raw(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
     ) -> list["GrepMatch"] | str:
-        """Search for a literal text pattern in files.
-
-        !!! warning "Deprecated"
-
-            Use `grep` instead.
-        """
-        warnings.warn(
-            "`grep_raw` is deprecated and will be removed in v0.7; use `grep` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Search for a literal text pattern in files."""
         result = self.grep(pattern, path, glob)
         if result.error is not None:
             return result.error
         return result.matches or []
 
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        alternative="agrep",
+        package="deepagents",
+    )
     async def agrep_raw(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
     ) -> list["GrepMatch"] | str:
-        """Async version of `grep_raw`.
-
-        !!! warning "Deprecated"
-
-            Use `agrep` instead.
-        """
-        warnings.warn(
-            "`agrep_raw` is deprecated and will be removed in v0.7; use `agrep` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Async version of `grep_raw`."""
         result = await self.agrep(pattern, path, glob)
         if result.error is not None:
             return result.error

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -197,17 +197,18 @@ def _normalize_files_update(
     if isinstance(files_update, _Unset):
         return None
 
-    # Use an explicit `message=` to bypass `langchain_core`'s auto-formatter,
-    # which mis-attributes the package as "LangChain" when `name` lacks a dot.
+    # `stacklevel=3` lifts attribution past `__init__` and this helper to the
+    # user's `WriteResult(...)` / `EditResult(...)` call site.
     warn_deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         message=(
             "`files_update` was deprecated in deepagents 0.5.0 and will be "
-            "removed in deepagents==0.6.0. State updates are now handled "
+            "removed in deepagents==0.7.0. State updates are now handled "
             "internally by the backend."
         ),
         package="deepagents",
+        stacklevel=3,
     )
     return files_update
 
@@ -320,18 +321,20 @@ class BackendProtocol(abc.ABC):  # noqa: B024
     Backends can store files in different locations (state, filesystem, database, etc.)
     and provide a uniform interface for file operations.
 
-    All file data is represented as dicts with the following structure::
+    All file data is represented as dicts with the following structure:
 
-        {
-            "content": str,  # Text content (utf-8) or base64-encoded binary
-            "encoding": str,  # "utf-8" for text, "base64" for binary data
-            "created_at": str,  # ISO format timestamp
-            "modified_at": str,  # ISO format timestamp
-        }
+    ```python
+    {
+        "content": str,  # Text content (utf-8) or base64-encoded binary
+        "encoding": str,  # "utf-8" for text, "base64" for binary data
+        "created_at": str,  # ISO format timestamp
+        "modified_at": str,  # ISO format timestamp
+    }
+    ```
 
     Note:
         Legacy data may still contain `"content": list[str]` (lines split on
-        `\\n`).  Backends accept this for backwards compatibility and emit a
+        `\\n`). Backends accept this for backwards compatibility and emit a
         `LangChainDeprecationWarning` (a `DeprecationWarning` subclass).
     """
 
@@ -342,13 +345,17 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             path: Absolute path to the directory to list. Must start with '/'.
 
         Returns:
-            LsResult with directory entries or error.
+            `LsResult` with directory entries or error.
+
+        Raises:
+            NotImplementedError: If the backend does not implement `ls` (or
+                the legacy `ls_info`).
         """
         if type(self).ls_info is not BackendProtocol.ls_info:
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
-                message=("`ls_info` is deprecated and will be removed in deepagents==0.6.0; rename to `ls` instead."),
+                removal="0.7.0",
+                message=("`ls_info` is deprecated and will be removed in deepagents==0.7.0; rename to `ls` instead."),
                 package="deepagents",
             )
             return LsResult(entries=self.ls_info(path))
@@ -429,12 +436,16 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
         Returns:
             `GrepResult` with matches or error.
+
+        Raises:
+            NotImplementedError: If the backend does not implement `grep` (or
+                the legacy `grep_raw`).
         """
         if type(self).grep_raw is not BackendProtocol.grep_raw:
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
-                message=("`grep_raw` is deprecated and will be removed in deepagents==0.6.0; rename to `grep` instead."),
+                removal="0.7.0",
+                message=("`grep_raw` is deprecated and will be removed in deepagents==0.7.0; rename to `grep` instead."),
                 package="deepagents",
             )
             result = self.grep_raw(pattern, path, glob)
@@ -473,13 +484,17 @@ class BackendProtocol(abc.ABC):  # noqa: B024
                 The pattern is applied relative to this path.
 
         Returns:
-            GlobResult with matching files or error.
+            `GlobResult` with matching files or error.
+
+        Raises:
+            NotImplementedError: If the backend does not implement `glob` (or
+                the legacy `glob_info`).
         """
         if type(self).glob_info is not BackendProtocol.glob_info:
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
-                message=("`glob_info` is deprecated and will be removed in deepagents==0.6.0; rename to `glob` instead."),
+                removal="0.7.0",
+                message=("`glob_info` is deprecated and will be removed in deepagents==0.7.0; rename to `glob` instead."),
                 package="deepagents",
             )
             return GlobResult(matches=self.glob_info(pattern, path))
@@ -611,12 +626,16 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         alternative="ls",
         package="deepagents",
     )
     def ls_info(self, path: str) -> list["FileInfo"]:
-        """List all files in a directory with metadata."""
+        """List all files in a directory with metadata.
+
+        !!! warning "Deprecated"
+            Use `ls` instead. Will be removed in `deepagents==0.7.0`.
+        """
         result = self.ls(path)
         if result.error is not None:
             msg = "This behavior is only available via the new `ls` API."
@@ -625,12 +644,17 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         alternative="als",
         package="deepagents",
     )
     async def als_info(self, path: str) -> list["FileInfo"]:
-        """Async version of `ls_info`."""
+        """Async version of `ls_info`.
+
+        !!! warning "Deprecated"
+
+            Use `als` instead. Will be removed in `deepagents==0.7.0`.
+        """
         result = await self.als(path)
         if result.error is not None:
             msg = "This behavior is only available via the new `als` API."
@@ -639,12 +663,17 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         alternative="glob",
         package="deepagents",
     )
     def glob_info(self, pattern: str, path: str = "/") -> list["FileInfo"]:
-        """Find files matching a glob pattern."""
+        """Find files matching a glob pattern.
+
+        !!! warning "Deprecated"
+
+            Use `glob` instead. Will be removed in `deepagents==0.7.0`.
+        """
         result = self.glob(pattern, path)
         if result.error is not None:
             msg = "This behavior is only available via the new `glob` API."
@@ -653,12 +682,17 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         alternative="aglob",
         package="deepagents",
     )
     async def aglob_info(self, pattern: str, path: str = "/") -> list["FileInfo"]:
-        """Async version of `glob_info`."""
+        """Async version of `glob_info`.
+
+        !!! warning "Deprecated"
+
+            Use `aglob` instead. Will be removed in `deepagents==0.7.0`.
+        """
         result = await self.aglob(pattern, path)
         if result.error is not None:
             msg = "This behavior is only available via the new `aglob` API."
@@ -667,7 +701,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         alternative="grep",
         package="deepagents",
     )
@@ -677,7 +711,12 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         path: str | None = None,
         glob: str | None = None,
     ) -> list["GrepMatch"] | str:
-        """Search for a literal text pattern in files."""
+        """Search for a literal text pattern in files.
+
+        !!! warning "Deprecated"
+
+            Use `grep` instead. Will be removed in `deepagents==0.7.0`.
+        """
         result = self.grep(pattern, path, glob)
         if result.error is not None:
             return result.error
@@ -685,7 +724,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
 
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         alternative="agrep",
         package="deepagents",
     )
@@ -695,7 +734,12 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         path: str | None = None,
         glob: str | None = None,
     ) -> list["GrepMatch"] | str:
-        """Async version of `grep_raw`."""
+        """Async version of `grep_raw`.
+
+        !!! warning "Deprecated"
+
+            Use `agrep` instead. Will be removed in `deepagents==0.7.0`.
+        """
         result = await self.agrep(pattern, path, glob)
         if result.error is not None:
             return result.error

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -15,8 +15,9 @@ from functools import lru_cache
 from typing import Any, Final, Literal, NotRequired, TypeAlias
 
 from langchain.tools import ToolRuntime
-from langchain_core._api.deprecation import deprecated, warn_deprecated
 from typing_extensions import TypedDict
+
+from deepagents._api.deprecation import deprecated, warn_deprecated
 
 FileFormat = Literal["v1", "v2"]
 r"""File storage format version.
@@ -196,11 +197,16 @@ def _normalize_files_update(
     if isinstance(files_update, _Unset):
         return None
 
+    # Use an explicit `message=` to bypass `langchain_core`'s auto-formatter,
+    # which mis-attributes the package as "LangChain" when `name` lacks a dot.
     warn_deprecated(
         since="0.5.0",
         removal="0.6.0",
-        name="files_update",
-        addendum="State updates are now handled internally by the backend.",
+        message=(
+            "`files_update` was deprecated in deepagents 0.5.0 and will be "
+            "removed in deepagents==0.6.0. State updates are now handled "
+            "internally by the backend."
+        ),
         package="deepagents",
     )
     return files_update
@@ -326,7 +332,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
     Note:
         Legacy data may still contain `"content": list[str]` (lines split on
         `\\n`).  Backends accept this for backwards compatibility and emit a
-        `DeprecationWarning`.
+        `LangChainDeprecationWarning` (a `DeprecationWarning` subclass).
     """
 
     def ls(self, path: str) -> "LsResult":
@@ -342,7 +348,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             warn_deprecated(
                 since="0.5.0",
                 removal="0.6.0",
-                message="`ls_info` is deprecated; rename to `ls` instead.",
+                message=("`ls_info` is deprecated and will be removed in deepagents==0.6.0; rename to `ls` instead."),
                 package="deepagents",
             )
             return LsResult(entries=self.ls_info(path))
@@ -428,7 +434,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             warn_deprecated(
                 since="0.5.0",
                 removal="0.6.0",
-                message="`grep_raw` is deprecated; rename to `grep` instead.",
+                message=("`grep_raw` is deprecated and will be removed in deepagents==0.6.0; rename to `grep` instead."),
                 package="deepagents",
             )
             result = self.grep_raw(pattern, path, glob)
@@ -473,7 +479,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             warn_deprecated(
                 since="0.5.0",
                 removal="0.6.0",
-                message="`glob_info` is deprecated; rename to `glob` instead.",
+                message=("`glob_info` is deprecated and will be removed in deepagents==0.6.0; rename to `glob` instead."),
                 package="deepagents",
             )
             return GlobResult(matches=self.glob_info(pattern, path))

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -1,9 +1,9 @@
 """StateBackend: Store files in LangGraph agent state (ephemeral)."""
 
 import base64
-import warnings
 from typing import Any
 
+from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.runnables import RunnableConfig
 from langgraph._internal._constants import CONFIG_KEY_READ, CONFIG_KEY_SEND
 from langgraph.config import get_config
@@ -64,12 +64,16 @@ class StateBackend(BackendProtocol):
                 plain `str` with an `encoding` field.
         """
         if runtime is not None:
-            warnings.warn(
-                "Passing `runtime` to StateBackend is deprecated and will be "
-                "removed in v0.7. StateBackend now reads and writes "
-                "state via `get_config()`. Simply use `StateBackend()` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=(
+                    "Passing `runtime` to `StateBackend` is deprecated and "
+                    "will be removed in deepagents==0.6.0. `StateBackend` now "
+                    "reads and writes state via `get_config()`. Use "
+                    "`StateBackend()` instead."
+                ),
+                package="deepagents",
             )
         self._file_format = file_format
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -66,10 +66,10 @@ class StateBackend(BackendProtocol):
         if runtime is not None:
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
+                removal="0.7.0",
                 message=(
                     "Passing `runtime` to `StateBackend` is deprecated and "
-                    "will be removed in deepagents==0.6.0. `StateBackend` now "
+                    "will be removed in deepagents==0.7.0. `StateBackend` now "
                     "reads and writes state via `get_config()`. Use "
                     "`StateBackend()` instead."
                 ),

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -3,11 +3,11 @@
 import base64
 from typing import Any
 
-from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.runnables import RunnableConfig
 from langgraph._internal._constants import CONFIG_KEY_READ, CONFIG_KEY_SEND
 from langgraph.config import get_config
 
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
     EditResult,

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -42,14 +42,28 @@ if TYPE_CHECKING:
     from langgraph.runtime import Runtime
 
 
+@deprecated(
+    since="0.5.0",
+    removal="0.7.0",
+    message=(
+        "`BackendContext` is deprecated and will be removed in "
+        "deepagents==0.7.0. Namespace factories now receive a `Runtime` "
+        "instance directly — migrate "
+        '`lambda ctx: (ctx.runtime.context.user_id, "fs")` '
+        'to `lambda rt: (rt.server_info.user.identity, "fs")`.'
+    ),
+    package="deepagents",
+)
 @dataclass
 class BackendContext(Generic[StateT, ContextT]):
     """Context passed to namespace factory functions.
 
-    Deprecated: `BackendContext` will be removed in version 0.6.0.
-    Namespace factories now receive a `Runtime` instance directly.
-    Migrate from `lambda ctx: (ctx.runtime.context.user_id, "fs")`
-    to `lambda rt: (rt.server_info.user.identity, "fs")`.
+    !!! warning "Deprecated"
+
+        `BackendContext` will be removed in `deepagents==0.7.0`. Namespace
+        factories now receive a `Runtime` instance directly. Migrate
+        `lambda ctx: (ctx.runtime.context.user_id, "fs")` to
+        `lambda rt: (rt.server_info.user.identity, "fs")`.
     """
 
     state: StateT
@@ -57,12 +71,12 @@ class BackendContext(Generic[StateT, ContextT]):
 
 
 class _NamespaceRuntimeCompat:
-    """Wrapper that duck-types as both Runtime and BackendContext.
+    """Wrapper that duck-types as both `Runtime` and `BackendContext`.
 
-    Allows old-style namespace factories (accessing ``.runtime`` / ``.state``)
-    to work alongside new-style factories (accessing ``Runtime`` attrs directly).
+    Allows old-style namespace factories (accessing `.runtime` / `.state`)
+    to work alongside new-style factories (accessing `Runtime` attrs directly).
 
-    Will be removed in deepagents 0.6.0.
+    Will be removed in `deepagents==0.7.0`.
     """
 
     def __init__(self, runtime: "Runtime[Any] | None", state: object = None) -> None:
@@ -72,10 +86,10 @@ class _NamespaceRuntimeCompat:
     @property
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         message=(
             "Accessing `.runtime` on the namespace factory argument is "
-            "deprecated and will be removed in deepagents==0.6.0. The "
+            "deprecated and will be removed in deepagents==0.7.0. The "
             "argument is now a Runtime instance — use its attributes directly "
             "(e.g. `rt.context` instead of `ctx.runtime.context`)."
         ),
@@ -87,10 +101,10 @@ class _NamespaceRuntimeCompat:
     @property
     @deprecated(
         since="0.5.0",
-        removal="0.6.0",
+        removal="0.7.0",
         message=(
             "Accessing `.state` on the namespace factory argument is "
-            "deprecated and will be removed in deepagents==0.6.0. Namespace "
+            "deprecated and will be removed in deepagents==0.7.0. Namespace "
             "resolution should not depend on state."
         ),
         package="deepagents",
@@ -105,9 +119,8 @@ class _NamespaceRuntimeCompat:
         return getattr(self._runtime, name)
 
 
-# Type alias for namespace factory functions.
-# Accepts Runtime directly. Old-style BackendContext callables still work
-# via _NamespaceRuntimeCompat but are deprecated (removed in deepagents 0.6.0).
+# Type alias for namespace factory functions. See `_NamespaceRuntimeCompat`
+# for the legacy-callable shim.
 NamespaceFactory = Callable[["Runtime[Any]"], tuple[str, ...]]
 
 # Allowed characters in namespace components: alphanumeric, plus characters
@@ -122,7 +135,7 @@ def _validate_namespace(namespace: tuple[str, ...]) -> tuple[str, ...]:
     alphanumeric (a-z, A-Z, 0-9), hyphen (-), underscore (_), dot (.),
     at sign (@), plus (+), colon (:), and tilde (~).
 
-    Characters like ``*``, ``?``, ``[``, ``]``, ``{``, ``}``, etc. are
+    Characters like `*`, `?`, `[`, `]`, `{`, `}`, etc. are
     rejected to prevent wildcard or glob injection in store lookups.
 
     Args:
@@ -177,23 +190,23 @@ class StoreBackend(BackendProtocol):
 
         Args:
             runtime: Deprecated - accepted for backward compatibility but
-                ignored.  Store and context are now obtained via
-                ``get_store()`` / ``get_runtime()``.
-            store: Optional ``BaseStore`` instance.  When provided, this store
-                is used directly.  When ``None`` (the default), the store is
-                obtained at call time via ``get_store()``, which requires
+                ignored. Store and context are now obtained via
+                `get_store()` / `get_runtime()`.
+            store: Optional `BaseStore` instance. When provided, this store
+                is used directly. When `None` (the default), the store is
+                obtained at call time via `get_store()`, which requires
                 a LangGraph graph execution context.
-            namespace: Optional callable that receives a ``Runtime`` and returns
+            namespace: Optional callable that receives a `Runtime` and returns
                 a namespace tuple for scoping store operations.
-                Wildcards (``*``) are forbidden.
-                If ``None``, uses legacy assistant_id detection from metadata (deprecated).
+                Wildcards (`*`) are forbidden.
+                If `None`, uses legacy assistant_id detection from metadata (deprecated).
 
-                Old-style callables that accept ``BackendContext`` still work
-                but are deprecated and will be removed in deepagents 0.6.0.
+                Old-style callables that accept `BackendContext` still work
+                but are deprecated and will be removed in `deepagents==0.7.0`.
 
             file_format: Storage format version. `"v1"` (default) stores
                 content as `list[str]` (lines split on `\\n`) without an
-                `encoding` field.  `"v2"` stores content as a plain `str`
+                `encoding` field. `"v2"` stores content as a plain `str`
                 with an `encoding` field.
 
         Example:
@@ -202,10 +215,10 @@ class StoreBackend(BackendProtocol):
         if runtime is not None:
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
+                removal="0.7.0",
                 message=(
                     "Passing `runtime` to `StoreBackend` is deprecated and "
-                    "will be removed in deepagents==0.6.0. `StoreBackend` "
+                    "will be removed in deepagents==0.7.0. `StoreBackend` "
                     "now obtains store and context via "
                     "`get_store()` / `get_runtime()`. Use `StoreBackend()` or "
                     "`StoreBackend(store=my_store)` instead."
@@ -220,7 +233,7 @@ class StoreBackend(BackendProtocol):
         """Return the store instance.
 
         Uses the store passed at init if available, otherwise falls back to
-        ``get_store()`` which reads from the LangGraph execution context.
+        `get_store()` which reads from the LangGraph execution context.
         """
         if self._store is not None:
             return self._store
@@ -237,8 +250,8 @@ class StoreBackend(BackendProtocol):
     def _get_namespace(self) -> tuple[str, ...]:
         """Get the namespace for store operations.
 
-        If namespace was provided at init, calls it with a ``_NamespaceRuntimeCompat``
-        wrapper that duck-types as both ``Runtime`` (new) and ``BackendContext`` (legacy).
+        If namespace was provided at init, calls it with a `_NamespaceRuntimeCompat`
+        wrapper that duck-types as both `Runtime` (new) and `BackendContext` (legacy).
         Otherwise, uses legacy assistant_id detection from metadata (deprecated).
         """
         if self._namespace is not None:
@@ -254,18 +267,19 @@ class StoreBackend(BackendProtocol):
     def _get_namespace_legacy(self) -> tuple[str, ...]:
         """Legacy namespace resolution: check metadata for assistant_id.
 
-        Uses ``get_config()`` to find assistant_id in metadata.
-        Defaults to ``("filesystem",)``.
+        Uses `get_config()` to find `assistant_id` in metadata. Returns
+        `(assistant_id, "filesystem")` when present; otherwise returns
+        `("filesystem",)`.
 
         !!! deprecated
             Pass `namespace` to `StoreBackend` instead of relying on legacy detection.
         """
         warn_deprecated(
             since="0.5.0",
-            removal="0.6.0",
+            removal="0.7.0",
             message=(
                 "`StoreBackend` without an explicit `namespace` is deprecated "
-                "and will be removed in deepagents==0.6.0. Pass "
+                "and will be removed in deepagents==0.7.0. Pass "
                 "`namespace=lambda ctx: (...)` to `StoreBackend`."
             ),
             package="deepagents",
@@ -305,10 +319,10 @@ class StoreBackend(BackendProtocol):
         if isinstance(raw_content, list):
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
+                removal="0.7.0",
                 message=(
                     "Store item with `list[str]` content is deprecated and "
-                    "will be removed in deepagents==0.6.0. Content should "
+                    "will be removed in deepagents==0.7.0. Content should "
                     "be stored as a plain `str`."
                 ),
                 package="deepagents",

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -2,11 +2,11 @@
 
 import base64
 import re
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic
 
+from langchain_core._api.deprecation import deprecated, warn_deprecated
 from langgraph.config import get_config, get_store
 from langgraph.runtime import get_runtime
 from langgraph.store.base import BaseStore, Item
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 class BackendContext(Generic[StateT, ContextT]):
     """Context passed to namespace factory functions.
 
-    Deprecated: `BackendContext` will be removed in version 0.7.0.
+    Deprecated: `BackendContext` will be removed in version 0.6.0.
     Namespace factories now receive a `Runtime` instance directly.
     Migrate from `lambda ctx: (ctx.runtime.context.user_id, "fs")`
     to `lambda rt: (rt.server_info.user.identity, "fs")`.
@@ -62,7 +62,7 @@ class _NamespaceRuntimeCompat:
     Allows old-style namespace factories (accessing ``.runtime`` / ``.state``)
     to work alongside new-style factories (accessing ``Runtime`` attrs directly).
 
-    Will be removed in v0.7.
+    Will be removed in v0.6.
     """
 
     def __init__(self, runtime: "Runtime[Any] | None", state: object = None) -> None:
@@ -70,26 +70,32 @@ class _NamespaceRuntimeCompat:
         self._state = state
 
     @property
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        message=(
+            "Accessing `.runtime` on the namespace factory argument is "
+            "deprecated and will be removed in deepagents==0.6.0. The "
+            "argument is now a Runtime instance — use its attributes directly "
+            "(e.g. `rt.context` instead of `ctx.runtime.context`)."
+        ),
+        package="deepagents",
+    )
     def runtime(self) -> "Runtime[Any] | None":
-        warnings.warn(
-            "Accessing .runtime on the namespace factory argument is deprecated. "
-            "The argument is now a Runtime instance — use its attributes directly "
-            "(e.g. `rt.context` instead of `ctx.runtime.context`). "
-            "This will be removed in v0.7.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._runtime
 
     @property
+    @deprecated(
+        since="0.5.0",
+        removal="0.6.0",
+        message=(
+            "Accessing `.state` on the namespace factory argument is "
+            "deprecated and will be removed in deepagents==0.6.0. Namespace "
+            "resolution should not depend on state."
+        ),
+        package="deepagents",
+    )
     def state(self) -> object:
-        warnings.warn(
-            "Accessing .state on the namespace factory argument is deprecated. "
-            "Namespace resolution should not depend on state. "
-            "This will be removed in v0.7.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._state
 
     def __getattr__(self, name: str) -> object:
@@ -101,7 +107,7 @@ class _NamespaceRuntimeCompat:
 
 # Type alias for namespace factory functions.
 # Accepts Runtime directly. Old-style BackendContext callables still work
-# via _NamespaceRuntimeCompat but are deprecated (removed in v0.7).
+# via _NamespaceRuntimeCompat but are deprecated (removed in v0.6).
 NamespaceFactory = Callable[["Runtime[Any]"], tuple[str, ...]]
 
 # Allowed characters in namespace components: alphanumeric, plus characters
@@ -183,7 +189,7 @@ class StoreBackend(BackendProtocol):
                 If ``None``, uses legacy assistant_id detection from metadata (deprecated).
 
                 Old-style callables that accept ``BackendContext`` still work
-                but are deprecated and will be removed in v0.7.
+                but are deprecated and will be removed in v0.6.
 
             file_format: Storage format version. `"v1"` (default) stores
                 content as `list[str]` (lines split on `\\n`) without an
@@ -194,13 +200,16 @@ class StoreBackend(BackendProtocol):
                     namespace=lambda rt: (rt.server_info.user.identity, "filesystem")
         """
         if runtime is not None:
-            warnings.warn(
-                "Passing `runtime` to StoreBackend is deprecated and will be "
-                "removed in v0.7. StoreBackend now obtains store "
-                "and context via `get_store()` / `get_runtime()`. Simply use "
-                "`StoreBackend()` or `StoreBackend(store=my_store)` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=(
+                    "Passing `runtime` to `StoreBackend` is deprecated. "
+                    "`StoreBackend` now obtains store and context via "
+                    "`get_store()` / `get_runtime()`. Use `StoreBackend()` or "
+                    "`StoreBackend(store=my_store)` instead."
+                ),
+                package="deepagents",
             )
         self._store = store
         self._namespace = namespace
@@ -250,11 +259,11 @@ class StoreBackend(BackendProtocol):
         .. deprecated::
             Pass `namespace` to StoreBackend instead of relying on legacy detection.
         """
-        warnings.warn(
-            "StoreBackend without explicit `namespace` is deprecated and will be removed in v0.7. "
-            "Pass `namespace=lambda ctx: (...)` to StoreBackend.",
-            DeprecationWarning,
-            stacklevel=3,
+        warn_deprecated(
+            since="0.5.0",
+            removal="0.6.0",
+            message=("`StoreBackend` without an explicit `namespace` is deprecated. Pass `namespace=lambda ctx: (...)` to `StoreBackend`."),
+            package="deepagents",
         )
         namespace = "filesystem"
 
@@ -289,10 +298,11 @@ class StoreBackend(BackendProtocol):
 
         # BACKWARDS COMPAT: legacy list[str] format
         if isinstance(raw_content, list):
-            warnings.warn(
-                "Store item with list[str] content is deprecated and will be removed in v0.7. Content should be stored as a plain str.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=("Store item with `list[str]` content is deprecated. Content should be stored as a plain `str`."),
+                package="deepagents",
             )
             content = "\n".join(raw_content)
         elif isinstance(raw_content, str):

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -6,12 +6,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic
 
-from langchain_core._api.deprecation import deprecated, warn_deprecated
 from langgraph.config import get_config, get_store
 from langgraph.runtime import get_runtime
 from langgraph.store.base import BaseStore, Item
 from langgraph.typing import ContextT, StateT
 
+from deepagents._api.deprecation import deprecated, warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
     EditResult,
@@ -62,7 +62,7 @@ class _NamespaceRuntimeCompat:
     Allows old-style namespace factories (accessing ``.runtime`` / ``.state``)
     to work alongside new-style factories (accessing ``Runtime`` attrs directly).
 
-    Will be removed in v0.6.
+    Will be removed in deepagents 0.6.0.
     """
 
     def __init__(self, runtime: "Runtime[Any] | None", state: object = None) -> None:
@@ -107,7 +107,7 @@ class _NamespaceRuntimeCompat:
 
 # Type alias for namespace factory functions.
 # Accepts Runtime directly. Old-style BackendContext callables still work
-# via _NamespaceRuntimeCompat but are deprecated (removed in v0.6).
+# via _NamespaceRuntimeCompat but are deprecated (removed in deepagents 0.6.0).
 NamespaceFactory = Callable[["Runtime[Any]"], tuple[str, ...]]
 
 # Allowed characters in namespace components: alphanumeric, plus characters
@@ -189,7 +189,7 @@ class StoreBackend(BackendProtocol):
                 If ``None``, uses legacy assistant_id detection from metadata (deprecated).
 
                 Old-style callables that accept ``BackendContext`` still work
-                but are deprecated and will be removed in v0.6.
+                but are deprecated and will be removed in deepagents 0.6.0.
 
             file_format: Storage format version. `"v1"` (default) stores
                 content as `list[str]` (lines split on `\\n`) without an
@@ -204,8 +204,9 @@ class StoreBackend(BackendProtocol):
                 since="0.5.0",
                 removal="0.6.0",
                 message=(
-                    "Passing `runtime` to `StoreBackend` is deprecated. "
-                    "`StoreBackend` now obtains store and context via "
+                    "Passing `runtime` to `StoreBackend` is deprecated and "
+                    "will be removed in deepagents==0.6.0. `StoreBackend` "
+                    "now obtains store and context via "
                     "`get_store()` / `get_runtime()`. Use `StoreBackend()` or "
                     "`StoreBackend(store=my_store)` instead."
                 ),
@@ -256,13 +257,17 @@ class StoreBackend(BackendProtocol):
         Uses ``get_config()`` to find assistant_id in metadata.
         Defaults to ``("filesystem",)``.
 
-        .. deprecated::
-            Pass `namespace` to StoreBackend instead of relying on legacy detection.
+        !!! deprecated
+            Pass `namespace` to `StoreBackend` instead of relying on legacy detection.
         """
         warn_deprecated(
             since="0.5.0",
             removal="0.6.0",
-            message=("`StoreBackend` without an explicit `namespace` is deprecated. Pass `namespace=lambda ctx: (...)` to `StoreBackend`."),
+            message=(
+                "`StoreBackend` without an explicit `namespace` is deprecated "
+                "and will be removed in deepagents==0.6.0. Pass "
+                "`namespace=lambda ctx: (...)` to `StoreBackend`."
+            ),
             package="deepagents",
         )
         namespace = "filesystem"
@@ -301,7 +306,11 @@ class StoreBackend(BackendProtocol):
             warn_deprecated(
                 since="0.5.0",
                 removal="0.6.0",
-                message=("Store item with `list[str]` content is deprecated. Content should be stored as a plain `str`."),
+                message=(
+                    "Store item with `list[str]` content is deprecated and "
+                    "will be removed in deepagents==0.6.0. Content should "
+                    "be stored as a plain `str`."
+                ),
                 package="deepagents",
             )
             content = "\n".join(raw_content)

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -89,10 +89,10 @@ def _normalize_content(file_data: FileData) -> str:
     if isinstance(content, list):
         warn_deprecated(
             since="0.5.0",
-            removal="0.6.0",
+            removal="0.7.0",
             message=(
                 "`FileData` with `list[str]` content is deprecated and will "
-                "be removed in deepagents==0.6.0. Content should be stored "
+                "be removed in deepagents==0.7.0. Content should be stored "
                 "as a plain `str`."
             ),
             package="deepagents",

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -7,13 +7,13 @@ enable composition without fragile string parsing.
 
 import os
 import re
-import warnings
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
 
 import wcmatch.glob as wcglob
+from langchain_core._api.deprecation import warn_deprecated
 
 from deepagents.backends.protocol import FileData, FileInfo as _FileInfo, GrepMatch as _GrepMatch, GrepResult, ReadResult
 
@@ -87,10 +87,11 @@ def _normalize_content(file_data: FileData) -> str:
     """
     content = file_data["content"]
     if isinstance(content, list):
-        warnings.warn(
-            "FileData with list[str] content is deprecated. Content should be stored as a plain str.",
-            DeprecationWarning,
-            stacklevel=2,
+        warn_deprecated(
+            since="0.5.0",
+            removal="0.6.0",
+            message=("`FileData` with `list[str]` content is deprecated. Content should be stored as a plain `str`."),
+            package="deepagents",
         )
         return "\n".join(content)
     return content

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -13,8 +13,8 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
 
 import wcmatch.glob as wcglob
-from langchain_core._api.deprecation import warn_deprecated
 
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import FileData, FileInfo as _FileInfo, GrepMatch as _GrepMatch, GrepResult, ReadResult
 
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
@@ -90,7 +90,11 @@ def _normalize_content(file_data: FileData) -> str:
         warn_deprecated(
             since="0.5.0",
             removal="0.6.0",
-            message=("`FileData` with `list[str]` content is deprecated. Content should be stored as a plain `str`."),
+            message=(
+                "`FileData` with `list[str]` content is deprecated and will "
+                "be removed in deepagents==0.6.0. Content should be stored "
+                "as a plain `str`."
+            ),
             package="deepagents",
         )
         return "\n".join(content)

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -6,7 +6,6 @@ middleware.
 """
 
 import logging
-import warnings
 from collections.abc import Callable, Sequence
 from typing import Any, cast
 
@@ -16,6 +15,11 @@ from langchain.agents.middleware.types import AgentMiddleware, ResponseT, _Input
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from langchain_core._api.deprecation import (
+    deprecated,
+    suppress_langchain_deprecation_warning,
+    warn_deprecated,
+)
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import SystemMessage
 from langchain_core.tools import BaseTool
@@ -98,6 +102,17 @@ this is used as the sole system prompt.
 # Replaceable via `_HarnessProfile.base_system_prompt` (internal)
 
 
+@deprecated(
+    since="0.5.4",
+    removal="1.0.0",
+    message=(
+        "Relying on the default model is deprecated and will be removed "
+        "alongside support for `model=None` in `create_deep_agent`. Specify a "
+        "model explicitly. "
+        "See https://docs.langchain.com/oss/python/deepagents/models"
+    ),
+    package="deepagents",
+)
 def get_default_model() -> ChatAnthropic:
     """Get the default model for Deep Agents.
 
@@ -416,17 +431,24 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     _model_spec: str | None = model if isinstance(model, str) else None
 
     if model is None:
-        warnings.warn(
-            "Passing `model=None` to `create_deep_agent` is deprecated and "
-            "will be removed in a future release. The `model` parameter type "
-            "will change from `BaseChatModel | str | None` to "
-            "`BaseChatModel | str`. Please specify a model explicitly. "
-            "See https://docs.langchain.com/oss/python/deepagents/models",
-            DeprecationWarning,
-            stacklevel=2,
+        warn_deprecated(
+            since="0.5.4",
+            removal="1.0.0",
+            message=(
+                "Passing `model=None` to `create_deep_agent` is deprecated. "
+                "The `model` parameter type will change from "
+                "`BaseChatModel | str | None` to `BaseChatModel | str`. "
+                "Specify a model explicitly. "
+                "See https://docs.langchain.com/oss/python/deepagents/models"
+            ),
+            package="deepagents",
         )
-
-    model = get_default_model() if model is None else resolve_model(model)
+        # Suppress the redundant `get_default_model` deprecation warning here;
+        # the caller has already been warned about `model=None` above.
+        with suppress_langchain_deprecation_warning():
+            model = get_default_model()
+    else:
+        model = resolve_model(model)
     _profile = _harness_profile_for_model(model, _model_spec)
 
     # Copy of `tools` with any provider-specific description rewrites.

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -110,18 +110,24 @@ def _build_default_model() -> ChatAnthropic:
 
 
 @deprecated(
-    since="0.5.4",
+    since="0.5.3",
     removal="1.0.0",
     message=(
         "Relying on the default model is deprecated and will be removed in "
         "deepagents==1.0.0 alongside support for `model=None` in "
-        "`create_deep_agent`. Specify a model explicitly. "
-        "See https://docs.langchain.com/oss/python/deepagents/models"
+        "`create_deep_agent`. Construct your model explicitly "
+        "(e.g., `ChatAnthropic(model_name=...)`). See "
+        "https://docs.langchain.com/oss/python/deepagents/models"
     ),
     package="deepagents",
 )
 def get_default_model() -> ChatAnthropic:
     """Get the default model for Deep Agents.
+
+    !!! deprecated
+        Deprecated since `0.5.3`; will be removed in `deepagents==1.0.0`.
+        Construct your model explicitly (e.g.,
+        `ChatAnthropic(model_name="claude-sonnet-4-6")`).
 
     Used as a fallback when `model=None` is passed to `create_deep_agent`.
 
@@ -437,14 +443,15 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
     if model is None:
         warn_deprecated(
-            since="0.5.4",
+            since="0.5.3",
             removal="1.0.0",
             message=(
                 "Passing `model=None` to `create_deep_agent` is deprecated "
                 "and will be removed in deepagents==1.0.0. The `model` "
                 "parameter type will change from `BaseChatModel | str | None` "
-                "to `BaseChatModel | str`. Specify a model explicitly. "
-                "See https://docs.langchain.com/oss/python/deepagents/models"
+                "to `BaseChatModel | str`. Specify a model explicitly "
+                "(e.g., `ChatAnthropic(model_name=...)`). See "
+                "https://docs.langchain.com/oss/python/deepagents/models"
             ),
             package="deepagents",
         )

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -15,11 +15,6 @@ from langchain.agents.middleware.types import AgentMiddleware, ResponseT, _Input
 from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
-from langchain_core._api.deprecation import (
-    deprecated,
-    suppress_langchain_deprecation_warning,
-    warn_deprecated,
-)
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import SystemMessage
 from langchain_core.tools import BaseTool
@@ -29,6 +24,7 @@ from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 from langgraph.typing import ContextT
 
+from deepagents._api.deprecation import deprecated, warn_deprecated
 from deepagents._models import get_model_identifier, get_model_provider, resolve_model
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
@@ -102,13 +98,24 @@ this is used as the sole system prompt.
 # Replaceable via `_HarnessProfile.base_system_prompt` (internal)
 
 
+def _build_default_model() -> ChatAnthropic:
+    """Construct the default model without emitting a deprecation warning.
+
+    Internal helper used by `create_deep_agent` so the parameter-level
+    `model=None` warning isn't paired with a separate function-level warning
+    from `get_default_model`. Direct user calls go through `get_default_model`,
+    which keeps its decorator and warns once per process.
+    """
+    return ChatAnthropic(model_name="claude-sonnet-4-6")
+
+
 @deprecated(
     since="0.5.4",
     removal="1.0.0",
     message=(
-        "Relying on the default model is deprecated and will be removed "
-        "alongside support for `model=None` in `create_deep_agent`. Specify a "
-        "model explicitly. "
+        "Relying on the default model is deprecated and will be removed in "
+        "deepagents==1.0.0 alongside support for `model=None` in "
+        "`create_deep_agent`. Specify a model explicitly. "
         "See https://docs.langchain.com/oss/python/deepagents/models"
     ),
     package="deepagents",
@@ -123,9 +130,7 @@ def get_default_model() -> ChatAnthropic:
     Returns:
         `ChatAnthropic` instance configured with `claude-sonnet-4-6`.
     """
-    return ChatAnthropic(
-        model_name="claude-sonnet-4-6",
-    )
+    return _build_default_model()
 
 
 def _resolve_extra_middleware(
@@ -435,18 +440,17 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             since="0.5.4",
             removal="1.0.0",
             message=(
-                "Passing `model=None` to `create_deep_agent` is deprecated. "
-                "The `model` parameter type will change from "
-                "`BaseChatModel | str | None` to `BaseChatModel | str`. "
-                "Specify a model explicitly. "
+                "Passing `model=None` to `create_deep_agent` is deprecated "
+                "and will be removed in deepagents==1.0.0. The `model` "
+                "parameter type will change from `BaseChatModel | str | None` "
+                "to `BaseChatModel | str`. Specify a model explicitly. "
                 "See https://docs.langchain.com/oss/python/deepagents/models"
             ),
             package="deepagents",
         )
-        # Suppress the redundant `get_default_model` deprecation warning here;
-        # the caller has already been warned about `model=None` above.
-        with suppress_langchain_deprecation_warning():
-            model = get_default_model()
+        # Use the un-decorated builder so we don't burn the dedupe flag on
+        # `get_default_model` — direct user callers still see one warning.
+        model = _build_default_model()
     else:
         model = resolve_model(model)
     _profile = _harness_profile_for_model(model, _model_spec)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -24,7 +24,6 @@ from langchain.agents.middleware.types import (
 )
 from langchain.tools import ToolRuntime
 from langchain.tools.tool_node import ToolCallRequest
-from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.messages import AnyMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.messages.content import ContentBlock
 from langchain_core.tools import BaseTool, StructuredTool
@@ -32,6 +31,7 @@ from langgraph.runtime import Runtime
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends import CompositeBackend, StateBackend
 from deepagents.backends.protocol import (
     BACKEND_TYPES as BACKEND_TYPES,  # Re-export type here for backwards compatibility
@@ -643,8 +643,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 since="0.5.0",
                 removal="0.6.0",
                 message=(
-                    "Passing a callable (factory) as `backend` is deprecated. "
-                    "Pass a `BackendProtocol` instance directly instead "
+                    "Passing a callable (factory) as `backend` is deprecated "
+                    "and will be removed in deepagents==0.6.0. Pass a "
+                    "`BackendProtocol` instance directly instead "
                     "(e.g. `StateBackend()`)."
                 ),
                 package="deepagents",
@@ -738,7 +739,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 warn_deprecated(
                     since="0.5.0",
                     removal="0.6.0",
-                    message=("Returning a plain `str` from `backend.read()` is deprecated. Return a `ReadResult` instead."),
+                    message=(
+                        "Returning a plain `str` from `backend.read()` is "
+                        "deprecated and will be removed in deepagents==0.6.0. "
+                        "Return a `ReadResult` instead."
+                    ),
                     package="deepagents",
                 )
                 # Legacy backends already format with line numbers

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -6,7 +6,6 @@ import concurrent.futures
 import contextvars
 import mimetypes
 import uuid
-import warnings
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired, cast
@@ -25,6 +24,7 @@ from langchain.agents.middleware.types import (
 )
 from langchain.tools import ToolRuntime
 from langchain.tools.tool_node import ToolCallRequest
+from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.messages import AnyMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.messages.content import ContentBlock
 from langchain_core.tools import BaseTool, StructuredTool
@@ -639,12 +639,15 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             Resolved backend instance.
         """
         if callable(self.backend):
-            warnings.warn(
-                "Passing a callable (factory) as `backend` is deprecated and "
-                "will be removed in v0.7. Pass a `BackendProtocol` instance "
-                "directly instead (e.g. `StateBackend()`).",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=(
+                    "Passing a callable (factory) as `backend` is deprecated. "
+                    "Pass a `BackendProtocol` instance directly instead "
+                    "(e.g. `StateBackend()`)."
+                ),
+                package="deepagents",
             )
             return self.backend(runtime)  # ty: ignore[call-top-callable]
         return self.backend
@@ -732,12 +735,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             limit: int,
         ) -> ToolMessage | str:
             if isinstance(read_result, str):
-                warnings.warn(
-                    "Returning a plain `str` from `backend.read()` is deprecated. "
-                    "Return a `ReadResult` instead. Returning `str` will not be "
-                    "supported in v0.7.",
-                    DeprecationWarning,
-                    stacklevel=2,
+                warn_deprecated(
+                    since="0.5.0",
+                    removal="0.6.0",
+                    message=("Returning a plain `str` from `backend.read()` is deprecated. Return a `ReadResult` instead."),
+                    package="deepagents",
                 )
                 # Legacy backends already format with line numbers
                 return _truncate(read_result, validated_path, limit)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -641,10 +641,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         if callable(self.backend):
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
+                removal="0.7.0",
                 message=(
                     "Passing a callable (factory) as `backend` is deprecated "
-                    "and will be removed in deepagents==0.6.0. Pass a "
+                    "and will be removed in deepagents==0.7.0. Pass a "
                     "`BackendProtocol` instance directly instead "
                     "(e.g. `StateBackend()`)."
                 ),
@@ -738,10 +738,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if isinstance(read_result, str):
                 warn_deprecated(
                     since="0.5.0",
-                    removal="0.6.0",
+                    removal="0.7.0",
                     message=(
                         "Returning a plain `str` from `backend.read()` is "
-                        "deprecated and will be removed in deepagents==0.6.0. "
+                        "deprecated and will be removed in deepagents==0.7.0. "
                         "Return a `ReadResult` instead."
                     ),
                     package="deepagents",

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -66,7 +66,6 @@ from langchain.agents.middleware.summarization import (
 )
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
 from langchain.tools import ToolRuntime
-from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage, get_buffer_string
 from langchain_core.messages.utils import count_tokens_approximately
@@ -75,6 +74,7 @@ from langgraph.types import Command
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends import CompositeBackend
 from deepagents.middleware._utils import append_to_system_message
 
@@ -273,7 +273,12 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
             warn_deprecated(
                 since="0.5.0",
                 removal="0.6.0",
-                message=("The argument `history_path_prefix` is deprecated. Use `CompositeBackend(artifacts_root='/my/root', ...)` instead."),
+                message=(
+                    "The argument `history_path_prefix` is deprecated and "
+                    "will be removed in deepagents==0.6.0. Use "
+                    "`CompositeBackend(artifacts_root='/my/root', ...)` "
+                    "instead."
+                ),
                 package="deepagents",
             )
 

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -66,6 +66,7 @@ from langchain.agents.middleware.summarization import (
 )
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ExtendedModelResponse, PrivateStateAttr
 from langchain.tools import ToolRuntime
+from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.exceptions import ContextOverflowError
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage, get_buffer_string
 from langchain_core.messages.utils import count_tokens_approximately
@@ -269,12 +270,11 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         """
         _deprecated_history_prefix = deprecated_kwargs.pop("history_path_prefix", None)
         if _deprecated_history_prefix is not None:
-            warnings.warn(
-                "The argument `history_path_prefix` was deprecated in deepagents 0.5"
-                " and will be removed in 0.7."
-                " Use CompositeBackend(artifacts_root='/my/root', ...) instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                since="0.5.0",
+                removal="0.6.0",
+                message=("The argument `history_path_prefix` is deprecated. Use `CompositeBackend(artifacts_root='/my/root', ...)` instead."),
+                package="deepagents",
             )
 
         # Initialize langchain helper for core summarization logic

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -272,10 +272,10 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         if _deprecated_history_prefix is not None:
             warn_deprecated(
                 since="0.5.0",
-                removal="0.6.0",
+                removal="0.7.0",
                 message=(
                     "The argument `history_path_prefix` is deprecated and "
-                    "will be removed in deepagents==0.6.0. Use "
+                    "will be removed in deepagents==0.7.0. Use "
                     "`CompositeBackend(artifacts_root='/my/root', ...)` "
                     "instead."
                 ),

--- a/libs/deepagents/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/deepagents/tests/unit_tests/_api/test_deprecation.py
@@ -1,0 +1,241 @@
+"""Tests for the `_api/deprecation` adapter."""
+
+import warnings
+from collections.abc import Callable
+
+import pytest
+
+from deepagents._api.deprecation import (
+    LangChainDeprecationWarning,
+    deprecated,
+    reset_deprecation_dedupe,
+    suppress_langchain_deprecation_warning,
+    warn_deprecated,
+)
+from tests.unit_tests.conftest import _DEDUPED_TARGETS
+
+# -- warn_deprecated wrapper -------------------------------------------------
+
+
+class TestWarnDeprecatedStacklevel:
+    """Stack attribution must point at the user call site, not internals."""
+
+    def test_default_stacklevel_attributes_to_caller(self) -> None:
+        def deprecated_fn() -> None:
+            warn_deprecated(
+                since="0.5.0",
+                removal="1.0.0",
+                message="x is deprecated",
+                package="deepagents",
+            )
+
+        def caller() -> None:
+            deprecated_fn()
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            caller()
+
+        assert len(captured) == 1
+        # `stacklevel=2` (default) attributes to the caller of `deprecated_fn`,
+        # which is `caller` — defined in this test file.
+        assert captured[0].filename == __file__
+
+    def test_explicit_stacklevel_lifts_through_extra_frames(self) -> None:
+        def helper() -> None:
+            warn_deprecated(
+                since="0.5.0",
+                removal="1.0.0",
+                message="y is deprecated",
+                package="deepagents",
+                stacklevel=3,
+            )
+
+        def deprecated_init() -> None:
+            helper()
+
+        def user_code() -> None:
+            deprecated_init()
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            user_code()
+
+        assert len(captured) == 1
+        assert captured[0].filename == __file__
+
+    def test_warning_category_is_langchain_deprecation_warning(self) -> None:
+        def deprecated_fn() -> None:
+            warn_deprecated(
+                since="0.5.0",
+                removal="1.0.0",
+                message="z is deprecated",
+                package="deepagents",
+            )
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            deprecated_fn()
+
+        assert len(captured) == 1
+        assert captured[0].category is LangChainDeprecationWarning
+
+
+# -- reset_deprecation_dedupe ------------------------------------------------
+
+
+def _make_decorated_function() -> Callable[[], int]:
+    @deprecated(
+        since="0.0.1",
+        removal="9.9.9",
+        message="example deprecation",
+        package="deepagents",
+    )
+    def example_fn() -> int:
+        return 42
+
+    return example_fn
+
+
+def _make_decorated_property() -> type:
+    class _Holder:
+        @property
+        @deprecated(
+            since="0.0.1",
+            removal="9.9.9",
+            message="example deprecation",
+            package="deepagents",
+        )
+        def value(self) -> int:
+            return 7
+
+    return _Holder
+
+
+class TestResetDeprecationDedupe:
+    """`reset_deprecation_dedupe` must re-arm per-call emission for tests."""
+
+    def test_function_dedupe_is_reset(self) -> None:
+        fn = _make_decorated_function()
+
+        with warnings.catch_warnings(record=True) as first:
+            warnings.simplefilter("always")
+            fn()
+            fn()
+        # `@deprecated` dedupes in-process, so back-to-back calls only
+        # produce one warning.
+        deprecations = [w for w in first if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+        reset_deprecation_dedupe(fn)
+
+        with warnings.catch_warnings(record=True) as second:
+            warnings.simplefilter("always")
+            fn()
+        deprecations = [w for w in second if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+    def test_property_dedupe_is_reset(self) -> None:
+        Holder = _make_decorated_property()  # noqa: N806
+        holder = Holder()
+
+        with warnings.catch_warnings(record=True) as first:
+            warnings.simplefilter("always")
+            _ = holder.value
+            _ = holder.value
+        deprecations = [w for w in first if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+        # Reset on the descriptor (`property` object) — `reset_deprecation_dedupe`
+        # detects this and resets the underlying `fget`'s closure.
+        reset_deprecation_dedupe(Holder.value)  # ty: ignore[unresolved-attribute]
+
+        with warnings.catch_warnings(record=True) as second:
+            warnings.simplefilter("always")
+            _ = holder.value
+        deprecations = [w for w in second if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+    def test_non_decorated_targets_are_silently_skipped(self) -> None:
+        """Passing plain callables/objects/classes must not raise."""
+
+        def plain_fn() -> None:
+            pass
+
+        # Should not raise — non-decorated objects are skipped.
+        reset_deprecation_dedupe(plain_fn, lambda: None, object(), 42, "string")
+
+    def test_mixed_targets_in_single_call(self) -> None:
+        """The loop must continue past targets that can't be reset."""
+        fn = _make_decorated_function()
+
+        # Prime the dedupe flag.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            fn()
+
+        # Mix a non-decorated callable with the decorated one.
+        reset_deprecation_dedupe(lambda: None, fn, object())
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            fn()
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+
+# -- suppress_langchain_deprecation_warning ---------------------------------
+
+
+def test_suppress_silences_warn_deprecated() -> None:
+    """The re-exported context manager must suppress emissions from `warn_deprecated`."""
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        with suppress_langchain_deprecation_warning():
+            warn_deprecated(
+                since="0.5.0",
+                removal="1.0.0",
+                message="suppressed",
+                package="deepagents",
+            )
+
+    deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+    assert deprecations == []
+
+
+# -- conftest drift detection -----------------------------------------------
+
+
+def test_conftest_dedupe_targets_cover_known_deprecations() -> None:
+    """Every `@deprecated`-decorated callable in deepagents must be in `_DEDUPED_TARGETS`.
+
+    Catches drift: a future `@deprecated` addition without conftest update would
+    re-introduce xdist reorder-flake before a single test exposed it.
+    """
+    target_names = {getattr(t.fget if isinstance(t, property) else t, "__qualname__", repr(t)) for t in _DEDUPED_TARGETS}
+
+    expected_subset = {
+        "BackendProtocol.ls_info",
+        "BackendProtocol.als_info",
+        "BackendProtocol.glob_info",
+        "BackendProtocol.aglob_info",
+        "BackendProtocol.grep_raw",
+        "BackendProtocol.agrep_raw",
+        "_NamespaceRuntimeCompat.runtime",
+        "_NamespaceRuntimeCompat.state",
+        "get_default_model",
+    }
+    missing = expected_subset - target_names
+    assert not missing, f"Drift: {missing} missing from `_DEDUPED_TARGETS`"
+
+
+@pytest.mark.parametrize("dummy", [None])
+def test_dedupe_reset_fixture_is_autouse(dummy: object) -> None:  # noqa: ARG001
+    """Smoke test: the autouse fixture in `conftest.py` runs before this test."""
+    fn = _make_decorated_function()
+    # If the fixture runs, dedupe was reset before this test, so we should
+    # observe a fresh warning emission.
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        fn()
+    assert any(issubclass(w.category, DeprecationWarning) for w in captured)

--- a/libs/deepagents/tests/unit_tests/backends/test_files_update_deprecation.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_files_update_deprecation.py
@@ -1,7 +1,7 @@
 """Tests for the deprecated ``files_update`` field on WriteResult and EditResult.
 
 ``files_update`` was removed in favour of internal backend state handling.
-Passing it should emit a DeprecationWarning (scheduled for removal in v0.7)
+Passing it should emit a DeprecationWarning (scheduled for removal in v0.6)
 but must not raise an error so existing callers aren't broken.
 """
 
@@ -30,7 +30,7 @@ class TestWriteResultFilesUpdateDeprecation:
         deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecation_warnings) == 1
         assert "files_update" in str(deprecation_warnings[0].message)
-        assert "v0.7" in str(deprecation_warnings[0].message)
+        assert "0.6.0" in str(deprecation_warnings[0].message)
         assert result.files_update is None
 
     def test_warning_with_files_update_dict(self) -> None:
@@ -71,7 +71,7 @@ class TestEditResultFilesUpdateDeprecation:
         deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecation_warnings) == 1
         assert "files_update" in str(deprecation_warnings[0].message)
-        assert "v0.7" in str(deprecation_warnings[0].message)
+        assert "0.6.0" in str(deprecation_warnings[0].message)
         assert result.files_update is None
         assert result.occurrences == 2
 

--- a/libs/deepagents/tests/unit_tests/backends/test_files_update_deprecation.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_files_update_deprecation.py
@@ -1,7 +1,7 @@
 """Tests for the deprecated ``files_update`` field on WriteResult and EditResult.
 
 ``files_update`` was removed in favour of internal backend state handling.
-Passing it should emit a DeprecationWarning (scheduled for removal in v0.6)
+Passing it should emit a DeprecationWarning (scheduled for removal in 0.6.0)
 but must not raise an error so existing callers aren't broken.
 """
 

--- a/libs/deepagents/tests/unit_tests/backends/test_files_update_deprecation.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_files_update_deprecation.py
@@ -1,12 +1,13 @@
-"""Tests for the deprecated ``files_update`` field on WriteResult and EditResult.
+"""Tests for the deprecated `files_update` field on `WriteResult` and `EditResult`.
 
-``files_update`` was removed in favour of internal backend state handling.
-Passing it should emit a DeprecationWarning (scheduled for removal in 0.6.0)
+`files_update` was removed in favour of internal backend state handling.
+Passing it should emit a `DeprecationWarning` (scheduled for removal in 0.7.0)
 but must not raise an error so existing callers aren't broken.
 """
 
 import warnings
 
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends.protocol import EditResult, WriteResult
 
 # -- WriteResult -----------------------------------------------------------
@@ -29,8 +30,12 @@ class TestWriteResultFilesUpdateDeprecation:
             result = WriteResult(path="/f.txt", files_update=None)
         deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecation_warnings) == 1
+        assert deprecation_warnings[0].category is LangChainDeprecationWarning
+        # Wording is asserted explicitly because the test below also relies on
+        # the literal `0.7.0` substring rather than `langchain_core`'s
+        # auto-formatted text.
         assert "files_update" in str(deprecation_warnings[0].message)
-        assert "0.6.0" in str(deprecation_warnings[0].message)
+        assert "0.7.0" in str(deprecation_warnings[0].message)
         assert result.files_update is None
 
     def test_warning_with_files_update_dict(self) -> None:
@@ -47,6 +52,15 @@ class TestWriteResultFilesUpdateDeprecation:
         result = WriteResult(error="File exists")
         assert result.error == "File exists"
         assert result.path is None
+
+    def test_warning_attributed_to_caller(self) -> None:
+        """The warning's filename must point at the caller, not deepagents internals."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            WriteResult(path="/f.txt", files_update=None)
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 1
+        assert deprecation_warnings[0].filename == __file__
 
 
 # -- EditResult ------------------------------------------------------------
@@ -71,7 +85,7 @@ class TestEditResultFilesUpdateDeprecation:
         deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecation_warnings) == 1
         assert "files_update" in str(deprecation_warnings[0].message)
-        assert "0.6.0" in str(deprecation_warnings[0].message)
+        assert "0.7.0" in str(deprecation_warnings[0].message)
         assert result.files_update is None
         assert result.occurrences == 2
 

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1,9 +1,11 @@
+import warnings
 from pathlib import Path
 
 import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -681,3 +683,28 @@ class TestEditCrlfNormalization:
         final = (tmp_path / "history.md").read_text()
         assert "## Summary 2" in final
         assert "Human: next" in final
+
+
+class TestVirtualModeDefaultDeprecation:
+    """`virtual_mode=None` (omitted) emits a deprecation; explicit values do not."""
+
+    def test_omitted_virtual_mode_warns(self, tmp_path: Path) -> None:
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            be = FilesystemBackend(root_dir=str(tmp_path))
+
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert deprecations[0].category is LangChainDeprecationWarning
+        assert "virtual_mode" in str(deprecations[0].message)
+        # Default falls back to `False` for backwards compatibility.
+        assert be.virtual_mode is False
+
+    def test_explicit_virtual_mode_does_not_warn(self, tmp_path: Path) -> None:
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+            FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning) and "virtual_mode" in str(w.message)]
+        assert deprecations == []

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -2,10 +2,12 @@
 
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 
 import pytest
 
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends.local_shell import LocalShellBackend
 from deepagents.backends.protocol import ExecuteResponse
 
@@ -307,3 +309,28 @@ async def test_local_shell_backend_async_filesystem_operations() -> None:
         content = await backend.aread("/async_test.txt")
         assert content.file_data is not None
         assert "modified content" in content.file_data["content"]
+
+
+class TestLocalShellVirtualModeDefaultDeprecation:
+    """`virtual_mode=None` (omitted) emits a deprecation; explicit values do not."""
+
+    def test_omitted_virtual_mode_warns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            be = LocalShellBackend(root_dir=tmpdir)
+
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert deprecations[0].category is LangChainDeprecationWarning
+        assert "virtual_mode" in str(deprecations[0].message)
+        # Default falls back to `False` for backwards compatibility.
+        assert be.virtual_mode is False
+
+    def test_explicit_virtual_mode_does_not_warn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            LocalShellBackend(root_dir=tmpdir, virtual_mode=False)
+            LocalShellBackend(root_dir=tmpdir, virtual_mode=True)
+
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning) and "virtual_mode" in str(w.message)]
+        assert deprecations == []

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -126,8 +126,11 @@ class TestDeprecatedMethodsRouteToNewNames:
             def ls(self, path: str) -> LsResult:
                 return LsResult(error="error")
 
-        with pytest.raises(NotImplementedError, match="new `ls` API"):
-            MyBackend().ls_info("/")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(NotImplementedError, match="new `ls` API"):
+                MyBackend().ls_info("/")
+        assert any("ls_info" in str(x.message) for x in w)
 
     def test_grep_raw_delegates_to_grep(self) -> None:
         class MyBackend(BackendProtocol):

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -126,11 +126,8 @@ class TestDeprecatedMethodsRouteToNewNames:
             def ls(self, path: str) -> LsResult:
                 return LsResult(error="error")
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with pytest.raises(NotImplementedError, match="new `ls` API"):
-                MyBackend().ls_info("/")
-        assert any("ls_info" in str(x.message) for x in w)
+        with pytest.raises(NotImplementedError, match="new `ls` API"):
+            MyBackend().ls_info("/")
 
     def test_grep_raw_delegates_to_grep(self) -> None:
         class MyBackend(BackendProtocol):

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -11,6 +11,7 @@ import warnings
 
 import pytest
 
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends.state import StateBackend
 
 
@@ -21,8 +22,11 @@ def test_state_backend_runtime_deprecation_warning():
         StateBackend(runtime="ignored_value")
         deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecation_warnings) == 1
-        assert "0.6.0" in str(deprecation_warnings[0].message)
+        assert deprecation_warnings[0].category is LangChainDeprecationWarning
+        assert "0.7.0" in str(deprecation_warnings[0].message)
         assert "runtime" in str(deprecation_warnings[0].message)
+        # The warning should attribute to this test file, not deepagents internals.
+        assert deprecation_warnings[0].filename == __file__
 
 
 def test_state_backend_no_deprecation_without_runtime():

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -21,7 +21,7 @@ def test_state_backend_runtime_deprecation_warning():
         StateBackend(runtime="ignored_value")
         deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecation_warnings) == 1
-        assert "v0.7" in str(deprecation_warnings[0].message)
+        assert "0.6.0" in str(deprecation_warnings[0].message)
         assert "runtime" in str(deprecation_warnings[0].message)
 
 

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -364,12 +364,11 @@ def test_compat_wrapper_old_style_factory_end_to_end() -> None:
     def old_factory(ctx: BackendContext) -> tuple[str, ...]:  # type: ignore[type-arg]
         return (ctx.runtime.context.user_id, "filesystem")  # type: ignore[union-attr]
 
-    # The `.runtime` deprecation warning is verified by
-    # `test_compat_wrapper_old_style_runtime_access_warns`; langchain's
-    # `@deprecated` decorator dedupes per-process, so we don't re-assert
-    # warning emission here.
-    result = old_factory(compat)  # type: ignore[arg-type]
-    assert result == ("bob", "filesystem")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = old_factory(compat)  # type: ignore[arg-type]
+        assert result == ("bob", "filesystem")
+        assert len(w) == 1  # one warning from .runtime access
 
 
 def test_compat_wrapper_new_style_factory_end_to_end() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -314,7 +314,7 @@ def test_compat_wrapper_old_style_runtime_access_warns() -> None:
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)
         assert ".runtime" in str(w[0].message)
-        assert "v0.7" in str(w[0].message)
+        assert "0.6.0" in str(w[0].message)
 
 
 def test_compat_wrapper_old_style_state_access_warns() -> None:
@@ -328,7 +328,7 @@ def test_compat_wrapper_old_style_state_access_warns() -> None:
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)
         assert ".state" in str(w[0].message)
-        assert "v0.7" in str(w[0].message)
+        assert "0.6.0" in str(w[0].message)
 
 
 def test_compat_wrapper_proxies_runtime_attrs() -> None:
@@ -364,11 +364,12 @@ def test_compat_wrapper_old_style_factory_end_to_end() -> None:
     def old_factory(ctx: BackendContext) -> tuple[str, ...]:  # type: ignore[type-arg]
         return (ctx.runtime.context.user_id, "filesystem")  # type: ignore[union-attr]
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        result = old_factory(compat)  # type: ignore[arg-type]
-        assert result == ("bob", "filesystem")
-        assert len(w) == 1  # one warning from .runtime access
+    # The `.runtime` deprecation warning is verified by
+    # `test_compat_wrapper_old_style_runtime_access_warns`; langchain's
+    # `@deprecated` decorator dedupes per-process, so we don't re-assert
+    # warning emission here.
+    result = old_factory(compat)  # type: ignore[arg-type]
+    assert result == ("bob", "filesystem")
 
 
 def test_compat_wrapper_new_style_factory_end_to_end() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -10,6 +10,7 @@ from langchain_core.messages import ToolMessage
 from langgraph.runtime import Runtime
 from langgraph.store.memory import InMemoryStore
 
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
 from deepagents.backends.store import BackendContext, StoreBackend, _NamespaceRuntimeCompat, _validate_namespace
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -312,9 +313,9 @@ def test_compat_wrapper_old_style_runtime_access_warns() -> None:
         result = compat.runtime
         assert result is None
         assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
+        assert w[0].category is LangChainDeprecationWarning
         assert ".runtime" in str(w[0].message)
-        assert "0.6.0" in str(w[0].message)
+        assert "0.7.0" in str(w[0].message)
 
 
 def test_compat_wrapper_old_style_state_access_warns() -> None:
@@ -326,9 +327,9 @@ def test_compat_wrapper_old_style_state_access_warns() -> None:
         result = compat.state
         assert result == {"messages": []}
         assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
+        assert w[0].category is LangChainDeprecationWarning
         assert ".state" in str(w[0].message)
-        assert "0.6.0" in str(w[0].message)
+        assert "0.7.0" in str(w[0].message)
 
 
 def test_compat_wrapper_proxies_runtime_attrs() -> None:

--- a/libs/deepagents/tests/unit_tests/conftest.py
+++ b/libs/deepagents/tests/unit_tests/conftest.py
@@ -1,0 +1,35 @@
+"""Shared fixtures for unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepagents._api.deprecation import reset_deprecation_dedupe
+from deepagents.backends.protocol import BackendProtocol
+from deepagents.backends.store import _NamespaceRuntimeCompat
+from deepagents.graph import get_default_model
+
+_DEDUPED_TARGETS: tuple[object, ...] = (
+    BackendProtocol.ls_info,
+    BackendProtocol.als_info,
+    BackendProtocol.glob_info,
+    BackendProtocol.aglob_info,
+    BackendProtocol.grep_raw,
+    BackendProtocol.agrep_raw,
+    _NamespaceRuntimeCompat.runtime,
+    _NamespaceRuntimeCompat.state,
+    get_default_model,
+)
+"""Callables/properties wrapped by `@deprecated` whose dedupe flag must reset
+between tests so per-call warning assertions are reorder-safe under xdist."""
+
+
+@pytest.fixture(autouse=True)
+def _reset_deprecation_dedupe() -> None:
+    """Reset `@deprecated` dedupe flags before each test.
+
+    The langchain_core decorator emits each warning at most once per process
+    via a closure-bound flag. Without this fixture, tests asserting per-call
+    emission become reorder-sensitive.
+    """
+    reset_deprecation_dedupe(*_DEDUPED_TARGETS)

--- a/libs/deepagents/tests/unit_tests/conftest.py
+++ b/libs/deepagents/tests/unit_tests/conftest.py
@@ -2,24 +2,51 @@
 
 from __future__ import annotations
 
+import importlib
+import inspect
+import pkgutil
+
 import pytest
 
+import deepagents
 from deepagents._api.deprecation import reset_deprecation_dedupe
-from deepagents.backends.protocol import BackendProtocol
-from deepagents.backends.store import _NamespaceRuntimeCompat
-from deepagents.graph import get_default_model
 
-_DEDUPED_TARGETS: tuple[object, ...] = (
-    BackendProtocol.ls_info,
-    BackendProtocol.als_info,
-    BackendProtocol.glob_info,
-    BackendProtocol.aglob_info,
-    BackendProtocol.grep_raw,
-    BackendProtocol.agrep_raw,
-    _NamespaceRuntimeCompat.runtime,
-    _NamespaceRuntimeCompat.state,
-    get_default_model,
-)
+
+def _is_deprecated_target(value: object) -> bool:
+    """Return whether `value` (or its `fget`) carries the dedupe `warned` freevar."""
+    fn = value.fget if isinstance(value, property) else value
+    code = getattr(fn, "__code__", None)
+    return code is not None and "warned" in code.co_freevars
+
+
+def _discover_deprecated_targets() -> tuple[object, ...]:
+    """Walk the `deepagents` package for `@deprecated`-wrapped callables.
+
+    Returns every property and function whose underlying closure carries the
+    `warned` freevar that langchain_core's `@deprecated` decorator installs.
+
+    This avoids drift: any new `@deprecated` decoration is automatically
+    covered by the dedupe-reset fixture, so per-call assertions stay
+    reorder-safe under `pytest -n auto` without manual list maintenance.
+    """
+    seen: dict[int, object] = {}
+    for module_info in pkgutil.walk_packages(deepagents.__path__, deepagents.__name__ + "."):
+        try:
+            module = importlib.import_module(module_info.name)
+        except Exception:  # noqa: BLE001, S112  # Skip optional/extras-gated modules.
+            continue
+        for _, value in inspect.getmembers(module):
+            if _is_deprecated_target(value):
+                seen.setdefault(id(value), value)
+                continue
+            if inspect.isclass(value):
+                for _, attr in inspect.getmembers(value):
+                    if _is_deprecated_target(attr):
+                        seen.setdefault(id(attr), attr)
+    return tuple(seen.values())
+
+
+_DEDUPED_TARGETS: tuple[object, ...] = _discover_deprecated_targets()
 """Callables/properties wrapped by `@deprecated` whose dedupe flag must reset
 between tests so per-call warning assertions are reorder-safe under xdist."""
 

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -10,6 +10,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.tools import BaseTool, StructuredTool
 
+from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents._version import __version__
 from deepagents.graph import (
     BASE_AGENT_PROMPT,
@@ -567,7 +568,10 @@ class TestModelNoneDeprecationWarning:
         assert "deprecated" in msg
         assert "BaseChatModel | str" in msg
         assert "https://docs.langchain.com/oss/python/deepagents/models" in msg
-        # The warning should not point inside deepagents itself.
+        # The warning must be a `LangChainDeprecationWarning`, not stdlib —
+        # this is the strongest signal that we routed through `warn_deprecated`.
+        assert deprecations[0].category is LangChainDeprecationWarning
+        # And it should not be attributed to a frame inside deepagents itself.
         assert "/deepagents/graph.py" not in deprecations[0].filename
 
     def test_model_none_default_emits_deprecation_warning(self) -> None:

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -19,6 +19,7 @@ from deepagents.graph import (
     _resolve_extra_middleware,
     _tool_name,
     create_deep_agent,
+    get_default_model,
 )
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.profiles import _HARNESS_PROFILES, _get_harness_profile, _HarnessProfile, _register_harness_profile
@@ -571,8 +572,9 @@ class TestModelNoneDeprecationWarning:
         # The warning must be a `LangChainDeprecationWarning`, not stdlib —
         # this is the strongest signal that we routed through `warn_deprecated`.
         assert deprecations[0].category is LangChainDeprecationWarning
-        # And it should not be attributed to a frame inside deepagents itself.
-        assert "/deepagents/graph.py" not in deprecations[0].filename
+        # And it should be attributed to the caller frame (this test file),
+        # not to a frame inside `deepagents` itself.
+        assert deprecations[0].filename == __file__
 
     def test_model_none_default_emits_deprecation_warning(self) -> None:
         """Calling create_deep_agent() with no model arg should emit a DeprecationWarning."""
@@ -592,3 +594,37 @@ class TestModelNoneDeprecationWarning:
 
         deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning) and "model=None" in str(w.message)]
         assert len(deprecations) == 0
+
+
+class TestBuildDefaultModelContract:
+    """Pin the contract that internal default-model construction does not burn `get_default_model`'s dedupe slot.
+
+    Direct callers of `get_default_model` should still see exactly one warning
+    after `create_deep_agent(model=None)` runs in the same process.
+    """
+
+    def test_create_deep_agent_does_not_consume_get_default_model_dedupe(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            create_deep_agent(model=None)
+            get_default_model()
+
+        get_default_model_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning) and "Relying on the default model" in str(w.message)
+        ]
+        # `create_deep_agent(model=None)` must not consume the
+        # `get_default_model` dedupe slot — the direct caller still gets a
+        # warning.
+        assert len(get_default_model_warnings) == 1
+
+    def test_get_default_model_emits_langchain_deprecation_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            get_default_model()
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert deprecations[0].category is LangChainDeprecationWarning
+        msg = str(deprecations[0].message)
+        assert "deprecated" in msg
+        assert "https://docs.langchain.com/oss/python/deepagents/models" in msg

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -567,8 +567,8 @@ class TestModelNoneDeprecationWarning:
         assert "deprecated" in msg
         assert "BaseChatModel | str" in msg
         assert "https://docs.langchain.com/oss/python/deepagents/models" in msg
-        # stacklevel=2 should point at the caller, not inside graph.py
-        assert deprecations[0].filename == __file__
+        # The warning should not point inside deepagents itself.
+        assert "/deepagents/graph.py" not in deprecations[0].filename
 
     def test_model_none_default_emits_deprecation_warning(self) -> None:
         """Calling create_deep_agent() with no model arg should emit a DeprecationWarning."""

--- a/libs/evals/CONTRIBUTING.md
+++ b/libs/evals/CONTRIBUTING.md
@@ -15,10 +15,10 @@ export ANTHROPIC_API_KEY="sk-ant-..."  # Required: For Claude model
 export LANGSMITH_API_KEY="lsv2_..."    # Required: For tracing
 export LANGSMITH_TRACING=true       # Required: Enable LangSmith tracing
 
-# All evals (default model)
-make evals
+# All evals
+make evals MODEL=claude-opus-4-7
 
-# Specific model
+# Specific model via raw pytest invocation
 LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest tests/evals --model claude-sonnet-4-6-20250514
 
 # Single test file

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -13,8 +13,12 @@ PYTEST_EXTRA ?=
 test: ## Run unit tests
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
-evals: ## Run evals
-	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest tests/evals -v --tb=short $(PYTEST_EXTRA)
+evals: ## Run evals (set MODEL=<id>; required)
+	@if [ -z "$(MODEL)" ]; then \
+		echo "ERROR: MODEL is required. Example: make evals MODEL=claude-opus-4-7" >&2; \
+		exit 1; \
+	fi
+	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest tests/evals -v --tb=short --model $(MODEL) $(PYTEST_EXTRA)
 
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw . -- $(TEST_FILE)

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -11,7 +11,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from deepagents import create_deep_agent
-from deepagents.graph import get_default_model
 from deepagents_cli.agent import create_cli_agent
 from dotenv import load_dotenv
 from harbor.agents.base import BaseAgent
@@ -75,7 +74,7 @@ class DeepAgentsWrapper(BaseAgent):
     def __init__(
         self,
         logs_dir: Path,
-        model_name: str | None = None,
+        model_name: str,
         temperature: float = 0.0,
         verbose: bool = True,
         use_cli_agent: bool = True,
@@ -99,27 +98,18 @@ class DeepAgentsWrapper(BaseAgent):
         """
         super().__init__(logs_dir, model_name, *args, **kwargs)
 
-        if openrouter_provider and (model_name is None or not model_name.startswith("openrouter:")):
+        if openrouter_provider and not model_name.startswith("openrouter:"):
             msg = "openrouter_provider requires an openrouter: model prefix"
             raise ValueError(msg)
 
-        if model_name is None:
-            # Keep Harbor default aligned with the SDK default model.
-            model = get_default_model()
-            # Apply Harbor's runtime temperature knob to the SDK default when supported.
-            if hasattr(model, "temperature"):
-                model = model.model_copy(update={"temperature": temperature})
-            self._model = model
-            self._model_name = model.model
-        else:
-            self._model_name = model_name
-            model_kwargs: dict[str, Any] = {}
-            if openrouter_provider:
-                model_kwargs["openrouter_provider"] = {
-                    "only": [openrouter_provider],
-                    "allow_fallbacks": False,
-                }
-            self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
+        self._model_name = model_name
+        model_kwargs: dict[str, Any] = {}
+        if openrouter_provider:
+            model_kwargs["openrouter_provider"] = {
+                "only": [openrouter_provider],
+                "allow_fallbacks": False,
+            }
+        self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
 
         self._temperature = temperature
         self._verbose = verbose

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -46,6 +46,27 @@ load_dotenv()
 
 _MAX_FILE_LISTING = 10  # maximum files shown in the system prompt directory context
 
+# Reasoning-only model name prefixes that reject `temperature` at the API.
+# Match is performed after stripping any provider prefix (e.g. `openai:`).
+_REASONING_MODEL_PREFIXES: tuple[str, ...] = (
+    "o1",
+    "o3",
+    "o4",
+    "gpt-5",
+)
+
+
+def _accepts_temperature(model_name: str) -> bool:
+    """Return whether the named model accepts a `temperature` parameter.
+
+    Reasoning-only models (`o1-*`, `o3-*`, `o4-*`, `gpt-5*`) reject
+    `temperature` at the OpenAI Responses API and fail at first call rather
+    than at construction.
+    """
+    bare = model_name.split(":", 1)[1] if ":" in model_name else model_name
+    return not bare.startswith(_REASONING_MODEL_PREFIXES)
+
+
 SYSTEM_MESSAGE = """
 You are an autonomous agent executing tasks in a sandboxed environment. Follow these instructions carefully.
 
@@ -86,8 +107,9 @@ class DeepAgentsWrapper(BaseAgent):
 
         Args:
             logs_dir: Directory for storing logs
-            model_name: Name of the LLM model to use
-            temperature: Temperature setting for the model
+            model_name: Name of the LLM model to use (required, non-empty).
+            temperature: Temperature setting for the model. Skipped for
+                reasoning-only models that reject the parameter.
             verbose: Enable verbose output
             use_cli_agent: If True, use create_cli_agent from deepagents-cli (default).
                 If False, use create_deep_agent from SDK.
@@ -95,7 +117,15 @@ class DeepAgentsWrapper(BaseAgent):
                 (e.g. `"MiniMax"`).
 
                 Requires an `openrouter:` model prefix.
+
+        Raises:
+            ValueError: If `model_name` is empty/whitespace, or if
+                `openrouter_provider` is set without an `openrouter:` prefix.
         """
+        if not model_name or not model_name.strip():
+            msg = "model_name must be a non-empty string"
+            raise ValueError(msg)
+
         super().__init__(logs_dir, model_name, *args, **kwargs)
 
         if openrouter_provider and not model_name.startswith("openrouter:"):
@@ -109,7 +139,12 @@ class DeepAgentsWrapper(BaseAgent):
                 "only": [openrouter_provider],
                 "allow_fallbacks": False,
             }
-        self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
+        # Reasoning-only models (o1/o3/o4/gpt-5*) reject `temperature`. Skip
+        # it for those — the failure would otherwise surface only at the first
+        # API call, after sandbox setup.
+        if _accepts_temperature(model_name):
+            model_kwargs["temperature"] = temperature
+        self._model = init_chat_model(model_name, **model_kwargs)
 
         self._temperature = temperature
         self._verbose = verbose

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -86,7 +86,7 @@ class DeepAgentsWrapper(BaseAgent):
 
         Args:
             logs_dir: Directory for storing logs
-            model_name: Name of the LLM model to use (required, non-empty).
+            model_name: Name of the LLM model to use.
             temperature: Temperature setting for the model.
             verbose: Enable verbose output
             use_cli_agent: If True, use create_cli_agent from deepagents-cli (default).

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -85,12 +85,13 @@ class DeepAgentsWrapper(BaseAgent):
         """Initialize Deep AgentsWrapper.
 
         Args:
-            logs_dir: Directory for storing logs
+            logs_dir: Directory for storing logs.
             model_name: Name of the LLM model to use.
             temperature: Temperature setting for the model.
-            verbose: Enable verbose output
-            use_cli_agent: If True, use create_cli_agent from deepagents-cli (default).
-                If False, use create_deep_agent from SDK.
+            verbose: Enable verbose output.
+            use_cli_agent: If `True`, use `create_cli_agent` from
+                `deepagents-cli` (default). If `False`, use
+                `create_deep_agent` from the SDK.
             openrouter_provider: Pin OpenRouter routing to a single provider
                 (e.g. `"MiniMax"`).
 

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -46,27 +46,6 @@ load_dotenv()
 
 _MAX_FILE_LISTING = 10  # maximum files shown in the system prompt directory context
 
-# Reasoning-only model name prefixes that reject `temperature` at the API.
-# Match is performed after stripping any provider prefix (e.g. `openai:`).
-_REASONING_MODEL_PREFIXES: tuple[str, ...] = (
-    "o1",
-    "o3",
-    "o4",
-    "gpt-5",
-)
-
-
-def _accepts_temperature(model_name: str) -> bool:
-    """Return whether the named model accepts a `temperature` parameter.
-
-    Reasoning-only models (`o1-*`, `o3-*`, `o4-*`, `gpt-5*`) reject
-    `temperature` at the OpenAI Responses API and fail at first call rather
-    than at construction.
-    """
-    bare = model_name.split(":", 1)[1] if ":" in model_name else model_name
-    return not bare.startswith(_REASONING_MODEL_PREFIXES)
-
-
 SYSTEM_MESSAGE = """
 You are an autonomous agent executing tasks in a sandboxed environment. Follow these instructions carefully.
 
@@ -108,8 +87,7 @@ class DeepAgentsWrapper(BaseAgent):
         Args:
             logs_dir: Directory for storing logs
             model_name: Name of the LLM model to use (required, non-empty).
-            temperature: Temperature setting for the model. Skipped for
-                reasoning-only models that reject the parameter.
+            temperature: Temperature setting for the model.
             verbose: Enable verbose output
             use_cli_agent: If True, use create_cli_agent from deepagents-cli (default).
                 If False, use create_deep_agent from SDK.
@@ -139,12 +117,7 @@ class DeepAgentsWrapper(BaseAgent):
                 "only": [openrouter_provider],
                 "allow_fallbacks": False,
             }
-        # Reasoning-only models (o1/o3/o4/gpt-5*) reject `temperature`. Skip
-        # it for those — the failure would otherwise surface only at the first
-        # API call, after sandbox setup.
-        if _accepts_temperature(model_name):
-            model_kwargs["temperature"] = temperature
-        self._model = init_chat_model(model_name, **model_kwargs)
+        self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
 
         self._temperature = temperature
         self._verbose = verbose

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
 from deepagents import __version__ as deepagents_version
-from deepagents.graph import get_default_model
 
 pytest_plugins = ["tests.evals.pytest_reporter"]
 
@@ -55,13 +54,20 @@ def pytest_configure(config: pytest.Config) -> None:
             returncode=1,
         )
 
+    if not config.getoption("--model"):
+        pytest.exit(
+            "Aborting: --model is required. Pass an explicit model identifier, "
+            "e.g. `--model claude-sonnet-4-6`.",
+            returncode=1,
+        )
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--model",
         action="store",
         default=None,
-        help="Model to run evals against. If omitted, uses deepagents.graph.get_default_model().model.",
+        help="Model to run evals against (required). E.g. --model claude-sonnet-4-6.",
     )
     parser.addoption(
         "--eval-category",
@@ -142,8 +148,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if "model_name" not in metafunc.fixturenames:
         return
 
-    model_opt = metafunc.config.getoption("--model")
-    model_name = model_opt or str(get_default_model().model)
+    model_name = metafunc.config.getoption("--model")
     metafunc.parametrize("model_name", [model_name])
 
 
@@ -173,13 +178,8 @@ def repl_name(request: pytest.FixtureRequest) -> ReplName | None:
 
 @pytest.fixture(scope="session")
 def langsmith_experiment_metadata(request: pytest.FixtureRequest) -> dict[str, Any]:
-    model_opt = request.config.getoption("--model")
-    default_model = get_default_model()
-    model_name = model_opt or str(
-        getattr(default_model, "model", None) or getattr(default_model, "model_name", "")
-    )
     return {
-        "model": model_name,
+        "model": request.config.getoption("--model"),
         "date": datetime.now(tz=UTC).strftime("%Y-%m-%d"),
         "deepagents_version": deepagents_version,
     }

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     import pytest
 
 from deepagents._version import __version__
-from deepagents.graph import get_default_model
 
 import tests.evals.utils as _evals_utils
 
@@ -146,10 +145,8 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         client = ls_client.Client()
         dataset = _get_test_suite(client, test_suite_name)
 
-        model_opt = session.config.getoption("--model", default=None)
-        model_name = model_opt or str(get_default_model().model)
         experiment_metadata = {
-            "model": model_name,
+            "model": session.config.getoption("--model"),
             "date": datetime.now(tz=UTC).strftime("%Y-%m-%d"),
             "deepagents_version": __version__,
         }
@@ -374,9 +371,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     payload: dict[str, object] = {
         "created_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
         "sdk_version": __version__,
-        "model": session.config.getoption("--model")
-        or str(session.config._inicache.get("model", ""))
-        or str(get_default_model().model),
+        "model": session.config.getoption("--model"),
         **_RESULTS,
         "correctness": correctness,
         "category_scores": category_scores,

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -423,6 +423,11 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if not report_path_opt:
         return
 
+    # Don't clobber an existing report with a `model: null` payload when the
+    # session aborted before `--model` validation in `pytest_configure`.
+    if not payload["model"]:
+        return
+
     report_path = Path(str(report_path_opt))
     report_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import statistics
 import sys
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
 from deepagents._version import __version__
 
 import tests.evals.utils as _evals_utils
+
+logger = logging.getLogger(__name__)
 
 _RESULTS: dict[str, int] = {
     "passed": 0,
@@ -426,6 +429,10 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     # Don't clobber an existing report with a `model: null` payload when the
     # session aborted before `--model` validation in `pytest_configure`.
     if not payload["model"]:
+        logger.warning(
+            "Skipping report write to %s: session aborted before --model validation.",
+            report_path_opt,
+        )
         return
 
     report_path = Path(str(report_path_opt))

--- a/libs/evals/tests/unit_tests/test_conftest_model_required.py
+++ b/libs/evals/tests/unit_tests/test_conftest_model_required.py
@@ -1,0 +1,88 @@
+"""End-to-end tests for the eval suite's `--model` requirement and report-skip behaviour.
+
+These spin up an isolated pytest invocation via `pytester` to exercise the
+real `pytest_configure` and `pytest_sessionfinish` hooks in
+`tests/evals/conftest.py` and `tests/evals/pytest_reporter.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.fixture
+def evals_pytester(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> pytest.Pytester:
+    """Pytester pre-configured to load the real eval conftest and reporter plugin."""
+    monkeypatch.setenv("LANGSMITH_TRACING", "true")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2-test")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    evals_conftest = (repo_root / "tests" / "evals" / "conftest.py").read_text(encoding="utf-8")
+    reporter_src = (repo_root / "tests" / "evals" / "pytest_reporter.py").read_text(
+        encoding="utf-8"
+    )
+    utils_src = (repo_root / "tests" / "evals" / "utils.py").read_text(encoding="utf-8")
+
+    tests_dir = pytester.mkpydir("tests")
+    evals_dir = tests_dir / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "__init__.py").write_text("", encoding="utf-8")
+    (evals_dir / "conftest.py").write_text(evals_conftest, encoding="utf-8")
+    (evals_dir / "pytest_reporter.py").write_text(reporter_src, encoding="utf-8")
+    (evals_dir / "utils.py").write_text(utils_src, encoding="utf-8")
+
+    pytester.makepyfile(
+        **{
+            "tests/evals/test_smoke.py": (
+                "import pytest\n\n@pytest.mark.langsmith\ndef test_smoke() -> None:\n    pass\n"
+            )
+        }
+    )
+    return pytester
+
+
+def test_missing_model_aborts_session(evals_pytester: pytest.Pytester) -> None:
+    """Without `--model`, the session must abort with a clear message."""
+    result = evals_pytester.runpytest_subprocess("tests/evals", "--no-header")
+    assert result.ret == 1
+    combined = "\n".join(result.outlines + result.errlines)
+    assert "--model is required" in combined
+
+
+def test_present_model_does_not_abort_for_model_reason(evals_pytester: pytest.Pytester) -> None:
+    """With `--model` set, conftest must not bail with the model-required message.
+
+    The session may still fail downstream (langsmith plugin etc.), but the
+    `--model` guard itself should not trigger.
+    """
+    result = evals_pytester.runpytest_subprocess(
+        "tests/evals",
+        "--model",
+        "claude-opus-4-7",
+        "--no-header",
+    )
+    combined = "\n".join(result.outlines + result.errlines)
+    assert "--model is required" not in combined
+
+
+def test_report_not_written_when_session_aborted(
+    evals_pytester: pytest.Pytester, tmp_path: Path
+) -> None:
+    """When the session aborts before `--model` validation, the report file
+    must not be clobbered with a `model: null` payload."""
+    report_path = tmp_path / "report.json"
+    pre_existing = '{"existing": "report"}\n'
+    report_path.write_text(pre_existing, encoding="utf-8")
+
+    result = evals_pytester.runpytest_subprocess(
+        "tests/evals",
+        f"--evals-report-file={report_path}",
+        "--no-header",
+    )
+    assert result.ret == 1
+    # The pre-existing report must be preserved.
+    assert report_path.read_text(encoding="utf-8") == pre_existing

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -23,11 +23,6 @@ class TestModelNameRequired:
         with pytest.raises(ValueError, match="model_name must be a non-empty string"):
             DeepAgentsWrapper(logs_dir=tmp_path, model_name="   ")
 
-    def test_none_raises(self, tmp_path: Path) -> None:
-        # Type system disallows this, but runtime guard must hold.
-        with pytest.raises(ValueError, match="model_name must be a non-empty string"):
-            DeepAgentsWrapper(logs_dir=tmp_path, model_name=None)  # type: ignore[arg-type]
-
 
 class TestOpenRouterPrefix:
     """`openrouter_provider` requires an `openrouter:` prefixed model."""

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -36,3 +36,18 @@ class TestOpenRouterPrefix:
                 model_name="claude-sonnet-4-6",
                 openrouter_provider="MiniMax",
             )
+
+
+class TestHappyPathConstruction:
+    """Wrapper construction succeeds with a valid model name and stashes state."""
+
+    def test_constructs_with_valid_model_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stub the credential so `init_chat_model` doesn't reject us.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        wrapper = DeepAgentsWrapper(logs_dir=tmp_path, model_name="claude-sonnet-4-6")
+
+        assert wrapper._model_name == "claude-sonnet-4-6"
+        assert wrapper._model is not None
+        assert wrapper._temperature == 0.0

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -1,0 +1,80 @@
+"""Unit tests for `DeepAgentsWrapper` initialization guards."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_harbor.deepagents_wrapper import (
+    DeepAgentsWrapper,
+    _accepts_temperature,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestAcceptsTemperature:
+    """`_accepts_temperature` recognizes reasoning-only model prefixes."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "o1-mini",
+            "o1-preview",
+            "o3-mini",
+            "o4-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "openai:o3-mini",
+            "openai:gpt-5-codex",
+        ],
+    )
+    def test_reasoning_models_reject_temperature(self, model_name: str) -> None:
+        assert _accepts_temperature(model_name) is False
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "claude-sonnet-4-6",
+            "anthropic:claude-opus-4-1",
+            "gpt-4o-mini",
+            "openai:gpt-4o",
+            "gemini-2.5-flash",
+            "openrouter:zai/glm-4.6",
+        ],
+    )
+    def test_chat_models_accept_temperature(self, model_name: str) -> None:
+        assert _accepts_temperature(model_name) is True
+
+
+class TestModelNameRequired:
+    """The wrapper rejects empty/whitespace `model_name` at construction."""
+
+    def test_empty_string_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="model_name must be a non-empty string"):
+            DeepAgentsWrapper(logs_dir=tmp_path, model_name="")
+
+    def test_whitespace_only_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="model_name must be a non-empty string"):
+            DeepAgentsWrapper(logs_dir=tmp_path, model_name="   ")
+
+    def test_none_raises(self, tmp_path: Path) -> None:
+        # Type system disallows this, but runtime guard must hold.
+        with pytest.raises(ValueError, match="model_name must be a non-empty string"):
+            DeepAgentsWrapper(logs_dir=tmp_path, model_name=None)  # type: ignore[arg-type]
+
+
+class TestOpenRouterPrefix:
+    """`openrouter_provider` requires an `openrouter:` prefixed model."""
+
+    def test_mismatched_prefix_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(
+            ValueError, match="openrouter_provider requires an openrouter: model prefix"
+        ):
+            DeepAgentsWrapper(
+                logs_dir=tmp_path,
+                model_name="claude-sonnet-4-6",
+                openrouter_provider="MiniMax",
+            )

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -6,47 +6,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from deepagents_harbor.deepagents_wrapper import (
-    DeepAgentsWrapper,
-    _accepts_temperature,
-)
+from deepagents_harbor.deepagents_wrapper import DeepAgentsWrapper
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-class TestAcceptsTemperature:
-    """`_accepts_temperature` recognizes reasoning-only model prefixes."""
-
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "o1-mini",
-            "o1-preview",
-            "o3-mini",
-            "o4-mini",
-            "gpt-5",
-            "gpt-5-mini",
-            "openai:o3-mini",
-            "openai:gpt-5-codex",
-        ],
-    )
-    def test_reasoning_models_reject_temperature(self, model_name: str) -> None:
-        assert _accepts_temperature(model_name) is False
-
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "claude-sonnet-4-6",
-            "anthropic:claude-opus-4-1",
-            "gpt-4o-mini",
-            "openai:gpt-4o",
-            "gemini-2.5-flash",
-            "openrouter:zai/glm-4.6",
-        ],
-    )
-    def test_chat_models_accept_temperature(self, model_name: str) -> None:
-        assert _accepts_temperature(model_name) is True
 
 
 class TestModelNameRequired:


### PR DESCRIPTION
Migrate the SDK's deprecation machinery to `langchain_core._api.deprecation` helpers (`warn_deprecated`, `@deprecated`, `suppress_langchain_deprecation_warning`). Evals lose the silent default-model fallback so `--model` is now required.