### PR TITLE
feat(deep-research): add query-expansion pipeline with dedup and semantic ranking

### DIFF
--- a/examples/deep_research/research_agent/eval_search.py
+++ b/examples/deep_research/research_agent/eval_search.py
@@ -1,0 +1,303 @@
+"""eval_search.py — Compare baseline vs. query-expansion search pipelines.
+
+Usage
+-----
+    python eval_search.py                          # embedding-based relevance
+    python eval_search.py --k 1 3 5 10             # override k values
+    python eval_search.py --max-results 5          # results per query
+    python eval_search.py --threshold 0.4          # cosine similarity cutoff
+
+Metrics
+-------
+Recall@k  : fraction of relevant URLs found in the top-k ranked list.
+MRR       : mean reciprocal rank of the first relevant URL.
+
+Relevance (priority order)
+--------------------------
+1. GROUND_TRUTH — labelled URL lists; highest fidelity when available.
+2. Embedding proxy — cosine similarity between the query embedding and each
+   result's title+content snippet (all-MiniLM-L6-v2). Results whose
+   similarity >= --threshold are treated as relevant. This is model-agnostic
+   and avoids the bias of pooled relevance toward the system that retrieves
+   more documents.
+
+    GROUND_TRUTH = {
+        "python async best practices": [
+            "https://docs.python.org/3/library/asyncio.html",
+        ],
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Any
+
+import numpy as np
+
+from tools import (
+    _get_embedding_model,
+    _text_from_result,
+    _url_from_result,
+    deduplicate_results,
+    expand_query,
+    parallel_search,
+    rank_results,
+    tavily_client,
+)
+
+# ── Eval configuration ────────────────────────────────────────────────────────
+
+EVAL_QUERIES: list[str] = [
+    "Python async best practices",
+    "transformer architecture explained",
+    "retrieval augmented generation overview",
+]
+
+# Map query → list of known-relevant URLs.
+# Leave empty to fall back to embedding-based proxy relevance.
+GROUND_TRUTH: dict[str, list[str]] = {}
+
+DEFAULT_K_VALUES: list[int] = [1, 3, 5, 10]
+DEFAULT_MAX_RESULTS: int = 5
+DEFAULT_EMBED_THRESHOLD: float = 0.35  # cosine similarity cutoff for proxy relevance
+TOPIC: str = "general"
+
+# ── Retrieval ─────────────────────────────────────────────────────────────────
+
+
+async def run_baseline(query: str, max_results: int) -> list[dict]:
+    """Single Tavily call. Returns result dicts in Tavily's scored order."""
+    result = await asyncio.to_thread(
+        tavily_client.search, query, max_results=max_results, topic=TOPIC
+    )
+    return [item for item in result.get("results", []) if item.get("url")]
+
+
+async def run_enhanced(query: str, max_results: int) -> list[dict]:
+    """expand_query → parallel_search → deduplicate → rank. Returns ranked result dicts."""
+
+    def _search(q: str) -> dict[str, Any]:
+        return tavily_client.search(q, max_results=max_results, topic=TOPIC)
+
+    queries = await expand_query(query)
+    raw = await parallel_search(queries, _search)
+    deduped = deduplicate_results(raw)
+    ranked = await rank_results(deduped, query, raw_results=raw)
+    return [r for r in ranked if _url_from_result(r)]
+
+
+def _ordered_urls(items: list[dict]) -> list[str]:
+    return [_url_from_result(r) for r in items if _url_from_result(r)]
+
+
+# ── Embedding-based proxy relevance ───────────────────────────────────────────
+
+
+async def _embed_relevance(
+    query: str,
+    items: list[dict],
+    threshold: float,
+) -> set[str]:
+    """Return URLs whose title+content embedding is within `threshold` of the query.
+
+    All items from both pipelines are deduplicated by URL before encoding so
+    the relevance judgement is independent of which system retrieved them.
+    """
+    # Deduplicate by URL to avoid double-scoring the same page
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for item in items:
+        url = _url_from_result(item)
+        if url and url not in seen:
+            seen.add(url)
+            unique.append(item)
+
+    if not unique:
+        return set()
+
+    model = _get_embedding_model()
+    texts = [query] + [_text_from_result(item) for item in unique]
+    embeddings: np.ndarray = await asyncio.to_thread(
+        model.encode, texts, normalize_embeddings=True, show_progress_bar=False
+    )
+
+    query_emb: np.ndarray = embeddings[0]
+    result_embs: np.ndarray = embeddings[1:]
+    sims: np.ndarray = result_embs @ query_emb  # cosine sim via dot product on L2-normed vecs
+
+    return {
+        _url_from_result(item)
+        for item, sim in zip(unique, sims)
+        if float(sim) >= threshold
+    }
+
+
+# ── Metrics ───────────────────────────────────────────────────────────────────
+
+
+def recall_at_k(ranked: list[str], relevant: set[str], k: int) -> float:
+    """Fraction of relevant URLs found in the top-k positions."""
+    if not relevant:
+        return 0.0
+    hits = sum(1 for u in ranked[:k] if u in relevant)
+    return hits / len(relevant)
+
+
+def reciprocal_rank(ranked: list[str], relevant: set[str]) -> float:
+    """1 / rank of the first relevant URL; 0.0 if none found."""
+    for rank, url in enumerate(ranked, start=1):
+        if url in relevant:
+            return 1.0 / rank
+    return 0.0
+
+
+# ── Formatting ────────────────────────────────────────────────────────────────
+
+_COL = {"metric": 15, "val": 10}
+_SEP = "=" * 60
+
+
+def _row(label: str, baseline: float, enhanced: float) -> str:
+    delta = enhanced - baseline
+    sign = "+" if delta >= 0 else ""
+    return (
+        f"{label:<{_COL['metric']}}"
+        f"{baseline:>{_COL['val']}.3f}"
+        f"{enhanced:>{_COL['val']}.3f}"
+        f"{sign}{delta:>{_COL['val'] - 1}.3f}"
+    )
+
+
+def _header() -> str:
+    return (
+        f"{'Metric':<{_COL['metric']}}"
+        f"{'Baseline':>{_COL['val']}}"
+        f"{'Enhanced':>{_COL['val']}}"
+        f"{'Delta':>{_COL['val']}}"
+    )
+
+
+# ── Evaluation loop ───────────────────────────────────────────────────────────
+
+
+async def evaluate(k_values: list[int], max_results: int, threshold: float) -> None:
+    per_query: list[dict[str, Any]] = []
+
+    for query in EVAL_QUERIES:
+        print(f"\n{_SEP}")
+        print(f"Query: {query}")
+        print(_SEP)
+
+        baseline_items, enhanced_items = await asyncio.gather(
+            run_baseline(query, max_results),
+            run_enhanced(query, max_results),
+        )
+
+        baseline_urls = _ordered_urls(baseline_items)
+        enhanced_urls = _ordered_urls(enhanced_items)
+
+        if query in GROUND_TRUTH:
+            relevant = set(GROUND_TRUTH[query])
+            rel_source = "ground truth"
+        else:
+            relevant = await _embed_relevance(
+                query, baseline_items + enhanced_items, threshold
+            )
+            rel_source = f"embedding (threshold={threshold})"
+
+        print(f"Relevant ({rel_source}): {len(relevant)}")
+        print(f"Baseline retrieved : {len(baseline_urls)}")
+        print(f"Enhanced retrieved : {len(enhanced_urls)}")
+
+        b_recalls = {k: recall_at_k(baseline_urls, relevant, k) for k in k_values}
+        e_recalls = {k: recall_at_k(enhanced_urls, relevant, k) for k in k_values}
+        b_mrr = reciprocal_rank(baseline_urls, relevant)
+        e_mrr = reciprocal_rank(enhanced_urls, relevant)
+
+        per_query.append(
+            {
+                "query": query,
+                "b_recalls": b_recalls,
+                "e_recalls": e_recalls,
+                "b_mrr": b_mrr,
+                "e_mrr": e_mrr,
+            }
+        )
+
+        header = _header()
+        print(f"\n{header}")
+        print("-" * len(header))
+        for k in k_values:
+            print(_row(f"Recall@{k}", b_recalls[k], e_recalls[k]))
+        print(_row("MRR", b_mrr, e_mrr))
+
+        # Side-by-side top-5 URL comparison; * marks relevant hits
+        print(f"\n{'Rank':<6} {'Baseline URL':<55} {'Enhanced URL'}")
+        print("-" * 120)
+        for i in range(max(len(baseline_urls[:5]), len(enhanced_urls[:5]))):
+            b_url = baseline_urls[i] if i < len(baseline_urls) else ""
+            e_url = enhanced_urls[i] if i < len(enhanced_urls) else ""
+            b_mark = " *" if b_url in relevant else ""
+            e_mark = " *" if e_url in relevant else ""
+            print(f"{i+1:<6} {(b_url + b_mark):<55} {e_url + e_mark}")
+
+    # ── Aggregate ─────────────────────────────────────────────────────────────
+    n = len(per_query)
+    print(f"\n{_SEP}")
+    print(f"AGGREGATE  (macro-average, n={n} queries)")
+    print(_SEP)
+
+    avg_b_recalls = {k: sum(r["b_recalls"][k] for r in per_query) / n for k in k_values}
+    avg_e_recalls = {k: sum(r["e_recalls"][k] for r in per_query) / n for k in k_values}
+    avg_b_mrr = sum(r["b_mrr"] for r in per_query) / n
+    avg_e_mrr = sum(r["e_mrr"] for r in per_query) / n
+
+    header = _header()
+    print(f"\n{header}")
+    print("-" * len(header))
+    for k in k_values:
+        print(_row(f"Recall@{k}", avg_b_recalls[k], avg_e_recalls[k]))
+    print(_row("MRR", avg_b_mrr, avg_e_mrr))
+    print()
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Eval baseline vs. enhanced search")
+    parser.add_argument(
+        "--k",
+        nargs="+",
+        type=int,
+        default=DEFAULT_K_VALUES,
+        metavar="K",
+        help="k values for Recall@k (default: 1 3 5 10)",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=DEFAULT_MAX_RESULTS,
+        dest="max_results",
+        help="results per Tavily call (default: 5)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_EMBED_THRESHOLD,
+        help="cosine similarity cutoff for embedding-based relevance (default: 0.35)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    asyncio.run(
+        evaluate(
+            k_values=sorted(args.k),
+            max_results=args.max_results,
+            threshold=args.threshold,
+        )
+    )

--- a/examples/deep_research/research_agent/tools.py
+++ b/examples/deep_research/research_agent/tools.py
@@ -4,13 +4,364 @@ This module provides search and content processing utilities for the research ag
 using Tavily for URL discovery and fetching full webpage content.
 """
 
+import asyncio
+import inspect
+import re
+from collections import Counter
+from typing import Any, Callable
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+import anthropic
 import httpx
 from langchain_core.tools import InjectedToolArg, tool
 from markdownify import markdownify
+from pydantic import BaseModel
 from tavily import TavilyClient
 from typing_extensions import Annotated, Literal
 
 tavily_client = TavilyClient()
+
+# Set to True to run expand_query → parallel_search → deduplicate → rank
+# before fetching page content. Falls back to a single Tavily call when False.
+USE_QUERY_EXPANSION: bool = False
+
+_async_anthropic_client: anthropic.AsyncAnthropic | None = None
+
+
+def _get_async_anthropic_client() -> anthropic.AsyncAnthropic:
+    global _async_anthropic_client
+    if _async_anthropic_client is None:
+        _async_anthropic_client = anthropic.AsyncAnthropic()
+    return _async_anthropic_client
+
+
+_EMBEDDING_MODEL_NAME = "all-MiniLM-L6-v2"
+_embedding_model: SentenceTransformer | None = None
+
+
+def _get_embedding_model() -> SentenceTransformer:
+    global _embedding_model
+    if _embedding_model is None:
+        _embedding_model = SentenceTransformer(_EMBEDDING_MODEL_NAME)
+    return _embedding_model
+
+
+class _ExpandedQueries(BaseModel):
+    paraphrase: str
+    broader: str
+    narrower: str
+    synonym_variation: str
+    related_concept: str
+
+
+_EXPAND_QUERY_SYSTEM_PROMPT = """\
+You are a search query expansion expert. Given a user query, produce exactly one \
+query for each of the following five roles:
+
+- paraphrase: reword the query while preserving its exact intent
+- broader: widen the scope to the parent topic or domain
+- narrower: drill into a specific aspect, subtopic, or use-case
+- synonym_variation: replace key terms with meaningful synonyms or alternate phrasing
+- related_concept: a query on a closely related concept that would yield complementary results
+
+Return only the five fields — no explanations."""
+
+
+async def expand_query(query: str) -> list[str]:
+    """Generate 6 diverse search queries (original + 5 structured variations) using Claude.
+
+    The five generated variants cover: paraphrase, broader scope, narrower scope,
+    synonym variation, and related concept. The original query is prepended so callers
+    always have the full set.
+
+    Args:
+        query: The original search query to expand.
+
+    Returns:
+        A list of 6 queries: [original, paraphrase, broader, narrower,
+        synonym_variation, related_concept].
+    """
+    client = _get_async_anthropic_client()
+
+    response = await client.messages.parse(
+        model="claude-opus-4-7",
+        max_tokens=512,
+        system=[
+            {
+                "type": "text",
+                "text": _EXPAND_QUERY_SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": f"Expand this query:\n\n{query}",
+            }
+        ],
+        output_format=_ExpandedQueries,
+    )
+
+    variants = response.parsed_output
+    return [
+        query,
+        variants.paraphrase,
+        variants.broader,
+        variants.narrower,
+        variants.synonym_variation,
+        variants.related_concept,
+    ]
+
+
+async def parallel_search(
+    queries: list[str],
+    search_fn: Callable[[str], Any],
+    timeout: float = 10.0,
+) -> list[Any]:
+    """Run multiple search queries concurrently and return combined results.
+
+    Accepts both sync and async search functions. Sync functions are offloaded
+    to a thread pool so they don't block the event loop. Each query has an
+    individual timeout; timed-out or failed queries are dropped so one slow
+    result never blocks the rest.
+
+    Args:
+        queries: List of search queries to execute.
+        search_fn: Callable that accepts a query string and returns results.
+                   May be sync or async.
+        timeout: Per-query timeout in seconds. Defaults to 10.
+
+    Returns:
+        Flat list of results in the same order as the input queries.
+        Timed-out or failed queries are omitted from the output.
+    """
+    if inspect.iscoroutinefunction(search_fn):
+        async def _call(q: str) -> Any:
+            return await asyncio.wait_for(search_fn(q), timeout=timeout)
+    else:
+        async def _call(q: str) -> Any:
+            return await asyncio.wait_for(
+                asyncio.to_thread(search_fn, q), timeout=timeout
+            )
+
+    results = await asyncio.gather(*[_call(q) for q in queries], return_exceptions=True)
+
+    return [r for r in results if not isinstance(r, BaseException)]
+
+
+# Compiled once at module level — used by both string and dict paths
+_URL_PATTERN = re.compile(r"\*\*URL:\*\*\s+(https?://\S+)")
+_TITLE_PATTERN = re.compile(r"^##\s+(.+)", re.MULTILINE)
+
+
+def _title_vector(title: str) -> Counter:
+    """Bag-of-words term-frequency vector for a title string."""
+    return Counter(re.findall(r"\w+", title.lower()))
+
+
+def _cosine_similarity(a: Counter, b: Counter) -> float:
+    """Cosine similarity between two term-frequency Counters."""
+    if not a or not b:
+        return 0.0
+    dot = sum(a[k] * b[k] for k in a if k in b)
+    mag_a = sum(v * v for v in a.values()) ** 0.5
+    mag_b = sum(v * v for v in b.values()) ** 0.5
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def _is_near_duplicate_title(
+    title: str,
+    kept_vectors: list[Counter],
+    threshold: float,
+) -> bool:
+    """Return True if title is too similar to any already-kept title."""
+    vec = _title_vector(title)
+    return any(_cosine_similarity(vec, kv) >= threshold for kv in kept_vectors)
+
+
+def deduplicate_results(
+    results: list[Any],
+    title_threshold: float = 0.85,
+) -> list[Any]:
+    """Remove duplicate and near-duplicate search results.
+
+    Two deduplication passes are applied in order:
+
+    1. **Exact URL dedup** — results sharing a URL are collapsed to the first
+       occurrence.
+    2. **Near-duplicate title dedup** — after URL dedup, results whose titles
+       exceed ``title_threshold`` cosine similarity (bag-of-words TF vectors)
+       with any already-kept title are dropped.
+
+    Handles two formats produced by search functions in this module:
+
+    - **String** (``tavily_search``): each item is a multi-result markdown
+      block. Sections are split on ``---``; titles are extracted from ``## …``
+      headers; URLs from ``**URL:** …`` lines.
+    - **Dict** (raw Tavily / ``web_search``): each item is a response dict
+      with a ``"results"`` list of ``{"url": …, "title": …, …}`` records.
+
+    In both cases the first occurrence of each URL is kept, insertion order is
+    preserved, and the output is a flat list of individual result items.
+
+    Args:
+        results: Output of ``parallel_search`` — a list of strings or dicts.
+        title_threshold: Cosine similarity cutoff for near-duplicate titles.
+            0.85 drops paraphrased headlines; lower values are more aggressive.
+
+    Returns:
+        Flat, deduplicated list of individual result items.
+    """
+    if not results:
+        return []
+
+    seen_urls: set[str] = set()
+    kept_title_vectors: list[Counter] = []
+
+    def _keep(url: str, title: str) -> bool:
+        """Return True and register if this result should be kept."""
+        if url and url in seen_urls:
+            return False
+        if title and _is_near_duplicate_title(title, kept_title_vectors, title_threshold):
+            return False
+        if url:
+            seen_urls.add(url)
+        if title:
+            kept_title_vectors.append(_title_vector(title))
+        return True
+
+    deduped: list[Any] = []
+
+    if isinstance(results[0], str):
+        for response in results:
+            for block in response.split("---"):
+                block = block.strip()
+                if not block:
+                    continue
+                url_match = _URL_PATTERN.search(block)
+                title_match = _TITLE_PATTERN.search(block)
+                url = url_match.group(1) if url_match else ""
+                title = title_match.group(1).strip() if title_match else ""
+                if _keep(url or block, title):
+                    deduped.append(block)
+        return deduped
+
+    # Dict format: {"results": [{"url": ..., "title": ..., ...}], "query": "..."}
+    for response in results:
+        for item in response.get("results", []):
+            url = item.get("url", "")
+            title = item.get("title", "")
+            if _keep(url, title):
+                deduped.append(item)
+    return deduped
+
+
+def _url_from_result(result: Any) -> str:
+    """Extract URL from a result regardless of format."""
+    if isinstance(result, dict):
+        return result.get("url", "")
+    match = _URL_PATTERN.search(result)
+    return match.group(1) if match else ""
+
+
+def _text_from_result(result: Any) -> str:
+    """Extract a bag-of-words-friendly text representation of a result."""
+    if isinstance(result, dict):
+        return f"{result.get('title', '')} {result.get('content', '')}"
+    # String format: strip markdown symbols for cleaner tokenisation
+    text = re.sub(r"[#*`>-]", " ", result)
+    return text[:2000]  # cap to avoid over-weighting long content
+
+
+def _url_frequency_map(raw_results: list[Any]) -> dict[str, int]:
+    """Count how many query responses each URL appeared in."""
+    counts: dict[str, int] = {}
+    for response in raw_results:
+        if isinstance(response, dict):
+            urls = {item.get("url", "") for item in response.get("results", [])}
+        else:
+            urls = set(_URL_PATTERN.findall(response))
+        for url in urls:
+            if url:
+                counts[url] = counts.get(url, 0) + 1
+    return counts
+
+
+async def rank_results(
+    results: list[Any],
+    original_query: str,
+    raw_results: list[Any] | None = None,
+    query_weight: float = 0.5,
+    frequency_weight: float = 0.5,
+) -> list[Any]:
+    """Rank search results by semantic similarity to the original query and
+    cross-query frequency.
+
+    Each result receives a combined score:
+
+    .. code-block:: text
+
+        score = query_weight    * query_similarity
+              + frequency_weight * frequency_score
+
+    - **query_similarity**: cosine similarity between the sentence embedding of
+      the original query and the embedding of each result's title + content
+      snippet. All texts are encoded in a single batched call to
+      ``all-MiniLM-L6-v2`` (run in a thread pool so the event loop is not
+      blocked).
+    - **frequency_score**: how many of the expanded queries returned this URL,
+      normalised to [0, 1] by the maximum observed count. Requires
+      ``raw_results`` (the pre-deduplication output of ``parallel_search``).
+      When omitted, the full weight falls on ``query_similarity``.
+
+    Args:
+        results: Deduplicated results from ``deduplicate_results``.
+        original_query: The original (unexpanded) query string.
+        raw_results: Pre-deduplication output of ``parallel_search``. Used to
+            count how many queries each URL appeared in. Optional — when
+            ``None``, frequency scoring is skipped.
+        query_weight: Weight for semantic similarity component (default 0.5).
+        frequency_weight: Weight for frequency component (default 0.5).
+            Ignored when ``raw_results`` is ``None``.
+
+    Returns:
+        Results sorted by descending score. Original list is not mutated.
+    """
+    if not results:
+        return []
+
+    # Build frequency map; normalise by the highest count seen
+    freq_map: dict[str, int] = _url_frequency_map(raw_results) if raw_results else {}
+    max_freq = max(freq_map.values(), default=1)
+
+    # Effective weights — collapse to query-only when no frequency data
+    eff_query_w = 1.0 if not freq_map else query_weight
+    eff_freq_w = 0.0 if not freq_map else frequency_weight
+
+    # Batch-encode query + all result texts in one call to avoid per-item overhead.
+    # SentenceTransformer.encode is CPU-bound; run in a thread pool.
+    texts = [original_query] + [_text_from_result(r) for r in results]
+    model = _get_embedding_model()
+    embeddings: np.ndarray = await asyncio.to_thread(
+        model.encode, texts, normalize_embeddings=True, show_progress_bar=False
+    )
+
+    # With L2-normalised vectors cosine similarity reduces to a dot product.
+    query_emb = embeddings[0]           # shape: (dim,)
+    result_embs = embeddings[1:]        # shape: (n_results, dim)
+    query_sims: np.ndarray = result_embs @ query_emb  # shape: (n_results,)
+
+    def _score(idx: int) -> float:
+        url = _url_from_result(results[idx])
+        freq_score = freq_map.get(url, 0) / max_freq if freq_map else 0.0
+        return float(eff_query_w * query_sims[idx] + eff_freq_w * freq_score)
+
+    indices = sorted(range(len(results)), key=_score, reverse=True)
+    return [results[i] for i in indices]
 
 
 def fetch_webpage_content(url: str, timeout: float = 10.0) -> str:
@@ -36,7 +387,7 @@ def fetch_webpage_content(url: str, timeout: float = 10.0) -> str:
 
 
 @tool(parse_docstring=True)
-def tavily_search(
+async def tavily_search(
     query: str,
     max_results: Annotated[int, InjectedToolArg] = 1,
     topic: Annotated[
@@ -46,6 +397,8 @@ def tavily_search(
     """Search the web for information on a given query.
 
     Uses Tavily to discover relevant URLs, then fetches and returns full webpage content as markdown.
+    When USE_QUERY_EXPANSION is enabled, the query is expanded into multiple variants and results
+    are deduplicated and ranked before page content is fetched.
 
     Args:
         query: Search query to execute
@@ -55,37 +408,27 @@ def tavily_search(
     Returns:
         Formatted search results with full webpage content
     """
-    # Use Tavily to discover URLs
-    search_results = tavily_client.search(
-        query,
-        max_results=max_results,
-        topic=topic,
-    )
+    def _search(q: str) -> dict:
+        return tavily_client.search(q, max_results=max_results, topic=topic)
 
-    # Fetch full content for each URL
+    if USE_QUERY_EXPANSION:
+        queries = await expand_query(query)
+        raw_results = await parallel_search(queries, _search)
+        deduped = deduplicate_results(raw_results)
+        ranked = await rank_results(deduped, query, raw_results=raw_results)
+        result_items = ranked
+    else:
+        search_results = await asyncio.to_thread(_search, query)
+        result_items = search_results.get("results", [])
+
     result_texts = []
-    for result in search_results.get("results", []):
-        url = result["url"]
-        title = result["title"]
+    for item in result_items:
+        url = item.get("url", "")
+        title = item.get("title", "")
+        content = await asyncio.to_thread(fetch_webpage_content, url)
+        result_texts.append(f"## {title}\n**URL:** {url}\n\n{content}\n\n---\n")
 
-        # Fetch webpage content
-        content = fetch_webpage_content(url)
-
-        result_text = f"""## {title}
-**URL:** {url}
-
-{content}
-
----
-"""
-        result_texts.append(result_text)
-
-    # Format final response
-    response = f"""🔍 Found {len(result_texts)} result(s) for '{query}':
-
-{chr(10).join(result_texts)}"""
-
-    return response
+    return f"🔍 Found {len(result_texts)} result(s) for '{query}':\n\n{chr(10).join(result_texts)}"
 
 
 @tool(parse_docstring=True)


### PR DESCRIPTION
## Summary

Adds a full query-expansion pipeline to the deep research agent's `tavily_search` tool. A new `USE_QUERY_EXPANSION` flag gates the enhanced path; the original single-query behaviour is preserved as the default. An evaluation script (`eval_search.py`) measures the impact using embedding-based proxy relevance when ground-truth labels are unavailable.

---

## Motivation

The existing `tavily_search` tool issues a single query and returns Tavily's own relevance ranking. This has two failure modes that compound each other in research tasks:

1. **Query specificity mismatch** — a single phrasing rarely matches the vocabulary of every relevant document. Broader, narrower, and synonym-variant phrasings each surface different high-quality pages.
2. **No re-ranking** — results are ordered by Tavily's internal score, which optimises for general relevance rather than the agent's specific research question.

---

## Implementation Details

All changes are in `examples/deep_research/research_agent/tools.py` and a new `eval_search.py`.

#### `expand_query(query) → list[str]`
Calls Claude (`claude-opus-4-7`) with a cached system prompt and structured output (`_ExpandedQueries` Pydantic model) to produce five typed variants: paraphrase, broader scope, narrower scope, synonym variation, and related concept. Returns the original query prepended so callers always work with the full set of six.

#### `parallel_search(queries, search_fn, timeout) → list[Any]`
Runs all queries concurrently via `asyncio.gather`. Accepts both sync and async search functions — sync callables are offloaded to a thread pool via `asyncio.to_thread`. Each query has an individual `asyncio.wait_for` timeout so a single slow result never blocks the rest; timed-out or failed queries are silently dropped.

#### `deduplicate_results(results, title_threshold=0.85) → list[Any]`
Two-pass deduplication:
1. **Exact URL** — first occurrence wins.
2. **Near-duplicate title** — bag-of-words TF cosine similarity; results whose title exceeds `title_threshold` against any already-kept title are dropped.

Handles both result formats produced in this codebase: the raw Tavily dict format (`{"results": [...]}`) and the formatted markdown string output of `tavily_search`.

#### `rank_results(results, original_query, raw_results, ...) → list[Any]`
Scores each deduplicated result as:

```
score = query_weight * cosine_sim(query_embedding, result_embedding)
      + freq_weight  * (url_occurrence_count / max_count)
```

Embeddings use `all-MiniLM-L6-v2` (lazy singleton); the full batch is encoded in a single `asyncio.to_thread` call. With L2-normalised vectors, cosine similarity reduces to a dot product, computed in one vectorised NumPy operation. `raw_results` (pre-dedup) is passed separately to count how many of the expanded queries each URL appeared in, since that cross-query frequency signal is lost after deduplication.

#### `tavily_search` tool (modified)
Converted from `def` to `async def`. The inner `_search` closure captures `max_results` and `topic`:

- **`USE_QUERY_EXPANSION = True`**: `expand_query → parallel_search → deduplicate_results → rank_results`, then fetch page content for ranked items.
- **`USE_QUERY_EXPANSION = False`** (default): single `asyncio.to_thread(_search, query)`, preserving the original behaviour without breaking callers.

`fetch_webpage_content` is also offloaded via `asyncio.to_thread` in both paths.

#### `eval_search.py`
Runs both pipelines concurrently per query (`asyncio.gather`) and reports Recall@k and MRR. Relevance is determined by priority:

1. `GROUND_TRUTH` dict, when populated.
2. **Embedding proxy** — cosine similarity between the query and each result's title+content snippet using the same `all-MiniLM-L6-v2` model. Items from both pipelines are pooled and deduplicated before encoding so the judgement is system-agnostic. Configurable via `--threshold` (default 0.35).

```
python eval_search.py --k 1 3 5 10 --max-results 5 --threshold 0.35
```

---

## Evaluation Results

Without labelled ground truth, the embedding proxy (threshold 0.35) is the available signal. Expected directional outcomes based on design:

| Metric | Baseline | Enhanced | Notes |
|---|---|---|---|
| Recall@5 | lower | higher | expansion surfaces pages the single query misses |
| Recall@10 | lower | higher | deduplication prevents the same page filling slots |
| MRR | comparable | higher | semantic re-ranking promotes the most query-relevant result |

Actual numbers depend on query set and Tavily quota. Run `eval_search.py` against `EVAL_QUERIES` to produce concrete figures for this environment.

---

## Risks

**Cost and latency.** `USE_QUERY_EXPANSION = True` issues up to 6 Tavily queries and one Claude call per `tavily_search` invocation. In a research agent that calls the tool many times per session this multiplies API spend and adds ~2–5 s of latency on the critical path. The flag is `False` by default to avoid surprising existing users.

**Embedding model cold-start.** `SentenceTransformer("all-MiniLM-L6-v2")` is loaded lazily on first use and cached as a module-level singleton. The first call in a process will download ~90 MB and take several seconds. Subsequent calls are fast.

**Threshold sensitivity in `eval_search.py`.** The proxy relevance signal is only as good as the embedding model's judgement for a given query domain. A threshold that is too low marks near-everything relevant (inflating recall); too high may leave the relevant set empty (making MRR undefined). The default of 0.35 is a reasonable starting point but should be validated against any labelled held-out set before drawing strong conclusions.

**Thread-pool contention.** `asyncio.to_thread` uses the default executor (8 threads on CPython). With 6 parallel queries each offloading a sync Tavily call, plus the embedding encode, the pool can saturate under concurrent agent load. Consider raising `loop.set_default_executor` thread count in high-throughput deployments.

**Format assumptions in deduplication.** `deduplicate_results` dispatches on `isinstance(results[0], str)`. If a future search function returns a mixed list (some strings, some dicts), the string path will silently discard the dict items. The assumption is documented but not enforced with a type guard.

---

#######################################

HIGH LEVEL DESIGN - 

The issue is low recall from a single query. So, I'll:

expand queries
run search in parallel
aggregate and dedupe
rank results

I'll wrap this around the existing tool.

#######################################

The following prompts were used to complete the coding task and achieve the final result (The  sub bullets after each prompt explains the thought process behind that prompt):

1. Clone the repo - https://github.com/langchain-ai/deepagents
2. Explain the structure of this repo and identify where the web search tool is implemented and how the agent calls it.
   1. I wanted to first understand how the current search tool is wired before modifying it. I wanted to make minimal, safe changes.
3. Search for files containing web_search or similar tools and open the relevant implementation
   1. I wanted to extend this instead of rewriting the agent.
4. Create a Python async function expand_query(query: str) that generates 5 diverse search queries using an LLM
   1. I wanted to start with query expansion as a modular component.
5. Improve the function to ensure diversity:
- paraphrase
- broader query
- narrower query
- synonym variation
- related concept
Also ensure original query is included
   1. I wanted diversity, not just paraphrases.
   2. I wanted to Include the original query to avoid drift.
6. Write an async function parallel_search(queries, search_fn) that runs all queries concurrently and returns combined results
   1. I wanted to execute searches across these queries in parallel to avoid latency blowup
7. Add timeout handling so that slow queries don't block the entire response
   1. I wanted to guard against slow queries
8. Create a deduplicate_results function that removes duplicate results based on URL
   1. Since, multiple queries would return overlapping results, so I needed deduplication.
9. Enhance deduplication by also removing near-duplicate titles using cosine similarity
   1. Since, same content could appear with different URLs, URL-based dedupe wasn't enough.
10. Create a ranking function that scores results using:
- similarity to original query
- frequency of occurrence across expanded queries
   1. I needed to rank results across queries.
11. Use embeddings to compute similarity between query and result snippets
12. Modify the existing web_search tool to:
- add a flag USE_QUERY_EXPANSION
- call enhanced pipeline when enabled
- fallback to original otherwise
   1. I wanted to integrate this into the existing web_search tool with a feature flag for safe rollout.
   2. I wanted to make the rollout reversible.
13. Create a script eval_search.py that:
- runs both old and new search
- compares results
- computes recall@k and MRR
   1. Before shipping, I wanted to validate offline.
14. If ground truth labels are missing, use embedding similarity between query and results as a proxy relevance metric
   1. Since, we may not have had labels, so I wanted to use proxy metrics.
15. Write a GitHub PR description including:
- summary
- motivation
- implementation details
- evaluation results
- risks
   1. I wanted to create a clean PR with explanation.
