### PR TITLE
chore(ci): bump `CodSpeedHQ/action` to v4.15.0

### DIFF
--- a/.github/workflows/_benchmark.yml
+++ b/.github/workflows/_benchmark.yml
@@ -57,7 +57,7 @@ jobs:
         run: uv sync --group test
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@dfaf2584d705312e4ab4e23a4dd3e2f56b71ef3b # v4
+        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v4.15.0
         with:
           working-directory: ${{ inputs.working-directory }}
           run: make bench
@@ -65,7 +65,7 @@ jobs:
 
       - name: "Run memory benchmarks"
         if: ${{ inputs.has-memory-benchmarks }}
-        uses: CodSpeedHQ/action@dfaf2584d705312e4ab4e23a4dd3e2f56b71ef3b # v4
+        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v4.15.0
         with:
           working-directory: ${{ inputs.working-directory }}
           run: make bench-memory


### PR DESCRIPTION
Bump `CodSpeedHQ/action` to v4.15.0 to clear the Node20 deprecation warning printed on every benchmark run. v4.15.0 internally uses `actions/cache@v5.0.4` and `actions/github-script@v8.0.0`, both Node24-compatible.