### PR TITLE
ci(infra): parse-check, branch-label rules, skip merged PRs

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -314,7 +314,7 @@ Notes:
 - To produce multiple changelog entries from one PR, separate corrected messages by a **blank line** with each starting `type(scope):`, or wrap each in `BEGIN_NESTED_COMMIT`/`END_NESTED_COMMIT` markers — release-please's splitter requires one of these forms; a bare newline between messages is parsed as a single commit's body.
 - Only effective with **squash merges**. release-please attaches the override to the squash commit by matching it to the PR's `merge_commit_sha`; for plain-merge or rebase-merge strategies the per-branch commits have no PR association and the override is ignored.
 - Effect lands when release-please next syncs the open release PR (push to `main` or manual workflow dispatch). Verify the entry moved/disappeared in the corresponding `release(<component>): X.Y.Z` PR.
-- Update via `gh api -X PATCH repos/langchain-ai/deepagents/pulls/<num> -f body=@<file>` to avoid shell-escaping the multi-line body.
+- Update via `gh pr edit <num> --body-file <file>` to avoid shell-escaping the multi-line body. (`gh api -f body=@<file>` does **not** work — `-f` writes the literal string `@<file>` rather than reading the file.)
 
 ### Yanking a Release
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -289,9 +289,32 @@ This most commonly bites when someone tries to "fix up" a merged PR's changelog 
 
 The `guard-empty-commit` job in [`release-please.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) blocks this at CI time: any push to `main` whose head commit changes zero files fails fast with a clear error before the release-please action runs.
 
-**If you need to amend a release note for a commit that already merged**, follow [release-please's official guidance](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) — edit the changelog directly in the open release PR, or revert and re-merge the original PR with the corrected title. Do not push empty commits to `main`.
+**If you need to amend a release note for a commit that already merged**, see [Overriding a Merged Commit's Changelog Entry](#overriding-a-merged-commits-changelog-entry) below. Do not push empty commits to `main`.
 
 **If a fan-out has already happened** (release PRs opened for packages you didn't change), revert the offending commit on `main`. release-please will reconcile the open release PRs on the next push that actually touches package files; PRs for unaffected packages can be closed manually.
+
+### Overriding a Merged Commit's Changelog Entry
+
+Append a `BEGIN_COMMIT_OVERRIDE` block to the **merged PR's body** when release-please needs to use a different message than the actual squash-merge commit. release-please reads merged PR bodies on every run within its lookback window and uses the override in place of the original commit message — no history rewrite, no force-push.
+
+Two situations call for this:
+
+1. **Wrong type/scope inferred** — e.g. a `feat:` that should have been `refactor:` or `chore:`.
+2. **Parser cannot read the commit body** — `@conventional-commits/parser` (which release-please uses) is grammar-strict and does not honor markdown code fences. Bodies containing function calls split across lines (`name(` followed by a newline), even inside ` ``` ` blocks, throw a parse error and the commit is silently dropped from the changelog. The pre-merge `release_please_parse_check.yml` check catches this before merge; if a commit slipped through, use the override to recover.
+
+```txt
+BEGIN_COMMIT_OVERRIDE
+refactor(scope): corrected description
+END_COMMIT_OVERRIDE
+```
+
+Notes:
+
+- Place the block at the bottom of the PR body, after a horizontal rule.
+- To produce multiple changelog entries from one PR, separate corrected messages by a **blank line** with each starting `type(scope):`, or wrap each in `BEGIN_NESTED_COMMIT`/`END_NESTED_COMMIT` markers — release-please's splitter requires one of these forms; a bare newline between messages is parsed as a single commit's body.
+- Only effective with **squash merges**. release-please attaches the override to the squash commit by matching it to the PR's `merge_commit_sha`; for plain-merge or rebase-merge strategies the per-branch commits have no PR association and the override is ignored.
+- Effect lands when release-please next syncs the open release PR (push to `main` or manual workflow dispatch). Verify the entry moved/disappeared in the corresponding `release(<component>): X.Y.Z` PR.
+- Update via `gh api -X PATCH repos/langchain-ai/deepagents/pulls/<num> -f body=@<file>` to avoid shell-escaping the multi-line body.
 
 ### Yanking a Release
 

--- a/.github/scripts/pr-labeler-config.json
+++ b/.github/scripts/pr-labeler-config.json
@@ -72,6 +72,12 @@
     "runloop": "runloop",
     "sdk": "deepagents"
   },
+  "branchRules": [
+    {
+      "label": "open-swe",
+      "prefix": "open-swe/"
+    }
+  ],
   "fileRules": [
     {
       "label": "deepagents",

--- a/.github/scripts/pr-labeler.js
+++ b/.github/scripts/pr-labeler.js
@@ -21,7 +21,7 @@ function loadConfig() {
     throw new Error(`Failed to parse pr-labeler-config.json: ${e.message}`);
   }
   const required = [
-    'labelColor', 'sizeThresholds', 'fileRules',
+    'labelColor', 'sizeThresholds', 'fileRules', 'branchRules',
     'typeToLabel', 'scopeToLabel', 'trustedThreshold',
     'excludedFiles', 'excludedPaths',
   ];
@@ -43,6 +43,7 @@ function init(github, owner, repo, config, core) {
     scopeToLabel,
     typeToLabel,
     fileRules: fileRulesDef,
+    branchRules: branchRulesDef,
     excludedFiles,
     excludedPaths,
   } = config;
@@ -127,6 +128,29 @@ function init(github, owner, repo, config, core) {
       if (candidates.some(f => rule.test(f.filename ?? ''))) {
         labels.add(rule.label);
       }
+    }
+    return labels;
+  }
+
+  // ── Branch-name-based labels ──────────────────────────────────────
+
+  function matchBranchLabels(headRef) {
+    const labels = new Set();
+    const ref = headRef ?? '';
+    if (!ref) return labels;
+    for (const rule of branchRulesDef) {
+      let matched = false;
+      if (rule.prefix) matched = ref.startsWith(rule.prefix);
+      else if (rule.suffix) matched = ref.endsWith(rule.suffix);
+      else if (rule.exact) matched = ref === rule.exact;
+      else if (rule.pattern) matched = new RegExp(rule.pattern).test(ref);
+      else {
+        throw new Error(
+          `branchRules entry (label: "${rule.label}") has no recognized matcher ` +
+          `(expected one of: prefix, suffix, exact, pattern)`,
+        );
+      }
+      if (matched) labels.add(rule.label);
     }
     return labels;
   }
@@ -290,6 +314,7 @@ function init(github, owner, repo, config, core) {
     computeSize,
     buildFileRules,
     matchFileLabels,
+    matchBranchLabels,
     matchTitleLabels,
     labelPR,
     allTypeLabels,

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -191,6 +191,12 @@ jobs:
               }
             }
 
+            // ── Branch-name-based labels ──
+            // Branch ref doesn't change for an existing PR, so no removal logic.
+            for (const label of h.matchBranchLabels(pr.head?.ref)) {
+              toAdd.add(label);
+            }
+
             // ── Title-based labels ──
             // Use renamed title if the scope-rename step rewrote it,
             // since pr.title still reflects the pre-update value.

--- a/.github/workflows/pr_labeler_backfill.yml
+++ b/.github/workflows/pr_labeler_backfill.yml
@@ -88,6 +88,11 @@ jobs:
                   labels.add(label);
                 }
 
+                // Branch-name labels
+                for (const label of h.matchBranchLabels(pr.head?.ref)) {
+                  labels.add(label);
+                }
+
                 // Title labels
                 const { labels: titleLabels } = h.matchTitleLabels(pr.title ?? '');
                 for (const tl of titleLabels) labels.add(tl);

--- a/.github/workflows/release_please_parse_check.yml
+++ b/.github/workflows/release_please_parse_check.yml
@@ -1,0 +1,252 @@
+# Pre-merge parse check for release-please.
+#
+# Why this exists:
+#   release-please runs every commit message through @conventional-commits/parser
+#   to build the changelog. The parser is grammar-strict and does NOT understand
+#   markdown code fences — function calls split across lines (e.g.
+#   `register_provider_profile(\n  "openai",\n  ...\n)`) are read as malformed
+#   conventional-commit scopes and cause the parser to throw. release-please
+#   catches the throw, logs a debug message, and silently drops the commit from
+#   the release PR. The drop is invisible until someone notices a missing
+#   changelog entry — by which point the commit is already merged.
+#
+#   This check runs the same parser the same way on the would-be squash-merge
+#   message at PR time, blocks merge if it would fail, and posts a sticky
+#   comment with a copy-paste-ready BEGIN_COMMIT_OVERRIDE block so the author
+#   can self-serve the fix.
+#
+# How it stays faithful to release-please:
+#   - Same parser package: @conventional-commits/parser, exact-pinned (NOT semver
+#     range) to match release-please's package.json. Bump in lock-step when
+#     release-please bumps. As of release-please 17.6.0 this is 0.4.1:
+#     https://github.com/googleapis/release-please/blob/v17.6.0/package.json
+#   - Mirrors release-please/src/commit.ts:preprocessCommitMessage — if the body
+#     contains BEGIN_COMMIT_OVERRIDE..END_COMMIT_OVERRIDE, only the override is
+#     parsed (release-please uses it verbatim, ignoring the rest).
+#   - Mirrors release-please/src/commit.ts:splitMessages — release-please splits
+#     on BEGIN_NESTED_COMMIT/END_NESTED_COMMIT and on blank-line + conventional-
+#     commit prefix regex, then parses each sub-message independently. We do the
+#     same and fail if ANY sub-message would fail to parse.
+#   - Mirrors GitHub's default squash-merge format: `<title> (#<number>)\n\n<body>`.
+#     Assumes the repo squash-merge default is "Pull request title and description".
+#
+# Limitations:
+#   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks
+#     get the failing check but no auto-comment. Acceptable: external authors
+#     will see the failure and a maintainer can paste the override.
+#   - Faithful to release-please's parse step only. Doesn't catch downstream
+#     issues like wrong-scope inference or path-filter mismatches.
+
+name: "🔍 Release-please parse check"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  parse-check:
+    name: "validate squash-merge message parses"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install @conventional-commits/parser
+        # Exact pin (NOT a semver range) — must equal release-please's
+        # package.json entry. A range would silently drift on minor bumps and
+        # the parsers can diverge — exactly the failure mode this check exists
+        # to prevent.
+        run: |
+          mkdir -p /tmp/parse-check
+          cd /tmp/parse-check
+          npm init -y >/dev/null
+          npm install '@conventional-commits/parser@0.4.1'
+
+      - name: Validate conventional-commit parse
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            // Load the parser FIRST, outside the parse try/catch. A
+            // MODULE_NOT_FOUND here is an infra error (npm install broke or
+            // the package layout changed) — surfacing it as "your commit
+            // cannot be parsed" would mislead the author.
+            let parser;
+            try {
+              parser = require('/tmp/parse-check/node_modules/@conventional-commits/parser');
+            } catch (loadErr) {
+              core.setFailed(`Failed to load @conventional-commits/parser — this is a CI infra error, not a problem with your PR: ${loadErr.message}`);
+              return;
+            }
+
+            const { title, body, number } = context.payload.pull_request;
+            // Normalize line endings — GitHub's API returns whatever the
+            // editor used, and CRLF leaves stray \r chars in offending-line
+            // displays.
+            const fullBody = (body || '').replace(/\r\n/g, '\n');
+            const STICKY_MARKER = '<!-- release-please-parse-check -->';
+
+            // Mirror release-please/src/commit.ts:preprocessCommitMessage. If
+            // BEGIN_COMMIT_OVERRIDE..END_COMMIT_OVERRIDE is present in the PR
+            // body, release-please uses only that — the rest is irrelevant.
+            const overrideHalves = fullBody.split('BEGIN_COMMIT_OVERRIDE');
+            const overrideMessage = overrideHalves.length > 1
+              ? overrideHalves[1].split('END_COMMIT_OVERRIDE')[0].trim()
+              : '';
+            if (overrideHalves.length > 2) {
+              core.warning('Multiple BEGIN_COMMIT_OVERRIDE blocks found; only the first is honored (matches release-please behavior).');
+            }
+
+            // Mirror release-please/src/commit.ts:splitMessages. release-please
+            // splits the preprocessed message into sub-messages and parses each
+            // independently — a body that splits into N pieces where one
+            // piece fails is rejected by release-please for that piece, even
+            // if the whole-message parse would have looked OK.
+            function splitMessages(message) {
+              const parts = message.split('BEGIN_NESTED_COMMIT');
+              const messages = [parts.shift()];
+              for (const part of parts) {
+                const [newMessage, ...rest] = part.split('END_NESTED_COMMIT');
+                messages.push(newMessage);
+                messages[0] = messages[0] + rest.join('END_NESTED_COMMIT');
+              }
+              const conventionalCommits = messages[0]
+                .split(/\r?\n\r?\n(?=(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\(.*?\))?: )/)
+                .filter(Boolean);
+              return [...conventionalCommits, ...messages.slice(1)];
+            }
+
+            const squashMessage = overrideMessage
+              ? overrideMessage
+              : `${title} (#${number})\n\n${fullBody}`;
+            const subMessages = splitMessages(squashMessage);
+
+            async function findStickyComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.find(c => c.body && c.body.startsWith(STICKY_MARKER));
+            }
+
+            // Try parsing each sub-message; first failure wins.
+            let parseError = null;
+            let failingSubMessage = null;
+            let failingIndex = -1;
+            for (let i = 0; i < subMessages.length; i++) {
+              try {
+                parser.parser(subMessages[i]);
+              } catch (err) {
+                parseError = err;
+                failingSubMessage = subMessages[i];
+                failingIndex = i;
+                break;
+              }
+            }
+
+            if (parseError === null) {
+              core.info(overrideMessage
+                ? `Parse OK (using BEGIN_COMMIT_OVERRIDE block; ${subMessages.length} sub-message(s))`
+                : `Parse OK (${subMessages.length} sub-message(s))`);
+              // Clean up any prior failure comment. Wrapped in try/catch
+              // because a transient API failure during cleanup must NOT turn
+              // a green parse into a red check.
+              try {
+                const existing = await findStickyComment();
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    ...context.repo,
+                    comment_id: existing.id,
+                  });
+                }
+              } catch (cleanupErr) {
+                core.warning(`Parse passed but could not clean up prior failure comment: ${cleanupErr.message}`);
+              }
+              return;
+            }
+
+            const errMessage = parseError.message || String(parseError);
+            const positionMatch = errMessage.match(/at (\d+):(\d+)/);
+            if (!positionMatch) {
+              core.warning('Could not extract line:col from parser error — parser error format may have changed. Check failure remains correct, but the offending-line callout in the PR comment will be omitted.');
+            }
+            const line = positionMatch ? parseInt(positionMatch[1], 10) : null;
+            const col = positionMatch ? parseInt(positionMatch[2], 10) : null;
+            const failingLines = (failingSubMessage || '').split(/\r?\n/);
+            const offending = (line && failingLines[line - 1] !== undefined)
+              ? failingLines[line - 1]
+              : null;
+
+            const suggested = [
+              '<!-- release-please override: parser-safe message used by release-please for changelog generation; the rest of the body is unaffected -->',
+              'BEGIN_COMMIT_OVERRIDE',
+              `${title} (#${number})`,
+              '',
+              '<one-paragraph description here, no `name(` followed by a newline>',
+              'END_COMMIT_OVERRIDE',
+            ].join('\n');
+
+            const sourceLabel = overrideMessage
+              ? 'BEGIN_COMMIT_OVERRIDE block in the PR description'
+              : `\`<title> (#${number})\\n\\n<body>\` (the would-be squash-merge message)`;
+
+            const subMessageLabel = subMessages.length > 1
+              ? ` (sub-message ${failingIndex + 1} of ${subMessages.length} after splitMessages)`
+              : '';
+
+            const offendingSection = (line && offending !== null)
+              ? `**Offending region** (line ${line}, col ${col} of ${sourceLabel}${subMessageLabel}):\n\n\`\`\`\n${offending}\n\`\`\`\n\n`
+              : '';
+
+            const overrideAdvice = overrideMessage
+              ? 'Your PR already has a `BEGIN_COMMIT_OVERRIDE` block, but the content inside it does not parse. Edit the override content to be a valid conventional commit message.'
+              : `The parser does **not** honor markdown code fences — content inside \` \`\`\` \` blocks is parsed the same as anything else. Bare function calls split across lines (\`name(\` followed by a newline) are a common trigger.\n\n### Fix options\n\n**(a) Reformat the offending content** — collapse multi-line function calls to one line, or trim the example out. Quickest if the rich body is not load-bearing.\n\n**(b) Add a release-please override block** at the end of this PR description. Release-please will use the clean message inside it for changelog generation and ignore the rest. Paste:\n\n\`\`\`\`\n${suggested}\n\`\`\`\`\n\nSave the description; this check will re-run automatically.`;
+
+            const commentBody = [
+              STICKY_MARKER,
+              '⚠️ **Release-please parser cannot parse this PR\'s would-be squash-merge message.**',
+              '',
+              'If this PR is merged as-is, the commit will be **silently dropped** from the next release PR — release-please skips commits whose bodies its parser rejects, with no error surfaced until the changelog entry is missing.',
+              '',
+              '**Parse error:**',
+              '```',
+              errMessage,
+              '```',
+              '',
+              offendingSection + overrideAdvice,
+              '',
+              '📖 [release-please override docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#overriding-commit-messages)',
+            ].join('\n');
+
+            try {
+              const existing = await findStickyComment();
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  ...context.repo,
+                  comment_id: existing.id,
+                  body: commentBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: number,
+                  body: commentBody,
+                });
+              }
+            } catch (commentErr) {
+              // Comment posting can fail for several reasons: fork PRs run
+              // with restricted tokens, secondary rate limits, transient API
+              // errors, or pagination failures during the lookup. Always
+              // surface the would-be comment to the job summary so a
+              // maintainer can copy-paste the remediation manually.
+              core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
+              await core.summary
+                .addHeading('Parse check failed; comment could not be posted')
+                .addRaw('Paste the following into the PR as a comment:')
+                .addCodeBlock(commentBody, 'markdown')
+                .write();
+            }
+            // Use only the first line of the parser error in the failure
+            // signal — GitHub renders multi-line ::error:: messages with
+            // literal %0A escapes in the check summary.
+            core.setFailed(errMessage.split('\n')[0]);

--- a/.github/workflows/release_please_parse_check.yml
+++ b/.github/workflows/release_please_parse_check.yml
@@ -85,16 +85,91 @@ jobs:
             const fullBody = (body || '').replace(/\r\n/g, '\n');
             const STICKY_MARKER = '<!-- release-please-parse-check -->';
 
+            async function findStickyComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.find(c => c.body && c.body.startsWith(STICKY_MARKER));
+            }
+
+            async function postStickyOrSummary(commentBody, summaryHeading) {
+              try {
+                const existing = await findStickyComment();
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    ...context.repo,
+                    comment_id: existing.id,
+                    body: commentBody,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    ...context.repo,
+                    issue_number: number,
+                    body: commentBody,
+                  });
+                }
+              } catch (commentErr) {
+                // Comment posting can fail for several reasons: fork PRs run
+                // with restricted tokens, secondary rate limits, transient API
+                // errors, or pagination failures during the lookup. Always
+                // surface the would-be comment to the job summary so a
+                // maintainer can copy-paste the remediation manually.
+                core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
+                await core.summary
+                  .addHeading(summaryHeading)
+                  .addRaw('Paste the following into the PR as a comment:')
+                  .addCodeBlock(commentBody, 'markdown')
+                  .write();
+              }
+            }
+
             // Mirror release-please/src/commit.ts:preprocessCommitMessage. If
             // BEGIN_COMMIT_OVERRIDE..END_COMMIT_OVERRIDE is present in the PR
             // body, release-please uses only that — the rest is irrelevant.
             const overrideHalves = fullBody.split('BEGIN_COMMIT_OVERRIDE');
-            const overrideMessage = overrideHalves.length > 1
+            const beginMarkerCount = overrideHalves.length - 1;
+
+            // Hard-fail when the body contains more than one literal
+            // `BEGIN_COMMIT_OVERRIDE`. release-please's preprocessCommitMessage
+            // uses `split('BEGIN_COMMIT_OVERRIDE')[1].split('END_COMMIT_OVERRIDE')[0]`
+            // — the FIRST occurrence wins, with no anchoring or escape support.
+            // The common trap: prose that mentions the marker name (even
+            // inside backticks) plus a real override block later — release-
+            // please picks the prose mention, the extracted "override" is
+            // garbage, and the commit is silently dropped from the changelog.
+            // Refuse to guess which occurrence is "real"; ask the author to
+            // dedupe.
+            if (beginMarkerCount > 1) {
+              const multiMarkerBody = [
+                STICKY_MARKER,
+                '⚠️ **Multiple `BEGIN_COMMIT_OVERRIDE` markers found in this PR\'s body.**',
+                '',
+                `Found **${beginMarkerCount}** occurrences. release-please uses the **first** one and treats everything from there to the next \`END_COMMIT_OVERRIDE\` as the changelog message. If the first occurrence is prose (the marker name mentioned in the description, even inside backticks), the extracted override will not parse and your commit will be **silently dropped** from the next release PR.`,
+                '',
+                '### Fix',
+                '',
+                'Keep at most one literal `BEGIN_COMMIT_OVERRIDE` in the PR body — the one inside the actual override block, if any. For the rest:',
+                '',
+                '- Rephrase to avoid the literal string (e.g., "the override marker").',
+                '- Or break the literal: `` `BEGIN_<wbr>COMMIT_OVERRIDE` `` renders the same in markdown but is no longer a single token to release-please\'s splitter.',
+                '',
+                'Save the description; this check will re-run automatically.',
+                '',
+                '📖 [How to override a commit\'s changelog entry](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#overriding-a-merged-commits-changelog-entry)',
+              ].join('\n');
+              await postStickyOrSummary(
+                multiMarkerBody,
+                'Multiple BEGIN_COMMIT_OVERRIDE markers; comment could not be posted',
+              );
+              core.setFailed(`Multiple BEGIN_COMMIT_OVERRIDE markers in PR body (${beginMarkerCount}); release-please uses the first occurrence.`);
+              return;
+            }
+
+            const overrideMessage = beginMarkerCount === 1
               ? overrideHalves[1].split('END_COMMIT_OVERRIDE')[0].trim()
               : '';
-            if (overrideHalves.length > 2) {
-              core.warning('Multiple BEGIN_COMMIT_OVERRIDE blocks found; only the first is honored (matches release-please behavior).');
-            }
 
             // Mirror release-please/src/commit.ts:splitMessages. release-please
             // splits the preprocessed message into sub-messages and parses each
@@ -119,15 +194,6 @@ jobs:
               ? overrideMessage
               : `${title} (#${number})\n\n${fullBody}`;
             const subMessages = splitMessages(squashMessage);
-
-            async function findStickyComment() {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                ...context.repo,
-                issue_number: number,
-                per_page: 100,
-              });
-              return comments.find(c => c.body && c.body.startsWith(STICKY_MARKER));
-            }
 
             // Try parsing each sub-message; first failure wins.
             let parseError = null;
@@ -215,37 +281,13 @@ jobs:
               '',
               offendingSection + overrideAdvice,
               '',
-              '📖 [release-please override docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#overriding-commit-messages)',
+              '📖 [How to override a commit\'s changelog entry](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#overriding-a-merged-commits-changelog-entry)',
             ].join('\n');
 
-            try {
-              const existing = await findStickyComment();
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  ...context.repo,
-                  comment_id: existing.id,
-                  body: commentBody,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  ...context.repo,
-                  issue_number: number,
-                  body: commentBody,
-                });
-              }
-            } catch (commentErr) {
-              // Comment posting can fail for several reasons: fork PRs run
-              // with restricted tokens, secondary rate limits, transient API
-              // errors, or pagination failures during the lookup. Always
-              // surface the would-be comment to the job summary so a
-              // maintainer can copy-paste the remediation manually.
-              core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
-              await core.summary
-                .addHeading('Parse check failed; comment could not be posted')
-                .addRaw('Paste the following into the PR as a comment:')
-                .addCodeBlock(commentBody, 'markdown')
-                .write();
-            }
+            await postStickyOrSummary(
+              commentBody,
+              'Parse check failed; comment could not be posted',
+            );
             // Use only the first line of the parser error in the failure
             // signal — GitHub renders multi-line ::error:: messages with
             // literal %0A escapes in the check summary.

--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -34,7 +34,12 @@ jobs:
     # or when "missing-issue-link" is removed (triggers maintainer override check).
     # Skip entirely when the PR already carries "trusted-contributor" or
     # "bypass-issue-check".
+    # Skip merged PRs: editing the title/body or relabeling a merged PR must
+    # not re-fire enforcement (label, comment, "close" no-op, failed check).
+    # Closed-but-not-merged PRs still flow through so contributors editing the
+    # body to add a `Fixes #N` link will be reopened.
     if: >-
+      github.event.pull_request.merged == false &&
       !contains(github.event.pull_request.labels.*.name, 'trusted-contributor') &&
       !contains(github.event.pull_request.labels.*.name, 'bypass-issue-check') &&
       (

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,26 +326,7 @@ See `.github/RELEASING.md` for the full workflow (version bumping, pre-releases,
 
 #### Overriding a merged commit's changelog entry
 
-Append a `BEGIN_COMMIT_OVERRIDE` block to the **merged PR's body** when release-please needs to use a different message than the actual squash-merge commit. release-please reads merged PR bodies on every run within its lookback window and uses the override in place of the original commit message — no history rewrite, no force-push.
-
-Two situations call for this:
-
-1. **Wrong type/scope inferred** — e.g. a `feat:` that should have been `refactor:` or `chore:`.
-2. **Parser cannot read the commit body** — `@conventional-commits/parser` (which release-please uses) is grammar-strict and does not honor markdown code fences. Bodies containing function calls split across lines (`name(` followed by a newline), even inside ` ``` ` blocks, throw a parse error and the commit is silently dropped from the changelog. The pre-merge `release_please_parse_check.yml` check catches this before merge; if a commit slipped through, use the override to recover.
-
-```txt
-BEGIN_COMMIT_OVERRIDE
-refactor(scope): corrected description
-END_COMMIT_OVERRIDE
-```
-
-Notes:
-
-- Place the block at the bottom of the PR body, after a horizontal rule.
-- To produce multiple changelog entries from one PR, separate corrected messages by a **blank line** with each starting `type(scope):`, or wrap each in `BEGIN_NESTED_COMMIT`/`END_NESTED_COMMIT` markers — release-please's splitter requires one of these forms; a bare newline between messages is parsed as a single commit's body.
-- Only effective with **squash merges**. release-please attaches the override to the squash commit by matching it to the PR's `merge_commit_sha`; for plain-merge or rebase-merge strategies the per-branch commits have no PR association and the override is ignored.
-- Effect lands when release-please next syncs the open release PR (push to `main` or manual workflow dispatch). Verify the entry moved/disappeared in the corresponding `release(<component>): X.Y.Z` PR.
-- Update via `gh api -X PATCH repos/langchain-ai/deepagents/pulls/<num> -f body=@<file>` to avoid shell-escaping the multi-line body.
+See [Overriding a Merged Commit's Changelog Entry](.github/RELEASING.md#overriding-a-merged-commits-changelog-entry) in `RELEASING.md` for the workflow (when to use it, the block format, and the squash-merge caveats).
 
 ### PR labeling and linting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,9 +324,34 @@ The release pipeline: build → unit tests against built package → publish to 
 
 See `.github/RELEASING.md` for the full workflow (version bumping, pre-releases, troubleshooting failed releases, and label management).
 
+#### Overriding a merged commit's changelog entry
+
+Append a `BEGIN_COMMIT_OVERRIDE` block to the **merged PR's body** when release-please needs to use a different message than the actual squash-merge commit. release-please reads merged PR bodies on every run within its lookback window and uses the override in place of the original commit message — no history rewrite, no force-push.
+
+Two situations call for this:
+
+1. **Wrong type/scope inferred** — e.g. a `feat:` that should have been `refactor:` or `chore:`.
+2. **Parser cannot read the commit body** — `@conventional-commits/parser` (which release-please uses) is grammar-strict and does not honor markdown code fences. Bodies containing function calls split across lines (`name(` followed by a newline), even inside ` ``` ` blocks, throw a parse error and the commit is silently dropped from the changelog. The pre-merge `release_please_parse_check.yml` check catches this before merge; if a commit slipped through, use the override to recover.
+
+```txt
+BEGIN_COMMIT_OVERRIDE
+refactor(scope): corrected description
+END_COMMIT_OVERRIDE
+```
+
+Notes:
+
+- Place the block at the bottom of the PR body, after a horizontal rule.
+- To produce multiple changelog entries from one PR, separate corrected messages by a **blank line** with each starting `type(scope):`, or wrap each in `BEGIN_NESTED_COMMIT`/`END_NESTED_COMMIT` markers — release-please's splitter requires one of these forms; a bare newline between messages is parsed as a single commit's body.
+- Only effective with **squash merges**. release-please attaches the override to the squash commit by matching it to the PR's `merge_commit_sha`; for plain-merge or rebase-merge strategies the per-branch commits have no PR association and the override is ignored.
+- Effect lands when release-please next syncs the open release PR (push to `main` or manual workflow dispatch). Verify the entry moved/disappeared in the corresponding `release(<component>): X.Y.Z` PR.
+- Update via `gh api -X PATCH repos/langchain-ai/deepagents/pulls/<num> -f body=@<file>` to avoid shell-escaping the multi-line body.
+
 ### PR labeling and linting
 
 **Title linting** (`.github/workflows/pr_lint.yml`) – Enforces Conventional Commits format with required scope on PR titles
+
+**Release-please parse check** (`.github/workflows/release_please_parse_check.yml`) – Runs `@conventional-commits/parser` on the would-be squash-merge message (`<title> (#<num>)\n\n<body>`) at PR time. Fails the check and posts a sticky comment with a paste-ready `BEGIN_COMMIT_OVERRIDE` block when the parser would reject the body, preventing silent changelog drops. Mirrors release-please's `preprocessCommitMessage` and `splitMessages` so per-sub-message parse failures are caught the same way release-please catches them. The parser is exact-pinned (not a semver range) and must stay in lock-step with `release-please/package.json`.
 
 **Auto-labeling:**
 


### PR DESCRIPTION
Bundle three CI improvements onto one branch: a new pre-merge gate that catches release-please parser failures (the class of bug that silently dropped #2892 from its release PR), branch-name-based PR labeling, and a guard so the issue-link workflow stops re-firing on merged PRs.

## Changes

**Release-please parse check** (new workflow `release_please_parse_check.yml`)
- Run `@conventional-commits/parser@0.4.1` on the would-be squash-merge message (`<title> (#<num>)\n\n<body>`) for every PR. Mirror release-please's `preprocessCommitMessage` (override-block extraction) and `splitMessages` (split on nested-commit markers and on `\n\n(?=type(scope)?:)`), then parse each sub-message independently — first failure wins.
- On parse failure: post a sticky PR comment with the parser error, the offending line text, and a paste-ready override-block scaffold derived from the PR title. On success: delete any stale failure comment. Comment-post failures (fork PRs, rate limits) fall back to `core.summary` so the remediation block is still recoverable.
- Hard-fail when the body contains more than one literal override-begin marker. release-please uses only the first occurrence; if the first one is a prose mention rather than a real block, the extracted "override" is garbage and the commit is silently dropped from the changelog. The check refuses to guess which marker is real and asks the author to dedupe (rephrase prose mentions, or break the literal with `<wbr>`).
- Parser version is exact-pinned (not a `^` range) and must move in lock-step with `release-please/package.json`.

**Branch-name PR labeling** (`pr-labeler.js`, both labeler workflows, config)
- Add `branchRules` to `pr-labeler-config.json` and a `matchBranchLabels` matcher in `pr-labeler.js` supporting `prefix` / `suffix` / `exact` / `pattern` clauses. Wire it into both `pr_labeler.yml` (online) and `pr_labeler_backfill.yml` (manual backfill).
- Seed with one rule: branches starting with `open-swe/` get the `open-swe` label. Branch ref is immutable for an existing PR, so this matcher only adds — no removal logic needed.

**Issue-link enforcement** (`require_issue_link.yml`)
- Skip the workflow when `github.event.pull_request.merged == true`. Editing a merged PR's title/body or shuffling labels was re-firing the enforcement (label add, comment, no-op close, failed check). Closed-but-not-merged PRs still flow through so a contributor editing the body to add `Fixes #N` triggers a reopen.

**Docs** (`RELEASING.md`, `AGENTS.md`)
- Move the override-block workflow to `RELEASING.md` under Troubleshooting and leave a one-line pointer in `AGENTS.md`. Document both reasons to use the override (wrong type/scope inferred, or parser-hostile body). Note the squash-merge-only constraint, the multi-message form requirements, and the `gh api -f` flag for multi-line bodies. List the new parse check under "PR labeling and linting".
