### PR TITLE
fix(quickjs): bound console buffering at capture time

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_format.py
+++ b/libs/partners/quickjs/langchain_quickjs/_format.py
@@ -114,10 +114,15 @@ def format_outcome(
 ) -> str:
     """Render an EvalOutcome-like object as the tool's wire format."""
     parts: list[str] = []
-    if outcome.stdout:
-        parts.append(
-            f"<stdout>\n{_truncate(outcome.stdout, max_result_chars)}\n</stdout>"
-        )
+    if outcome.stdout or outcome.stdout_truncated_chars > 0:
+        stdout = outcome.stdout
+        if outcome.stdout_truncated_chars > 0:
+            stdout = _truncate(
+                outcome.stdout,
+                max_result_chars,
+                dropped=outcome.stdout_truncated_chars,
+            )
+        parts.append(f"<stdout>\n{stdout}\n</stdout>")
     if outcome.error_type is not None:
         inner = outcome.error_message
         if outcome.error_stack:
@@ -135,7 +140,15 @@ def format_outcome(
     return "\n".join(parts)
 
 
-def _truncate(text: str, limit: int) -> str:
+def _truncate(text: str, limit: int, *, dropped: int | None = None) -> str:
+    # stdout path -- we've already truncated the result, so we just add the marker
+    if dropped is not None:
+        marker = _TRUNCATE_MARKER.format(n=dropped)
+        if len(marker) >= limit:
+            return marker[: max(0, limit)]
+        keep = max(0, limit - len(marker))
+        return text[:keep] + marker
+    # result/error path -- these values need to be truncated
     if len(text) <= limit:
         return text
     keep = max(0, limit - len(_TRUNCATE_MARKER.format(n=0)))

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -69,6 +69,7 @@ class EvalOutcome:
     """
 
     stdout: str = ""
+    stdout_truncated_chars: int = 0
     result: str | None = None
     result_kind: str | None = None  # "handle" when marshaling fell back
     error_type: str | None = None
@@ -86,19 +87,31 @@ class _ConsoleBuffer:
     smaller.
     """
 
-    def __init__(self) -> None:
-        self._lines: list[str] = []
+    def __init__(self, max_chars: int) -> None:
+        self._max_chars = max(0, max_chars)
+        self._stdout = ""
+        self._dropped_chars = 0
 
     def append(self, level: str, args: tuple[Any, ...]) -> None:
         del level  # flattened; see class docstring
-        self._lines.append(" ".join(stringify(a) for a in args))
+        line = " ".join(stringify(a) for a in args)
+        chunk = line if not self._stdout else f"\n{line}"
+        remaining = self._max_chars - len(self._stdout)
+        if remaining <= 0:
+            self._dropped_chars += len(chunk)
+            return
+        kept = chunk[:remaining]
+        self._stdout += kept
+        self._dropped_chars += len(chunk) - len(kept)
 
-    def drain(self) -> str:
-        if not self._lines:
-            return ""
-        out = "\n".join(self._lines)
-        self._lines.clear()
-        return out
+    def drain(self) -> tuple[str, int]:
+        if not self._stdout and self._dropped_chars == 0:
+            return "", 0
+        out = self._stdout
+        dropped = self._dropped_chars
+        self._stdout = ""
+        self._dropped_chars = 0
+        return out, dropped
 
 
 def _normalize_tool_input(raw: Any) -> dict[str, Any]:
@@ -242,6 +255,7 @@ class _ThreadREPL:
         *,
         timeout: float,
         capture_console: bool,
+        max_stdout_chars: int,
     ) -> None:
         self._worker = worker
         self._runtime = runtime
@@ -251,7 +265,7 @@ class _ThreadREPL:
         # and what we describe in the system prompt.
         self._per_call_timeout = timeout
         self._capture_console = capture_console
-        self._console = _ConsoleBuffer()
+        self._console = _ConsoleBuffer(max_stdout_chars)
         self._ctx: Context | None = None
         # PTC state. ``_registered_tools`` tracks which camel-case names
         # have already had their host-function bridge installed on the
@@ -527,7 +541,10 @@ class _ThreadREPL:
                 if errors:
                     outcome.error_type = "SkillNotAvailable"
                     outcome.error_message = "; ".join(str(error) for error in errors)
-                    outcome.stdout = self._console.drain()
+                    (
+                        outcome.stdout,
+                        outcome.stdout_truncated_chars,
+                    ) = self._console.drain()
                     return outcome
         try:
             value = await ctx.eval_async(code, timeout=self._per_call_timeout)
@@ -562,7 +579,7 @@ class _ThreadREPL:
         finally:
             outcome.commands.extend(self._ptc_command_buffer)
             self._ptc_command_buffer.clear()
-            outcome.stdout = self._console.drain()
+            outcome.stdout, outcome.stdout_truncated_chars = self._console.drain()
         return outcome
 
     def _record_js_error(self, outcome: EvalOutcome, e: JSError) -> None:
@@ -638,6 +655,7 @@ class _Registry:
     memory_limit: int
     timeout: float
     capture_console: bool
+    max_stdout_chars: int
     _slots: dict[str, _Slot] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -672,6 +690,7 @@ class _Registry:
             runtime,
             timeout=self.timeout,
             capture_console=self.capture_console,
+            max_stdout_chars=self.max_stdout_chars,
         )
         return _Slot(worker=worker, runtime=runtime, repl=repl)
 

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -96,7 +96,8 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         tool_name: Name of the tool exposed to the model. Default ``eval``.
         max_result_chars: Result and stdout blocks are independently
             truncated to this many characters before being sent back to
-            the model. Default 4000.
+            the model. Console buffering is also bounded to this value
+            during collection. Default 4000.
         capture_console: If ``True``, install a ``console`` object that
             buffers ``console.log/warn/error`` calls and emits them in
             ``<stdout>`` blocks alongside the result. Default ``True``.
@@ -168,6 +169,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             memory_limit=memory_limit,
             timeout=timeout,
             capture_console=capture_console,
+            max_stdout_chars=max_result_chars,
         )
         self._base_system_prompt = render_repl_system_prompt(
             tool_name=tool_name,

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -188,7 +188,13 @@ def runtime(worker: ThreadWorker) -> Runtime:
 
 @pytest.fixture
 def repl(worker: ThreadWorker, runtime: Runtime) -> _ThreadREPL:
-    return _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
+    return _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -52,7 +52,13 @@ def runtime(worker: ThreadWorker) -> Runtime:
 
 @pytest.fixture
 def repl(worker: ThreadWorker, runtime: Runtime) -> _ThreadREPL:
-    return _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
+    return _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +167,20 @@ def test_state_persists_across_evals(repl: _ThreadREPL) -> None:
 
 
 def test_threads_are_isolated(worker: ThreadWorker, runtime: Runtime) -> None:
-    a = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
-    b = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=True)
+    a = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
+    b = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     a.eval_sync("let shared = 'from_a'")
     outcome = b.eval_sync("typeof shared")
     # QuickJS returns "undefined" for missing globals — an isolated context
@@ -190,7 +208,13 @@ def test_syntax_error_surfaces(repl: _ThreadREPL) -> None:
 
 
 def test_timeout(worker: ThreadWorker, runtime: Runtime) -> None:
-    tight = _ThreadREPL(worker, runtime, timeout=0.1, capture_console=True)
+    tight = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=0.1,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     outcome = tight.eval_sync("while(true){}")
     assert outcome.error_type == "Timeout"
 
@@ -211,10 +235,87 @@ def test_console_log_is_captured(repl: _ThreadREPL) -> None:
 
 
 def test_console_can_be_disabled(worker: ThreadWorker, runtime: Runtime) -> None:
-    quiet = _ThreadREPL(worker, runtime, timeout=5.0, capture_console=False)
+    quiet = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=False,
+        max_stdout_chars=4000,
+    )
     outcome = quiet.eval_sync("typeof console")
     # With the bridge off, the global is absent.
     assert outcome.result == "undefined"
+
+
+def test_console_capture_is_bounded_at_append_time(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    bounded = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=64,
+    )
+    outcome = bounded.eval_sync(
+        "console.log('x'.repeat(80)); console.log('y'.repeat(80)); 1"
+    )
+    assert outcome.result == "1"
+    assert len(outcome.stdout) <= 64
+    assert outcome.stdout_truncated_chars > 0
+    formatted = format_outcome(outcome, max_result_chars=64)
+    assert "truncated" in formatted
+
+
+def test_console_overflow_preserves_prefix(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    bounded = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=10,
+    )
+    outcome = bounded.eval_sync("console.log('abcdef'); console.log('ghij');")
+    assert outcome.stdout == "abcdef\nghi"
+    assert outcome.stdout_truncated_chars == 1
+
+
+def test_console_truncation_state_resets_between_evals(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    bounded = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=10,
+    )
+    first = bounded.eval_sync("console.log('abcdef'); console.log('ghij');")
+    assert first.stdout_truncated_chars == 1
+    second = bounded.eval_sync("console.log('ok'); 2")
+    assert second.result == "2"
+    assert second.stdout == "ok"
+    assert second.stdout_truncated_chars == 0
+
+
+def test_console_truncation_marker_emits_with_zero_budget(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    bounded = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=0,
+    )
+    outcome = bounded.eval_sync("console.log('hello'); 1")
+    assert outcome.stdout == ""
+    assert outcome.stdout_truncated_chars > 0
+    formatted = format_outcome(outcome, max_result_chars=60)
+    assert "<stdout>" in formatted
+    assert "truncated" in formatted
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +352,12 @@ def test_large_result_is_truncated(repl: _ThreadREPL) -> None:
 
 
 def test_registry_reuses_thread_repl() -> None:
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         r1 = reg.get("thread-a")
         r2 = reg.get("thread-a")
@@ -276,7 +382,12 @@ def test_middleware_del_closes_runtime() -> None:
 
 def test_per_thread_slot_has_own_worker_and_runtime() -> None:
     """Each thread_id gets its own ThreadWorker and Runtime — not shared."""
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         reg.get("thread-a")
         reg.get("thread-b")
@@ -292,7 +403,12 @@ def test_per_thread_slot_has_own_worker_and_runtime() -> None:
 
 def test_evict_closes_and_removes_slot() -> None:
     """``evict`` closes the runtime and drops the slot from the registry."""
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         reg.get("thread-a")
         rt = reg._slots["thread-a"].runtime
@@ -306,7 +422,12 @@ def test_evict_closes_and_removes_slot() -> None:
 
 def test_evict_returns_fresh_slot_on_next_get() -> None:
     """After eviction, ``get`` rebuilds a new slot for the same thread_id."""
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         first = reg.get("thread-a")
         first_runtime = reg._slots["thread-a"].runtime
@@ -320,7 +441,12 @@ def test_evict_returns_fresh_slot_on_next_get() -> None:
 
 def test_evict_unknown_thread_id_is_noop() -> None:
     """Evicting a thread_id that was never registered does not raise."""
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         reg.evict("never-existed")
         assert reg._slots == {}
@@ -330,7 +456,12 @@ def test_evict_unknown_thread_id_is_noop() -> None:
 
 async def test_aevict_closes_and_removes_slot() -> None:
     """``aevict`` closes the runtime via the worker loop and drops the slot."""
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         reg.get("thread-a")
         rt = reg._slots["thread-a"].runtime

--- a/libs/partners/quickjs/tests/unit_tests/test_skills_integration.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_skills_integration.py
@@ -48,7 +48,12 @@ def _cache_key(meta: SkillMetadata) -> tuple[str, str, str | None]:
 
 @pytest.fixture
 def registry() -> _Registry:
-    reg = _Registry(memory_limit=64 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=64 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         yield reg
     finally:
@@ -203,7 +208,12 @@ async def test_install_cache_avoids_second_fetch(
 
 async def test_slot_skill_cache_is_cleared_on_slot_eviction(tmp_path: Path) -> None:
     """``Registry.evict`` clears the slot-local skill cache for that thread."""
-    reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+    )
     try:
         backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
         skill_dir = str(tmp_path / "skills" / "persist")


### PR DESCRIPTION
## Summary

This PR fixes unbounded console buffering in `langchain-quickjs` by enforcing the stdout cap at capture time instead of only truncating at final formatting. This keeps model-visible behavior consistent while preventing memory growth from repeated `console.log` spam in a single eval.

## Changes

### `langchain-quickjs`

- Bound `_ConsoleBuffer` by `max_result_chars` so console output is clipped as logs are appended, not after the fact.
- Added `stdout_truncated_chars` to `EvalOutcome` so formatting can surface how much console output was dropped.
- Threaded the stdout budget through `REPLMiddleware -> _Registry -> _ThreadREPL -> _ConsoleBuffer`.
- Updated stdout formatting to append a truncation marker after captured output when drops occurred, while keeping result/error truncation behavior unchanged.
- Extended unit tests to cover bounded capture, overflow prefix behavior, zero-budget marker behavior, reset semantics across evals, and constructor callsites that now pass the stdout cap.
