### PR TITLE
test(quickjs): add benchmarks

### DIFF
--- a/.github/workflows/_benchmark.yml
+++ b/.github/workflows/_benchmark.yml
@@ -21,6 +21,11 @@ on:
         # Pin 3.13.11 — CodSpeed walltime segfaults on 3.13.12+
         # https://github.com/CodSpeedHQ/pytest-codspeed/issues/106
         default: "3.13.11"
+      has-memory-benchmarks:
+        description: "Whether the package defines memory_benchmark tests"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -59,3 +64,11 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           run: uv run --no-sync pytest ./tests -m benchmark --codspeed
           mode: walltime
+
+      - name: "Run memory benchmarks"
+        if: ${{ inputs.has-memory-benchmarks }}
+        uses: CodSpeedHQ/action@dfaf2584d705312e4ab4e23a4dd3e2f56b71ef3b # v4
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          run: uv run --no-sync pytest ./tests -m "memory_benchmark" --codspeed
+          mode: memory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
+              - '.github/workflows/_benchmark.yml'
               - '.github/actions/**'
             repl:
               - 'libs/repl/**'
@@ -278,6 +279,16 @@ jobs:
       working-directory: "libs/cli"
     secrets: inherit
 
+  benchmark-quickjs:
+    name: "⏱️ Benchmark quickjs"
+    needs: changes
+    if: needs.changes.outputs.quickjs == 'true' || github.event_name == 'push'
+    uses: ./.github/workflows/_benchmark.yml
+    with:
+      working-directory: "libs/partners/quickjs"
+      has-memory-benchmarks: true
+    secrets: inherit
+
   # Verify release.yml dropdown options stay in sync with package directories
   check-release-options:
     name: "Validate Release Options"
@@ -315,6 +326,7 @@ jobs:
       - test-repl
       - benchmark-deepagents
       - benchmark-cli
+      - benchmark-quickjs
       - check-release-options
     if: always()
     runs-on: ubuntu-latest

--- a/examples/repl_swarm/uv.lock
+++ b/examples/repl_swarm/uv.lock
@@ -645,6 +645,8 @@ test = [
     { name = "build" },
     { name = "pytest", specifier = ">=7.3.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
     { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },

--- a/examples/rlm_agent/uv.lock
+++ b/examples/rlm_agent/uv.lock
@@ -645,6 +645,8 @@ test = [
     { name = "build" },
     { name = "pytest", specifier = ">=7.3.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
     { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -2605,6 +2605,8 @@ test = [
     { name = "build" },
     { name = "pytest", specifier = ">=7.3.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
     { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },

--- a/libs/partners/quickjs/Makefile
+++ b/libs/partners/quickjs/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test tests integration_test integration_tests lint format help
+.PHONY: test tests integration_test integration_tests lint format benchmark help
 
 .DEFAULT_GOAL := help
 
@@ -32,6 +32,10 @@ integration_test integration_tests:
 
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw --now . -- -vv $(TEST_FILE)
+
+benchmark: ## Run benchmark tests
+	uv run --group test pytest ./tests -m benchmark
+	uv run --group test pytest ./tests -m memory_benchmark
 
 update_snapshots: ## Update smoke test prompt snapshots
 	uv run --group test pytest tests/unit_tests/smoke_tests/test_system_prompt.py --update-snapshots

--- a/libs/partners/quickjs/README.md
+++ b/libs/partners/quickjs/README.md
@@ -68,13 +68,13 @@ The middleware:
 
 1. registers an `eval` tool (configurable name) that runs JS in a persistent context;
 2. appends a short system-prompt snippet explaining the tool's semantics (sandbox, timeout, memory limit);
-3. gives every LangGraph `thread_id` its own QuickJS `Context`, so two conversations can't see each other's globals.
+3. gives every LangGraph `thread_id` its own QuickJS `Runtime`, so two conversations can't see each other's globals.
 
 ## What the REPL is
 
 ### Persistence
 
-The REPL is module-flavoured: top-level `let`/`const`/`function` persist across `eval` calls in the same thread. Assign to `globalThis.X` to keep a value around under an explicit name.
+The REPL is module-flavoured: top-level `let`/`const`/`function` persist across `eval` calls within the same run. Assign to `globalThis.X` to keep a value around under an explicit name.
 
 ```js
 // call 1
@@ -170,9 +170,6 @@ REPLMiddleware(ptc=["search_web"])            # explicit allowlist
 REPLMiddleware(ptc=[search_tool])             # explicit tool object allowlist
 ```
 
-Boolean `ptc` values are not supported. Use `ptc=None` (or omit `ptc`) to disable.
-Dict `ptc` configs are not supported.
-
 The REPL's own tool is always excluded from PTC; `tools.eval("tools.eval(...)")` would be pointless recursion, and if the model wants nested code it can just write nested code in one call.
 
 ### What the model sees
@@ -182,8 +179,10 @@ When PTC is on, the system-prompt snippet grows an *API Reference — `tools` na
 ```ts
 /** Search the web for the given query. */
 async tools.searchWeb(input: {
-  /** The query string. */ query: string;
-  /** Max results. */ limit?: number;
+  /** The query string. */
+  query: string;
+  /** Max results. */
+  limit?: number;
 }): Promise<string>
 ```
 
@@ -195,10 +194,6 @@ Enums, `anyOf` unions, nested objects, and arrays are all supported by the schem
 - `globalThis.tools` is rebuilt every turn from the currently-exposed name set. So if an upstream middleware filters tools on a per-turn basis, the `tools` namespace follows along.
 - When the bridge invokes a tool, it forwards the `ToolRuntime` captured from the outer `eval` call — so subagent tools like `task` see graph `state`, `store`, `context`, and a synthesised child `tool_call_id`.
 - Tool return values are coerced to strings: strings pass through, `ToolMessage`s get unwrapped, a `Command` has its last-message content extracted, everything else gets `json.dumps`'d.
-
-### Why `ainvoke`, not `invoke`
-
-PTC bridges are async host functions. QuickJS refuses to run async host functions from a synchronous `ctx.eval` — doing so raises `ConcurrentEvalError` ("sync eval encountered a registered async host function"). Use `await agent.ainvoke(...)`.
 
 ## Skills: importable JS/TS modules
 

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -60,6 +60,18 @@ logger = logging.getLogger(__name__)
 _HANDLE_PLACEHOLDER = "[unmarshalable value]"
 
 
+def _clear_exception_references(exc: BaseException) -> None:
+    """Drop traceback links to avoid cross-thread GC finalizing QJS handles.
+
+    quickjs_rs exceptions may keep traceback frames that hold temporary
+    ``QjsHandle`` objects. If those cycles are collected on a different
+    thread, quickjs_rs raises "unsendable ... dropped on another thread".
+    """
+    exc.__traceback__ = None
+    exc.__context__ = None
+    exc.__cause__ = None
+
+
 @dataclass
 class EvalOutcome:
     """Normalized result of a single REPL eval.
@@ -532,12 +544,14 @@ class _ThreadREPL:
         try:
             value = await ctx.eval_async(code, timeout=self._per_call_timeout)
             outcome.result = stringify(value)
-        except MarshalError:
+        except MarshalError as e:
             outcome.result_kind = "handle"
             outcome.result = await self._describe_via_handle_async(code)
+            _clear_exception_references(e)
         except QJSTimeoutError as e:
             outcome.error_type = "Timeout"
             outcome.error_message = str(e)
+            _clear_exception_references(e)
         except DeadlockError as e:
             # Top-level Promise never resolved and no async host work in
             # flight. Surface as a distinct error type because the fix
@@ -546,6 +560,7 @@ class _ThreadREPL:
             # message without context would make this hard to diagnose.
             outcome.error_type = "Deadlock"
             outcome.error_message = str(e)
+            _clear_exception_references(e)
         except HostCancellationError:
             # JS declined to catch a cancellation — re-raise as
             # CancelledError so asyncio unwinds the caller's task.
@@ -553,12 +568,15 @@ class _ThreadREPL:
             raise asyncio.CancelledError from None
         except JSError as e:
             self._record_js_error(outcome, e)
+            _clear_exception_references(e)
         except ConcurrentEvalError as e:
             outcome.error_type = "ConcurrentEval"
             outcome.error_message = str(e)
+            _clear_exception_references(e)
         except MemoryLimitError as e:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
+            _clear_exception_references(e)
         finally:
             outcome.commands.extend(self._ptc_command_buffer)
             self._ptc_command_buffer.clear()
@@ -676,12 +694,19 @@ class _Registry:
         return _Slot(worker=worker, runtime=runtime, repl=repl)
 
     def _close_slot(self, slot: _Slot) -> None:
+        # Close the context on its owning worker thread before closing the
+        # runtime. This avoids unsendable handle wrappers being finalized on
+        # a non-owner thread during later GC.
+        with contextlib.suppress(Exception):
+            slot.repl.close()
         # Best-effort; never block shutdown on a misbehaving runtime.
         with contextlib.suppress(Exception):
             slot.worker.run_sync(_aclose_runtime(slot.runtime))
         slot.worker.close()
 
     async def _aclose_slot(self, slot: _Slot) -> None:
+        with contextlib.suppress(Exception):
+            await slot.worker.run_async(slot.repl._aclose())
         with contextlib.suppress(Exception):
             await slot.worker.run_async(_aclose_runtime(slot.runtime))
         slot.worker.close()

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -609,6 +609,9 @@ class _ThreadREPL:
     def close(self) -> None:
         self._worker.run_sync(self._aclose())
 
+    async def aclose(self) -> None:
+        await self._worker.run_async(self._aclose())
+
     async def _aclose(self) -> None:
         if self._ctx is not None:
             self._ctx.close()
@@ -706,7 +709,7 @@ class _Registry:
 
     async def _aclose_slot(self, slot: _Slot) -> None:
         with contextlib.suppress(Exception):
-            await slot.worker.run_async(slot.repl._aclose())
+            await slot.repl.aclose()
         with contextlib.suppress(Exception):
             await slot.worker.run_async(_aclose_runtime(slot.runtime))
         slot.worker.close()

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -41,6 +41,8 @@ Documentation = "https://github.com/langchain-ai/deepagents/tree/main/libs/partn
 [dependency-groups]
 test = [
     "pytest>=7.3.0,<10.0.0",
+    "pytest-benchmark",
+    "pytest-codspeed",
     "pytest-cov",
     "pytest-socket",
     "pytest-xdist",
@@ -102,6 +104,9 @@ markers = [
     "requires: mark tests as requiring a specific library",
     "compile: mark placeholder test used to compile integration tests without running them",
     "scheduled: mark tests to run in scheduled testing",
+    "benchmark: mark benchmark tests",
+    "memory_benchmark: mark benchmarks intended for CodSpeed memory mode",
+    "throughput_benchmark: mark throughput benchmarks",
 ]
 asyncio_mode = "auto"
 filterwarnings = []

--- a/libs/partners/quickjs/tests/benchmarks/_common.py
+++ b/libs/partners/quickjs/tests/benchmarks/_common.py
@@ -1,0 +1,115 @@
+"""Shared helpers for QuickJS CodSpeed benchmark suites."""
+
+from __future__ import annotations
+
+from collections.abc import (
+    Iterator,  # noqa: TC003  # pydantic resolves this annotation at runtime
+    Sequence,  # noqa: TC003  # used in runtime-accessed annotations
+)
+from typing import TYPE_CHECKING, Any
+
+from deepagents import create_deep_agent
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from pydantic import Field
+
+if TYPE_CHECKING:
+    from langchain_quickjs import REPLMiddleware
+
+CONSOLE_LOG_CODE = "for (let i = 0; i < 200; i += 1) {  console.log(`line-${i}`);}'ok';"
+PTC_ONLY_CODE = (
+    "const values = [];"
+    "for (let i = 0; i < 100; i += 1) {"
+    "  values.push(await tools.echoPayload({value: `value-${i}`}));"
+    "}"
+    "values.length;"
+)
+PTC_AND_CONSOLE_CODE = (
+    "await (async () => {"
+    "  const values = [];"
+    "  for (let i = 0; i < 20; i += 1) {"
+    "    const value = await tools.echoPayload({value: `value-${i}`});"
+    "    values.push(value);"
+    "    console.log(value);"
+    "  }"
+    "  return values.length;"
+    "})();"
+)
+THROUGHPUT_ITERATIONS = 200
+
+
+class FakeChatModel(GenericFakeChatModel):
+    """Generic fake chat model whose ``bind_tools`` keeps scripted messages."""
+
+    messages: Iterator[AIMessage | str] = Field(exclude=True)
+
+    def bind_tools(self, tools: Sequence[Any], **_: Any) -> FakeChatModel:
+        del tools
+        return self
+
+
+@tool("echo_payload")
+def echo_payload(value: str) -> str:
+    """Echo an input payload for PTC benchmark calls."""
+    return value
+
+
+def tool_call_message(code: str, *, call_id: str = "call_1") -> AIMessage:
+    """Build the model message that calls the REPL eval tool."""
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "eval",
+                "args": {"code": code},
+                "id": call_id,
+                "type": "tool_call",
+            },
+        ],
+    )
+
+
+def finite_script(code: str, *, repeats: int) -> Iterator[AIMessage]:
+    """Build a finite tool-call script for the fake model."""
+    messages: list[AIMessage] = []
+    for index in range(repeats):
+        messages.append(tool_call_message(code, call_id=f"call_{index}"))
+        messages.append(AIMessage(content="done"))
+    return iter(messages)
+
+
+def make_agent(
+    *,
+    code: str,
+    middleware: REPLMiddleware,
+    repeats: int,
+) -> Any:
+    """Create a deep agent with a scripted fake chat model."""
+    messages = finite_script(code, repeats=repeats)
+    return create_deep_agent(
+        model=FakeChatModel(messages=messages),
+        middleware=[middleware],
+    )
+
+
+def invoke_payload() -> dict[str, list[HumanMessage]]:
+    """Return the human message payload used by benchmark runs."""
+    return {"messages": [HumanMessage(content="run benchmark workload")]}
+
+
+def eval_tool_message(result: dict[str, Any]) -> ToolMessage:
+    """Return the last eval ToolMessage from an agent result payload."""
+    messages = [
+        message
+        for message in result["messages"]
+        if isinstance(message, ToolMessage) and message.name == "eval"
+    ]
+    assert messages, "expected at least one eval ToolMessage"
+    return messages[-1]
+
+
+def assert_eval_succeeded(result: dict[str, Any]) -> None:
+    """Assert the REPL eval did not produce a tool error envelope."""
+    tool_message = eval_tool_message(result)
+    assert "<error" not in tool_message.content, tool_message.content

--- a/libs/partners/quickjs/tests/benchmarks/_common.py
+++ b/libs/partners/quickjs/tests/benchmarks/_common.py
@@ -45,7 +45,6 @@ class FakeChatModel(GenericFakeChatModel):
     messages: Iterator[AIMessage | str] = Field(exclude=True)
 
     def bind_tools(self, tools: Sequence[Any], **_: Any) -> FakeChatModel:
-        del tools
         return self
 
 

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -41,7 +41,7 @@ class TestQuickJSMemoryBenchmarks:
     ) -> None:
         def _worker(index: int) -> None:
             middleware = REPLMiddleware(
-                timeout=10.0,
+                timeout=20.0,
                 capture_console=True,
                 ptc=[echo_payload] if use_ptc else None,
             )

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -41,7 +41,7 @@ class TestQuickJSMemoryBenchmarks:
     ) -> None:
         def _worker(index: int) -> None:
             middleware = REPLMiddleware(
-                timeout=20.0,
+                timeout=45.0,
                 capture_console=True,
                 ptc=[echo_payload] if use_ptc else None,
             )

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -9,7 +9,6 @@ different thread counts and tool shapes.
 
 from __future__ import annotations
 
-import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
@@ -40,15 +39,12 @@ class TestQuickJSMemoryBenchmarks:
         code: str,
         use_ptc: bool,
     ) -> None:
-        start_barrier = threading.Barrier(thread_count)
-
         def _worker(index: int) -> None:
             middleware = REPLMiddleware(
                 capture_console=True,
                 ptc=[echo_payload] if use_ptc else None,
             )
             agent = make_agent(code=code, middleware=middleware, repeats=1)
-            start_barrier.wait()
             result = agent.invoke(
                 invoke_payload(),
                 config={"configurable": {"thread_id": f"memory-bench-{index}"}},

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -1,0 +1,91 @@
+"""Memory benchmarks for QuickJS REPL middleware.
+
+Run locally:  `make benchmark`
+Run with CodSpeed:  `uv run --group test pytest ./tests -m benchmark --codspeed`
+
+These tests exercise memory-targeted workloads for QuickJS eval execution under
+different thread counts and tool shapes.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import pytest
+
+from langchain_quickjs import REPLMiddleware
+from tests.benchmarks._common import (
+    CONSOLE_LOG_CODE,
+    PTC_ONLY_CODE,
+    assert_eval_succeeded,
+    echo_payload,
+    invoke_payload,
+    make_agent,
+)
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+
+@pytest.mark.memory_benchmark
+class TestQuickJSMemoryBenchmarks:
+    """Benchmarks that compare Python heap pressure under common REPL workloads."""
+
+    def _run_concurrent_memory_workload(
+        self,
+        *,
+        thread_count: int,
+        code: str,
+        use_ptc: bool,
+    ) -> None:
+        start_barrier = threading.Barrier(thread_count)
+
+        def _worker(index: int) -> None:
+            middleware = REPLMiddleware(
+                capture_console=True,
+                ptc=[echo_payload] if use_ptc else None,
+            )
+            agent = make_agent(code=code, middleware=middleware, repeats=1)
+            start_barrier.wait()
+            result = agent.invoke(
+                invoke_payload(),
+                config={"configurable": {"thread_id": f"memory-bench-{index}"}},
+            )
+            assert_eval_succeeded(result)
+
+        with ThreadPoolExecutor(max_workers=thread_count) as executor:
+            list(executor.map(_worker, range(thread_count)))
+
+    @pytest.mark.parametrize(
+        "thread_count", [1, 8, 32, 64], ids=lambda n: f"{n}_threads"
+    )
+    @pytest.mark.parametrize(
+        ("scenario", "code", "use_ptc"),
+        [
+            ("console_log", CONSOLE_LOG_CODE, False),
+            ("ptc_tools", PTC_ONLY_CODE, True),
+        ],
+        ids=["console_log", "ptc_tools"],
+    )
+    def test_repl_memory_peak(
+        self,
+        benchmark: BenchmarkFixture,
+        thread_count: int,
+        scenario: str,
+        code: str,
+        use_ptc: bool,
+    ) -> None:
+        """Measure memory-instrumented workload cost for each scenario."""
+
+        @benchmark
+        def _() -> None:
+            self._run_concurrent_memory_workload(
+                thread_count=thread_count,
+                code=code,
+                use_ptc=use_ptc,
+            )
+
+        benchmark.extra_info["scenario"] = scenario
+        benchmark.extra_info["thread_count"] = thread_count

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -41,6 +41,7 @@ class TestQuickJSMemoryBenchmarks:
     ) -> None:
         def _worker(index: int) -> None:
             middleware = REPLMiddleware(
+                timeout=10.0,
                 capture_console=True,
                 ptc=[echo_payload] if use_ptc else None,
             )

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
@@ -1,0 +1,140 @@
+"""Wall-time throughput benchmarks for QuickJS REPL middleware.
+
+Run locally:  `make benchmark`
+Run with CodSpeed:  `uv run --group test pytest ./tests -m benchmark --codspeed`
+
+These tests measure throughput for many single-thread eval iterations where the
+workload combines PTC tool calls with ``console.log`` output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from deepagents import create_deep_agent
+from langchain_core.messages import AIMessage
+
+from langchain_quickjs import REPLMiddleware
+from tests.benchmarks._common import (
+    PTC_AND_CONSOLE_CODE,
+    THROUGHPUT_ITERATIONS,
+    FakeChatModel,
+    assert_eval_succeeded,
+    echo_payload,
+    eval_tool_message,
+    invoke_payload,
+    make_agent,
+    tool_call_message,
+)
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+
+@pytest.mark.benchmark
+class TestQuickJSThroughputBenchmarks:
+    """Benchmarks that track eval throughput for hot single-thread loops."""
+
+    def _make_multi_turn_agent(
+        self,
+        *,
+        middleware: REPLMiddleware,
+        codes: list[str],
+    ) -> Any:
+        messages: list[AIMessage] = []
+        for index, code in enumerate(codes):
+            messages.append(tool_call_message(code, call_id=f"call_{index}"))
+            messages.append(AIMessage(content="done"))
+        return create_deep_agent(
+            model=FakeChatModel(messages=iter(messages)),
+            middleware=[middleware],
+        )
+
+    def _record_turn_metrics(
+        self,
+        *,
+        benchmark: BenchmarkFixture,
+        turns_per_round: int,
+    ) -> None:
+        benchmark.extra_info["turns_per_round"] = turns_per_round
+        stats = getattr(getattr(benchmark, "stats", None), "stats", None)
+        mean_seconds = getattr(stats, "mean", None)
+        if isinstance(mean_seconds, (int, float)) and mean_seconds > 0:
+            benchmark.extra_info["turns_per_second"] = round(
+                turns_per_round / mean_seconds,
+                3,
+            )
+
+    def test_single_thread_many_iterations_ptc_and_console_log(
+        self,
+        benchmark: BenchmarkFixture,
+    ) -> None:
+        """Measure throughput for many eval calls in one thread and process."""
+        middleware = REPLMiddleware(capture_console=True, ptc=[echo_payload])
+
+        @benchmark
+        def _() -> None:
+            agent = make_agent(
+                code=PTC_AND_CONSOLE_CODE,
+                middleware=middleware,
+                repeats=THROUGHPUT_ITERATIONS,
+            )
+            for _ in range(THROUGHPUT_ITERATIONS):
+                result = agent.invoke(
+                    invoke_payload(),
+                    config={"configurable": {"thread_id": "throughput-bench-thread"}},
+                )
+                assert_eval_succeeded(result)
+
+        benchmark.extra_info["thread_count"] = 1
+        benchmark.extra_info["iterations_per_round"] = THROUGHPUT_ITERATIONS
+        benchmark.extra_info["workload"] = "ptc_tools_plus_console_log"
+        self._record_turn_metrics(
+            benchmark=benchmark,
+            turns_per_round=THROUGHPUT_ITERATIONS,
+        )
+
+    def test_single_thread_multi_turn(
+        self,
+        benchmark: BenchmarkFixture,
+    ) -> None:
+        """Measure two-turn throughput while verifying same-context persistence."""
+        middleware = REPLMiddleware(capture_console=True)
+        turn_count = THROUGHPUT_ITERATIONS // 2
+        codes: list[str] = []
+        for index in range(turn_count):
+            token = f"token-{index}"
+            codes.extend(
+                [
+                    f"globalThis.__benchToken = '{token}'; globalThis.__benchToken;",
+                    "globalThis.__benchToken;",
+                ]
+            )
+
+        @benchmark
+        def _() -> None:
+            agent = self._make_multi_turn_agent(middleware=middleware, codes=codes)
+            for index in range(turn_count):
+                set_result = agent.invoke(
+                    invoke_payload(),
+                    config={"configurable": {"thread_id": "multi-turn-bench-thread"}},
+                )
+                assert_eval_succeeded(set_result)
+                expected = f"token-{index}"
+                assert expected in eval_tool_message(set_result).content
+
+                read_result = agent.invoke(
+                    invoke_payload(),
+                    config={"configurable": {"thread_id": "multi-turn-bench-thread"}},
+                )
+                assert_eval_succeeded(read_result)
+                assert expected in eval_tool_message(read_result).content
+
+        benchmark.extra_info["thread_count"] = 1
+        benchmark.extra_info["pairs_per_round"] = turn_count
+        benchmark.extra_info["workload"] = "multi_turn_same_context_persistence"
+        self._record_turn_metrics(
+            benchmark=benchmark,
+            turns_per_round=turn_count * 2,
+        )

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
@@ -9,6 +9,7 @@ workload combines PTC tool calls with ``console.log`` output.
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -115,10 +116,11 @@ class TestQuickJSThroughputBenchmarks:
         @benchmark
         def _() -> None:
             agent = self._make_multi_turn_agent(middleware=middleware, codes=codes)
+            thread_id = f"multi-turn-bench-thread-{uuid.uuid4().hex}"
             for index in range(turn_count):
                 set_result = agent.invoke(
                     invoke_payload(),
-                    config={"configurable": {"thread_id": "multi-turn-bench-thread"}},
+                    config={"configurable": {"thread_id": thread_id}},
                 )
                 assert_eval_succeeded(set_result)
                 expected = f"token-{index}"
@@ -126,7 +128,7 @@ class TestQuickJSThroughputBenchmarks:
 
                 read_result = agent.invoke(
                     invoke_payload(),
-                    config={"configurable": {"thread_id": "multi-turn-bench-thread"}},
+                    config={"configurable": {"thread_id": thread_id}},
                 )
                 assert_eval_succeeded(read_result)
                 assert expected in eval_tool_message(read_result).content

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
@@ -9,7 +9,6 @@ workload combines PTC tool calls with ``console.log`` output.
 
 from __future__ import annotations
 
-import uuid
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -23,7 +22,6 @@ from tests.benchmarks._common import (
     FakeChatModel,
     assert_eval_succeeded,
     echo_payload,
-    eval_tool_message,
     invoke_payload,
     make_agent,
     tool_call_message,
@@ -94,49 +92,4 @@ class TestQuickJSThroughputBenchmarks:
         self._record_turn_metrics(
             benchmark=benchmark,
             turns_per_round=THROUGHPUT_ITERATIONS,
-        )
-
-    def test_single_thread_multi_turn(
-        self,
-        benchmark: BenchmarkFixture,
-    ) -> None:
-        """Measure two-turn throughput while verifying same-context persistence."""
-        middleware = REPLMiddleware(capture_console=True)
-        turn_count = THROUGHPUT_ITERATIONS // 2
-        codes: list[str] = []
-        for index in range(turn_count):
-            token = f"token-{index}"
-            codes.extend(
-                [
-                    f"globalThis.__benchToken = '{token}'; globalThis.__benchToken;",
-                    "globalThis.__benchToken;",
-                ]
-            )
-
-        @benchmark
-        def _() -> None:
-            agent = self._make_multi_turn_agent(middleware=middleware, codes=codes)
-            thread_id = f"multi-turn-bench-thread-{uuid.uuid4().hex}"
-            for index in range(turn_count):
-                set_result = agent.invoke(
-                    invoke_payload(),
-                    config={"configurable": {"thread_id": thread_id}},
-                )
-                assert_eval_succeeded(set_result)
-                expected = f"token-{index}"
-                assert expected in eval_tool_message(set_result).content
-
-                read_result = agent.invoke(
-                    invoke_payload(),
-                    config={"configurable": {"thread_id": thread_id}},
-                )
-                assert_eval_succeeded(read_result)
-                assert expected in eval_tool_message(read_result).content
-
-        benchmark.extra_info["thread_count"] = 1
-        benchmark.extra_info["pairs_per_round"] = turn_count
-        benchmark.extra_info["workload"] = "multi_turn_same_context_persistence"
-        self._record_turn_metrics(
-            benchmark=benchmark,
-            turns_per_round=turn_count * 2,
         )

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -16,7 +16,7 @@ from quickjs_rs import Runtime, ThreadWorker
 
 from langchain_quickjs import REPLMiddleware
 from langchain_quickjs._format import format_outcome
-from langchain_quickjs._repl import _Registry, _ThreadREPL
+from langchain_quickjs._repl import _Registry, _ThreadREPL, _clear_exception_references
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -274,6 +274,26 @@ def test_middleware_del_closes_runtime() -> None:
         assert close_spy.called
 
 
+def test_clear_exception_references_removes_traceback_links() -> None:
+    """Clears traceback/context/cause to avoid cross-thread GC cycles."""
+    first = RuntimeError("first")
+    try:
+        raise ValueError("outer")
+    except ValueError:
+        try:
+            raise first
+        except RuntimeError as caught:
+            second = RuntimeError("second")
+            caught.__cause__ = second
+            assert caught.__traceback__ is not None
+            assert caught.__context__ is not None
+            assert caught.__cause__ is not None
+            _clear_exception_references(caught)
+            assert caught.__traceback__ is None
+            assert caught.__context__ is None
+            assert caught.__cause__ is None
+
+
 def test_per_thread_slot_has_own_worker_and_runtime() -> None:
     """Each thread_id gets its own ThreadWorker and Runtime — not shared."""
     reg = _Registry(memory_limit=32 * 1024 * 1024, timeout=5.0, capture_console=True)
@@ -296,8 +316,13 @@ def test_evict_closes_and_removes_slot() -> None:
     try:
         reg.get("thread-a")
         rt = reg._slots["thread-a"].runtime
-        with patch.object(rt, "close", wraps=rt.close) as close_spy:
+        repl = reg._slots["thread-a"].repl
+        with (
+            patch.object(repl, "close", wraps=repl.close) as repl_close_spy,
+            patch.object(rt, "close", wraps=rt.close) as close_spy,
+        ):
             reg.evict("thread-a")
+        assert repl_close_spy.called
         assert close_spy.called
         assert "thread-a" not in reg._slots
     finally:
@@ -334,8 +359,13 @@ async def test_aevict_closes_and_removes_slot() -> None:
     try:
         reg.get("thread-a")
         rt = reg._slots["thread-a"].runtime
-        with patch.object(rt, "close", wraps=rt.close) as close_spy:
+        repl = reg._slots["thread-a"].repl
+        with (
+            patch.object(repl, "_aclose", wraps=repl._aclose) as repl_close_spy,
+            patch.object(rt, "close", wraps=rt.close) as close_spy,
+        ):
             await reg.aevict("thread-a")
+        assert repl_close_spy.called
         assert close_spy.called
         assert "thread-a" not in reg._slots
     finally:

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -16,7 +16,7 @@ from quickjs_rs import Runtime, ThreadWorker
 
 from langchain_quickjs import REPLMiddleware
 from langchain_quickjs._format import format_outcome
-from langchain_quickjs._repl import _Registry, _ThreadREPL, _clear_exception_references
+from langchain_quickjs._repl import _clear_exception_references, _Registry, _ThreadREPL
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -276,22 +276,29 @@ def test_middleware_del_closes_runtime() -> None:
 
 def test_clear_exception_references_removes_traceback_links() -> None:
     """Clears traceback/context/cause to avoid cross-thread GC cycles."""
-    first = RuntimeError("first")
-    try:
-        raise ValueError("outer")
-    except ValueError:
+    outer_msg = "outer"
+    first_msg = "first"
+    second_msg = "second"
+
+    def _raise_outer() -> None:
+        raise ValueError(outer_msg)
+
+    def _raise_with_links() -> None:
         try:
-            raise first
-        except RuntimeError as caught:
-            second = RuntimeError("second")
-            caught.__cause__ = second
-            assert caught.__traceback__ is not None
-            assert caught.__context__ is not None
-            assert caught.__cause__ is not None
-            _clear_exception_references(caught)
-            assert caught.__traceback__ is None
-            assert caught.__context__ is None
-            assert caught.__cause__ is None
+            _raise_outer()
+        except ValueError:
+            raise RuntimeError(first_msg) from RuntimeError(second_msg)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _raise_with_links()
+    caught = exc_info.value
+    assert caught.__traceback__ is not None
+    assert caught.__context__ is not None
+    assert caught.__cause__ is not None
+    _clear_exception_references(caught)
+    assert caught.__traceback__ is None
+    assert caught.__context__ is None
+    assert caught.__cause__ is None
 
 
 def test_per_thread_slot_has_own_worker_and_runtime() -> None:
@@ -361,7 +368,7 @@ async def test_aevict_closes_and_removes_slot() -> None:
         rt = reg._slots["thread-a"].runtime
         repl = reg._slots["thread-a"].repl
         with (
-            patch.object(repl, "_aclose", wraps=repl._aclose) as repl_close_spy,
+            patch.object(repl, "aclose", wraps=repl.aclose) as repl_close_spy,
             patch.object(rt, "close", wraps=rt.close) as close_spy,
         ):
             await reg.aevict("thread-a")

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -889,6 +889,8 @@ test = [
     { name = "build" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
@@ -913,6 +915,8 @@ test = [
     { name = "build" },
     { name = "pytest", specifier = ">=7.3.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
     { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
@@ -1198,6 +1202,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1389,6 +1402,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/1e/213eb4d263140fb907e9fcc5813fdcadb864d6832bf8e2d3f7fd88ca0096/pytest_codspeed-4.5.0.tar.gz", hash = "sha256:deb6ab9c9b07eba56fcb7b97206c7e48aaff697b6f73a013d8dbe4f62e76afd3", size = 209664, upload-time = "2026-04-28T13:12:17.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/f9/be1fa43649c9f71cc06d9f2330fb1cac3beddf6357effc9a1817f4831728/pytest_codspeed-4.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b6da6f26435512110736dd258021bbf7859caf4d2a21c7ed06a86b67a999fac7", size = 222523, upload-time = "2026-04-28T13:11:54.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/89/9237a2d569b60f84183f6ae6193c6a4a135e5644ee08fed44bcf03d26545/pytest_codspeed-4.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be191120b1cb0252b443ef37887c94772bab4ca0c42cad7c15bcbcfcbb656ac4", size = 822696, upload-time = "2026-04-28T13:11:55.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/15/7dd0a37fb85e19d8b2b7366f9615c4e17335f23060275dcfa792ce8b482f/pytest_codspeed-4.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474730e996d424b17f7301d4b846261cca92d195b9fcb7de38599be9d68ee9ac", size = 823671, upload-time = "2026-04-28T13:11:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/3d/bf21b10c6d497378785b47e9cefcfc4a43e543443e120c03469940f14a61/pytest_codspeed-4.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db706a7a4200e8e236c31c77935fedcc0edbf44959ab8c156297909d9e8cfd33", size = 222601, upload-time = "2026-04-28T13:11:58.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/65/97823f28ae60921bf353773490906f9095e9d208a6d4bec2e7913695a5e6/pytest_codspeed-4.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac844078bd8760e7fc66debe1e90b4593dfce15f60f26b334e1137d4902df3a9", size = 822916, upload-time = "2026-04-28T13:11:59.648Z" },
+    { url = "https://files.pythonhosted.org/packages/95/10/4763d26e8255f243c96e39543d398afb2c64900d3785b8af1898b23a6ce0/pytest_codspeed-4.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66ecd52a277a5e5f0013e29084b49f9c5f60026d0585f58b86463cb188df5029", size = 823963, upload-time = "2026-04-28T13:12:00.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7b/8108a06fcad6160759efc0a1d44e359414a4d23e52bb7079ca95be24058e/pytest_codspeed-4.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fcc3309d046082a6e0dbd1d9f2bc5c83b0446c93ff011e3880b47c69bf8042cf", size = 222602, upload-time = "2026-04-28T13:12:01.974Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b4/4a43ce824cabe2ab8a727e31f90aa403dd2cd580576057024065a3ea74a3/pytest_codspeed-4.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12b49954268ed6828ce5a8d87aff13888946c254bff4ef9472bb4d5ae5272667", size = 822868, upload-time = "2026-04-28T13:12:02.988Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f0/a319da002c800915b9f6a63b2da1e6cdd3230cafb9dea255cec4033e85f8/pytest_codspeed-4.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbeeb76d98335037670068c0d30319415f896e9c37eca510249b74684b460925", size = 823928, upload-time = "2026-04-28T13:12:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5b/d46caecce8aa7519477df75351e312203a20836bec2fcc15256ec34c001b/pytest_codspeed-4.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1b73f71e7cb5c83cf5d765d5ca39d08bb1090a9d2d2268496a22ca24b1776e3a", size = 222618, upload-time = "2026-04-28T13:12:05.482Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1d/8f34de29cfc3516df25a4553a6d7912735fbde9a276d448b1e00eb35a345/pytest_codspeed-4.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:399e146240a52458aa4b5fc861a88551bc52eb9e2d30c8f8b328ddebc084e4f6", size = 822814, upload-time = "2026-04-28T13:12:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3d/089614f7bd75fee1388885b886c3f6c1a332ffdce28a4b6b77d3aac7014f/pytest_codspeed-4.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4b43f59d1c31e7c193567369f767647e466f95126671c90be084c58633544f", size = 823857, upload-time = "2026-04-28T13:12:08.081Z" },
+    { url = "https://files.pythonhosted.org/packages/df/69/5f4a032df6508e8c59049b2fcfce568b79e40b82878df12a2e401a034336/pytest_codspeed-4.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4ef8651294386c032d86070893f8349929280162cf22210dbd488697ce26de21", size = 222781, upload-time = "2026-04-28T13:12:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/86a1efde2968bfc83e4fcd60ef1a1094be7f83460799296a12d563522a67/pytest_codspeed-4.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca31f5d0e783823a78442d5434382eb32f3885153d1833eb645c92d0c499470b", size = 828703, upload-time = "2026-04-28T13:12:10.502Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4e/eae070c50cb82e44f831dd5b24c854cb641906732bdf74f6314e71c1f266/pytest_codspeed-4.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:16ddd1a9f2dc0615479b2ba3f445a2e3587ce1316296fc79224700e73db06408", size = 829278, upload-time = "2026-04-28T13:12:11.879Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/8dd5e44a5518ba3cd1d63d1f2e631e318330d28cfbe15e548e89d429e289/pytest_codspeed-4.5.0-py3-none-any.whl", hash = "sha256:b19bfb734dcbd47b78022285a6eb9f2bf6331ef1bb8c15c2775058945d5f4ce3", size = 214090, upload-time = "2026-04-28T13:12:16.755Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a memory benchmark mode to CI, adds a benchmark suite for quickjs, and wires it into CI so benchmark regressions

## Changes

- Add QuickJS benchmark test modules under `tests/benchmarks` using fake chat models:
  - memory-focused scenarios (`console.log` and PTC tool usage) with parameterized concurrency
  - throughput-focused scenarios including repeated single-thread runs and multi-turn same-context persistence on a shared `thread_id`
- Add a `benchmark` make target for QuickJS package benchmark execution.
- Register benchmark-related pytest markers in QuickJS test config and add benchmark dependencies (`pytest-benchmark`, `pytest-codspeed`).
- Extend reusable CodSpeed workflow (`_benchmark.yml`) with optional memory-mode execution behind `has-memory-benchmarks`.
- Add a QuickJS benchmark job in `ci.yml` that:
  - runs on QuickJS package changes
  - enables memory benchmark mode for QuickJS
  - is included in the `ci_success` required job aggregation
- Update QuickJS change detection filters so `_benchmark.yml` changes also trigger QuickJS benchmark CI.
