### PR TITLE
refactor(evals): partition matrix per provider for real queueing

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -638,12 +638,107 @@ _WORKFLOW_CONFIG: dict[str, tuple[str, dict[str, str | None]]] = {
     "harbor": ("HARBOR_MODELS", _HARBOR_PRESETS),
 }
 
+_EVAL_PROVIDER_OUTPUTS: tuple[str, ...] = (
+    "anthropic",
+    "baseten",
+    "fireworks",
+    "google_genai",
+    "groq",
+    "nvidia",
+    "ollama",
+    "openai",
+    "openrouter",
+    "xai",
+    "other",
+)
+"""Names of the per-provider matrix outputs emitted for the evals workflow.
+
+All entries except `"other"` are real provider prefixes matched against
+`_provider(model_spec)`. The `"other"` bucket is a catch-all for model specs
+whose provider is not enumerated here, so they still flow into a real eval
+job (see `_matrix_outputs`). Adding a new provider here also requires adding
+a matching `eval-<provider>` job in `evals.yml`; the test suite enforces this
+contract.
+"""
+
+_ARTIFACT_KEY_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+"""Characters disallowed in GHA artifact names (model specs use `:` and `/`)."""
+
 
 def _filter_by_tag(prefix: str, tag: str | None) -> list[str]:
     """Return model specs matching a tag filter, in REGISTRY order."""
     if tag is not None:
         return [m.spec for m in REGISTRY if tag in m.groups]
     return [m.spec for m in REGISTRY if any(g.startswith(prefix) for g in m.groups)]
+
+
+def _provider(model_spec: str) -> str:
+    """Return the provider prefix from a model spec."""
+    return model_spec.split(":", 1)[0]
+
+
+def _artifact_key(index: int, model_spec: str) -> str:
+    """Build a stable, artifact-safe key for one model matrix entry.
+
+    GitHub Actions artifact names disallow several characters that appear in
+    model specs (e.g., `:` and `/`), and two artifacts cannot share a name
+    within a workflow run. The numeric `index` prefix guarantees uniqueness
+    even if two specs collapse to the same slug; the regex replaces every
+    disallowed character with `-`.
+    """
+    slug = _ARTIFACT_KEY_RE.sub("-", model_spec).strip("-")
+    return f"{index:03d}-{slug}"
+
+
+def _matrix_entry(index: int, model_spec: str) -> dict[str, str]:
+    """Build one GitHub Actions matrix entry for a model."""
+    return {
+        "model": model_spec,
+        "provider": _provider(model_spec),
+        "artifact_key": _artifact_key(index, model_spec),
+    }
+
+
+def _matrix_outputs(workflow: str, models: list[str]) -> dict[str, object]:
+    """Build matrix outputs consumed by GitHub Actions workflows.
+
+    The evals workflow needs one matrix per provider so each provider can use
+    `strategy.max-parallel: 1` as a real per-provider queue. The catch-all
+    `other` matrix runs any models whose provider is not enumerated in
+    `_EVAL_PROVIDER_OUTPUTS`, so newly added providers (or one-off
+    `models_override` entries) still execute even before a dedicated
+    `eval-<provider>` job is wired up in `evals.yml`.
+
+    Args:
+        workflow: "eval" or "harbor".
+        models: Ordered model specs selected for the workflow.
+
+    Returns:
+        Mapping of GitHub output names to JSON-serializable values.
+    """
+    entries = [_matrix_entry(index, model) for index, model in enumerate(models)]
+    outputs: dict[str, object] = {"matrix": {"include": entries}}
+
+    if workflow != "eval":
+        return outputs
+
+    provider_entries: dict[str, list[dict[str, str]]] = {
+        provider: [] for provider in _EVAL_PROVIDER_OUTPUTS
+    }
+    for entry in entries:
+        provider = entry["provider"]
+        output_provider = provider if provider in provider_entries else "other"
+        provider_entries[output_provider].append(entry)
+
+    # Empty includes are emitted intentionally and *must* be guarded by
+    # `<provider>_has_models == 'true'` in evals.yml — GitHub Actions fails
+    # the workflow when `matrix.include == []`. See the per-provider job
+    # `if:` clauses in evals.yml.
+    for provider, include in provider_entries.items():
+        outputs[f"{provider}_matrix"] = {"include": include}
+        outputs[f"{provider}_has_models"] = bool(include)
+
+    return outputs
 
 
 def _resolve_models(workflow: str, selection: str) -> list[str]:
@@ -690,17 +785,17 @@ def main() -> None:
     env_var, _ = _WORKFLOW_CONFIG[workflow]
     selection = os.environ.get(env_var, "all")
     models = _resolve_models(workflow, selection)
-    matrix = {
-        "include": [{"model": m, "provider": m.split(":")[0]} for m in models],
-    }
+    outputs = _matrix_outputs(workflow, models)
 
     github_output = os.environ.get("GITHUB_OUTPUT")
-    line = f"matrix={json.dumps(matrix, separators=(',', ':'))}"
     if github_output:
         with open(github_output, "a") as f:  # noqa: PTH123
-            f.write(line + "\n")
+            for key, value in outputs.items():
+                payload = json.dumps(value, separators=(",", ":"))
+                f.write(f"{key}={payload}\n")
     else:
-        print(line)  # noqa: T201
+        payload = json.dumps(outputs["matrix"], separators=(",", ":"))
+        print(f"matrix={payload}")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_models.py
+++ b/.github/scripts/test_models.py
@@ -1,0 +1,248 @@
+"""Tests for the GitHub Actions model matrix helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODELS_SCRIPT = REPO_ROOT / ".github" / "scripts" / "models.py"
+EVALS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "evals.yml"
+
+
+def _load_models_script() -> ModuleType:
+    """Load `.github/scripts/models.py` as a module.
+
+    The script lives outside any importable package, so import-by-path is the
+    only way to exercise its internals from a test.
+    """
+    spec = importlib.util.spec_from_file_location("gha_models", MODELS_SCRIPT)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module spec for {MODELS_SCRIPT}"
+        raise AssertionError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def models() -> ModuleType:
+    """Module-scoped handle to the loaded `models.py` script."""
+    return _load_models_script()
+
+
+def test_eval_matrix_outputs_are_partitioned_by_provider(models: ModuleType) -> None:
+    """Eval matrix outputs should queue each provider independently."""
+    outputs = models._matrix_outputs(
+        "eval",
+        [
+            "anthropic:claude-sonnet-4-6",
+            "openrouter:moonshotai/kimi-k2.6",
+            "new_provider:model-1",
+        ],
+    )
+
+    assert outputs["anthropic_has_models"] is True
+    assert outputs["openrouter_has_models"] is True
+    assert outputs["other_has_models"] is True
+    assert outputs["openai_has_models"] is False
+    assert outputs["anthropic_matrix"] == {
+        "include": [
+            {
+                "model": "anthropic:claude-sonnet-4-6",
+                "provider": "anthropic",
+                "artifact_key": "000-anthropic-claude-sonnet-4-6",
+            }
+        ]
+    }
+    assert outputs["openrouter_matrix"] == {
+        "include": [
+            {
+                "model": "openrouter:moonshotai/kimi-k2.6",
+                "provider": "openrouter",
+                "artifact_key": "001-openrouter-moonshotai-kimi-k2.6",
+            }
+        ]
+    }
+    assert outputs["other_matrix"] == {
+        "include": [
+            {
+                "model": "new_provider:model-1",
+                "provider": "new_provider",
+                "artifact_key": "002-new_provider-model-1",
+            }
+        ]
+    }
+
+
+def test_harbor_matrix_output_stays_flat(models: ModuleType) -> None:
+    """Harbor should keep the existing single-matrix output contract."""
+    outputs = models._matrix_outputs("harbor", ["openai:gpt-5.4"])
+
+    assert outputs == {
+        "matrix": {
+            "include": [
+                {
+                    "model": "openai:gpt-5.4",
+                    "provider": "openai",
+                    "artifact_key": "000-openai-gpt-5.4",
+                }
+            ]
+        }
+    }
+
+
+def test_eval_matrix_outputs_with_no_models(models: ModuleType) -> None:
+    """Empty model list emits empty includes for every declared provider.
+
+    The per-provider job `if:` guards in `evals.yml` are the only thing
+    keeping GHA from rejecting a `matrix.include == []` configuration, so
+    this lock-in test ensures the empty shape is preserved verbatim.
+    """
+    outputs = models._matrix_outputs("eval", [])
+
+    assert outputs["matrix"] == {"include": []}
+    for provider in models._EVAL_PROVIDER_OUTPUTS:
+        assert outputs[f"{provider}_has_models"] is False
+        assert outputs[f"{provider}_matrix"] == {"include": []}
+
+
+def test_eval_outputs_cover_every_declared_provider(models: ModuleType) -> None:
+    """Every name in `_EVAL_PROVIDER_OUTPUTS` must produce both output keys."""
+    for provider in models._EVAL_PROVIDER_OUTPUTS:
+        spec = f"{provider}:dummy" if provider != "other" else "unknown:dummy"
+        outputs = models._matrix_outputs("eval", [spec])
+        assert outputs[f"{provider}_has_models"] is True, provider
+        assert outputs[f"{provider}_matrix"]["include"], provider
+
+
+def test_eval_workflow_outputs_match_provider_constant(models: ModuleType) -> None:
+    """`evals.yml` prep outputs must stay in sync with `_EVAL_PROVIDER_OUTPUTS`.
+
+    Mirrors `test_release_options.py`: parses the workflow YAML and compares
+    declared output names against the source set, so a drift in either
+    direction (new provider, deleted provider, typo) fails fast.
+    """
+    workflow = yaml.safe_load(EVALS_WORKFLOW.read_text())
+    declared = set(workflow["jobs"]["prep"]["outputs"].keys()) - {"matrix"}
+
+    expected = {f"{p}_matrix" for p in models._EVAL_PROVIDER_OUTPUTS} | {
+        f"{p}_has_models" for p in models._EVAL_PROVIDER_OUTPUTS
+    }
+
+    assert declared == expected, (
+        "evals.yml prep outputs are out of sync with _EVAL_PROVIDER_OUTPUTS — "
+        f"missing: {expected - declared}, extra: {declared - expected}"
+    )
+
+
+def test_eval_workflow_per_provider_jobs_match_provider_constant(
+    models: ModuleType,
+) -> None:
+    """Each provider in `_EVAL_PROVIDER_OUTPUTS` has a matching `eval-*` job.
+
+    The job name uses dashes (e.g. `eval-google-genai`) while the constant
+    uses underscores (`google_genai`); compare with that mapping in mind.
+    """
+    workflow = yaml.safe_load(EVALS_WORKFLOW.read_text())
+    job_names = set(workflow["jobs"].keys())
+
+    for provider in models._EVAL_PROVIDER_OUTPUTS:
+        job = f"eval-{provider.replace('_', '-')}"
+        assert job in job_names, (
+            f"_EVAL_PROVIDER_OUTPUTS includes {provider!r} but evals.yml is "
+            f"missing job {job!r}"
+        )
+
+
+def test_has_models_serializes_to_lowercase_bool(models: ModuleType) -> None:
+    """`_has_models` must serialize to `true`/`false` for GHA string compare.
+
+    `evals.yml` gates each per-provider job on `... == 'true'`; if the JSON
+    encoding of the python `bool` ever drifts (e.g., to Python `True`),
+    every gate would silently evaluate false.
+    """
+    outputs = models._matrix_outputs("eval", ["anthropic:claude-sonnet-4-6"])
+    assert json.dumps(outputs["anthropic_has_models"]) == "true"
+    assert json.dumps(outputs["openai_has_models"]) == "false"
+
+
+@pytest.mark.parametrize(
+    ("index", "spec", "expected"),
+    [
+        (0, "openrouter:moonshotai/kimi-k2.6", "000-openrouter-moonshotai-kimi-k2.6"),
+        (5, "openrouter:foo//bar", "005-openrouter-foo-bar"),
+        (12, ":leading-colon", "012-leading-colon"),
+        (99, "trailing-slash/", "099-trailing-slash"),
+        (7, "anthropic:claude-opus-4-7", "007-anthropic-claude-opus-4-7"),
+    ],
+)
+def test_artifact_key_handles_disallowed_characters(
+    models: ModuleType, index: int, spec: str, expected: str
+) -> None:
+    """`_artifact_key` strips/collapses every char outside `[a-zA-Z0-9._-]`."""
+    assert models._artifact_key(index, spec) == expected
+
+
+def test_artifact_key_index_disambiguates_identical_slugs(
+    models: ModuleType,
+) -> None:
+    """Same spec at different indexes still produces unique keys."""
+    spec = "anthropic:claude-sonnet-4-6"
+    assert models._artifact_key(0, spec) != models._artifact_key(1, spec)
+
+
+def test_provider_returns_whole_string_when_no_colon(models: ModuleType) -> None:
+    """`_provider` falls through cleanly when the spec lacks a `:` separator.
+
+    Upstream `_resolve_models` rejects colon-less specs, but a future caller
+    of `_provider`/`_matrix_entry` might not — this lock-in test pins the
+    behavior so a silent rerouting to `other` is at least visible in tests.
+    """
+    assert models._provider("anthropic:claude-foo") == "anthropic"
+    assert models._provider("standalone-name") == "standalone-name"
+
+
+def test_main_writes_per_provider_outputs_to_github_output(
+    models: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`main()` writes one line per output key with compact JSON values.
+
+    GitHub Actions parses `key=value\\n` lines from `$GITHUB_OUTPUT`. Multi-line
+    values would require heredoc syntax; this test guards against a future
+    refactor to `json.dumps(..., indent=2)` and confirms `_has_models` is
+    written as the lowercase string `true`/`false` that the workflow gates
+    compare against.
+    """
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+
+    monkeypatch.setenv("EVAL_MODELS", "anthropic:claude-sonnet-4-6")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setattr("sys.argv", ["models.py", "eval"])
+
+    models.main()
+
+    written = output_file.read_text().splitlines()
+    keyed = dict(line.split("=", 1) for line in written)
+
+    assert keyed["anthropic_has_models"] == "true"
+    assert keyed["openai_has_models"] == "false"
+    assert keyed["other_has_models"] == "false"
+
+    matrix = json.loads(keyed["matrix"])
+    assert matrix["include"][0]["model"] == "anthropic:claude-sonnet-4-6"
+
+    anthropic_matrix = json.loads(keyed["anthropic_matrix"])
+    assert anthropic_matrix["include"][0]["provider"] == "anthropic"
+
+    for line in written:
+        assert "\n" not in line

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -1,0 +1,284 @@
+# Reusable workflow: one GHA eval run for a single model.
+#
+# Called by the per-provider matrix jobs in `evals.yml`. Inputs are validated
+# upstream by `prep` (`_SAFE_SPEC_RE` in `.github/scripts/models.py`); this
+# workflow trusts that contract.
+
+name: "📊 Eval"
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "Full model spec to evaluate."
+        required: true
+        type: string
+      provider:
+        description: "Provider prefix for the model spec."
+        required: true
+        type: string
+      artifact_key:
+        description: "Stable, artifact-safe suffix for uploaded reports."
+        required: true
+        type: string
+      eval_categories:
+        description: "Comma-separated eval categories to run."
+        required: false
+        default: ""
+        type: string
+      eval_tiers:
+        description: "Comma-separated eval tiers to run."
+        required: false
+        default: ""
+        type: string
+      analyze_failures:
+        description: "Run the LLM failure-analysis step after evals."
+        required: false
+        default: false
+        type: boolean
+      analysis_model:
+        description: "Model for failure analysis. Only used when `analyze_failures` is true."
+        required: false
+        default: "anthropic:claude-haiku-4-5-20251001"
+        type: string
+      openrouter_provider:
+        description: "Pin OpenRouter to a single provider."
+        required: false
+        default: ""
+        type: string
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: false
+      BASETEN_API_KEY:
+        required: false
+      FIREWORKS_API_KEY:
+        required: false
+      GOOGLE_API_KEY:
+        required: false
+      GROQ_API_KEY:
+        required: false
+      LANGSMITH_API_KEY:
+        required: false
+      NVIDIA_API_KEY:
+        required: false
+      OLLAMA_API_KEY:
+        required: false
+      OPENAI_API_KEY:
+        required: false
+      OPENROUTER_API_KEY:
+        required: false
+      XAI_API_KEY:
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  UV_NO_SYNC: "true"
+  UV_FROZEN: "true"
+
+jobs:
+  eval:
+    name: "📊 Eval (${{ inputs.model }})"
+    runs-on: ubuntu-latest
+    environment: evals
+    timeout-minutes: 360
+
+    defaults:
+      run:
+        working-directory: libs/evals
+    env:
+      PYTEST_ADDOPTS: "--evals-report-file evals_report.json"
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
+      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+      LANGSMITH_TRACING: "true"
+      LANGSMITH_EXPERIMENT: ${{ inputs.model }}
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+      OLLAMA_HOST: "https://ollama.com"
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "🐍 Set up Python + UV"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.12"
+          cache-suffix: evals
+          working-directory: libs/evals
+
+      - name: "📦 Install Dependencies"
+        run: uv sync --group test
+
+      - name: "🏷️ Apply category filter"
+        if: inputs.eval_categories != ''
+        env:
+          EVAL_CATEGORIES: ${{ inputs.eval_categories }}
+        run: |
+          flags=()
+          IFS=',' read -ra cats <<< "${EVAL_CATEGORIES}"
+          for cat in "${cats[@]}"; do
+            cat=$(echo "$cat" | xargs)
+            [ -z "$cat" ] && continue
+            flags+=(--eval-category "$cat")
+          done
+          printf 'PYTEST_ADDOPTS=%s %s\n' "${PYTEST_ADDOPTS}" "${flags[*]}" >> "$GITHUB_ENV"
+
+      - name: "🏷️ Apply tier filter"
+        if: inputs.eval_tiers != ''
+        env:
+          EVAL_TIERS: ${{ inputs.eval_tiers }}
+        run: |
+          flags=()
+          IFS=',' read -ra tiers <<< "${EVAL_TIERS}"
+          for tier in "${tiers[@]}"; do
+            tier=$(echo "$tier" | xargs)
+            [ -z "$tier" ] && continue
+            flags+=(--eval-tier "$tier")
+          done
+          printf 'PYTEST_ADDOPTS=%s %s\n' "${PYTEST_ADDOPTS}" "${flags[*]}" >> "$GITHUB_ENV"
+
+      - name: "🔒 Apply OpenRouter provider pin"
+        if: inputs.openrouter_provider != '' && inputs.provider == 'openrouter'
+        env:
+          OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
+        run: echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS} --openrouter-provider ${OPENROUTER_PROVIDER}" >> "$GITHUB_ENV"
+
+      - name: "📊 Run Evals"
+        env:
+          MODEL: ${{ inputs.model }}
+        run: make evals MODEL="$MODEL"
+
+      - name: "🔍 Check eval report"
+        if: "!cancelled()"
+        run: |
+          if [ ! -f evals_report.json ]; then
+            echo "::error::evals_report.json not found. pytest likely crashed before sessionfinish could write the report. Check the 'Run Evals' step logs for errors."
+            exit 1
+          fi
+
+      - name: "📊 Post results to summary"
+        if: "!cancelled()"
+        run: |
+          python3 << 'PYEOF'
+          import json, os, sys, traceback
+          from pathlib import Path
+
+          report_path = Path("evals_report.json")
+          # The upstream "Check eval report" step already emits ::error:: and
+          # exits 1 when this file is missing; exit 0 here so we don't
+          # double-fail the job.
+          if not report_path.exists():
+              print("evals_report.json not found, skipping summary", file=sys.stderr)
+              sys.exit(0)
+
+          try:
+              report = json.loads(report_path.read_text())
+          except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+              print(f"::error::evals_report.json is malformed: {exc}")
+              sys.exit(1)
+          model = report.get("model", "unknown")
+          if model == "unknown":
+              print("::warning::evals_report.json has no 'model' key; using 'unknown'")
+
+          # Load category labels for friendly display names.
+          cats_json = Path("deepagents_evals/categories.json")
+          labels = {}
+          try:
+              labels = json.loads(cats_json.read_text()).get("labels", {})
+          except (FileNotFoundError, json.JSONDecodeError) as exc:
+              print(f"::warning::Could not load category labels from {cats_json}: {exc}")
+
+          lines = [
+              "<details>",
+              "<summary>(click to expand)</summary>",
+              "",
+          ]
+
+          try:
+              # -- Metrics table --
+              metrics = [
+                  ("passed", None), ("failed", None), ("skipped", None),
+                  ("total", None), ("correctness", None), ("solve_rate", "n/a"),
+                  ("step_ratio", "n/a"), ("tool_call_ratio", "n/a"),
+                  ("median_duration_s", None),
+              ]
+              header = "| " + " | ".join(f"`{k}`" for k, _ in metrics) + " |"
+              sep = "|" + "|".join("---:" for _ in metrics) + "|"
+              vals = []
+              for key, default in metrics:
+                  val = report.get(key, default)
+                  if val is None:
+                      val = 0
+                  vals.append(str(val))
+              row = "| " + " | ".join(vals) + " |"
+              lines += [header, sep, row]
+
+              # -- Per-category scores (horizontal) --
+              cat_scores = report.get("category_scores")
+              if isinstance(cat_scores, dict) and cat_scores:
+                  sorted_cats = sorted(cat_scores.items())
+                  def esc(s): return str(s).replace("|", "\\|")
+                  cat_header = "| " + " | ".join(esc(labels.get(c, c)) for c, _ in sorted_cats) + " |"
+                  cat_sep = "|" + "|".join("---:" for _ in sorted_cats) + "|"
+                  cat_row = "| " + " | ".join(esc(s) for _, s in sorted_cats) + " |"
+                  lines += ["", "### Per-category correctness", "", cat_header, cat_sep, cat_row]
+
+              # -- Experiment links --
+              exp_links = report.get("experiment_links")
+              if isinstance(exp_links, list) and exp_links:
+                  lines += ["", "### LangSmith experiments", ""]
+                  for link in exp_links:
+                      if not isinstance(link, dict):
+                          continue
+                      name = link.get("name", "")
+                      url = link.get("url", "")
+                      public_url = link.get("public_url", "")
+                      if public_url:
+                          lines.append(f"- [{name}]({public_url}) ([internal]({url}))")
+                      elif url:
+                          lines.append(f"- [{name or url}]({url})")
+          except (KeyError, TypeError, ValueError, AttributeError) as exc:
+              tb = traceback.format_exc()
+              lines.append(f"\n\n**Error building summary:** `{exc}` (see job logs)\n")
+              print(f"::warning::Error building summary for {model}: {exc}\n{tb}")
+          finally:
+              lines += ["", "</details>"]
+
+          text = "\n".join(lines) + "\n"
+          summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
+          if summary:
+              with open(summary, "a") as f:
+                  f.write(text)
+          print(text)
+          PYEOF
+
+      - name: "🧠 Analyze eval failures"
+        if: ${{ !cancelled() && inputs.analyze_failures }}
+        continue-on-error: true
+        env:
+          ANALYSIS_MODEL: ${{ inputs.analysis_model }}
+        run: uv run python ../../.github/scripts/analyze_eval_failures.py evals_report.json
+
+      - name: "📤 Upload failure analysis"
+        if: ${{ !cancelled() && inputs.analyze_failures }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: failure-analysis-${{ inputs.artifact_key }}
+          path: libs/evals/failure_analysis.json
+          if-no-files-found: warn
+
+      - name: "📤 Upload eval report"
+        if: "!cancelled()"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: evals-report-${{ inputs.artifact_key }}
+          path: libs/evals/evals_report.json
+          if-no-files-found: error

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -149,7 +149,9 @@ jobs:
         if: inputs.openrouter_provider != '' && inputs.provider == 'openrouter'
         env:
           OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
-        run: echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS} --openrouter-provider ${OPENROUTER_PROVIDER}" >> "$GITHUB_ENV"
+        run: |
+          provider=$(echo "$OPENROUTER_PROVIDER" | xargs)
+          printf 'PYTEST_ADDOPTS=%s --openrouter-provider %s\n' "${PYTEST_ADDOPTS}" "${provider}" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,10 @@ jobs:
       has-memory-benchmarks: true
     secrets: inherit
 
-  # Verify release.yml dropdown options stay in sync with package directories
+  # Validates every helper script under .github/scripts/test_*.py — currently
+  # `test_release_options.py` (release dropdown ↔ package directories) and
+  # `test_models.py` (eval matrix outputs ↔ evals.yml). Job id/name are kept
+  # for branch-protection compatibility; rename only with a coordinated PR.
   check-release-options:
     name: "Validate Release Options"
     runs-on: ubuntu-latest
@@ -327,8 +330,8 @@ jobs:
           python-version: "3.11"
       - name: "📦 Install Dependencies"
         run: python -m pip install pyyaml pytest
-      - name: "🔍 Check release dropdown matches packages"
-        run: python -m pytest .github/scripts/test_release_options.py -v
+      - name: "🔍 Check workflow helper scripts"
+        run: python -m pytest .github/scripts/test_*.py -v
 
   # Final status check - ensures all jobs passed
   ci_success:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,7 +1,8 @@
-# Daily evaluation workflow for Deep Agents
+# Evaluation workflow for Deep Agents.
 #
-# Runs tests/evals on a cron schedule (once per day).
-# Single job; model/provider is selected via workflow input `model`.
+# Triggered manually via workflow_dispatch. Models are partitioned into
+# per-provider matrix jobs so each provider can serialize calls independently
+# (strategy.max-parallel: 1) while different providers run in parallel.
 #
 # Required secrets:
 #   LANGSMITH_API_KEY  — used for tracing
@@ -191,6 +192,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      anthropic_matrix: ${{ steps.set-matrix.outputs.anthropic_matrix }}
+      anthropic_has_models: ${{ steps.set-matrix.outputs.anthropic_has_models }}
+      baseten_matrix: ${{ steps.set-matrix.outputs.baseten_matrix }}
+      baseten_has_models: ${{ steps.set-matrix.outputs.baseten_has_models }}
+      fireworks_matrix: ${{ steps.set-matrix.outputs.fireworks_matrix }}
+      fireworks_has_models: ${{ steps.set-matrix.outputs.fireworks_has_models }}
+      google_genai_matrix: ${{ steps.set-matrix.outputs.google_genai_matrix }}
+      google_genai_has_models: ${{ steps.set-matrix.outputs.google_genai_has_models }}
+      groq_matrix: ${{ steps.set-matrix.outputs.groq_matrix }}
+      groq_has_models: ${{ steps.set-matrix.outputs.groq_has_models }}
+      nvidia_matrix: ${{ steps.set-matrix.outputs.nvidia_matrix }}
+      nvidia_has_models: ${{ steps.set-matrix.outputs.nvidia_has_models }}
+      ollama_matrix: ${{ steps.set-matrix.outputs.ollama_matrix }}
+      ollama_has_models: ${{ steps.set-matrix.outputs.ollama_has_models }}
+      openai_matrix: ${{ steps.set-matrix.outputs.openai_matrix }}
+      openai_has_models: ${{ steps.set-matrix.outputs.openai_has_models }}
+      openrouter_matrix: ${{ steps.set-matrix.outputs.openrouter_matrix }}
+      openrouter_has_models: ${{ steps.set-matrix.outputs.openrouter_has_models }}
+      xai_matrix: ${{ steps.set-matrix.outputs.xai_matrix }}
+      xai_has_models: ${{ steps.set-matrix.outputs.xai_has_models }}
+      other_matrix: ${{ steps.set-matrix.outputs.other_matrix }}
+      other_has_models: ${{ steps.set-matrix.outputs.other_has_models }}
     steps:
       - name: "📝 Log dispatch inputs"
         continue-on-error: true
@@ -269,218 +292,248 @@ jobs:
         env:
           EVAL_MODELS: ${{ inputs.models_override || inputs.models || 'all' }}
 
-  eval:
-    name: "📊 Eval (${{ matrix.model }})"
+
+  # Per-provider serialization: each provider runs as its own matrix job with
+  # max-parallel: 1 so calls to a single provider queue rather than fan out
+  # (avoids rate-limit failures). Different providers run in parallel.
+  # GHA has no built-in "queue per matrix value", so the partition is encoded
+  # as separate jobs whose matrices come from `prep`'s per-provider outputs;
+  # see _EVAL_PROVIDER_OUTPUTS in .github/scripts/models.py for the source set.
+  eval-anthropic:
+    name: "📊 Eval Anthropic (${{ matrix.model }})"
     needs: prep
-    runs-on: ubuntu-latest
-    environment: evals
-    timeout-minutes: 360
-    # Per-provider concurrency: jobs sharing a provider queue (no cancellation),
-    # jobs on different providers run in parallel.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.provider }}
-      cancel-in-progress: false
+    if: ${{ needs.prep.outputs.anthropic_has_models == 'true' }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.anthropic_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-    defaults:
-      run:
-        working-directory: libs/evals
-    env:
-      PYTEST_ADDOPTS: "--model ${{ matrix.model }} --evals-report-file evals_report.json"
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
-      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-      LANGSMITH_TRACING: "true"
-      LANGSMITH_EXPERIMENT: ${{ matrix.model }}
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-      OLLAMA_HOST: "https://ollama.com"
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-    steps:
-      - name: "📋 Checkout Code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+  eval-baseten:
+    name: "📊 Eval Baseten (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.baseten_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.baseten_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "🐍 Set up Python + UV"
-        uses: "./.github/actions/uv_setup"
-        with:
-          python-version: "3.12"
-          cache-suffix: evals
-          working-directory: libs/evals
+  eval-fireworks:
+    name: "📊 Eval Fireworks (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.fireworks_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.fireworks_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "📦 Install Dependencies"
-        run: uv sync --group test
+  eval-google-genai:
+    name: "📊 Eval Google GenAI (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.google_genai_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.google_genai_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "🏷️ Apply category filter"
-        if: inputs.eval_categories_override != '' || inputs.eval_categories != ''
-        env:
-          EVAL_CATEGORIES: ${{ inputs.eval_categories_override || inputs.eval_categories }}
-        run: |
-          flags=""
-          IFS=',' read -ra cats <<< "${EVAL_CATEGORIES}"
-          for cat in "${cats[@]}"; do
-            cat=$(echo "$cat" | xargs)
-            [ -z "$cat" ] && continue
-            flags="$flags --eval-category $cat"
-          done
-          echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS}${flags}" >> "$GITHUB_ENV"
+  eval-groq:
+    name: "📊 Eval Groq (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.groq_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.groq_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "🏷️ Apply tier filter"
-        if: inputs.eval_tiers_override != '' || inputs.eval_tiers != ''
-        env:
-          EVAL_TIERS: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
-        run: |
-          flags=""
-          IFS=',' read -ra tiers <<< "${EVAL_TIERS}"
-          for tier in "${tiers[@]}"; do
-            tier=$(echo "$tier" | xargs)
-            [ -z "$tier" ] && continue
-            flags="$flags --eval-tier $tier"
-          done
-          echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS}${flags}" >> "$GITHUB_ENV"
+  eval-nvidia:
+    name: "📊 Eval NVIDIA (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.nvidia_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.nvidia_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "🔒 Apply OpenRouter provider pin"
-        if: inputs.openrouter_provider != '' && matrix.provider == 'openrouter'
-        env:
-          OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
-        run: echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS} --openrouter-provider ${OPENROUTER_PROVIDER}" >> "$GITHUB_ENV"
+  eval-ollama:
+    name: "📊 Eval Ollama (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.ollama_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.ollama_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "📊 Run Evals"
-        run: make evals
+  eval-openai:
+    name: "📊 Eval OpenAI (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.openai_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.openai_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "🔍 Check eval report"
-        if: "!cancelled()"
-        run: |
-          if [ ! -f evals_report.json ]; then
-            echo "::error::evals_report.json not found. pytest likely crashed before sessionfinish could write the report. Check the 'Run Evals' step logs for errors."
-            exit 1
-          fi
+  eval-openrouter:
+    name: "📊 Eval OpenRouter (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.openrouter_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.openrouter_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-      - name: "📊 Post results to summary"
-        if: "!cancelled()"
-        run: |
-          python3 << 'PYEOF'
-          import json, os, sys
-          from pathlib import Path
+  eval-xai:
+    name: "📊 Eval xAI (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.xai_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.xai_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
-          report_path = Path("evals_report.json")
-          if not report_path.exists():
-              print("evals_report.json not found, skipping summary", file=sys.stderr)
-              sys.exit(0)
-
-          try:
-              report = json.loads(report_path.read_text())
-          except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-              print(f"::error::evals_report.json is malformed: {exc}")
-              sys.exit(1)
-          model = report.get("model", "unknown")
-          if model == "unknown":
-              print("::warning::evals_report.json has no 'model' key; using 'unknown'")
-
-          # Load category labels for friendly display names.
-          labels = {}
-          try:
-              cats_json = Path("deepagents_evals/categories.json")
-              labels = json.loads(cats_json.read_text()).get("labels", {})
-          except (FileNotFoundError, json.JSONDecodeError) as exc:
-              print(f"::warning::Could not load category labels from {cats_json}: {exc}")
-
-          lines = [
-              "<details>",
-              "<summary>(click to expand)</summary>",
-              "",
-          ]
-
-          try:
-              # -- Metrics table --
-              metrics = [
-                  ("passed", None), ("failed", None), ("skipped", None),
-                  ("total", None), ("correctness", None), ("solve_rate", "n/a"),
-                  ("step_ratio", "n/a"), ("tool_call_ratio", "n/a"),
-                  ("median_duration_s", None),
-              ]
-              header = "| " + " | ".join(f"`{k}`" for k, _ in metrics) + " |"
-              sep = "|" + "|".join("---:" for _ in metrics) + "|"
-              vals = []
-              for key, default in metrics:
-                  val = report.get(key, default)
-                  if val is None:
-                      val = 0
-                  vals.append(str(val))
-              row = "| " + " | ".join(vals) + " |"
-              lines += [header, sep, row]
-
-              # -- Per-category scores (horizontal) --
-              cat_scores = report.get("category_scores")
-              if isinstance(cat_scores, dict) and cat_scores:
-                  sorted_cats = sorted(cat_scores.items())
-                  esc = lambda s: str(s).replace("|", "\\|")
-                  cat_header = "| " + " | ".join(esc(labels.get(c, c)) for c, _ in sorted_cats) + " |"
-                  cat_sep = "|" + "|".join("---:" for _ in sorted_cats) + "|"
-                  cat_row = "| " + " | ".join(esc(s) for _, s in sorted_cats) + " |"
-                  lines += ["", "### Per-category correctness", "", cat_header, cat_sep, cat_row]
-
-              # -- Experiment links --
-              exp_links = report.get("experiment_links")
-              if isinstance(exp_links, list) and exp_links:
-                  lines += ["", "### LangSmith experiments", ""]
-                  for link in exp_links:
-                      if not isinstance(link, dict):
-                          continue
-                      name = link.get("name", "")
-                      url = link.get("url", "")
-                      public_url = link.get("public_url", "")
-                      if public_url:
-                          lines.append(f"- [{name}]({public_url}) ([internal]({url}))")
-                      elif url:
-                          lines.append(f"- [{name or url}]({url})")
-          except Exception as exc:
-              lines.append(f"\n\n**Error building summary:** {exc}\n")
-              print(f"::warning::Error building summary for {model}: {exc}")
-          finally:
-              lines += ["", "</details>"]
-
-          text = "\n".join(lines) + "\n"
-          summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
-          if summary:
-              with open(summary, "a") as f:
-                  f.write(text)
-          print(text)
-          PYEOF
-
-      - name: "🧠 Analyze eval failures"
-        if: "!cancelled() && inputs.analyze_failures"
-        continue-on-error: true
-        env:
-          ANALYSIS_MODEL: ${{ inputs.analysis_model || 'anthropic:claude-haiku-4-5-20251001' }}
-        run: uv run python ../../.github/scripts/analyze_eval_failures.py evals_report.json
-
-      - name: "📤 Upload failure analysis"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: failure-analysis-${{ strategy.job-index }}
-          path: libs/evals/failure_analysis.json
-          if-no-files-found: warn
-
-      - name: "📤 Upload eval report"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: evals-report-${{ strategy.job-index }}
-          path: libs/evals/evals_report.json
-          if-no-files-found: error
+  eval-other:
+    name: "📊 Eval Other (${{ matrix.model }})"
+    needs: prep
+    if: ${{ needs.prep.outputs.other_has_models == 'true' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.prep.outputs.other_matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ matrix.model }}
+      provider: ${{ matrix.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
+      analyze_failures: ${{ inputs.analyze_failures }}
+      analysis_model: ${{ inputs.analysis_model }}
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+    secrets: inherit
 
   aggregate:
     name: "📋 Aggregate evals"
     runs-on: ubuntu-latest
-    needs: [eval]
+    needs:
+      - eval-anthropic
+      - eval-baseten
+      - eval-fireworks
+      - eval-google-genai
+      - eval-groq
+      - eval-nvidia
+      - eval-ollama
+      - eval-openai
+      - eval-openrouter
+      - eval-xai
+      - eval-other
     if: always()
     steps:
       - name: "📋 Checkout Code"
@@ -508,11 +561,43 @@ jobs:
         run: uv sync --extra charts
 
       - name: "📊 Generate radar chart"
+        id: radar-chart
         if: hashFiles('evals_summary.json') != '' && steps.install-evals.outcome == 'success'
+        continue-on-error: true
         working-directory: libs/evals
         env:
-          EVAL_OUTCOME: ${{ needs.eval.result }}
+          # Inspect each per-provider job's `result` directly so the outcome
+          # cannot be perturbed by job-level outputs (current and future) that
+          # might contain the literal substring `failure` or `cancelled`.
+          EVAL_OUTCOME: >-
+            ${{ (needs.eval-anthropic.result == 'failure'
+                 || needs.eval-baseten.result == 'failure'
+                 || needs.eval-fireworks.result == 'failure'
+                 || needs.eval-google-genai.result == 'failure'
+                 || needs.eval-groq.result == 'failure'
+                 || needs.eval-nvidia.result == 'failure'
+                 || needs.eval-ollama.result == 'failure'
+                 || needs.eval-openai.result == 'failure'
+                 || needs.eval-openrouter.result == 'failure'
+                 || needs.eval-xai.result == 'failure'
+                 || needs.eval-other.result == 'failure') && 'failure'
+            || (needs.eval-anthropic.result == 'cancelled'
+                 || needs.eval-baseten.result == 'cancelled'
+                 || needs.eval-fireworks.result == 'cancelled'
+                 || needs.eval-google-genai.result == 'cancelled'
+                 || needs.eval-groq.result == 'cancelled'
+                 || needs.eval-nvidia.result == 'cancelled'
+                 || needs.eval-ollama.result == 'cancelled'
+                 || needs.eval-openai.result == 'cancelled'
+                 || needs.eval-openrouter.result == 'cancelled'
+                 || needs.eval-xai.result == 'cancelled'
+                 || needs.eval-other.result == 'cancelled') && 'cancelled'
+            || 'success' }}
         run: uv run --extra charts python scripts/generate_radar.py --summary ../../evals_summary.json -o ../../charts/radar.png --individual-dir ../../charts/individual --title "Deep Agents Eval Results"
+
+      - name: "⚠️ Note radar chart failure"
+        if: steps.radar-chart.outcome == 'failure'
+        run: echo "::warning::Radar chart generation failed; see the 'Generate radar chart' step logs. Subsequent chart upload/publish steps will be skipped."
 
       - name: "📤 Upload JSON summary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Replace the single `eval` matrix job — which used GHA `concurrency` to serialize calls per provider but silently dropped queued runs beyond the first — with one `workflow_call` job per provider, each running its own matrix at `max-parallel: 1`. The new shape gives every provider a real serial queue while preserving cross-provider parallelism, so big matrices no longer lose work to `concurrency` cancellation.

## Changes
- Fan out the old `eval` job into eleven `eval-<provider>` jobs in `evals.yml`, each calling a new reusable `_eval.yml` workflow at `max-parallel: 1`. Cross-provider runs stay parallel.
- Extract the per-model eval body (pytest, results-to-summary heredoc, optional `analyze_eval_failures.py`, artifact uploads) into `.github/workflows/_eval.yml` as a `workflow_call` workflow. Inputs are validated upstream by `_resolve_models`/`_SAFE_SPEC_RE`.
- Add `_matrix_outputs`, `_matrix_entry`, `_provider`, `_artifact_key` helpers to `.github/scripts/models.py`. `_matrix_outputs` partitions selected models into `<provider>_matrix`/`<provider>_has_models` outputs plus a catch-all `other` bucket for `models_override` specs whose provider isn't enumerated in `_EVAL_PROVIDER_OUTPUTS`. `_artifact_key` produces stable, globally unique upload names (`000-anthropic-claude-sonnet-4-6`) so partitioned matrices don't collide.
- Broaden the helper-script validation job in `ci.yml` from `test_release_options.py` to `.github/scripts/test_*.py`, so future helpers are picked up automatically.
- Replace the fragile `EVAL_OUTCOME: contains(toJSON(needs), '"failure"')` substring scan in the aggregate step with explicit `needs.eval-*.result` enumeration, and add a `continue-on-error` + warning fallback to `Generate radar chart` so a chart-generation crash no longer silently skips uploads.
- Pass `MODEL` into `make evals` via an env var instead of direct expression interpolation, narrow the `except Exception` in the summary heredoc to specific exception types with a `traceback.format_exc()` warning, and gate `Upload failure analysis` on `inputs.analyze_failures` to drop the spurious `if-no-files-found: warn` on every non-opt-in run.