### PR TITLE
style(cli): separate queued message from thinking spinner

### DIFF
--- a/libs/cli/deepagents_cli/widgets/loading.py
+++ b/libs/cli/deepagents_cli/widgets/loading.py
@@ -60,7 +60,7 @@ class LoadingWidget(Static):
     LoadingWidget {
         height: auto;
         padding: 0 1;
-        margin-top: 1;
+        margin: 0 0 1 0;
     }
 
     LoadingWidget .loading-container {


### PR DESCRIPTION
Fix a layout bug where a queued user message rendered immediately below the "Thinking..." spinner had no visual separation. `LoadingWidget` was the only message-area widget using a top margin instead of the bottom-margin convention every sibling widget follows, so it carried no trailing space when another widget rendered after it.