### PR TITLE
chore(quickjs): remove status check for quickjs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,6 @@ jobs:
       - test-repl
       - benchmark-deepagents
       - benchmark-cli
-      - benchmark-quickjs
       - check-release-options
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
follow up to [#3129](https://github.com/langchain-ai/deepagents/pull/3129)