### PR TITLE
docs(sdk): document removing the task tool

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -308,6 +308,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             Entries that match nothing in the assembled stack raise
             `ValueError`, as does excluding scaffolding classes
             (`FilesystemMiddleware`, `SubAgentMiddleware`).
+
+            To run without the `task` tool, set
+            `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
+            on the active harness profile and pass no synchronous
+            subagents via `subagents=`. Async subagents are unaffected.
         subagents: Subagent specs available to the main agent.
 
             This collection supports three forms:
@@ -336,7 +341,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             If no subagent named `general-purpose` is provided, a default
             general-purpose synchronous subagent is added automatically unless
-            the active harness profile disables it.
+            the active harness profile disables it. With no synchronous
+            subagents in play — none passed and the default disabled via
+            `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
+            — the `task` tool is not exposed. Async subagents are independent.
 
         skills: List of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
 

--- a/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
@@ -295,6 +295,15 @@ class HarnessProfileConfig:
 
     This is the canonical on-disk representation used by `to_dict` /
     `from_dict`.
+
+    !!! note "Removing the `task` tool"
+
+        `excluded_middleware` won't drop `"SubAgentMiddleware"` (or
+        `"FilesystemMiddleware"`) — they're required scaffolding. To run
+        without the `task` tool, set `general_purpose_subagent.enabled`
+        to `false` on this config and pass no synchronous subagents via
+        `subagents=` on `create_deep_agent`. Async subagents are
+        unaffected.
     """
 
     general_purpose_subagent: GeneralPurposeSubagentProfile | None = None
@@ -303,6 +312,11 @@ class HarnessProfileConfig:
     Unset is equivalent to passing a default-constructed
     `GeneralPurposeSubagentProfile()` — the auto-added subagent runs with
     its stock description and prompt.
+
+    Set `enabled` to `false` on a populated sub-profile to remove
+    the default `general-purpose` subagent. Pair that with no synchronous
+    subagents via `subagents=` on `create_deep_agent` and the `task` tool
+    is dropped too. Async subagents are unaffected.
     """
 
     def __post_init__(self) -> None:
@@ -659,6 +673,15 @@ class HarnessProfile:
             `create_deep_agent` resolves the profile.
         - Entries that match no middleware in the assembled stack are
             rejected as likely typos or stale profiles.
+
+    !!! note "Removing the `task` tool"
+
+        Don't reach for `excluded_middleware` here — it intentionally raises
+        `ValueError` on `SubAgentMiddleware`. Instead, set
+        `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
+        and pass no synchronous subagents via `subagents=` on
+        `create_deep_agent`. With nothing to back, the `task` tool is gone.
+        Async subagents are independent.
     """
 
     extra_middleware: Sequence[AgentMiddleware] | Callable[[], Sequence[AgentMiddleware]] = ()
@@ -688,6 +711,9 @@ class HarnessProfile:
     `GeneralPurposeSubagentProfile()` — the auto-added subagent runs with
     its stock description and prompt. Set `enabled=False` on a populated
     sub-profile to remove the default `general-purpose` subagent entirely.
+    Pair that with no synchronous subagents via `subagents=` on
+    `create_deep_agent` and the `task` tool is dropped too. Async
+    subagents are unaffected.
     """
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
Add docstring guidance for running an agent without the `task` tool. A user recently hit `ValueError` trying `excluded_middleware={"SubAgentMiddleware"}` (the wrong knob — `SubAgentMiddleware` is required scaffolding) and bounced without discovering the supported recipe. The fix is twofold: disable the auto-added GP subagent via the harness profile, and pass no synchronous subagents — `SubAgentMiddleware` is only attached when at least one sync subagent exists.