### PR TITLE
fix(ci): require release version before dispatch

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -207,8 +207,9 @@ For hotfixes or exceptional cases, you can trigger a release manually. Use the `
 1. Go to **Actions** > `⚠️ Manual Package Release`
 2. Click **Run workflow**
 3. Select the package to release
-4. **Provide `release-sha`**: the SHA of the release-PR merge commit. Look it up with `gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid`. The workflow validates the commit's subject matches `release(<package>): <version>` and refuses to run otherwise.
-5. (Optionally enable `dangerous-nonmain-release` for hotfix branches AKA not `main` — when set, `release-sha` may be left empty and the dispatched HEAD is used instead. Validation is skipped.)
+4. **Provide `version`**: the version being released (e.g. `0.0.35`). This is required and used for the run name and a sanity-check warning against `pyproject.toml` — it does not control the released version.
+5. **Provide `release-sha`**: the SHA of the release-PR merge commit. Look it up with `gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid`. The workflow validates the commit's subject matches `release(<package>): <version>` and refuses to run otherwise.
+6. (Optionally enable `dangerous-nonmain-release` for hotfix branches AKA not `main` — when set, `release-sha` may be left empty and the dispatched HEAD is used instead. Validation is skipped.)
 
 > [!WARNING]
 > Manual releases should be rare. Prefer the standard release-please flow for managed packages. Manual dispatch bypasses the changelog detection in `release-please.yml` and skips the lockfile update job. Only use it for recovery scenarios (e.g., the release workflow failed after the release PR was already merged).
@@ -250,6 +251,7 @@ Alpha releases use a **throwaway branch** + [manual release](#manual-release). T
    - Go to **Actions** > `⚠️ Manual Package Release` > **Run workflow**
    - Branch: `alpha/<PACKAGE>-<VERSION>`
    - Package: `<PACKAGE>`
+   - Version: `<VERSION>` (e.g. `0.0.35a1`) — required input; surfaces in the run name
    - Enable `dangerous-nonmain-release` ✓
    - (CLI only): leave `dangerous-skip-sdk-pin-check` unchecked (unless the SDK pin is intentionally behind)
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -143,7 +143,11 @@ jobs:
           if [ -n "$RELEASE_VERSION" ]; then
             echo "Extracted release version: $RELEASE_VERSION"
           elif echo "$COMMIT_MSG" | grep -qE "^release\("; then
-            echo "::warning::Commit looks like a release but version extraction failed: $COMMIT_MSG"
+            # release.yml requires `version` as a non-empty input. Fail loudly
+            # here rather than dispatch with an empty annotation that the
+            # downstream workflow would silently accept via the API.
+            echo "::error::Commit looks like a release but version extraction failed: $COMMIT_MSG"
+            exit 1
           fi
 
           # grep -q in an `if` conditional is safe under set -eo pipefail;
@@ -388,6 +392,15 @@ jobs:
 
           DISPATCHED=()
           FAILED=()
+
+          # release.yml's `version` input is required and the API silently accepts
+          # an empty string, so guard here. release-please.yml's extraction step
+          # already aborts on regex misses, but `if:` guards on this job could
+          # still let an empty `release-version` reach the dispatch.
+          if [ -z "$VERSION" ]; then
+            echo "::error::release-version is empty — refusing to dispatch release.yml without a version annotation."
+            exit 1
+          fi
 
           # Validate that an output value is exactly "true" or "false". Catches the
           # case where release-please ever emits an empty/unexpected value, which


### PR DESCRIPTION
Fail release-please dispatches before they can call `release.yml` with an empty `version` input. GitHub's dispatch API accepts empty required inputs, so the release handoff now stops at the source instead of creating poorly annotated downstream runs.