### PR TITLE
feat(quickjs): add `max_ptc_calls` budget for ptc calls

### DIFF
--- a/libs/partners/quickjs/README.md
+++ b/libs/partners/quickjs/README.md
@@ -123,6 +123,16 @@ The runtime has a shared memory limit across every context under it (default 64 
 <error type="OutOfMemory">...</error>
 ```
 
+PTC host-function calls are also budgeted per eval call (default 256 `tools.*`
+invocations). Exceeding the budget surfaces as:
+
+```xml
+<error type="PTCCallBudgetExceeded">...</error>
+```
+
+Set `max_ptc_calls=None` only in trusted environments. Disabling the
+budget allows unbounded PTC-call loops and increases DoS risk.
+
 Top-level `await` works on the async path — the promise settles before the call returns. An un-resolvable top-level promise (no host work in flight, no resolver) surfaces as `<error type="Deadlock">`.
 
 ### Result formatting
@@ -231,6 +241,7 @@ There's a hard cap of 1 MiB per skill bundle. If you hit it, split the skill or 
 REPLMiddleware(
     memory_limit=64 * 1024 * 1024,  # bytes, shared across contexts
     timeout=5.0,                     # per-call seconds
+    max_ptc_calls=256,     # per-eval `tools.*` bridge calls, None disables (DoS risk)
     tool_name="eval",                # what the model calls it
     max_result_chars=4000,           # result/stdout truncation, each
     capture_console=True,            # install console.log/warn/error bridge
@@ -246,8 +257,9 @@ REPLMiddleware(
 | `SyntaxError`, `TypeError`, `ReferenceError`, ... | User-code error. Re-surfaces the JS error name verbatim. |
 | `Timeout` | Call exceeded `timeout=`. |
 | `OutOfMemory` | Runtime hit `memory_limit=`. |
-| `Deadlock` | Top-level promise never resolved with no async host work in flight. |
+| `PTCCallBudgetExceeded` | Uncaught `tools.*` call-budget overflow in one eval (`max_ptc_calls=`). |
 | `HostError` | A registered host function (console bridge, tool bridge) threw on the Python side. |
+| `Deadlock` | Top-level promise never resolved with no async host work in flight. |
 | `ConcurrentEval` | Shouldn't happen under locks; defensive mapping for QuickJS `ConcurrentEvalError`. |
 | `SkillNotAvailable` | Source referenced `@/skills/<name>` we couldn't resolve or install. |
 

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -13,7 +13,7 @@ import json
 import logging
 import threading
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, cast
 
 from langgraph.types import Command
@@ -95,27 +95,21 @@ class _PTCCallBudgetExceededError(RuntimeError):
         )
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class _PTCState:
-    """Mutable per-eval PTC state (reset on each eval call)."""
+    """Per-eval PTC state (reset on each eval call)."""
 
     remaining_calls: int | None
-    command_buffer: list[Command] = field(default_factory=list)
-
-    @classmethod
-    def create(cls, *, max_ptc_calls: int | None) -> _PTCState:
-        """Build a fresh per-eval state object from static budget config."""
-        return cls(remaining_calls=max_ptc_calls)
+    command_buffer: tuple[Command, ...] = field(default_factory=tuple)
 
     def consume_call_budget(
         self, *, function_name: str, max_ptc_calls: int | None
-    ) -> None:
+    ) -> _PTCState:
         """Count one PTC bridge call and enforce the per-eval limit."""
         if self.remaining_calls is None:
-            return
+            return self
         if self.remaining_calls > 0:
-            self.remaining_calls -= 1
-            return
+            return replace(self, remaining_calls=self.remaining_calls - 1)
 
         normalized_limit = max_ptc_calls if max_ptc_calls is not None else 0
         raise _PTCCallBudgetExceededError(
@@ -123,6 +117,12 @@ class _PTCState:
             attempted=normalized_limit + 1,
             function_name=function_name,
         )
+
+    def append_commands(self, commands: list[Command]) -> _PTCState:
+        """Return a copy with additional commands captured for this eval."""
+        if not commands:
+            return self
+        return replace(self, command_buffer=(*self.command_buffer, *commands))
 
 
 class _ConsoleBuffer:
@@ -471,7 +471,7 @@ class _ThreadREPL:
             if self._ptc_state is None:
                 msg = "PTC bridge called outside active eval"
                 raise RuntimeError(msg)
-            self._ptc_state.consume_call_budget(
+            self._ptc_state = self._ptc_state.consume_call_budget(
                 function_name=f"tools.{camel}",
                 max_ptc_calls=self._max_ptc_calls,
             )
@@ -485,7 +485,11 @@ class _ThreadREPL:
             result = await tool.ainvoke(
                 {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
             )
-            self._ptc_state.command_buffer.extend(_extract_commands(result))
+            ptc_state = self._ptc_state
+            if ptc_state is None:
+                msg = "PTC bridge called outside active eval"
+                raise RuntimeError(msg)
+            self._ptc_state = ptc_state.append_commands(_extract_commands(result))
             return coerce_tool_output(result)
 
         bridge_symbol = _bridge_symbol_name(camel)
@@ -602,7 +606,7 @@ class _ThreadREPL:
                         outcome.stdout_truncated_chars,
                     ) = self._console.drain()
                     return outcome
-        self._ptc_state = _PTCState.create(max_ptc_calls=self._max_ptc_calls)
+        self._ptc_state = _PTCState(remaining_calls=self._max_ptc_calls)
         try:
             value = await ctx.eval_async(code, timeout=self._per_call_timeout)
             outcome.result = stringify(value)

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -85,7 +85,12 @@ class _PTCCallBudgetExceededError(RuntimeError):
         self.limit = limit
         self.attempted = attempted
         self.function_name = function_name
-        super().__init__(self.render_message())
+        msg = (
+            "PTC call budget exceeded "
+            f"(limit={limit}, attempted={attempted}, "
+            f"function={function_name})"
+        )
+        super().__init__(msg)
 
     def render_message(self) -> str:
         return (

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -78,6 +78,53 @@ class EvalOutcome:
     commands: list[Command] = field(default_factory=list)
 
 
+class _PTCCallBudgetExceededError(RuntimeError):
+    """Raised when one eval exceeds its configured PTC call budget."""
+
+    def __init__(self, *, limit: int, attempted: int, function_name: str) -> None:
+        self.limit = limit
+        self.attempted = attempted
+        self.function_name = function_name
+        super().__init__(self.render_message())
+
+    def render_message(self) -> str:
+        return (
+            "PTC call budget exceeded "
+            f"(limit={self.limit}, attempted={self.attempted}, "
+            f"function={self.function_name})"
+        )
+
+
+@dataclass
+class _PTCState:
+    """Mutable per-eval PTC state (reset on each eval call)."""
+
+    remaining_calls: int | None
+    command_buffer: list[Command] = field(default_factory=list)
+
+    @classmethod
+    def create(cls, *, max_ptc_calls: int | None) -> _PTCState:
+        """Build a fresh per-eval state object from static budget config."""
+        return cls(remaining_calls=max_ptc_calls)
+
+    def consume_call_budget(
+        self, *, function_name: str, max_ptc_calls: int | None
+    ) -> None:
+        """Count one PTC bridge call and enforce the per-eval limit."""
+        if self.remaining_calls is None:
+            return
+        if self.remaining_calls > 0:
+            self.remaining_calls -= 1
+            return
+
+        normalized_limit = max_ptc_calls if max_ptc_calls is not None else 0
+        raise _PTCCallBudgetExceededError(
+            limit=normalized_limit,
+            attempted=normalized_limit + 1,
+            function_name=function_name,
+        )
+
+
 class _ConsoleBuffer:
     """Accumulates ``console.*`` output between evals.
 
@@ -256,6 +303,7 @@ class _ThreadREPL:
         timeout: float,
         capture_console: bool,
         max_stdout_chars: int,
+        max_ptc_calls: int | None = 256,
     ) -> None:
         self._worker = worker
         self._runtime = runtime
@@ -265,6 +313,8 @@ class _ThreadREPL:
         # and what we describe in the system prompt.
         self._per_call_timeout = timeout
         self._capture_console = capture_console
+        # Static budget config; mutable counters live in ``_ptc_state``.
+        self._max_ptc_calls = max_ptc_calls
         self._console = _ConsoleBuffer(max_stdout_chars)
         self._ctx: Context | None = None
         # PTC state. ``_registered_tools`` tracks which camel-case names
@@ -287,9 +337,9 @@ class _ThreadREPL:
         # graph state, store, context, etc. Set via ``set_outer_runtime``
         # from the middleware's tool handler immediately before eval.
         self._outer_runtime: ToolRuntime | None = None
-        # ``Command`` values emitted by PTC-invoked tools during the
-        # currently-running eval call. Drained into ``EvalOutcome``.
-        self._ptc_command_buffer: list[Command] = []
+        # Mutable per-eval PTC state. Allocated at eval start and cleared
+        # in finally so bridge calls can't leak buffered state across evals.
+        self._ptc_state: _PTCState | None = None
         # Slot-local skill install cache. Kept on the REPL (not registry)
         # so thread-scoped backends can resolve same-named skills
         # differently across threads.
@@ -418,6 +468,13 @@ class _ThreadREPL:
                 # it, fail loud.
                 msg = f"tool '{camel}' not registered"
                 raise RuntimeError(msg)
+            if self._ptc_state is None:
+                msg = "PTC bridge called outside active eval"
+                raise RuntimeError(msg)
+            self._ptc_state.consume_call_budget(
+                function_name=f"tools.{camel}",
+                max_ptc_calls=self._max_ptc_calls,
+            )
             payload = _normalize_tool_input(raw_input)
             call_id = _synth_tool_call_id(tool.name)
             # Build a ToolCall-shaped input so InjectedToolCallId and the
@@ -428,7 +485,7 @@ class _ThreadREPL:
             result = await tool.ainvoke(
                 {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
             )
-            self._ptc_command_buffer.extend(_extract_commands(result))
+            self._ptc_state.command_buffer.extend(_extract_commands(result))
             return coerce_tool_output(result)
 
         bridge_symbol = _bridge_symbol_name(camel)
@@ -531,7 +588,6 @@ class _ThreadREPL:
         """
         ctx = cast("Context", self._ctx)
         outcome = EvalOutcome()
-        self._ptc_command_buffer.clear()
         if skills_backend is not None:
             referenced = scan_skill_references(code)
             if referenced:
@@ -546,6 +602,7 @@ class _ThreadREPL:
                         outcome.stdout_truncated_chars,
                     ) = self._console.drain()
                     return outcome
+        self._ptc_state = _PTCState.create(max_ptc_calls=self._max_ptc_calls)
         try:
             value = await ctx.eval_async(code, timeout=self._per_call_timeout)
             outcome.result = stringify(value)
@@ -577,8 +634,10 @@ class _ThreadREPL:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
         finally:
-            outcome.commands.extend(self._ptc_command_buffer)
-            self._ptc_command_buffer.clear()
+            ptc_state = self._ptc_state
+            if ptc_state is not None:
+                outcome.commands.extend(ptc_state.command_buffer)
+            self._ptc_state = None
             outcome.stdout, outcome.stdout_truncated_chars = self._console.drain()
         return outcome
 
@@ -587,7 +646,13 @@ class _ThreadREPL:
         # so operators can distinguish a bug in our console bridge
         # from a user-code error.
         if isinstance(e, HostError):
-            logger.warning("console-bridge host error", exc_info=e.__cause__)
+            cause = e.__cause__
+            if isinstance(cause, _PTCCallBudgetExceededError):
+                outcome.error_type = "PTCCallBudgetExceeded"
+                outcome.error_message = cause.render_message()
+                outcome.error_stack = None
+                return
+            logger.warning("console-bridge host error", exc_info=cause)
             outcome.error_type = "HostError"
         else:
             outcome.error_type = e.name
@@ -656,6 +721,7 @@ class _Registry:
     timeout: float
     capture_console: bool
     max_stdout_chars: int
+    max_ptc_calls: int | None = 256
     _slots: dict[str, _Slot] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -691,6 +757,7 @@ class _Registry:
             timeout=self.timeout,
             capture_console=self.capture_console,
             max_stdout_chars=self.max_stdout_chars,
+            max_ptc_calls=self.max_ptc_calls,
         )
         return _Slot(worker=worker, runtime=runtime, repl=repl)
 

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MEMORY_LIMIT = 64 * 1024 * 1024
 _DEFAULT_TIMEOUT = 5.0
+_DEFAULT_MAX_PTC_CALLS = 256
 _DEFAULT_MAX_RESULT_CHARS = 4_000
 _DEFAULT_TOOL_NAME = "eval"
 _EvalToolResult = ToolMessage | list[Command | ToolMessage]
@@ -93,6 +94,18 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             contexts under the same Runtime. Default 64 MiB.
         timeout: Per-call wall-clock timeout in seconds. Applied to every
             ``eval`` on every context. Default 5.
+        max_ptc_calls: Maximum number of ``tools.*`` bridge calls allowed
+            during one ``eval`` execution. Exceeding this budget throws
+            from the host-function bridge before invoking the tool.
+            Uncaught overflows surface as ``PTCCallBudgetExceeded``.
+            ``None`` disables the budget (unsafe for untrusted prompts;
+            enables PTC-call DoS patterns). Default 256.
+
+            !!! warning
+                Setting ``max_ptc_calls=None`` disables the call budget and can allow
+                unbounded PTC host-call loops (DoS risk). Only disable in trusted
+                environments.
+
         tool_name: Name of the tool exposed to the model. Default ``eval``.
         max_result_chars: Result and stdout blocks are independently
             truncated to this many characters before being sent back to
@@ -150,6 +163,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         *,
         memory_limit: int = _DEFAULT_MEMORY_LIMIT,
         timeout: float = _DEFAULT_TIMEOUT,
+        max_ptc_calls: int | None = _DEFAULT_MAX_PTC_CALLS,
         tool_name: str = _DEFAULT_TOOL_NAME,
         max_result_chars: int = _DEFAULT_MAX_RESULT_CHARS,
         capture_console: bool = True,
@@ -158,8 +172,12 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     ) -> None:
         """Initialize REPL middleware state and build the exposed eval tool."""
         super().__init__()
+        if max_ptc_calls is not None and max_ptc_calls < 1:
+            msg = "`max_ptc_calls` must be >= 1 or None"
+            raise ValueError(msg)
         self._memory_limit = memory_limit
         self._timeout = timeout
+        self._max_ptc_calls = max_ptc_calls
         self._tool_name = tool_name
         self._max_result_chars = max_result_chars
         self._capture_console = capture_console
@@ -170,6 +188,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             timeout=timeout,
             capture_console=capture_console,
             max_stdout_chars=max_result_chars,
+            max_ptc_calls=max_ptc_calls,
         )
         self._base_system_prompt = render_repl_system_prompt(
             tool_name=tool_name,

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -251,11 +251,7 @@ def test_quickjs_sync_host_call_budget_exceeded() -> None:
         "'done'",
         REPLMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
     ).invoke(
-        {
-            "messages": [
-                HumanMessage(content="Use eval and call sync_label twice.")
-            ]
-        }
+        {"messages": [HumanMessage(content="Use eval and call sync_label twice.")]}
     )
     tool_message = _eval_tool_message(result)
     assert '<error type="PTCCallBudgetExceeded">' in tool_message.content

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -243,6 +243,25 @@ def test_quickjs_sync_tool_exception() -> None:
     assert "Host function failed" in tool_message.content
 
 
+def test_quickjs_sync_host_call_budget_exceeded() -> None:
+    """Verify sync eval surfaces per-eval PTC call budget exhaustion."""
+    result = _make_agent(
+        "await tools.syncLabel({value: 'a'});\n"
+        "await tools.syncLabel({value: 'b'});\n"
+        "'done'",
+        REPLMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
+    ).invoke(
+        {
+            "messages": [
+                HumanMessage(content="Use eval and call sync_label twice.")
+            ]
+        }
+    )
+    tool_message = _eval_tool_message(result)
+    assert '<error type="PTCCallBudgetExceeded">' in tool_message.content
+    assert "limit=1" in tool_message.content
+
+
 def test_quickjs_sync_toolruntime_configurable_foreign_function() -> None:
     """Verify sync PTC tool calls see configurable runtime data."""
     result = _make_agent(

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
@@ -227,11 +227,7 @@ async def test_quickjs_async_host_call_budget_exceeded() -> None:
         "'done'",
         REPLMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
     ).ainvoke(
-        {
-            "messages": [
-                HumanMessage(content="Use eval and call sync_label twice.")
-            ]
-        }
+        {"messages": [HumanMessage(content="Use eval and call sync_label twice.")]}
     )
     tool_message = _eval_tool_message(result)
     assert '<error type="PTCCallBudgetExceeded">' in tool_message.content

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
@@ -219,6 +219,25 @@ async def test_quickjs_async_tool_exception() -> None:
     assert "Host function failed" in tool_message.content
 
 
+async def test_quickjs_async_host_call_budget_exceeded() -> None:
+    """Verify async eval surfaces per-eval PTC call budget exhaustion."""
+    result = await _make_agent(
+        "await tools.syncLabel({value: 'a'});\n"
+        "await tools.syncLabel({value: 'b'});\n"
+        "'done'",
+        REPLMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
+    ).ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="Use eval and call sync_label twice.")
+            ]
+        }
+    )
+    tool_message = _eval_tool_message(result)
+    assert '<error type="PTCCallBudgetExceeded">' in tool_message.content
+    assert "limit=1" in tool_message.content
+
+
 async def test_quickjs_async_toolruntime_configurable_foreign_function() -> None:
     """Verify async PTC tool calls see configurable runtime data."""
     result = await _make_agent(

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -462,6 +462,95 @@ async def test_install_tools_shrinks_namespace(repl: _ThreadREPL) -> None:
     assert outcome2.result == "function"
 
 
+async def test_ptc_host_call_budget_exceeded_surfaces_error(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    limited = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4_000,
+        max_ptc_calls=2,
+    )
+    limited.install_tools([_greet_tool()])
+    outcome = await limited.eval_async(
+        "await tools.greet({name: 'a'});\n"
+        "await tools.greet({name: 'b'});\n"
+        "await tools.greet({name: 'c'});\n"
+        "'done'"
+    )
+    assert outcome.error_type == "PTCCallBudgetExceeded"
+    assert "limit=2" in outcome.error_message
+    assert "attempted=3" in outcome.error_message
+    assert "function=tools.greet" in outcome.error_message
+
+
+async def test_ptc_host_call_budget_catch_surfaces_generic_host_error(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    limited = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4_000,
+        max_ptc_calls=1,
+    )
+    limited.install_tools([_greet_tool()])
+    outcome = await limited.eval_async(
+        "try {\n"
+        "  await tools.greet({name: 'ok'});\n"
+        "  await tools.greet({name: 'overflow'});\n"
+        "  'not-caught';\n"
+        "} catch (e) {\n"
+        "  `${e.name}:${e.message}`;\n"
+        "}"
+    )
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result == "HostError:Host function failed"
+
+
+async def test_ptc_host_call_budget_resets_each_eval(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    limited = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4_000,
+        max_ptc_calls=1,
+    )
+    limited.install_tools([_greet_tool()])
+    first = await limited.eval_async("await tools.greet({name: 'a'})")
+    second = await limited.eval_async("await tools.greet({name: 'b'})")
+    assert first.error_type is None, first.error_message
+    assert second.error_type is None, second.error_message
+
+
+async def test_ptc_host_call_budget_none_disables_limit(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    unlimited = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4_000,
+        max_ptc_calls=None,
+    )
+    unlimited.install_tools([_greet_tool()])
+    outcome = await unlimited.eval_async(
+        "await tools.greet({name: 'a'});\n"
+        "await tools.greet({name: 'b'});\n"
+        "await tools.greet({name: 'c'});\n"
+        "'done'"
+    )
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result == "done"
+
+
 # ---------------------------------------------------------------------------
 # Middleware integration
 # ---------------------------------------------------------------------------

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -117,6 +117,11 @@ def test_legacy_system_prompt_alias_removed() -> None:
     assert not hasattr(mw, "system_prompt")
 
 
+def test_rejects_invalid_max_ptc_calls() -> None:
+    with pytest.raises(ValueError, match="must be >= 1 or None"):
+        REPLMiddleware(max_ptc_calls=0)
+
+
 def test_system_prompt_injected_once() -> None:
     """wrap_model_call appends exactly one snippet per call, idempotent in content."""
     mw = REPLMiddleware(timeout=7.0, memory_limit=32 * 1024 * 1024)


### PR DESCRIPTION
This change adds a per-eval budget for `tools.*` host bridge calls in `langchain-quickjs` to prevent prompt-driven host-call flooding.

It introduces `max_ptc_calls` on `REPLMiddleware` (default `256`), enforces the budget inside the bridge before tool invocation, and resets mutable PTC state for each eval. This keeps normal tool use unchanged while bounding worst-case bridge amplification.

## Changes

- Add `max_ptc_calls` middleware/config plumbing and validation (`>= 1` or `None`)
- Track per-eval PTC state (`remaining_calls`, buffered commands) and reset it at eval boundaries
- Raise and surface `PTCCallBudgetExceeded` for uncaught overflows while still allowing JS `try/catch` to observe generic `HostError`
- Document DoS risk when `max_ptc_calls=None` via docstring warning and README updates
- Add unit and end-to-end coverage for overflow, reset semantics, `None` escape hatch, and invalid config

## Review Focus

- Error-surface behavior for caught vs uncaught overflow paths
- Per-eval lifecycle of PTC state and command buffering
- Middleware/docs wording around the `None` escape hatch and risk
