### PR TITLE
fix(quickjs): add `ls_code_input_language` metadata to `eval` tool

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -282,6 +282,7 @@ class REPLMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             coroutine=async_eval,
             infer_schema=False,
             args_schema=EvalSchema,
+            metadata={"ls_code_input_language": "javascript"},
         )
 
     def _skills_for_eval(

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -97,6 +97,7 @@ def test_tool_registered_with_default_name() -> None:
     tools = agent.nodes["tools"].bound._tools_by_name
     assert "eval" in tools
     assert "persistent" in tools["eval"].description.lower()
+    assert tools["eval"].metadata["ls_code_input_language"] == "javascript"
 
 
 def test_tool_registered_with_custom_name() -> None:
@@ -110,6 +111,7 @@ def test_tool_registered_with_custom_name() -> None:
     tools = agent.nodes["tools"].bound._tools_by_name
     assert "js" in tools
     assert "eval" not in tools
+    assert tools["js"].metadata["ls_code_input_language"] == "javascript"
 
 
 def test_legacy_system_prompt_alias_removed() -> None:


### PR DESCRIPTION
Add `ls_code_input_language` metadata to the QuickJS `eval` tool so LangSmith can correctly treat tool input as JavaScript code.

## Changes

- Updated `JavaScriptREPLMiddleware` to pass `metadata={"ls_code_input_language": "javascript"}` when constructing the structured `eval` tool.
- Added unit test assertions to verify the metadata is present for both default and custom tool names.
