### PR TITLE
chore(quickjs): correct release-please, remove system_prompt alias

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -174,8 +174,6 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             timeout=timeout,
             memory_limit_mb=memory_limit // (1024 * 1024),
         )
-        # Backwards-compatible alias used in tests / external introspection.
-        self.system_prompt = self._base_system_prompt
         self._ptc_prompt_cache: tuple[frozenset[str], str] | None = None
         # Stable fallback thread id — used when ``thread_id`` isn't in
         # langgraph config. Must be instance-scoped so ``wrap_model_call``

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -106,6 +106,11 @@ def test_tool_registered_with_custom_name() -> None:
     assert "eval" not in tools
 
 
+def test_legacy_system_prompt_alias_removed() -> None:
+    mw = REPLMiddleware()
+    assert not hasattr(mw, "system_prompt")
+
+
 def test_system_prompt_injected_once() -> None:
     """wrap_model_call appends exactly one snippet per call, idempotent in content."""
     mw = REPLMiddleware(timeout=7.0, memory_limit=32 * 1024 * 1024)


### PR DESCRIPTION
Partially a corrective action for release-please, #2977 was an empty commit meant to target langchain-quickjs only, but because release-please targets on files changed instead of scope it means it wanted to introduce breaking changes for all associated packages

This PR will be merged with the appropriate changelog line and a low-stakes code change is being made here so that it targets langchain-quickjs only
