### PR TITLE
fix(ci): pass `MODEL` to `make evals` after guard

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -286,7 +286,7 @@ jobs:
       run:
         working-directory: libs/evals
     env:
-      PYTEST_ADDOPTS: "--model ${{ matrix.model }} --evals-report-file evals_report.json"
+      PYTEST_ADDOPTS: "--evals-report-file evals_report.json"
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
@@ -350,7 +350,7 @@ jobs:
         run: echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS} --openrouter-provider ${OPENROUTER_PROVIDER}" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
-        run: make evals
+        run: make evals MODEL=${{ matrix.model }}
 
       - name: "🔍 Check eval report"
         if: "!cancelled()"


### PR DESCRIPTION
Pass the matrix model through to `make evals` so the Makefile guard added in #2978 is satisfied. The eval workflow ran `make evals` with the model only in `PYTEST_ADDOPTS`, which the Makefile target doesn't read — every job exited immediately with `ERROR: MODEL is required` before pytest could write a report, then the artifact upload failed because no report existed.