### PR TITLE
chore(sdk): harden sandbox and clarify trust boundary

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -348,6 +348,14 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
     script for small payloads and uploads old/new strings as temp files with
     a server-side replace for large ones.
 
+    !!! note
+
+        `BaseSandbox` does not reduce or partition the trust boundary of
+        `execute()`. Its helper methods are convenience wrappers built on top of
+        the subclass-provided command-execution primitive and assume callers who
+        can use `BaseSandbox` already have whatever shell-execution capability
+        that backend exposes.
+
     Subclasses must implement `execute()`, `upload_files()`, `download_files()`,
     and the `id` property.
     """
@@ -703,7 +711,7 @@ except PermissionError:
         # Add glob pattern if specified
         glob_pattern = ""
         if glob:
-            glob_pattern = f"--include='{glob}'"
+            glob_pattern = f"--include={shlex.quote(glob)}"
 
         # Escape pattern for shell
         pattern_escaped = shlex.quote(pattern)

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -657,6 +657,23 @@ def test_sandbox_grep_literal_search() -> None:
     assert "grep -rHnF" in sandbox.last_command
 
 
+def test_sandbox_grep_quotes_include_glob() -> None:
+    """Test that grep shell-quotes the include glob pattern."""
+    sandbox = MockSandbox()
+
+    def mock_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
+        sandbox.last_command = command
+        return ExecuteResponse(output="", exit_code=0, truncated=False)
+
+    sandbox.execute = mock_execute
+
+    sandbox.grep("needle", path="/test", glob="x' ; echo injected ; #")
+
+    assert sandbox.last_command is not None
+    assert "--include='x'\"'\"' ; echo injected ; #'" in sandbox.last_command
+    assert "--include='x'\"'\"' ; echo injected ; #' -e needle /test" in sandbox.last_command
+
+
 # -- upload/download failure tests --------------------------------------------
 
 


### PR DESCRIPTION
* clarify the trust boundary for BaseSandbox
* harden implementation (future proofing) if we ever change the assumptions for the trust boundary