### PR TITLE
feat(sdk): add GPT-5.5 harness profile

### DIFF
--- a/libs/deepagents/deepagents/profiles/_builtin_profiles.py
+++ b/libs/deepagents/deepagents/profiles/_builtin_profiles.py
@@ -31,6 +31,7 @@ from deepagents.profiles.harness import (
     _anthropic_opus_4_7,
     _anthropic_sonnet_4_6,
     _openai_codex,
+    _openai_gpt_5_5,
 )
 from deepagents.profiles.harness.harness_profiles import _HARNESS_PROFILES
 from deepagents.profiles.provider import _openai, _openrouter
@@ -151,6 +152,7 @@ def _ensure_builtin_profiles_loaded() -> None:
         _anthropic_sonnet_4_6.register()
         _anthropic_haiku_4_5.register()
         _openai_codex.register()
+        _openai_gpt_5_5.register()
         _invoke_profile_plugins(_PROVIDER_PROFILE_GROUP)
         _invoke_profile_plugins(_HARNESS_PROFILE_GROUP)
         bootstrap_harness_keys = frozenset(_HARNESS_PROFILES)

--- a/libs/deepagents/deepagents/profiles/harness/_openai_gpt_5_5.py
+++ b/libs/deepagents/deepagents/profiles/harness/_openai_gpt_5_5.py
@@ -1,0 +1,52 @@
+"""Built-in OpenAI GPT-5.5 harness profile.
+
+Registers a `HarnessProfile` for `openai:gpt-5.5` with a concise,
+outcome-first `system_prompt_suffix` drawn from OpenAI's GPT-5.5 prompting
+guidance: define success criteria and stopping conditions, keep user-visible
+updates short, use tools selectively, and validate before finalizing.
+
+The profile is keyed to GPT-5.5 rather than the `"openai"` provider because
+OpenAI recommends treating GPT-5.5 as a new model family to tune for, not as a
+drop-in replacement for earlier GPT-5 models.
+"""
+
+from deepagents.profiles.harness.harness_profiles import (
+    HarnessProfile,
+    _register_harness_profile_impl,
+)
+
+_MODEL_SPEC = "openai:gpt-5.5"
+"""Model spec that receives the GPT-5.5 harness profile."""
+
+_SYSTEM_PROMPT_SUFFIX: str = """\
+## GPT-5.5-Specific Behavior
+
+- Prefer outcome-first execution: identify the target result, success criteria, constraints, and available evidence, then choose an efficient path.
+- Avoid process-heavy or mechanical step sequences unless the user or task requires them. Use strict words only for true invariants.
+- If the request is clear enough and the next step is reversible and low-risk, proceed with reasonable assumptions. Ask only for missing information \
+that would materially change the outcome or create risk.
+
+## User Updates
+
+- For multi-step or tool-heavy work, send a brief user-visible update before the first tool call that states the first step.
+- Keep progress updates sparse and outcome-based. Do not narrate routine tool calls.
+
+## Tool Use and Stopping Rules
+
+- Use tools when they materially improve correctness, completeness, grounding, or validation.
+- Prefer independent parallel retrieval when it reduces wall-clock time, but do not parallelize steps with real dependencies.
+- Stop once you can satisfy the user's core request with sufficient evidence. Do not add extra searches only to improve phrasing or gather details.
+
+## Validation
+
+- Before finalizing, check that the answer satisfies the request, is grounded in context or tool outputs, and follows the requested format.
+- If validation cannot be run, state why and describe the next best check."""
+"""Text appended to the assembled base system prompt."""
+
+
+def register() -> None:
+    """Register the built-in GPT-5.5 harness profile."""
+    _register_harness_profile_impl(
+        _MODEL_SPEC,
+        HarnessProfile(system_prompt_suffix=_SYSTEM_PROMPT_SUFFIX),
+    )


### PR DESCRIPTION
Add a built-in harness profile for `openai:gpt-5.5` so Deep Agents can apply model-specific prompt guidance automatically. The profile stays model-keyed rather than provider-wide because GPT-5.5 guidance recommends treating it as a new model family, not a drop-in replacement for earlier OpenAI models.

## Changes
- Add `_openai_gpt_5_5.register` with a `HarnessProfile` targeting `openai:gpt-5.5`
- Add a GPT-5.5-specific `system_prompt_suffix` focused on outcome-first execution, sparse user updates, selective tool use, stopping rules, and final validation
- Wire `_openai_gpt_5_5.register` into `_ensure_builtin_profiles_loaded` alongside the existing Anthropic and Codex built-ins

---

> [!NOTE]
> Reverted by #3160 before the 0.5.7 release shipped. Multi-trial eval data showed the profile produced a marginal correctness lift (+2pp medium, ~0pp xhigh) at a ~17% latency tax, with `solve_rate` regressing in every cell. The override block below re-types this commit as `chore(sdk):` so it drops from the 0.5.7 changelog (Path A — Quiet revert per `.github/RELEASING.md`).

BEGIN_COMMIT_OVERRIDE
chore(sdk): add GPT-5.5 harness profile
END_COMMIT_OVERRIDE
