### PR TITLE
feat(sdk): add context_lines parameter to grep for surrounding-line visibility

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -309,6 +309,7 @@ class CompositeBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search files for literal text pattern.
 
@@ -320,6 +321,8 @@ class CompositeBackend(BackendProtocol):
             path: Directory to search. None searches all backends.
             glob: Glob pattern to filter files (e.g., "*.py", "**/*.txt").
                 Filters by filename, not content.
+            context_lines: Number of surrounding lines to include with each match.
+                0 (default) returns only the matching line.
 
         Returns:
             GrepResult with matches or error.
@@ -338,7 +341,7 @@ class CompositeBackend(BackendProtocol):
                 path=path,
             )
             if route_prefix is not None:
-                grep_result = self._coerce_grep_result(backend.grep(pattern, backend_path, glob))
+                grep_result = self._coerce_grep_result(backend.grep(pattern, backend_path, glob, context_lines))
                 if grep_result.error:
                     return grep_result
                 return GrepResult(matches=[_remap_grep_path(m, route_prefix) for m in (grep_result.matches or [])])
@@ -347,26 +350,27 @@ class CompositeBackend(BackendProtocol):
         # Otherwise, search only the default backend
         if path is None or path == "/":
             all_matches: list[GrepMatch] = []
-            default_result = self._coerce_grep_result(self.default.grep(pattern, path, glob))
+            default_result = self._coerce_grep_result(self.default.grep(pattern, path, glob, context_lines))
             if default_result.error:
                 return default_result
             all_matches.extend(default_result.matches or [])
 
             for route_prefix, backend in self.routes.items():
-                grep_result = self._coerce_grep_result(backend.grep(pattern, "/", glob))
+                grep_result = self._coerce_grep_result(backend.grep(pattern, "/", glob, context_lines))
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
 
             return GrepResult(matches=all_matches)
         # Path specified but doesn't match a route - search only default
-        return self._coerce_grep_result(self.default.grep(pattern, path, glob))
+        return self._coerce_grep_result(self.default.grep(pattern, path, glob, context_lines))
 
     async def agrep(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Async version of grep.
 
@@ -379,7 +383,7 @@ class CompositeBackend(BackendProtocol):
                 path=path,
             )
             if route_prefix is not None:
-                grep_result = self._coerce_grep_result(await backend.agrep(pattern, backend_path, glob))
+                grep_result = self._coerce_grep_result(await backend.agrep(pattern, backend_path, glob, context_lines))
                 if grep_result.error:
                     return grep_result
                 return GrepResult(matches=[_remap_grep_path(m, route_prefix) for m in (grep_result.matches or [])])
@@ -388,20 +392,20 @@ class CompositeBackend(BackendProtocol):
         # Otherwise, search only the default backend
         if path is None or path == "/":
             all_matches: list[GrepMatch] = []
-            default_result = self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
+            default_result = self._coerce_grep_result(await self.default.agrep(pattern, path, glob, context_lines))
             if default_result.error:
                 return default_result
             all_matches.extend(default_result.matches or [])
 
             for route_prefix, backend in self.routes.items():
-                grep_result = self._coerce_grep_result(await backend.agrep(pattern, "/", glob))
+                grep_result = self._coerce_grep_result(await backend.agrep(pattern, "/", glob, context_lines))
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
 
             return GrepResult(matches=all_matches)
         # Path specified but doesn't match a route - search only default
-        return self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
+        return self._coerce_grep_result(await self.default.agrep(pattern, path, glob, context_lines))
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching a glob pattern, routing by path prefix."""

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -514,6 +514,7 @@ class FilesystemBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search for a literal text pattern in files.
 
@@ -523,6 +524,7 @@ class FilesystemBackend(BackendProtocol):
             pattern: Literal string to search for (NOT regex).
             path: Directory or file path to search in. Defaults to current directory.
             glob: Optional glob pattern to filter which files to search.
+            context_lines: Number of lines to include before and after each match.
 
         Returns:
             GrepResult with matches or error.
@@ -544,30 +546,32 @@ class FilesystemBackend(BackendProtocol):
             return GrepResult(error=f"Error searching path '{search_path}': {e}", matches=[])
 
         # Try ripgrep first (with -F flag for literal search)
-        results = self._ripgrep_search(pattern, base_full, glob)
+        results = self._ripgrep_search(pattern, base_full, glob, context_lines)
         if results is None:
             # Python fallback needs escaped pattern for literal search
-            results = self._python_search(re.escape(pattern), base_full, glob)
+            results = self._python_search(re.escape(pattern), base_full, glob, context_lines)
 
         matches: list[GrepMatch] = []
-        for fpath, items in results.items():
-            for line_num, line_text in items:
-                matches.append({"path": fpath, "line": int(line_num), "text": line_text})
+        for file_matches in results.values():
+            matches.extend(file_matches)
         return GrepResult(matches=matches)
 
-    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:  # noqa: C901  # Split except clauses for logging
+    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None, context_lines: int = 0) -> dict[str, list[GrepMatch]] | None:  # noqa: C901, PLR0912, PLR0915
         """Search using ripgrep with fixed-string (literal) mode.
 
         Args:
             pattern: Literal string to search for (unescaped).
             base_full: Resolved base path to search in.
             include_glob: Optional glob pattern to filter files.
+            context_lines: Number of surrounding lines to collect per match.
 
         Returns:
-            Dict mapping file paths to list of `(line_number, line_text)` tuples.
+            Dict mapping file paths to lists of GrepMatch dicts.
                 Returns `None` if ripgrep is unavailable or times out.
         """
         cmd = ["rg", "--json", "-F"]  # -F enables fixed-string (literal) mode
+        if context_lines > 0:
+            cmd.extend(["-C", str(context_lines)])
         if include_glob:
             cmd.extend(["--glob", include_glob])
         cmd.extend(["--", pattern, str(base_full)])
@@ -583,13 +587,16 @@ class FilesystemBackend(BackendProtocol):
         except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
             return None
 
-        results: dict[str, list[tuple[int, str]]] = {}
-        for line in proc.stdout.splitlines():
+        # Collect match and context entries per resolved virtual path.
+        file_data: dict[str, dict] = {}
+
+        for raw_line in proc.stdout.splitlines():
             try:
-                data = json.loads(line)
+                data = json.loads(raw_line)
             except json.JSONDecodeError:
                 continue
-            if data.get("type") != "match":
+            entry_type = data.get("type")
+            if entry_type not in ("match", "context"):
                 continue
             pdata = data.get("data", {})
             ftext = pdata.get("path", {}).get("text")
@@ -611,11 +618,28 @@ class FilesystemBackend(BackendProtocol):
             lt = pdata.get("lines", {}).get("text", "").rstrip("\n")
             if ln is None:
                 continue
-            results.setdefault(virt, []).append((int(ln), lt))
+            fd = file_data.setdefault(virt, {"matches": [], "contexts": {}})
+            if entry_type == "match":
+                fd["matches"].append((int(ln), lt))
+            else:
+                fd["contexts"][int(ln)] = lt
+
+        # Assemble GrepMatch objects, attaching context windows to each match.
+        results: dict[str, list[GrepMatch]] = {}
+        for virt, fd in file_data.items():
+            contexts: dict[int, str] = fd["contexts"]
+            file_matches: list[GrepMatch] = []
+            for match_ln, match_text in fd["matches"]:
+                match: GrepMatch = {"path": virt, "line": match_ln, "text": match_text}
+                if context_lines > 0:
+                    match["context_before"] = [(ln, contexts[ln]) for ln in range(match_ln - context_lines, match_ln) if ln in contexts]
+                    match["context_after"] = [(ln, contexts[ln]) for ln in range(match_ln + 1, match_ln + context_lines + 1) if ln in contexts]
+                file_matches.append(match)
+            results[virt] = file_matches
 
         return results
 
-    def _python_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]]:  # noqa: C901, PLR0912
+    def _python_search(self, pattern: str, base_full: Path, include_glob: str | None, context_lines: int = 0) -> dict[str, list[GrepMatch]]:  # noqa: C901, PLR0912
         """Fallback search using Python when ripgrep is unavailable.
 
         Recursively searches files, respecting `max_file_size_bytes` limit.
@@ -624,14 +648,15 @@ class FilesystemBackend(BackendProtocol):
             pattern: Escaped regex pattern (from re.escape) for literal search.
             base_full: Resolved base path to search in.
             include_glob: Optional glob pattern to filter files by name.
+            context_lines: Number of surrounding lines to collect per match.
 
         Returns:
-            Dict mapping file paths to list of `(line_number, line_text)` tuples.
+            Dict mapping file paths to lists of GrepMatch dicts.
         """
         # Compile escaped pattern once for efficiency (used in loop)
         regex = re.compile(pattern)
 
-        results: dict[str, list[tuple[int, str]]] = {}
+        results: dict[str, list[GrepMatch]] = {}
         root = base_full if base_full.is_dir() else base_full.parent
 
         for fp in root.rglob("*"):
@@ -653,7 +678,8 @@ class FilesystemBackend(BackendProtocol):
                 content = fp.read_text()
             except (UnicodeDecodeError, PermissionError, OSError, RuntimeError):
                 continue
-            for line_num, line in enumerate(content.splitlines(), 1):
+            file_lines = content.splitlines()
+            for line_idx, line in enumerate(file_lines):
                 if regex.search(line):
                     if self.virtual_mode:
                         try:
@@ -666,7 +692,14 @@ class FilesystemBackend(BackendProtocol):
                             continue
                     else:
                         virt_path = str(fp)
-                    results.setdefault(virt_path, []).append((line_num, line))
+                    line_num = line_idx + 1
+                    match: GrepMatch = {"path": virt_path, "line": line_num, "text": line}
+                    if context_lines > 0:
+                        before_start = max(0, line_idx - context_lines)
+                        match["context_before"] = [(before_start + i + 1, file_lines[before_start + i]) for i in range(line_idx - before_start)]
+                        after_end = min(len(file_lines), line_idx + 1 + context_lines)
+                        match["context_after"] = [(line_idx + 2 + i, file_lines[line_idx + 1 + i]) for i in range(after_end - line_idx - 1)]
+                    results.setdefault(virt_path, []).append(match)
 
         return results
 

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -153,6 +153,12 @@ class GrepMatch(TypedDict):
     text: str
     """Content of the matching line."""
 
+    context_before: NotRequired[list[tuple[int, str]]]
+    """Lines preceding the match as (line_number, text) pairs. Present when context_lines > 0."""
+
+    context_after: NotRequired[list[tuple[int, str]]]
+    """Lines following the match as (line_number, text) pairs. Present when context_lines > 0."""
+
 
 class FileData(TypedDict):
     """Data structure for storing file contents with metadata."""
@@ -401,6 +407,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,  # noqa: ARG002
     ) -> "GrepResult":
         """Search for a literal text pattern in files.
 
@@ -427,6 +434,11 @@ class BackendProtocol(abc.ABC):  # noqa: B024
                 - `**` matches any directories recursively
                 - `?` matches single character
                 - `[abc]` matches one character from set
+
+            context_lines: Number of surrounding lines to include with each match.
+
+                0 (default) returns only the matching line.
+                Positive values attach up to N lines before and after each match.
 
         Examples:
             - `'*.py'` - only search Python files
@@ -460,9 +472,10 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> "GrepResult":
         """Async version of `grep`."""
-        return await asyncio.to_thread(self.grep, pattern, path, glob)
+        return await asyncio.to_thread(self.grep, pattern, path, glob, context_lines)
 
     def glob(self, pattern: str, path: str = "/") -> "GlobResult":
         """Find files matching a glob pattern.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -727,11 +727,12 @@ except PermissionError:
             )
         return EditResult(error=f"Error editing file '{file_path}': {error}")
 
-    def grep(
+    def grep(  # noqa: C901, PLR0912, PLR0915
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search file contents for a literal string using `grep -F`.
 
@@ -742,6 +743,7 @@ except PermissionError:
                 Defaults to `"."`.
             glob: Optional file-name glob to restrict the search
                 (e.g. `'*.py'`).
+            context_lines: Number of lines to include before and after each match.
 
         Returns:
             `GrepResult` with a list of `GrepMatch` dicts, or `error` on failure.
@@ -750,6 +752,8 @@ except PermissionError:
 
         # Build grep command to get structured output
         grep_opts = "-rHnF"  # recursive, with filename, with line number, fixed-strings (literal)
+        if context_lines > 0:
+            grep_opts += f" -C {context_lines}"
 
         # Add glob pattern if specified
         glob_pattern = ""
@@ -766,19 +770,65 @@ except PermissionError:
         if not output:
             return GrepResult(matches=[])
 
-        # Parse grep output into GrepMatch objects
         matches: list[GrepMatch] = []
-        for line in output.split("\n"):
-            # Format is: path:line_number:text
-            parts = line.split(":", 2)
-            if len(parts) >= 3:  # noqa: PLR2004  # Grep output field count
-                matches.append(
-                    {
-                        "path": parts[0],
-                        "line": int(parts[1]),
-                        "text": parts[2],
-                    }
-                )
+
+        if context_lines == 0:
+            # Simple case: each line is "path:line_number:text"
+            for line in output.split("\n"):
+                parts = line.split(":", 2)
+                if len(parts) >= 3:  # noqa: PLR2004  # Grep output field count
+                    try:
+                        matches.append({"path": parts[0], "line": int(parts[1]), "text": parts[2]})
+                    except ValueError:
+                        continue
+        else:
+            # Context case: match lines use "path:num:text", context lines use "path-num-text",
+            # groups are separated by "--".
+            pending_before: list[tuple[int, str]] = []
+            current_match: GrepMatch | None = None
+
+            for raw_line in output.split("\n"):
+                if raw_line == "--":
+                    if current_match is not None:
+                        matches.append(current_match)
+                        current_match = None
+                    pending_before = []
+                    continue
+
+                # Try match format first: "path:linenum:text"
+                colon_parts = raw_line.split(":", 2)
+                if len(colon_parts) >= 3:  # noqa: PLR2004
+                    try:
+                        line_num = int(colon_parts[1])
+                        if current_match is not None:
+                            matches.append(current_match)
+                        current_match = {
+                            "path": colon_parts[0],
+                            "line": line_num,
+                            "text": colon_parts[2],
+                            "context_before": pending_before,
+                            "context_after": [],
+                        }
+                        pending_before = []
+                        continue
+                    except ValueError:
+                        pass
+
+                # Try context format: "path-linenum-text"
+                dash_parts = raw_line.split("-", 2)
+                if len(dash_parts) >= 3:  # noqa: PLR2004
+                    try:
+                        ctx_ln = int(dash_parts[1])
+                        if current_match is not None:
+                            current_match.setdefault("context_after", []).append((ctx_ln, dash_parts[2]))
+                        else:
+                            pending_before.append((ctx_ln, dash_parts[2]))
+                        continue
+                    except ValueError:
+                        pass
+
+            if current_match is not None:
+                matches.append(current_match)
 
         return GrepResult(matches=matches)
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -295,10 +295,11 @@ class StateBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search state files for a literal text pattern."""
         files = self._read_files()
-        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob)
+        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob, context_lines)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Get FileInfo for files matching glob pattern."""

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -688,6 +688,7 @@ class StoreBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search store files for a literal text pattern."""
         store = self._get_store()
@@ -699,7 +700,7 @@ class StoreBackend(BackendProtocol):
                 files[item.key] = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
-        return grep_matches_from_files(files, pattern, path, glob)
+        return grep_matches_from_files(files, pattern, path, glob, context_lines)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching a glob pattern in the store."""

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -697,6 +697,7 @@ def grep_matches_from_files(
     pattern: str,
     path: str | None = None,
     glob: str | None = None,
+    context_lines: int = 0,
 ) -> GrepResult:
     """Return structured grep matches from an in-memory files mapping.
 
@@ -716,12 +717,20 @@ def grep_matches_from_files(
     if glob:
         filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
 
-    matches: list[GrepMatch] = []
+    matches: list[_GrepMatch] = []
     for file_path, file_data in filtered.items():
         content_str = _normalize_content(file_data)
-        for line_num, line in enumerate(content_str.split("\n"), 1):
+        file_lines = content_str.split("\n")
+        for line_idx, line in enumerate(file_lines):
             if pattern in line:  # Simple substring search for literal matching
-                matches.append({"path": file_path, "line": int(line_num), "text": line})
+                line_num = line_idx + 1
+                match: _GrepMatch = {"path": file_path, "line": line_num, "text": line}
+                if context_lines > 0:
+                    before_start = max(0, line_idx - context_lines)
+                    match["context_before"] = [(before_start + i + 1, file_lines[before_start + i]) for i in range(line_idx - before_start)]
+                    after_end = min(len(file_lines), line_idx + 1 + context_lines)
+                    match["context_after"] = [(line_idx + 2 + i, file_lines[line_idx + 1 + i]) for i in range(after_end - line_idx - 1)]
+                matches.append(match)
     return GrepResult(matches=matches)
 
 
@@ -733,11 +742,33 @@ def build_grep_results_dict(matches: list[GrepMatch]) -> dict[str, list[tuple[in
     return grouped
 
 
-def format_grep_matches(
-    matches: list[GrepMatch],
+def format_grep_matches(  # noqa: C901
+    matches: list[_GrepMatch],
     output_mode: Literal["files_with_matches", "content", "count"],
 ) -> str:
     """Format structured grep matches using existing formatting logic."""
     if not matches:
         return "No matches found"
+    has_context = any("context_before" in m or "context_after" in m for m in matches)
+    if output_mode == "content" and has_context:
+        grouped: dict[str, list[_GrepMatch]] = {}
+        for m in matches:
+            grouped.setdefault(m["path"], []).append(m)
+        lines = []
+        for file_path in sorted(grouped.keys()):
+            lines.append(f"{file_path}:")
+            emitted: set[int] = set()
+            for match in grouped[file_path]:
+                for ctx_ln, ctx_text in match.get("context_before", []):
+                    if ctx_ln not in emitted:
+                        lines.append(f"  {ctx_ln}: {ctx_text}")
+                        emitted.add(ctx_ln)
+                if match["line"] not in emitted:
+                    lines.append(f"  {match['line']}: {match['text']}")
+                    emitted.add(match["line"])
+                for ctx_ln, ctx_text in match.get("context_after", []):
+                    if ctx_ln not in emitted:
+                        lines.append(f"  {ctx_ln}: {ctx_text}")
+                        emitted.add(ctx_ln)
+        return "\n".join(lines)
     return _format_grep_results(build_grep_results_dict(matches), output_mode)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -294,6 +294,11 @@ class GrepSchema(BaseModel):
         default="files_with_matches",
         description="Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
     )
+    context_lines: int = Field(
+        default=0,
+        ge=0,
+        description="Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+    )
 
 
 class ExecuteSchema(BaseModel):
@@ -1353,6 +1358,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            context_lines: Annotated[
+                int,
+                "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            ] = 0,
         ) -> ToolMessage:
             """Synchronous wrapper for grep tool."""
             if path is not None:
@@ -1373,7 +1382,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = resolved_backend.grep(pattern, path=path, glob=glob)
+            grep_result = resolved_backend.grep(pattern, path=path, glob=glob, context_lines=context_lines)
             if grep_result.error:
                 return ToolMessage(
                     content=grep_result.error,
@@ -1400,6 +1409,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            context_lines: Annotated[
+                int,
+                "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            ] = 0,
         ) -> ToolMessage:
             """Asynchronous wrapper for grep tool."""
             if path is not None:
@@ -1420,7 +1433,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob)
+            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob, context_lines=context_lines)
             if grep_result.error:
                 return ToolMessage(
                     content=grep_result.error,

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1042,7 +1042,7 @@ def test_composite_grep_error_in_routed_backend() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        def grep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        def grep(self, pattern: str, path: str | None = None, glob: str | None = None, context_lines: int = 0):
             return "Invalid regex pattern error"
 
     error_backend = ErrorBackend()
@@ -1061,7 +1061,7 @@ def test_composite_grep_error_in_routed_backend_at_root() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        def grep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        def grep(self, pattern: str, path: str | None = None, glob: str | None = None, context_lines: int = 0):
             return "Backend error occurred"
 
     error_backend = ErrorBackend()
@@ -1080,7 +1080,7 @@ def test_composite_grep_error_in_default_backend_at_root() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorDefaultBackend(StoreBackend):
-        def grep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        def grep(self, pattern: str, path: str | None = None, glob: str | None = None, context_lines: int = 0):
             return "Default backend error"
 
     error_default = ErrorDefaultBackend()

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -928,7 +928,7 @@ async def test_composite_agrep_error_in_routed_backend_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, context_lines: int = 0):
             return "Invalid regex pattern error"
 
     error_backend = ErrorBackend()
@@ -947,7 +947,7 @@ async def test_composite_agrep_error_in_routed_backend_at_root_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, context_lines: int = 0):
             return "Backend error occurred"
 
     error_backend = ErrorBackend()
@@ -966,7 +966,7 @@ async def test_composite_agrep_error_in_default_backend_at_root_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorDefaultBackend(StoreBackend):
-        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, context_lines: int = 0):
             return "Default backend error"
 
     error_default = ErrorDefaultBackend()

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -8,6 +8,7 @@ from langchain_core.messages import ToolMessage
 from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
+from deepagents.backends.utils import format_grep_matches
 from deepagents.middleware.filesystem import FilesystemMiddleware
 
 
@@ -557,6 +558,57 @@ def test_grep_literal_search_with_special_chars(tmp_path: Path, pattern: str, ex
     matches = be.grep(pattern, path="/").matches
     assert matches is not None
     assert any(expected_file in m["path"] for m in matches), f"Pattern '{pattern}' not found in {expected_file}"
+
+
+def test_grep_context_lines_zero_has_no_context_fields(tmp_path: Path) -> None:
+    """context_lines=0 (default) must not add context_before/context_after to matches."""
+    (tmp_path / "f.py").write_text("alpha\nbeta\ngamma\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    matches = be.grep("beta", path="/", context_lines=0).matches
+    assert len(matches) == 1
+    assert "context_before" not in matches[0]
+    assert "context_after" not in matches[0]
+
+
+def test_grep_context_lines_returns_surrounding_lines(tmp_path: Path) -> None:
+    """context_lines=N attaches N lines of context before and after each match."""
+    (tmp_path / "f.py").write_text("alpha\nbeta\ngamma\ndelta\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    matches = be.grep("beta", path="/", context_lines=1).matches
+    assert len(matches) == 1
+    m = matches[0]
+    assert m["line"] == 2
+    assert m["context_before"] == [(1, "alpha")]
+    assert m["context_after"] == [(3, "gamma")]
+
+
+def test_grep_context_lines_clamps_at_file_boundaries(tmp_path: Path) -> None:
+    """context_lines never goes past the start or end of the file."""
+    (tmp_path / "f.py").write_text("alpha\nbeta\ngamma\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    # Match on first line: no context_before
+    matches = be.grep("alpha", path="/", context_lines=2).matches
+    assert len(matches) == 1
+    assert matches[0]["context_before"] == []
+    assert len(matches[0]["context_after"]) == 2
+
+    # Match on last non-empty line: no context_after
+    matches = be.grep("gamma", path="/", context_lines=2).matches
+    assert len(matches) == 1
+    assert len(matches[0]["context_before"]) == 2
+
+
+def test_grep_context_lines_no_duplicate_lines_when_matches_overlap(tmp_path: Path) -> None:
+    """format_grep_matches must not emit the same line number twice for overlapping context windows."""
+    (tmp_path / "f.py").write_text("a\nmatch1\nb\nmatch2\nc\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    matches = be.grep("match", path="/", context_lines=1).matches
+    assert len(matches) == 2
+    formatted = format_grep_matches(matches, output_mode="content")
+    content_lines = [ln for ln in formatted.split("\n") if ln.strip() and ":" in ln.strip()[:5]]
+    line_nums = [ln.strip().split(":")[0] for ln in content_lines if ln.strip()[0].isdigit()]
+    assert len(line_nums) == len(set(line_nums)), f"Duplicate line numbers in output: {line_nums}"
 
 
 class TestToVirtualPath:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -657,6 +657,49 @@ def test_sandbox_grep_literal_search() -> None:
     assert "grep -rHnF" in sandbox.last_command
 
 
+def test_sandbox_grep_context_lines_zero_has_no_context_fields() -> None:
+    """context_lines=0 (default) must not add context_before/context_after to sandbox matches."""
+    sandbox = MockSandbox()
+
+    def mock_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
+        return ExecuteResponse(
+            output="/test/f.py:2:beta",
+            exit_code=0,
+            truncated=False,
+        )
+
+    sandbox.execute = mock_execute
+    matches = sandbox.grep("beta", path="/test", context_lines=0).matches
+    assert len(matches) == 1
+    assert "context_before" not in matches[0]
+    assert "context_after" not in matches[0]
+
+
+def test_sandbox_grep_context_lines_passes_flag_and_parses_output() -> None:
+    """context_lines=N appends -C N to the grep command and parses context lines."""
+    sandbox = MockSandbox()
+
+    def mock_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
+        sandbox.last_command = command
+        # Simulate grep -C 1 output: context lines use dash separator, matches use colon
+        return ExecuteResponse(
+            output="/test/f.py-1-alpha\n/test/f.py:2:beta\n/test/f.py-3-gamma",
+            exit_code=0,
+            truncated=False,
+        )
+
+    sandbox.execute = mock_execute
+    matches = sandbox.grep("beta", path="/test", context_lines=1).matches
+    assert sandbox.last_command is not None
+    assert "-C 1" in sandbox.last_command
+    assert len(matches) == 1
+    m = matches[0]
+    assert m["line"] == 2
+    assert m["text"] == "beta"
+    assert m["context_before"] == [(1, "alpha")]
+    assert m["context_after"] == [(3, "gamma")]
+
+
 def test_sandbox_grep_quotes_include_glob() -> None:
     """Test that grep shell-quotes the include glob pattern."""
     sandbox = MockSandbox()

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -435,6 +435,30 @@ def test_store_backend_grep_literal_search_special_chars(pattern: str, expected_
     assert any(expected_file in m["path"] for m in matches), f"Pattern '{pattern}' not found in {expected_file}"
 
 
+def test_store_backend_grep_context_lines_zero_has_no_context_fields() -> None:
+    """context_lines=0 must not add context_before/context_after to store-backend matches."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/f.txt", "alpha\nbeta\ngamma\n")
+    matches = be.grep("beta", path="/", context_lines=0).matches
+    assert len(matches) == 1
+    assert "context_before" not in matches[0]
+    assert "context_after" not in matches[0]
+
+
+def test_store_backend_grep_context_lines_returns_surrounding_lines() -> None:
+    """context_lines=N attaches N surrounding lines to each store-backend match."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/f.txt", "alpha\nbeta\ngamma\ndelta\n")
+    matches = be.grep("beta", path="/", context_lines=1).matches
+    assert len(matches) == 1
+    m = matches[0]
+    assert m["line"] == 2
+    assert m["context_before"] == [(1, "alpha")]
+    assert m["context_after"] == [(3, "gamma")]
+
+
 # --- _validate_namespace tests ---
 
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -174,6 +174,12 @@
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -174,6 +174,12 @@
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -174,6 +174,12 @@
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -174,6 +174,12 @@
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -174,6 +174,12 @@
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines to include before and after each match. 0 (default) returns the matching line only.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {


### PR DESCRIPTION
Fixes #3109

Adds a `context_lines: int = 0` parameter to the `grep` tool across all backends. When `context_lines > 0`, each `GrepMatch` includes `context_before` and `context_after` as `(line_number, text)` pairs, so agents can see surrounding code in a single call instead of issuing follow-up `read_file` requests. The default of `0` preserves current behaviour exactly — no breaking change.

Three evals in `libs/evals/tests/evals/test_grep_context_lines.py` benchmark how well models use the new parameter: a prompted correctness check, a multi-file efficiency check (single grep call vs. N read_file fallbacks), and an unprompted discovery check that benchmarks whether a model reaches for `context_lines` on its own. All three pass at 1.00 correctness on claude-haiku-4-5.


**How did you verify your code works?**

Unit tests across all backends (filesystem ripgrep path, Python fallback, sandbox, store, composite) cover: zero context leaves no extra keys, N-line windows are correct, boundaries are clamped, overlapping windows are deduplicated in `format_grep_matches`. Smoke-test snapshots updated. Three evals run and pass end-to-end against a live model.
`LANGSMITH_TRACING=true make evals MODEL=claude-haiku-4-5-20251001 PYTEST_EXTRA="-k test_grep_context_lines -v --tb=short"`
<img width="1439" height="248" alt="image" src="https://github.com/user-attachments/assets/6461d83b-87b3-4e42-8f25-e97f6a11ab63" />

## Social handles (optional)
LinkedIn: https://linkedin.com/in/ninaadrao