### PR TITLE
Surface Perplexity as a first-class provider in the CLI

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1935,9 +1935,14 @@ def _get_provider_kwargs(
     base_url = config.get_base_url(provider)
     if base_url:
         result["base_url"] = base_url
-    from deepagents_cli.model_config import PROVIDER_API_KEY_ENV, resolve_env_var
+    from deepagents_cli.model_config import (
+        PROVIDER_API_KEY_ENV,
+        PROVIDER_API_KEY_ENV_FALLBACKS,
+        resolve_env_var,
+    )
 
     api_key_env = config.get_api_key_env(provider)
+    fallback_envs: tuple[str, ...] = ()
     if not api_key_env:
         api_key_env = PROVIDER_API_KEY_ENV.get(provider)
         if api_key_env:
@@ -1946,8 +1951,19 @@ def _get_provider_kwargs(
                 " using hardcoded provider env var",
                 provider,
             )
+            fallback_envs = PROVIDER_API_KEY_ENV_FALLBACKS.get(provider, ())
     if api_key_env:
         api_key = resolve_env_var(api_key_env)
+        if not api_key:
+            for fallback in fallback_envs:
+                api_key = resolve_env_var(fallback)
+                if api_key:
+                    logger.debug(
+                        "Using fallback env var %s for provider '%s'",
+                        fallback,
+                        provider,
+                    )
+                    break
         if api_key:
             result["api_key"] = api_key
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -279,7 +279,7 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     "nvidia": "NVIDIA_API_KEY",
     "openai": "OPENAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
-    "perplexity": "PPLX_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
     "together": "TOGETHER_API_KEY",
     "xai": "XAI_API_KEY",
 }
@@ -292,6 +292,18 @@ time.
 
 Providers not listed here fall through to the config-file check or the langchain
 registry fallback.
+"""
+
+PROVIDER_API_KEY_ENV_FALLBACKS: dict[str, tuple[str, ...]] = {
+    "perplexity": ("PPLX_API_KEY",),
+}
+"""Legacy env-var names checked when the primary `PROVIDER_API_KEY_ENV` value is unset.
+
+Some providers ship under a canonical env var (e.g. `PERPLEXITY_API_KEY`) but
+also support an older name (`PPLX_API_KEY`) for backwards compatibility with
+the upstream SDK. Listing the legacy names here lets the credential pre-check
+and the api_key kwarg resolution recognise either, while keeping the canonical
+name visible in error messages.
 """
 
 IMPLICIT_AUTH_PROVIDERS: frozenset[str] = frozenset({"google_vertexai"})
@@ -801,7 +813,14 @@ def has_provider_credentials(provider: str) -> bool | None:
     # Fall back to hardcoded well-known providers.
     env_var = PROVIDER_API_KEY_ENV.get(provider)
     if env_var:
-        return bool(resolve_env_var(env_var))
+        if resolve_env_var(env_var):
+            return True
+        # Some providers accept legacy env-var names (e.g. PPLX_API_KEY for
+        # Perplexity). Treat the credential as available when any fallback is set.
+        for fallback in PROVIDER_API_KEY_ENV_FALLBACKS.get(provider, ()):
+            if resolve_env_var(fallback):
+                return True
+        return False
 
     # Provider not found in config or hardcoded map — credential status is
     # unknown. The provider itself will report auth failures at
@@ -817,7 +836,10 @@ def get_credential_env_var(provider: str) -> str | None:
     """Return the env var name that holds credentials for a provider.
 
     Checks the config file first (user override), then falls back to the
-    hardcoded `PROVIDER_API_KEY_ENV` map.
+    hardcoded `PROVIDER_API_KEY_ENV` map. Always returns the canonical primary
+    env var; legacy fallbacks (see `PROVIDER_API_KEY_ENV_FALLBACKS`) are not
+    surfaced here so that credential-missing messages prompt for the
+    user-facing canonical name.
 
     Args:
         provider: Provider name.

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -11,6 +11,7 @@ import pytest
 from deepagents_cli import model_config
 from deepagents_cli.model_config import (
     PROVIDER_API_KEY_ENV,
+    PROVIDER_API_KEY_ENV_FALLBACKS,
     THREAD_COLUMN_DEFAULTS,
     ModelConfig,
     ModelConfigError,
@@ -134,6 +135,23 @@ class TestHasProviderCredentials:
             clear=True,
         ):
             assert has_provider_credentials("anthropic") is True
+
+    def test_perplexity_resolves_via_canonical_env_var(self):
+        """Perplexity recognises `PERPLEXITY_API_KEY` as the primary env var."""
+        with patch.dict(
+            "os.environ", {"PERPLEXITY_API_KEY": "pplx-test"}, clear=True
+        ):
+            assert has_provider_credentials("perplexity") is True
+
+    def test_perplexity_resolves_via_legacy_env_var(self):
+        """Perplexity falls back to `PPLX_API_KEY` when canonical name is unset."""
+        with patch.dict("os.environ", {"PPLX_API_KEY": "pplx-legacy"}, clear=True):
+            assert has_provider_credentials("perplexity") is True
+
+    def test_perplexity_returns_false_when_neither_env_var_set(self):
+        """Perplexity reports missing credentials when neither var is set."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert has_provider_credentials("perplexity") is False
 
 
 class TestThreadColumnPersistence:
@@ -498,9 +516,13 @@ class TestProviderApiKeyEnv:
         assert PROVIDER_API_KEY_ENV["nvidia"] == "NVIDIA_API_KEY"
         assert PROVIDER_API_KEY_ENV["openai"] == "OPENAI_API_KEY"
         assert PROVIDER_API_KEY_ENV["openrouter"] == "OPENROUTER_API_KEY"
-        assert PROVIDER_API_KEY_ENV["perplexity"] == "PPLX_API_KEY"
+        assert PROVIDER_API_KEY_ENV["perplexity"] == "PERPLEXITY_API_KEY"
         assert PROVIDER_API_KEY_ENV["together"] == "TOGETHER_API_KEY"
         assert PROVIDER_API_KEY_ENV["xai"] == "XAI_API_KEY"
+
+    def test_perplexity_legacy_fallback_registered(self):
+        """`PPLX_API_KEY` remains a recognised legacy fallback for Perplexity."""
+        assert "PPLX_API_KEY" in PROVIDER_API_KEY_ENV_FALLBACKS["perplexity"]
 
 
 class TestModelConfigLoad:


### PR DESCRIPTION
Closes #3059

## Summary

Aligns the CLI's well-known provider env-var registry for Perplexity with the canonical, user-facing name (`PERPLEXITY_API_KEY`) used across the [Perplexity API docs](https://docs.perplexity.ai), while keeping backwards compatibility with the legacy `PPLX_API_KEY` env var that the upstream `langchain-perplexity` SDK ships with by default.

The `langchain-perplexity` package itself (recently merged via [langchain-ai/langchain#37082](https://github.com/langchain-ai/langchain/pull/37082)) already plugs into the `init_chat_model` registry, so `perplexity:sonar-pro` already resolves to `ChatPerplexity` via the existing prefix-mapping path — and the `perplexity` extra in `pyproject.toml` already pulls in `langchain-perplexity`. The remaining gap is the env-var convention: the CLI's `PROVIDER_API_KEY_ENV` table previously hard-coded the legacy `PPLX_API_KEY` name, which means the credential pre-check and the missing-credentials error message both pointed users at a non-canonical variable.

Why first-class: Perplexity is a direct provider with its own SDK (not a router/proxy like OpenRouter or LiteLLM), so it belongs alongside OpenAI/Anthropic/etc. in the providers section. The published [providers reference](https://docs.langchain.com/oss/python/deepagents/cli/providers) already lists it that way; this PR brings the in-tree env-var convention in line.

## Changes

- `PROVIDER_API_KEY_ENV["perplexity"]` is now `PERPLEXITY_API_KEY` (canonical).
- New `PROVIDER_API_KEY_ENV_FALLBACKS` map records legacy aliases checked when the primary env var is unset; seeded with `PPLX_API_KEY` for Perplexity so existing setups keep working.
- `has_provider_credentials` and the `api_key` kwarg resolution in `_get_provider_kwargs` consult the fallback chain.
- `get_credential_env_var` keeps returning the canonical name so the "missing credentials" message prompts users for `PERPLEXITY_API_KEY`.

## Testing

- `uv run pytest tests/unit_tests/test_model_config.py` — 197 passed.
- `uv run pytest tests/unit_tests/test_config.py` — 181 passed.
- New tests cover: canonical-only, legacy-only, and neither-set credential resolution; presence of the legacy fallback in the registry.

## References

- Perplexity docs: https://docs.perplexity.ai
- Upstream `langchain-perplexity` PR: https://github.com/langchain-ai/langchain/pull/37082
