### PR TITLE
fix(sdk): support read-your-writes in `StateBackend`

### DIFF
--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -112,14 +112,15 @@ class StateBackend(BackendProtocol):
         initialize StateBackend once and fetch state on demand from any
         graph context (tools, middleware nodes, etc.).
 
-        `fresh=False` reads the value as of the *start* of the current
-        superstep (checkpointed value + writes from prior steps). Writes
-        queued during the current step aren't applied until the node boundary,
-        so every call within the same step sees a consistent snapshot.
+        `fresh=True` applies any pending task writes through the channel's
+        reducer before returning, giving read-your-writes semantics within
+        a single superstep — e.g. a tool that writes a file and then reads
+        it back, or a code interpreter that issues multiple sub-tool calls
+        inside one eval.
         """
         config = self._get_config()
         read = config["configurable"][CONFIG_KEY_READ]
-        fresh = False
+        fresh = True
         return read("files", fresh) or {}
 
     def _send_files_update(self, update: dict[str, Any]) -> None:
@@ -136,9 +137,9 @@ class StateBackend(BackendProtocol):
         uses a dict-merge reducer, so we only need to include changed
         files — unchanged ones are preserved by the reducer.
 
-        Writes are not applied until the node boundary, so they won't be
-        visible to other calls in the same step (see `_read_files` and
-        its use of `fresh=False`).
+        Sends are visible to subsequent `_read_files` calls within the
+        same superstep via `fresh=True`; they are committed to state at
+        the node boundary.
         """
         config = self._get_config()
         send = config["configurable"][CONFIG_KEY_SEND]

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -2619,6 +2619,52 @@ class TestStateBackendConfigKeys:
 
         assert result["files"]["/injected.txt"]["content"] == "from middleware"
 
+    def test_state_backend_read_your_writes_within_one_tool_call(self) -> None:
+        """Write + read in the same tool call — read sees the pending write.
+
+        Both operations happen inside a single ToolNode superstep, so the
+        write is still in `task.writes` (not yet committed). `fresh=True`
+        in `_read_files` applies pending writes through the channel reducer,
+        giving read-your-writes semantics.
+        """
+        backend = StateBackend()
+
+        @tool
+        def write_then_read(path: str, content: str) -> str:
+            """Write a file via StateBackend, then immediately read it back."""
+            backend.write(path, content)
+            result = backend.read(path)
+            if result.error:
+                return f"ERROR: {result.error}"
+            file_data = result.file_data or {}
+            return str(file_data.get("content", ""))
+
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "write_then_read",
+                                "args": {"path": "/pending.txt", "content": "buffered"},
+                                "id": "call_wr",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model, backend=backend, tools=[write_then_read])
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+
+        tool_msg = next(m for m in result["messages"] if m.type == "tool" and m.tool_call_id == "call_wr")
+        assert "buffered" in tool_msg.content
+        assert "ERROR" not in tool_msg.content
+
 
 class TestArtifactsRoot:
     """Test that artifacts_root on CompositeBackend parameterizes internal paths."""


### PR DESCRIPTION
Support doing things like this with state backend:
```python
@tool
def write_then_read(path: str, content: str) -> str:
    backend.write(path, content)
    return backend.read(path).file_data
```
Motivated by programmatic writes and reads using a REPL with state backend.