### PR TITLE
fix(subagents): guard against IndexError when messages list is empty

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -406,6 +406,8 @@ def _build_task_tool(  # noqa: C901
                 content = json.dumps(dataclasses.asdict(structured))
             else:
                 content = json.dumps(structured)
+        elif not result["messages"]:
+            content = ""
         else:
             # Strip trailing whitespace to prevent API errors with Anthropic
             content = result["messages"][-1].text.rstrip() if result["messages"][-1].text else ""


### PR DESCRIPTION
Fixes #3043.

`_return_command_with_state_update` checks that the `messages` key exists but does not guard against an empty list before accessing `result["messages"][-1]` on line 411. When a subagent returns `{"messages": []}`, this crashes with `IndexError` before the `.text` conditional is even evaluated. Added an empty list check that returns empty content instead of crashing.