### PR TITLE
style(ci): require version input in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,8 @@ on:
         default: ""
         description: "Override: custom package name (takes precedence over dropdown)"
       version:
-        required: false
+        required: true
         type: string
-        default: ""
         description: "Version string — does NOT control the released version"
       release-sha:
         required: false


### PR DESCRIPTION
Make the `version` input mandatory in the `release.yml` workflow dispatch. Previously, the field defaulted to an empty string, which made it easy to trigger a release run without an explicit version annotation.