### PR TITLE
fix(cli): move internal state under hidden directory

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -269,12 +269,28 @@ def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]
     return agents
 
 
+def _is_agent_dir_entry(entry: Path) -> bool:
+    """Return whether a `~/.deepagents/` entry should be listed as an agent.
+
+    Filters out symlinks (so dangling links don't masquerade as agents)
+    and dot-prefixed names — `.state/` (CLI internal state) plus any
+    other hidden directory the user may have placed there.
+
+    `OSError` from `is_dir`/`is_symlink` propagates so callers can log
+    with the failing entry's name as context.
+    """
+    if entry.name.startswith("."):
+        return False
+    return entry.is_dir() and not entry.is_symlink()
+
+
 def get_available_agent_names() -> list[str]:
     """Return a sorted list of available agent names from `~/.deepagents/`.
 
     Scans the user's `.deepagents` directory and returns each real
     subdirectory found there. Symlinks excluded so a dangling link does not
-    masquerade as an agent.
+    masquerade as an agent. Dot-prefixed entries (e.g., `.state/`) are
+    skipped so CLI internal state never appears as an agent.
 
     Filesystem errors (missing parent, permission denied, broken entries) are
     logged and surfaced as an empty list rather than raised — the caller shows
@@ -296,7 +312,7 @@ def get_available_agent_names() -> list[str]:
     names: list[str] = []
     for entry in entries:
         try:
-            if entry.is_dir() and not entry.is_symlink():
+            if _is_agent_dir_entry(entry):
                 names.append(entry.name)
         except OSError:
             logger.debug(
@@ -315,8 +331,9 @@ def list_agents(*, output_format: OutputFormat = "text") -> None:
         output_format: Output format — `'text'` (Rich) or `'json'`.
     """
     agents_dir = settings.user_deepagents_dir
+    names = get_available_agent_names()
 
-    if not agents_dir.exists() or not any(agents_dir.iterdir()):
+    if not names:
         if output_format == "json":
             from deepagents_cli.output import write_json
 
@@ -334,17 +351,16 @@ def list_agents(*, output_format: OutputFormat = "text") -> None:
         from deepagents_cli.output import write_json
 
         agents = []
-        for agent_path in sorted(agents_dir.iterdir()):
-            if agent_path.is_dir():
-                agent_name = agent_path.name
-                agents.append(
-                    {
-                        "name": agent_name,
-                        "path": str(agent_path),
-                        "has_agents_md": (agent_path / "AGENTS.md").exists(),
-                        "is_default": agent_name == DEFAULT_AGENT_NAME,
-                    }
-                )
+        for name in names:
+            agent_path = agents_dir / name
+            agents.append(
+                {
+                    "name": name,
+                    "path": str(agent_path),
+                    "has_agents_md": (agent_path / "AGENTS.md").exists(),
+                    "is_default": name == DEFAULT_AGENT_NAME,
+                }
+            )
         write_json("list", agents)
         return
 
@@ -352,33 +368,28 @@ def list_agents(*, output_format: OutputFormat = "text") -> None:
 
     console.print("\n[bold]Available Agents:[/bold]\n", style=theme.PRIMARY)
 
-    for agent_path in sorted(agents_dir.iterdir()):
-        if agent_path.is_dir():
-            agent_name = escape_markup(agent_path.name)
-            agent_md = agent_path / "AGENTS.md"
-            is_default = agent_path.name == DEFAULT_AGENT_NAME
-            default_label = " [dim](default)[/dim]" if is_default else ""
+    bullet = get_glyphs().bullet
+    for name in names:
+        agent_path = agents_dir / name
+        agent_name = escape_markup(name)
+        is_default = name == DEFAULT_AGENT_NAME
+        default_label = " [dim](default)[/dim]" if is_default else ""
 
-            bullet = get_glyphs().bullet
-            if agent_md.exists():
-                console.print(
-                    f"  {bullet} [bold]{agent_name}[/bold]{default_label}",
-                    style=theme.PRIMARY,
-                )
-                console.print(
-                    f"    {escape_markup(str(agent_path))}",
-                    style=theme.MUTED,
-                )
-            else:
-                console.print(
-                    f"  {bullet} [bold]{agent_name}[/bold]{default_label}"
-                    " [dim](incomplete)[/dim]",
-                    style=theme.WARNING,
-                )
-                console.print(
-                    f"    {escape_markup(str(agent_path))}",
-                    style=theme.MUTED,
-                )
+        if (agent_path / "AGENTS.md").exists():
+            console.print(
+                f"  {bullet} [bold]{agent_name}[/bold]{default_label}",
+                style=theme.PRIMARY,
+            )
+        else:
+            console.print(
+                f"  {bullet} [bold]{agent_name}[/bold]{default_label}"
+                " [dim](incomplete)[/dim]",
+                style=theme.WARNING,
+            )
+        console.print(
+            f"    {escape_markup(str(agent_path))}",
+            style=theme.MUTED,
+        )
 
     console.print()
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1444,6 +1444,21 @@ def cli_main() -> None:
     try:
         args = parse_args()
 
+        # Best-effort, idempotent migration. Placed after parse_args so
+        # --help / --version exit before any I/O. Wrapped broadly so an
+        # unexpected non-OSError (e.g., RuntimeError from `Path.home()`
+        # when $HOME is unset on a CI runner) cannot crash startup —
+        # state migration has zero functional value vs. failing-soft.
+        try:
+            from deepagents_cli.state_migration import migrate_legacy_state
+
+            migrate_legacy_state()
+        except Exception:
+            logger.warning(
+                "Legacy state migration failed unexpectedly; continuing.",
+                exc_info=True,
+            )
+
         # Import console/settings AFTER arg parsing so --help (which exits
         # inside parse_args) never pays the settings bootstrap cost.
         from deepagents_cli.config import console, settings

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -165,8 +165,13 @@ def _interpolate(s: str, *, header: str, server_name: str | None) -> str:
 
 
 def _tokens_dir() -> Path:
-    """Return `~/.deepagents/mcp-tokens/`."""
-    return Path.home() / ".deepagents" / "mcp-tokens"
+    """Return `~/.deepagents/.state/mcp-tokens/`.
+
+    Resolved at call time (not at module import) so tests that monkeypatch
+    `Path.home()` after import still redirect token storage into a temp
+    directory.
+    """
+    return Path.home() / ".deepagents" / ".state" / "mcp-tokens"
 
 
 def _token_file_stem(server_name: str, server_url: str | None) -> str:
@@ -183,21 +188,21 @@ def _token_file_stem(server_name: str, server_url: str | None) -> str:
 
 
 class FileTokenStorage(TokenStorage):
-    """File-backed `TokenStorage` under `~/.deepagents/mcp-tokens/`."""
+    """File-backed `TokenStorage` under `~/.deepagents/.state/mcp-tokens/`."""
 
     def __init__(self, server_name: str, *, server_url: str | None = None) -> None:
         """Bind this storage to a configured MCP server identity.
 
         Raises:
             ValueError: If `server_name` contains characters that would let
-                it escape the `~/.deepagents/mcp-tokens/` directory when
-                used as the token-file basename.
+                it escape the `~/.deepagents/.state/mcp-tokens/` directory
+                when used as the token-file basename.
         """
         if not _SAFE_SERVER_NAME_RE.fullmatch(server_name):
             msg = (
                 f"Invalid MCP server name {server_name!r}: token storage "
                 "names must match [A-Za-z0-9_-]+ to keep the on-disk path "
-                "inside ~/.deepagents/mcp-tokens/."
+                "inside ~/.deepagents/.state/mcp-tokens/."
             )
             raise ValueError(msg)
         self._server_name = server_name

--- a/libs/cli/deepagents_cli/mcp_auth.py
+++ b/libs/cli/deepagents_cli/mcp_auth.py
@@ -19,8 +19,7 @@ import os
 import re
 import stat
 from collections.abc import Awaitable, Callable
-from pathlib import Path
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 from mcp.client.auth import OAuthClientProvider, TokenStorage
@@ -29,6 +28,9 @@ from mcp.shared.auth import (
     OAuthToken,
 )
 from pydantic import BaseModel, ConfigDict, ValidationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class _DeviceCodeResponse(BaseModel):
@@ -167,11 +169,12 @@ def _interpolate(s: str, *, header: str, server_name: str | None) -> str:
 def _tokens_dir() -> Path:
     """Return `~/.deepagents/.state/mcp-tokens/`.
 
-    Resolved at call time (not at module import) so tests that monkeypatch
-    `Path.home()` after import still redirect token storage into a temp
-    directory.
+    The deferred import lets tests redirect token storage into a temp
+    directory by patching `deepagents_cli.model_config.DEFAULT_STATE_DIR`.
     """
-    return Path.home() / ".deepagents" / ".state" / "mcp-tokens"
+    from deepagents_cli.model_config import DEFAULT_STATE_DIR
+
+    return DEFAULT_STATE_DIR / "mcp-tokens"
 
 
 def _token_file_stem(server_name: str, server_url: str | None) -> str:

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -262,6 +262,15 @@ DEFAULT_CONFIG_DIR = Path.home() / ".deepagents"
 DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.toml"
 """Path to the user's model configuration file (`~/.deepagents/config.toml`)."""
 
+DEFAULT_STATE_DIR = DEFAULT_CONFIG_DIR / ".state"
+"""Directory for CLI-managed internal state (`~/.deepagents/.state`).
+
+Holds files the CLI writes for its own bookkeeping — OAuth tokens, the
+sessions database, version-check caches, input history. Kept separate from
+top-level user-facing config and agent directories so listing/iterating
+`~/.deepagents` doesn't conflate state with agents.
+"""
+
 PROVIDER_API_KEY_ENV: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "azure_openai": "AZURE_OPENAI_API_KEY",

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -236,9 +236,12 @@ def get_db_path() -> Path:
     global _db_path  # noqa: PLW0603  # Module-level cache requires global statement
     if _db_path is not None:
         return _db_path
-    db_dir = Path.home() / ".deepagents"
-    db_dir.mkdir(parents=True, exist_ok=True)
-    _db_path = db_dir / "sessions.db"
+    # Resolved at call time (rather than via the import-time-frozen
+    # `model_config.DEFAULT_STATE_DIR`) so tests that monkeypatch
+    # `Path.home` see the redirected path. Matches `mcp_auth._tokens_dir`.
+    state_dir = Path.home() / ".deepagents" / ".state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    _db_path = state_dir / "sessions.db"
     return _db_path
 
 

--- a/libs/cli/deepagents_cli/sessions.py
+++ b/libs/cli/deepagents_cli/sessions.py
@@ -236,12 +236,10 @@ def get_db_path() -> Path:
     global _db_path  # noqa: PLW0603  # Module-level cache requires global statement
     if _db_path is not None:
         return _db_path
-    # Resolved at call time (rather than via the import-time-frozen
-    # `model_config.DEFAULT_STATE_DIR`) so tests that monkeypatch
-    # `Path.home` see the redirected path. Matches `mcp_auth._tokens_dir`.
-    state_dir = Path.home() / ".deepagents" / ".state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    _db_path = state_dir / "sessions.db"
+    from deepagents_cli.model_config import DEFAULT_STATE_DIR
+
+    DEFAULT_STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _db_path = DEFAULT_STATE_DIR / "sessions.db"
     return _db_path
 
 

--- a/libs/cli/deepagents_cli/state_migration.py
+++ b/libs/cli/deepagents_cli/state_migration.py
@@ -1,0 +1,134 @@
+"""One-time migration of legacy CLI state files into `~/.deepagents/.state/`.
+
+Earlier versions wrote internal state directly under `~/.deepagents/`,
+mixing it with user-facing agent directories (so e.g. `mcp-tokens/`
+showed up in `deepagents agents list`). State now lives in a dedicated
+`.state/` subdirectory; this module moves any legacy files into place
+on startup.
+
+The migration is best-effort and idempotent: it skips entries whose
+destination already exists, logs and continues on per-entry failures,
+and never blocks startup on I/O errors.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from deepagents_cli.model_config import DEFAULT_CONFIG_DIR, DEFAULT_STATE_DIR
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+_LEGACY_NAMES: tuple[str, ...] = (
+    "mcp-tokens",
+    "sessions.db",
+    "sessions.db-wal",
+    "sessions.db-shm",
+    "latest_version.json",
+    "update_state.json",
+    "history.jsonl",
+)
+"""Names directly under `~/.deepagents/` that now live in `.state/`.
+
+`sessions.db-wal` and `sessions.db-shm` are SQLite sidecar files that may
+or may not be present depending on whether the database was opened in WAL
+mode and whether a checkpoint had run before shutdown.
+"""
+
+
+def _iter_migrations(
+    config_dir: Path,
+    state_dir: Path,
+    names: Iterable[str],
+) -> Iterable[tuple[Path, Path]]:
+    for name in names:
+        yield config_dir / name, state_dir / name
+
+
+def migrate_legacy_state(
+    *,
+    config_dir: Path = DEFAULT_CONFIG_DIR,
+    state_dir: Path = DEFAULT_STATE_DIR,
+) -> None:
+    """Move legacy state entries from `config_dir` into `state_dir`.
+
+    Idempotent: each entry is skipped when the destination already exists
+    (the migration ran on a prior invocation) or when the source does not
+    exist (nothing to move). Errors on individual entries are logged and
+    swallowed so a single unmovable file does not block the rest.
+
+    Args:
+        config_dir: Directory holding legacy state. Defaults to
+            `~/.deepagents/`.
+        state_dir: Destination directory for state files. Defaults to
+            `~/.deepagents/.state/`.
+    """
+    try:
+        if not config_dir.is_dir():
+            return
+    except OSError:
+        logger.debug(
+            "Could not stat %s; skipping state migration",
+            config_dir,
+            exc_info=True,
+        )
+        return
+
+    pending: list[tuple[Path, Path]] = []
+    for src, dst in _iter_migrations(config_dir, state_dir, _LEGACY_NAMES):
+        try:
+            src_exists = src.exists()
+        except OSError:
+            continue
+        if not src_exists:
+            continue
+        try:
+            dst_exists = dst.exists()
+        except OSError:
+            continue
+        if dst_exists:
+            # Both exist — typically a CLI downgrade after the migration
+            # already ran once (the older version recreates a fresh file
+            # at the legacy path) or a manually pre-populated `.state/`.
+            # Clobbering either copy could lose data, so skip and warn so
+            # the user can resolve it.
+            logger.warning(
+                "Cannot migrate %s -> %s: destination already exists. "
+                "Inspect both files and either delete the obsolete one "
+                "or move the legacy file in manually.",
+                src,
+                dst,
+            )
+            continue
+        pending.append((src, dst))
+    if not pending:
+        return
+
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.warning(
+            "Could not create state directory %s; skipping state migration",
+            state_dir,
+            exc_info=True,
+        )
+        return
+
+    for src, dst in pending:
+        try:
+            src.rename(dst)
+        except OSError:
+            logger.warning(
+                "Failed to migrate %s -> %s; leaving legacy file in place",
+                src,
+                dst,
+                exc_info=True,
+            )
+            continue
+        logger.info("Migrated %s -> %s", src, dst)

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -28,13 +28,35 @@ from deepagents_cli._version import PYPI_URL, SDK_PYPI_URL, USER_AGENT, __versio
 if TYPE_CHECKING:
     from pathlib import Path
 
-from deepagents_cli.model_config import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_PATH
+from deepagents_cli.model_config import DEFAULT_CONFIG_PATH, DEFAULT_STATE_DIR
 
 logger = logging.getLogger(__name__)
 
-CACHE_FILE: Path = DEFAULT_CONFIG_DIR / "latest_version.json"
-UPDATE_STATE_FILE: Path = DEFAULT_CONFIG_DIR / "update_state.json"
+CACHE_FILE: Path = DEFAULT_STATE_DIR / "latest_version.json"
+"""On-disk cache of the latest published CLI/SDK versions and SDK release times.
+
+Populated by `get_latest_version`; reads short-circuit on the cached payload
+when it is younger than `CACHE_TTL`. SDK upload timestamps are stored under
+`_SDK_RELEASE_TIMES_KEY`.
+"""
+
+UPDATE_STATE_FILE: Path = DEFAULT_STATE_DIR / "update_state.json"
+"""Persistent flags for the update-notification UX.
+
+Tracks which version the user has been notified about (`notified_version`,
+`notified_at`) and the most recent version they've seen the splash for
+(`seen_version`, `seen_at`). Read by `should_notify_update` and friends
+to suppress repeat notifications across invocations. Auto-update opt-outs
+live in `config.toml`, not here.
+"""
+
 CACHE_TTL = 86_400  # 24 hours
+"""Maximum age in seconds before `CACHE_FILE` entries are considered stale.
+
+A cached `latest_version.json` younger than this is reused without an HTTP
+call to PyPI; older payloads trigger a fresh fetch. Set conservatively at
+24h since release cadence is on the order of days, not minutes.
+"""
 
 _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 """`CACHE_FILE` key for cached SDK upload timestamps, keyed by version string."""

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -44,10 +44,11 @@ logger = logging.getLogger(__name__)
 def _default_history_path() -> Path:
     """Return the default history file path.
 
-    Extracted as a function so tests can monkeypatch it to a temp path,
-    preventing test runs from polluting `~/.deepagents/history.jsonl`.
+    Extracted as a function so tests can monkeypatch it (or `Path.home`)
+    to a temp path, preventing test runs from polluting
+    `~/.deepagents/.state/history.jsonl`.
     """
-    return Path.home() / ".deepagents" / "history.jsonl"
+    return Path.home() / ".deepagents" / ".state" / "history.jsonl"
 
 
 _PASTE_BURST_CHAR_GAP_SECONDS = 0.03
@@ -1076,7 +1077,8 @@ class ChatInput(Vertical):
 
         Args:
             cwd: Current working directory for file completion
-            history_file: Path to history file (default: ~/.deepagents/history.jsonl)
+            history_file: Override path for persisted input history.
+                Resolved by `_default_history_path()` when `None`.
             image_tracker: Optional tracker for attached images
             **kwargs: Additional arguments for parent
         """

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -44,11 +44,12 @@ logger = logging.getLogger(__name__)
 def _default_history_path() -> Path:
     """Return the default history file path.
 
-    Extracted as a function so tests can monkeypatch it (or `Path.home`)
-    to a temp path, preventing test runs from polluting
-    `~/.deepagents/.state/history.jsonl`.
+    Extracted as a function so tests can monkeypatch it to a temp path,
+    preventing test runs from polluting `~/.deepagents/.state/history.jsonl`.
     """
-    return Path.home() / ".deepagents" / ".state" / "history.jsonl"
+    from deepagents_cli.model_config import DEFAULT_STATE_DIR
+
+    return DEFAULT_STATE_DIR / "history.jsonl"
 
 
 _PASTE_BURST_CHAR_GAP_SECONDS = 0.03

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -131,8 +131,8 @@ def _isolate_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Redirect ChatInput history to a temp file.
 
     Without this, every test that mounts a `ChatInput` widget writes to the
-    real `~/.deepagents/history.jsonl`, causing duplicate/stale entries that
-    persist across test runs and branch switches.
+    real `~/.deepagents/.state/history.jsonl`, causing duplicate/stale
+    entries that persist across test runs and branch switches.
     """
     monkeypatch.setattr(
         "deepagents_cli.widgets.chat_input._default_history_path",

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -963,6 +963,60 @@ class TestListAgentsJson:
         result = json.loads(buf.getvalue())
         assert result["data"] == []
 
+    def test_json_output_excludes_state_dir(self, tmp_path: Path) -> None:
+        """`.state/` is never surfaced as an agent in JSON output."""
+        import json
+        from io import StringIO
+
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / DEFAULT_AGENT_NAME).mkdir()
+        (agents_dir / DEFAULT_AGENT_NAME / "AGENTS.md").touch()
+        (agents_dir / ".state").mkdir()
+        (agents_dir / ".state" / "sessions.db").touch()
+
+        mock_settings = Mock()
+        mock_settings.user_deepagents_dir = agents_dir
+
+        buf = StringIO()
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("sys.stdout", buf),
+        ):
+            list_agents(output_format="json")
+
+        result = json.loads(buf.getvalue())
+        names = [a["name"] for a in result["data"]]
+        assert names == [DEFAULT_AGENT_NAME]
+        assert ".state" not in names
+
+    def test_text_output_excludes_state_dir(self, tmp_path: Path) -> None:
+        """`.state/` is never surfaced as an agent in Rich output."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / DEFAULT_AGENT_NAME).mkdir()
+        (agents_dir / DEFAULT_AGENT_NAME / "AGENTS.md").touch()
+        (agents_dir / ".state").mkdir()
+        (agents_dir / ".state" / "sessions.db").touch()
+
+        mock_settings = Mock()
+        mock_settings.user_deepagents_dir = agents_dir
+
+        output: list[str] = []
+
+        def capture_print(*args: Any, **_: Any) -> None:
+            output.append(" ".join(str(a) for a in args))
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.console") as mock_console,
+        ):
+            mock_console.print = capture_print
+            list_agents()
+
+        joined = "\n".join(output)
+        assert ".state" not in joined
+
 
 class TestResetAgentJson:
     """Tests for reset_agent JSON output."""
@@ -2337,6 +2391,17 @@ class TestGetAvailableAgentNames:
 
         with patch("deepagents_cli.agent.settings", _mock_agents_dir(agents_dir)):
             assert get_available_agent_names() == ["real"]
+
+    def test_ignores_dot_prefixed_dirs(self, tmp_path: Path) -> None:
+        """`.state/` and other hidden dirs are excluded from the agent list."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "agent").mkdir()
+        (agents_dir / ".state").mkdir()
+        (agents_dir / ".cache").mkdir()
+
+        with patch("deepagents_cli.agent.settings", _mock_agents_dir(agents_dir)):
+            assert get_available_agent_names() == ["agent"]
 
     def test_permission_error_returns_empty(self, tmp_path: Path) -> None:
         """PermissionError on iterdir → logged + empty list, not raised."""

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -20,10 +20,19 @@ from deepagents_cli.mcp_auth import (
 
 @pytest.fixture
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect `Path.home()` to a temp directory."""
+    """Redirect `Path.home()` and `DEFAULT_STATE_DIR` into a temp directory.
+
+    `Path.home` is patched for code that resolves it at call time;
+    `DEFAULT_STATE_DIR` is patched for code (like `mcp_auth._tokens_dir`)
+    that pulls from the import-time-frozen constant in `model_config`.
+    """
     fake = tmp_path / "home"
     fake.mkdir()
     monkeypatch.setattr(Path, "home", staticmethod(lambda: fake))
+    monkeypatch.setattr(
+        "deepagents_cli.model_config.DEFAULT_STATE_DIR",
+        fake / ".deepagents" / ".state",
+    )
     return fake
 
 

--- a/libs/cli/tests/unit_tests/test_mcp_auth.py
+++ b/libs/cli/tests/unit_tests/test_mcp_auth.py
@@ -109,14 +109,14 @@ class TestFileTokenStorage:
         storage = FileTokenStorage("notion")
         await storage.set_tokens(_make_tokens())
 
-        token_path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
+        token_path = fake_home / ".deepagents" / ".state" / "mcp-tokens" / "notion.json"
         assert token_path.exists()
         if hasattr(token_path, "stat"):
             assert token_path.stat().st_mode & 0o777 == 0o600
 
     async def test_corrupt_file_raises(self, fake_home: Path) -> None:
         """Corrupt files fail with a remediation hint."""
-        path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
+        path = fake_home / ".deepagents" / ".state" / "mcp-tokens" / "notion.json"
         path.parent.mkdir(parents=True)
         path.write_text("{not json")
         storage = FileTokenStorage("notion")
@@ -371,7 +371,7 @@ class TestFileTokenStorageExtras:
     async def test_version_mismatch_raises(self, fake_home: Path) -> None:
         """Token files with an unknown version fail with a remediation hint."""
         storage = FileTokenStorage("notion")
-        path = fake_home / ".deepagents" / "mcp-tokens" / "notion.json"
+        path = fake_home / ".deepagents" / ".state" / "mcp-tokens" / "notion.json"
         path.parent.mkdir(parents=True)
         path.write_text(json.dumps({"version": 999, "tokens": {}}))
 
@@ -383,7 +383,8 @@ class TestFileTokenStorageExtras:
         storage = FileTokenStorage("notion")
         await storage.set_tokens_and_client_info(_make_tokens(), _make_client_info())
 
-        raw = (fake_home / ".deepagents" / "mcp-tokens" / "notion.json").read_text()
+        token_path = fake_home / ".deepagents" / ".state" / "mcp-tokens" / "notion.json"
+        raw = token_path.read_text()
         data = json.loads(raw)
         assert "tokens" in data
         assert "client_info" in data

--- a/libs/cli/tests/unit_tests/test_state_migration.py
+++ b/libs/cli/tests/unit_tests/test_state_migration.py
@@ -1,0 +1,201 @@
+"""Tests for the legacy-state migration helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents_cli.state_migration import migrate_legacy_state
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _snapshot(state_dir: Path) -> list[tuple[str, bytes | None]]:
+    """Return a sorted (relpath, content) snapshot of `state_dir`."""
+    items: list[tuple[str, bytes | None]] = []
+    for entry in state_dir.rglob("*"):
+        rel = str(entry.relative_to(state_dir))
+        items.append((rel, entry.read_bytes() if entry.is_file() else None))
+    return sorted(items)
+
+
+def _seed_legacy(config_dir: Path) -> None:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "sessions.db").write_bytes(b"db")
+    (config_dir / "history.jsonl").write_text("h\n")
+    (config_dir / "latest_version.json").write_text(json.dumps({"v": "1"}))
+    tokens = config_dir / "mcp-tokens"
+    tokens.mkdir()
+    (tokens / "notion-x.json").write_text("{}")
+
+
+class TestMigrateLegacyState:
+    """Behaviour of `migrate_legacy_state`."""
+
+    def test_moves_files_into_state_dir(self, tmp_path: Path) -> None:
+        """Each legacy entry is moved under `.state/`."""
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+        _seed_legacy(config_dir)
+
+        migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+
+        assert (state_dir / "sessions.db").read_bytes() == b"db"
+        assert (state_dir / "history.jsonl").read_text() == "h\n"
+        assert json.loads((state_dir / "latest_version.json").read_text()) == {"v": "1"}
+        assert (state_dir / "mcp-tokens" / "notion-x.json").exists()
+
+        for legacy_name in (
+            "sessions.db",
+            "history.jsonl",
+            "latest_version.json",
+            "mcp-tokens",
+        ):
+            assert not (config_dir / legacy_name).exists(), legacy_name
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        """Re-running with no legacy left in place does nothing."""
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+        _seed_legacy(config_dir)
+
+        migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+        before = _snapshot(state_dir)
+        # Second run must be a no-op.
+        migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+        assert _snapshot(state_dir) == before
+
+    def test_skips_when_dest_already_exists(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If a file already exists at dest, legacy is left alone with a warning."""
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+        config_dir.mkdir()
+        state_dir.mkdir()
+        (config_dir / "sessions.db").write_bytes(b"old")
+        (state_dir / "sessions.db").write_bytes(b"new")
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.state_migration"):
+            migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+
+        # Destination preserved; legacy not clobbered, not moved.
+        assert (state_dir / "sessions.db").read_bytes() == b"new"
+        assert (config_dir / "sessions.db").read_bytes() == b"old"
+        # The collision is loud — users hitting this scenario need to see it.
+        assert any(
+            "destination already exists" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_no_legacy_no_state_dir_created(self, tmp_path: Path) -> None:
+        """When nothing needs moving, the state dir isn't created."""
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+        config_dir.mkdir()
+
+        migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+
+        assert not state_dir.exists()
+
+    def test_missing_config_dir_is_no_op(self, tmp_path: Path) -> None:
+        """Fresh installs (no `~/.deepagents/`) are handled silently."""
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+
+        migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+
+        assert not config_dir.exists()
+        assert not state_dir.exists()
+
+    def test_sqlite_sidecars_migrate_with_main_db(self, tmp_path: Path) -> None:
+        """`sessions.db-wal` and `-shm` move alongside `sessions.db`.
+
+        Splitting the main DB from its WAL would corrupt the database on
+        next open, so the sidecars must travel as a group. Locks in the
+        contract that `_LEGACY_NAMES` keeps them together.
+        """
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+        config_dir.mkdir()
+        (config_dir / "sessions.db").write_bytes(b"main")
+        (config_dir / "sessions.db-wal").write_bytes(b"wal")
+        (config_dir / "sessions.db-shm").write_bytes(b"shm")
+
+        migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+
+        assert (state_dir / "sessions.db").read_bytes() == b"main"
+        assert (state_dir / "sessions.db-wal").read_bytes() == b"wal"
+        assert (state_dir / "sessions.db-shm").read_bytes() == b"shm"
+        for name in ("sessions.db", "sessions.db-wal", "sessions.db-shm"):
+            assert not (config_dir / name).exists(), name
+
+    def test_state_dir_mkdir_failure_is_logged(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If `.state/` cannot be created, warn and leave legacy alone."""
+        config_dir = tmp_path / ".deepagents"
+        config_dir.mkdir()
+        # `.state` is a regular file — `mkdir(exist_ok=True)` will raise.
+        state_path = config_dir / ".state"
+        state_path.write_text("not a directory")
+        (config_dir / "sessions.db").write_bytes(b"db")
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.state_migration"):
+            migrate_legacy_state(config_dir=config_dir, state_dir=state_path)
+
+        # Legacy untouched, warning emitted.
+        assert (config_dir / "sessions.db").read_bytes() == b"db"
+        assert state_path.read_text() == "not a directory"
+        assert any(
+            "Could not create state directory" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_per_entry_rename_failure_does_not_block_others(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed rename on one entry must not abort the rest.
+
+        Mirrors the partial-failure path callers rely on (e.g., one
+        sidecar locked on Windows shouldn't strand `history.jsonl`).
+        """
+        config_dir = tmp_path / ".deepagents"
+        state_dir = config_dir / ".state"
+        config_dir.mkdir()
+        (config_dir / "sessions.db").write_bytes(b"db")
+        (config_dir / "history.jsonl").write_text("h\n")
+
+        original_rename = Path.rename
+
+        def selective_rename(self: Path, target: Path) -> Path:
+            if self.name == "sessions.db":
+                msg = "simulated lock"
+                raise OSError(msg)
+            return original_rename(self, target)
+
+        monkeypatch.setattr(Path, "rename", selective_rename)
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.state_migration"):
+            migrate_legacy_state(config_dir=config_dir, state_dir=state_dir)
+
+        # Failing entry stays at legacy; non-failing entry moved.
+        assert (config_dir / "sessions.db").read_bytes() == b"db"
+        assert not (state_dir / "sessions.db").exists()
+        assert (state_dir / "history.jsonl").read_text() == "h\n"
+        assert not (config_dir / "history.jsonl").exists()
+        # Failure is logged with file context.
+        assert any(
+            "Failed to migrate" in record.getMessage()
+            and "sessions.db" in record.getMessage()
+            for record in caplog.records
+        )


### PR DESCRIPTION
Move CLI-owned files out of the user-facing `~/.deepagents/` root and into `~/.deepagents/.state/`. This keeps internal bookkeeping like MCP tokens, session databases, update caches, and input history from being treated as agents while preserving existing state through a best-effort migration.

## Changes
- Add `DEFAULT_STATE_DIR` and route CLI-managed files through `~/.deepagents/.state/`, including `FileTokenStorage`, `get_db_path`, update-check cache files, and `ChatInput` history
- Add `migrate_legacy_state` to move legacy entries like `mcp-tokens`, `sessions.db`, SQLite sidecars, `latest_version.json`, `update_state.json`, and `history.jsonl` into `.state/`
- Run `migrate_legacy_state` during `cli_main` startup after argument parsing, with failures logged and swallowed so migration cannot block CLI launch
- Update `get_available_agent_names` and `list_agents` to skip dot-prefixed directories, preventing `.state/` or other hidden folders from appearing in text or JSON agent listings
- Keep state path resolution for token storage, sessions, and history call-time based so tests that monkeypatch `Path.home()` still isolate filesystem writes