### PR TITLE
refactor(cli): defer "Connecting..." banner

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1225,6 +1225,7 @@ class DeepAgentsApp(App):
                 connecting=self._connecting,
                 resuming=self._resume_thread_intent is not None,
                 local_server=self._server_kwargs is not None,
+                defer_connecting_display=self._connecting,
                 id="welcome-banner",
             )
             yield Container(id="messages")
@@ -3603,6 +3604,11 @@ class DeepAgentsApp(App):
             queued_widget = QueuedUserMessage(value)
             self._queued_widgets.append(queued_widget)
             await self._mount_message(queued_widget)
+            if self._connecting:
+                with suppress(NoMatches):
+                    self.query_one(
+                        "#welcome-banner", WelcomeBanner
+                    ).reveal_connecting_footer()
             return
 
         await self._process_message(value, mode)

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -13,6 +13,7 @@ from textual.widgets import Static
 
 if TYPE_CHECKING:
     from textual.events import Click
+    from textual.timer import Timer
 
 from deepagents_cli import theme
 from deepagents_cli._version import __version__
@@ -48,6 +49,15 @@ _TIPS: dict[str, int] = {
 """Rotating tips shown in the welcome footer, with relative selection weights.
 
 One is picked per session. Higher weights are picked more often.
+"""
+
+_CONNECTING_FOOTER_DELAY_SECONDS = 5.0
+"""Seconds the banner waits before revealing the "Connecting..." footer.
+
+Startup is usually fast enough that flashing the spinner makes the CLI feel
+slower than it is; the welcome footer renders immediately and the connecting
+footer only appears if startup is genuinely taking a while or the user
+submits a message before the agent is reachable.
 """
 
 
@@ -90,6 +100,7 @@ class WelcomeBanner(Static):
         connecting: bool = False,
         resuming: bool = False,
         local_server: bool = False,
+        defer_connecting_display: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the welcome banner.
@@ -108,6 +119,12 @@ class WelcomeBanner(Static):
                 CLI).
 
                 Ignored when `resuming` is `True`.
+            defer_connecting_display: When `True` and `connecting` is `True`,
+                suppress the connecting footer initially and render the ready
+                footer instead, so a fast startup feels instantaneous. The
+                connecting footer is revealed by `reveal_connecting_footer`
+                (called when the user submits a message during startup) or
+                automatically after `_CONNECTING_FOOTER_DELAY_SECONDS`.
             **kwargs: Additional arguments passed to parent.
         """
         # Avoid collision with Widget._thread_id (Textual internal int)
@@ -119,6 +136,8 @@ class WelcomeBanner(Static):
         self._resuming = resuming
         self._local_server = local_server
         self._idle = False
+        self._defer_connecting_display = defer_connecting_display and connecting
+        self._defer_timer: Timer | None = None
         self._project_name: str | None = get_langsmith_project_name()
         self._project_url: str | None = None
         self._tip: str = _pick_tip()
@@ -130,6 +149,36 @@ class WelcomeBanner(Static):
         self.watch(self.app, "theme", self._on_theme_change, init=False)
         if self._project_name:
             self.run_worker(self._fetch_and_update, exclusive=True)
+        if self._defer_connecting_display:
+            self._defer_timer = self.set_timer(
+                _CONNECTING_FOOTER_DELAY_SECONDS, self._on_defer_timer_fired
+            )
+
+    def _cancel_defer_timer(self) -> None:
+        """Stop and drop the deferred-display timer if it is still pending."""
+        if self._defer_timer is not None:
+            self._defer_timer.stop()
+            self._defer_timer = None
+
+    def _on_defer_timer_fired(self) -> None:
+        """Reveal the connecting footer once the deferral window expires."""
+        self._defer_timer = None
+        self.reveal_connecting_footer()
+
+    def reveal_connecting_footer(self) -> None:
+        """Stop deferring the "Connecting..." footer and render it now.
+
+        No-op when the banner is not currently deferring (already revealed,
+        already connected, or never was connecting). Called when the user
+        submits a message before startup completes so the queued state has
+        explicit feedback.
+        """
+        if not self._defer_connecting_display:
+            return
+        self._cancel_defer_timer()
+        self._defer_connecting_display = False
+        if self._connecting:
+            self.update(self._build_banner(self._project_url))
 
     def _on_theme_change(self) -> None:
         """Re-render the banner when the app theme changes."""
@@ -175,6 +224,8 @@ class WelcomeBanner(Static):
         """
         self._connecting = False
         self._idle = False
+        self._defer_connecting_display = False
+        self._cancel_defer_timer()
         self._mcp_tool_count = mcp_tool_count
         self._mcp_unauthenticated = mcp_unauthenticated
         self._mcp_errored = mcp_errored
@@ -185,11 +236,14 @@ class WelcomeBanner(Static):
 
         Used when the server is being restarted mid-session (e.g., switching
         agents via `/agents`), so the banner reflects that no agent is
-        currently reachable.
+        currently reachable. Mid-session swaps show the connecting footer
+        immediately — only the initial app launch defers it.
         """
         self._connecting = True
         self._idle = False
         self._resuming = False
+        self._defer_connecting_display = False
+        self._cancel_defer_timer()
         self.update(self._build_banner(self._project_url))
 
     def set_idle(self) -> None:
@@ -203,6 +257,8 @@ class WelcomeBanner(Static):
         """
         self._connecting = False
         self._idle = True
+        self._defer_connecting_display = False
+        self._cancel_defer_timer()
         self.update(self._build_banner(self._project_url))
 
     def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
@@ -328,7 +384,8 @@ class WelcomeBanner(Static):
                 ]
             )
 
-        if self._connecting:
+        show_connecting = self._connecting and not self._defer_connecting_display
+        if show_connecting:
             parts.append(
                 build_connecting_footer(
                     resuming=self._resuming,

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -52,12 +52,14 @@ One is picked per session. Higher weights are picked more often.
 """
 
 _CONNECTING_FOOTER_DELAY_SECONDS = 5.0
-"""Seconds the banner waits before revealing the "Connecting..." footer.
+"""Upper bound on how long the banner waits before revealing "Connecting...".
 
 Startup is usually fast enough that flashing the spinner makes the CLI feel
 slower than it is; the welcome footer renders immediately and the connecting
 footer only appears if startup is genuinely taking a while or the user
-submits a message before the agent is reachable.
+submits a message before the agent is reachable. The timer is cancelled
+early when `set_connected`, `set_idle`, or `set_connecting` runs first, so
+this delay is the maximum — not a fixed wait.
 """
 
 
@@ -120,11 +122,12 @@ class WelcomeBanner(Static):
 
                 Ignored when `resuming` is `True`.
             defer_connecting_display: When `True` and `connecting` is `True`,
-                suppress the connecting footer initially and render the ready
-                footer instead, so a fast startup feels instantaneous. The
-                connecting footer is revealed by `reveal_connecting_footer`
-                (called when the user submits a message during startup) or
-                automatically after `_CONNECTING_FOOTER_DELAY_SECONDS`.
+                suppress the connecting footer initially so a fast startup
+                feels instantaneous; the welcome footer remains visible until
+                startup resolves. The connecting footer is revealed by
+                `reveal_connecting_footer` (called when the user submits a
+                message during startup) or automatically after
+                `_CONNECTING_FOOTER_DELAY_SECONDS`.
             **kwargs: Additional arguments passed to parent.
         """
         # Avoid collision with Widget._thread_id (Textual internal int)
@@ -168,10 +171,11 @@ class WelcomeBanner(Static):
     def reveal_connecting_footer(self) -> None:
         """Stop deferring the "Connecting..." footer and render it now.
 
-        No-op when the banner is not currently deferring (already revealed,
-        already connected, or never was connecting). Called when the user
-        submits a message before startup completes so the queued state has
-        explicit feedback.
+        No-op once the deferred state has been cleared (by reveal, connect,
+        idle, or because deferral was never active). Two callers reach this:
+        the deferral timer (`_on_defer_timer_fired`) when the wait window
+        elapses, and the app when the user submits a message during startup
+        so the queued state has explicit feedback.
         """
         if not self._defer_connecting_display:
             return

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -456,3 +456,73 @@ class TestBannerConnectingFooterVariants:
         plain = widget._build_banner().plain
         assert "Resuming..." in plain
         assert "local server" not in plain
+
+
+class TestDeferredConnectingDisplay:
+    """Tests for deferred display of the connecting footer at startup."""
+
+    def test_deferred_shows_ready_footer(self) -> None:
+        """When deferring, the welcome footer renders despite `connecting=True`."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, defer_connecting_display=True)
+        plain = widget._build_banner().plain
+        assert "Connecting to server..." not in plain
+        assert "Ready to code" in plain
+
+    def test_defer_flag_ignored_when_not_connecting(self) -> None:
+        """`defer_connecting_display` is a no-op when `connecting` is `False`."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=False, defer_connecting_display=True)
+        assert widget._defer_connecting_display is False
+        assert "Ready to code" in widget._build_banner().plain
+
+    def test_reveal_shows_connecting_footer(self) -> None:
+        """`reveal_connecting_footer` flips the banner to the connecting state."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, defer_connecting_display=True)
+        with patch.object(widget, "update"):
+            widget.reveal_connecting_footer()
+        plain = widget._build_banner().plain
+        assert "Connecting to server..." in plain
+        assert "Ready to code" not in plain
+
+    def test_reveal_is_noop_when_not_deferring(self) -> None:
+        """Calling `reveal_connecting_footer` without deferral does nothing."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True)
+        with patch.object(widget, "update") as mock_update:
+            widget.reveal_connecting_footer()
+        mock_update.assert_not_called()
+
+    def test_set_connected_clears_deferred_state(self) -> None:
+        """`set_connected` resets the deferral flag and stops the timer."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, defer_connecting_display=True)
+        timer = MagicMock()
+        widget._defer_timer = timer
+        with patch.object(widget, "update"):
+            widget.set_connected()
+        assert widget._defer_connecting_display is False
+        assert widget._defer_timer is None
+        timer.stop.assert_called_once()
+
+    def test_set_idle_clears_deferred_state(self) -> None:
+        """`set_idle` resets the deferral flag and stops the timer."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner(connecting=True, defer_connecting_display=True)
+        timer = MagicMock()
+        widget._defer_timer = timer
+        with patch.object(widget, "update"):
+            widget.set_idle()
+        assert widget._defer_connecting_display is False
+        assert widget._defer_timer is None
+        timer.stop.assert_called_once()
+
+    def test_set_connecting_does_not_defer(self) -> None:
+        """Mid-session `set_connecting` shows the connecting footer immediately."""
+        with patch.dict("os.environ", {}, clear=True):
+            widget = WelcomeBanner()
+        with patch.object(widget, "update"):
+            widget.set_connecting()
+        assert widget._defer_connecting_display is False
+        assert "Connecting to server..." in widget._build_banner().plain


### PR DESCRIPTION
Defer the welcome banner's "Connecting to server..." footer for the first 5 seconds of startup so a fast launch never flashes the spinner. If the user submits a message before the agent is reachable — or the deferral window expires — the connecting footer appears so queued state has explicit feedback.