### PR TITLE
feat(sdk): add `delete_file` tool to filesystem middleware

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -23,6 +23,7 @@ from typing import cast
 
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     ExecuteResponse,
     FileDownloadResponse,
@@ -531,6 +532,29 @@ class CompositeBackend(BackendProtocol):
         """Async version of edit."""
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.aedit(stripped_key, old_string, new_string, replace_all=replace_all)
+        if res.path is not None:
+            res = replace(res, path=file_path)
+        return res
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file, routing to the appropriate backend.
+
+        Args:
+            file_path: Absolute file path.
+
+        Returns:
+            DeleteResult
+        """
+        backend, stripped_key = self._get_backend_and_key(file_path)
+        res = backend.delete(stripped_key)
+        if res.path is not None:
+            res = replace(res, path=file_path)
+        return res
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of delete."""
+        backend, stripped_key = self._get_backend_and_key(file_path)
+        res = await backend.adelete(stripped_key)
         if res.path is not None:
             res = replace(res, path=file_path)
         return res

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -19,6 +19,7 @@ from deepagents.backends.protocol import (
     IS_DIRECTORY,
     PERMISSION_DENIED,
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -508,6 +509,31 @@ class FilesystemBackend(BackendProtocol):
             return EditResult(path=file_path, occurrences=int(occurrences))
         except (OSError, UnicodeDecodeError, UnicodeEncodeError) as e:
             return EditResult(error=f"Error editing file '{file_path}': {e}")
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file from the filesystem.
+
+        Args:
+            file_path: Path to the file to delete.
+
+        Returns:
+            `DeleteResult` with path on success, or error if the file doesn't exist
+            or deletion fails.
+        """
+        try:
+            resolved_path = self._resolve_path(file_path)
+        except (OSError, RuntimeError) as e:
+            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+
+        try:
+            if resolved_path.is_dir():
+                return DeleteResult(error=f"Error: '{file_path}' is a directory, not a file")
+            if not resolved_path.exists():
+                return DeleteResult(error=f"File '{file_path}' not found")
+            resolved_path.unlink()
+            return DeleteResult(path=file_path)
+        except OSError as e:
+            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -276,6 +276,23 @@ class EditResult:
 
 
 @dataclass
+class DeleteResult:
+    """Result from backend delete operations.
+
+    Attributes:
+        error: Error message on failure, None on success.
+        path: Absolute path of deleted file, None on failure.
+
+    Examples:
+        >>> DeleteResult(path="/f.txt")
+        >>> DeleteResult(error="File not found")
+    """
+
+    error: str | None = None
+    path: str | None = None
+
+
+@dataclass
 class LsResult:
     """Result from backend ls operations.
 
@@ -567,6 +584,24 @@ class BackendProtocol(abc.ABC):  # noqa: B024
     ) -> EditResult:
         """Async version of edit."""
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
+
+    def delete(self, file_path: str) -> "DeleteResult":
+        """Delete a file from the filesystem.
+
+        Args:
+            file_path: Absolute path to the file to delete. Must start with `'/'`.
+
+        Returns:
+            `DeleteResult` with path on success, or error on failure.
+
+        Raises:
+            NotImplementedError: If the backend does not implement `delete`.
+        """
+        raise NotImplementedError
+
+    async def adelete(self, file_path: str) -> "DeleteResult":
+        """Async version of delete."""
+        return await asyncio.to_thread(self.delete, file_path)
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files to the sandbox.

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -10,6 +10,7 @@ from langgraph.config import get_config
 from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -289,6 +290,18 @@ class StateBackend(BackendProtocol):
         new_file_data = update_file_data(file_data, new_content)
         self._send_files_update({file_path: self._prepare_for_storage(new_file_data)})
         return EditResult(path=file_path, occurrences=int(occurrences))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file from state.
+
+        Sends `{file_path: None}` via `CONFIG_KEY_SEND`; the `_file_data_reducer`
+        treats `None` values as deletion markers.
+        """
+        files = self._read_files()
+        if file_path not in files:
+            return DeleteResult(error=f"File '{file_path}' not found")
+        self._send_files_update({file_path: None})
+        return DeleteResult(path=file_path)
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -38,6 +38,7 @@ from deepagents.backends import CompositeBackend, StateBackend
 from deepagents.backends.protocol import (
     BACKEND_TYPES as BACKEND_TYPES,  # Re-export type here for backwards compatibility
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData as FileData,  # Re-export for backwards compatibility
     FileInfo,
@@ -69,6 +70,7 @@ _DEFAULT_FS_TOOL_OPS: dict[str, FilesystemOperation] = {
     "grep": "read",
     "write_file": "write",
     "edit_file": "write",
+    "delete_file": "write",
 }
 
 
@@ -277,6 +279,12 @@ class EditFileSchema(BaseModel):
     )
 
 
+class DeleteFileSchema(BaseModel):
+    """Input schema for the `delete_file` tool."""
+
+    file_path: str = Field(description="Absolute path to the file to delete. Must be absolute, not relative.")
+
+
 class GlobSchema(BaseModel):
     """Input schema for the `glob` tool."""
 
@@ -349,6 +357,14 @@ WRITE_FILE_TOOL_DESCRIPTION = """Writes to a new file in the filesystem.
 Usage:
 - The write_file tool will create the a new file.
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
+"""
+
+DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file from the filesystem.
+
+Usage:
+- Permanently removes the specified file.
+- This operation cannot be undone.
+- Returns an error if the file does not exist or if the path points to a directory.
 """
 
 GLOB_TOOL_DESCRIPTION = """Find files matching a glob pattern.
@@ -449,6 +465,12 @@ Use this tool to run commands, scripts, tests, builds, and other shell operation
 
 - execute: run a shell command in the sandbox (returns output and exit code)"""
 
+DELETION_SYSTEM_PROMPT = """## Delete Tool `delete_file`
+
+You have access to a `delete_file` tool for permanently removing files from the filesystem.
+
+- delete_file: permanently delete a file (cannot be undone)"""
+
 
 def supports_execution(backend: BackendProtocol) -> bool:
     """Check if a backend supports command execution.
@@ -468,6 +490,30 @@ def supports_execution(backend: BackendProtocol) -> bool:
 
     # For other backends, use isinstance check
     return isinstance(backend, SandboxBackendProtocol)
+
+
+def _get_tool_name(tool: object) -> str | None:
+    """Return the name of a tool, whether it's a BaseTool instance or a dict."""
+    if hasattr(tool, "name"):
+        return tool.name  # type: ignore[union-attr]
+    if hasattr(tool, "get"):
+        return tool.get("name")  # type: ignore[union-attr]
+    return None
+
+
+def supports_delete(backend: BackendProtocol) -> bool:
+    """Check if a backend supports file deletion.
+
+    Returns True if the backend class overrides `delete` (i.e. doesn't
+    inherit the `NotImplementedError` stub from `BackendProtocol`).
+
+    Args:
+        backend: The backend to check.
+
+    Returns:
+        True if the backend supports deletion, False otherwise.
+    """
+    return type(backend).delete is not BackendProtocol.delete
 
 
 # Tools that should be excluded from the large result eviction logic.
@@ -498,6 +544,7 @@ TOOLS_EXCLUDED_FROM_EVICTION = (
     "read_file",
     "edit_file",
     "write_file",
+    "delete_file",
 )
 
 
@@ -762,6 +809,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_read_file_tool(),
             self._create_write_file_tool(),
             self._create_edit_file_tool(),
+            self._create_delete_file_tool(),
             self._create_glob_tool(),
             self._create_grep_tool(),
             self._create_execute_tool(),
@@ -1107,6 +1155,65 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
+    def _create_delete_file_tool(self) -> BaseTool:
+        """Create the delete_file tool."""
+        tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
+
+        def sync_delete_file(
+            file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> ToolMessage | str:
+            """Synchronous wrapper for delete_file tool."""
+            resolved_backend = self._get_backend(runtime)
+            try:
+                validated_path = validate_path(file_path)
+            except ValueError as e:
+                return f"Error: {e}"
+
+            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+                return ToolMessage(
+                    content=f"Error: permission denied for write on {validated_path}",
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            res: DeleteResult = resolved_backend.delete(validated_path)
+            if res.error:
+                return res.error
+            return f"Deleted file {res.path}"
+
+        async def async_delete_file(
+            file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> ToolMessage | str:
+            """Asynchronous wrapper for delete_file tool."""
+            resolved_backend = self._get_backend(runtime)
+            try:
+                validated_path = validate_path(file_path)
+            except ValueError as e:
+                return f"Error: {e}"
+
+            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+                return ToolMessage(
+                    content=f"Error: permission denied for write on {validated_path}",
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            res = await resolved_backend.adelete(validated_path)
+            if res.error:
+                return res.error
+            return f"Deleted file {res.path}"
+
+        return StructuredTool.from_function(
+            name="delete_file",
+            description=tool_description,
+            func=sync_delete_file,
+            coroutine=async_delete_file,
+            infer_schema=False,
+            args_schema=DeleteFileSchema,
+        )
+
     def _create_glob_tool(self) -> BaseTool:  # noqa: C901  # Tool wiring + permission/result shaping
         """Create the glob tool."""
         tool_description = self._custom_tool_descriptions.get("glob") or GLOB_TOOL_DESCRIPTION
@@ -1397,7 +1504,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=ExecuteSchema,
         )
 
-    def wrap_model_call(
+    def wrap_model_call(  # noqa: C901, PLR0912
         self,
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
@@ -1422,20 +1529,28 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             The model response, or an `ExtendedModelResponse` with a state
             update tagging a newly evicted message.
         """
-        # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
+        # Check if execute/delete tools are present and filter based on backend support
+        has_execute_tool = any(_get_tool_name(t) == "execute" for t in request.tools)
+        has_delete_tool = any(_get_tool_name(t) == "delete_file" for t in request.tools)
 
         backend_supports_execution = False
-        if has_execute_tool:
-            # Resolve backend to check execution support
+        backend_supports_deletion = False
+        if has_execute_tool or has_delete_tool:
             backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
-            backend_supports_execution = supports_execution(backend)
+            if has_execute_tool:
+                backend_supports_execution = supports_execution(backend)
+            if has_delete_tool:
+                backend_supports_deletion = supports_delete(backend)
 
-            # If execute tool exists but backend doesn't support it, filter it out
-            if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
-                request = request.override(tools=filtered_tools)
-                has_execute_tool = False
+        tools_to_filter = set()
+        if has_execute_tool and not backend_supports_execution:
+            tools_to_filter.add("execute")
+            has_execute_tool = False
+        if has_delete_tool and not backend_supports_deletion:
+            tools_to_filter.add("delete_file")
+            has_delete_tool = False
+        if tools_to_filter:
+            request = request.override(tools=[t for t in request.tools if _get_tool_name(t) not in tools_to_filter])
 
         # Use custom system prompt if provided, otherwise generate dynamically
         if self._custom_system_prompt is not None:
@@ -1448,9 +1563,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             ]
 
-            # Add execution instructions if execute tool is available
             if has_execute_tool and backend_supports_execution:
                 prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
+            if has_delete_tool and backend_supports_deletion:
+                prompt_parts.append(DELETION_SYSTEM_PROMPT)
 
             system_prompt = "\n\n".join(prompt_parts).strip()
 
@@ -1469,7 +1585,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         return handler(request)
 
-    async def awrap_model_call(
+    async def awrap_model_call(  # noqa: C901, PLR0912
         self,
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
@@ -1487,20 +1603,28 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             The model response from the handler, or an `ExtendedModelResponse`
             with a state update tagging newly evicted messages.
         """
-        # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
+        # Check if execute/delete tools are present and filter based on backend support
+        has_execute_tool = any(_get_tool_name(t) == "execute" for t in request.tools)
+        has_delete_tool = any(_get_tool_name(t) == "delete_file" for t in request.tools)
 
         backend_supports_execution = False
-        if has_execute_tool:
-            # Resolve backend to check execution support
+        backend_supports_deletion = False
+        if has_execute_tool or has_delete_tool:
             backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
-            backend_supports_execution = supports_execution(backend)
+            if has_execute_tool:
+                backend_supports_execution = supports_execution(backend)
+            if has_delete_tool:
+                backend_supports_deletion = supports_delete(backend)
 
-            # If execute tool exists but backend doesn't support it, filter it out
-            if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
-                request = request.override(tools=filtered_tools)
-                has_execute_tool = False
+        tools_to_filter = set()
+        if has_execute_tool and not backend_supports_execution:
+            tools_to_filter.add("execute")
+            has_execute_tool = False
+        if has_delete_tool and not backend_supports_deletion:
+            tools_to_filter.add("delete_file")
+            has_delete_tool = False
+        if tools_to_filter:
+            request = request.override(tools=[t for t in request.tools if _get_tool_name(t) not in tools_to_filter])
 
         # Use custom system prompt if provided, otherwise generate dynamically
         if self._custom_system_prompt is not None:
@@ -1513,9 +1637,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             ]
 
-            # Add execution instructions if execute tool is available
             if has_execute_tool and backend_supports_execution:
                 prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
+            if has_delete_tool and backend_supports_deletion:
+                prompt_parts.append(DELETION_SYSTEM_PROMPT)
 
             system_prompt = "\n\n".join(prompt_parts).strip()
 

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "langchain-core>=1.3.2,<2.0.0",
     "langsmith>=0.7.35",
-    "langchain>=1.2.15,<2.0.0",
+    "langchain>=1.3.0a1,<2.0.0",
     "langchain-anthropic>=1.4.2,<2.0.0",
     "langchain-google-genai>=4.2.2,<5.0.0",
     "wcmatch",

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "langchain-core>=1.3.2,<2.0.0",
     "langsmith>=0.7.35",
-    "langchain>=1.3.0a1,<2.0.0",
+    "langchain>=1.2.15,<2.0.0",
     "langchain-anthropic>=1.4.2,<2.0.0",
     "langchain-google-genai>=4.2.2,<5.0.0",
     "wcmatch",

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
@@ -80,6 +80,12 @@ All file paths must start with a /. Follow the tool docs for the available tools
 
 When a tool result is too large, it may be offloaded into the filesystem instead of being returned inline. In those cases, use `read_file` to inspect the saved result in chunks, or use `grep` within `/large_tool_results/` if you need to search across offloaded tool results and do not know the exact file path. Offloaded tool results are stored under `/large_tool_results/<tool_call_id>`.
 
+## Delete Tool `delete_file`
+
+You have access to a `delete_file` tool for permanently removing files from the filesystem.
+
+- delete_file: permanently delete a file (cannot be undone)
+
 
 ## `task` (subagent spawner)
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the specified file.\n- This operation cannot be undone.\n- Returns an error if the file does not exist or if the path points to a directory.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
@@ -85,6 +85,12 @@ Use this tool to run commands, scripts, tests, builds, and other shell operation
 
 - execute: run a shell command in the sandbox (returns output and exit code)
 
+## Delete Tool `delete_file`
+
+You have access to a `delete_file` tool for permanently removing files from the filesystem.
+
+- delete_file: permanently delete a file (cannot be undone)
+
 
 ## `task` (subagent spawner)
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the specified file.\n- This operation cannot be undone.\n- Returns an error if the file does not exist or if the path points to a directory.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -125,6 +125,12 @@ All file paths must start with a /. Follow the tool docs for the available tools
 
 When a tool result is too large, it may be offloaded into the filesystem instead of being returned inline. In those cases, use `read_file` to inspect the saved result in chunks, or use `grep` within `/large_tool_results/` if you need to search across offloaded tool results and do not know the exact file path. Offloaded tool results are stored under `/large_tool_results/<tool_call_id>`.
 
+## Delete Tool `delete_file`
+
+You have access to a `delete_file` tool for permanently removing files from the filesystem.
+
+- delete_file: permanently delete a file (cannot be undone)
+
 
 ## `task` (subagent spawner)
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the specified file.\n- This operation cannot be undone.\n- Returns an error if the file does not exist or if the path points to a directory.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
@@ -78,6 +78,12 @@ All file paths must start with a /. Follow the tool docs for the available tools
 
 When a tool result is too large, it may be offloaded into the filesystem instead of being returned inline. In those cases, use `read_file` to inspect the saved result in chunks, or use `grep` within `/large_tool_results/` if you need to search across offloaded tool results and do not know the exact file path. Offloaded tool results are stored under `/large_tool_results/<tool_call_id>`.
 
+## Delete Tool `delete_file`
+
+You have access to a `delete_file` tool for permanently removing files from the filesystem.
+
+- delete_file: permanently delete a file (cannot be undone)
+
 
 ## `task` (subagent spawner)
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the specified file.\n- This operation cannot be undone.\n- Returns an error if the file does not exist or if the path points to a directory.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
@@ -78,6 +78,12 @@ All file paths must start with a /. Follow the tool docs for the available tools
 
 When a tool result is too large, it may be offloaded into the filesystem instead of being returned inline. In those cases, use `read_file` to inspect the saved result in chunks, or use `grep` within `/large_tool_results/` if you need to search across offloaded tool results and do not know the exact file path. Offloaded tool results are stored under `/large_tool_results/<tool_call_id>`.
 
+## Delete Tool `delete_file`
+
+You have access to a `delete_file` tool for permanently removing files from the filesystem.
+
+- delete_file: permanently delete a file (cannot be undone)
+
 
 ## `task` (subagent spawner)
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the specified file.\n- This operation cannot be undone.\n- Returns an error if the file does not exist or if the path points to a directory.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -117,27 +117,27 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_with_composite_backend(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend)
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_custom_system_prompt_default(self):
         middleware = FilesystemMiddleware(system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_custom_system_prompt_with_composite(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend, system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_custom_tool_descriptions_default(self):
         middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})


### PR DESCRIPTION
Adds a `delete_file` tool to `FilesystemMiddleware`.

## Backwards compatibility

- **Existing backends are unaffected.** `BackendProtocol.delete` raises `NotImplementedError` by default; custom backends that don't override it simply won't see the tool.
- Follows the same pattern as `execute`: `supports_delete(backend)` checks whether the backend class overrides `delete`. If not, `delete_file` is filtered from `request.tools` and omitted from the system prompt before the model call — the LLM never sees a tool it can't use.
- All three built-in backends (`StateBackend`, `FilesystemBackend`, `CompositeBackend`) implement `delete`/`adelete`.
- `StateBackend` reuses the existing `None`-valued reducer logic (`_file_data_reducer` already treats `None` as a deletion marker).
- Permissions: `delete_file` is treated as a `"write"` operation, consistent with the existing permission model.