### PR TITLE
feat(cli): set-as-default in `/agents` picker, harden persistence

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1767,6 +1767,37 @@ class DeepAgentsApp(App):
         # are already set eagerly for the status bar display; this call
         # does the heavy langchain import + SDK init and may refine them
         # (e.g., context_limit from the model profile).
+        # Persist the user-chosen default so a later bare `deepagents`
+        # relaunch brings the user back to it. See
+        # `_restart_server_for_agent_swap` for why one-off resumes don't
+        # mutate `_default_assistant_id` and why the persisted default
+        # is decoupled from the per-session `_assistant_id`.
+        # Runs BEFORE deferred model creation so a `ModelConfigError`
+        # (e.g., missing API key) doesn't prevent the recent-agent write
+        # — the user's intent to use this agent shouldn't depend on
+        # whether their credentials happened to be valid this launch.
+        if self._default_assistant_id:
+            from deepagents_cli.model_config import save_recent_agent
+
+            saved = await asyncio.to_thread(
+                save_recent_agent, self._default_assistant_id
+            )
+            if not saved:
+                logger.warning(
+                    "Could not persist recent agent %r to config at startup",
+                    self._default_assistant_id,
+                )
+                # Mirror the visibility of the picker-swap path: if the
+                # write fails here, the user has no way to know unless
+                # we surface it. Toast severity matches the swap path.
+                self.notify(
+                    "Could not save recent agent to config at startup; "
+                    "next bare launch will not return to it.",
+                    severity="warning",
+                    timeout=6,
+                    markup=False,
+                )
+
         if self._model_kwargs is not None:
             # Block on prewarm before re-entering the import graph; see
             # `_await_prewarm_imports` for the deadlock rationale.
@@ -1783,21 +1814,6 @@ class DeepAgentsApp(App):
             result.apply_to_settings()
             save_recent_model(f"{result.provider}:{result.model_name}")
             self._model_kwargs = None  # consumed
-
-        # Persist the user-chosen default so a later bare `deepagents`
-        # relaunch brings the user back to it. See `_default_assistant_id`
-        # for why this is decoupled from `_assistant_id`.
-        if self._default_assistant_id:
-            from deepagents_cli.model_config import save_recent_agent
-
-            saved = await asyncio.to_thread(
-                save_recent_agent, self._default_assistant_id
-            )
-            if not saved:
-                logger.warning(
-                    "Could not persist recent agent %r to config at startup",
-                    self._default_assistant_id,
-                )
 
         from deepagents_cli.server_manager import start_server_and_get_agent
 
@@ -6029,9 +6045,13 @@ class DeepAgentsApp(App):
     async def _show_agent_selector(self) -> None:
         """Show the interactive agent selector modal."""
         from deepagents_cli.agent import get_available_agent_names
+        from deepagents_cli.model_config import load_default_agent
         from deepagents_cli.widgets.agent_selector import AgentSelectorScreen
 
-        agent_names = await asyncio.to_thread(get_available_agent_names)
+        agent_names, default_agent = await asyncio.gather(
+            asyncio.to_thread(get_available_agent_names),
+            asyncio.to_thread(load_default_agent),
+        )
 
         def handle_result(result: str | None) -> None:
             """Handle the agent selector result."""
@@ -6043,6 +6063,7 @@ class DeepAgentsApp(App):
         screen = AgentSelectorScreen(
             current_agent=self._assistant_id,
             agent_names=agent_names,
+            default_agent=default_agent,
         )
         self.push_screen(screen, handle_result)
 
@@ -6359,11 +6380,28 @@ class DeepAgentsApp(App):
                     agent_name,
                 )
 
+            # Mount the "Switched to X" confirmation BEFORE surfacing any
+            # save-failure toast. Otherwise the toast hovers next to a
+            # success line that scrolls past, which makes the causality
+            # confusing — the user reads success while the toast warns.
             confirmation = Content.from_markup(
                 "Switched to $name. New thread started.",
                 name=agent_name,
             )
             await self._mount_message(AppMessage(confirmation))
+
+            if not saved:
+                # Surface the failure visibly — silent logger.warnings
+                # leave users wondering why their picker selection didn't
+                # stick across launches. See `model_config.save_recent_agent`
+                # for the underlying I/O codepath.
+                self.notify(
+                    "Could not save recent agent to config; "
+                    "next bare launch will not return to it.",
+                    severity="warning",
+                    timeout=6,
+                    markup=False,
+                )
 
             # Surface a resume command for the previous session so the
             # previous thread isn't stranded out of reach. `-r <thread>`

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -43,11 +43,15 @@ def _resolve_agent_arg(args: argparse.Namespace) -> str:
     1. Explicit `-a <name>` (stored as `args.agent` by argparse).
     2. `-r <thread>` is present → use `DEFAULT_AGENT_NAME`. The real agent is
         inferred later by `_resolve_resume_thread` via thread metadata
-        (`get_thread_agent`), so we must NOT pre-seed a recent-agent here or
+        (`get_thread_agent`), so we must NOT pre-seed a stored agent here or
         it would suppress that inference.
-    3. `[agents].recent` from config, if it points at an agent whose
-        directory still exists.
-    4. `DEFAULT_AGENT_NAME` as the final fallback.
+    3. `[agents].default` from config — the user's intentional sticky
+        default (set via Ctrl+S in the `/agents` picker).
+    4. `[agents].recent` from config — the most recently switched-to agent.
+    5. `DEFAULT_AGENT_NAME` as the final fallback.
+
+    Both `default` and `recent` are gated by `_recent_agent_is_valid` so a
+    stale entry pointing at a deleted agent directory is ignored.
 
     Extracted from the `cli_main` body so it's unit-testable without
     constructing the full arg tree.
@@ -65,7 +69,11 @@ def _resolve_agent_arg(args: argparse.Namespace) -> str:
     if getattr(args, "resume_thread", None) is not None:
         return DEFAULT_AGENT_NAME
 
-    from deepagents_cli.model_config import load_recent_agent
+    from deepagents_cli.model_config import load_default_agent, load_recent_agent
+
+    default = load_default_agent()
+    if default and _recent_agent_is_valid(default):
+        return default
 
     recent = load_recent_agent()
     if recent and _recent_agent_is_valid(recent):
@@ -675,8 +683,9 @@ def parse_args() -> argparse.Namespace:
         metavar="NAME",
         help=(
             "Agent to use (e.g., coder, researcher). "
-            "If omitted, falls back to [agents].recent in config, then "
-            f"the '{DEFAULT_AGENT_NAME}' default."
+            "If omitted, falls back to [agents].default, then "
+            "[agents].recent, then "
+            f"the '{DEFAULT_AGENT_NAME}' built-in default."
         ),
     )
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -1415,7 +1415,11 @@ def _save_toml_field(
             with contextlib.suppress(OSError):
                 Path(tmp_path).unlink()
             raise
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        # `TypeError` covers `tomli_w.dump` rejecting a non-serializable
+        # payload; `ValueError` covers things like `os.fdopen` on a
+        # closed fd. Folding them in keeps the `bool` contract intact for
+        # the UI branches that toggle on the return value.
         logger.exception("Could not save %s.%s preference", section, field)
         return False
     else:
@@ -1505,7 +1509,9 @@ def clear_default_model(config_path: Path | None = None) -> bool:
             with contextlib.suppress(OSError):
                 Path(tmp_path).unlink()
             raise
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        # See `_save_toml_field` for why `TypeError` / `ValueError` are
+        # folded into the bool return contract.
         logger.exception("Could not clear default model preference")
         return False
     else:
@@ -2023,6 +2029,106 @@ def load_recent_agent(config_path: Path | None = None) -> str | None:
         The saved agent name, or `None` if the file or key is missing or
         the file is unreadable.
     """
+    return _load_agents_field("recent", config_path)
+
+
+def save_default_agent(agent_name: str, config_path: Path | None = None) -> bool:
+    """Update the default agent in config file.
+
+    Writes to `[agents].default`. This is the user's intentional sticky
+    default — set via `Ctrl+S` in the `/agents` picker — and takes
+    precedence over `[agents].recent` on bare-launch resolution.
+
+    Args:
+        agent_name: The agent directory name (e.g., `'coder'`).
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        True if save succeeded, False if it failed due to I/O errors.
+    """
+    return _save_toml_field("agents", "default", agent_name, config_path)
+
+
+def clear_default_agent(config_path: Path | None = None) -> bool:
+    """Remove the default agent from the config file.
+
+    Deletes the `[agents].default` key so that future launches fall back
+    to `[agents].recent` and then `DEFAULT_AGENT_NAME`.
+
+    Args:
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        True if the key was removed (or was already absent), False on I/O error.
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+
+    if not config_path.exists():
+        return True
+
+    try:
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+
+        agents_section = data.get("agents")
+        if not isinstance(agents_section, dict) or "default" not in agents_section:
+            return True
+
+        del agents_section["default"]
+
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        # See `_save_toml_field` for why `TypeError` / `ValueError` are
+        # folded into the bool return contract.
+        logger.exception("Could not clear default agent preference")
+        return False
+    else:
+        global _default_config_cache  # noqa: PLW0603  # Module-level cache requires global statement
+        _default_config_cache = None
+        return True
+
+
+def load_default_agent(config_path: Path | None = None) -> str | None:
+    """Read `[agents].default` from the config file.
+
+    Args:
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        The saved agent name, or `None` if the file or key is missing or
+        the file is unreadable.
+    """
+    return _load_agents_field("default", config_path)
+
+
+def _load_agents_field(field: str, config_path: Path | None = None) -> str | None:
+    """Read `[agents].<field>` from the config file.
+
+    Args:
+        field: Key under the `[agents]` table (e.g., `'recent'`, `'default'`).
+        config_path: Path to config file.
+
+            Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        The trimmed string value, or `None` if the file, section, or key
+        is missing or the file is unreadable.
+    """
     if config_path is None:
         config_path = DEFAULT_CONFIG_PATH
     if not config_path.exists():
@@ -2031,10 +2137,10 @@ def load_recent_agent(config_path: Path | None = None) -> str | None:
         with config_path.open("rb") as f:
             data = tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError):
-        logger.warning("Could not read recent agent from config", exc_info=True)
+        logger.warning("Could not read agents.%s from config", field, exc_info=True)
         return None
     agents_section = data.get("agents", {})
-    recent = agents_section.get("recent")
-    if isinstance(recent, str) and recent.strip():
-        return recent.strip()
+    value = agents_section.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
     return None

--- a/libs/cli/deepagents_cli/widgets/agent_selector.py
+++ b/libs/cli/deepagents_cli/widgets/agent_selector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
@@ -16,7 +18,8 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
 
 from deepagents_cli import theme
-from deepagents_cli.config import get_glyphs, is_ascii_mode
+from deepagents_cli.config import Glyphs, get_glyphs, is_ascii_mode
+from deepagents_cli.model_config import clear_default_agent, save_default_agent
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +29,23 @@ class AgentSelectorScreen(ModalScreen[str | None]):
 
     Displays agents found in `~/.deepagents/` in an `OptionList`. Returns the
     selected agent name on Enter, or `None` on Esc (no change).
+    `Ctrl+S` toggles the highlighted agent as the persisted default
+    (`[agents].default`), mirroring the model selector's affordance.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Cancel", show=False),
         Binding("tab", "cursor_down", "Next", show=False, priority=True),
         Binding("shift+tab", "cursor_up", "Previous", show=False, priority=True),
+        Binding("ctrl+s", "set_default", "Set default", show=False, priority=True),
     ]
     """Key bindings for the selector.
 
     Esc dismisses without switching agents. Arrow keys, Enter, and letter
     navigation are handled natively by the embedded `OptionList`; Tab /
     Shift+Tab are bound here to advance the cursor for consistency with
-    other selector screens.
+    other selector screens. Ctrl+S toggles the highlighted agent as the
+    persisted default.
     """
 
     CSS = """
@@ -48,7 +55,7 @@ class AgentSelectorScreen(ModalScreen[str | None]):
     }
 
     AgentSelectorScreen > Vertical {
-        width: 50;
+        width: 60;
         max-width: 90%;
         height: auto;
         max-height: 80%;
@@ -78,7 +85,7 @@ class AgentSelectorScreen(ModalScreen[str | None]):
     }
 
     AgentSelectorScreen .agent-selector-help {
-        height: 1;
+        height: auto;
         color: $text-muted;
         text-style: italic;
         margin-top: 1;
@@ -87,7 +94,13 @@ class AgentSelectorScreen(ModalScreen[str | None]):
     """
     """Styling for the centered modal shell, title, option list, and help footer."""
 
-    def __init__(self, current_agent: str | None, agent_names: list[str]) -> None:
+    def __init__(
+        self,
+        current_agent: str | None,
+        agent_names: list[str],
+        *,
+        default_agent: str | None = None,
+    ) -> None:
         """Initialize the `AgentSelectorScreen`.
 
         Args:
@@ -96,10 +109,13 @@ class AgentSelectorScreen(ModalScreen[str | None]):
 
                 May be `None` when no agent is active.
             agent_names: Sorted list of available agent names to display.
+            default_agent: The persisted default agent name from
+                `[agents].default`, or `None` if no default is set.
         """
         super().__init__()
         self._current_agent = current_agent
         self._agent_names = agent_names
+        self._default_agent = default_agent
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout.
@@ -108,35 +124,21 @@ class AgentSelectorScreen(ModalScreen[str | None]):
             Widgets for the agent selector UI.
         """
         glyphs = get_glyphs()
-        options: list[Option] = []
-        highlight_index = 0
-
-        # Render labels via `Content.from_markup` so agent directory names
-        # containing Rich markup characters (e.g. `[`) don't break rendering
-        # or corrupt the option prompt.
-        for i, name in enumerate(self._agent_names):
-            if name == self._current_agent:
-                label = Content.from_markup("$name [dim](current)[/dim]", name=name)
-                highlight_index = i
-            else:
-                label = Content.from_markup("$name", name=name)
-            options.append(Option(label, id=name))
 
         with Vertical():
             yield Static("Select Agent", classes="agent-selector-title")
-            if options:
+            if self._agent_names:
                 yield Static(
                     "Switching restarts the agent and starts a new thread.",
                     classes="agent-selector-subtitle",
                 )
-                option_list = OptionList(*options, id="agent-options")
-                option_list.highlighted = highlight_index
-                yield option_list
-                help_text = (
-                    f"{glyphs.arrow_up}/{glyphs.arrow_down} or Tab switch"
-                    f" {glyphs.bullet} Enter select"
-                    f" {glyphs.bullet} Esc cancel"
+                option_list = OptionList(
+                    *self._build_options(),
+                    id="agent-options",
                 )
+                option_list.highlighted = self._current_index()
+                yield option_list
+                help_text = self._help_text(glyphs)
             else:
                 yield Static(
                     "No agents found in ~/.deepagents/.\n"
@@ -144,7 +146,74 @@ class AgentSelectorScreen(ModalScreen[str | None]):
                     classes="agent-selector-help",
                 )
                 help_text = f"{glyphs.bullet} Esc close"
-            yield Static(help_text, classes="agent-selector-help")
+            yield Static(help_text, classes="agent-selector-help", id="agent-help")
+
+    def _build_options(self) -> list[Option]:
+        """Build option entries with `(current)` / `(default)` suffixes.
+
+        Render labels via `Content.from_markup` so agent directory names
+        containing Rich markup characters (e.g. `[`) don't break rendering.
+
+        Returns:
+            One `Option` per agent name in `self._agent_names`.
+        """
+        return [Option(self._format_label(name), id=name) for name in self._agent_names]
+
+    def _format_label(self, name: str) -> Content:
+        """Render an agent's label with `(current)` / `(default)` markers.
+
+        Args:
+            name: The agent directory name.
+
+        Returns:
+            Styled `Content` label.
+        """
+        is_current = name == self._current_agent
+        is_default = name == self._default_agent
+        if is_current and is_default:
+            return Content.from_markup(
+                "$name [dim](current,[/dim] [bold]default[/bold][dim])[/dim]",
+                name=name,
+            )
+        if is_current:
+            return Content.from_markup("$name [dim](current)[/dim]", name=name)
+        if is_default:
+            return Content.from_markup(
+                "$name [dim]([/dim][bold]default[/bold][dim])[/dim]", name=name
+            )
+        return Content.from_markup("$name", name=name)
+
+    def _current_index(self) -> int:
+        """Return the index of the current agent in the option list, or 0."""
+        if self._current_agent is None:
+            return 0
+        try:
+            return self._agent_names.index(self._current_agent)
+        except ValueError:
+            return 0
+
+    @staticmethod
+    def _help_text(glyphs: Glyphs) -> str:
+        r"""Build the help-line text shown beneath the option list.
+
+        Split into two balanced rows joined by `\n` so the wrap is
+        predictable at the modal's fixed 60-column width — Textual's
+        default word-wrap might otherwise break mid-phrase (e.g.,
+        between "set" and "default"), which reads as a bug. The Static
+        host has `height: auto` and `text-align: center`, so each row
+        centers on its own line.
+
+        Args:
+            glyphs: Glyph set for the active terminal mode.
+
+        Returns:
+            Two-line help string describing the available key bindings.
+        """
+        return (
+            f"{glyphs.arrow_up}/{glyphs.arrow_down} or Tab switch"
+            f" {glyphs.bullet} Enter select\n"
+            f"Ctrl+S set default {glyphs.bullet} Esc cancel"
+        )
 
     def on_mount(self) -> None:
         """Apply ASCII border if needed."""
@@ -177,6 +246,169 @@ class AgentSelectorScreen(ModalScreen[str | None]):
         option_list = self._option_list()
         if option_list is not None:
             option_list.action_cursor_up()
+
+    async def action_set_default(self) -> None:
+        """Toggle the highlighted agent as the persisted default.
+
+        If the highlighted agent is already the default, clears it.
+        Otherwise sets it as the new default. Disk I/O is offloaded to a
+        thread so the modal stays responsive. The help line shows a
+        transient confirmation/error message; the option list is rebuilt
+        in place so the `(default)` marker tracks the new state.
+
+        Robustness notes:
+            * The `to_thread` call is wrapped in `try/except Exception` so
+                an unexpected error inside the persistence functions
+                (e.g., `tomli_w.dump` raising a `TypeError`) is treated as
+                a normal save failure rather than killing the modal.
+            * Post-await `query_one` is guarded against `NoMatches` so a
+                user dismissing the modal mid-flight does not surface a
+                Textual callback error.
+            * The option-list rebuild is staged in `_refresh_options`,
+                which builds the new options first and only swaps on
+                success. A failure mid-rebuild leaves the existing list
+                intact and shows an error in the help line.
+        """
+        from textual.css.query import NoMatches
+
+        option_list = self._option_list()
+        if option_list is None or not self._agent_names:
+            return
+
+        highlighted = option_list.highlighted
+        if highlighted is None or not (0 <= highlighted < len(self._agent_names)):
+            return
+        name = self._agent_names[highlighted]
+
+        if name == self._default_agent:
+            new_default: str | None = None
+            success_msg = "Default cleared"
+            failure_msg = "Failed to clear default"
+            try:
+                ok = await asyncio.to_thread(clear_default_agent)
+            except Exception:
+                logger.exception("clear_default_agent raised unexpectedly")
+                ok = False
+        else:
+            new_default = name
+            success_msg = f"Default set to {name}"
+            failure_msg = "Failed to save default"
+            try:
+                ok = await asyncio.to_thread(save_default_agent, name)
+            except Exception:
+                logger.exception("save_default_agent raised unexpectedly for %r", name)
+                ok = False
+
+        # The user may have dismissed the modal while the disk I/O was in
+        # flight; don't try to mutate widgets on an unmounted screen.
+        try:
+            help_widget = self.query_one("#agent-help", Static)
+        except NoMatches:
+            return
+
+        if not ok:
+            help_widget.update(
+                Content.styled(
+                    failure_msg,
+                    f"bold {theme.get_theme_colors(self).error}",
+                )
+            )
+            self.set_timer(3.0, self._restore_help_text)
+            return
+
+        # Apply the rebuild before mutating `_default_agent` so a failure
+        # leaves the picker visually consistent with on-disk state.
+        if not self._refresh_options(option_list, highlighted, new_default):
+            help_widget.update(
+                Content.styled(
+                    "Failed to refresh agent list",
+                    f"bold {theme.get_theme_colors(self).error}",
+                )
+            )
+            self.set_timer(3.0, self._restore_help_text)
+            return
+
+        self._default_agent = new_default
+        help_widget.update(Content.styled(success_msg, "bold"))
+        self.set_timer(3.0, self._restore_help_text)
+
+    def _refresh_options(
+        self,
+        option_list: OptionList,
+        highlighted: int,
+        new_default: str | None,
+    ) -> bool:
+        """Rebuild option labels in place to track the new `(default)` state.
+
+        Builds the new option list with `new_default` applied first and
+        only mutates the live `OptionList` once construction succeeds.
+        Failure mid-build leaves the existing list intact, avoiding the
+        catastrophic empty-picker state where `clear_options()` had
+        succeeded but `add_options(...)` raised.
+
+        `OptionList.clear_options()` resets the highlight to `None`, so
+        restore it explicitly to the previously selected row to avoid
+        appearing to lose the cursor after a Ctrl+S toggle.
+
+        Args:
+            option_list: The live `OptionList` to rebuild in place.
+            highlighted: Index to restore as the highlighted row.
+            new_default: The agent name about to become the default
+                (`None` for clear).
+
+                Passed in rather than read from `self._default_agent`
+                so the caller can decide whether to commit the new
+                default based on the rebuild's success.
+
+        Returns:
+            `True` when the rebuild applied cleanly, `False` if option
+                construction or mounting raised. On `False`, the live
+                option list has been left untouched.
+        """
+        previous_default = self._default_agent
+        self._default_agent = new_default
+        try:
+            new_options = self._build_options()
+        except Exception:
+            logger.exception("Failed to build new agent picker options")
+            self._default_agent = previous_default
+            return False
+
+        try:
+            option_list.clear_options()
+            option_list.add_options(new_options)
+        except Exception:
+            logger.exception("Failed to mount rebuilt agent picker options")
+            self._default_agent = previous_default
+            # Best-effort restore of the prior options so the user is
+            # not left staring at an empty picker.
+            with contextlib.suppress(Exception):
+                option_list.clear_options()
+                option_list.add_options(self._build_options())
+            return False
+
+        if 0 <= highlighted < len(self._agent_names):
+            option_list.highlighted = highlighted
+        # `_default_agent` is set on entry so `_build_options` reflects
+        # the new state; revert it here so the caller can commit only
+        # after the rebuild has fully succeeded.
+        self._default_agent = previous_default
+        return True
+
+    def _restore_help_text(self) -> None:
+        """Restore the default help text after a transient message.
+
+        Guarded against the user having dismissed the modal during the
+        3-second timer; without the guard, `query_one` would raise
+        `NoMatches` and Textual would surface it as a callback error.
+        """
+        from textual.css.query import NoMatches
+
+        try:
+            help_widget = self.query_one("#agent-help", Static)
+        except NoMatches:
+            return
+        help_widget.update(self._help_text(get_glyphs()))
 
     def _option_list(self) -> OptionList | None:
         """Return the agent `OptionList`, or `None` when the screen is empty."""

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -42,6 +42,7 @@ _TIPS: dict[str, int] = {
     "Use /skill-creator to build reusable agent skills": 1,
     "Use /auto-update to toggle automatic CLI updates": 1,
     "Use /agents to browse and switch between your available agents": 2,
+    "In /agents, press Ctrl+S to set the highlighted agent as your default": 1,
     "Use --startup-cmd to run a shell command before the first prompt": 1,
     "Run `deepagents mcp login <server>` to authorize a remote MCP server": 1,
     "Deep Agents can explain its own features and look up its docs. Ask it how to use.": 3,  # noqa: E501

--- a/libs/cli/tests/unit_tests/test_agent_selector.py
+++ b/libs/cli/tests/unit_tests/test_agent_selector.py
@@ -23,10 +23,12 @@ class AgentSelectorTestApp(App):
         self,
         current_agent: str | None = "agent",
         agent_names: list[str] | None = None,
+        default_agent: str | None = None,
     ) -> None:
         super().__init__()
         self._current = current_agent
         self._names = agent_names if agent_names is not None else list(_AGENT_NAMES)
+        self._default = default_agent
         self.result: str | None = None
         self.dismissed = False
 
@@ -43,6 +45,7 @@ class AgentSelectorTestApp(App):
         screen = AgentSelectorScreen(
             current_agent=self._current,
             agent_names=self._names,
+            default_agent=self._default,
         )
         self.push_screen(screen, handle_result)
 
@@ -206,3 +209,258 @@ class TestAgentSelectorEmptyStateHelp:
             rendered = " ".join(str(s.render()) for s in statics)
             assert "Enter" not in rendered
             assert "Esc" in rendered
+
+
+class TestAgentSelectorDefaultLabel:
+    """The persisted default agent should be marked `(default)` in the picker."""
+
+    async def test_default_agent_label_includes_default(self) -> None:
+        """The default agent option should show '(default)' in its label."""
+        async with AgentSelectorTestApp(
+            current_agent="agent", default_agent="researcher"
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            option_list = app.screen.query_one("#agent-options", OptionList)
+            # researcher is index 2; its label should contain "(default)"
+            option = option_list.get_option_at_index(2)
+            assert "(default)" in str(option.prompt)
+
+    async def test_current_and_default_combine(self) -> None:
+        """When the same agent is current and default, both markers appear."""
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent="coder"
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            option_list = app.screen.query_one("#agent-options", OptionList)
+            option = option_list.get_option_at_index(1)
+            prompt = str(option.prompt)
+            assert "current" in prompt
+            assert "default" in prompt
+
+    async def test_help_text_advertises_set_default(self) -> None:
+        """The help line should mention `Ctrl+S set default`."""
+        async with AgentSelectorTestApp().run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            statics = app.screen.query(".agent-selector-help")
+            rendered = " ".join(str(s.render()) for s in statics)
+            assert "Ctrl+S" in rendered
+            assert "set default" in rendered
+
+
+class TestAgentSelectorSetDefault:
+    """Ctrl+S should toggle the highlighted agent as the persisted default."""
+
+    async def test_set_default_persists_via_save_function(self, monkeypatch) -> None:
+        """Pressing Ctrl+S calls `save_default_agent` with the highlighted name."""
+        save_calls: list[str] = []
+
+        def fake_save(name: str) -> bool:
+            save_calls.append(name)
+            return True
+
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.save_default_agent",
+            fake_save,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent=None
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+        # "coder" is the highlighted (current) agent, so Ctrl+S sets it default
+        assert save_calls == ["coder"]
+
+    async def test_set_default_updates_label_in_place(self, monkeypatch) -> None:
+        """After Ctrl+S, the highlighted option's label gains `(default)`."""
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.save_default_agent",
+            lambda _name: True,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent=None
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            option_list = app.screen.query_one("#agent-options", OptionList)
+            assert option_list.highlighted == 1
+            prompt = str(option_list.get_option_at_index(1).prompt)
+            assert "default" in prompt
+
+    async def test_set_default_clears_when_already_default(self, monkeypatch) -> None:
+        """Pressing Ctrl+S on the existing default clears it."""
+        clear_calls: list[None] = []
+
+        def fake_clear() -> bool:
+            clear_calls.append(None)
+            return True
+
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.clear_default_agent",
+            fake_clear,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent="coder"
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            option_list = app.screen.query_one("#agent-options", OptionList)
+            prompt = str(option_list.get_option_at_index(1).prompt)
+            assert "default" not in prompt
+
+        assert len(clear_calls) == 1
+
+    async def test_set_default_no_op_with_empty_list(self, monkeypatch) -> None:
+        """Ctrl+S on an empty selector must not raise."""
+        save_calls: list[str] = []
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.save_default_agent",
+            lambda name: save_calls.append(name) or True,
+        )
+        async with AgentSelectorTestApp(agent_names=[]).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+        assert save_calls == []
+
+
+class TestAgentSelectorSetDefaultErrorPaths:
+    """Defensive guards around the Ctrl+S flow.
+
+    The user's stated concern was silent persistence failures. These
+    tests pin the behavior of the failure paths so a regression that
+    accidentally turns them silent (or, worse, crashes the modal) is
+    caught.
+    """
+
+    async def test_save_failure_shows_error_in_help(self, monkeypatch) -> None:
+        """`save_default_agent` returning False updates the help line, no crash."""
+        from textual.widgets import Static
+
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.save_default_agent",
+            lambda _name: False,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent=None
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            help_widget = app.screen.query_one("#agent-help", Static)
+            rendered = str(help_widget.render())
+            # Help line surfaces the failure — picker still alive.
+            assert "Failed to save" in rendered
+            # Modal is still mounted; user can dismiss with Esc cleanly.
+            assert not app.dismissed
+
+    async def test_save_unexpected_exception_treated_as_failure(
+        self, monkeypatch
+    ) -> None:
+        """An unexpected exception in `save_default_agent` is caught.
+
+        Without the `try/except Exception` guard in `action_set_default`,
+        a `TypeError` from `tomli_w.dump` would bubble out and kill the
+        modal. The fix treats it as `ok = False`.
+        """
+        from textual.widgets import Static
+
+        def boom(_name: str) -> bool:
+            msg = "unexpected"
+            raise TypeError(msg)
+
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.save_default_agent",
+            boom,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent=None
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            help_widget = app.screen.query_one("#agent-help", Static)
+            rendered = str(help_widget.render())
+            assert "Failed to save" in rendered
+            assert not app.dismissed
+
+    async def test_clear_unexpected_exception_treated_as_failure(
+        self, monkeypatch
+    ) -> None:
+        """Same defensive guard for the clear path."""
+        from textual.widgets import Static
+
+        def boom() -> bool:
+            msg = "unexpected"
+            raise TypeError(msg)
+
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.clear_default_agent",
+            boom,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent="coder"
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            help_widget = app.screen.query_one("#agent-help", Static)
+            rendered = str(help_widget.render())
+            assert "Failed to clear" in rendered
+            assert not app.dismissed
+
+    async def test_save_failure_keeps_default_unchanged(self, monkeypatch) -> None:
+        """A failed save must not update the in-memory `_default_agent`.
+
+        Otherwise the picker's `(default)` marker would advertise a state
+        that did not actually persist to disk.
+        """
+        from textual.widgets import OptionList
+
+        monkeypatch.setattr(
+            "deepagents_cli.widgets.agent_selector.save_default_agent",
+            lambda _name: False,
+        )
+
+        async with AgentSelectorTestApp(
+            current_agent="coder", default_agent=None
+        ).run_test() as pilot:
+            app = _app(pilot)
+            app.show_selector()
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            option_list = app.screen.query_one("#agent-options", OptionList)
+            for i in range(option_list.option_count):
+                prompt = str(option_list.get_option_at_index(i).prompt)
+                assert "(default)" not in prompt
+                assert "default)" not in prompt

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -4770,6 +4770,75 @@ class TestRestartServerForAgentSwap:
         assert any("Switched to researcher" in s for s in plain)
         assert not any("to resume" in s for s in plain)
 
+    async def test_swap_save_failure_notifies_after_confirmation(self) -> None:
+        """A failed `save_recent_agent` after a swap must surface a toast.
+
+        Locks two invariants:
+            1. The notify is wired with `markup=False` and `severity="warning"`.
+                `markup=False` is load-bearing — the message contains a
+                semicolon and stray commas, and the Toast renderer would
+                crash if markup parsing were enabled.
+            2. The "Switched to X" confirmation lands BEFORE the warning
+                notify. Otherwise the toast hovers next to a green
+                success line, making the causality unreadable.
+        """
+        from deepagents_cli.widgets.message_store import MessageData, MessageType
+
+        app, _server_proc = self._make_app()
+        app._message_store.append(
+            MessageData(type=MessageType.ASSISTANT, content="hi there")
+        )
+
+        order: list[str] = []
+        mounted: list[object] = []
+
+        def record_mount(msg: object) -> None:
+            mounted.append(msg)
+            content_str = str(getattr(msg, "_content", msg))
+            if "Switched to" in content_str:
+                order.append("confirmation")
+
+        def record_notify(*args: Any, **kwargs: Any) -> None:
+            if kwargs.get("severity") == "warning" and "config" in str(args[0]).lower():
+                order.append("notify")
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_cli.model_config.save_recent_agent",
+                    return_value=False,
+                ),
+                patch.object(
+                    app, "_mount_message", AsyncMock(side_effect=record_mount)
+                ),
+                patch.object(app, "run_worker"),
+                patch.object(app, "notify", side_effect=record_notify) as notify_mock,
+            ):
+                await app._restart_server_for_agent_swap("researcher")
+
+        # Confirmation message reached the user.
+        plain = [str(getattr(m, "_content", m)) for m in mounted]
+        assert any("Switched to researcher" in s for s in plain)
+
+        # The save-failure warning notify fired with the right kwargs.
+        warning_calls = [
+            notify_call
+            for notify_call in notify_mock.call_args_list
+            if notify_call.kwargs.get("severity") == "warning"
+        ]
+        assert warning_calls, (
+            f"expected a warning notify; got {notify_mock.call_args_list}"
+        )
+        for notify_call in warning_calls:
+            assert notify_call.kwargs.get("markup") is False
+            assert "agent" in str(notify_call.args[0]).lower()
+
+        # Confirmation must precede the notify in the observed sequence.
+        assert order == ["confirmation", "notify"], (
+            f"confirmation must precede notify; got {order}"
+        )
+
     async def test_failure_rolls_back_identity_and_posts_failed(
         self,
     ) -> None:
@@ -6400,3 +6469,116 @@ class TestPrewarmAwait:
             await app._start_server_background()
 
         save_agent_mock.assert_called_once_with("agent")
+
+    async def test_start_server_background_persists_agent_before_create_model(
+        self,
+    ) -> None:
+        """`save_recent_agent` must run BEFORE `create_model`.
+
+        Locks the reorder that fixes the silent-persistence-loss bug:
+        if `create_model` raises a `ModelConfigError` (e.g., missing API
+        key), the user's intent to use this agent must already be
+        persisted. A regression that moves the save back below
+        `create_model` plus a credential miss silently drops the write
+        with no test signal.
+        """
+        from deepagents_cli import config as cli_config
+        from deepagents_cli.model_config import ModelConfigError
+
+        call_order: list[str] = []
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        app._model_kwargs = {"model_spec": "anthropic:claude-opus-4-7"}
+        app._server_kwargs = None
+        app._mcp_preload_kwargs = None
+        app._resume_thread_intent = None
+        app._assistant_id = None
+        app._default_assistant_id = "agent"
+
+        def record_save_agent(name: str) -> bool:
+            call_order.append(f"save_recent_agent:{name}")
+            return True
+
+        def record_create_model(**_: Any) -> MagicMock:
+            call_order.append("create_model")
+            msg = "no credentials"
+            raise ModelConfigError(msg)
+
+        with (
+            patch.object(app, "_await_prewarm_imports", AsyncMock()),
+            patch.object(cli_config, "create_model", side_effect=record_create_model),
+            patch(
+                "deepagents_cli.model_config.save_recent_agent",
+                side_effect=record_save_agent,
+            ),
+            patch("deepagents_cli.model_config.save_recent_model"),
+            patch.object(app, "post_message"),
+            patch.object(app, "notify"),
+        ):
+            await app._start_server_background()
+
+        # Save must have happened, and must precede create_model in the
+        # call sequence — guarding the reorder fix.
+        assert "save_recent_agent:agent" in call_order
+        assert call_order.index("save_recent_agent:agent") < call_order.index(
+            "create_model"
+        ), f"save_recent_agent must precede create_model; got {call_order}"
+
+    async def test_start_server_background_notifies_on_save_failure(self) -> None:
+        """A failed startup save must surface a visible toast.
+
+        The user explicitly suspected that recent-agent writes were
+        silently dropping. Pair with the swap-path notify so both
+        codepaths produce a user-visible signal on persistence failure
+        rather than only a log line. `markup=False` is load-bearing —
+        flipping it back to default `True` re-introduces the Toast
+        `MarkupError` risk.
+        """
+        from deepagents_cli import config as cli_config
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        app._model_kwargs = {"model_spec": "anthropic:claude-opus-4-7"}
+        app._server_kwargs = None
+        app._mcp_preload_kwargs = None
+        app._resume_thread_intent = None
+        app._assistant_id = None
+        app._default_assistant_id = "agent"
+
+        def fake_create_model(**_: Any) -> MagicMock:
+            result = MagicMock()
+            result.apply_to_settings = MagicMock()
+            result.provider = "anthropic"
+            result.model_name = "claude-opus-4-7"
+            return result
+
+        with (
+            patch.object(app, "_await_prewarm_imports", AsyncMock()),
+            patch.object(cli_config, "create_model", side_effect=fake_create_model),
+            patch("deepagents_cli.model_config.save_recent_model"),
+            patch(
+                "deepagents_cli.model_config.save_recent_agent",
+                return_value=False,
+            ),
+            patch.object(app, "post_message"),
+            patch.object(app, "notify") as notify_mock,
+            contextlib.suppress(Exception),
+        ):
+            await app._start_server_background()
+
+        # At least one notify call must report the save failure with
+        # markup disabled and warning severity.
+        warning_calls = [
+            notify_call
+            for notify_call in notify_mock.call_args_list
+            if notify_call.kwargs.get("severity") == "warning"
+            and "agent" in str(notify_call.args[0]).lower()
+            and "config" in str(notify_call.args[0]).lower()
+        ]
+        assert warning_calls, (
+            f"expected a warning notify about agent save failure; got "
+            f"{notify_mock.call_args_list}"
+        )
+        # markup=False is required so commas/brackets in the message
+        # don't crash the Toast renderer (see CLAUDE.md guidance).
+        for notify_call in warning_calls:
+            assert notify_call.kwargs.get("markup") is False

--- a/libs/cli/tests/unit_tests/test_main_args.py
+++ b/libs/cli/tests/unit_tests/test_main_args.py
@@ -699,36 +699,90 @@ class TestResolveAgentArg:
         return argparse.Namespace(**defaults)
 
     def test_explicit_agent_wins(self) -> None:
-        """An explicit `-a <name>` bypasses recent/default lookup entirely."""
+        """An explicit `-a <name>` bypasses default/recent lookup entirely."""
         from deepagents_cli.main import _resolve_agent_arg
 
-        with patch("deepagents_cli.model_config.load_recent_agent") as load:
+        with (
+            patch("deepagents_cli.model_config.load_default_agent") as load_default,
+            patch("deepagents_cli.model_config.load_recent_agent") as load_recent,
+        ):
             assert _resolve_agent_arg(self._args(agent="coder")) == "coder"
-            load.assert_not_called()
+            load_default.assert_not_called()
+            load_recent.assert_not_called()
 
     def test_resume_thread_forces_default(self) -> None:
         """With -r present, default lets thread-metadata inference pick the agent."""
         from deepagents_cli._constants import DEFAULT_AGENT_NAME
         from deepagents_cli.main import _resolve_agent_arg
 
-        with patch(
-            "deepagents_cli.model_config.load_recent_agent",
-            return_value="researcher",
-        ) as load:
+        with (
+            patch(
+                "deepagents_cli.model_config.load_default_agent",
+                return_value="coder",
+            ) as load_default,
+            patch(
+                "deepagents_cli.model_config.load_recent_agent",
+                return_value="researcher",
+            ) as load_recent,
+        ):
             result = _resolve_agent_arg(self._args(resume_thread="abc123"))
             assert result == DEFAULT_AGENT_NAME
-            load.assert_not_called()
+            load_default.assert_not_called()
+            load_recent.assert_not_called()
 
-    def test_uses_recent_when_valid(self) -> None:
-        """No -a, no -r: use `[agents].recent` when the dir still exists."""
+    def test_default_takes_precedence_over_recent(self) -> None:
+        """`[agents].default` (Ctrl+S in picker) wins over `[agents].recent`."""
         from deepagents_cli.main import _resolve_agent_arg
 
         with (
+            patch(
+                "deepagents_cli.model_config.load_default_agent",
+                return_value="researcher",
+            ),
             patch(
                 "deepagents_cli.model_config.load_recent_agent",
                 return_value="coder",
             ),
             patch("deepagents_cli.main._recent_agent_is_valid", return_value=True),
+        ):
+            assert _resolve_agent_arg(self._args()) == "researcher"
+
+    def test_uses_recent_when_valid(self) -> None:
+        """No -a, no -r, no default: use `[agents].recent` when the dir exists."""
+        from deepagents_cli.main import _resolve_agent_arg
+
+        with (
+            patch("deepagents_cli.model_config.load_default_agent", return_value=None),
+            patch(
+                "deepagents_cli.model_config.load_recent_agent",
+                return_value="coder",
+            ),
+            patch("deepagents_cli.main._recent_agent_is_valid", return_value=True),
+        ):
+            assert _resolve_agent_arg(self._args()) == "coder"
+
+    def test_falls_back_when_default_missing_dir(self) -> None:
+        """Stale `[agents].default` pointing at a deleted dir falls through."""
+        from deepagents_cli.main import _resolve_agent_arg
+
+        # `_recent_agent_is_valid` is called for both default and recent;
+        # return False for the default name, True for the recent name.
+        def _validate(name: str) -> bool:
+            return name == "coder"
+
+        with (
+            patch(
+                "deepagents_cli.model_config.load_default_agent",
+                return_value="ghost",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_recent_agent",
+                return_value="coder",
+            ),
+            patch(
+                "deepagents_cli.main._recent_agent_is_valid",
+                side_effect=_validate,
+            ),
         ):
             assert _resolve_agent_arg(self._args()) == "coder"
 
@@ -738,6 +792,7 @@ class TestResolveAgentArg:
         from deepagents_cli.main import _resolve_agent_arg
 
         with (
+            patch("deepagents_cli.model_config.load_default_agent", return_value=None),
             patch(
                 "deepagents_cli.model_config.load_recent_agent",
                 return_value="ghost",
@@ -751,7 +806,34 @@ class TestResolveAgentArg:
         from deepagents_cli._constants import DEFAULT_AGENT_NAME
         from deepagents_cli.main import _resolve_agent_arg
 
-        with patch("deepagents_cli.model_config.load_recent_agent", return_value=None):
+        with (
+            patch("deepagents_cli.model_config.load_default_agent", return_value=None),
+            patch("deepagents_cli.model_config.load_recent_agent", return_value=None),
+        ):
+            assert _resolve_agent_arg(self._args()) == DEFAULT_AGENT_NAME
+
+    def test_falls_back_when_both_default_and_recent_stale(self) -> None:
+        """Both keys point at deleted dirs → final fallback to DEFAULT_AGENT_NAME.
+
+        Locks the chained validity check: a stale `default` does not
+        suppress the `recent` lookup, but if `recent` is also stale we
+        must reach `DEFAULT_AGENT_NAME` rather than returning a name
+        whose directory no longer exists.
+        """
+        from deepagents_cli._constants import DEFAULT_AGENT_NAME
+        from deepagents_cli.main import _resolve_agent_arg
+
+        with (
+            patch(
+                "deepagents_cli.model_config.load_default_agent",
+                return_value="ghost-default",
+            ),
+            patch(
+                "deepagents_cli.model_config.load_recent_agent",
+                return_value="ghost-recent",
+            ),
+            patch("deepagents_cli.main._recent_agent_is_valid", return_value=False),
+        ):
             assert _resolve_agent_arg(self._args()) == DEFAULT_AGENT_NAME
 
 

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -24,14 +24,17 @@ from deepagents_cli.model_config import (
     _load_provider_profiles,
     _profile_module_from_class_path,
     clear_caches,
+    clear_default_agent,
     clear_default_model,
     get_available_models,
     get_model_profiles,
     get_provider_auth_status,
     has_provider_credentials,
     is_warning_suppressed,
+    load_default_agent,
     load_recent_agent,
     load_thread_columns,
+    save_default_agent,
     save_recent_agent,
     save_recent_model,
     save_thread_columns,
@@ -2710,6 +2713,146 @@ recent = "researcher"
         config_path.write_text("[agents]\nrecent = 123\n")
 
         assert load_recent_agent(config_path) is None
+
+
+class TestDefaultAgent:
+    """save_default_agent + clear_default_agent + load_default_agent round-trip."""
+
+    def test_save_creates_file_with_agents_default(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        assert save_default_agent("coder", config_path) is True
+
+        assert config_path.exists()
+        assert 'default = "coder"' in config_path.read_text()
+
+    def test_save_preserves_recent_and_other_sections(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models]
+default = "anthropic:claude-sonnet-4-5"
+
+[agents]
+recent = "researcher"
+""")
+        save_default_agent("coder", config_path)
+
+        content = config_path.read_text()
+        assert 'default = "anthropic:claude-sonnet-4-5"' in content
+        assert 'recent = "researcher"' in content
+        assert 'default = "coder"' in content
+
+    def test_load_returns_default(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        save_default_agent("coder", config_path)
+
+        assert load_default_agent(config_path) == "coder"
+
+    def test_load_missing_file_returns_none(self, tmp_path):
+        assert load_default_agent(tmp_path / "missing.toml") is None
+
+    def test_load_missing_section_returns_none(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models]\ndefault = "x"\n')
+
+        assert load_default_agent(config_path) is None
+
+    def test_load_non_string_returns_none(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[agents]\ndefault = 123\n")
+
+        assert load_default_agent(config_path) is None
+
+    def test_load_independent_of_recent(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[agents]
+recent = "researcher"
+""")
+        assert load_default_agent(config_path) is None
+        assert load_recent_agent(config_path) == "researcher"
+
+    def test_clear_removes_default_only(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[agents]
+default = "coder"
+recent = "researcher"
+""")
+        assert clear_default_agent(config_path) is True
+
+        assert load_default_agent(config_path) is None
+        assert load_recent_agent(config_path) == "researcher"
+
+    def test_clear_missing_file_returns_true(self, tmp_path):
+        assert clear_default_agent(tmp_path / "missing.toml") is True
+
+    def test_clear_missing_key_returns_true(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[agents]\nrecent = "researcher"\n')
+        assert clear_default_agent(config_path) is True
+        assert load_recent_agent(config_path) == "researcher"
+
+    def test_save_returns_false_on_oserror(self, tmp_path, monkeypatch):
+        """OSError during write must produce `False`, not propagate.
+
+        The picker UI branches on the boolean — an unhandled exception
+        would crash the modal mid-action.
+        """
+        import tomli_w
+
+        config_path = tmp_path / "config.toml"
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            msg = "disk full"
+            raise OSError(msg)
+
+        monkeypatch.setattr(tomli_w, "dump", boom)
+        assert save_default_agent("coder", config_path) is False
+
+    def test_save_returns_false_on_typeerror(self, tmp_path, monkeypatch):
+        """TypeError from `tomli_w.dump` falls into the bool contract."""
+        import tomli_w
+
+        config_path = tmp_path / "config.toml"
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            msg = "unsupported type"
+            raise TypeError(msg)
+
+        monkeypatch.setattr(tomli_w, "dump", boom)
+        assert save_default_agent("coder", config_path) is False
+
+    def test_clear_returns_false_on_oserror(self, tmp_path, monkeypatch):
+        """OSError during clear must produce `False`, not propagate."""
+        import tomli_w
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[agents]\ndefault = "coder"\n')
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            msg = "disk full"
+            raise OSError(msg)
+
+        monkeypatch.setattr(tomli_w, "dump", boom)
+        assert clear_default_agent(config_path) is False
+
+    def test_load_returns_none_for_whitespace(self, tmp_path):
+        """Whitespace-only string is treated as missing, not as a valid name."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[agents]\ndefault = "   "\n')
+        assert load_default_agent(config_path) is None
+
+    def test_load_returns_none_for_empty_string(self, tmp_path):
+        """Empty string is treated as missing."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[agents]\ndefault = ""\n')
+        assert load_default_agent(config_path) is None
+
+    def test_load_returns_none_for_list_type(self, tmp_path):
+        """A list under `[agents].default` is rejected, not coerced."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[agents]\ndefault = [1, 2]\n")
+        assert load_default_agent(config_path) is None
 
 
 class TestModelConfigLoadRecent:


### PR DESCRIPTION
Add a `Ctrl+S` "set as default" affordance to the `/agents` picker (mirroring `/model`'s sticky-default pattern) and harden the agent-persistence path. Previously the `/agents` picker silently rewrote `[agents].recent` on every startup with no opt-out, so picking a non-default agent once made it permanently sticky; a missing API key on launch could silently drop the recent-agent write entirely.