### PR TITLE
feat(evals): add `docs` model preset

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -106,10 +106,12 @@ REGISTRY: tuple[Model, ...] = (
                 "eval:set0",
                 "eval:set1",
                 "eval:frontier",
+                "eval:docs",
                 "eval:anthropic",
                 "harbor:set0",
                 "harbor:set1",
                 "harbor:frontier",
+                "harbor:docs",
                 "harbor:anthropic",
             }
         ),
@@ -149,7 +151,16 @@ REGISTRY: tuple[Model, ...] = (
     ),
     Model(
         "baseten:moonshotai/Kimi-K2.6",
-        frozenset({"eval:set0", "eval:baseten", "harbor:set0", "harbor:baseten"}),
+        frozenset(
+            {
+                "eval:set0",
+                "eval:docs",
+                "eval:baseten",
+                "harbor:set0",
+                "harbor:docs",
+                "harbor:baseten",
+            }
+        ),
     ),
     Model(
         "baseten:nvidia/Nemotron-120B-A12B",
@@ -244,10 +255,12 @@ REGISTRY: tuple[Model, ...] = (
                 "eval:set0",
                 "eval:set1",
                 "eval:frontier",
+                "eval:docs",
                 "eval:google_genai",
                 "harbor:set0",
                 "harbor:set1",
                 "harbor:frontier",
+                "harbor:docs",
                 "harbor:google_genai",
             }
         ),
@@ -451,10 +464,12 @@ REGISTRY: tuple[Model, ...] = (
                 "eval:set0",
                 "eval:set1",
                 "eval:frontier",
+                "eval:docs",
                 "eval:openai",
                 "harbor:set0",
                 "harbor:set1",
                 "harbor:frontier",
+                "harbor:docs",
                 "harbor:openai",
             }
         ),
@@ -486,7 +501,9 @@ REGISTRY: tuple[Model, ...] = (
         "openrouter:minimax/minimax-m2.7",
         frozenset(
             {
+                "eval:docs",
                 "eval:openrouter",
+                "harbor:docs",
                 "harbor:openrouter",
             }
         ),
@@ -514,8 +531,10 @@ REGISTRY: tuple[Model, ...] = (
         frozenset(
             {
                 "eval:open",
+                "eval:docs",
                 "eval:openrouter",
                 "harbor:open",
+                "harbor:docs",
                 "harbor:openrouter",
             }
         ),
@@ -525,6 +544,17 @@ REGISTRY: tuple[Model, ...] = (
         frozenset(
             {
                 "eval:openrouter",
+                "harbor:openrouter",
+            }
+        ),
+    ),
+    Model(
+        "openrouter:deepseek/deepseek-v4-pro",
+        frozenset(
+            {
+                "eval:docs",
+                "eval:openrouter",
+                "harbor:docs",
                 "harbor:openrouter",
             }
         ),
@@ -561,6 +591,7 @@ _PRESET_SECTIONS: list[tuple[str | None, list[tuple[str, str | None]]]] = [
             ("mega", "mega"),
             ("fast", "fast"),
             ("open", "open"),
+            ("docs", "docs"),
         ],
     ),
     (

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -39,6 +39,7 @@ on:
           - mega
           - fast
           - open
+          - docs
           - anthropic
           - baseten
           - fireworks
@@ -107,6 +108,7 @@ on:
           - "openrouter:moonshotai/kimi-k2.5"
           - "openrouter:moonshotai/kimi-k2.6"
           - "openrouter:z-ai/glm-5.1"
+          - "openrouter:deepseek/deepseek-v4-pro"
           - "openrouter:nvidia/nemotron-3-super-120b-a12b"
           - "xai:grok-4"
           - "xai:grok-3-mini-fast"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -45,6 +45,7 @@ on:
           - mega
           - fast
           - open
+          - docs
           - anthropic
           - baseten
           - fireworks
@@ -113,6 +114,7 @@ on:
           - "openrouter:moonshotai/kimi-k2.5"
           - "openrouter:moonshotai/kimi-k2.6"
           - "openrouter:z-ai/glm-5.1"
+          - "openrouter:deepseek/deepseek-v4-pro"
           - "openrouter:nvidia/nemotron-3-super-120b-a12b"
           - "xai:grok-4"
           - "xai:grok-3-mini-fast"

--- a/libs/evals/MODEL_GROUPS.md
+++ b/libs/evals/MODEL_GROUPS.md
@@ -109,6 +109,16 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `ollama:minimax-m2.7:cloud`
 - `openrouter:z-ai/glm-5.1`
 
+### `docs` (7 models)
+
+- `anthropic:claude-opus-4-7`
+- `baseten:moonshotai/Kimi-K2.6`
+- `google_genai:gemini-3.1-pro-preview`
+- `openai:gpt-5.5`
+- `openrouter:minimax/minimax-m2.7`
+- `openrouter:z-ai/glm-5.1`
+- `openrouter:deepseek/deepseek-v4-pro`
+
 ## Provider groups
 
 ### `anthropic` (8 models)
@@ -188,20 +198,21 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openai:gpt-5.5`
 - `openai:gpt-5.4-mini`
 
-### `openrouter` (5 models)
+### `openrouter` (6 models)
 
 - `openrouter:minimax/minimax-m2.7`
 - `openrouter:moonshotai/kimi-k2.5`
 - `openrouter:moonshotai/kimi-k2.6`
 - `openrouter:z-ai/glm-5.1`
 - `openrouter:nvidia/nemotron-3-super-120b-a12b`
+- `openrouter:deepseek/deepseek-v4-pro`
 
 ### `xai` (2 models)
 
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`
 
-## `all` (61 models)
+## `all` (62 models)
 
 - `anthropic:claude-haiku-4-5-20251001`
 - `anthropic:claude-haiku-4-5`
@@ -262,5 +273,6 @@ Source of truth: [`.github/scripts/models.py`](../../.github/scripts/models.py).
 - `openrouter:moonshotai/kimi-k2.6`
 - `openrouter:z-ai/glm-5.1`
 - `openrouter:nvidia/nemotron-3-super-120b-a12b`
+- `openrouter:deepseek/deepseek-v4-pro`
 - `xai:grok-4`
 - `xai:grok-3-mini-fast`


### PR DESCRIPTION
Add a `docs` model preset to the eval/harbor workflow registry that mirrors the 7 models showcased in the Deep Agents documentation's "Model evaluations" table. Lets contributors reproduce the table with a single dispatch (`gh workflow run evals.yml -f models=docs`) instead of copy-pasting a `models_override` string.