### PR TITLE
fix(cli): broken filesystem permissions import

### DIFF
--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -590,7 +590,7 @@ from deepagents import create_deep_agent
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.store import StoreBackend
-from deepagents.middleware.permissions import FilesystemPermission
+from deepagents.middleware.filesystem import FilesystemPermission
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,


### PR DESCRIPTION
Reverts #3040, restoring #3033's import-path fix in the deploy template (originally by @emanbareket).

## Background

#2992 moved `FilesystemPermission` out of `deepagents.middleware.permissions` and into `deepagents.middleware.filesystem`, deleting the old module. This broke `main` for anyone importing the old path. #3033 patched `templates.py` to import from the new module path; #3040 reverted because that path was unreleased at the time. #3036 then landed a backwards-compat re-export of `deepagents.middleware.permissions`, and 0.5.5 shipped to PyPI with both #2992 and #3036.

## Where this leaves the template

The template's *original* line — `from deepagents.middleware.permissions import FilesystemPermission` — works against every released SDK: 0.5.3 and 0.5.4 ship the real module; 0.5.5 ships the re-export shim. So the template at its current pin (`deepagents==0.5.3`) is not broken in user-facing deploys.

This PR's diff swaps to `from deepagents.middleware.filesystem import FilesystemPermission`. That path only exists in 0.5.5+, so the change actually narrows version compat relative to the original line. It also pulls a deep middleware path into a generated user file, which Eugene flagged in Slack: `FilesystemPermission` is intended to be imported from the top-level `deepagents` namespace, with the `middleware.*` modules treated as internal.

## Suggested merge plan

Pick one:

- **Close this PR** — original line works against every released version; nothing to fix.
- **Re-target this PR to the top-level import** — change the diff to `from deepagents import FilesystemPermission`. Public API, version-agnostic, matches Eugene's guidance, no template pin bump required.
- **Land as-is** — only safe if the template's `deepagents==0.5.3` pin is also bumped to `>=0.5.5` so the deep-middleware path exists at install time. Still not the recommended import style.