### PR TITLE
fix(cli): apply `--model-params` on `/model` re-select

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -347,6 +347,21 @@ def _extract_model_params_flag(raw_arg: str) -> tuple[str, dict[str, Any] | None
     return remaining, params
 
 
+def _format_model_params(extra_kwargs: dict[str, Any] | None) -> str:
+    """Render `--model-params` as a stable, key-sorted JSON suffix.
+
+    Args:
+        extra_kwargs: The parsed `--model-params` payload, or `None`.
+
+    Returns:
+        ` with model params {json}` when `extra_kwargs` is non-empty;
+        otherwise an empty string so callers can unconditionally concatenate.
+    """
+    if not extra_kwargs:
+        return ""
+    return f" with model params {json.dumps(extra_kwargs, sort_keys=True)}"
+
+
 InputMode = Literal["normal", "shell", "command"]
 
 _TYPING_IDLE_THRESHOLD_SECONDS: float = 2.0
@@ -6703,7 +6718,19 @@ class DeepAgentsApp(App):
                 not provider or provider == settings.model_provider
             ):
                 current = f"{settings.model_provider}:{settings.model_name}"
-                await self._mount_message(AppMessage(f"Already using {current}"))
+                # Mirror the regular-switch path so `--model-params` semantics
+                # are consistent across same-model and different-model cases:
+                # passing params applies them, omitting params clears any
+                # prior per-session override.
+                self._model_override = current
+                self._model_params_override = extra_kwargs
+                params_suffix = _format_model_params(extra_kwargs)
+                await self._mount_message(
+                    AppMessage(f"Already using {current}{params_suffix}")
+                )
+                logger.info(
+                    "Model unchanged (%s); model_params=%s", current, extra_kwargs
+                )
                 return
 
             # Build the provider:model spec for the configurable middleware.
@@ -6744,8 +6771,15 @@ class DeepAgentsApp(App):
                     )
                 )
             else:
-                await self._mount_message(AppMessage(f"Switched to {display}"))
-            logger.info("Model switched to %s (via configurable middleware)", display)
+                params_suffix = _format_model_params(extra_kwargs)
+                await self._mount_message(
+                    AppMessage(f"Switched to {display}{params_suffix}")
+                )
+            logger.info(
+                "Model switched to %s (via configurable middleware); model_params=%s",
+                display,
+                extra_kwargs,
+            )
 
             # Anchor to bottom so the confirmation message is visible
             with suppress(NoMatches, ScreenStackError):

--- a/libs/cli/tests/unit_tests/test_model_switch.py
+++ b/libs/cli/tests/unit_tests/test_model_switch.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from deepagents_cli import model_config
-from deepagents_cli.app import DeepAgentsApp, _extract_model_params_flag
+from deepagents_cli.app import (
+    DeepAgentsApp,
+    _extract_model_params_flag,
+    _format_model_params,
+)
 from deepagents_cli.config import settings
 from deepagents_cli.model_config import ModelSpec, clear_caches
 from deepagents_cli.remote_client import RemoteAgent
@@ -97,6 +101,41 @@ def mock_create_model() -> Iterator[Mock]:
         yield mock
 
 
+class TestFormatModelParams:
+    """Tests for the `_format_model_params` rendering helper."""
+
+    def test_none_returns_empty_string(self) -> None:
+        """`None` produces no suffix so callers can concatenate unconditionally."""
+        assert _format_model_params(None) == ""
+
+    def test_empty_dict_returns_empty_string(self) -> None:
+        """An empty dict has no params worth echoing — collapse to empty."""
+        assert _format_model_params({}) == ""
+
+    def test_single_key_renders_with_leading_space(self) -> None:
+        """Single key renders as a space-prefixed suffix that callers append."""
+        assert _format_model_params({"num_ctx": 16384}) == (
+            ' with model params {"num_ctx": 16384}'
+        )
+
+    def test_keys_are_sorted_regardless_of_insertion_order(self) -> None:
+        """`sort_keys=True` must produce stable output across call sites and dicts.
+
+        Insertion-reversed keys would render in insertion order without
+        `sort_keys=True`, so this test would fail if the flag were dropped.
+        """
+        params = {"temperature": 0.2, "num_ctx": 16384}
+        assert _format_model_params(params) == (
+            ' with model params {"num_ctx": 16384, "temperature": 0.2}'
+        )
+
+    def test_string_values_are_json_escaped(self) -> None:
+        """Values containing quotes must be JSON-escaped, not interpolated raw."""
+        assert _format_model_params({"stop": '"end"'}) == (
+            ' with model params {"stop": "\\"end\\""}'
+        )
+
+
 class TestModelSwitchNoOp:
     """Tests for no-op when switching to the same model."""
 
@@ -140,6 +179,77 @@ class TestModelSwitchNoOp:
         assert "Already using" in captured_messages[0]
         assert "Switched to" not in captured_messages[0]
         assert app._model_switching is False
+
+    async def test_same_model_with_new_params_applies_overrides(self) -> None:
+        """`/model <current> --model-params {...}` should apply params per-session.
+
+        Regression test for the bug where the early return on the
+        already-active-model branch silently dropped `--model-params`,
+        leaving `_model_params_override` unset.
+        """
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._agent = _make_remote_agent()
+
+        settings.model_name = "claude-opus-4-5"
+        settings.model_provider = "anthropic"
+
+        captured_messages: list[str] = []
+        original_init = AppMessage.__init__
+
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
+            captured_messages.append(message)
+            original_init(self, message, **kwargs)
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch.object(AppMessage, "__init__", capture_init),
+        ):
+            await app._switch_model(
+                "anthropic:claude-opus-4-5",
+                extra_kwargs={"num_ctx": 16384, "temperature": 0.2},
+            )
+
+        assert app._model_override == "anthropic:claude-opus-4-5"
+        assert app._model_params_override == {
+            "num_ctx": 16384,
+            "temperature": 0.2,
+        }
+        assert len(captured_messages) == 1
+        message = captured_messages[0]
+        assert message.startswith("Already using anthropic:claude-opus-4-5")
+        # Stable, key-sorted JSON in the echoed suffix.
+        assert 'with model params {"num_ctx": 16384, "temperature": 0.2}' in message
+
+    async def test_same_model_without_params_clears_prior_override(self) -> None:
+        """Re-selecting the same model with no params must clear stale params.
+
+        Regression test for the asymmetry where the regular-switch path always
+        wrote `_model_params_override = extra_kwargs` (clearing on `None`) but
+        the already-active branch left previously-set params in place.
+        """
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._agent = _make_remote_agent()
+
+        settings.model_name = "claude-opus-4-5"
+        settings.model_provider = "anthropic"
+
+        # Simulate a prior `/model <current> --model-params {...}` call.
+        app._model_override = "anthropic:claude-opus-4-5"
+        app._model_params_override = {"num_ctx": 16384}
+
+        with patch(
+            "deepagents_cli.model_config.has_provider_credentials",
+            return_value=True,
+        ):
+            await app._switch_model("anthropic:claude-opus-4-5")
+
+        assert app._model_override == "anthropic:claude-opus-4-5"
+        assert app._model_params_override is None
 
 
 class TestModelSwitchErrorHandling:
@@ -319,6 +429,41 @@ class TestModelSwitchErrorHandling:
             "temperature": 0.7,
             "max_tokens": 1024,
         }
+
+    async def test_switched_to_message_echoes_params(self) -> None:
+        """The 'Switched to' confirmation should echo `--model-params`."""
+        app = DeepAgentsApp()
+        app._mount_message = AsyncMock()  # type: ignore[method-assign]
+        app._agent = _make_remote_agent()
+
+        settings.model_name = "gpt-4o"
+        settings.model_provider = "openai"
+
+        captured_messages: list[str] = []
+        original_init = AppMessage.__init__
+
+        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
+            captured_messages.append(message)
+            original_init(self, message, **kwargs)
+
+        with (
+            patch(
+                "deepagents_cli.model_config.has_provider_credentials",
+                return_value=True,
+            ),
+            patch("deepagents_cli.model_config.save_recent_model", return_value=True),
+            patch.object(AppMessage, "__init__", capture_init),
+        ):
+            await app._switch_model(
+                "anthropic:claude-sonnet-4-5",
+                extra_kwargs={"temperature": 0.7, "num_ctx": 16384},
+            )
+
+        assert any(
+            m == "Switched to anthropic:claude-sonnet-4-5 with model params "
+            '{"num_ctx": 16384, "temperature": 0.7}'
+            for m in captured_messages
+        )
 
 
 class TestModelSwitchConcurrencyGuard:


### PR DESCRIPTION
Fix `/model --model-params` silently dropping params when the user re-selects the active model, and echo the applied params in the confirmation message so it's visible whether they took effect.