### PR TITLE
fix(sdk): auto-added GP subagent inherits parent permissions

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -578,6 +578,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             FilesystemMiddleware(
                 backend=backend,
                 custom_tool_descriptions=_profile.tool_description_overrides,
+                _permissions=permissions,
             ),
             create_summarization_middleware(model, backend),
             PatchToolCallsMiddleware(),

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -3,12 +3,14 @@
 import pytest
 from langchain.tools import ToolRuntime
 from langchain.tools.tool_node import ToolCallRequest
-from langchain_core.messages import ToolMessage
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.protocol import EditResult, ExecuteResponse, ReadResult, SandboxBackendProtocol, WriteResult
+from deepagents.graph import create_deep_agent
 from deepagents.middleware.filesystem import (
     FilesystemMiddleware,
     FilesystemPermission,
@@ -16,6 +18,7 @@ from deepagents.middleware.filesystem import (
     _check_fs_permission,
     _filter_paths_by_permission,
 )
+from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
 
 def _runtime(tool_call_id: str = "") -> ToolRuntime:
@@ -916,11 +919,6 @@ class TestGeneralPurposeSubagentPermissionInheritance:
     """Regression tests: auto-added GP subagent must inherit parent permissions."""
 
     def test_auto_added_gp_subagent_inherits_parent_permissions(self):
-        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-        from langchain_core.messages import AIMessage
-
-        from deepagents.graph import create_deep_agent
-
         parent_perms = [
             FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
         ]
@@ -933,12 +931,6 @@ class TestGeneralPurposeSubagentPermissionInheritance:
         assert _filesystem_permissions_for(agent, "general-purpose") == parent_perms
 
     def test_explicit_gp_subagent_permissions_override_parent(self):
-        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-        from langchain_core.messages import AIMessage
-
-        from deepagents.graph import create_deep_agent
-        from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
-
         parent_perms = [
             FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
         ]

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -900,18 +900,12 @@ def _filesystem_permissions_for(agent, subagent_name: str | None = None):
     if subagent_name is not None:
         task_tool = agent.nodes["tools"].bound._tools_by_name["task"]
         agents_dict = next(
-            cell.cell_contents
-            for cell in task_tool.func.__closure__
-            if isinstance(cell.cell_contents, dict) and subagent_name in cell.cell_contents
+            cell.cell_contents for cell in task_tool.func.__closure__ if isinstance(cell.cell_contents, dict) and subagent_name in cell.cell_contents
         )
         agent = agents_dict[subagent_name]
 
     read_tool = agent.nodes["tools"].bound._tools_by_name["read_file"]
-    fs = next(
-        cell.cell_contents
-        for cell in read_tool.func.__closure__
-        if isinstance(cell.cell_contents, FilesystemMiddleware)
-    )
+    fs = next(cell.cell_contents for cell in read_tool.func.__closure__ if isinstance(cell.cell_contents, FilesystemMiddleware))
     return fs._permissions
 
 

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -886,3 +886,70 @@ class TestAsyncFilesystemMiddlewarePermissions:
         rules = [FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="deny")]
         result = await _ainvoke_with_permissions(ls_tool, {"path": "/"}, rules)
         assert "/secrets/b.txt" not in result
+
+
+def _filesystem_permissions_for(agent, subagent_name: str | None = None):
+    """Walk a compiled deep agent to fetch a `FilesystemMiddleware._permissions`.
+
+    When `subagent_name` is None, returns the main agent's permissions.
+    Otherwise descends into the named subagent registered on the `task` tool.
+    """
+    if subagent_name is not None:
+        task_tool = agent.nodes["tools"].bound._tools_by_name["task"]
+        agents_dict = next(
+            cell.cell_contents
+            for cell in task_tool.func.__closure__
+            if isinstance(cell.cell_contents, dict) and subagent_name in cell.cell_contents
+        )
+        agent = agents_dict[subagent_name]
+
+    read_tool = agent.nodes["tools"].bound._tools_by_name["read_file"]
+    fs = next(
+        cell.cell_contents
+        for cell in read_tool.func.__closure__
+        if isinstance(cell.cell_contents, FilesystemMiddleware)
+    )
+    return fs._permissions
+
+
+class TestGeneralPurposeSubagentPermissionInheritance:
+    """Regression tests: auto-added GP subagent must inherit parent permissions."""
+
+    def test_auto_added_gp_subagent_inherits_parent_permissions(self):
+        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+        from langchain_core.messages import AIMessage
+
+        from deepagents.graph import create_deep_agent
+
+        parent_perms = [
+            FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
+        ]
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            permissions=parent_perms,
+        )
+
+        assert _filesystem_permissions_for(agent) == parent_perms
+        assert _filesystem_permissions_for(agent, "general-purpose") == parent_perms
+
+    def test_explicit_gp_subagent_permissions_override_parent(self):
+        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+        from langchain_core.messages import AIMessage
+
+        from deepagents.graph import create_deep_agent
+        from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
+
+        parent_perms = [
+            FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
+        ]
+        override_perms = [
+            FilesystemPermission(operations=["read"], paths=["/foo/**"], mode="deny"),
+        ]
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+            permissions=parent_perms,
+            subagents=[{**GENERAL_PURPOSE_SUBAGENT, "permissions": override_perms}],
+        )
+
+        assert _filesystem_permissions_for(agent) == parent_perms
+        assert _filesystem_permissions_for(agent, "general-purpose") == override_perms


### PR DESCRIPTION
## Summary
- Auto-added general-purpose subagent now inherits the parent agent's `permissions` (one-line fix in `libs/deepagents/deepagents/graph.py`), matching the user-supplied subagent path and the main-agent path
- Restores the documented contract — *"subagents inherit these rules unless they specify their own"* (`graph.py:369`, `subagents.py:92`) — and closes a privilege-escalation-by-delegation gap where a restricted parent could sidestep its own permissions by handing work to GP
- Adds `TestGeneralPurposeSubagentPermissionInheritance` to `test_permissions.py` covering both inheritance and explicit-override cases

## Test plan
- [x] `uv run python -m pytest tests/unit_tests/test_permissions.py -q` (76 passed)
- [x] `uv run python -m pytest tests/unit_tests/test_subagents.py -q` (32 passed, 1 xfailed)
- [x] `uv run python -m pytest tests/unit_tests/test_end_to_end.py -q` (93 passed)
- [ ] CI green