### PR TITLE
chore(sdk): return `ToolMessage` with status from all filesystem tools

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -798,13 +798,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         def sync_ls(
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str, "Absolute path to the directory to list. Must be absolute, not relative."],
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Synchronous wrapper for ls tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="ls",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if _check_fs_permission(self._permissions, "read", validated_path) == "deny":
                 return ToolMessage(
                     content=f"Error: permission denied for read on {validated_path}",
@@ -814,25 +819,36 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             ls_result = resolved_backend.ls(validated_path)
             if ls_result.error:
-                return f"Error: {ls_result.error}"
+                return ToolMessage(
+                    content=f"Error: {ls_result.error}",
+                    name="ls",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             infos = ls_result.entries or []
             paths = _apply_permissions_to_ls_results(self._permissions, infos)
             return ToolMessage(
                 content=str(truncate_if_too_long(paths)),
                 tool_call_id=runtime.tool_call_id,
                 name="ls",
+                status="success",
             )
 
         async def async_ls(
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str, "Absolute path to the directory to list. Must be absolute, not relative."],
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for ls tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="ls",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if _check_fs_permission(self._permissions, "read", validated_path) == "deny":
                 return ToolMessage(
                     content=f"Error: permission denied for read on {validated_path}",
@@ -842,13 +858,19 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             ls_result = await resolved_backend.als(validated_path)
             if ls_result.error:
-                return f"Error: {ls_result.error}"
+                return ToolMessage(
+                    content=f"Error: {ls_result.error}",
+                    name="ls",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             infos = ls_result.entries or []
             paths = _apply_permissions_to_ls_results(self._permissions, infos)
             return ToolMessage(
                 content=str(truncate_if_too_long(paths)),
                 tool_call_id=runtime.tool_call_id,
                 name="ls",
+                status="success",
             )
 
         return StructuredTool.from_function(
@@ -884,7 +906,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             tool_call_id: str | None,
             offset: int,
             limit: int,
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             if isinstance(read_result, str):
                 warn_deprecated(
                     since="0.5.0",
@@ -897,13 +919,28 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     package="deepagents",
                 )
                 # Legacy backends already format with line numbers
-                return _truncate(read_result, validated_path, limit)
+                return ToolMessage(
+                    content=_truncate(read_result, validated_path, limit),
+                    name="read_file",
+                    tool_call_id=tool_call_id,
+                    status="success",
+                )
 
             if read_result.error:
-                return f"Error: {read_result.error}"
+                return ToolMessage(
+                    content=f"Error: {read_result.error}",
+                    name="read_file",
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
 
             if read_result.file_data is None:
-                return f"Error: no data returned for '{validated_path}'"
+                return ToolMessage(
+                    content=f"Error: no data returned for '{validated_path}'",
+                    name="read_file",
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
 
             file_type = _get_file_type(validated_path)
             content = read_result.file_data["content"]
@@ -915,29 +952,45 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     name="read_file",
                     tool_call_id=tool_call_id,
                     additional_kwargs={"read_file_path": validated_path, "read_file_media_type": mime_type},
+                    status="success",
                 )
 
             empty_msg = check_empty_content(content)
             if empty_msg:
-                return empty_msg
+                return ToolMessage(
+                    content=empty_msg,
+                    name="read_file",
+                    tool_call_id=tool_call_id,
+                    status="success",
+                )
 
             content = format_content_with_line_numbers(content, start_line=offset + 1)
             # We apply truncation again after formatting content as continuation lines
             # can increase line count
-            return _truncate(content, validated_path, limit)
+            return ToolMessage(
+                content=_truncate(content, validated_path, limit),
+                name="read_file",
+                tool_call_id=tool_call_id,
+                status="success",
+            )
 
         def sync_read_file(
             file_path: Annotated[str, "Absolute path to the file to read. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
             offset: Annotated[int, "Line number to start reading from (0-indexed). Use for pagination of large files."] = DEFAULT_READ_OFFSET,
             limit: Annotated[int, "Maximum number of lines to read. Use for pagination of large files."] = DEFAULT_READ_LIMIT,
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Synchronous wrapper for read_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="read_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if _check_fs_permission(self._permissions, "read", validated_path) == "deny":
                 return ToolMessage(
                     content=f"Error: permission denied for read on {validated_path}",
@@ -953,13 +1006,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             runtime: ToolRuntime[None, FilesystemState],
             offset: Annotated[int, "Line number to start reading from (0-indexed). Use for pagination of large files."] = DEFAULT_READ_OFFSET,
             limit: Annotated[int, "Maximum number of lines to read. Use for pagination of large files."] = DEFAULT_READ_LIMIT,
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for read_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="read_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if _check_fs_permission(self._permissions, "read", validated_path) == "deny":
                 return ToolMessage(
                     content=f"Error: permission denied for read on {validated_path}",
@@ -987,13 +1045,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Synchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="write_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
 
             if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
                 return ToolMessage(
@@ -1004,20 +1067,35 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             res: WriteResult = resolved_backend.write(validated_path, content)
             if res.error:
-                return res.error
-            return f"Updated file {res.path}"
+                return ToolMessage(
+                    content=res.error,
+                    name="write_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Updated file {res.path}",
+                name="write_file",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
 
         async def async_write_file(
             file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for write_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="write_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
 
             if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
                 return ToolMessage(
@@ -1028,8 +1106,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             res: WriteResult = await resolved_backend.awrite(validated_path, content)
             if res.error:
-                return res.error
-            return f"Updated file {res.path}"
+                return ToolMessage(
+                    content=res.error,
+                    name="write_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Updated file {res.path}",
+                name="write_file",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
 
         return StructuredTool.from_function(
             name="write_file",
@@ -1051,13 +1139,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             runtime: ToolRuntime[None, FilesystemState],
             *,
             replace_all: Annotated[bool, "If True, replace all occurrences of old_string. If False (default), old_string must be unique."] = False,
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Synchronous wrapper for edit_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="edit_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
 
             if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
                 return ToolMessage(
@@ -1068,8 +1161,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             res: EditResult = resolved_backend.edit(validated_path, old_string, new_string, replace_all=replace_all)
             if res.error:
-                return res.error
-            return f"Successfully replaced {res.occurrences} instance(s) of the string in '{res.path}'"
+                return ToolMessage(
+                    content=res.error,
+                    name="edit_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Successfully replaced {res.occurrences} instance(s) of the string in '{res.path}'",
+                name="edit_file",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
 
         async def async_edit_file(
             file_path: Annotated[str, "Absolute path to the file to edit. Must be absolute, not relative."],
@@ -1078,13 +1181,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             runtime: ToolRuntime[None, FilesystemState],
             *,
             replace_all: Annotated[bool, "If True, replace all occurrences of old_string. If False (default), old_string must be unique."] = False,
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for edit_file tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="edit_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
 
             if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
                 return ToolMessage(
@@ -1095,8 +1203,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
             res: EditResult = await resolved_backend.aedit(validated_path, old_string, new_string, replace_all=replace_all)
             if res.error:
-                return res.error
-            return f"Successfully replaced {res.occurrences} instance(s) of the string in '{res.path}'"
+                return ToolMessage(
+                    content=res.error,
+                    name="edit_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Successfully replaced {res.occurrences} instance(s) of the string in '{res.path}'",
+                name="edit_file",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
 
         return StructuredTool.from_function(
             name="edit_file",
@@ -1115,13 +1233,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             pattern: Annotated[str, "Glob pattern to match files (e.g., '**/*.py', '*.txt', '/subdir/**/*.md')."],
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str, "Base directory to search from. Defaults to root '/'."] = "/",
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Synchronous wrapper for glob tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="glob",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if _check_fs_permission(self._permissions, "read", validated_path) == "deny":
                 return ToolMessage(
                     content=f"Error: permission denied for read on {validated_path}",
@@ -1135,28 +1258,44 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 try:
                     glob_result = future.result(timeout=GLOB_TIMEOUT)
                 except concurrent.futures.TimeoutError:
-                    return f"Error: glob timed out after {GLOB_TIMEOUT}s. Try a more specific pattern or a narrower path."
+                    return ToolMessage(
+                        content=f"Error: glob timed out after {GLOB_TIMEOUT}s. Try a more specific pattern or a narrower path.",
+                        name="glob",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
             if glob_result.error:
-                return f"Error: {glob_result.error}"
+                return ToolMessage(
+                    content=f"Error: {glob_result.error}",
+                    name="glob",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
                 content=str(truncate_if_too_long(paths)),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
+                status="success",
             )
 
         async def async_glob(
             pattern: Annotated[str, "Glob pattern to match files (e.g., '**/*.py', '*.txt', '/subdir/**/*.md')."],
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str, "Base directory to search from. Defaults to root '/'."] = "/",
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for glob tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(path)
             except ValueError as e:
-                return f"Error: {e}"
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="glob",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if _check_fs_permission(self._permissions, "read", validated_path) == "deny":
                 return ToolMessage(
                     content=f"Error: permission denied for read on {validated_path}",
@@ -1170,15 +1309,26 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     timeout=GLOB_TIMEOUT,
                 )
             except TimeoutError:
-                return f"Error: glob timed out after {GLOB_TIMEOUT}s. Try a more specific pattern or a narrower path."
+                return ToolMessage(
+                    content=f"Error: glob timed out after {GLOB_TIMEOUT}s. Try a more specific pattern or a narrower path.",
+                    name="glob",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             if glob_result.error:
-                return f"Error: {glob_result.error}"
+                return ToolMessage(
+                    content=f"Error: {glob_result.error}",
+                    name="glob",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
                 content=str(truncate_if_too_long(paths)),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
+                status="success",
             )
 
         return StructuredTool.from_function(
@@ -1203,13 +1353,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Synchronous wrapper for grep tool."""
             if path is not None:
                 try:
                     path = validate_path(path)
                 except ValueError as e:
-                    return f"Error: {e}"
+                    return ToolMessage(
+                        content=f"Error: {e}",
+                        name="grep",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
                 if _check_fs_permission(self._permissions, "read", path) == "deny":
                     return ToolMessage(
                         content=f"Error: permission denied for read on {path}",
@@ -1220,7 +1375,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             resolved_backend = self._get_backend(runtime)
             grep_result = resolved_backend.grep(pattern, path=path, glob=glob)
             if grep_result.error:
-                return grep_result.error
+                return ToolMessage(
+                    content=grep_result.error,
+                    name="grep",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             matches = grep_result.matches or []
             filtered_matches = _filter_grep_matches_by_permission(self._permissions, matches, operation="read")
             formatted = format_grep_matches(filtered_matches, output_mode)
@@ -1228,6 +1388,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 content=truncate_if_too_long(formatted),
                 tool_call_id=runtime.tool_call_id,
                 name="grep",
+                status="success",
             )
 
         async def async_grep(
@@ -1239,13 +1400,18 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
-        ) -> ToolMessage | str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for grep tool."""
             if path is not None:
                 try:
                     path = validate_path(path)
                 except ValueError as e:
-                    return f"Error: {e}"
+                    return ToolMessage(
+                        content=f"Error: {e}",
+                        name="grep",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
                 if _check_fs_permission(self._permissions, "read", path) == "deny":
                     return ToolMessage(
                         content=f"Error: permission denied for read on {path}",
@@ -1256,7 +1422,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             resolved_backend = self._get_backend(runtime)
             grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob)
             if grep_result.error:
-                return grep_result.error
+                return ToolMessage(
+                    content=grep_result.error,
+                    name="grep",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             matches = grep_result.matches or []
             filtered_matches = _filter_grep_matches_by_permission(self._permissions, matches, operation="read")
             formatted = format_grep_matches(filtered_matches, output_mode)
@@ -1264,6 +1435,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 content=truncate_if_too_long(formatted),
                 tool_call_id=runtime.tool_call_id,
                 name="grep",
+                status="success",
             )
 
         return StructuredTool.from_function(
@@ -1286,52 +1458,86 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 int | None,
                 "Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it.",
             ] = None,
-        ) -> str:
+        ) -> ToolMessage:
             """Synchronous wrapper for execute tool."""
             if timeout is not None:
                 if timeout < 0:
-                    return f"Error: timeout must be non-negative, got {timeout}."
+                    return ToolMessage(
+                        content=f"Error: timeout must be non-negative, got {timeout}.",
+                        name="execute",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
                 if timeout > self._max_execute_timeout:
-                    return f"Error: timeout {timeout}s exceeds maximum allowed ({self._max_execute_timeout}s)."
+                    return ToolMessage(
+                        content=f"Error: timeout {timeout}s exceeds maximum allowed ({self._max_execute_timeout}s).",
+                        name="execute",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
 
             resolved_backend = self._get_backend(runtime)
 
             # Runtime check - fail gracefully if not supported
             if not supports_execution(resolved_backend):
-                return (
-                    "Error: Execution not available. This agent's backend "
-                    "does not support command execution (SandboxBackendProtocol). "
-                    "To use the execute tool, provide a backend that implements SandboxBackendProtocol."
+                return ToolMessage(
+                    content=(
+                        "Error: Execution not available. This agent's backend "
+                        "does not support command execution (SandboxBackendProtocol). "
+                        "To use the execute tool, provide a backend that implements SandboxBackendProtocol."
+                    ),
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
                 )
 
             # Safe cast: supports_execution validates that execute()/aexecute() exist
             # (either SandboxBackendProtocol or CompositeBackend with sandbox default)
             executable = cast("SandboxBackendProtocol", resolved_backend)
             if timeout is not None and not execute_accepts_timeout(type(executable)):
-                return (
-                    "Error: This sandbox backend does not support per-command "
-                    "timeout overrides. Update your sandbox package to the "
-                    "latest version, or omit the timeout parameter."
+                return ToolMessage(
+                    content=(
+                        "Error: This sandbox backend does not support per-command "
+                        "timeout overrides. Update your sandbox package to the "
+                        "latest version, or omit the timeout parameter."
+                    ),
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
                 )
             try:
                 result = executable.execute(command, timeout=timeout) if timeout is not None else executable.execute(command)
             except NotImplementedError as e:
-                # Handle case where execute() exists but raises NotImplementedError
-                return f"Error: Execution not available. {e}"
+                return ToolMessage(
+                    content=f"Error: Execution not available. {e}",
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             except ValueError as e:
-                return f"Error: Invalid parameter. {e}"
+                return ToolMessage(
+                    content=f"Error: Invalid parameter. {e}",
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
 
             # Format output for LLM consumption
             parts = [result.output]
 
             if result.exit_code is not None:
-                status = "succeeded" if result.exit_code == 0 else "failed"
-                parts.append(f"\n[Command {status} with exit code {result.exit_code}]")
+                cmd_status = "succeeded" if result.exit_code == 0 else "failed"
+                parts.append(f"\n[Command {cmd_status} with exit code {result.exit_code}]")
 
             if result.truncated:
                 parts.append("\n[Output was truncated due to size limits]")
 
-            return "".join(parts)
+            return ToolMessage(
+                content="".join(parts),
+                name="execute",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
 
         async def async_execute(  # noqa: PLR0911 - early returns for distinct error conditions
             command: Annotated[str, "Shell command to execute in the sandbox environment."],
@@ -1342,51 +1548,85 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 int | None,
                 "Optional timeout in seconds for this command. Overrides the default timeout. Use 0 for no-timeout execution on backends that support it.",
             ] = None,
-        ) -> str:
+        ) -> ToolMessage:
             """Asynchronous wrapper for execute tool."""
             if timeout is not None:
                 if timeout < 0:
-                    return f"Error: timeout must be non-negative, got {timeout}."
+                    return ToolMessage(
+                        content=f"Error: timeout must be non-negative, got {timeout}.",
+                        name="execute",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
                 if timeout > self._max_execute_timeout:
-                    return f"Error: timeout {timeout}s exceeds maximum allowed ({self._max_execute_timeout}s)."
+                    return ToolMessage(
+                        content=f"Error: timeout {timeout}s exceeds maximum allowed ({self._max_execute_timeout}s).",
+                        name="execute",
+                        tool_call_id=runtime.tool_call_id,
+                        status="error",
+                    )
 
             resolved_backend = self._get_backend(runtime)
 
             # Runtime check - fail gracefully if not supported
             if not supports_execution(resolved_backend):
-                return (
-                    "Error: Execution not available. This agent's backend "
-                    "does not support command execution (SandboxBackendProtocol). "
-                    "To use the execute tool, provide a backend that implements SandboxBackendProtocol."
+                return ToolMessage(
+                    content=(
+                        "Error: Execution not available. This agent's backend "
+                        "does not support command execution (SandboxBackendProtocol). "
+                        "To use the execute tool, provide a backend that implements SandboxBackendProtocol."
+                    ),
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
                 )
 
             # Safe cast: supports_execution validates that execute()/aexecute() exist
             executable = cast("SandboxBackendProtocol", resolved_backend)
             if timeout is not None and not execute_accepts_timeout(type(executable)):
-                return (
-                    "Error: This sandbox backend does not support per-command "
-                    "timeout overrides. Update your sandbox package to the "
-                    "latest version, or omit the timeout parameter."
+                return ToolMessage(
+                    content=(
+                        "Error: This sandbox backend does not support per-command "
+                        "timeout overrides. Update your sandbox package to the "
+                        "latest version, or omit the timeout parameter."
+                    ),
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
                 )
             try:
                 result = await executable.aexecute(command, timeout=timeout) if timeout is not None else await executable.aexecute(command)
             except NotImplementedError as e:
-                # Handle case where execute() exists but raises NotImplementedError
-                return f"Error: Execution not available. {e}"
+                return ToolMessage(
+                    content=f"Error: Execution not available. {e}",
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
             except ValueError as e:
-                return f"Error: Invalid parameter. {e}"
+                return ToolMessage(
+                    content=f"Error: Invalid parameter. {e}",
+                    name="execute",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
 
             # Format output for LLM consumption
             parts = [result.output]
 
             if result.exit_code is not None:
-                status = "succeeded" if result.exit_code == 0 else "failed"
-                parts.append(f"\n[Command {status} with exit code {result.exit_code}]")
+                cmd_status = "succeeded" if result.exit_code == 0 else "failed"
+                parts.append(f"\n[Command {cmd_status} with exit code {result.exit_code}]")
 
             if result.truncated:
                 parts.append("\n[Output was truncated due to size limits]")
 
-            return "".join(parts)
+            return ToolMessage(
+                content="".join(parts),
+                name="execute",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
 
         return StructuredTool.from_function(
             name="execute",

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -429,7 +429,7 @@ class TestFilesystemMiddleware:
                 }
             )
 
-        assert result == "Error: glob timed out after 0.5s. Try a more specific pattern or a narrower path."
+        assert result.content == "Error: glob timed out after 0.5s. Try a more specific pattern or a narrower path."
 
     def test_glob_search_truncates_large_results(self):
         """Test that glob results are truncated when they exceed token limit."""
@@ -1237,8 +1237,8 @@ class TestFilesystemMiddleware:
         read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
         result = read_file_tool.invoke({"file_path": "/app/missing.png", "runtime": runtime})
 
-        assert isinstance(result, str)
-        assert result == "Error: file_not_found"
+        assert isinstance(result, ToolMessage)
+        assert result.content == "Error: file_not_found"
 
     def test_read_file_handles_str_from_backend(self):
         """Test that read_file works when backend.read() returns a plain str."""
@@ -1262,8 +1262,8 @@ class TestFilesystemMiddleware:
         with pytest.warns(DeprecationWarning, match="Returning a plain `str`"):
             result = read_file_tool.invoke({"file_path": "/app/file.txt", "runtime": runtime})
 
-        assert isinstance(result, str)
-        assert "line one" in result
+        assert isinstance(result, ToolMessage)
+        assert "line one" in result.content
 
     def test_read_file_str_backend_line_limit_truncation(self):
         """Legacy str backend respects the line-count limit."""
@@ -1287,8 +1287,8 @@ class TestFilesystemMiddleware:
         with pytest.warns(DeprecationWarning, match="Returning a plain `str`"):
             result = read_file_tool.invoke({"file_path": "/app/big.txt", "limit": 50, "runtime": runtime})
 
-        assert isinstance(result, str)
-        output_lines = [ln for ln in result.splitlines() if ln.strip()]
+        assert isinstance(result, ToolMessage)
+        output_lines = [ln for ln in result.content.splitlines() if ln.strip()]
         assert len(output_lines) <= 50
 
     def test_read_file_str_backend_token_truncation(self):
@@ -1317,9 +1317,9 @@ class TestFilesystemMiddleware:
         with pytest.warns(DeprecationWarning, match="Returning a plain `str`"):
             result = read_file_tool.invoke({"file_path": "/app/huge.txt", "runtime": runtime})
 
-        assert isinstance(result, str)
-        assert "Output was truncated due to size limits" in result
-        assert len(result) <= NUM_CHARS_PER_TOKEN * token_limit
+        assert isinstance(result, ToolMessage)
+        assert "Output was truncated due to size limits" in result.content
+        assert len(result.content) <= NUM_CHARS_PER_TOKEN * token_limit
 
     def test_read_file_empty_file_returns_warning(self):
         """ReadResult with empty content returns the empty-content warning."""
@@ -1332,8 +1332,8 @@ class TestFilesystemMiddleware:
         read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
         result = read_file_tool.invoke({"file_path": "/empty.txt", "runtime": runtime})
 
-        assert isinstance(result, str)
-        assert result == EMPTY_CONTENT_WARNING
+        assert isinstance(result, ToolMessage)
+        assert result.content == EMPTY_CONTENT_WARNING
 
     def test_execute_tool_returns_error_when_backend_doesnt_support(self):
         """Test that execute tool returns friendly error instead of raising exception."""
@@ -1356,9 +1356,9 @@ class TestFilesystemMiddleware:
         # Execute should return error message, not raise exception
         result = execute_tool.invoke({"command": "ls -la", "runtime": runtime})
 
-        assert isinstance(result, str)
-        assert "Error: Execution not available" in result
-        assert "does not support command execution" in result
+        assert isinstance(result, ToolMessage)
+        assert "Error: Execution not available" in result.content
+        assert "does not support command execution" in result.content
 
     def test_execute_tool_output_formatting(self):
         """Test execute tool formats output correctly."""
@@ -1392,9 +1392,9 @@ class TestFilesystemMiddleware:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = execute_tool.invoke({"command": "echo test", "runtime": rt})
 
-        assert "Hello world\nLine 2" in result
-        assert "succeeded" in result
-        assert "exit code 0" in result
+        assert "Hello world\nLine 2" in result.content
+        assert "succeeded" in result.content
+        assert "exit code 0" in result.content
 
     def test_execute_tool_output_formatting_with_failure(self):
         """Test execute tool formats failure output correctly."""
@@ -1428,9 +1428,9 @@ class TestFilesystemMiddleware:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = execute_tool.invoke({"command": "nonexistent", "runtime": rt})
 
-        assert "Error: command not found" in result
-        assert "failed" in result
-        assert "exit code 127" in result
+        assert "Error: command not found" in result.content
+        assert "failed" in result.content
+        assert "exit code 127" in result.content
 
     def test_execute_tool_output_formatting_with_truncation(self):
         """Test execute tool formats truncated output correctly."""
@@ -1464,8 +1464,8 @@ class TestFilesystemMiddleware:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = execute_tool.invoke({"command": "cat large_file", "runtime": rt})
 
-        assert "Very long output..." in result
-        assert "truncated" in result
+        assert "Very long output..." in result.content
+        assert "truncated" in result.content
 
     def testsupports_execution_helper_with_composite_backend(self):
         """Test supports_execution correctly identifies CompositeBackend capabilities."""
@@ -1957,8 +1957,8 @@ class TestBuiltinTruncationTools:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = execute_tool.invoke({"command": "echo hello", "timeout": 0, "runtime": rt})
 
-        assert isinstance(result, str)
-        assert "ok" in result
+        assert isinstance(result, ToolMessage)
+        assert "ok" in result.content
         assert captured_timeout["value"] == 0
 
     def test_execute_tool_rejects_negative_timeout(self):
@@ -1988,9 +1988,9 @@ class TestBuiltinTruncationTools:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = execute_tool.invoke({"command": "echo hello", "timeout": -5, "runtime": rt})
 
-        assert isinstance(result, str)
-        assert "error" in result.lower()
-        assert "non-negative" in result.lower()
+        assert isinstance(result, ToolMessage)
+        assert "error" in result.content.lower()
+        assert "non-negative" in result.content.lower()
 
     def test_execute_tool_forwards_valid_timeout_to_backend(self):
         """Middleware should forward a valid timeout to the backend."""
@@ -2050,10 +2050,10 @@ class TestBuiltinTruncationTools:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = execute_tool.invoke({"command": "echo hello", "timeout": 601, "runtime": rt})
 
-        assert isinstance(result, str)
-        assert "error" in result.lower()
-        assert "601" in result
-        assert "600" in result
+        assert isinstance(result, ToolMessage)
+        assert "error" in result.content.lower()
+        assert "601" in result.content
+        assert "600" in result.content
 
     def test_execute_tool_accepts_timeout_at_max(self):
         """Middleware should accept timeout exactly equal to max_execute_timeout."""

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -314,7 +314,7 @@ class TestFilesystemMiddlewareAsync:
                 }
             )
 
-        assert result == "Error: glob timed out after 0.5s. Try a more specific pattern or a narrower path."
+        assert result.content == "Error: glob timed out after 0.5s. Try a more specific pattern or a narrower path."
 
     async def test_agrep_search_shortterm_files_with_matches(self):
         """Test async grep with files_with_matches mode."""
@@ -536,9 +536,9 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": _runtime(),
             }
         )
-        assert "Hello world" in result
-        assert "Line 2" in result
-        assert "Line 3" in result
+        assert "Hello world" in result.content
+        assert "Line 2" in result.content
+        assert "Line 3" in result.content
 
     async def test_aread_file_with_offset(self):
         """Test async read_file tool with offset."""
@@ -560,10 +560,10 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": _runtime(),
             }
         )
-        assert "Line 2" in result
-        assert "Line 3" in result
-        assert "Line 1" not in result
-        assert "Line 4" not in result
+        assert "Line 2" in result.content
+        assert "Line 3" in result.content
+        assert "Line 1" not in result.content
+        assert "Line 4" not in result.content
 
     async def test_awrite_file(self):
         """Test async write_file tool."""
@@ -577,8 +577,7 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc1", store=None, stream_writer=lambda _: None, config={}),
             }
         )
-        # StoreBackend writes to the store and returns a plain string
-        assert isinstance(result, str)
+        assert isinstance(result, ToolMessage)
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
     async def test_aedit_file(self):
@@ -601,8 +600,7 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc2", store=None, stream_writer=lambda _: None, config={}),
             }
         )
-        # StoreBackend writes to the store and returns a plain string
-        assert isinstance(result, str)
+        assert isinstance(result, ToolMessage)
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
     async def test_aedit_file_replace_all(self):
@@ -626,7 +624,7 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": ToolRuntime(state={}, context=None, tool_call_id="tc3", store=None, stream_writer=lambda _: None, config={}),
             }
         )
-        assert isinstance(result, str)
+        assert isinstance(result, ToolMessage)
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
     async def test_aexecute_tool_returns_error_when_backend_doesnt_support(self):
@@ -650,9 +648,9 @@ class TestFilesystemMiddlewareAsync:
         # Execute should return error message, not raise exception
         result = await execute_tool.ainvoke({"command": "ls -la", "runtime": runtime})
 
-        assert isinstance(result, str)
-        assert "Error: Execution not available" in result
-        assert "does not support command execution" in result
+        assert isinstance(result, ToolMessage)
+        assert "Error: Execution not available" in result.content
+        assert "does not support command execution" in result.content
 
     async def test_aexecute_tool_forwards_zero_timeout_to_backend(self):
         """Async execute tool should forward timeout=0 for no-timeout backends."""
@@ -691,7 +689,7 @@ class TestFilesystemMiddlewareAsync:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = await execute_tool.ainvoke({"command": "echo hello", "timeout": 0, "runtime": rt})
 
-        assert "async ok" in result
+        assert "async ok" in result.content
         assert captured_timeout["value"] == 0
 
     async def test_aexecute_tool_output_formatting(self):
@@ -733,9 +731,9 @@ class TestFilesystemMiddlewareAsync:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = await execute_tool.ainvoke({"command": "echo test", "runtime": rt})
 
-        assert "Async Hello world\nAsync Line 2" in result
-        assert "succeeded" in result
-        assert "exit code 0" in result
+        assert "Async Hello world\nAsync Line 2" in result.content
+        assert "succeeded" in result.content
+        assert "exit code 0" in result.content
 
     async def test_aexecute_tool_output_formatting_with_failure(self):
         """Test async execute tool formats failure output correctly."""
@@ -776,9 +774,9 @@ class TestFilesystemMiddlewareAsync:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = await execute_tool.ainvoke({"command": "nonexistent", "runtime": rt})
 
-        assert "Async Error: command not found" in result
-        assert "failed" in result
-        assert "exit code 127" in result
+        assert "Async Error: command not found" in result.content
+        assert "failed" in result.content
+        assert "exit code 127" in result.content
 
     async def test_aexecute_tool_output_formatting_with_truncation(self):
         """Test async execute tool formats truncated output correctly."""
@@ -819,5 +817,5 @@ class TestFilesystemMiddlewareAsync:
         execute_tool = next(tool for tool in middleware.tools if tool.name == "execute")
         result = await execute_tool.ainvoke({"command": "cat large_file", "runtime": rt})
 
-        assert "Async Very long output..." in result
-        assert "truncated" in result
+        assert "Async Very long output..." in result.content
+        assert "truncated" in result.content

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -434,7 +434,7 @@ class TestFilesystemMiddlewarePermissions:
         middleware = FilesystemMiddleware(backend=backend)
         read_tool = next(t for t in middleware.tools if t.name == "read_file")
         result = read_tool.invoke({"runtime": _runtime(), "file_path": "/secrets/key.txt"})
-        assert "permission denied" not in result
+        assert "permission denied" not in result.content
 
     def test_ls_denied_on_restricted_root(self):
         backend = _make_backend({"/secrets/key.txt": "top secret"})
@@ -580,7 +580,7 @@ class TestCanonicalizationBypass:
         middleware = FilesystemMiddleware(backend=backend)
         read_tool = next(t for t in middleware.tools if t.name == "read_file")
         result = read_tool.invoke({"runtime": _runtime(), "file_path": "/workspace/../secrets/key.txt"})
-        assert "Path traversal not allowed" in result
+        assert "Path traversal not allowed" in result.content
 
     def test_redundant_separators_normalized(self):
         # /secrets//key.txt is normalized by validate_path to /secrets/key.txt


### PR DESCRIPTION
## Summary

- All filesystem tools (`ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute`) now always return a `ToolMessage` instead of mixing plain strings and `ToolMessage` objects
- Success paths return `status="success"`, error paths return `status="error"`
- Updated tests to check `result.content` / `isinstance(result, ToolMessage)` accordingly

## Test plan

- [x] `make test` passes (`1485 passed, 84 skipped, 4 xfailed`)
- [x] `make lint` — no new errors introduced (3 pre-existing errors unchanged)
- [x] `make format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)