### PR TITLE
feat(cli): surface server log tail on agent failure in non-interactive mode

### DIFF
--- a/libs/cli/deepagents_cli/non_interactive.py
+++ b/libs/cli/deepagents_cli/non_interactive.py
@@ -977,7 +977,7 @@ async def run_non_interactive(
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
             interactive=False,
-        ) as (agent, _server_proc):
+        ) as (agent, server_proc):
             # Collect MCP preload result (ran concurrently with server startup)
             if mcp_task is not None:
                 try:
@@ -997,17 +997,43 @@ async def run_non_interactive(
 
             file_op_tracker = FileOpTracker(assistant_id=assistant_id, backend=None)
 
-            await _run_agent_loop(
-                agent,
-                message,
-                config,
-                console,
-                file_op_tracker,
-                quiet=quiet,
-                stream=stream,
-                message_kwargs=message_kwargs,
-                thread_url_lookup=thread_url_lookup,
-            )
+            try:
+                await _run_agent_loop(
+                    agent,
+                    message,
+                    config,
+                    console,
+                    file_op_tracker,
+                    quiet=quiet,
+                    stream=stream,
+                    message_kwargs=message_kwargs,
+                    thread_url_lookup=thread_url_lookup,
+                )
+            except BaseException:
+                # Surface server-side log tail before the server context
+                # exits and the log file may be cleaned up. Without this,
+                # `langgraph_api` errors reach the client as a generic
+                # "An internal error occurred" because the wire format
+                # strips messages for types outside its whitelist (OSError,
+                # ImportError, etc.) — the real cause sits in the server
+                # log only. Best-effort: any failure to read the log is
+                # silently swallowed so the original exception propagates
+                # cleanly to the outer handlers, which decide the exit
+                # code.
+                if server_proc is not None:
+                    try:
+                        log_tail = server_proc.tail_log()
+                    except Exception:  # noqa: BLE001
+                        log_tail = ""
+                    if log_tail.strip():
+                        console.print(
+                            "\n[dim]── server log (last lines) ──[/dim]"
+                        )
+                        console.print(escape_markup(log_tail), highlight=False)
+                        console.print(
+                            "[dim]── end server log ──[/dim]\n"
+                        )
+                raise
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted[/yellow]")

--- a/libs/cli/deepagents_cli/server.py
+++ b/libs/cli/deepagents_cli/server.py
@@ -352,6 +352,28 @@ class ServerProcess:
             )
             return ""
 
+    def tail_log(self, n_lines: int = 80) -> str:
+        r"""Return the last `n_lines` of the server log (best-effort).
+
+        Useful for surfacing the actual server-side traceback after a
+        `RemoteException` reaches the client with a sanitized message such
+        as `'An internal error occurred'` — `langgraph_api` strips messages
+        for exception types outside its serialization whitelist, so the
+        client otherwise sees only the type name.
+
+        Args:
+            n_lines: Maximum number of trailing lines to return.
+
+        Returns:
+            Up to `n_lines` lines from the end of the log, joined by `\n`.
+            Empty string if the log file is unavailable or unreadable.
+        """
+        raw = self._read_log_file()
+        if not raw:
+            return ""
+        lines = raw.splitlines()
+        return "\n".join(lines[-n_lines:])
+
     async def start(
         self,
         *,

--- a/libs/cli/tests/unit_tests/test_server.py
+++ b/libs/cli/tests/unit_tests/test_server.py
@@ -286,3 +286,58 @@ class TestServerProcess:
         assert os.environ.get("DEEPAGENTS_CLI_SERVER_MODEL") == old_value
         # Overrides NOT cleared (available for retry)
         assert "DEEPAGENTS_CLI_SERVER_MODEL" in server._env_overrides
+
+
+class TestServerProcessTailLog:
+    """`tail_log` surfaces the trailing portion of the server log file.
+
+    This is what `non_interactive` prints when `RemoteException` reaches the
+    client with a sanitized `'An internal error occurred'` message — without
+    it, the actual server-side traceback is invisible to the user.
+    """
+
+    def _server_with_log_file(self, tmp_path: Path, content: str) -> ServerProcess:
+        log_path = tmp_path / "server.log"
+        log_path.write_text(content)
+        log_file = MagicMock()
+        log_file.name = str(log_path)
+        log_file.flush = MagicMock()
+
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+        server = ServerProcess(config_dir=config_dir, owns_config_dir=False)
+        server._log_file = log_file
+        return server
+
+    def test_returns_last_n_lines(self, tmp_path: Path) -> None:
+        content = "\n".join(f"line {i}" for i in range(1, 200))
+        server = self._server_with_log_file(tmp_path, content)
+
+        out = server.tail_log(n_lines=10)
+
+        lines = out.splitlines()
+        assert len(lines) == 10
+        assert lines[0] == "line 190"
+        assert lines[-1] == "line 199"
+
+    def test_returns_full_log_when_shorter_than_n_lines(self, tmp_path: Path) -> None:
+        server = self._server_with_log_file(tmp_path, "only one line")
+        assert server.tail_log(n_lines=80) == "only one line"
+
+    def test_returns_empty_when_no_log_file(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+        server = ServerProcess(config_dir=config_dir, owns_config_dir=False)
+        server._log_file = None
+        assert server.tail_log() == ""
+
+    def test_returns_empty_on_read_error(self, tmp_path: Path) -> None:
+        log_file = MagicMock()
+        log_file.name = "/no/such/path/that/exists.log"
+        log_file.flush = MagicMock()
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+        server = ServerProcess(config_dir=config_dir, owns_config_dir=False)
+        server._log_file = log_file
+        # Read fails internally; tail_log returns "" without raising.
+        assert server.tail_log() == ""


### PR DESCRIPTION
Fixes #3012

## Why

When the langgraph dev server raises an exception whose type is outside
`langgraph_api/serde.py`'s serialization whitelist (OSError, ImportError,
RuntimeError, etc.), the wire format strips the message and the CLI surfaces:

```
RemoteException: {'error': 'OSError', 'message': 'An internal error occurred'}
```

The actual filename, errno, and traceback already sit in
`\$TMPDIR/deepagents_server_log_*.txt`, written by `ServerProcess`. The CLI
just never shows them. This makes every wire-stripped error look identical —
a symlink loop, a missing import in a middleware, a permission issue, a
transient network blip — all appear as `'An internal error occurred'`.

In our case (#3011) it took ~30 minutes of guess-and-check + locally
patching upstream `langgraph_api/serde.py` to expose `str(obj)` before the
real cause (`OSError(ELOOP)` on a symlinked `SKILL.md`) became visible.

## What

Two small changes in `libs/cli/deepagents_cli/`:

- `ServerProcess.tail_log(n_lines=80)`: public best-effort accessor that
  returns the trailing portion of the existing server log file.
  Reuses the private `_read_log_file()` helper.
- `non_interactive.run_non_interactive`: wrap `_run_agent_loop` in a
  `BaseException` catch INSIDE the `server_session` context; on failure,
  dump the server log tail to the user's console before re-raising. The
  existing outer exception handlers keep choosing the exit code; this only
  adds visibility, doesn't change control flow.

## After

```
$ deepagents -n "hi" -q --no-mcp
...
── server log (last lines) ──
... full server-side traceback ...
[Errno 62] Too many levels of symbolic links:
'/Users/<me>/.claude/skills/<skill>/SKILL.md'
── end server log ──

Unexpected error (RemoteException): {'error': 'OSError', 'message': 'An internal error occurred'}
```

The original RemoteException still propagates and exit codes are unchanged;
the user just gets the actual cause.

## Tests

- 4 new tests for `ServerProcess.tail_log`: empty, short log, long log
  (asserts only last N lines returned), read error (returns "" without
  raising).
- 52 existing server / exception-handling unit tests pass.
- `ruff check` clean on the modified files.