### PR TITLE
fix(cli): broken filesystem permissions import

### DIFF
--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -590,7 +590,7 @@ from deepagents import create_deep_agent
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.store import StoreBackend
-from deepagents.middleware.permissions import FilesystemPermission
+from deepagents.middleware.filesystem import FilesystemPermission
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,


### PR DESCRIPTION
PR: [#2992 chore(sdk): inline file permission logic](https://github.com/langchain-ai/deepagents/pull/2992) 
moved FilesystemPermissions from deepagents.middleware.permissions into deepagents.middleware.filesystem and deleted the old permissions.py module, but libs/cli/deepagents_cli/deploy/templates.py still generated code importing from the deleted module. this pr fixes it by changing the import to deepagents.middleware.filesystem

verified that deepagents deploy works with the updated import path