### PR TITLE
feat(evals): stable OpenRouter `session_id` for CI runs

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -102,6 +102,12 @@ jobs:
       OLLAMA_HOST: "https://ollama.com"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      # Group all OpenRouter calls in this per-model eval job under a stable
+      # session ID derived from GHA runner env. Picked up by ChatOpenRouter
+      # via from_env (langchain-openrouter >= 0.2.2). Re-runs get a new
+      # session via run_attempt; different models get distinct sessions via
+      # artifact_key.
+      OPENROUTER_SESSION_ID: deepagents-evals-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.artifact_key }}
       XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
     steps:
       - name: "📋 Checkout Code"

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "langchain-nvidia-ai-endpoints>=1.0.0",
     "langchain-ollama>=1.0.0",
     "langchain-openai>=1.1.14",
-    "langchain-openrouter>=0.1.0",
+    "langchain-openrouter>=0.2.2",
     "langchain-xai>=1.0.0",
     # Eval-specific dependencies
     "datasets>=3.0.0",

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1303,7 +1303,7 @@ requires-dist = [
     { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.0.0" },
     { name = "langchain-ollama", specifier = ">=1.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.14" },
-    { name = "langchain-openrouter", specifier = ">=0.1.0" },
+    { name = "langchain-openrouter", specifier = ">=0.2.2" },
     { name = "langchain-quickjs", editable = "../partners/quickjs" },
     { name = "langchain-repl", editable = "../repl" },
     { name = "langchain-xai", specifier = ">=1.0.0" },
@@ -2556,15 +2556,15 @@ wheels = [
 
 [[package]]
 name = "langchain-openrouter"
-version = "0.1.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openrouter" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/6e/6e8a4156da07ba4827030302abad3b3e3c757f3c186f9cbb448d87cdd6fb/langchain_openrouter-0.1.0.tar.gz", hash = "sha256:3321fdab013a7bf370391497553a61a0368f81955128ceee020a815912bdbd62", size = 151982, upload-time = "2026-03-04T21:09:55.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/b2/8367602498b380becac01080827d4a36b2872584626f737a20bbbe7fb658/langchain_openrouter-0.2.2.tar.gz", hash = "sha256:689536cc34adc5dbe876e2a45495719923100ccc0fc1e59bc4cfb2ef60217378", size = 161550, upload-time = "2026-05-01T18:21:50.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/7a/e371200933a0091f62a7bc2011eb2894539f9fd21b31625f650aa3496519/langchain_openrouter-0.1.0-py3-none-any.whl", hash = "sha256:263a2d6e133a8a39cacafe499a7c29a191e39af8352e6f177d73af78673ebe8d", size = 18723, upload-time = "2026-03-04T21:09:54.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/17/5a1e5b1b0849730d6fca8f2ac7c990f64945517293b095a44554a7d44966/langchain_openrouter-0.2.2-py3-none-any.whl", hash = "sha256:5dd00982937ca8982ea83ba8ec7f15d63168856c8b1025dab203c678773a5141", size = 22387, upload-time = "2026-05-01T18:21:49.557Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wire OpenRouter's broadcast `session_id` into the per-model eval CI job so every request from a given model's evaluation groups under one identifier in OpenRouter's observability view. The session ID is derived from workflow context, so re-runs and sibling models stay isolated automatically.