### PR TITLE
test(sdk): silence expected `UserWarnings`

### DIFF
--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -1160,6 +1160,7 @@ class TestProfilePluginLoader:
 
         with (
             caplog.at_level(logging.ERROR, logger="deepagents.profiles._builtin_profiles"),
+            pytest.warns(UserWarning, match="failed to load entry point"),
             patch(
                 "deepagents.profiles._builtin_profiles.entry_points",
                 side_effect=fake_entry_points,
@@ -1190,6 +1191,7 @@ class TestProfilePluginLoader:
 
         with (
             caplog.at_level(logging.ERROR, logger="deepagents.profiles._builtin_profiles"),
+            pytest.warns(UserWarning, match="did not resolve to a callable"),
             patch(
                 "deepagents.profiles._builtin_profiles.entry_points",
                 return_value=[ep],
@@ -1218,6 +1220,7 @@ class TestProfilePluginLoader:
 
         with (
             caplog.at_level(logging.ERROR, logger="deepagents.profiles._builtin_profiles"),
+            pytest.warns(UserWarning, match="registration callable .* raised"),
             patch(
                 "deepagents.profiles._builtin_profiles.entry_points",
                 return_value=[ep],
@@ -1236,6 +1239,7 @@ class TestProfilePluginLoader:
 
         with (
             caplog.at_level(logging.WARNING, logger="deepagents.profiles._builtin_profiles"),
+            pytest.warns(UserWarning, match="Failed to enumerate"),
             patch(
                 "deepagents.profiles._builtin_profiles.entry_points",
                 side_effect=RuntimeError("malformed dist-info"),

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -1690,6 +1690,7 @@ class TestSubAgents:
         assert len(received_configs) > 0, "Lambda should have been invoked"
         assert all(t in received_configs[0].get("tags", []) for t in test_tags), f"Missing tags in config: {received_configs[0].get('tags')}"
 
+    @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
     def test_context_passed_to_subagent_tool_runtime(self) -> None:
         """Test that context passed to main agent is available in subagent's ToolRuntime.context."""
         received_contexts: list[Any] = []


### PR DESCRIPTION
Quiet two unrelated `UserWarning` sources that pytest was surfacing in the test output.