### PR TITLE
style(cli): hide "credentials set" indicator in `/model` header

### DIFF
--- a/libs/cli/deepagents_cli/widgets/model_selector.py
+++ b/libs/cli/deepagents_cli/widgets/model_selector.py
@@ -631,19 +631,21 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         all_widgets: list[Static] = []
 
         for provider, model_entries in by_provider.items():
-            # Provider header with auth/readiness indicator.
+            # Provider header; auth/readiness indicator appended only when non-empty.
             auth_status = auth_statuses[provider]
             auth_indicator = self._format_auth_indicator(auth_status, glyphs)
-            all_widgets.append(
-                Static(
-                    Content.from_markup(
-                        "[bold]$provider[/bold] [dim]$auth[/dim]",
-                        provider=provider,
-                        auth=auth_indicator,
-                    ),
-                    classes="model-provider-header",
+            if auth_indicator:
+                header_content = Content.from_markup(
+                    "[bold]$provider[/bold] [dim]$auth[/dim]",
+                    provider=provider,
+                    auth=auth_indicator,
                 )
-            )
+            else:
+                header_content = Content.from_markup(
+                    "[bold]$provider[/bold]",
+                    provider=provider,
+                )
+            all_widgets.append(Static(header_content, classes="model-provider-header"))
 
             for model_spec, _prov in model_entries:
                 is_current = model_spec == current_spec
@@ -705,12 +707,13 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             glyphs: Glyph table for the active terminal mode.
 
         Returns:
-            Text shown next to the provider name.
+            Text shown next to the provider name, or an empty string when no
+                indicator should be rendered (e.g., `CONFIGURED`).
         """
         state = auth_status.state
         match state:
             case ProviderAuthState.CONFIGURED:
-                return f"{glyphs.checkmark} credentials set"
+                return ""
             case ProviderAuthState.MISSING:
                 if auth_status.env_var:
                     return f"{glyphs.warning} missing {auth_status.env_var}"

--- a/libs/cli/tests/unit_tests/test_model_selector.py
+++ b/libs/cli/tests/unit_tests/test_model_selector.py
@@ -935,8 +935,8 @@ class TestFormatOptionLabel:
 class TestFormatAuthIndicator:
     """Tests for provider auth indicator labels."""
 
-    def test_configured_auth_uses_checkmark(self) -> None:
-        """Configured credentials should show an explicit credentials label."""
+    def test_configured_auth_renders_no_indicator(self) -> None:
+        """Configured credentials hide the indicator to keep headers clean."""
         indicator = ModelSelectorScreen._format_auth_indicator(
             ProviderAuthStatus(
                 state=ProviderAuthState.CONFIGURED,
@@ -946,10 +946,10 @@ class TestFormatAuthIndicator:
             get_glyphs(),
         )
 
-        assert "credentials set" in indicator
+        assert indicator == ""
 
     def test_ollama_local_auth_has_no_checkmark(self) -> None:
-        """Local Ollama should not reuse the credentials-set checkmark."""
+        """Local Ollama uses its own detail, not the CONFIGURED empty indicator."""
         indicator = ModelSelectorScreen._format_auth_indicator(
             ProviderAuthStatus(
                 state=ProviderAuthState.NOT_REQUIRED,


### PR DESCRIPTION
Drop the `✓ credentials set` indicator from configured providers in the `/model` switcher — when credentials are present, the header reads cleanly with just the provider name instead of a redundant confirmation. Other auth states (missing, implicit, custom, unknown) keep their indicators since they convey real signal.