### PR TITLE
fix(sdk): guard empty subagent messages

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -408,7 +408,12 @@ def _build_task_tool(  # noqa: C901
                 content = json.dumps(structured)
         else:
             # Strip trailing whitespace to prevent API errors with Anthropic
-            content = result["messages"][-1].text.rstrip() if result["messages"][-1].text else ""
+            messages = result.get("messages", [])
+            if not messages:
+                content = ""
+            else:
+                last_message = messages[-1]
+                content = last_message.text.rstrip() if getattr(last_message, "text", None) else ""
 
         return Command(
             update={


### PR DESCRIPTION
Fixes #3046

Guard against empty `messages` lists when building subagent tool responses to avoid `IndexError` when a subagent returns no messages.

AI-assisted: Yes.