### PR TITLE
perf(cli): skip runtime imports for bare command help

### DIFF
--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -381,24 +381,50 @@ async def _preload_session_mcp_server_info(
                 )
 
 
+_HELP_SPECS: dict[str, tuple[str | None, str]] = {
+    "help": (None, "show_help"),
+    "agents": ("agents_command", "show_agents_help"),
+    "skills": ("skills_command", "show_skills_help"),
+    "threads": ("threads_command", "show_threads_help"),
+    "mcp": ("mcp_command", "show_mcp_help"),
+}
+"""Maps top-level command names to their startup-fast-path help dispatch.
+
+Each value is `(subcommand_dest, ui_help_fn_name)`:
+
+- `subcommand_dest` is the argparse `dest=` for the group's sub-subparsers,
+    or `None` for leaf commands like `help`. When non-`None` and the parsed
+    namespace has a value at that attribute, a real subcommand was given and
+    the fast path declines.
+- `ui_help_fn_name` is the attribute on `deepagents_cli.ui` invoked to
+    render the help screen.
+
+When adding a new top-level command group with sub-subparsers, register it
+here and add a corresponding `show_<group>_help` to `ui.py`. The drift
+test in `tests/unit_tests/test_startup_fast_paths.py` enforces this.
+"""
+
+
 def _show_bare_command_group_help(args: argparse.Namespace) -> bool:
-    """Print help for command groups invoked without a subcommand.
+    """Render help for `help` and bare command groups before the heavy bootstrap.
+
+    Short-circuits before `console`/`settings` are imported so help-only
+    invocations stay snappy. Mirrors the dispatch in `cli_main` for the
+    `help`, `agents`, `skills`, `threads`, and `mcp` commands when no
+    subcommand was given.
 
     Args:
-        args: Parsed arguments namespace.
+        args: Namespace from `parse_args()`. Only `command` and the per-group
+            `<group>_command` attributes are read; both may be absent.
 
     Returns:
-        `True` when a help screen was printed and no further work is needed.
+        `True` when help was rendered and the caller should exit; `False`
+            when the command requires the full runtime path.
     """
     command = getattr(args, "command", None)
-    help_specs = {
-        "help": (None, "show_help"),
-        "agents": ("agents_command", "show_agents_help"),
-        "skills": ("skills_command", "show_skills_help"),
-        "threads": ("threads_command", "show_threads_help"),
-        "mcp": ("mcp_command", "show_mcp_help"),
-    }
-    spec = help_specs.get(command)
+    if not isinstance(command, str):
+        return False
+    spec = _HELP_SPECS.get(command)
     if spec is None:
         return False
 
@@ -408,6 +434,9 @@ def _show_bare_command_group_help(args: argparse.Namespace) -> bool:
 
     from deepagents_cli import ui
 
+    # 2-arg `getattr` is intentional: a missing/renamed `show_*_help` in
+    # `ui.py` is a developer bug and should raise `AttributeError` loudly
+    # rather than fall through to a silent no-op.
     getattr(ui, help_fn_name)()
     return True
 
@@ -1478,8 +1507,9 @@ def cli_main() -> None:
         if _show_bare_command_group_help(args):
             return
 
-        # Import console/settings AFTER arg parsing so help-only commands never
-        # pay the settings bootstrap cost.
+        # Import console/settings AFTER arg parsing and after the bare-help
+        # fast path so neither argparse's `--help`/`-h` exit nor
+        # `deepagents <group>` pays the settings bootstrap cost.
         from deepagents_cli.config import console, settings
 
         model_params: dict[str, Any] | None = None

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -381,6 +381,37 @@ async def _preload_session_mcp_server_info(
                 )
 
 
+def _show_bare_command_group_help(args: argparse.Namespace) -> bool:
+    """Print help for command groups invoked without a subcommand.
+
+    Args:
+        args: Parsed arguments namespace.
+
+    Returns:
+        `True` when a help screen was printed and no further work is needed.
+    """
+    command = getattr(args, "command", None)
+    help_specs = {
+        "help": (None, "show_help"),
+        "agents": ("agents_command", "show_agents_help"),
+        "skills": ("skills_command", "show_skills_help"),
+        "threads": ("threads_command", "show_threads_help"),
+        "mcp": ("mcp_command", "show_mcp_help"),
+    }
+    spec = help_specs.get(command)
+    if spec is None:
+        return False
+
+    command_attr, help_fn_name = spec
+    if command_attr is not None and getattr(args, command_attr, None) is not None:
+        return False
+
+    from deepagents_cli import ui
+
+    getattr(ui, help_fn_name)()
+    return True
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments.
 
@@ -1444,8 +1475,11 @@ def cli_main() -> None:
     try:
         args = parse_args()
 
-        # Import console/settings AFTER arg parsing so --help (which exits
-        # inside parse_args) never pays the settings bootstrap cost.
+        if _show_bare_command_group_help(args):
+            return
+
+        # Import console/settings AFTER arg parsing so help-only commands never
+        # pay the settings bootstrap cost.
         from deepagents_cli.config import console, settings
 
         model_params: dict[str, Any] | None = None

--- a/libs/cli/tests/unit_tests/test_startup_fast_paths.py
+++ b/libs/cli/tests/unit_tests/test_startup_fast_paths.py
@@ -1,7 +1,13 @@
-"""Tests for lightweight CLI help-only paths."""
+"""Tests for lightweight CLI help-only paths.
+
+Each test runs `cli_main` in a subprocess so `sys.modules` reflects only
+what that invocation loaded, guarding the startup-perf contract documented
+in `CLAUDE.md`.
+"""
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys
@@ -9,15 +15,29 @@ import textwrap
 
 import pytest
 
-_HEAVY_RUNTIME_MODULES = (
+from deepagents_cli.main import _HELP_SPECS, _show_bare_command_group_help, parse_args
+
+# Module *prefixes* that must not appear in `sys.modules` after a help-only
+# invocation. Using prefixes (rather than an explicit allowlist) catches
+# regressions from any new top-level import in `main.py` or `ui.py` that
+# pulls in a heavy framework.
+_HEAVY_MODULE_PREFIXES = (
+    "deepagents.",
     "deepagents_cli.agent",
     "deepagents_cli.sessions",
     "deepagents_cli.model_config",
     "deepagents_cli.project_utils",
+    "langchain",
+    "langgraph",
+    "textual",
+    "httpx",
 )
 
 
 def _run_cli_main(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    # `check_cli_dependencies` is patched purely for environment portability —
+    # it only calls `importlib.util.find_spec` (no real imports), so patching
+    # it does not hide any heavy module load.
     code = """
         import json
         import sys
@@ -32,12 +52,18 @@ def _run_cli_main(argv: list[str]) -> subprocess.CompletedProcess[str]:
         ):
             cli_main()
 
-        loaded = [
-            name
-            for name in json.loads(sys.argv[2])
-            if name in sys.modules
-        ]
-        print("LOADED_MODULES=" + json.dumps(loaded))
+        prefixes = tuple(json.loads(sys.argv[2]))
+        loaded = sorted(
+            name for name in sys.modules if name.startswith(prefixes)
+        )
+        config_module = sys.modules.get("deepagents_cli.config")
+        bootstrap_done = (
+            getattr(config_module, "_bootstrap_done", None)
+            if config_module is not None
+            else None
+        )
+        print("LOADED_MODULES=" + json.dumps(loaded), file=sys.stderr)
+        print("BOOTSTRAP_DONE=" + json.dumps(bootstrap_done), file=sys.stderr)
     """
     return subprocess.run(
         [
@@ -45,13 +71,21 @@ def _run_cli_main(argv: list[str]) -> subprocess.CompletedProcess[str]:
             "-c",
             textwrap.dedent(code),
             json.dumps(argv),
-            json.dumps(_HEAVY_RUNTIME_MODULES),
+            json.dumps(_HEAVY_MODULE_PREFIXES),
         ],
         capture_output=True,
         text=True,
         timeout=30,
         check=False,
     )
+
+
+def _read_marker(stderr: str, prefix: str) -> object:
+    for line in reversed(stderr.splitlines()):
+        if line.startswith(prefix):
+            return json.loads(line[len(prefix) :])
+    msg = f"marker {prefix!r} not found in stderr"
+    raise AssertionError(msg)
 
 
 @pytest.mark.parametrize(
@@ -64,14 +98,116 @@ def _run_cli_main(argv: list[str]) -> subprocess.CompletedProcess[str]:
         (["mcp"], "deepagents mcp <command>"),
     ],
 )
-def test_bare_help_commands_skip_runtime_imports(
+def test_help_only_commands_skip_runtime_imports(
     argv: list[str], expected: str
 ) -> None:
-    """Bare command groups should print help without runtime imports."""
+    """Help-only commands must not import heavy runtime modules."""
     result = _run_cli_main(argv)
 
     assert result.returncode == 0, result.stderr
     assert expected in result.stdout
 
-    marker = result.stdout.rsplit("LOADED_MODULES=", maxsplit=1)[-1].splitlines()[0]
-    assert json.loads(marker) == []
+    loaded = _read_marker(result.stderr, "LOADED_MODULES=")
+    assert loaded == [], f"unexpected heavy modules loaded: {loaded}"
+
+    bootstrap_done = _read_marker(result.stderr, "BOOTSTRAP_DONE=")
+    # Either `deepagents_cli.config` was never imported (None) or it was
+    # imported transitively but `_ensure_bootstrap()` never ran (False).
+    # In neither case may the heavy settings/dotenv path have executed.
+    assert bootstrap_done in (None, False), (
+        f"settings bootstrap must not run on the fast path; got {bootstrap_done!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["agents", "list"],
+        ["skills", "list"],
+        ["threads", "list"],
+        ["mcp", "login", "example.com"],
+    ],
+)
+def test_subcommands_bypass_fast_path(argv: list[str]) -> None:
+    """When a subcommand is given, the fast path must not fire.
+
+    A `dest=` rename on a subparser would silently swallow the user's
+    subcommand if the fast-path's `getattr(..., None) is not None` check
+    fell through. This test locks the contract.
+    """
+    args = parse_args_from(argv)
+    assert _show_bare_command_group_help(args) is False
+
+
+def test_unknown_command_bypasses_fast_path() -> None:
+    """`command=None` (no command at all) must not trigger help dispatch."""
+    args = parse_args_from([])
+    assert _show_bare_command_group_help(args) is False
+
+
+def test_help_specs_covers_every_subparser_group() -> None:
+    """Drift guard: every top-level group with sub-subparsers is in `_HELP_SPECS`.
+
+    If a future PR adds a new command group with `add_subparsers(...)` but
+    forgets to register it here, the fast path silently regresses for that
+    group. This mirrors `test_args.TestHelpScreenDrift`.
+    """
+    parser = _build_top_level_parser()
+    groups_with_subparsers = _top_level_subparser_groups(parser)
+    missing = groups_with_subparsers - set(_HELP_SPECS)
+    assert not missing, (
+        f"Top-level command groups have sub-subparsers but are missing from "
+        f"`_HELP_SPECS` in main.py: {sorted(missing)}.\n"
+        f"Add an entry mapping each group to its `<group>_command` dest and "
+        f"`show_<group>_help` UI function."
+    )
+
+
+def parse_args_from(argv: list[str]) -> argparse.Namespace:
+    """Run `parse_args()` with a controlled argv."""
+    from unittest.mock import patch
+
+    with patch.object(sys, "argv", ["deepagents", *argv]):
+        return parse_args()
+
+
+def _build_top_level_parser() -> argparse.ArgumentParser:
+    """Capture the top-level parser by hooking `ArgumentParser.parse_args`."""
+    from typing import Any
+    from unittest.mock import patch
+
+    captured: dict[str, argparse.ArgumentParser] = {}
+    real_parse_args = argparse.ArgumentParser.parse_args
+
+    def _capture(
+        self: argparse.ArgumentParser,
+        *a: Any,
+        **kw: Any,
+    ) -> argparse.Namespace:
+        captured.setdefault("parser", self)
+        return real_parse_args(self, *a, **kw)
+
+    with (
+        patch.object(sys, "argv", ["deepagents", "help"]),
+        patch.object(argparse.ArgumentParser, "parse_args", _capture),
+    ):
+        parse_args()
+
+    return captured["parser"]
+
+
+def _top_level_subparser_groups(parser: argparse.ArgumentParser) -> set[str]:
+    """Return names of top-level subparsers that themselves have subparsers."""
+    from typing import cast
+
+    groups: set[str] = set()
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        choices = cast("dict[str, argparse.ArgumentParser]", action.choices)
+        for name, sub in choices.items():
+            for sub_action in sub._actions:
+                if isinstance(sub_action, argparse._SubParsersAction):
+                    groups.add(name)
+                    break
+    return groups

--- a/libs/cli/tests/unit_tests/test_startup_fast_paths.py
+++ b/libs/cli/tests/unit_tests/test_startup_fast_paths.py
@@ -1,0 +1,77 @@
+"""Tests for lightweight CLI help-only paths."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_HEAVY_RUNTIME_MODULES = (
+    "deepagents_cli.agent",
+    "deepagents_cli.sessions",
+    "deepagents_cli.model_config",
+    "deepagents_cli.project_utils",
+)
+
+
+def _run_cli_main(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    code = """
+        import json
+        import sys
+        from unittest.mock import patch
+
+        from deepagents_cli.main import cli_main
+
+        argv = ["deepagents", *json.loads(sys.argv[1])]
+        with (
+            patch.object(sys, "argv", argv),
+            patch("deepagents_cli.main.check_cli_dependencies"),
+        ):
+            cli_main()
+
+        loaded = [
+            name
+            for name in json.loads(sys.argv[2])
+            if name in sys.modules
+        ]
+        print("LOADED_MODULES=" + json.dumps(loaded))
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(code),
+            json.dumps(argv),
+            json.dumps(_HEAVY_RUNTIME_MODULES),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["help"], "Start interactive thread"),
+        (["agents"], "deepagents agents <command>"),
+        (["skills"], "deepagents skills <command>"),
+        (["threads"], "deepagents threads <command>"),
+        (["mcp"], "deepagents mcp <command>"),
+    ],
+)
+def test_bare_help_commands_skip_runtime_imports(
+    argv: list[str], expected: str
+) -> None:
+    """Bare command groups should print help without runtime imports."""
+    result = _run_cli_main(argv)
+
+    assert result.returncode == 0, result.stderr
+    assert expected in result.stdout
+
+    marker = result.stdout.rsplit("LOADED_MODULES=", maxsplit=1)[-1].splitlines()[0]
+    assert json.loads(marker) == []


### PR DESCRIPTION
Keep bare CLI command groups on the same lightweight path as `deepagents -h` and `deepagents -v`. Previously, `deepagents agents` parsed successfully but imported runtime modules before falling through to help, which made the help screen lag.