### PR TITLE
fix(sdk): surface EOF-newline mismatch in `edit_file`

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -344,15 +344,18 @@ class FilesystemBackend(BackendProtocol):
             if empty_msg:
                 return ReadResult(file_data=FileData(content=empty_msg, encoding="utf-8"))
 
-            lines = content.splitlines()
+            # `splitlines(keepends=True)` preserves whether the final line
+            # has a terminator; joining with `""` round-trips the file's
+            # trailing-newline state. Required so `edit()` can detect
+            # EOF-newline mismatches in the model's `old_string`.
+            lines = content.splitlines(keepends=True)
             start_idx = offset
             end_idx = min(start_idx + limit, len(lines))
 
             if start_idx >= len(lines):
                 return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
 
-            selected_lines = lines[start_idx:end_idx]
-            return ReadResult(file_data=FileData(content="\n".join(selected_lines), encoding="utf-8"))
+            return ReadResult(file_data=FileData(content="".join(lines[start_idx:end_idx]), encoding="utf-8"))
         except (OSError, UnicodeDecodeError) as e:
             return ReadResult(error=f"Error reading file '{file_path}': {e}")
 

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -291,50 +291,23 @@ def slice_read_response(
     if not content or content.strip() == "":
         return content
 
-    lines = content.splitlines()
+    # Normalize line endings to LF before slicing. State/Store backends may
+    # carry CRLF or CR content as written; downstream tooling (edit match,
+    # grep, format) assumes LF.
+    content = content.replace("\r\n", "\n").replace("\r", "\n")
+
+    # `splitlines(keepends=True)` retains each line's terminator, including
+    # the absence of one on the final line. Joining with `""` therefore
+    # round-trips the trailing-newline state of the file faithfully —
+    # required so `edit()` can report EOF-newline mismatches accurately.
+    lines = content.splitlines(keepends=True)
     start_idx = offset
     end_idx = min(start_idx + limit, len(lines))
 
     if start_idx >= len(lines):
         return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
 
-    selected_lines = lines[start_idx:end_idx]
-    return "\n".join(selected_lines)
-
-
-def format_read_response(
-    file_data: FileData,
-    offset: int,
-    limit: int,
-) -> str:
-    """Format file data for read response with line numbers.
-
-    .. deprecated::
-        Use `slice_read_response` and apply
-        `format_content_with_line_numbers` separately.
-
-    Args:
-        file_data: FileData dict
-        offset: Line offset (0-indexed)
-        limit: Maximum number of lines
-
-    Returns:
-        Formatted content or error message
-    """
-    content = file_data_to_string(file_data)
-    empty_msg = check_empty_content(content)
-    if empty_msg:
-        return empty_msg
-
-    lines = content.splitlines()
-    start_idx = offset
-    end_idx = min(start_idx + limit, len(lines))
-
-    if start_idx >= len(lines):
-        return f"Error: Line offset {offset} exceeds file length ({len(lines)} lines)"
-
-    selected_lines = lines[start_idx:end_idx]
-    return format_content_with_line_numbers(selected_lines, start_line=start_idx + 1)
+    return "".join(lines[start_idx:end_idx])
 
 
 def perform_string_replacement(
@@ -357,6 +330,31 @@ def perform_string_replacement(
     occurrences = content.count(old_string)
 
     if occurrences == 0:
+        # Detect a common EOF mismatch: `old_string` carries a trailing
+        # newline that the file lacks at the same position. Models infer a
+        # terminator on what looks like a "well-formed" line; exact-match
+        # consumers must surface a precise hint rather than silently relax
+        # the contract — silent recovery on a stripped key risks corrupting
+        # interior text that happens to share a prefix.
+        if old_string.endswith("\n") and len(old_string) > 1 and content.endswith(old_string.removesuffix("\n")):
+            stripped = old_string.removesuffix("\n")
+            stripped_count = content.count(stripped)
+            if stripped_count == 1:
+                return (
+                    "Error: old_string ends with a newline, but the file does "
+                    "not end with a newline. Retry with the trailing newline "
+                    "removed from old_string (and from new_string if it also "
+                    "ends with a newline)."
+                )
+            # Stripped key is ambiguous: the model needs both fixes at once
+            # (drop the newline AND add surrounding context).
+            return (
+                f"Error: old_string ends with a newline, but the file does "
+                f"not end with a newline. With the trailing newline removed, "
+                f"old_string would appear {stripped_count} times in the file. "
+                f"Retry with the trailing newline removed and add surrounding "
+                f"context so the match is unique."
+            )
         return f"Error: String not found in file: '{old_string}'"
 
     if occurrences > 1 and not replace_all:

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -708,3 +708,53 @@ class TestVirtualModeDefaultDeprecation:
 
         deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning) and "virtual_mode" in str(w.message)]
         assert deprecations == []
+
+
+class TestReadTrailingNewlineRoundtrip:
+    """`FilesystemBackend.read` must round-trip the file's trailing-newline state.
+
+    That state feeds `perform_string_replacement`'s EOF-mismatch detection.
+    Dropping it here re-introduces the silent-failure loop from #2856.
+    """
+
+    def test_preserves_trailing_newline(self, tmp_path: Path) -> None:
+        target = tmp_path / "with_newline.txt"
+        target.write_text("foo\nbar\n")
+
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        result = be.read(str(target))
+
+        assert isinstance(result, ReadResult)
+        assert result.file_data is not None
+        assert result.file_data["content"] == "foo\nbar\n"
+
+    def test_preserves_no_trailing_newline(self, tmp_path: Path) -> None:
+        target = tmp_path / "no_newline.txt"
+        target.write_text("foo\nbar")
+
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        result = be.read(str(target))
+
+        assert isinstance(result, ReadResult)
+        assert result.file_data is not None
+        assert result.file_data["content"] == "foo\nbar"
+
+    def test_read_then_edit_eof_mismatch_surfaces_hint(self, tmp_path: Path) -> None:
+        """End-to-end: read+edit on an unterminated file emits the EOF hint.
+
+        Pins the #2856 fix at the boundary that matters — the model-facing
+        flow — not just the inner predicate.
+        """
+        target = tmp_path / "memory.md"
+        target.write_text("# Agent Role:\nyou are an assistant")
+
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+        result = be.edit(
+            str(target),
+            "# Agent Role:\nyou are an assistant\n",
+            "# Agent Role:\nyou are an assistant\nYou can do anything\n",
+        )
+
+        assert result.error is not None
+        assert "old_string ends with a newline" in result.error
+        assert target.read_text() == "# Agent Role:\nyou are an assistant"

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -6,10 +6,13 @@ import pytest
 from langchain_core.messages.content import ContentBlock
 from pydantic import TypeAdapter
 
+from deepagents.backends.protocol import FileData, ReadResult
 from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
     _get_file_type,
     _glob_search_files,
+    perform_string_replacement,
+    slice_read_response,
     to_posix_path,
     validate_path,
 )
@@ -206,3 +209,147 @@ def test_get_file_type_non_text_values_are_valid_content_block_types() -> None:
     for file_type in _EXTENSION_TO_FILE_TYPE.values():
         block = {"type": file_type, "base64": "dGVzdA==", "mime_type": "application/octet-stream"}
         _content_block_adapter.validate_python(block)
+
+
+class TestPerformStringReplacement:
+    """`perform_string_replacement` underpins every backend's `edit()` path."""
+
+    def test_basic_single_replacement(self) -> None:
+        result = perform_string_replacement("hello world", "world", "there")
+        assert result == ("hello there", 1)
+
+    def test_not_found_returns_error_string(self) -> None:
+        result = perform_string_replacement("hello world", "missing", "x")
+        assert isinstance(result, str)
+        assert "not found" in result
+
+    def test_multiple_matches_without_replace_all(self) -> None:
+        result = perform_string_replacement("a a a", "a", "b")
+        assert isinstance(result, str)
+        assert "appears 3 times" in result
+
+    def test_multiple_matches_with_replace_all(self) -> None:
+        result = perform_string_replacement("a a a", "a", "b", replace_all=True)
+        assert result == ("b b b", 3)
+
+    def test_eof_newline_mismatch_returns_actionable_error(self) -> None:
+        """Trailing-newline mismatch at EOF must surface a precise hint.
+
+        Models infer terminators on what looks like a well-formed line. When
+        the file lacks one, exact-match must hold; the caller needs an
+        actionable error so it can self-correct rather than loop on a
+        generic "not found".
+        """
+        content = "# Agent Role:\nyou are an assistant"
+        old_string = "# Agent Role:\nyou are an assistant\n"
+        new_string = "# Agent Role:\nyou are an assistant\nYou can do anything\n"
+        result = perform_string_replacement(content, old_string, new_string)
+        assert isinstance(result, str)
+        assert "old_string ends with a newline" in result
+        assert "Retry with the trailing newline removed" in result
+
+    def test_eof_newline_mismatch_reports_ambiguous_stripped_match(self) -> None:
+        """When the stripped key would also be ambiguous, the hint must say so.
+
+        Otherwise the caller fixes the trailing newline, retries, and hits a
+        separate `appears N times` error — two round-trips for one cause.
+        """
+        content = "x x x"
+        old_string = "x\n"
+        new_string = "Y\n"
+        result = perform_string_replacement(content, old_string, new_string)
+        assert isinstance(result, str)
+        assert "old_string ends with a newline" in result
+        assert "appear 3 times" in result
+        assert "add surrounding context" in result
+
+    def test_eof_newline_mismatch_does_not_fire_when_match_succeeds(self) -> None:
+        """Primary match wins; the EOF-mismatch hint stays dormant."""
+        content = "alpha\nbeta\n"
+        old_string = "beta\n"
+        new_string = "BETA\n"
+        result = perform_string_replacement(content, old_string, new_string)
+        assert result == ("alpha\nBETA\n", 1)
+
+    def test_eof_newline_mismatch_does_not_fire_for_lone_newline(self) -> None:
+        """A lone-newline `old_string` falls through to the generic error."""
+        result = perform_string_replacement("hello", "\n", "x")
+        assert isinstance(result, str)
+        assert "not found" in result
+        assert "old_string ends with a newline" not in result
+
+    def test_eof_newline_mismatch_does_not_fire_for_interior_prefix(self) -> None:
+        """Interior prefix matches must not trigger the EOF hint.
+
+        `old_string="return foo\n"` against `content="return foobar"`: the
+        stripped key matches mid-content, not at EOF. Caller gets the
+        generic "not found" error, never a misleading EOF hint that would
+        invite a corrupting retry.
+        """  # noqa: D301
+        content = "return foobar"
+        old_string = "return foo\n"
+        new_string = "return baz\n"
+        result = perform_string_replacement(content, old_string, new_string)
+        assert isinstance(result, str)
+        assert "not found" in result
+        assert "old_string ends with a newline" not in result
+
+    def test_eof_newline_mismatch_does_not_fire_when_eof_text_differs(self) -> None:
+        """If file's EOF text doesn't match the stripped key, no EOF hint."""
+        content = "x foo y"
+        old_string = "x foo\n"
+        new_string = "REPLACED\n"
+        result = perform_string_replacement(content, old_string, new_string)
+        assert isinstance(result, str)
+        assert "not found" in result
+        assert "old_string ends with a newline" not in result
+
+
+class TestSliceReadResponse:
+    """`slice_read_response` must round-trip the file's trailing-newline state.
+
+    That state is the load-bearing input to `perform_string_replacement`'s
+    EOF-mismatch detection. If it gets dropped here, the EOF hint can't
+    fire and callers fall back to the generic "not found" loop.
+    """
+
+    @staticmethod
+    def _file(content: str) -> FileData:
+        return FileData(content=content, encoding="utf-8")
+
+    def test_preserves_trailing_newline_when_file_has_one(self) -> None:
+        result = slice_read_response(self._file("foo\nbar\n"), offset=0, limit=2000)
+        assert result == "foo\nbar\n"
+
+    def test_preserves_no_trailing_newline_when_file_lacks_one(self) -> None:
+        result = slice_read_response(self._file("foo\nbar"), offset=0, limit=2000)
+        assert result == "foo\nbar"
+
+    def test_normalizes_crlf_to_lf(self) -> None:
+        """State/Store callers may carry CRLF; downstream tooling assumes LF."""
+        result = slice_read_response(self._file("foo\r\nbar\r\n"), offset=0, limit=2000)
+        assert isinstance(result, str)
+        assert "\r" not in result
+        assert result == "foo\nbar\n"
+
+    def test_normalizes_bare_cr_to_lf(self) -> None:
+        result = slice_read_response(self._file("foo\rbar\r"), offset=0, limit=2000)
+        assert isinstance(result, str)
+        assert "\r" not in result
+        assert result == "foo\nbar\n"
+
+    def test_partial_window_keeps_terminator_on_internal_lines(self) -> None:
+        """A window ending on a non-terminal line still ends with that line's terminator."""
+        result = slice_read_response(self._file("a\nb\nc\nd\n"), offset=1, limit=2)
+        assert result == "b\nc\n"
+
+    def test_partial_window_ending_on_unterminated_last_line(self) -> None:
+        """A window covering the last line keeps that line's missing-terminator state."""
+        result = slice_read_response(self._file("a\nb\nc"), offset=2, limit=1)
+        assert result == "c"
+
+    def test_offset_beyond_file_returns_error_result(self) -> None:
+        result = slice_read_response(self._file("a\nb"), offset=10, limit=5)
+        assert isinstance(result, ReadResult)
+        assert result.error is not None
+        assert "exceeds file length" in result.error

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -26,8 +26,8 @@ from deepagents.backends.utils import (
     TRUNCATION_GUIDANCE,
     create_file_data,
     format_content_with_line_numbers,
-    format_read_response,
     sanitize_tool_call_id,
+    slice_read_response,
     truncate_if_too_long,
     update_file_data,
 )
@@ -869,7 +869,9 @@ class TestFilesystemMiddleware:
         long_line = "z" * 15000
         content = f"first line\n{long_line}\nthird line"
         file_data = create_file_data(content)
-        result = format_read_response(file_data, offset=0, limit=100)
+        sliced = slice_read_response(file_data, offset=0, limit=100)
+        assert isinstance(sliced, str)
+        result = format_content_with_line_numbers(sliced, start_line=1)
         lines = result.split("\n")
         assert len(lines) == 5  # 1 first + 3 continuation (2, 2.1, 2.2) + 1 third
         assert "     1\tfirst line" in lines[0]
@@ -886,7 +888,9 @@ class TestFilesystemMiddleware:
         long_line = "m" * 12000
         content = f"line1\nline2\n{long_line}\nline4"
         file_data = create_file_data(content)
-        result = format_read_response(file_data, offset=2, limit=10)
+        sliced = slice_read_response(file_data, offset=2, limit=10)
+        assert isinstance(sliced, str)
+        result = format_content_with_line_numbers(sliced, start_line=3)
         lines = result.split("\n")
         assert len(lines) == 4  # 3 continuation (3, 3.1, 3.2) + 1 line4
         assert "     3\t" in lines[0]


### PR DESCRIPTION
Closes #2856

---

`edit_file` looped on `Error: String not found in file` whenever the model's `old_string` differed from the file's trailing text by exactly one newline — common for memory and config files that don't carry a final `\n`. The model couldn't see whether the file ended with one because read paths sliced via `splitlines()` + `"\n".join()`, which silently drops that bit. Fixed at both ends: read preserves the file's trailing-newline state, and exact-match consumers surface a precise, recoverable error instead of a generic miss.

## Changes

- `perform_string_replacement` now detects the EOF-newline mismatch (`old_string` ends with `\n`, file doesn't, stripped key matches at EOF) and returns an actionable error telling the caller to retry without the trailing newline. The exact-match contract is preserved — no silent recovery, since stripping the `\n` and replacing could corrupt interior text that shares a prefix (e.g. `old_string="return foo\n"` against `content="return foobar"`).
- The error is tiered: when the stripped key is unambiguous, it just says "remove the trailing newline"; when the stripped key would also match elsewhere, it says "remove the newline AND add surrounding context" so the caller fixes both issues in one round-trip.
- `slice_read_response` and `FilesystemBackend.read` now use `splitlines(keepends=True)` + `"".join()` so the file's trailing-newline state round-trips through paginated reads. `slice_read_response` also gains explicit `\r\n`/`\r` → `\n` normalization, replacing the implicit normalization the old `splitlines()` + `"\n".join()` used to perform.
- Drop `format_read_response` from `backends/utils.py`. All three backends migrated to `slice_read_response` + `format_content_with_line_numbers` in #1869; the only remaining users were two tests in `test_middleware.py`, now updated to call the same composition the backends use.