### PR TITLE
feat(cli): auto-discover Textual built-in themes

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -195,7 +195,7 @@ def _load_theme_preference() -> str:
     # Migrate legacy `textual-ansi` preference (pre-Textual 8.2.5) to `ansi-light`.
     if name == "textual-ansi":
         name = "ansi-light"
-    if isinstance(name, str) and name in theme.ThemeEntry.REGISTRY:
+    if isinstance(name, str) and name in theme.get_registry():
         return name
     if isinstance(name, str):
         logger.warning(
@@ -214,7 +214,7 @@ def save_theme_preference(name: str) -> bool:
     Returns:
         `True` if the preference was saved, `False` if any error occurred.
     """
-    if name not in theme.ThemeEntry.REGISTRY:
+    if name not in theme.get_registry():
         logger.warning("Refusing to save unknown theme '%s'", name)
         return False
 
@@ -5370,7 +5370,7 @@ class DeepAgentsApp(App):
 
     def _register_custom_themes(self) -> None:
         """Register all custom themes (built-in LC + user-defined) with Textual."""
-        for name, entry in theme.ThemeEntry.REGISTRY.items():
+        for name, entry in theme.get_registry().items():
             if entry.custom:
                 c = entry.colors
                 try:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -192,6 +192,9 @@ def _load_theme_preference() -> str:
         return theme.DEFAULT_THEME
 
     name = data.get("ui", {}).get("theme")
+    # Migrate legacy `textual-ansi` preference (pre-Textual 8.2.5) to `ansi-light`.
+    if name == "textual-ansi":
+        name = "ansi-light"
     if isinstance(name, str) and name in theme.ThemeEntry.REGISTRY:
         return name
     if isinstance(name, str):

--- a/libs/cli/deepagents_cli/theme.py
+++ b/libs/cli/deepagents_cli/theme.py
@@ -10,7 +10,7 @@ variables (`$mode-bash`, `$mode-command`, `$skill`, `$skill-hover`, `$tool`,
 
 Code that needs custom CSS variable values should call
 `get_css_variable_defaults(dark=...)`. For the full semantic color palette, look
-up the `ThemeColors` instance via `ThemeEntry.REGISTRY`.
+up the `ThemeColors` instance via `get_registry()`.
 
 Users can define custom themes in `~/.deepagents/config.toml` under
 `[themes.<name>]` sections. Each new theme section must include `label` (str);
@@ -22,12 +22,13 @@ colors without replacing it. See `_load_user_themes()` for details.
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
 from dataclasses import dataclass, fields
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -402,12 +403,6 @@ class ThemeEntry:
     `False` for Textual built-in themes that Textual already knows about.
     """
 
-    REGISTRY: ClassVar[Mapping[str, ThemeEntry]]
-    """All registered theme entries, keyed by Textual theme name.
-
-    Read-only after module load (`MappingProxyType`).
-    """
-
     def __post_init__(self) -> None:
         """Validate that the label is a non-empty string.
 
@@ -477,13 +472,20 @@ def _builtin_themes() -> dict[str, ThemeEntry]:
     return r
 
 
-_BUILTIN_NAMES: frozenset[str] = frozenset(_builtin_themes())
-"""Names of built-in themes.
+@functools.cache
+def _builtin_names() -> frozenset[str]:
+    """Names of built-in themes; lazily computed and cached.
 
-User `[themes.<name>]` sections matching a built-in name override its colors
-rather than creating a new theme. Derived from `_builtin_themes()` to stay in
-sync automatically.
-"""
+    User `[themes.<name>]` sections matching a built-in name override its colors
+    rather than creating a new theme. Derived from `_builtin_themes()` so the
+    set stays in sync automatically. Lazy because `_builtin_themes()` imports
+    `textual.theme.BUILTIN_THEMES`, and we don't want to pull Textual onto the
+    `deepagents --help` / `deepagents -v` cold-start path.
+
+    Returns:
+        Frozen set of built-in theme names.
+    """
+    return frozenset(_builtin_themes())
 
 
 def _load_user_themes(
@@ -590,7 +592,7 @@ def _load_user_themes(
                 )
 
         # --- Built-in override: merge color tweaks into the existing entry
-        if name in _BUILTIN_NAMES:
+        if name in _builtin_names():
             existing = builtins.get(name)
             if existing is None:
                 logger.warning(
@@ -672,20 +674,26 @@ def _build_registry(
     return MappingProxyType(r)
 
 
-ThemeEntry.REGISTRY = _build_registry()
-"""Read-only mapping of Textual theme names to `ThemeEntry` instances.
+@functools.cache
+def get_registry() -> MappingProxyType[str, ThemeEntry]:
+    """Return the read-only theme registry, building it on first access.
 
-Built via `_build_registry()` so the mutable staging dict is scoped to a
-function call and cannot be mutated after freeze. The `ClassVar` declaration on
-`ThemeEntry` provides the type; this assignment supplies the value.
-"""
+    Lazy so that `theme.py` can be imported on the `deepagents --help` cold
+    path without pulling in `textual.theme.BUILTIN_THEMES` (which transitively
+    imports Textual, ~470ms). Inside a Textual app, the build is microseconds
+    because Textual is already loaded; callers like `_register_custom_themes()`
+    iterate the result during `App.__init__`, which warms the cache before any
+    user-facing surface (e.g. the theme picker) reads it.
+    """
+    return _build_registry()
+
 
 DEFAULT_THEME = "langchain"
 """Theme name used when no preference is saved."""
 
 
 def reload_registry() -> MappingProxyType[str, ThemeEntry]:
-    """Rebuild the theme registry from disk and update `ThemeEntry.REGISTRY`.
+    """Rebuild the theme registry from disk.
 
     Re-reads `~/.deepagents/config.toml` for user-defined themes so that
     `/reload` can pick up config changes without restarting the app.
@@ -693,8 +701,9 @@ def reload_registry() -> MappingProxyType[str, ThemeEntry]:
     Returns:
         The new frozen registry.
     """
-    ThemeEntry.REGISTRY = _build_registry()
-    return ThemeEntry.REGISTRY
+    get_registry.cache_clear()
+    _builtin_names.cache_clear()
+    return get_registry()
 
 
 def get_css_variable_defaults(
@@ -829,7 +838,7 @@ def get_theme_colors(widget_or_app: App | object | None = None) -> ThemeColors:
         except (ImportError, LookupError):
             return DARK_COLORS
     app = _resolve_app(widget_or_app)
-    entry = ThemeEntry.REGISTRY.get(app.theme)  # type: ignore[attr-defined]
+    entry = get_registry().get(app.theme)  # type: ignore[attr-defined]
     # Custom themes (LC-branded / user-defined) use pre-built colors.
     if entry is not None and entry.custom:
         return entry.colors

--- a/libs/cli/deepagents_cli/theme.py
+++ b/libs/cli/deepagents_cli/theme.py
@@ -419,8 +419,35 @@ class ThemeEntry:
             raise ValueError(msg)
 
 
+# Curated labels for Textual built-in themes. Themes not listed here fall back
+# to a humanized version of the slug (e.g. `ansi-dark` → `Ansi Dark`), so newly
+# shipped Textual themes appear in the picker without code changes.
+_TEXTUAL_THEME_LABELS: Mapping[str, str] = MappingProxyType(
+    {
+        "textual-dark": "Textual Dark",
+        "textual-light": "Textual Light",
+        "ansi-dark": "Terminal ANSI Dark",
+        "ansi-light": "Terminal ANSI Light",
+        "catppuccin-frappe": "Catppuccin Frappé",
+        "rose-pine": "Rosé Pine",
+        "rose-pine-dawn": "Rosé Pine Dawn",
+        "rose-pine-moon": "Rosé Pine Moon",
+        "tokyo-night": "Tokyo Night",
+    }
+)
+
+
 def _builtin_themes() -> dict[str, ThemeEntry]:
     """Return the built-in theme entries as a mutable dict.
+
+    Textual built-ins are discovered from `textual.theme.BUILTIN_THEMES` so
+    newly shipped Textual themes appear automatically. They are not registered
+    via `register_theme()` — Textual's own `$primary`, `$background`, etc.
+    apply. The `colors` field provides fallback values for app-specific CSS
+    vars (`$mode-bash`, `$mode-command`) and Python-side styling. For standard
+    properties (primary, secondary, etc.), `get_theme_colors()` dynamically
+    resolves from the actual Textual theme at runtime so the Python and CSS
+    color systems stay in sync.
 
     Returns:
         Dict of built-in theme names to `ThemeEntry` instances.
@@ -436,42 +463,17 @@ def _builtin_themes() -> dict[str, ThemeEntry]:
         dark=False,
         colors=LIGHT_COLORS,
     )
-    # Textual built-in themes — not registered via register_theme() (Textual's
-    # own $primary, $background, etc. apply). The `colors` field provides
-    # fallback values for app-specific CSS vars ($mode-bash, $mode-command) and
-    # Python-side styling.  For standard properties (primary, secondary, etc.),
-    # get_theme_colors() dynamically resolves from the actual Textual theme at
-    # runtime so the Python and CSS color systems stay in sync.
 
-    def _bi(label: str, *, is_dark: bool) -> ThemeEntry:
-        return ThemeEntry(
+    from textual.theme import BUILTIN_THEMES
+
+    for name, builtin in BUILTIN_THEMES.items():
+        label = _TEXTUAL_THEME_LABELS.get(name) or name.replace("-", " ").title()
+        r[name] = ThemeEntry(
             label=label,
-            dark=is_dark,
-            colors=DARK_COLORS if is_dark else LIGHT_COLORS,
+            dark=builtin.dark,
+            colors=DARK_COLORS if builtin.dark else LIGHT_COLORS,
             custom=False,
         )
-
-    r["textual-dark"] = _bi("Textual Dark", is_dark=True)
-    r["textual-light"] = _bi("Textual Light", is_dark=False)
-    r["textual-ansi"] = _bi("Terminal (ANSI)", is_dark=False)
-    # Popular community themes (all ship with Textual >= 8.0)
-    r["atom-one-dark"] = _bi("Atom One Dark", is_dark=True)
-    r["atom-one-light"] = _bi("Atom One Light", is_dark=False)
-    r["catppuccin-frappe"] = _bi("Catppuccin Frappé", is_dark=True)
-    r["catppuccin-latte"] = _bi("Catppuccin Latte", is_dark=False)
-    r["catppuccin-macchiato"] = _bi("Catppuccin Macchiato", is_dark=True)
-    r["catppuccin-mocha"] = _bi("Catppuccin Mocha", is_dark=True)
-    r["dracula"] = _bi("Dracula", is_dark=True)
-    r["flexoki"] = _bi("Flexoki", is_dark=True)
-    r["gruvbox"] = _bi("Gruvbox", is_dark=True)
-    r["monokai"] = _bi("Monokai", is_dark=True)
-    r["nord"] = _bi("Nord", is_dark=True)
-    r["rose-pine"] = _bi("Rosé Pine", is_dark=True)
-    r["rose-pine-dawn"] = _bi("Rosé Pine Dawn", is_dark=False)
-    r["rose-pine-moon"] = _bi("Rosé Pine Moon", is_dark=True)
-    r["solarized-dark"] = _bi("Solarized Dark", is_dark=True)
-    r["solarized-light"] = _bi("Solarized Light", is_dark=False)
-    r["tokyo-night"] = _bi("Tokyo Night", is_dark=True)
     return r
 
 

--- a/libs/cli/deepagents_cli/widgets/theme_selector.py
+++ b/libs/cli/deepagents_cli/widgets/theme_selector.py
@@ -100,7 +100,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         options: list[Option] = []
         highlight_index = 0
 
-        for i, (name, entry) in enumerate(theme.ThemeEntry.REGISTRY.items()):
+        for i, (name, entry) in enumerate(theme.get_registry().items()):
             label = entry.label
             if name == self._current_theme:
                 label = f"{label} (current)"
@@ -135,7 +135,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             event: The option highlighted event.
         """
         name = event.option.id
-        if name is not None and name in theme.ThemeEntry.REGISTRY:
+        if name is not None and name in theme.get_registry():
             try:
                 self.app.theme = name
                 # refresh_css only repaints the active (modal) screen's layout;
@@ -162,7 +162,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             event: The option selected event.
         """
         name = event.option.id
-        if name is not None and name in theme.ThemeEntry.REGISTRY:
+        if name is not None and name in theme.get_registry():
             self.dismiss(name)
         else:
             logger.warning("Selected theme '%s' is no longer available", name)

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -210,7 +210,7 @@ class WelcomeBanner(Static):
         """
         parts: list[str | tuple[str, str | TStyle] | Content] = []
         colors = theme.get_theme_colors(self)
-        ansi = self.app.theme == "textual-ansi"
+        ansi = self.app.theme in {"ansi-dark", "ansi-light"}
 
         banner = get_banner()
         primary_style: str | TStyle = (

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # Workaround for Textualize/textual#6378 lives in `_textual_patches.py`.
     # On bump, run `tests/unit_tests/test_textual_patches.py` and delete the
     # patch if the upstream issue is fixed.
-    "textual>=8.0.0,<9.0.0",
+    "textual>=8.2.5,<9.0.0",
     "textual-autocomplete>=3.0.0,<5.0.0",
     "textual-speedups>=0.2.1,<1.0.0",
     "prompt-toolkit>=3.0.52,<4.0.0",

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -2011,8 +2011,15 @@ class TestBackslashEnterNewline:
     pair and collapses it into a newline.
     """
 
-    async def test_backslash_then_enter_inserts_newline(self) -> None:
+    async def test_backslash_then_enter_inserts_newline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Rapid backslash + enter should produce a newline, not submit."""
+        # Widen the gap so wall-clock timing between pilot.press calls on slow
+        # CI runners cannot push the enter past the 150ms default and trip the
+        # submit path.
+        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -2057,8 +2064,12 @@ class TestBackslashEnterNewline:
 
             assert ta.text == "\\a"
 
-    async def test_backslash_enter_on_empty_prompt_does_not_submit(self) -> None:
+    async def test_backslash_enter_on_empty_prompt_does_not_submit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Backslash + enter on empty prompt should not submit."""
+        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -13,16 +13,17 @@ if TYPE_CHECKING:
 
 from deepagents_cli import theme
 from deepagents_cli.theme import (
-    _BUILTIN_NAMES,
     DARK_COLORS,
     DEFAULT_THEME,
     LIGHT_COLORS,
     ThemeColors,
     ThemeEntry,
     _build_registry,
+    _builtin_names,
     _builtin_themes,
     _load_user_themes,
     get_css_variable_defaults,
+    get_registry,
     get_theme_colors,
 )
 
@@ -101,23 +102,23 @@ class TestColorSets:
 
 
 # ---------------------------------------------------------------------------
-# ThemeEntry.REGISTRY
+# Theme registry
 # ---------------------------------------------------------------------------
 
 
 class TestThemeEntryRegistry:
-    """ThemeEntry.REGISTRY contents and immutability."""
+    """Theme registry contents and immutability."""
 
     def test_registry_contains_builtin_keys(self) -> None:
-        assert set(ThemeEntry.REGISTRY.keys()) >= _BUILTIN_NAMES
+        assert set(get_registry().keys()) >= _builtin_names()
 
     def test_registry_is_read_only(self) -> None:
-        assert isinstance(ThemeEntry.REGISTRY, MappingProxyType)
+        assert isinstance(get_registry(), MappingProxyType)
         with pytest.raises(TypeError):
-            ThemeEntry.REGISTRY["bad"] = None  # type: ignore[index]
+            get_registry()["bad"] = None  # type: ignore[index]
 
     def test_default_theme_in_registry(self) -> None:
-        assert DEFAULT_THEME in ThemeEntry.REGISTRY
+        assert DEFAULT_THEME in get_registry()
 
     @pytest.mark.parametrize(
         ("name", "dark", "custom"),
@@ -143,16 +144,16 @@ class TestThemeEntryRegistry:
         ],
     )
     def test_entry_flags(self, name: str, dark: bool, custom: bool) -> None:
-        entry = ThemeEntry.REGISTRY[name]
+        entry = get_registry()[name]
         assert entry.dark is dark
         assert entry.custom is custom
 
     def test_every_entry_has_non_empty_label(self) -> None:
-        for name, entry in ThemeEntry.REGISTRY.items():
+        for name, entry in get_registry().items():
             assert entry.label.strip(), f"Entry '{name}' has empty label"
 
     def test_every_entry_has_valid_colors(self) -> None:
-        for name, entry in ThemeEntry.REGISTRY.items():
+        for name, entry in get_registry().items():
             assert isinstance(entry.colors, ThemeColors), (
                 f"Entry '{name}' has invalid colors"
             )
@@ -739,24 +740,24 @@ primary = "#ABCDEF"
         registry = _build_registry(config_path=config)
         assert isinstance(registry, MappingProxyType)
         assert "custom-dark" in registry
-        assert set(registry.keys()) >= _BUILTIN_NAMES
+        assert set(registry.keys()) >= _builtin_names()
         assert registry["custom-dark"].colors.primary == "#ABCDEF"
 
     def test_no_config_still_has_builtins(self, tmp_path: Path) -> None:
         registry = _build_registry(config_path=tmp_path / "missing.toml")
-        assert set(registry.keys()) == _BUILTIN_NAMES
+        assert set(registry.keys()) == _builtin_names()
 
 
 # ---------------------------------------------------------------------------
-# _BUILTIN_NAMES consistency
+# _builtin_names() consistency
 # ---------------------------------------------------------------------------
 
 
 class TestBuiltinNamesConsistency:
-    """_BUILTIN_NAMES stays in sync with _builtin_themes()."""
+    """_builtin_names() stays in sync with _builtin_themes()."""
 
     def test_builtin_names_matches_builtin_themes(self) -> None:
-        assert frozenset(_builtin_themes()) == _BUILTIN_NAMES
+        assert frozenset(_builtin_themes()) == _builtin_names()
 
 
 # ---------------------------------------------------------------------------
@@ -984,7 +985,7 @@ class TestThemeSelectorScreen:
             app.push_screen(screen)
             await pilot.pause()
             option_list = screen.query_one("#theme-options", OptionList)
-            assert option_list.option_count == len(theme.ThemeEntry.REGISTRY)
+            assert option_list.option_count == len(theme.get_registry())
 
     async def test_current_theme_highlighted(self) -> None:
         from textual.app import App
@@ -1046,4 +1047,4 @@ class TestThemeSelectorScreen:
             await pilot.pause()
             assert len(results) == 1
             assert results[0] is not None
-            assert results[0] in theme.ThemeEntry.REGISTRY
+            assert results[0] in theme.get_registry()

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -126,7 +126,8 @@ class TestThemeEntryRegistry:
             ("langchain-light", False, True),
             ("textual-dark", True, False),
             ("textual-light", False, False),
-            ("textual-ansi", False, False),
+            ("ansi-dark", True, False),
+            ("ansi-light", False, False),
             # Community themes
             ("dracula", True, False),
             ("monokai", True, False),
@@ -332,11 +333,11 @@ class TestGetThemeColors:
             surface = "ansi_default"
 
         class FakeApp:
-            theme = "textual-ansi"
+            theme = "ansi-light"
             current_theme = CurrentTheme()
 
         colors = get_theme_colors(FakeApp())
-        # Non-hex values fall back to light base (ansi theme is dark=False)
+        # Non-hex values fall back to light base (ansi-light is dark=False)
         assert colors.primary == LIGHT_COLORS.primary
         assert colors.background == LIGHT_COLORS.background
 

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -1226,7 +1226,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.0.0,<3.0.0" },
     { name = "rich", specifier = ">=14.0.0,<15.0.0" },
     { name = "tavily-python", specifier = ">=0.7.21,<1.0.0" },
-    { name = "textual", specifier = ">=8.0.0,<9.0.0" },
+    { name = "textual", specifier = ">=8.2.5,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=3.0.0,<5.0.0" },
     { name = "textual-speedups", specifier = ">=0.2.1,<1.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
@@ -5551,7 +5551,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "8.2.3"
+version = "8.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -5561,9 +5561,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/1e/1eedc5bac184d00aaa5f9a99095f7e266af3ec46fa926c1051be5d358da1/textual-8.2.5.tar.gz", hash = "sha256:6c894e65a879dadb4f6cf46ddcfedb0173ff7e0cb1fe605ff7b357a597bdbc90", size = 1851596, upload-time = "2026-04-30T08:02:58.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/01/c4555f9c8a692ff83d84930150540f743ce94c89234f9e9a15ff4baba3a8/textual-8.2.5-py3-none-any.whl", hash = "sha256:247d2aa2faf222749c321f88a736247f37ee2c023604079c7490bfacddfcd4b2", size = 727050, upload-time = "2026-04-30T08:03:01.421Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1207,7 +1207,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.0.0,<3.0.0" },
     { name = "rich", specifier = ">=14.0.0,<15.0.0" },
     { name = "tavily-python", specifier = ">=0.7.21,<1.0.0" },
-    { name = "textual", specifier = ">=8.0.0,<9.0.0" },
+    { name = "textual", specifier = ">=8.2.5,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=3.0.0,<5.0.0" },
     { name = "textual-speedups", specifier = ">=0.2.1,<1.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0,<2.0.0" },
@@ -5035,7 +5035,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "8.1.1"
+version = "8.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -5045,9 +5045,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/23/8c709655c5f2208ee82ab81b8104802421865535c278a7649b842b129db1/textual-8.1.1.tar.gz", hash = "sha256:eef0256a6131f06a20ad7576412138c1f30f92ddeedd055953c08d97044bc317", size = 1843002, upload-time = "2026-03-10T10:01:38.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/1e/1eedc5bac184d00aaa5f9a99095f7e266af3ec46fa926c1051be5d358da1/textual-8.2.5.tar.gz", hash = "sha256:6c894e65a879dadb4f6cf46ddcfedb0173ff7e0cb1fe605ff7b357a597bdbc90", size = 1851596, upload-time = "2026-04-30T08:02:58.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/21/421b02bf5943172b7a9320712a5e0d74a02a8f7597284e3f8b5b06c70b8d/textual-8.1.1-py3-none-any.whl", hash = "sha256:6712f96e335cd782e76193dee16b9c8875fe0699d923bc8d3f1228fd23e773a6", size = 719598, upload-time = "2026-03-10T10:01:48.318Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/01/c4555f9c8a692ff83d84930150540f743ce94c89234f9e9a15ff4baba3a8/textual-8.2.5-py3-none-any.whl", hash = "sha256:247d2aa2faf222749c321f88a736247f37ee2c023604079c7490bfacddfcd4b2", size = 727050, upload-time = "2026-04-30T08:03:01.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pick up `ansi-dark` / `ansi-light` themes shipped in Textual 8.2.5 and stop hand-maintaining the list of Textual built-ins. The picker now stays in sync with whatever Textual ships.