### PR TITLE
ci(infra): dispatch `release.yml` instead of using `workflow_call`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -258,131 +258,176 @@ jobs:
             git push origin "HEAD:${RELEASE_BRANCH}"
           fi
 
-  # Trigger release workflow when CLI release PR is merged
-  # GitHub release is created by release.yml AFTER all checks pass
+  # Dispatch release.yml for each merged release PR.
   #
-  # release-sha pins the release tag to the release-PR merge commit. github.sha
-  # here IS the merge commit because release-please.yml only fires on push events,
-  # and the release PR was just merged. Forwarding it explicitly means release.yml
-  # always reads inputs.release-sha — the auto path and workflow_dispatch retries
-  # share one code path, so neither can silently tag a different commit (see
-  # RELEASING.md -> Manual Release).
-  release-deepagents-cli:
+  # We use `gh workflow run` (workflow_dispatch) rather than `uses:` (workflow_call)
+  # because PyPI Trusted Publishing does not officially support reusable workflows
+  # (https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github).
+  # Dispatching makes each release run a top-level workflow, so the OIDC token
+  # claim points at release.yml directly. Trade-off: release.yml runs are
+  # separate runs in the Actions tab rather than nested under release-please.
+  #
+  # release-sha pins the release *artifact* (build, tests, GitHub release tag) to
+  # the release-PR merge commit. github.sha here IS the merge commit because
+  # release-please.yml only fires on push events, and the release PR was just
+  # merged. Forwarding it explicitly means release.yml always reads
+  # inputs.release-sha — the auto path and workflow_dispatch retries share one
+  # code path, so neither can silently tag a different commit (see RELEASING.md
+  # -> Manual Release).
+  #
+  # Note: `gh workflow run --ref main` resolves the *workflow YAML* against
+  # main@HEAD at dispatch time, not against $RELEASE_SHA. The dispatches API
+  # accepts only branch/tag names for `ref`, not SHAs, so this race window
+  # (commit lands on main between this push event and the dispatch call) is
+  # unfixable. In practice it is benign: release.yml itself rarely changes, and
+  # the artifact still builds from $RELEASE_SHA via the checkout step.
+  trigger-releases:
     needs: release-please
-    if: needs.release-please.outputs.cli-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: deepagents-cli
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
+    if: |
+      needs.release-please.outputs.cli-release == 'true' ||
+      needs.release-please.outputs.sdk-release == 'true' ||
+      needs.release-please.outputs.acp-release == 'true' ||
+      needs.release-please.outputs.daytona-release == 'true' ||
+      needs.release-please.outputs.modal-release == 'true' ||
+      needs.release-please.outputs.runloop-release == 'true' ||
+      needs.release-please.outputs.quickjs-release == 'true' ||
+      needs.release-please.outputs.repl-release == 'true'
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
-      # write needed to update PR label from "autorelease: pending" to "autorelease: tagged"
-      pull-requests: write
+      actions: write # required for `gh workflow run` to dispatch release.yml
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ needs.release-please.outputs.release-version }}
+      RELEASE_SHA: ${{ github.sha }}
+      RELEASE_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml
+      CLI_RELEASE: ${{ needs.release-please.outputs.cli-release }}
+      SDK_RELEASE: ${{ needs.release-please.outputs.sdk-release }}
+      ACP_RELEASE: ${{ needs.release-please.outputs.acp-release }}
+      DAYTONA_RELEASE: ${{ needs.release-please.outputs.daytona-release }}
+      MODAL_RELEASE: ${{ needs.release-please.outputs.modal-release }}
+      RUNLOOP_RELEASE: ${{ needs.release-please.outputs.runloop-release }}
+      QUICKJS_RELEASE: ${{ needs.release-please.outputs.quickjs-release }}
+      REPL_RELEASE: ${{ needs.release-please.outputs.repl-release }}
+    steps:
+      - name: Dispatch release workflows
+        # Best-effort: each package dispatch is independent. If one fails (transient
+        # API blip, rate limit, ...), continue with the rest — partial dispatch is
+        # better than a half-state where some packages are pending and others were
+        # never even attempted. Failures are aggregated and the job exits nonzero
+        # at the end so the operator sees them.
+        #
+        # We also write a markdown banner to $GITHUB_STEP_SUMMARY pointing at the
+        # release.yml workflow page. This job only *kicks off* the publish runs;
+        # the build/test/PyPI-publish steps live in those separate runs, so the
+        # operator needs to click through to find them. The summary makes that
+        # one click instead of "where did the publish go?".
+        run: |
+          set -uo pipefail
 
-  # Trigger release workflow when SDK release PR is merged
-  release-deepagents:
-    needs: release-please
-    if: needs.release-please.outputs.sdk-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: deepagents
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          DISPATCHED=()
+          FAILED=()
 
-  # Trigger release workflow when ACP release PR is merged
-  release-deepagents-acp:
-    needs: release-please
-    if: needs.release-please.outputs.acp-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: deepagents-acp
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          # Validate that an output value is exactly "true" or "false". Catches the
+          # case where release-please ever emits an empty/unexpected value, which
+          # would otherwise silently no-op the dispatch under the `= "true"` check.
+          assert_bool() {
+            local name="$1" value="$2"
+            case "$value" in
+              true|false) ;;
+              *)
+                echo "::warning::$name has unexpected value '$value' (expected 'true' or 'false'); treating as false"
+                ;;
+            esac
+          }
 
-  # Trigger release workflow when Daytona release PR is merged
-  release-langchain-daytona:
-    needs: release-please
-    if: needs.release-please.outputs.daytona-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: langchain-daytona
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          dispatch() {
+            local package="$1"
+            echo "Dispatching release for $package (version=$VERSION, sha=$RELEASE_SHA)"
+            if gh workflow run release.yml \
+              --ref main \
+              -f package="$package" \
+              -f version="$VERSION" \
+              -f release-sha="$RELEASE_SHA"; then
+              # gh workflow run returns 0 once the dispatch is queued but yields
+              # no run ID. Surface a pointer so operators can find the dispatched
+              # run quickly without a manual scroll through Actions.
+              echo "Queued. Watch at: $RELEASE_WORKFLOW_URL"
+              DISPATCHED+=("$package")
+            else
+              echo "::error::Failed to dispatch release.yml for $package"
+              FAILED+=("$package")
+            fi
+          }
 
-  # Trigger release workflow when Modal release PR is merged
-  release-langchain-modal:
-    needs: release-please
-    if: needs.release-please.outputs.modal-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: langchain-modal
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          # ${VAR:-false} guards against an output ever being unset/empty. assert_bool
+          # surfaces a warning if the value is something other than "true"/"false".
+          CLI_RELEASE="${CLI_RELEASE:-false}";         assert_bool CLI_RELEASE     "$CLI_RELEASE"
+          SDK_RELEASE="${SDK_RELEASE:-false}";         assert_bool SDK_RELEASE     "$SDK_RELEASE"
+          ACP_RELEASE="${ACP_RELEASE:-false}";         assert_bool ACP_RELEASE     "$ACP_RELEASE"
+          DAYTONA_RELEASE="${DAYTONA_RELEASE:-false}"; assert_bool DAYTONA_RELEASE "$DAYTONA_RELEASE"
+          MODAL_RELEASE="${MODAL_RELEASE:-false}";     assert_bool MODAL_RELEASE   "$MODAL_RELEASE"
+          RUNLOOP_RELEASE="${RUNLOOP_RELEASE:-false}"; assert_bool RUNLOOP_RELEASE "$RUNLOOP_RELEASE"
+          QUICKJS_RELEASE="${QUICKJS_RELEASE:-false}"; assert_bool QUICKJS_RELEASE "$QUICKJS_RELEASE"
+          REPL_RELEASE="${REPL_RELEASE:-false}";       assert_bool REPL_RELEASE    "$REPL_RELEASE"
 
-  # Trigger release workflow when Runloop release PR is merged
-  release-langchain-runloop:
-    needs: release-please
-    if: needs.release-please.outputs.runloop-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: langchain-runloop
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          # Banner: log + step summary. The step summary renders at the top of the
+          # run page, so operators see the link before scrolling through step logs.
+          echo ""
+          echo "================================================================"
+          echo "  Publish runs (build / tests / PyPI) live in release.yml:"
+          echo "  $RELEASE_WORKFLOW_URL"
+          echo "  This job only kicks them off."
+          echo "================================================================"
+          echo ""
 
-  # Trigger release workflow when QuickJS release PR is merged
-  release-langchain-quickjs:
-    needs: release-please
-    if: needs.release-please.outputs.quickjs-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: langchain-quickjs
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          {
+            echo "## Release dispatched"
+            echo ""
+            echo "This job only **kicks off** the publish workflow. Build, tests, and the actual PyPI publish run as separate \`release.yml\` runs."
+            echo ""
+            echo "👉 **[View \`release.yml\` runs]($RELEASE_WORKFLOW_URL)** to watch each publish."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
-  # Trigger release workflow when REPL release PR is merged
-  release-langchain-repl:
-    needs: release-please
-    if: needs.release-please.outputs.repl-release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      package: langchain-repl
-      version: ${{ needs.release-please.outputs.release-version }}
-      release-sha: ${{ github.sha }}
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+          if [ "$CLI_RELEASE" = "true" ];     then dispatch deepagents-cli;      fi
+          if [ "$SDK_RELEASE" = "true" ];     then dispatch deepagents;          fi
+          if [ "$ACP_RELEASE" = "true" ];     then dispatch deepagents-acp;      fi
+          if [ "$DAYTONA_RELEASE" = "true" ]; then dispatch langchain-daytona;   fi
+          if [ "$MODAL_RELEASE" = "true" ];   then dispatch langchain-modal;     fi
+          if [ "$RUNLOOP_RELEASE" = "true" ]; then dispatch langchain-runloop;   fi
+          if [ "$QUICKJS_RELEASE" = "true" ]; then dispatch langchain-quickjs;   fi
+          if [ "$REPL_RELEASE" = "true" ];    then dispatch langchain-repl;      fi
+
+          # Append per-package status to the step summary so operators see at a
+          # glance which packages were queued vs. which need a manual retry.
+          {
+            echo "### Dispatched (${#DISPATCHED[@]})"
+            if [ "${#DISPATCHED[@]}" -gt 0 ]; then
+              for p in "${DISPATCHED[@]}"; do echo "- \`$p\` @ \`$VERSION\`"; done
+            else
+              echo "_none_"
+            fi
+            echo ""
+            echo "### Failed (${#FAILED[@]})"
+            if [ "${#FAILED[@]}" -gt 0 ]; then
+              for p in "${FAILED[@]}"; do echo "- \`$p\`"; done
+              echo ""
+              echo "Recover with:"
+              echo ""
+              echo '```'
+              for p in "${FAILED[@]}"; do
+                echo "gh workflow run release.yml -f package=$p -f version=$VERSION -f release-sha=$RELEASE_SHA"
+              done
+              echo '```'
+            else
+              echo "_none_"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${#FAILED[@]}" -gt 0 ]; then
+            echo "::error::Failed to dispatch ${#FAILED[@]} release(s): ${FAILED[*]}"
+            echo "::error::Recover with: gh workflow run release.yml -f package=<name> -f version=$VERSION -f release-sha=$RELEASE_SHA"
+            exit 1
+          fi
+
+          echo "All release workflows dispatched. Watch at: $RELEASE_WORKFLOW_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,15 @@
 # Builds and publishes deepagents packages to PyPI.
 #
 # Triggers:
-# - Automatically via workflow_call from release-please.yml when a release PR is merged
-# - Manually via workflow_dispatch
+# - Automatically via workflow_dispatch from release-please.yml when a release
+#   PR is merged (release-please.yml's `trigger-releases` job calls
+#   `gh workflow run release.yml ...`).
+# - Manually via workflow_dispatch from the Actions UI or `gh` CLI.
+#
+# This workflow is intentionally NOT a reusable workflow (no `workflow_call`
+# trigger): PyPI Trusted Publishing does not officially support reusable
+# workflows, so the auto path uses workflow_dispatch instead. See:
+# https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
 #
 # Flow: build -> pre-release-checks -> test-pypi -> publish -> release
 
@@ -10,23 +17,6 @@ name: "⚠️ Manual Package Release"
 run-name: "release(${{ inputs.package-override || inputs.package }}):${{
   inputs.version && format(' {0}', inputs.version) || '' }}"
 on:
-  workflow_call:
-    inputs:
-      package:
-        required: true
-        type: string
-        description: "Package to release"
-      version:
-        required: false
-        type: string
-        default: ""
-        description: "Version being released (used in run name)"
-      release-sha:
-        required: true
-        type: string
-        description: "Release-PR merge commit SHA. Pinned to the GitHub release tag
-          and used to look up the release PR for label updates. Auto-passed by
-          release-please.yml."
   workflow_dispatch:
     inputs:
       package:


### PR DESCRIPTION
Switch the auto-release path from `workflow_call` to `workflow_dispatch` so PyPI Trusted Publishing no longer flags `release.yml` as a reusable workflow. The `pypa/gh-action-pypi-publish` action warns about this today and reserves the right to break it without notice — dispatching makes each release a top-level run, so the OIDC token claim points at `release.yml` directly. Trade-off: publish runs now appear as separate top-level entries in the Actions tab (the same pattern `RELEASING.md`'s manual-release flow already uses).