### PR TITLE
fix(cli): startup import deadlock

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -849,6 +849,13 @@ class DeepAgentsApp(App):
         self._shell_running = False
         """True while a `!` shell command is executing."""
 
+        self._prewarm_worker: Worker[None] | None = None
+        """Background worker that prewarms `deepagents`/LangChain imports.
+
+        Awaited via `_await_prewarm_imports` before any caller on the event
+        loop re-enters the same module graph (see that method for why).
+        """
+
         # Lifecycle flags & re-entry guards
         self._connecting = server_kwargs is not None
         """True while the backing server is being started or restarted.
@@ -1038,6 +1045,39 @@ class DeepAgentsApp(App):
         colors = theme.get_theme_colors(self)
         return theme.get_css_variable_defaults(colors=colors)
 
+    def _fatal_error(self) -> None:
+        """Render an unhandled-exception traceback without leaking secrets.
+
+        Textual's default `_fatal_error` renders with `show_locals=True`,
+        which prints local variables — including resolved API keys carried
+        in `kwargs` dicts on the call path through `create_model`. Locals
+        are only re-enabled when `DEEPAGENTS_CLI_DEBUG` matches a truthy
+        token (`"1"`, `"true"`, `"yes"`); any other value, including `"0"`
+        and `"false"`, leaves them disabled.
+        """
+        try:
+            import rich
+            from rich.segment import Segments
+            from rich.traceback import Traceback
+
+            from deepagents_cli._env_vars import DEBUG
+        except Exception:  # noqa: BLE001  # mid-teardown import errors fall through to Textual's default rather than double-fault and swallow the original crash
+            super()._fatal_error()
+            return
+
+        self.bell()
+        show_locals = os.environ.get(DEBUG, "").lower() in {"1", "true", "yes"}
+        traceback = Traceback(
+            show_locals=show_locals,
+            width=None,
+            locals_max_length=5,
+            suppress=[rich],
+        )
+        self._exit_renderables.append(
+            Segments(self.console.render(traceback, self.console.options))
+        )
+        self._close_messages_no_wait()
+
     def compose(self) -> ComposeResult:
         """Compose the application layout.
 
@@ -1108,7 +1148,8 @@ class DeepAgentsApp(App):
         # Prewarm heavy imports in a thread while the first frame renders.
         # The user can't type yet, so GIL contention is harmless.  By the
         # time _post_paint_init fires its inline imports are dict lookups.
-        self.run_worker(
+        # Handle is captured so `_await_prewarm_imports` can block on it.
+        self._prewarm_worker = self.run_worker(
             asyncio.to_thread(self._prewarm_deferred_imports),
             exclusive=True,
             group="startup-import-prewarm",
@@ -1580,6 +1621,10 @@ class DeepAgentsApp(App):
         # does the heavy langchain import + SDK init and may refine them
         # (e.g., context_limit from the model profile).
         if self._model_kwargs is not None:
+            # Block on prewarm before re-entering the import graph; see
+            # `_await_prewarm_imports` for the deadlock rationale.
+            await self._await_prewarm_imports()
+
             from deepagents_cli.config import create_model
             from deepagents_cli.model_config import ModelConfigError, save_recent_model
 
@@ -1718,6 +1763,30 @@ class DeepAgentsApp(App):
                 w.remove()
             self._queued_widgets.clear()
         self._deferred_actions.clear()
+
+    async def _await_prewarm_imports(self) -> None:
+        """Wait for prewarm imports before re-entering their module graph.
+
+        Prevents a multi-threaded import deadlock: the prewarm worker runs in
+        `asyncio.to_thread`, and any caller that imports `deepagents` or
+        LangChain from the event-loop thread while it's still running can
+        race on partially-initialized module locks.
+
+        `CancelledError` propagates so app shutdown isn't silently absorbed.
+        """
+        from textual.worker import WorkerFailed
+
+        worker = self._prewarm_worker
+        if worker is None:
+            return
+        try:
+            await worker.wait()
+        except WorkerFailed:
+            # Prewarm body best-efforts third-party imports and already
+            # warns; logging at WARNING here surfaces unexpected failures
+            # (e.g. a regression that breaks a non-optional import) that
+            # the body itself didn't catch.
+            logger.warning("Import prewarm worker failed", exc_info=True)
 
     @staticmethod
     def _prewarm_deferred_imports() -> None:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import io
 import os
@@ -5472,3 +5473,187 @@ class TestNotificationCenterIntegration:
             await pilot.pause()
 
             assert isinstance(app.screen, NotificationCenterScreen)
+
+
+class TestFatalErrorRedaction:
+    """`_fatal_error` must not leak local variables (which carry secrets).
+
+    Locals on the `create_model` call path include resolved API keys in a
+    `kwargs` dict. Textual's default rendering uses `show_locals=True`,
+    which would print them. We disable locals unless `DEEPAGENTS_CLI_DEBUG`
+    is set to a truthy token.
+    """
+
+    @staticmethod
+    def _call_fatal_error(app: DeepAgentsApp) -> MagicMock:
+        """Run `_fatal_error` with the rendering pipeline patched out.
+
+        Returns the `Traceback` mock so callers can inspect its kwargs.
+        """
+        with (
+            patch("rich.traceback.Traceback") as mock_traceback,
+            patch("rich.segment.Segments"),
+            patch.object(app, "console", MagicMock()),
+            patch.object(app, "_close_messages_no_wait"),
+            patch.object(app, "bell"),
+        ):
+            app._fatal_error()
+        return mock_traceback
+
+    def test_show_locals_disabled_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default crash rendering hides locals so secrets don't reach stderr."""
+        monkeypatch.delenv("DEEPAGENTS_CLI_DEBUG", raising=False)
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        mock_traceback = self._call_fatal_error(app)
+
+        mock_traceback.assert_called_once()
+        assert mock_traceback.call_args.kwargs["show_locals"] is False
+
+    def test_show_locals_enabled_when_debug_env_truthy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Truthy `DEEPAGENTS_CLI_DEBUG` re-enables locals for debugging."""
+        monkeypatch.setenv("DEEPAGENTS_CLI_DEBUG", "1")
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        mock_traceback = self._call_fatal_error(app)
+
+        assert mock_traceback.call_args.kwargs["show_locals"] is True
+
+    @pytest.mark.parametrize("falsy", ["0", "false", "no", "", "False", "  "])
+    def test_show_locals_disabled_for_falsy_strings(
+        self, monkeypatch: pytest.MonkeyPatch, falsy: str
+    ) -> None:
+        """`DEEPAGENTS_CLI_DEBUG=0` (or other falsy strings) MUST NOT enable locals.
+
+        Regression guard: an earlier `bool(os.environ.get(...))` check would
+        have flipped to `True` for any non-empty string, leaking the API key
+        whenever a user set the var to `"0"` or `"false"` thinking they were
+        disabling the flag.
+        """
+        monkeypatch.setenv("DEEPAGENTS_CLI_DEBUG", falsy)
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        mock_traceback = self._call_fatal_error(app)
+
+        assert mock_traceback.call_args.kwargs["show_locals"] is False
+
+    def test_falls_back_to_super_on_import_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the override's own imports fail, defer to Textual's default.
+
+        Otherwise the user double-faults during a real crash and never sees
+        any traceback at all.
+        """
+        monkeypatch.delenv("DEEPAGENTS_CLI_DEBUG", raising=False)
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        with (
+            patch.dict("sys.modules", {"rich.traceback": None}),
+            patch("textual.app.App._fatal_error") as super_fatal,
+        ):
+            app._fatal_error()
+
+        super_fatal.assert_called_once()
+
+
+class TestPrewarmAwait:
+    """`_start_server_background` must wait for the prewarm worker first.
+
+    The prewarm worker imports `deepagents`/LangChain in a separate thread
+    via `asyncio.to_thread`. If `_start_server_background` triggers the
+    same module graph from the event-loop thread before prewarm finishes,
+    Python's per-module locks form a cycle and CPython raises
+    `_DeadlockError` from the import system.
+    """
+
+    async def test_await_prewarm_imports_no_worker(self) -> None:
+        """No-op when the prewarm worker handle isn't set."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        assert app._prewarm_worker is None
+        await app._await_prewarm_imports()  # must not raise
+
+    async def test_await_prewarm_imports_waits_for_worker(self) -> None:
+        """Awaits `Worker.wait()` so the import-prewarm thread is fully done."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        worker = MagicMock()
+        worker.wait = AsyncMock()
+        app._prewarm_worker = worker
+
+        await app._await_prewarm_imports()
+
+        worker.wait.assert_awaited_once()
+
+    async def test_await_prewarm_imports_swallows_worker_failure(self) -> None:
+        """`WorkerFailed` is non-fatal; main path proceeds regardless."""
+        from textual.worker import WorkerFailed
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        worker = MagicMock()
+        worker.wait = AsyncMock(side_effect=WorkerFailed(RuntimeError("boom")))
+        app._prewarm_worker = worker
+
+        await app._await_prewarm_imports()  # must not raise
+
+        worker.wait.assert_awaited_once()
+
+    async def test_await_prewarm_imports_propagates_cancellation(self) -> None:
+        """`CancelledError` MUST propagate so app shutdown isn't absorbed."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        worker = MagicMock()
+        worker.wait = AsyncMock(side_effect=asyncio.CancelledError())
+        app._prewarm_worker = worker
+
+        with pytest.raises(asyncio.CancelledError):
+            await app._await_prewarm_imports()
+
+    async def test_start_server_background_awaits_prewarm_before_create_model(
+        self,
+    ) -> None:
+        """Locks the call-order invariant that fixes the deadlock.
+
+        A future refactor that moves the `await _await_prewarm_imports()`
+        after `create_model` (or drops it) silently re-introduces the
+        production crash. This is the only test that catches that.
+        """
+        from deepagents_cli import config as cli_config
+
+        call_order: list[str] = []
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        app._model_kwargs = {"model_spec": "anthropic:claude-opus-4-7"}
+        app._server_kwargs = None
+        app._mcp_preload_kwargs = None
+        app._resume_thread_intent = None
+        app._assistant_id = None
+
+        async def record_prewarm() -> None:
+            call_order.append("prewarm")
+            await asyncio.sleep(0)  # yield so any out-of-order calls would land first
+
+        def record_create_model(**_: Any) -> MagicMock:
+            call_order.append("create_model")
+            result = MagicMock()
+            result.apply_to_settings = MagicMock()
+            result.provider = "anthropic"
+            result.model_name = "claude-opus-4-7"
+            return result
+
+        with (
+            patch.object(app, "_await_prewarm_imports", side_effect=record_prewarm),
+            patch.object(cli_config, "create_model", side_effect=record_create_model),
+            patch("deepagents_cli.model_config.save_recent_model"),
+            patch.object(app, "post_message"),
+            # `_start_server_background` continues past `create_model` into
+            # server + MCP setup we don't care about for an ordering test.
+            contextlib.suppress(Exception),
+        ):
+            await app._start_server_background()
+
+        assert call_order[:2] == ["prewarm", "create_model"], (
+            f"prewarm must precede create_model; got {call_order}"
+        )


### PR DESCRIPTION
Fix two latent startup bugs surfaced together in a single user-reported crash: a multi-threaded import deadlock on `deepagents._api.deprecation`, and the resolved API key printing in the resulting traceback's local-variables section.