### PR TITLE
fix(cli): preserve recent agent across thread resume

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -744,13 +744,21 @@ class DeepAgentsApp(App):
         """
 
         self._assistant_id = assistant_id
-        """Current agent identity.
+        """Current session agent identity.
 
         Scopes per-agent memory (`~/.deepagents/<id>/`) and skill discovery,
         keys `FileOpTracker` file-op history, and is attached to LangSmith
         traces as `assistant_id` / `agent_name`. Mutated by `/agents` swaps
         and by `-r` resume when the resumed thread belongs to a different
         agent.
+        """
+
+        self._default_assistant_id = assistant_id
+        """User-intended default agent — persisted as `[agents].recent`.
+
+        Tracks only explicit user choice (`-a`, picker, recent fallback);
+        never mutated by `-r` resume. Mirrors `recent_model`'s invariant —
+        a one-off thread resume must not redefine the default.
         """
 
         self._backend = backend
@@ -1633,8 +1641,10 @@ class DeepAgentsApp(App):
 
         Consumes `self._resume_thread_intent` and resolves it into a concrete
         thread ID. Mutates `self._lc_thread_id` and optionally
-        `self._assistant_id` / `self._server_kwargs`. Falls back to a fresh
-        thread on any DB error.
+        `self._assistant_id` / `self._server_kwargs`. Does NOT touch
+        `self._default_assistant_id` — a one-off resume should not redefine
+        the user's persisted default agent. Falls back to a fresh thread on
+        any DB error.
         """
         from deepagents_cli.sessions import (
             find_similar_threads,
@@ -1736,16 +1746,19 @@ class DeepAgentsApp(App):
             save_recent_model(f"{result.provider}:{result.model_name}")
             self._model_kwargs = None  # consumed
 
-        # Persist the agent in use so a later bare `deepagents` relaunch
-        # brings the user back to it (same pattern as `save_recent_model`).
-        if self._assistant_id:
+        # Persist the user-chosen default so a later bare `deepagents`
+        # relaunch brings the user back to it. See `_default_assistant_id`
+        # for why this is decoupled from `_assistant_id`.
+        if self._default_assistant_id:
             from deepagents_cli.model_config import save_recent_agent
 
-            saved = await asyncio.to_thread(save_recent_agent, self._assistant_id)
+            saved = await asyncio.to_thread(
+                save_recent_agent, self._default_assistant_id
+            )
             if not saved:
                 logger.warning(
                     "Could not persist recent agent %r to config at startup",
-                    self._assistant_id,
+                    self._default_assistant_id,
                 )
 
         from deepagents_cli.server_manager import start_server_and_get_agent
@@ -5741,6 +5754,7 @@ class DeepAgentsApp(App):
             return _RemoteAgent(url=url, graph_name="agent")
 
         previous_agent = self._assistant_id
+        previous_default_agent = self._default_assistant_id
         previous_thread_id = self._lc_thread_id
         # Only offer a resume hint if the previous thread produced agent-side
         # output. `USER` alone is not enough: local-only flows (`/update`,
@@ -5858,7 +5872,10 @@ class DeepAgentsApp(App):
             # `restart()` so the subprocess picks up the new assistant_id
             # from the staged env override; on failure, both are rolled
             # back and the old server is confirmed dead (ServerStartFailed).
+            # Picker switches are explicit user choice, so update both the
+            # session id and the persisted default.
             self._assistant_id = agent_name
+            self._default_assistant_id = agent_name
             if self._server_kwargs is not None:
                 self._server_kwargs["assistant_id"] = agent_name
 
@@ -5873,6 +5890,7 @@ class DeepAgentsApp(App):
                 self._agent = _build_agent(server_proc.url)
             except Exception as exc:
                 self._assistant_id = previous_agent
+                self._default_assistant_id = previous_default_agent
                 if self._server_kwargs is not None:
                     self._server_kwargs["assistant_id"] = previous_agent
                 self._agent = None

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -4111,6 +4111,9 @@ class TestRestartServerForAgentSwap:
             )
             server_proc.restart.assert_awaited_once()
             assert app._assistant_id == "researcher"
+            # Picker switch is explicit user choice — both the session id
+            # and the persisted default should advance together.
+            assert app._default_assistant_id == "researcher"
             assert app._server_kwargs is not None
             assert app._server_kwargs["assistant_id"] == "researcher"
             assert app._agent is not None
@@ -4236,6 +4239,9 @@ class TestRestartServerForAgentSwap:
                 await app._restart_server_for_agent_swap("researcher")
 
         assert app._assistant_id == "coder"
+        # Both ids roll back together; a failed swap must not leave the
+        # persisted default pointing at an agent the user never reached.
+        assert app._default_assistant_id == "coder"
         assert app._server_kwargs is not None
         assert app._server_kwargs["assistant_id"] == "coder"
         assert app._agent is None
@@ -4248,6 +4254,99 @@ class TestRestartServerForAgentSwap:
         failures = [m for m in posted if isinstance(m, DeepAgentsApp.ServerStartFailed)]
         assert len(failures) == 1
         assert failures[0].error is boom
+
+
+class TestResolveResumeThread:
+    """Resume-thread inference must not pollute the persisted default agent."""
+
+    @staticmethod
+    def _make_app(assistant_id: str = "agent") -> DeepAgentsApp:
+        # `server_kwargs=None` so the auto-mounted `_start_server_background`
+        # worker doesn't fire and consume `_resume_thread_intent` before the
+        # test gets to call `_resolve_resume_thread` directly.
+        return DeepAgentsApp(
+            agent=MagicMock(),
+            assistant_id=assistant_id,
+            server_kwargs=None,
+            server_proc=None,
+        )
+
+    async def test_specific_thread_resume_leaves_default_alone(self) -> None:
+        """`-r <thread>` from a different agent updates session id only."""
+        app = self._make_app("agent")
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._resume_thread_intent = "thread-from-coder"
+            with (
+                patch(
+                    "deepagents_cli.sessions.thread_exists",
+                    AsyncMock(return_value=True),
+                ),
+                patch(
+                    "deepagents_cli.sessions.get_thread_agent",
+                    AsyncMock(return_value="coder"),
+                ),
+            ):
+                await app._resolve_resume_thread()
+
+            assert app._assistant_id == "coder"
+            # The default — and therefore what `[agents].recent` will be
+            # written as at startup — must reflect user choice, not whatever
+            # agent happened to own the resumed thread.
+            assert app._default_assistant_id == "agent"
+
+    async def test_explicit_a_blocks_specific_thread_override(self) -> None:
+        """`-a coder -r <thread>` keeps both ids on `coder` regardless of thread agent.
+
+        Locks the gate at `_resolve_resume_thread`'s `elif` branch
+        (`if self._assistant_id == default_agent`): explicit `-a` suppresses
+        the agent inference, so the thread's owner ("researcher" here) is
+        never queried and neither id changes.
+        """
+        app = self._make_app("coder")
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._resume_thread_intent = "thread-from-researcher"
+            get_thread_agent_mock = AsyncMock(return_value="researcher")
+            with (
+                patch(
+                    "deepagents_cli.sessions.thread_exists",
+                    AsyncMock(return_value=True),
+                ),
+                patch(
+                    "deepagents_cli.sessions.get_thread_agent",
+                    get_thread_agent_mock,
+                ),
+            ):
+                await app._resolve_resume_thread()
+
+            assert app._assistant_id == "coder"
+            assert app._default_assistant_id == "coder"
+            get_thread_agent_mock.assert_not_called()
+
+    async def test_most_recent_resume_leaves_default_alone(self) -> None:
+        """`-r` (no thread id) must not redefine the default either."""
+        app = self._make_app("agent")
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._resume_thread_intent = "__MOST_RECENT__"
+            with (
+                patch(
+                    "deepagents_cli.sessions.get_most_recent",
+                    AsyncMock(return_value="recent-thread"),
+                ),
+                patch(
+                    "deepagents_cli.sessions.get_thread_agent",
+                    AsyncMock(return_value="coder"),
+                ),
+            ):
+                await app._resolve_resume_thread()
+
+            assert app._assistant_id == "coder"
+            assert app._default_assistant_id == "agent"
 
 
 def _missing_dep_entry(
@@ -5711,3 +5810,48 @@ class TestPrewarmAwait:
         assert call_order[:2] == ["prewarm", "create_model"], (
             f"prewarm must precede create_model; got {call_order}"
         )
+
+    async def test_start_server_background_persists_default_not_session_id(
+        self,
+    ) -> None:
+        """`save_recent_agent` must receive the user-chosen default.
+
+        Locks the parity invariant: when `-r` resume has overridden the
+        session id but the user's default is unchanged, the next bare
+        relaunch must still return to the default — not the resumed
+        thread's owning agent. Without this assertion a future refactor
+        that swaps the argument back to `_assistant_id` is invisible.
+        """
+        from deepagents_cli import config as cli_config
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        app._model_kwargs = {"model_spec": "anthropic:claude-opus-4-7"}
+        app._server_kwargs = None
+        app._mcp_preload_kwargs = None
+        app._resume_thread_intent = None
+        # Simulate post-resume state: session ran in `coder`, but the user's
+        # chosen default is `agent`.
+        app._assistant_id = "coder"
+        app._default_assistant_id = "agent"
+
+        def fake_create_model(**_: Any) -> MagicMock:
+            result = MagicMock()
+            result.apply_to_settings = MagicMock()
+            result.provider = "anthropic"
+            result.model_name = "claude-opus-4-7"
+            return result
+
+        with (
+            patch.object(app, "_await_prewarm_imports", AsyncMock()),
+            patch.object(cli_config, "create_model", side_effect=fake_create_model),
+            patch("deepagents_cli.model_config.save_recent_model"),
+            patch(
+                "deepagents_cli.model_config.save_recent_agent",
+                return_value=True,
+            ) as save_agent_mock,
+            patch.object(app, "post_message"),
+            contextlib.suppress(Exception),
+        ):
+            await app._start_server_background()
+
+        save_agent_mock.assert_called_once_with("agent")


### PR DESCRIPTION
Track the CLI's persisted default agent separately from the active session agent. Resuming a thread from another agent can still switch the running session, but it no longer rewrites `[agents].recent` and changes what a later bare `deepagents` launch opens.