### PR TITLE
fix(sdk): map bare OSError to io_error in filesystem backend

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -734,7 +734,7 @@ class FilesystemBackend(BackendProtocol):
         return responses
 
 
-def _map_exception_to_standard_error(exc: Exception) -> FileOperationError | None:
+def _map_exception_to_standard_error(exc: Exception) -> FileOperationError | None:  # noqa: PLR0911
     """Map a caught exception to a standardized `FileOperationError` code.
 
     Classification is based on exception type only (stdlib hierarchy).
@@ -757,4 +757,17 @@ def _map_exception_to_standard_error(exc: Exception) -> FileOperationError | Non
         return "invalid_path"
     if isinstance(exc, ValueError):
         return "invalid_path"
+    # Generic OSError catch-all so that errno cases without a dedicated
+    # subclass (ELOOP, ENAMETOOLONG, EIO, transient FS issues) become a
+    # per-file response instead of bubbling up and tearing down the agent.
+    # In particular, ELOOP fires from `os.open(..., O_NOFOLLOW)` when the
+    # final path component is a symlink — common for skill registries that
+    # point SKILL.md files at a canonical location via symlinks.
+    if isinstance(exc, OSError):
+        return "io_error"
+    # Python 3.12+'s `pathlib.Path.resolve()` raises a bare `RuntimeError`
+    # (not OSError) when it detects a symlink cycle. Same intent: surface
+    # as a recoverable per-file error instead of crashing the caller.
+    if isinstance(exc, RuntimeError) and "symlink loop" in str(exc).lower():
+        return "io_error"
     return None

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -35,6 +35,7 @@ FileOperationError = Literal[
     "permission_denied",
     "is_directory",
     "invalid_path",
+    "io_error",
 ]
 """Standardized error codes for file upload/download operations.
 
@@ -45,6 +46,10 @@ potentially fix:
 - permission_denied: Access denied for the operation
 - is_directory: Attempted to download a directory as a file
 - invalid_path: Path syntax is malformed or contains invalid characters
+- io_error: Generic OS-level filesystem error (e.g. ELOOP from a symlink
+  targeted by O_NOFOLLOW, ENAMETOOLONG, transient I/O failure). Distinct
+  from invalid_path so callers can tell user-fixable path issues from
+  environment-level failures.
 """
 
 

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -386,6 +386,37 @@ def test_filesystem_download_errors(tmp_path: Path):
     assert responses[0].content is None
 
 
+def test_filesystem_download_oserror_returns_io_error(tmp_path: Path):
+    """Bare OSError surfaces as a per-path `io_error` response, not a raise.
+
+    Simulated with a symlink cycle, which makes `Path.resolve()` raise
+    `OSError(ELOOP)` on POSIX systems.
+
+    Regression: previously such errors fell through `_map_exception_to_
+    standard_error` (returned None) and `download_files` re-raised, which
+    in agent contexts surfaced as a generic 'An internal error occurred'
+    that aborted the entire run.
+    """
+    if not hasattr(__import__("os"), "symlink"):
+        pytest.skip("symlinks not available on this platform")
+
+    root = tmp_path
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+
+    # A → B → A (cycle). Path.resolve() raises OSError(ELOOP).
+    a = root / "a.txt"
+    b = root / "b.txt"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    responses = be.download_files(["/a.txt"])
+    assert len(responses) == 1
+    assert responses[0].path == "/a.txt"
+    assert responses[0].content is None
+    # Must be a recognized error code, not a raised exception.
+    assert responses[0].error == "io_error"
+
+
 def test_filesystem_upload_errors(tmp_path: Path):
     """Test upload error handling."""
     root = tmp_path

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -218,10 +218,30 @@ class TestMapFileOperationError:
         assert _map_exception_to_standard_error(exc) == expected
 
     def test_unrecognized_returns_none(self) -> None:
-        """Non-stdlib exception types return None regardless of message."""
+        """Non-OS exception types return None regardless of message."""
         assert _map_exception_to_standard_error(RuntimeError("something else")) is None
         assert _map_exception_to_standard_error(RuntimeError("permission denied")) is None
-        assert _map_exception_to_standard_error(OSError("is a directory")) is None
+
+    def test_bare_oserror_maps_to_io_error(self) -> None:
+        """Bare OSError (and errno-only subclasses) map to io_error.
+
+        Errno-only subclasses without a dedicated stdlib class (ELOOP,
+        ENAMETOOLONG, EIO) need a generic catch so callers return a per-path
+        error response instead of re-raising.
+        """
+        assert _map_exception_to_standard_error(OSError("generic")) == "io_error"
+        # ELOOP — what motivated adding io_error in the first place
+        eloop = OSError(62, "Too many levels of symbolic links")
+        assert _map_exception_to_standard_error(eloop) == "io_error"
+
+    def test_pathlib_symlink_loop_runtime_error_maps_to_io_error(self) -> None:
+        """Python 3.12+ pathlib `Symlink loop` RuntimeError also maps to io_error.
+
+        On 3.12+, `Path.resolve()` raises a bare RuntimeError on cycles
+        instead of OSError. Same recoverable failure mode, just a different
+        exception type per Python version.
+        """
+        assert _map_exception_to_standard_error(RuntimeError("Symlink loop from /x")) == "io_error"
 
     def test_value_error_maps_to_invalid_path(self) -> None:
         """All ValueError instances map to invalid_path regardless of message."""


### PR DESCRIPTION
Fixes #3011

## Bug

`FilesystemBackend.download_files` re-raises any exception not classified by
`_map_exception_to_standard_error`. The classifier whitelists specific stdlib
subclasses (`FileNotFoundError`, `PermissionError`, `IsADirectoryError`,
`NotADirectoryError`, `FileExistsError`, `ValueError`) and returns `None` for
everything else — including bare `OSError`.

This breaks `SkillsMiddleware` against any skill registry where `SKILL.md`
files are symlinks (Claude Code's `~/.claude/skills` is one such registry):

- `os.open(resolved_path, O_RDONLY | O_NOFOLLOW)` raises `OSError(ELOOP)` if
  the final path component is a symlink.
- On Python 3.12+, `Path.resolve()` raises a bare `RuntimeError("Symlink loop ...")`
  on cycles instead of `OSError`.

Either shape falls through the classifier, gets re-raised by `download_files`,
and surfaces in the agent loop as a generic `langgraph_api` `'An internal
error occurred'` (because `langgraph_api/serde.py` only un-strips messages
for a hard whitelist of exception types). The actual filename and errno are
hidden, which makes this very hard to diagnose.

## Reproduction

A user with a symlinked SKILL.md (we hit it via the `gstack` skill bundle in
`~/.claude/skills/`):

```bash
mkdir -p /tmp/skills/myskill
echo "..." > /tmp/canonical_skill.md
ln -s /tmp/canonical_skill.md /tmp/skills/myskill/SKILL.md
# Then any agent created with enable_skills=True and source /tmp/skills aborts
# on first invocation with: RemoteException: {'error': 'OSError', 'message':
# 'An internal error occurred'}
```

A more deterministic reproduction (added as a test) creates a symlink cycle
`a -> b -> a`; `Path.resolve()` then raises and `download_files` aborts.

## Fix

- New `FileOperationError` code `io_error` for generic OS-level filesystem
  failures (ELOOP, ENAMETOOLONG, EIO, transient I/O).
- `_map_exception_to_standard_error` catches bare `OSError` after the
  specific subclasses, and also catches Py3.12+'s
  `RuntimeError("Symlink loop ...")`.
- New tests: cycle-based `download_files` regression + direct classifier
  tests for both exception shapes.
- One existing test (`test_unrecognized_returns_none`, which asserted bare
  OSError returned `None`) updated to reflect the new contract.

`pytest tests/unit_tests/backends/`: 73 passed.
`pytest tests/unit_tests/`: 632 passed (+2 xfailed unrelated).