### PR TITLE
fix(cli): gate async task tools by actual names

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -881,9 +881,9 @@ def _add_interrupt_on() -> dict[str, InterruptOnConfig]:
         "web_search": web_search_interrupt_config,
         "fetch_url": fetch_url_interrupt_config,
         "task": task_interrupt_config,
-        "launch_async_subagent": async_subagent_interrupt_config,
-        "update_async_subagent": async_subagent_interrupt_config,
-        "cancel_async_subagent": async_subagent_interrupt_config,
+        "start_async_task": async_subagent_interrupt_config,
+        "update_async_task": async_subagent_interrupt_config,
+        "cancel_async_task": async_subagent_interrupt_config,
     }
 
     if REQUIRE_COMPACT_TOOL_APPROVAL:

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from deepagents_cli.agent import (
     DEFAULT_AGENT_NAME,
+    _add_interrupt_on,
     _format_edit_file_description,
     _format_execute_description,
     _format_fetch_url_description,
@@ -37,6 +38,14 @@ def _make_fake_chat_model() -> GenericFakeChatModel:
     model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
     model.profile = {"max_input_tokens": 200000}
     return model
+
+
+def test_add_interrupt_on_gates_async_task_tools() -> None:
+    """Async subagent tools should use their actual tool names in HITL config."""
+    interrupt_on = _add_interrupt_on()
+
+    for tool_name in ("start_async_task", "update_async_task", "cancel_async_task"):
+        assert tool_name in interrupt_on
 
 
 def test_format_write_file_description_create_new_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Fix the CLI's HITL gating for async subagent tools. The interrupt map still used the old `launch_async_subagent` naming, so approval config did not attach to the actual `start_async_task`, `update_async_task`, and `cancel_async_task` tools.