### PR TITLE
fix(quickjs): remove ptc command buffering

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -120,6 +120,7 @@ class _PTCState:
             function_name=function_name,
         )
 
+
 class _ConsoleBuffer:
     """Accumulates ``console.*`` output between evals.
 

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -16,7 +16,6 @@ import uuid
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, cast
 
-from langgraph.types import Command
 from quickjs_rs import (
     UNDEFINED,
     ConcurrentEvalError,
@@ -75,7 +74,6 @@ class EvalOutcome:
     error_type: str | None = None
     error_message: str = ""
     error_stack: str | None = None
-    commands: list[Command] = field(default_factory=list)
 
 
 class _PTCCallBudgetExceededError(RuntimeError):
@@ -105,7 +103,6 @@ class _PTCState:
     """Per-eval PTC state (reset on each eval call)."""
 
     remaining_calls: int | None
-    command_buffer: tuple[Command, ...] = field(default_factory=tuple)
 
     def consume_call_budget(
         self, *, function_name: str, max_ptc_calls: int | None
@@ -122,13 +119,6 @@ class _PTCState:
             attempted=normalized_limit + 1,
             function_name=function_name,
         )
-
-    def append_commands(self, commands: list[Command]) -> _PTCState:
-        """Return a copy with additional commands captured for this eval."""
-        if not commands:
-            return self
-        return replace(self, command_buffer=(*self.command_buffer, *commands))
-
 
 class _ConsoleBuffer:
     """Accumulates ``console.*`` output between evals.
@@ -182,15 +172,6 @@ def _normalize_tool_input(raw: Any) -> dict[str, Any]:
     # schema validation produces an informative error rather than a
     # silent miss.
     return {"input": raw}
-
-
-def _extract_commands(value: Any) -> list[Command]:
-    """Collect LangGraph ``Command`` values from a tool return payload."""
-    if isinstance(value, Command):
-        return [value]
-    if isinstance(value, list):
-        return [entry for entry in value if isinstance(entry, Command)]
-    return []
 
 
 def _synth_tool_call_id(tool_name: str) -> str:
@@ -343,7 +324,7 @@ class _ThreadREPL:
         # from the middleware's tool handler immediately before eval.
         self._outer_runtime: ToolRuntime | None = None
         # Mutable per-eval PTC state. Allocated at eval start and cleared
-        # in finally so bridge calls can't leak buffered state across evals.
+        # in finally so bridge calls can't run outside the current eval.
         self._ptc_state: _PTCState | None = None
         # Slot-local skill install cache. Kept on the REPL (not registry)
         # so thread-scoped backends can resolve same-named skills
@@ -490,11 +471,6 @@ class _ThreadREPL:
             result = await tool.ainvoke(
                 {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
             )
-            ptc_state = self._ptc_state
-            if ptc_state is None:
-                msg = "PTC bridge called outside active eval"
-                raise RuntimeError(msg)
-            self._ptc_state = ptc_state.append_commands(_extract_commands(result))
             return coerce_tool_output(result)
 
         bridge_symbol = _bridge_symbol_name(camel)
@@ -643,9 +619,6 @@ class _ThreadREPL:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
         finally:
-            ptc_state = self._ptc_state
-            if ptc_state is not None:
-                outcome.commands.extend(ptc_state.command_buffer)
             self._ptc_state = None
             outcome.stdout, outcome.stdout_truncated_chars = self._console.drain()
         return outcome

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -209,9 +209,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         fallback_id = self._fallback_thread_id
         middleware = self
 
-        def _run(
-            outcome_fn: Any, code: str, tool_call_id: str | None
-        ) -> ToolMessage:
+        def _run(outcome_fn: Any, code: str, tool_call_id: str | None) -> ToolMessage:
             outcome = outcome_fn(code)
             return ToolMessage(
                 content=format_outcome(outcome, max_result_chars=max_chars),

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -22,7 +22,6 @@ from langchain.tools import BaseTool, ToolRuntime
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 from langgraph.config import get_config
-from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
@@ -46,7 +45,6 @@ _DEFAULT_TIMEOUT = 5.0
 _DEFAULT_MAX_PTC_CALLS = 256
 _DEFAULT_MAX_RESULT_CHARS = 4_000
 _DEFAULT_TOOL_NAME = "eval"
-_EvalToolResult = ToolMessage | list[Command | ToolMessage]
 
 
 class EvalSchema(BaseModel):
@@ -213,16 +211,13 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         def _run(
             outcome_fn: Any, code: str, tool_call_id: str | None
-        ) -> _EvalToolResult:
+        ) -> ToolMessage:
             outcome = outcome_fn(code)
-            message = ToolMessage(
+            return ToolMessage(
                 content=format_outcome(outcome, max_result_chars=max_chars),
                 tool_call_id=tool_call_id,
                 name=tool_name,
             )
-            if outcome.commands:
-                return [*outcome.commands, message]
-            return message
 
         code_doc = (
             "JavaScript expression or statement(s) to evaluate in the persistent REPL."
@@ -231,7 +226,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         def sync_eval(
             runtime: ToolRuntime[None, Any],
             code: Annotated[str, code_doc],
-        ) -> _EvalToolResult:
+        ) -> ToolMessage:
             repl = registry.get(_resolve_thread_id(fallback_id))
             skills = middleware._skills_for_eval(runtime)
             # The sync path doesn't support PTC (host-fn bridges are
@@ -253,7 +248,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         async def async_eval(
             runtime: ToolRuntime[None, Any],
             code: Annotated[str, code_doc],
-        ) -> _EvalToolResult:
+        ) -> ToolMessage:
             repl = registry.get(_resolve_thread_id(fallback_id))
             skills = middleware._skills_for_eval(runtime)
             # Capture the outer runtime so PTC bridges can forward
@@ -270,14 +265,11 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 )
             finally:
                 repl.set_outer_runtime(None)
-            message = ToolMessage(
+            return ToolMessage(
                 content=format_outcome(outcome, max_result_chars=max_chars),
                 tool_call_id=runtime.tool_call_id,
                 name=tool_name,
             )
-            if outcome.commands:
-                return [*outcome.commands, message]
-            return message
 
         return StructuredTool.from_function(
             name=tool_name,

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -342,7 +342,7 @@ async def test_promise_all_runs_tools_concurrently(repl: _ThreadREPL) -> None:
     assert {c["name"] for c in calls} == {"a", "b"}
 
 
-async def test_command_tool_updates_are_collected_from_single_eval(
+async def test_command_tool_output_is_visible_to_js(
     repl: _ThreadREPL,
 ) -> None:
     repl.install_tools([_command_tool()])
@@ -353,18 +353,20 @@ async def test_command_tool_updates_are_collected_from_single_eval(
     )
     assert outcome.error_type is None, outcome.error_message
     assert outcome.result == "done"
-    assert [cmd.update.get("ptc_values") for cmd in outcome.commands] == [
-        [1],
-        [2],
-    ]
 
 
-async def test_command_buffer_is_scoped_to_one_eval(repl: _ThreadREPL) -> None:
+async def test_command_tool_does_not_change_eval_outcome_shape(
+    repl: _ThreadREPL,
+) -> None:
     repl.install_tools([_command_tool()])
     first = await repl.eval_async("await tools.emitCommand({value: 7})")
-    assert len(first.commands) == 1
+    assert first.error_type is None, first.error_message
+    assert first.result == "value=7"
+    assert not hasattr(first, "commands")
     second = await repl.eval_async("1 + 1")
-    assert second.commands == []
+    assert second.error_type is None, second.error_message
+    assert second.result == "2"
+    assert not hasattr(second, "commands")
 
 
 async def test_toolmessage_list_uses_last_message_content(repl: _ThreadREPL) -> None:
@@ -372,18 +374,15 @@ async def test_toolmessage_list_uses_last_message_content(repl: _ThreadREPL) -> 
     outcome = await repl.eval_async("await tools.emitMessages({value: 9})")
     assert outcome.error_type is None, outcome.error_message
     assert outcome.result == "second=9"
-    assert outcome.commands == []
 
 
-async def test_mixed_list_collects_commands_and_uses_tail_message(
+async def test_mixed_list_uses_tail_message(
     repl: _ThreadREPL,
 ) -> None:
     repl.install_tools([_mixed_list_tool()])
     outcome = await repl.eval_async("await tools.emitMixed({value: 11})")
     assert outcome.error_type is None, outcome.error_message
     assert outcome.result == "from-list-tail=11"
-    assert len(outcome.commands) == 1
-    assert outcome.commands[0].update.get("ptc_values") == [11]
 
 
 async def test_tool_failure_surfaces_as_js_error(repl: _ThreadREPL) -> None:
@@ -611,7 +610,7 @@ async def test_ptc_install_and_eval_resolve_to_same_repl() -> None:
     assert outcome.result == "function"
 
 
-async def test_middleware_eval_tool_returns_commands_plus_tool_message() -> None:
+async def test_middleware_eval_tool_returns_tool_message_only() -> None:
     from types import SimpleNamespace
 
     from langchain.tools import ToolRuntime
@@ -634,12 +633,9 @@ async def test_middleware_eval_tool_returns_commands_plus_tool_message() -> None
         runtime=runtime,
         code="await tools.emitCommand({value: 5})",
     )
-    assert isinstance(result, list)
-    assert len(result) == 2
-    assert isinstance(result[0], Command)
-    assert result[0].update.get("ptc_values") == [5]
-    assert isinstance(result[1], ToolMessage)
-    assert result[1].name == "eval"
+    assert isinstance(result, ToolMessage)
+    assert result.name == "eval"
+    assert "<result>value=5</result>" in result.content
 
 
 def test_middleware_rejects_boolean_ptc_config_during_prepare() -> None:


### PR DESCRIPTION
## Summary

PTC in QuickJS REPL was assuming tools called within `eval` should propagate returned `Command` objects into parent graph history. That assumption is wrong for this path and can unintentionally mutate parent message/state (notably for tools like `task` that return `Command` with `ToolMessage`).

This PR removes command buffering/forwarding from the PTC REPL flow so PTC tool calls remain in-eval operations and do not inject command updates into parent history.

## Changes

- Remove `command_buffer` and command extraction/aggregation from REPL per-eval state.
- Stop prepending propagated `Command` objects from eval middleware; return only the eval `ToolMessage`.
- Update QuickJS PTC unit tests to assert non-propagation behavior and the updated eval result shape.
