### PR TITLE
fix(cli): support modified backspace word deletion

### DIFF
--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -332,6 +332,12 @@ class ChatTextArea(TextArea):
             show=False,
             priority=True,
         ),
+        Binding(
+            "ctrl+backspace,alt+backspace",
+            "delete_word_left",
+            "Delete left to start of word",
+            show=False,
+        ),
     ]
     """Key bindings for the chat text area.
 

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -25,7 +25,6 @@ from deepagents_cli.widgets.chat_input import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
     from textual.pilot import Pilot
 
 
@@ -239,6 +238,18 @@ class TestChatTextAreaKeybindings:
 
         assert "ctrl+m" not in newline_keys
         assert "ctrl+m" not in ChatTextArea._NEWLINE_KEYS
+
+    def test_modified_backspace_deletes_word_left(self) -> None:
+        """Modified Backspace aliases should delete the previous word."""
+        word_delete_keys = {
+            key.strip()
+            for binding in ChatTextArea.BINDINGS
+            if binding.action == "delete_word_left"
+            for key in binding.key.split(",")
+        }
+
+        assert "ctrl+backspace" in word_delete_keys
+        assert "alt+backspace" in word_delete_keys
 
 
 class _ImagePasteApp(App[None]):
@@ -2220,6 +2231,28 @@ class TestCtrlUDeleteToLineStart:
 
             assert ta.text == "line one\n two\nline three"
             assert ta.cursor_location == (1, 0)
+
+
+class TestModifiedBackspaceDeleteWordLeft:
+    """Test modified Backspace aliases for word deletion."""
+
+    @pytest.mark.parametrize("key", ["ctrl+backspace", "alt+backspace"])
+    async def test_modified_backspace_deletes_previous_word(self, key: str) -> None:
+        """Modified Backspace should delete the word before the cursor."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello world")
+            await pilot.pause()
+
+            await pilot.press(key)
+            await pilot.pause()
+
+            assert ta.text == "hello "
+            assert ta.cursor_location == (0, 6)
 
 
 class _TextAreaTypingApp(App[None]):


### PR DESCRIPTION
Add terminal-friendly word deletion aliases to the CLI chat input. `Option+Delete` and `Ctrl+Backspace` now route to Textual's existing `delete_word_left` action, matching common terminal/editor behavior without requiring users to remap iTerm2.