### PR TITLE
feat(sdk): add opt-in general-purpose middleware propagation

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -211,6 +211,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     *,
     system_prompt: str | SystemMessage | None = None,
     middleware: Sequence[AgentMiddleware] = (),
+    propagate_middleware_to_general_purpose: bool = False,
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
@@ -315,6 +316,24 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             `ValueError`, as does excluding scaffolding classes
             (`FilesystemMiddleware`, `SubAgentMiddleware`,
             `_PermissionMiddleware`).
+        propagate_middleware_to_general_purpose: Whether to add the
+            caller-provided `middleware` sequence to the auto-added
+            `general-purpose` subagent.
+
+            This is opt-in for backwards compatibility. When enabled, the
+            middleware is inserted into the default `general-purpose` stack at
+            the same relative position used by the main agent: after the base
+            Deep Agents middleware (including `SkillsMiddleware`, when
+            configured) and before harness-profile extras, prompt caching, and
+            permission middleware. If `interrupt_on` is inherited by the
+            subagent, `SubAgentMiddleware` still applies human-in-the-loop
+            handling after this assembled stack.
+
+            This option only affects the default `general-purpose` subagent
+            that `create_deep_agent` adds automatically. If `subagents`
+            includes a synchronous or compiled subagent named
+            `general-purpose`, that explicit spec remains the override and
+            only uses the middleware declared on that spec.
         subagents: Subagent specs available to the main agent.
 
             This collection supports three forms:
@@ -582,6 +601,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         ]
         if skills is not None:
             gp_middleware.append(SkillsMiddleware(backend=backend, sources=skills))
+
+        if propagate_middleware_to_general_purpose and middleware:
+            gp_middleware.extend(middleware)
 
         # Add harness-profile middleware, if any
         gp_middleware.extend(_profile.materialize_extra_middleware())

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -38,7 +38,7 @@ from deepagents.profiles.harness.harness_profiles import (
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from langchain.agents.middleware.types import ModelRequest
 
@@ -705,6 +705,81 @@ class _OtherStubMW(AgentMiddleware[Any, Any, Any]):
 
 class _StubSubMW(_StubMW):
     """Subclass of `_StubMW` used to verify exact-type (not isinstance) exclusion."""
+
+
+class TestGeneralPurposeMiddlewarePropagation:
+    """Tests for opt-in user middleware propagation to the default general-purpose subagent."""
+
+    def _capture_main_and_general_purpose_stacks(
+        self,
+        *,
+        middleware: Sequence[AgentMiddleware[Any, Any, Any]],
+        **kwargs: Any,
+    ) -> tuple[list[AgentMiddleware[Any, Any, Any]], list[AgentMiddleware[Any, Any, Any]]]:
+        """Run `create_deep_agent` and return the main and default GP middleware stacks."""
+        fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+
+        with (
+            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents.graph.SubAgentMiddleware", return_value=MagicMock()) as mock_subagents,
+            patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+        ):
+            create_deep_agent(
+                model="testprov:some-model",
+                middleware=middleware,
+                **kwargs,
+            )
+
+        main_stack = mock_create.call_args.kwargs["middleware"]
+        subagents = mock_subagents.call_args.kwargs["subagents"]
+        general_purpose = next(spec for spec in subagents if spec["name"] == "general-purpose")
+        return main_stack, general_purpose["middleware"]
+
+    def test_general_purpose_does_not_inherit_user_middleware_by_default(self) -> None:
+        """Caller middleware remains parent-only unless propagation is explicitly enabled."""
+        custom = _StubMW()
+
+        main_stack, gp_stack = self._capture_main_and_general_purpose_stacks(
+            middleware=[custom],
+        )
+
+        assert any(m is custom for m in main_stack), "caller middleware missing from main stack"
+        assert not any(m is custom for m in gp_stack), "caller middleware leaked into default general-purpose stack"
+
+    def test_general_purpose_inherits_user_middleware_when_enabled(self) -> None:
+        """The opt-in flag adds caller middleware to the auto-added general-purpose subagent."""
+        custom = _StubMW()
+
+        main_stack, gp_stack = self._capture_main_and_general_purpose_stacks(
+            middleware=[custom],
+            propagate_middleware_to_general_purpose=True,
+        )
+
+        assert any(m is custom for m in main_stack), "caller middleware missing from main stack"
+        assert any(m is custom for m in gp_stack), "caller middleware missing from default general-purpose stack"
+
+    def test_explicit_general_purpose_subagent_is_not_augmented(self) -> None:
+        """An explicit `general-purpose` spec remains the override path."""
+        parent_middleware = _StubMW()
+        explicit_middleware = _OtherStubMW()
+
+        _, gp_stack = self._capture_main_and_general_purpose_stacks(
+            middleware=[parent_middleware],
+            propagate_middleware_to_general_purpose=True,
+            subagents=[
+                {
+                    "name": "general-purpose",
+                    "description": "Caller-owned general-purpose subagent.",
+                    "system_prompt": "Handle delegated work.",
+                    "middleware": [explicit_middleware],
+                }
+            ],
+        )
+
+        assert any(m is explicit_middleware for m in gp_stack), "explicit subagent middleware was not preserved"
+        assert not any(m is parent_middleware for m in gp_stack), "parent middleware was added to an explicit general-purpose spec"
 
 
 class TestMiddlewareExclusionWiring:


### PR DESCRIPTION
Closes #2744

---

Adds `propagate_middleware_to_general_purpose` as a backwards-compatible opt-in for callers who want `create_deep_agent(middleware=...)` entries to also run inside the auto-added `general-purpose` subagent.

The default remains parent-only to avoid surprising existing users. When enabled, caller middleware is inserted after the default Deep Agents subagent stack and before harness-profile extras, prompt caching, and permission middleware, matching the main agent's extension point. Explicit `general-purpose` subagents remain the override path and are not augmented by this flag.

Validated with `make lint_diff` and the full SDK unit suite.
