### PR TITLE
feat(cli): richer provider auth states, hosted Ollama auth

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1930,7 +1930,11 @@ def _get_provider_kwargs(
     base_url = config.get_base_url(provider)
     if base_url:
         result["base_url"] = base_url
-    from deepagents_cli.model_config import PROVIDER_API_KEY_ENV, resolve_env_var
+    from deepagents_cli.model_config import (
+        OPTIONAL_AUTH_ENV,
+        PROVIDER_API_KEY_ENV,
+        resolve_env_var,
+    )
 
     api_key_env = config.get_api_key_env(provider)
     if not api_key_env:
@@ -1945,6 +1949,39 @@ def _get_provider_kwargs(
         api_key = resolve_env_var(api_key_env)
         if api_key:
             result["api_key"] = api_key
+
+    # `langchain-ollama` has no `api_key` kwarg; hosted Ollama (Cloud or
+    # gateway) needs the bearer token threaded through `client_kwargs.headers`.
+    if provider == "ollama":
+        optional_env = OPTIONAL_AUTH_ENV.get(provider)
+        optional_key = resolve_env_var(optional_env) if optional_env else None
+        if optional_key:
+            client_kwargs = result.get("client_kwargs")
+            if client_kwargs is not None and not isinstance(client_kwargs, dict):
+                logger.warning(
+                    "Provider 'ollama' has non-mapping client_kwargs (%s);"
+                    " skipping Authorization header injection",
+                    type(client_kwargs).__name__,
+                )
+            else:
+                client_kwargs = dict(client_kwargs) if client_kwargs else {}
+                headers = client_kwargs.get("headers")
+                if headers is not None and not isinstance(headers, dict):
+                    logger.warning(
+                        "Provider 'ollama' has non-mapping client_kwargs.headers"
+                        " (%s); skipping Authorization header injection",
+                        type(headers).__name__,
+                    )
+                else:
+                    headers = dict(headers) if headers else {}
+                    has_auth_header = any(
+                        isinstance(k, str) and k.lower() == "authorization"
+                        for k in headers
+                    )
+                    if not has_auth_header:
+                        headers["Authorization"] = f"Bearer {optional_key}"
+                        client_kwargs["headers"] = headers
+                        result["client_kwargs"] = client_kwargs
 
     return result
 

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
 # Suppress Pydantic v1 compatibility warnings from langchain on Python 3.14+
 warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarning)
 
-from deepagents_cli._constants import DEFAULT_AGENT_NAME as _DEFAULT_AGENT_NAME
 from deepagents_cli._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -42,13 +41,13 @@ def _resolve_agent_arg(args: argparse.Namespace) -> str:
     Precedence, highest first:
 
     1. Explicit `-a <name>` (stored as `args.agent` by argparse).
-    2. `-r <thread>` is present → use `_DEFAULT_AGENT_NAME`. The real agent is
+    2. `-r <thread>` is present → use `DEFAULT_AGENT_NAME`. The real agent is
         inferred later by `_resolve_resume_thread` via thread metadata
         (`get_thread_agent`), so we must NOT pre-seed a recent-agent here or
         it would suppress that inference.
     3. `[agents].recent` from config, if it points at an agent whose
         directory still exists.
-    4. `_DEFAULT_AGENT_NAME` as the final fallback.
+    4. `DEFAULT_AGENT_NAME` as the final fallback.
 
     Extracted from the `cli_main` body so it's unit-testable without
     constructing the full arg tree.
@@ -59,17 +58,19 @@ def _resolve_agent_arg(args: argparse.Namespace) -> str:
     Returns:
         The agent identifier to hand downstream.
     """
+    from deepagents_cli._constants import DEFAULT_AGENT_NAME
+
     if args.agent is not None:
         return args.agent
     if getattr(args, "resume_thread", None) is not None:
-        return _DEFAULT_AGENT_NAME
+        return DEFAULT_AGENT_NAME
 
     from deepagents_cli.model_config import load_recent_agent
 
     recent = load_recent_agent()
     if recent and _recent_agent_is_valid(recent):
         return recent
-    return _DEFAULT_AGENT_NAME
+    return DEFAULT_AGENT_NAME
 
 
 def _recent_agent_is_valid(name: str) -> bool:
@@ -444,6 +445,7 @@ def parse_args() -> argparse.Namespace:
     Returns:
         Parsed arguments namespace.
     """
+    from deepagents_cli._constants import DEFAULT_AGENT_NAME
     from deepagents_cli.deploy import setup_deploy_parsers
     from deepagents_cli.mcp_commands import setup_mcp_parsers
     from deepagents_cli.output import add_json_output_arg
@@ -674,7 +676,7 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Agent to use (e.g., coder, researcher). "
             "If omitted, falls back to [agents].recent in config, then "
-            f"the '{_DEFAULT_AGENT_NAME}' default."
+            f"the '{DEFAULT_AGENT_NAME}' default."
         ),
     )
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -14,9 +14,11 @@ import tempfile
 import threading
 import tomllib
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
+from urllib.parse import urlparse
 
 import tomli_w
 
@@ -98,6 +100,69 @@ class MissingCredentialsError(ModelConfigError):
         super().__init__(message)
         self.provider = provider
         self.env_var = env_var
+
+
+class ProviderAuthState(StrEnum):
+    """Credential readiness state for a model provider."""
+
+    CONFIGURED = "configured"
+    """An explicit credential source is configured and non-empty."""
+
+    MISSING = "missing"
+    """An explicit credential source is required but missing."""
+
+    NOT_REQUIRED = "not_required"
+    """This provider configuration does not require API-key credentials."""
+
+    IMPLICIT = "implicit"
+    """The provider supports ambient auth outside CLI env-var checks."""
+
+    MANAGED = "managed"
+    """A custom provider class is expected to manage auth itself."""
+
+    UNKNOWN = "unknown"
+    """The CLI cannot determine whether provider auth is ready."""
+
+
+@dataclass(frozen=True)
+class ProviderAuthStatus:
+    """Credential readiness information for a provider.
+
+    Args:
+        state: Provider auth state.
+        provider: Provider name.
+        env_var: Env var name associated with the state, when applicable.
+        detail: Short user-facing context for selectors and logs.
+    """
+
+    state: ProviderAuthState
+    provider: str
+    env_var: str | None = None
+    detail: str | None = None
+
+    @property
+    def blocks_start(self) -> bool:
+        """Whether this status should block model creation or switching."""
+        return self.state is ProviderAuthState.MISSING
+
+    def as_legacy_bool(self) -> bool | None:
+        """Return the historic `has_provider_credentials` tri-state value."""
+        if self.state is ProviderAuthState.MISSING:
+            return False
+        if self.state is ProviderAuthState.UNKNOWN:
+            return None
+        return True
+
+    def missing_detail(self) -> str:
+        """Return a user-facing reason for a missing-credential status."""
+        if self.env_var:
+            return f"{self.env_var} is not set or is empty"
+        if self.detail:
+            return self.detail
+        return (
+            f"provider '{self.provider}' is not recognized. "
+            "Add it to ~/.deepagents/config.toml with an api_key_env field"
+        )
 
 
 @dataclass(frozen=True)
@@ -304,12 +369,22 @@ registry fallback.
 """
 
 IMPLICIT_AUTH_PROVIDERS: frozenset[str] = frozenset({"google_vertexai"})
-"""Providers that support implicit auth (e.g., ADC, local servers).
+"""Providers that support ambient auth outside CLI env-var checks.
 
 These providers can authenticate without the env var listed in
 `PROVIDER_API_KEY_ENV`, so a missing env var should not be treated as a hard
-credential failure. Used by `create_model` to skip the early credential check.
+credential failure. Used by `create_model` to skip the early credential check
+and by `get_provider_auth_status` for user-facing auth labels.
 """
+
+NO_AUTH_REQUIRED_PROVIDERS: frozenset[str] = frozenset({"ollama"})
+"""Providers whose default local configuration does not require API keys."""
+
+OPTIONAL_AUTH_ENV: dict[str, str] = {"ollama": "OLLAMA_API_KEY"}
+"""Optional env vars that enable authenticated provider modes when present."""
+
+PROVIDER_HOST_ENV: dict[str, str] = {"ollama": "OLLAMA_HOST"}
+"""Provider-specific env vars that can point a local provider at a remote host."""
 
 
 # Module-level caches — cleared by `clear_caches()`.
@@ -760,57 +835,177 @@ def get_model_profiles(
     return frozen
 
 
-def has_provider_credentials(provider: str) -> bool | None:
-    """Check if credentials are available for a provider.
+_LOCAL_HOSTNAMES: frozenset[str] = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",  # noqa: S104  # hostname comparison, not socket binding
+    }
+)
 
-    Combines two credential sources to decide whether a provider's API key
-    is present *before* attempting model creation:
 
-    1. **Config-file providers** (`config.toml` `[providers.<name>]`):
+def _is_local_endpoint(url: str | None) -> bool:
+    """Return whether a provider endpoint points at the local machine."""
+    if not url:
+        return True
+    if not isinstance(url, str):
+        return False
+
+    # Bare hostname literal (no scheme, no port) — short-circuit so IPv6
+    # forms like `::1` don't get misparsed by urlparse.
+    if url in _LOCAL_HOSTNAMES:
+        return True
+
+    candidate = url if "://" in url else f"http://{url}"
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        return False
+    return parsed.hostname in _LOCAL_HOSTNAMES
+
+
+def _get_provider_endpoint(provider: str, config: ModelConfig) -> str | None:
+    """Return a provider endpoint from config or provider-specific env vars."""
+    base_url = config.get_base_url(provider)
+    if base_url:
+        return base_url
+
+    host_env = PROVIDER_HOST_ENV.get(provider)
+    if not host_env:
+        return None
+    return resolve_env_var(host_env)
+
+
+def get_provider_auth_status(provider: str) -> ProviderAuthStatus:
+    """Return credential readiness details for a provider.
+
+    Combines config, well-known provider metadata, optional provider auth,
+    and implicit-auth provider metadata before attempting model creation:
+
+    1. **Config-file providers** (`config.toml`
+        `[models.providers.<name>]`):
         - If the section declares `api_key_env`, that env var is checked
             via `resolve_env_var()` (which honors `DEEPAGENTS_CLI_` prefixes).
-
-            Returns `True`/`False` accordingly.
         - If the section has `class_path` but no `api_key_env`, the provider is
-            assumed to manage its own auth (e.g., custom headers, JWT, mTLS) and
-            `True` is returned.
+            assumed to manage its own auth (e.g., custom headers, JWT, mTLS).
         - If neither `api_key_env` nor `class_path` is set, falls through
-            to step 2.
+            to provider-specific defaults.
     2. **Hardcoded registry** (`PROVIDER_API_KEY_ENV`): a module-level dict
-        mapping 18 well-known provider names to their canonical env var
+        mapping well-known provider names to their canonical env var
         (e.g., `"anthropic"` → `"ANTHROPIC_API_KEY"`). The env var is checked
         via `resolve_env_var()`.
-    3. **Unknown providers** not present in either source: returns `None` so
-        callers can decide whether to block or defer to the provider SDK's own
-        auth handling.
+    3. **Implicit auth providers** (e.g., Vertex AI ADC): a missing env var is
+        not treated as missing credentials.
+    4. **Optional auth env vars** (`OPTIONAL_AUTH_ENV`): when present, mark
+        the provider as configured for hosted/cloud use.
+    5. **No-auth-required providers** (`NO_AUTH_REQUIRED_PROVIDERS`): default
+        local endpoints report `NOT_REQUIRED`; non-local endpoints fall back
+        to `UNKNOWN` so the SDK can decide.
+    6. **Unknown providers** not present in any source defer auth failures to
+        the provider SDK.
+
+    Use `has_provider_credentials()` when compatibility with the historic
+    `True`/`False`/`None` contract is required.
 
     Args:
         provider: Provider name (e.g., `"anthropic"`, `"openai"`).
 
     Returns:
-        `True` if credentials are confirmed available or the provider is
-            expected to manage its own auth (e.g., `class_path` providers).
-        `False` if the required env var is known but not set.
-        `None` if credential status cannot be determined (provider not in
-            config or `PROVIDER_API_KEY_ENV`).
+        Provider auth status for selectors, startup checks, and compatibility
+            wrappers.
     """
     # Config-file providers take priority when api_key_env is specified.
     config = ModelConfig.load()
     provider_config = config.providers.get(provider)
     if provider_config:
-        result = config.has_credentials(provider)
-        if result is not None:
-            return result
+        env_var = provider_config.get("api_key_env")
+        if env_var:
+            if resolve_env_var(env_var):
+                return ProviderAuthStatus(
+                    state=ProviderAuthState.CONFIGURED,
+                    provider=provider,
+                    env_var=env_var,
+                    detail="credentials set",
+                )
+            return ProviderAuthStatus(
+                state=ProviderAuthState.MISSING,
+                provider=provider,
+                env_var=env_var,
+                detail=f"{env_var} is not set or is empty",
+            )
         # class_path providers that omit api_key_env manage their own auth
-        # (e.g., custom headers, JWT, mTLS) — treat as available.
+        # (e.g., custom headers, JWT, mTLS).
         if provider_config.get("class_path"):
-            return True
-        # No api_key_env in config — fall through to hardcoded map.
+            return ProviderAuthStatus(
+                state=ProviderAuthState.MANAGED,
+                provider=provider,
+                detail="custom auth",
+            )
+        # No api_key_env in config — fall through to provider-specific and
+        # hardcoded maps.
 
     # Fall back to hardcoded well-known providers.
     env_var = PROVIDER_API_KEY_ENV.get(provider)
     if env_var:
-        return bool(resolve_env_var(env_var))
+        if resolve_env_var(env_var):
+            return ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider=provider,
+                env_var=env_var,
+                detail="credentials set",
+            )
+        if provider in IMPLICIT_AUTH_PROVIDERS:
+            return ProviderAuthStatus(
+                state=ProviderAuthState.IMPLICIT,
+                provider=provider,
+                env_var=env_var,
+                detail="implicit auth",
+            )
+        return ProviderAuthStatus(
+            state=ProviderAuthState.MISSING,
+            provider=provider,
+            env_var=env_var,
+            detail=f"{env_var} is not set or is empty",
+        )
+
+    if provider in IMPLICIT_AUTH_PROVIDERS:
+        return ProviderAuthStatus(
+            state=ProviderAuthState.IMPLICIT,
+            provider=provider,
+            detail="implicit auth",
+        )
+
+    optional_env = OPTIONAL_AUTH_ENV.get(provider)
+    if optional_env and resolve_env_var(optional_env):
+        return ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider=provider,
+            env_var=optional_env,
+            detail="credentials set",
+        )
+
+    if provider in NO_AUTH_REQUIRED_PROVIDERS:
+        endpoint = _get_provider_endpoint(provider, config)
+        if _is_local_endpoint(endpoint):
+            return ProviderAuthStatus(
+                state=ProviderAuthState.NOT_REQUIRED,
+                provider=provider,
+                detail="local provider",
+            )
+        # Remote endpoint may or may not require auth (private network vs.
+        # hosted). Don't block; surface the optional env var as a hint.
+        detail = (
+            f"remote endpoint; set {optional_env} if auth is required"
+            if optional_env
+            else "remote endpoint"
+        )
+        return ProviderAuthStatus(
+            state=ProviderAuthState.UNKNOWN,
+            provider=provider,
+            env_var=optional_env,
+            detail=detail,
+        )
 
     # Provider not found in config or hardcoded map — credential status is
     # unknown. The provider itself will report auth failures at
@@ -819,7 +1014,31 @@ def has_provider_credentials(provider: str) -> bool | None:
         "No credential information for provider '%s'; deferring auth to provider",
         provider,
     )
-    return None
+    return ProviderAuthStatus(
+        state=ProviderAuthState.UNKNOWN,
+        provider=provider,
+        detail="credentials unknown",
+    )
+
+
+def has_provider_credentials(provider: str) -> bool | None:
+    """Check if credentials are available for a provider.
+
+    This compatibility wrapper preserves the historic tri-state contract while
+    `get_provider_auth_status()` carries the richer user-facing distinctions:
+    configured credentials, missing credentials, no-auth local providers,
+    implicit auth, custom provider-managed auth, and unknown providers.
+
+    Args:
+        provider: Provider name (e.g., `"anthropic"`, `"openai"`).
+
+    Returns:
+        `True` if auth is configured, implicit, provider-managed, or not
+            required.
+        `False` if a required env var is known but not set.
+        `None` if credential status cannot be determined.
+    """
+    return get_provider_auth_status(provider).as_legacy_bool()
 
 
 def get_credential_env_var(provider: str) -> str | None:

--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, assert_never
 
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
@@ -27,10 +27,12 @@ from deepagents_cli.config import Glyphs, get_glyphs, is_ascii_mode
 from deepagents_cli.model_config import (
     ModelConfig,
     ModelProfileEntry,
+    ProviderAuthState,
+    ProviderAuthStatus,
     clear_default_model,
     get_available_models,
     get_model_profiles,
-    has_provider_credentials,
+    get_provider_auth_status,
     save_default_model,
 )
 
@@ -40,9 +42,18 @@ _FRONTIER_RECOMMENDED_MODELS: frozenset[str] = frozenset(
     {
         "anthropic:claude-opus-4-6",
         "anthropic:claude-opus-4-7",
+        "baseten:moonshotai/Kimi-K2.6",
         "google_genai:gemini-3.1-pro-preview",
+        "ollama:deepseek-v4-pro:cloud",
+        "ollama:glm-5.1:cloud",
+        "ollama:kimi-k2.6:cloud",
+        "ollama:minimax-m2.7:cloud",
         "openai:gpt-5.4",
         "openai:gpt-5.5",
+        "openrouter:deepseek/deepseek-v4-pro",
+        "openrouter:minimax/minimax-m2.7",
+        "openrouter:moonshotai/kimi-k2.6",
+        "openrouter:z-ai/glm-5.1",
     }
 )
 """Curated frontier-tier models shown in the onboarding picker."""
@@ -58,7 +69,7 @@ class ModelOption(Static):
         provider: str,
         index: int,
         *,
-        has_creds: bool | None = True,
+        auth_status: ProviderAuthStatus | None = None,
         classes: str = "",
     ) -> None:
         """Initialize a model option.
@@ -69,15 +80,18 @@ class ModelOption(Static):
             model_spec: The model specification (provider:model format).
             provider: The provider name.
             index: The index of this option in the filtered list.
-            has_creds: Whether the provider has valid credentials. True if
-                confirmed, False if missing, None if unknown.
+            auth_status: Provider auth/readiness status.
             classes: CSS classes for styling.
         """
         super().__init__(label, classes=classes)
         self.model_spec = model_spec
         self.provider = provider
         self.index = index
-        self.has_creds = has_creds
+        self.auth_status = auth_status or ProviderAuthStatus(
+            state=ProviderAuthState.UNKNOWN,
+            provider=provider,
+            detail="credentials unknown",
+        )
 
     class Clicked(Message):
         """Message sent when a model option is clicked."""
@@ -593,29 +607,24 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         if self._current_model and self._current_provider:
             current_spec = f"{self._current_provider}:{self._current_model}"
 
-        # Resolve credentials upfront so the widget-building loop
+        # Resolve provider auth upfront so the widget-building loop
         # stays focused on layout
-        creds = {p: has_provider_credentials(p) for p in by_provider}
+        auth_statuses = {p: get_provider_auth_status(p) for p in by_provider}
 
         # Collect all widgets first, then batch-mount once to avoid
         # individual DOM mutations per widget
         all_widgets: list[Static] = []
 
         for provider, model_entries in by_provider.items():
-            # Provider header with credential indicator
-            has_creds = creds[provider]
-            if has_creds is True:
-                cred_indicator = glyphs.checkmark
-            elif has_creds is False:
-                cred_indicator = f"{glyphs.warning} missing credentials"
-            else:
-                cred_indicator = f"{glyphs.question} credentials unknown"
+            # Provider header with auth/readiness indicator.
+            auth_status = auth_statuses[provider]
+            auth_indicator = self._format_auth_indicator(auth_status, glyphs)
             all_widgets.append(
                 Static(
                     Content.from_markup(
-                        "[bold]$provider[/bold] [dim]$cred[/dim]",
+                        "[bold]$provider[/bold] [dim]$auth[/dim]",
                         provider=provider,
-                        cred=cred_indicator,
+                        auth=auth_indicator,
                     ),
                     classes="model-provider-header",
                 )
@@ -635,7 +644,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                     model_spec,
                     selected=is_selected,
                     current=is_current,
-                    has_creds=has_creds,
+                    auth_status=auth_status,
                     is_default=model_spec == self._default_spec,
                     status=self._get_model_status(model_spec),
                 )
@@ -644,7 +653,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                     model_spec=model_spec,
                     provider=provider,
                     index=flat_index,
-                    has_creds=has_creds,
+                    auth_status=auth_status,
                     classes=classes,
                 )
                 all_widgets.append(widget)
@@ -670,12 +679,46 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._update_footer()
 
     @staticmethod
+    def _format_auth_indicator(
+        auth_status: ProviderAuthStatus,
+        glyphs: Glyphs,
+    ) -> str:
+        """Build the provider header auth indicator.
+
+        Args:
+            auth_status: Provider auth/readiness status.
+            glyphs: Glyph table for the active terminal mode.
+
+        Returns:
+            Text shown next to the provider name.
+        """
+        state = auth_status.state
+        match state:
+            case ProviderAuthState.CONFIGURED:
+                return f"{glyphs.checkmark} credentials set"
+            case ProviderAuthState.MISSING:
+                if auth_status.env_var:
+                    return f"{glyphs.warning} missing {auth_status.env_var}"
+                return f"{glyphs.warning} missing credentials"
+            case ProviderAuthState.NOT_REQUIRED:
+                return auth_status.detail or "no API key required"
+            case ProviderAuthState.IMPLICIT:
+                return auth_status.detail or "implicit auth"
+            case ProviderAuthState.MANAGED:
+                return auth_status.detail or "custom auth"
+            case ProviderAuthState.UNKNOWN:
+                detail = auth_status.detail or "credentials unknown"
+                return f"{glyphs.question} {detail}"
+            case _:
+                assert_never(state)
+
+    @staticmethod
     def _format_option_label(
         model_spec: str,
         *,
         selected: bool,
         current: bool,
-        has_creds: bool | None,
+        auth_status: ProviderAuthStatus,
         is_default: bool = False,
         status: str | None = None,
     ) -> Content:
@@ -685,7 +728,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             model_spec: The `provider:model` string.
             selected: Whether this option is currently highlighted.
             current: Whether this is the active model.
-            has_creds: Credential status (True/False/None).
+            auth_status: Provider auth/readiness status.
             is_default: Whether this is the configured default model.
             status: Model status from profile (e.g., `'deprecated'`,
                 `'beta'`, `'alpha'`). `'deprecated'` renders in red;
@@ -700,7 +743,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         # When selected, skip the inline primary color — CSS already flips the
         # row to ($primary bg, $background fg). Keep `bold` so the default
         # emphasis survives both states.
-        if not has_creds:
+        if auth_status.blocks_start:
             spec = Content.styled(model_spec, colors.warning)
         elif is_default and selected:
             spec = Content.styled(model_spec, "bold")
@@ -894,7 +937,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 old_widget.model_spec,
                 selected=False,
                 current=old_widget.model_spec == self._current_spec,
-                has_creds=old_widget.has_creds,
+                auth_status=old_widget.auth_status,
                 is_default=old_widget.model_spec == self._default_spec,
                 status=self._get_model_status(old_widget.model_spec),
             )
@@ -908,7 +951,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 new_widget.model_spec,
                 selected=True,
                 current=new_widget.model_spec == self._current_spec,
-                has_creds=new_widget.has_creds,
+                auth_status=new_widget.auth_status,
                 is_default=new_widget.model_spec == self._default_spec,
                 status=self._get_model_status(new_widget.model_spec),
             )

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -3945,20 +3945,19 @@ class TestDefaultAgentNameDrift:
 
     `_constants.DEFAULT_AGENT_NAME` is the single source of truth. This test
     asserts that every consumer (`agent.DEFAULT_AGENT_NAME`,
-    `_server_config.DEFAULT_ASSISTANT_ID`, `main._DEFAULT_AGENT_NAME`,
-    `app.DEFAULT_ASSISTANT_ID`) resolves back to it — guarding against a
-    future refactor that re-introduces a hardcoded `"agent"` literal.
+    `_server_config.DEFAULT_ASSISTANT_ID`, `app.DEFAULT_ASSISTANT_ID`)
+    resolves back to it — guarding against a future refactor that
+    re-introduces a hardcoded `"agent"` literal.
     """
 
     def test_all_default_agent_constants_match(self) -> None:
         """All consumers of the default identifier must point at `_constants`."""
-        from deepagents_cli import _constants, _server_config, agent, app, main
+        from deepagents_cli import _constants, _server_config, agent, app
 
         canonical = _constants.DEFAULT_AGENT_NAME
         assert canonical == "agent"
         assert agent.DEFAULT_AGENT_NAME is canonical
         assert _server_config.DEFAULT_ASSISTANT_ID is canonical
-        assert main._DEFAULT_AGENT_NAME is canonical
         assert app.DEFAULT_ASSISTANT_ID is canonical
 
 

--- a/libs/cli/tests/unit_tests/test_args.py
+++ b/libs/cli/tests/unit_tests/test_args.py
@@ -8,8 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from rich.console import Console
 
-from deepagents_cli.agent import DEFAULT_AGENT_NAME
-from deepagents_cli.main import _DEFAULT_AGENT_NAME, parse_args
+from deepagents_cli.main import parse_args
 from deepagents_cli.ui import show_help, show_threads_list_help
 
 
@@ -458,11 +457,6 @@ class TestAutoUpdateArg:
         with patch.object(sys, "argv", ["deepagents"]):
             args = parse_args()
         assert args.auto_update is False
-
-
-def test_default_agent_name_matches_canonical() -> None:
-    """Ensure the duplicated constant in main.py stays in sync with agent.py."""
-    assert _DEFAULT_AGENT_NAME == DEFAULT_AGENT_NAME
 
 
 class TestHelpScreenDrift:

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1508,7 +1508,7 @@ api_key_env = "FIREWORKS_API_KEY"
 """)
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
-            patch.dict("os.environ", {"FIREWORKS_API_KEY": "test-key"}, clear=False),
+            patch.dict("os.environ", {"FIREWORKS_API_KEY": "test-key"}, clear=True),
         ):
             kwargs = _get_provider_kwargs("fireworks")
 
@@ -1525,7 +1525,7 @@ api_key_env = "TOGETHER_API_KEY"
 """)
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
-            patch.dict("os.environ", {"TOGETHER_API_KEY": "together-key"}, clear=False),
+            patch.dict("os.environ", {"TOGETHER_API_KEY": "together-key"}, clear=True),
         ):
             kwargs = _get_provider_kwargs("together")
 
@@ -1548,7 +1548,7 @@ api_key_env = "FIREWORKS_API_KEY"
                     "FIREWORKS_API_KEY": "canonical",
                     "DEEPAGENTS_CLI_FIREWORKS_API_KEY": "prefixed",
                 },
-                clear=False,
+                clear=True,
             ),
         ):
             kwargs = _get_provider_kwargs("fireworks")
@@ -1600,7 +1600,7 @@ max_tokens = 4096
 """)
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
-            patch.dict("os.environ", {"CUSTOM_KEY": "secret"}, clear=False),
+            patch.dict("os.environ", {"CUSTOM_KEY": "secret"}, clear=True),
         ):
             kwargs = _get_provider_kwargs("custom")
 
@@ -1648,6 +1648,127 @@ temperature = 0.5
 
         assert kwargs["temperature"] == 0
 
+    def test_ollama_optional_api_key_sets_authorization_header(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """OLLAMA_API_KEY is forwarded through client_kwargs for cloud use."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+models = ["llama3"]
+base_url = "https://ollama.example.com"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {"OLLAMA_API_KEY": "test-key"}, clear=True),
+        ):
+            kwargs = _get_provider_kwargs("ollama")
+
+        assert kwargs["client_kwargs"]["headers"]["Authorization"] == (
+            "Bearer test-key"
+        )
+
+    def test_ollama_prefixed_optional_api_key_overrides_canonical(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The CLI-scoped Ollama key follows normal env override behavior."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+models = ["llama3"]
+base_url = "https://ollama.example.com"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict(
+                "os.environ",
+                {
+                    "OLLAMA_API_KEY": "canonical",
+                    "DEEPAGENTS_CLI_OLLAMA_API_KEY": "prefixed",
+                },
+                clear=True,
+            ),
+        ):
+            kwargs = _get_provider_kwargs("ollama")
+
+        assert kwargs["client_kwargs"]["headers"]["Authorization"] == (
+            "Bearer prefixed"
+        )
+
+    def test_ollama_preserves_user_authorization_header(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Existing Authorization header (any case) is not overwritten."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+models = ["llama3"]
+base_url = "https://ollama.example.com"
+
+[models.providers.ollama.params.llama3]
+client_kwargs = { headers = { authorization = "Bearer user-supplied" } }
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {"OLLAMA_API_KEY": "env-key"}, clear=True),
+        ):
+            kwargs = _get_provider_kwargs("ollama", model_name="llama3")
+
+        headers = kwargs["client_kwargs"]["headers"]
+        assert headers["authorization"] == "Bearer user-supplied"
+        assert "Authorization" not in headers
+
+    def test_ollama_preserves_unrelated_headers_and_client_kwargs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Sibling client_kwargs and headers entries survive Authorization injection."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+models = ["llama3"]
+base_url = "https://ollama.example.com"
+
+[models.providers.ollama.params.llama3]
+client_kwargs = { timeout = 30, headers = { "X-Trace-Id" = "abc" } }
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {"OLLAMA_API_KEY": "env-key"}, clear=True),
+        ):
+            kwargs = _get_provider_kwargs("ollama", model_name="llama3")
+
+        client_kwargs = kwargs["client_kwargs"]
+        assert client_kwargs["timeout"] == 30
+        assert client_kwargs["headers"]["X-Trace-Id"] == "abc"
+        assert client_kwargs["headers"]["Authorization"] == "Bearer env-key"
+
+    def test_ollama_local_endpoint_does_not_inject_header(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Without OLLAMA_API_KEY, no Authorization header is injected."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+models = ["llama3"]
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            kwargs = _get_provider_kwargs("ollama")
+
+        client_kwargs = kwargs.get("client_kwargs", {})
+        headers = (
+            client_kwargs.get("headers", {}) if isinstance(client_kwargs, dict) else {}
+        )
+        assert "Authorization" not in headers
+        assert "authorization" not in headers
+
     def test_base_url_and_api_key_override_config_params(self, tmp_path: Path) -> None:
         """base_url/api_key from config fields override same keys in params."""
         config_path = tmp_path / "config.toml"
@@ -1662,7 +1783,7 @@ base_url = "https://wrong-url.com"
 """)
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
-            patch.dict("os.environ", {"CUSTOM_KEY": "secret"}, clear=False),
+            patch.dict("os.environ", {"CUSTOM_KEY": "secret"}, clear=True),
         ):
             kwargs = _get_provider_kwargs("custom")
 

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -708,14 +708,15 @@ class TestResolveAgentArg:
 
     def test_resume_thread_forces_default(self) -> None:
         """With -r present, default lets thread-metadata inference pick the agent."""
-        from deepagents_cli.main import _DEFAULT_AGENT_NAME, _resolve_agent_arg
+        from deepagents_cli._constants import DEFAULT_AGENT_NAME
+        from deepagents_cli.main import _resolve_agent_arg
 
         with patch(
             "deepagents_cli.model_config.load_recent_agent",
             return_value="researcher",
         ) as load:
             result = _resolve_agent_arg(self._args(resume_thread="abc123"))
-            assert result == _DEFAULT_AGENT_NAME
+            assert result == DEFAULT_AGENT_NAME
             load.assert_not_called()
 
     def test_uses_recent_when_valid(self) -> None:
@@ -733,7 +734,8 @@ class TestResolveAgentArg:
 
     def test_falls_back_when_recent_missing_dir(self) -> None:
         """Stale `[agents].recent` pointing at a deleted dir falls through."""
-        from deepagents_cli.main import _DEFAULT_AGENT_NAME, _resolve_agent_arg
+        from deepagents_cli._constants import DEFAULT_AGENT_NAME
+        from deepagents_cli.main import _resolve_agent_arg
 
         with (
             patch(
@@ -742,14 +744,15 @@ class TestResolveAgentArg:
             ),
             patch("deepagents_cli.main._recent_agent_is_valid", return_value=False),
         ):
-            assert _resolve_agent_arg(self._args()) == _DEFAULT_AGENT_NAME
+            assert _resolve_agent_arg(self._args()) == DEFAULT_AGENT_NAME
 
     def test_falls_back_when_no_recent(self) -> None:
         """No saved recent agent: final fallback is the hard-coded default."""
-        from deepagents_cli.main import _DEFAULT_AGENT_NAME, _resolve_agent_arg
+        from deepagents_cli._constants import DEFAULT_AGENT_NAME
+        from deepagents_cli.main import _resolve_agent_arg
 
         with patch("deepagents_cli.model_config.load_recent_agent", return_value=None):
-            assert _resolve_agent_arg(self._args()) == _DEFAULT_AGENT_NAME
+            assert _resolve_agent_arg(self._args()) == DEFAULT_AGENT_NAME
 
 
 class TestRecentAgentIsValid:

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -16,14 +16,18 @@ from deepagents_cli.model_config import (
     ModelConfigError,
     ModelProfileEntry,
     ModelSpec,
+    ProviderAuthState,
+    ProviderAuthStatus,
     _get_builtin_providers,
     _get_provider_profile_modules,
+    _is_local_endpoint,
     _load_provider_profiles,
     _profile_module_from_class_path,
     clear_caches,
     clear_default_model,
     get_available_models,
     get_model_profiles,
+    get_provider_auth_status,
     has_provider_credentials,
     is_warning_suppressed,
     load_recent_agent,
@@ -1637,14 +1641,62 @@ class TestHasProviderCredentialsFallback:
     """Tests for has_provider_credentials() falling back to ModelConfig."""
 
     def test_falls_back_to_config_no_key_required(self, tmp_path):
-        """Returns None for config provider with no api_key_env (unknown)."""
+        """Returns True for local Ollama with no api_key_env."""
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
 [models.providers.ollama]
 models = ["llama3"]
 """)
         with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
-            assert has_provider_credentials("ollama") is None
+            assert has_provider_credentials("ollama") is True
+
+    def test_ollama_remote_without_key_is_unknown(self, tmp_path):
+        """Remote Ollama without optional auth should not claim local readiness."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+base_url = "https://ollama.example.com"
+models = ["llama3"]
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            status = get_provider_auth_status("ollama")
+            legacy = has_provider_credentials("ollama")
+
+        assert status.state is ProviderAuthState.UNKNOWN
+        assert status.env_var == "OLLAMA_API_KEY"
+        assert "OLLAMA_API_KEY" in (status.detail or "")
+        assert legacy is None
+
+    def test_ollama_optional_api_key_is_configured(self, tmp_path):
+        """OLLAMA_API_KEY marks Ollama as configured for cloud/hosted use."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+base_url = "https://ollama.example.com"
+models = ["llama3"]
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {"OLLAMA_API_KEY": "test-key"}, clear=True),
+        ):
+            status = get_provider_auth_status("ollama")
+            legacy = has_provider_credentials("ollama")
+
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.env_var == "OLLAMA_API_KEY"
+        assert legacy is True
+
+    def test_google_vertexai_missing_project_uses_implicit_auth(self):
+        """Vertex AI should not fail just because GOOGLE_CLOUD_PROJECT is unset."""
+        with patch.dict("os.environ", {}, clear=True):
+            status = get_provider_auth_status("google_vertexai")
+            legacy = has_provider_credentials("google_vertexai")
+
+        assert status.state is ProviderAuthState.IMPLICIT
+        assert legacy is True
 
     def test_falls_back_to_config_with_key_set(self, tmp_path):
         """Returns True for config provider with api_key_env set in env."""
@@ -1711,6 +1763,148 @@ api_key_env = "CIS_API_KEY"
         auth failures at model-creation time.
         """
         assert has_provider_credentials("nonexistent_provider_xyz") is None
+
+
+class TestIsLocalEndpoint:
+    """Tests for _is_local_endpoint URL classification."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            None,
+            "",
+            "localhost",
+            "localhost:11434",
+            "http://localhost",
+            "http://localhost:11434",
+            "127.0.0.1:11434",
+            "http://127.0.0.1",
+            "::1",
+            "http://[::1]:11434",
+            "0.0.0.0",
+            "http://0.0.0.0:11434",
+        ],
+    )
+    def test_local_endpoints(self, url: str | None) -> None:
+        """Loopback hostnames and bare URLs resolve as local."""
+        assert _is_local_endpoint(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://ollama.example.com",
+            "http://192.168.1.5:11434",
+            "https://api.cloud.com/v1",
+            "remote-host:11434",
+        ],
+    )
+    def test_non_local_endpoints(self, url: str) -> None:
+        """Non-loopback hostnames resolve as remote."""
+        assert _is_local_endpoint(url) is False
+
+    def test_non_string_input_returns_false(self) -> None:
+        """Non-string input must not raise (defensive against TOML drift)."""
+        assert _is_local_endpoint(123) is False  # type: ignore[arg-type]
+
+
+class TestProviderAuthStatusBranches:
+    """Direct coverage of get_provider_auth_status states beyond Ollama."""
+
+    def test_managed_state_for_class_path_provider(self, tmp_path: Path) -> None:
+        """class_path without api_key_env returns MANAGED with custom-auth detail."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.cis]
+class_path = "agent_forge.integrations:CISChat"
+models = ["aviato-turbo"]
+""")
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            status = get_provider_auth_status("cis")
+
+        assert status.state is ProviderAuthState.MANAGED
+        assert status.detail == "custom auth"
+        assert status.env_var is None
+
+    def test_missing_state_for_known_provider_without_env(self) -> None:
+        """Hardcoded provider with no env set returns MISSING with the env name."""
+        with patch.dict("os.environ", {}, clear=True):
+            status = get_provider_auth_status("anthropic")
+
+        assert status.state is ProviderAuthState.MISSING
+        assert status.env_var == "ANTHROPIC_API_KEY"
+        assert status.blocks_start is True
+
+    def test_missing_state_for_config_provider_with_empty_env(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Config provider with api_key_env set but unset env returns MISSING."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.fireworks]
+models = ["llama-v3p1-70b"]
+api_key_env = "FIREWORKS_API_KEY"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            status = get_provider_auth_status("fireworks")
+
+        assert status.state is ProviderAuthState.MISSING
+        assert status.env_var == "FIREWORKS_API_KEY"
+
+    def test_ollama_host_env_drives_locality(self, tmp_path: Path) -> None:
+        """OLLAMA_HOST env var controls local vs. remote when no base_url is set."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.ollama]
+models = ["llama3"]
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict(
+                "os.environ",
+                {"OLLAMA_HOST": "https://ollama.example.com"},
+                clear=True,
+            ),
+        ):
+            status = get_provider_auth_status("ollama")
+
+        assert status.state is ProviderAuthState.UNKNOWN
+        assert status.env_var == "OLLAMA_API_KEY"
+
+
+class TestProviderAuthStatusMissingDetail:
+    """Tests for ProviderAuthStatus.missing_detail() rendering."""
+
+    def test_with_env_var_uses_env_var_message(self) -> None:
+        """env_var presence yields a 'not set or is empty' message."""
+        status = ProviderAuthStatus(
+            state=ProviderAuthState.MISSING,
+            provider="anthropic",
+            env_var="ANTHROPIC_API_KEY",
+        )
+        assert status.missing_detail() == "ANTHROPIC_API_KEY is not set or is empty"
+
+    def test_with_detail_only_falls_back_to_detail(self) -> None:
+        """Without env_var but with a detail string, returns the detail."""
+        status = ProviderAuthStatus(
+            state=ProviderAuthState.MISSING,
+            provider="custom",
+            detail="bespoke auth missing",
+        )
+        assert status.missing_detail() == "bespoke auth missing"
+
+    def test_without_env_var_or_detail_returns_unknown_provider_hint(self) -> None:
+        """Bare MISSING falls back to a 'not recognized' hint."""
+        status = ProviderAuthStatus(
+            state=ProviderAuthState.MISSING,
+            provider="phantom",
+        )
+        message = status.missing_detail()
+        assert "phantom" in message
+        assert "not recognized" in message
 
 
 class TestModelConfigGetClassPath:

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -8,7 +8,12 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
-from deepagents_cli.model_config import ModelProfileEntry
+from deepagents_cli.config import get_glyphs
+from deepagents_cli.model_config import (
+    ModelProfileEntry,
+    ProviderAuthState,
+    ProviderAuthStatus,
+)
 from deepagents_cli.widgets.model_selector import ModelSelectorScreen
 
 
@@ -809,7 +814,10 @@ class TestFormatOptionLabel:
             "anthropic:old-model",
             selected=False,
             current=False,
-            has_creds=True,
+            auth_status=ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider="anthropic",
+            ),
             status="deprecated",
         )
         from deepagents_cli.theme import DARK_COLORS
@@ -823,7 +831,10 @@ class TestFormatOptionLabel:
             "anthropic:claude-sonnet-4-5",
             selected=False,
             current=False,
-            has_creds=True,
+            auth_status=ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider="anthropic",
+            ),
             status=None,
         )
         assert "(deprecated)" not in label.plain
@@ -834,7 +845,10 @@ class TestFormatOptionLabel:
             "anthropic:new-model",
             selected=False,
             current=False,
-            has_creds=True,
+            auth_status=ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider="anthropic",
+            ),
             status="beta",
         )
         assert "(deprecated)" not in label.plain
@@ -849,13 +863,144 @@ class TestFormatOptionLabel:
             "anthropic:old-model",
             selected=False,
             current=True,
-            has_creds=True,
+            auth_status=ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider="anthropic",
+            ),
             is_default=True,
             status="deprecated",
         )
         assert "(current)" in label.plain
         assert "(default)" in label.plain
         assert "(deprecated)" in label.plain
+
+    def test_missing_credentials_warning_styles_model(self) -> None:
+        """Missing credentials should warn on the model row."""
+        label = ModelSelectorScreen._format_option_label(
+            "anthropic:claude-sonnet-4-5",
+            selected=False,
+            current=False,
+            auth_status=ProviderAuthStatus(
+                state=ProviderAuthState.MISSING,
+                provider="anthropic",
+                env_var="ANTHROPIC_API_KEY",
+            ),
+        )
+        from deepagents_cli.theme import DARK_COLORS
+
+        assert DARK_COLORS.warning in label.markup
+
+    def test_no_auth_required_does_not_warning_style_model(self) -> None:
+        """No-auth local providers should not look like missing credentials."""
+        label = ModelSelectorScreen._format_option_label(
+            "ollama:llama3",
+            selected=False,
+            current=False,
+            auth_status=ProviderAuthStatus(
+                state=ProviderAuthState.NOT_REQUIRED,
+                provider="ollama",
+                detail="local provider",
+            ),
+        )
+        from deepagents_cli.theme import DARK_COLORS
+
+        assert DARK_COLORS.warning not in label.markup
+
+
+class TestFormatAuthIndicator:
+    """Tests for provider auth indicator labels."""
+
+    def test_configured_auth_uses_checkmark(self) -> None:
+        """Configured credentials should show an explicit credentials label."""
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.CONFIGURED,
+                provider="openai",
+                env_var="OPENAI_API_KEY",
+            ),
+            get_glyphs(),
+        )
+
+        assert "credentials set" in indicator
+
+    def test_ollama_local_auth_has_no_checkmark(self) -> None:
+        """Local Ollama should not reuse the credentials-set checkmark."""
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.NOT_REQUIRED,
+                provider="ollama",
+                detail="local provider",
+            ),
+            get_glyphs(),
+        )
+
+        assert indicator == "local provider"
+
+    def test_missing_auth_names_env_var(self) -> None:
+        """Missing credentials should show the missing env var name."""
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.MISSING,
+                provider="anthropic",
+                env_var="ANTHROPIC_API_KEY",
+            ),
+            get_glyphs(),
+        )
+
+        assert "missing ANTHROPIC_API_KEY" in indicator
+
+    def test_missing_auth_without_env_var_uses_generic_message(self) -> None:
+        """MISSING without env_var falls back to a generic missing-creds label."""
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.MISSING,
+                provider="custom",
+            ),
+            get_glyphs(),
+        )
+
+        assert "missing credentials" in indicator
+
+    def test_implicit_auth_uses_detail(self) -> None:
+        """IMPLICIT state surfaces its detail string."""
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.IMPLICIT,
+                provider="google_vertexai",
+                detail="implicit auth",
+            ),
+            get_glyphs(),
+        )
+
+        assert indicator == "implicit auth"
+
+    def test_managed_auth_uses_detail(self) -> None:
+        """MANAGED state surfaces its detail string."""
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.MANAGED,
+                provider="custom",
+                detail="custom auth",
+            ),
+            get_glyphs(),
+        )
+
+        assert indicator == "custom auth"
+
+    def test_unknown_auth_uses_question_glyph(self) -> None:
+        """UNKNOWN state prefixes the detail with the question glyph."""
+        glyphs = get_glyphs()
+        indicator = ModelSelectorScreen._format_auth_indicator(
+            ProviderAuthStatus(
+                state=ProviderAuthState.UNKNOWN,
+                provider="ollama",
+                detail="remote endpoint; set OLLAMA_API_KEY if auth is required",
+            ),
+            glyphs,
+        )
+
+        assert indicator.startswith(glyphs.question)
+        assert "OLLAMA_API_KEY" in indicator
 
 
 class TestGetModelStatus:


### PR DESCRIPTION
The model selector now describes provider auth in plain language and supports both local and hosted Ollama out of the box.

## Before

- Local Ollama appeared as `? credentials unknown` even though no API key is needed — confusing for the most common Ollama setup.
- Hosted Ollama / Ollama Cloud had no first-class support — using it required hand-crafting `client_kwargs.headers` in `config.toml` or embedding Basic-auth credentials in the URL. There was no env-var path like `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`.
- Vertex AI showed as `missing credentials` even when Application Default Credentials were configured correctly, because the CLI only checked for an env var that Vertex doesn't actually require.
- Custom providers with a `class_path` (managing their own JWT, mTLS, custom headers, etc.) showed as `unknown` because the credential check was a binary yes/no/unknown.
- Missing-credential warnings just said "missing credentials" without telling you *which* env var to set.

## Now

- Each provider gets a state-specific label in the selector: `✓ credentials set`, `! missing OPENAI_API_KEY` (names the actual env var), `local provider`, `implicit auth`, `custom auth`, or `? remote endpoint; set OLLAMA_API_KEY if auth is required`.
- Local Ollama works with zero setup and is labelled correctly.
- Hosted Ollama works by setting `OLLAMA_API_KEY` — the CLI threads it through as `Authorization: Bearer <token>` in the underlying httpx client, while preserving any custom headers or client kwargs you've already configured.
- Vertex AI is recognized as implicit-auth, so ADC users no longer see false missing-credential warnings.
- Custom `class_path` providers are recognized as managing their own auth.

## Changes

- New `ProviderAuthState` enum and `ProviderAuthStatus` value type in `model_config.py`, plus `get_provider_auth_status()` to resolve them. The old `has_provider_credentials()` is kept as a compatibility shim.
- New registries — `OPTIONAL_AUTH_ENV`, `PROVIDER_HOST_ENV`, `NO_AUTH_REQUIRED_PROVIDERS` — so future no-auth or hosted-mode providers are a one-line declarative add.
- `_is_local_endpoint()` distinguishes local vs. remote endpoints (loopback hostnames, bare IPv6, scheme-less `host:port`) for providers like Ollama whose default config needs no auth but whose remote config might.
- `ModelSelectorScreen` switches from a `bool | None` credentials flag to the full `ProviderAuthStatus`; `_format_auth_indicator` renders the per-state label and uses `typing.assert_never` so any future state addition fails at type-check time instead of silently breaking the UI.