### PR TITLE
feat(evals): OpenAI reasoning effort workflow input

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -46,6 +46,11 @@ on:
         required: false
         default: ""
         type: string
+      openai_reasoning_effort:
+        description: "Reasoning effort for OpenAI models (minimal | low | medium | high | xhigh)."
+        required: false
+        default: ""
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -152,6 +157,14 @@ jobs:
         run: |
           provider=$(echo "$OPENROUTER_PROVIDER" | xargs)
           printf 'PYTEST_ADDOPTS=%s --openrouter-provider %s\n' "${PYTEST_ADDOPTS}" "${provider}" >> "$GITHUB_ENV"
+
+      - name: "🧠 Apply OpenAI reasoning effort"
+        if: inputs.openai_reasoning_effort != '' && inputs.provider == 'openai'
+        env:
+          OPENAI_REASONING_EFFORT: ${{ inputs.openai_reasoning_effort }}
+        run: |
+          effort=$(echo "$OPENAI_REASONING_EFFORT" | xargs)
+          printf 'PYTEST_ADDOPTS=%s --openai-reasoning-effort %s\n' "${PYTEST_ADDOPTS}" "${effort}" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
         env:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -178,6 +178,18 @@ on:
         required: false
         default: ""
         type: string
+      openai_reasoning_effort:
+        description: "Reasoning effort for OpenAI models (applied as the `reasoning_effort` model kwarg). Only applies to openai: models."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - minimal
+          - low
+          - medium
+          - high
+          - xhigh
 
 permissions:
   contents: write
@@ -223,6 +235,7 @@ jobs:
           EVAL_CATEGORIES: ${{ inputs.eval_categories_override || inputs.eval_categories || '(all)' }}
           EVAL_TIERS: ${{ inputs.eval_tiers_override || inputs.eval_tiers || '(all)' }}
           OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
+          OPENAI_REASONING_EFFORT: ${{ inputs.openai_reasoning_effort }}
           ANALYZE_FAILURES: ${{ inputs.analyze_failures }}
           ANALYSIS_MODEL: ${{ inputs.analysis_model || 'anthropic:claude-haiku-4-5-20251001' }}
         run: |
@@ -275,6 +288,9 @@ jobs:
           if [ -n "${OPENROUTER_PROVIDER}" ]; then
             echo "| \`openrouter_provider\` | \`${OPENROUTER_PROVIDER}\` |" >> "$GITHUB_STEP_SUMMARY"
           fi
+          if [ -n "${OPENAI_REASONING_EFFORT}" ]; then
+            echo "| \`openai_reasoning_effort\` | \`${OPENAI_REASONING_EFFORT}\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "${ANALYZE_FAILURES}" = "true" ]; then
             echo "| \`analyze_failures\` | ✅ enabled (\`${ANALYSIS_MODEL}\`) |" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -317,6 +333,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-baseten:
@@ -337,6 +354,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-fireworks:
@@ -357,6 +375,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-google-genai:
@@ -377,6 +396,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-groq:
@@ -397,6 +417,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-nvidia:
@@ -417,6 +438,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-ollama:
@@ -437,6 +459,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-openai:
@@ -457,6 +480,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-openrouter:
@@ -477,6 +501,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-xai:
@@ -497,6 +522,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   eval-other:
@@ -517,6 +543,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
     secrets: inherit
 
   aggregate:

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -88,6 +88,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Pin OpenRouter to a specific provider. E.g. --openrouter-provider MiniMax",
     )
     parser.addoption(
+        "--openai-reasoning-effort",
+        action="store",
+        choices=("minimal", "low", "medium", "high", "xhigh"),
+        default=None,
+        help="Apply reasoning effort to OpenAI models. E.g. --openai-reasoning-effort high",
+    )
+    parser.addoption(
         "--repl",
         action="store",
         choices=("quickjs", "langchain"),
@@ -202,4 +209,10 @@ def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
         # 5s read timeout. This causes indefinite hangs on TCP stalls.
         # See: https://github.com/OpenRouterTeam/python-sdk/issues/72
         kwargs["timeout"] = 120_000  # ms
+    reasoning_effort = request.config.getoption("--openai-reasoning-effort")
+    if reasoning_effort:
+        if not model_name.startswith("openai:"):
+            msg = "--openai-reasoning-effort requires an openai: model prefix"
+            raise ValueError(msg)
+        kwargs["reasoning_effort"] = reasoning_effort
     return init_chat_model(model_name, **kwargs)


### PR DESCRIPTION
Add an `openai_reasoning_effort` dropdown to the evals workflow_dispatch UI so manual eval runs can apply OpenAI's `reasoning_effort` model kwarg (`minimal`/`low`/`medium`/`high`/`xhigh`) without editing code or maintaining a separate model spec per effort. Mirrors the existing `openrouter_provider` plumbing pattern.