### PR TITLE
fix(cli): recover from failed server startup via `/model`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -428,6 +428,24 @@ def _truncate(text: str, *, limit: int) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
+def _log_task_exception(task: asyncio.Task[Any]) -> None:
+    """Done-callback that surfaces unhandled exceptions from fire-and-forget tasks.
+
+    Default `asyncio` behavior is to log "Task exception was never retrieved"
+    only when the task is GC'd — easy to miss. This callback runs at task
+    completion and routes failures through `logger.warning` with `exc_info`,
+    matching the codebase pattern at `_finalize_git_branch_refresh`. Use
+    when scheduling a coroutine via `asyncio.create_task` whose result is
+    not awaited (e.g. event-handler cleanup, single-fire mounts).
+    """
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.warning("Background task failed unexpectedly", exc_info=True)
+
+
 def _format_startup_error(error: BaseException) -> str:
     """Format a server-startup exception for the welcome banner.
 
@@ -905,6 +923,25 @@ class DeepAgentsApp(App):
         Shown in place of the generic 'Agent not configured' message.
         """
 
+        self._server_startup_missing_credentials_provider: str | None = None
+        """Set to the offending provider name when startup failed with
+        `MissingCredentialsError`; `None` otherwise. Gates the `/model`
+        recovery hint without string-matching on the formatted error.
+        """
+
+        self._retry_status_widget: AppMessage | None = None
+        """Transient "Retrying startup with X…" breadcrumb. Mounted via
+        `_mount_before_queued` (not `_mount_message`) because it is ephemeral
+        state and must not appear in scrollback or serialized history.
+        """
+
+        self._startup_failure_widget: ErrorMessage | None = None
+        """Transient chat surface for the most recent server-startup failure.
+        Mounted by `on_deep_agents_app_server_start_failed`; removed on
+        `ServerReady` so a successful `/model` retry doesn't leave the stale
+        error dangling in scrollback.
+        """
+
         self._quit_pending = False
         """True after a first `Ctrl+C` so a second press within the window quits."""
 
@@ -1180,6 +1217,14 @@ class DeepAgentsApp(App):
 
         # Focus the input immediately so the cursor is visible on first paint
         self._chat_input.focus_input()
+
+        # Pre-import `html.entities` on the main thread before the worker
+        # starts. Python 3.14 replaced the global import lock with per-module
+        # locks; a worker importing `markdown_it` (which transitively pulls
+        # `html.entities`) can race main-thread code looking up `html` *while
+        # `html` itself is still being initialized*, raising `KeyError: 'html'`
+        # from `_find_and_load_unlocked`.
+        import html.entities  # noqa: F401
 
         # Prewarm heavy imports in a thread while the first frame renders.
         # The user can't type yet, so GIL contention is harmless.  By the
@@ -1742,6 +1787,28 @@ class DeepAgentsApp(App):
         self._agent = event.agent
         self._server_proc = event.server_proc
         self._mcp_server_info = event.mcp_server_info
+
+        # Drop transient failure-state widgets — banner state and the agent
+        # response now convey "connected", so the prior error and breadcrumb
+        # would just dangle in scrollback.
+        for attr in ("_retry_status_widget", "_startup_failure_widget"):
+            widget = getattr(self, attr)
+            if widget is None:
+                continue
+            setattr(self, attr, None)
+
+            async def _drop(w: Widget = widget) -> None:
+                # Mount may still be in flight when `ServerReady` arrives;
+                # short-circuit on un-attached widgets instead of raising.
+                # `NoMatches`/`ScreenStackError` cover later-stage detach
+                # races (screen torn down mid-removal).
+                if not w.is_attached:
+                    return
+                with suppress(NoMatches, ScreenStackError):
+                    await w.remove()
+
+            task = asyncio.create_task(_drop())
+            task.add_done_callback(_log_task_exception)
         self._mcp_tool_count = sum(len(s.tools) for s in (event.mcp_server_info or []))
         self._mcp_unauthenticated = sum(
             1 for s in (event.mcp_server_info or []) if s.status == "unauthenticated"
@@ -1797,6 +1864,7 @@ class DeepAgentsApp(App):
     def on_deep_agents_app_server_start_failed(self, event: ServerStartFailed) -> None:
         """Handle background server startup failure."""
         from deepagents_cli.mcp_tools import MCPConfigError
+        from deepagents_cli.model_config import MissingCredentialsError
 
         self._connecting = False
         if isinstance(event.error, MCPConfigError):
@@ -1804,21 +1872,67 @@ class DeepAgentsApp(App):
             self._server_startup_error = str(event.error)
         else:
             self._server_startup_error = _format_startup_error(event.error)
+
+        # Stash the provider for the `/model` recovery hint. Reset on every
+        # failure so a non-credentials retry-failure clears the prior flag.
+        self._server_startup_missing_credentials_provider = (
+            event.error.provider
+            if isinstance(event.error, MissingCredentialsError)
+            else None
+        )
         logger.error("Server startup failed: %s", event.error, exc_info=event.error)
-        # Update banner to show persistent failure state
+
+        # Drop the banner's connecting spinner — chat surface owns the error.
         try:
             banner = self.query_one("#welcome-banner", WelcomeBanner)
-            banner.set_failed(self._server_startup_error)
+            banner.set_idle()
         except NoMatches:
             logger.warning("Welcome banner not found during server failure transition")
 
-        # Discard any messages queued while the server was starting
-        if self._pending_messages:
-            self._pending_messages.clear()
-            for w in self._queued_widgets:
-                w.remove()
-            self._queued_widgets.clear()
+        # Keep any queued messages and widgets in place — `/model` retry can
+        # bring the server up, at which point `_run_session_start_sequence`
+        # drains them. Deferred actions (model/thread switches queued during
+        # the initial connect) are dropped because the failure invalidates
+        # their assumptions; the user can re-issue them after recovery.
         self._deferred_actions.clear()
+
+        # Failure surfaces only in chat — keeps recovery hint adjacent to the
+        # input. Banner is set to idle above to drop the connecting spinner.
+        text = f"Server failed to start: {self._server_startup_error}"
+        if (
+            self._server_startup_missing_credentials_provider is not None
+            and self._server_kwargs is not None
+        ):
+            text += (
+                "\n\nHint: run `/model <provider>:<model>` to retry "
+                "startup with a provider you have credentials for."
+            )
+
+        async def _mount_failure() -> None:
+            # Drop any prior failure widget (re-entrant on retry-then-fail).
+            prior = self._startup_failure_widget
+            self._startup_failure_widget = None
+            if prior is not None and prior.is_attached:
+                with suppress(NoMatches, ScreenStackError):
+                    await prior.remove()
+
+            try:
+                messages = self.query_one("#messages", Container)
+            except (NoMatches, ScreenStackError):
+                return
+            if not messages.is_attached:
+                return
+
+            new_widget = ErrorMessage(text)
+            # Mount before storing the reference so `ServerReady` racing this
+            # await cannot observe a half-mounted widget.
+            await self._mount_before_queued(messages, new_widget)
+            self._startup_failure_widget = new_widget
+
+        # Fire-and-forget mount: this is the *only* failure surface, so log
+        # any exception loudly via `_log_task_exception`.
+        task = asyncio.create_task(_mount_failure())
+        task.add_done_callback(_log_task_exception)
 
     async def _await_prewarm_imports(self) -> None:
         """Wait for prewarm imports before re-entering their module graph.
@@ -3065,14 +3179,17 @@ class DeepAgentsApp(App):
             )
             return
 
-        # If the app is busy or still sequencing startup work, enqueue instead
-        # of processing. Messages queued during startup are drained once the
-        # session reaches its first stable idle/running state.
+        # If the app is busy, still sequencing startup work, or holding a
+        # post-failure recovery state (server hasn't come up yet but `/model`
+        # retry is still possible), enqueue instead of processing. Messages
+        # queued in any of these states are drained once the session reaches
+        # its first stable idle/running state.
         if (
             self._agent_running
             or self._shell_running
             or self._connecting
             or self._startup_sequence_running
+            or self._server_startup_error is not None
         ):
             if mode == "command" and self._can_bypass_queue(value.lower().strip()):
                 await self._process_message(value, mode)
@@ -4120,11 +4237,10 @@ class DeepAgentsApp(App):
                 self._run_agent_task(message, message_kwargs=message_kwargs),
                 exclusive=False,
             )
-        elif self._server_startup_error:
-            await self._mount_message(
-                ErrorMessage(f"Server failed to start: {self._server_startup_error}")
-            )
-        else:
+        elif not self._server_startup_error:
+            # When a server-startup failure is in flight, the chat
+            # `ErrorMessage` mounted by `on_deep_agents_app_server_start_failed`
+            # is the single source of truth — don't duplicate it here.
             await self._mount_message(
                 AppMessage("Agent not configured for this session.")
             )
@@ -6530,6 +6646,18 @@ class DeepAgentsApp(App):
                         timeout=3,
                     )
                     return
+                # Recover from a failed startup (e.g., `MissingCredentialsError`).
+                # The server never came up, so the only way out without
+                # restarting the CLI is to retry startup with the new model.
+                # Only valid for CLI-owned servers.
+                if (
+                    self._server_startup_error is not None
+                    and self._server_kwargs is not None
+                ):
+                    await self._retry_startup_with_model(
+                        model_spec, extra_kwargs=extra_kwargs
+                    )
+                    return
                 await self._mount_message(
                     ErrorMessage("Model switching requires a server-backed session.")
                 )
@@ -6621,6 +6749,107 @@ class DeepAgentsApp(App):
                 self.query_one("#chat", VerticalScroll).anchor()
         finally:
             self._model_switching = False
+
+    async def _retry_startup_with_model(
+        self,
+        model_spec: str,
+        *,
+        extra_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Retry deferred server startup after a failed initial startup.
+
+        Exists because the server never came up (typically a
+        `MissingCredentialsError`), so the only escape without restarting
+        the CLI is re-running the deferred startup worker with a new spec.
+
+        Args:
+            model_spec: The new model specification (`provider:model` or bare
+                model name for auto-detection).
+            extra_kwargs: Extra constructor kwargs from `--model-params`.
+        """
+        from deepagents_cli.config import detect_provider
+        from deepagents_cli.model_config import (
+            ModelSpec,
+            get_credential_env_var,
+            has_provider_credentials,
+        )
+
+        if self._server_kwargs is None:
+            await self._mount_message(
+                ErrorMessage("Cannot retry startup: server is not CLI-owned.")
+            )
+            return
+
+        parsed = ModelSpec.try_parse(model_spec)
+        if parsed:
+            provider: str | None = parsed.provider
+            model_name = parsed.model
+        else:
+            model_name = model_spec
+            provider = detect_provider(model_spec)
+
+        # Tri-state credentials check (`None` = unknown provider, treated as
+        # proceed); bail early so retrying with still-missing creds doesn't
+        # loop right back into the same `MissingCredentialsError`.
+        has_creds = has_provider_credentials(provider) if provider else None
+        if has_creds is False and provider is not None:
+            env_var = get_credential_env_var(provider)
+            detail = (
+                f"{env_var} is not set or is empty"
+                if env_var
+                else (
+                    f"provider '{provider}' is not recognized. "
+                    "Add it to ~/.deepagents/config.toml with an "
+                    "api_key_env field"
+                )
+            )
+            await self._mount_message(ErrorMessage(f"Missing credentials: {detail}"))
+            return
+
+        display = model_spec
+        if provider and not parsed:
+            display = f"{provider}:{model_name}"
+
+        new_model_kwargs: dict[str, Any] = {
+            "model_spec": display,
+            "extra_kwargs": extra_kwargs,
+            "profile_overrides": self._profile_override,
+        }
+        self._model_kwargs = new_model_kwargs
+        self._server_kwargs["model_name"] = display
+        if extra_kwargs is not None:
+            self._server_kwargs["model_params"] = extra_kwargs
+
+        self._server_startup_error = None
+        self._server_startup_missing_credentials_provider = None
+        self._connecting = True
+        try:
+            banner = self.query_one("#welcome-banner", WelcomeBanner)
+            banner.set_connecting()
+        except (NoMatches, ScreenStackError):
+            logger.debug("Welcome banner not found during startup retry", exc_info=True)
+
+        if self._retry_status_widget is not None:
+            with suppress(NoMatches, ScreenStackError):
+                await self._retry_status_widget.remove()
+            self._retry_status_widget = None
+        try:
+            messages = self.query_one("#messages", Container)
+        except (NoMatches, ScreenStackError):
+            messages = None
+        if messages is not None and messages.is_attached:
+            new_widget = AppMessage(f"Retrying startup with {display}…")
+            # Mount before storing the reference so `on_deep_agents_app_server_ready`
+            # cannot observe a half-mounted widget if it races during this await.
+            await self._mount_before_queued(messages, new_widget)
+            self._retry_status_widget = new_widget
+        logger.info("Retrying server startup with model %s", display)
+
+        self.run_worker(
+            self._start_server_background,
+            exclusive=True,
+            group="server-startup",
+        )
 
     async def _set_default_model(self, model_spec: str) -> None:
         """Set the default model in config without switching the current session.

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -2194,9 +2194,10 @@ def create_model(
         A `ModelResult` containing the model and its metadata.
 
     Raises:
-        ModelConfigError: If provider cannot be determined from the model name,
-            required provider package is not installed, or no credentials are
-            configured.
+        ModelConfigError: If provider cannot be determined from the model name
+            or required provider package is not installed.
+        MissingCredentialsError: If no credentials are configured for the
+            resolved provider.
 
     Examples:
         >>> model = create_model("anthropic:claude-sonnet-4-5")
@@ -2248,12 +2249,15 @@ def create_model(
     if provider and provider not in IMPLICIT_AUTH_PROVIDERS:
         cred_status = has_provider_credentials(provider)
         if cred_status is False:
-            env_var = get_credential_env_var(provider) or f"<{provider} API key>"
+            from deepagents_cli.model_config import MissingCredentialsError
+
+            env_var = get_credential_env_var(provider)
+            display_env = env_var or f"<{provider} API key>"
             msg = (
                 f"No credentials found for provider '{provider}'. "
-                f"Please set the {env_var} environment variable."
+                f"Please set the {display_env} environment variable."
             )
-            raise ModelConfigError(msg)
+            raise MissingCredentialsError(msg, provider=provider, env_var=env_var)
 
     # Provider-specific kwargs (with per-model overrides)
     kwargs = _get_provider_kwargs(provider, model_name=model_name)

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -72,6 +72,34 @@ class ModelConfigError(Exception):
     """Raised when model configuration or creation fails."""
 
 
+class MissingCredentialsError(ModelConfigError):
+    """Raised when a provider is selected but its API key env var is unset.
+
+    Subclasses `ModelConfigError` so existing `except ModelConfigError` blocks
+    keep working. Carries the `provider` name and the canonical `env_var` so
+    callers can render targeted recovery hints (e.g., "set OPENAI_API_KEY" or
+    "run `/model <other_provider>:<model>`") without string-matching on the
+    formatted exception message and without re-deriving the env-var name.
+    """
+
+    def __init__(
+        self, message: str, *, provider: str, env_var: str | None = None
+    ) -> None:
+        """Initialize the error.
+
+        Args:
+            message: Human-readable message describing the missing credential.
+            provider: The provider whose credentials are missing
+                (e.g., `'openai'`).
+            env_var: The canonical env var name expected to hold the
+                credential (e.g., `'OPENAI_API_KEY'`). `None` when the
+                provider has no registered env-var mapping.
+        """
+        super().__init__(message)
+        self.provider = provider
+        self.env_var = env_var
+
+
 @dataclass(frozen=True)
 class ModelSpec:
     """A model specification in `provider:model` format.

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -105,8 +105,7 @@ class WelcomeBanner(Static):
         self._connecting = connecting
         self._resuming = resuming
         self._local_server = local_server
-        self._failed = False
-        self._failure_error: str = ""
+        self._idle = False
         self._project_name: str | None = get_langsmith_project_name()
         self._project_url: str | None = None
         self._tip: str = random.choice(_TIPS)  # noqa: S311
@@ -162,7 +161,7 @@ class WelcomeBanner(Static):
             mcp_errored: Number of MCP servers that failed to load.
         """
         self._connecting = False
-        self._failed = False
+        self._idle = False
         self._mcp_tool_count = mcp_tool_count
         self._mcp_unauthenticated = mcp_unauthenticated
         self._mcp_errored = mcp_errored
@@ -176,19 +175,21 @@ class WelcomeBanner(Static):
         currently reachable.
         """
         self._connecting = True
-        self._failed = False
+        self._idle = False
         self._resuming = False
         self.update(self._build_banner(self._project_url))
 
-    def set_failed(self, error: str) -> None:
-        """Transition from "connecting" to a persistent failure state.
+    def set_idle(self) -> None:
+        """Transition to a neutral state with no connecting spinner or footer.
 
-        Args:
-            error: Error message describing the server startup failure.
+        Used after a fatal startup failure so the banner stops claiming
+        progress (the failure is communicated via the chat surface). The
+        banner keeps its identity rows (title, version, install path,
+        LangSmith project, thread ID) but appends no footer line, leaving
+        the chat error as the sole source of failure context.
         """
         self._connecting = False
-        self._failed = True
-        self._failure_error = error
+        self._idle = True
         self.update(self._build_banner(self._project_url))
 
     def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
@@ -314,36 +315,18 @@ class WelcomeBanner(Static):
                 ]
             )
 
-        if self._failed:
-            parts.append(build_failure_footer(self._failure_error))
-        elif self._connecting:
+        if self._connecting:
             parts.append(
                 build_connecting_footer(
                     resuming=self._resuming,
                     local_server=self._local_server,
                 )
             )
-        else:
+        elif not self._idle:
             ready_color = "bold" if ansi else colors.primary
             parts.append(build_welcome_footer(primary_color=ready_color, tip=self._tip))
+        # `_idle` ⇒ no footer; chat-surface owns the failure message.
         return Content.assemble(*parts)
-
-
-def build_failure_footer(error: str) -> Content:
-    """Build a footer shown when the server failed to start.
-
-    Args:
-        error: Error message describing the failure.
-
-    Returns:
-        Content with a persistent failure message.
-    """
-    colors = theme.get_theme_colors()
-    return Content.assemble(
-        ("\nServer failed to start: ", f"bold {colors.error}"),
-        (error, colors.error),
-        ("\n", colors.error),
-    )
 
 
 def build_connecting_footer(

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -3743,8 +3743,13 @@ class TestDeferredActions:
 class TestServerStartupError:
     """Test error messages when the server fails to start."""
 
-    async def test_send_to_agent_shows_server_error(self) -> None:
-        """_send_to_agent should show the server startup error as an ErrorMessage."""
+    async def test_send_to_agent_silent_when_server_error_set(self) -> None:
+        """`_send_to_agent` does not mount anything when a startup error is set.
+
+        `on_deep_agents_app_server_start_failed` is the single source of truth
+        for the failure surface; the send path used to duplicate the
+        `ErrorMessage` per submit attempt and was collapsed.
+        """
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -3755,10 +3760,8 @@ class TestServerStartupError:
             await app._send_to_agent("hello")
             await pilot.pause()
 
-            msgs = app.query(ErrorMessage)
-            assert len(msgs) == 1
-            assert "Server failed to start" in str(msgs[0]._content)
-            assert "exited with code 3" in str(msgs[0]._content)
+            assert len(app.query(ErrorMessage)) == 0
+            assert len(app.query(AppMessage)) == 0
 
     async def test_send_to_agent_shows_generic_when_no_server_error(self) -> None:
         """_send_to_agent should show the generic AppMessage when no server error."""

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -445,6 +445,143 @@ class TestModelSwitchSessionReadiness:
         assert app._model_switching is False
 
 
+class TestModelSwitchFailedStartupRecovery:
+    """Tests for `/model` recovery after a failed initial server startup."""
+
+    async def test_retries_startup_with_new_model(self) -> None:
+        """Failed startup + `/model` retries `_start_server_background`.
+
+        Regression: when the CLI launches without the API key for the
+        configured model, `_start_server_background` raises
+        `ModelConfigError` before the server comes up, leaving the user
+        unable to switch via `/model` (the old code path bailed with
+        "Model switching requires a server-backed session"). `/model`
+        should now rewire deferred-startup state and re-run the worker.
+        """
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._agent = None
+        app._connecting = False
+        app._server_startup_error = "ModelConfigError: ANTHROPIC_API_KEY not set"
+        app._server_kwargs = {
+            "assistant_id": None,
+            "model_name": "anthropic:claude-opus-4-5",
+            "model_params": None,
+            "interactive": True,
+        }
+        app._model_kwargs = {
+            "model_spec": "anthropic:claude-opus-4-5",
+            "extra_kwargs": None,
+            "profile_overrides": None,
+        }
+        run_worker_mock = Mock()
+        app.run_worker = run_worker_mock  # type: ignore[method-assign]
+
+        with patch(
+            "deepagents_cli.model_config.has_provider_credentials",
+            return_value=True,
+        ):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        # Failure state cleared and a fresh startup worker scheduled.
+        assert app._server_startup_error is None
+        assert app._connecting is True
+        run_worker_mock.assert_called_once()
+        worker_args, worker_kwargs = run_worker_mock.call_args
+        assert worker_args[0] == app._start_server_background
+        assert worker_kwargs.get("group") == "server-startup"
+
+        # Deferred-startup kwargs rewired with the new spec.
+        assert app._model_kwargs == {
+            "model_spec": "anthropic:claude-sonnet-4-5",
+            "extra_kwargs": None,
+            "profile_overrides": None,
+        }
+        assert app._server_kwargs["model_name"] == "anthropic:claude-sonnet-4-5"
+        assert app._model_switching is False
+
+    async def test_retry_with_still_missing_credentials_errors(self) -> None:
+        """Retrying with creds still missing surfaces the credentials error.
+
+        Avoids looping right back into the same `ModelConfigError` by
+        applying the standard tri-state credentials check before
+        re-launching the startup worker.
+        """
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._agent = None
+        app._connecting = False
+        app._server_startup_error = "ModelConfigError: ANTHROPIC_API_KEY not set"
+        app._server_kwargs = {
+            "assistant_id": None,
+            "model_name": "anthropic:claude-opus-4-5",
+            "model_params": None,
+            "interactive": True,
+        }
+        run_worker_mock = Mock()
+        app.run_worker = run_worker_mock  # type: ignore[method-assign]
+
+        captured_errors: list[str] = []
+        original_init = ErrorMessage.__init__
+
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
+            captured_errors.append(message)
+            original_init(self, message, **kwargs)
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_cli.model_config.get_credential_env_var",
+                return_value="ANTHROPIC_API_KEY",
+            ),
+            patch.object(ErrorMessage, "__init__", capture_init),
+        ):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        # No worker scheduled, failure state preserved so the user can retry.
+        run_worker_mock.assert_not_called()
+        assert app._server_startup_error == (
+            "ModelConfigError: ANTHROPIC_API_KEY not set"
+        )
+        assert app._connecting is False
+        assert any(
+            "Missing credentials" in msg and "ANTHROPIC_API_KEY" in msg
+            for msg in captured_errors
+        )
+
+    async def test_remote_server_mode_keeps_original_error(self) -> None:
+        """In remote-server mode (no `_server_kwargs`), recovery is not possible.
+
+        The CLI doesn't own the subprocess so it can't restart it; fall back
+        to the existing "server-backed session" error rather than silently
+        no-op'ing.
+        """
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._agent = None
+        app._connecting = False
+        app._server_startup_error = "RuntimeError: connection refused"
+        app._server_kwargs = None
+        run_worker_mock = Mock()
+        app.run_worker = run_worker_mock  # type: ignore[method-assign]
+
+        captured_errors: list[str] = []
+        original_init = ErrorMessage.__init__
+
+        def capture_init(self: ErrorMessage, message: str, **kwargs: Any) -> None:
+            captured_errors.append(message)
+            original_init(self, message, **kwargs)
+
+        with patch.object(ErrorMessage, "__init__", capture_init):
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+
+        run_worker_mock.assert_not_called()
+        assert any("server-backed session" in msg for msg in captured_errors)
+
+
 class TestModelSwitchConfigProvider:
     """Tests for switching to config-file-defined providers."""
 

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -10,7 +10,6 @@ from deepagents_cli.widgets.welcome import (
     _TIPS,
     WelcomeBanner,
     build_connecting_footer,
-    build_failure_footer,
     build_welcome_footer,
 )
 
@@ -393,20 +392,6 @@ class TestBannerFooterPosition:
         idx = plain.index("Ready to code")
         assert plain[idx - 1] == "\n"
         assert plain[idx - 2] == "\n"
-
-
-class TestBuildFailureFooter:
-    """Tests for the `build_failure_footer` standalone function."""
-
-    def test_returns_content(self) -> None:
-        """Footer should return a `Content` object."""
-        assert isinstance(build_failure_footer("oops"), Content)
-
-    def test_contains_error_message(self) -> None:
-        """Footer should include the failure prefix and error text."""
-        plain = build_failure_footer("connection refused").plain
-        assert "Server failed to start: " in plain
-        assert "connection refused" in plain
 
 
 class TestBuildConnectingFooter:


### PR DESCRIPTION
Previously, a failed server startup (typically a missing API key) was a dead end — `/model` returned "Model switching requires a server-backed session." and the user had to quit and re-launch with valid credentials. `/model X` now routes through a new recovery flow that rewires deferred kwargs and re-runs the startup worker without restarting the CLI.