### PR TITLE
fix(quickjs): preserve loop affinity for `task` calls in PTC

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import contextvars
 import hashlib
 import json
 import logging
@@ -131,6 +132,14 @@ class _PTCState:
             attempted=normalized_limit + 1,
             function_name=function_name,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _PTCEvalContext:
+    """Per-eval dispatch context for PTC host-function bridges."""
+
+    runtime: ToolRuntime | None
+    outer_loop: asyncio.AbstractEventLoop | None
 
 
 class _ConsoleBuffer:
@@ -331,11 +340,15 @@ class _ThreadREPL:
         # ``typeof tools.X`` throws ReferenceError instead of returning
         # ``"undefined"``).
         self._tools_installed: bool = False
-        # Outer ToolRuntime captured for the current eval. PTC bridges
-        # forward it into their tool calls so `task`/subagent tools see
-        # graph state, store, context, etc. Set via ``set_outer_runtime``
-        # from the middleware's tool handler immediately before eval.
-        self._outer_runtime: ToolRuntime | None = None
+        # Outer ToolRuntime + loop captured for the current eval.
+        # PTC bridges read this context so tool calls can inject
+        # state/store/config (for Injected* args) and execute on the
+        # outer LangGraph loop instead of the QuickJS worker loop.
+        # Stored as task-local eval-scoped context; reset via token in
+        # _aeval_async to avoid stale cross-call leakage.
+        self._ptc_eval_context: contextvars.ContextVar[_PTCEvalContext | None] = (
+            contextvars.ContextVar("quickjs_ptc_eval_context", default=None)
+        )
         # Mutable per-eval PTC state. Allocated at eval start and cleared
         # in finally so bridge calls can't run outside the current eval.
         self._ptc_state: _PTCState | None = None
@@ -443,16 +456,25 @@ class _ThreadREPL:
         self._active_tool_names = target_names
         self._tools_installed = True
 
-    def set_outer_runtime(self, runtime: ToolRuntime | None) -> None:
-        """Record the outer ``ToolRuntime`` for the current eval.
-
-        PTC bridges forward this into their ``tool.ainvoke`` calls so
-        tools that depend on ``state`` / ``store`` / ``tool_call_id``
-        (notably subagent ``task`` tools) see the orchestrator's graph
-        context. The middleware calls this immediately before each eval
-        and again with ``None`` after.
-        """
-        self._outer_runtime = runtime
+    async def _ainvoke_tool_on_outer_loop(
+        self,
+        tool: BaseTool,
+        tool_call: dict[str, Any],
+        *,
+        outer_loop: asyncio.AbstractEventLoop | None,
+    ) -> Any:
+        """Run ``tool.ainvoke`` on the outer runtime's loop when available."""
+        if outer_loop is None:
+            return await tool.ainvoke(tool_call)
+        current_loop = asyncio.get_running_loop()
+        if current_loop is outer_loop:
+            return await tool.ainvoke(tool_call)
+        future = asyncio.run_coroutine_threadsafe(tool.ainvoke(tool_call), outer_loop)
+        try:
+            return await asyncio.wrap_future(future)
+        except asyncio.CancelledError:
+            future.cancel()
+            raise
 
     def _register_tool_bridge(self, camel: str) -> str:
         """Install a host-function bridge for one camel-cased tool name.
@@ -483,13 +505,18 @@ class _ThreadREPL:
             )
             payload = _normalize_tool_input(raw_input)
             call_id = _synth_tool_call_id(tool.name)
+            eval_context = self._ptc_eval_context.get()
+            outer_runtime = eval_context.runtime if eval_context is not None else None
+            outer_loop = eval_context.outer_loop if eval_context is not None else None
             # Build a ToolCall-shaped input so InjectedToolCallId and the
             # runtime-arg injection in _inject_tool_args_for_ptc fire.
             args = _inject_tool_args_for_ptc(
-                tool, payload, self._outer_runtime, call_id
+                tool, payload, outer_runtime, call_id
             )
-            result = await tool.ainvoke(
+            result = await self._ainvoke_tool_on_outer_loop(
+                tool,
                 {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
+                outer_loop=outer_loop,
             )
             return coerce_tool_output(result)
 
@@ -503,6 +530,7 @@ class _ThreadREPL:
         *,
         skills: dict[str, SkillMetadata] | None = None,
         skills_backend: BackendProtocol | None = None,
+        outer_runtime: ToolRuntime | None = None,
     ) -> EvalOutcome:
         # Both sync and async entry points funnel through ctx.eval_async on
         # the worker loop. Sync ctx.eval can't dispatch async host functions
@@ -513,6 +541,7 @@ class _ThreadREPL:
                 code,
                 skills=skills,
                 skills_backend=skills_backend,
+                outer_runtime=outer_runtime,
             )
         )
 
@@ -522,12 +551,16 @@ class _ThreadREPL:
         *,
         skills: dict[str, SkillMetadata] | None = None,
         skills_backend: BackendProtocol | None = None,
+        outer_runtime: ToolRuntime | None = None,
+        outer_loop: asyncio.AbstractEventLoop | None = None,
     ) -> EvalOutcome:
         return await self._worker.run_async(
             self._aeval_async(
                 code,
                 skills=skills,
                 skills_backend=skills_backend,
+                outer_runtime=outer_runtime,
+                outer_loop=outer_loop,
             )
         )
 
@@ -618,6 +651,8 @@ class _ThreadREPL:
         *,
         skills: dict[str, SkillMetadata] | None = None,
         skills_backend: BackendProtocol | None = None,
+        outer_runtime: ToolRuntime | None = None,
+        outer_loop: asyncio.AbstractEventLoop | None = None,
     ) -> EvalOutcome:
         """Uses ``ctx.eval_async`` directly.
 
@@ -647,6 +682,9 @@ class _ThreadREPL:
         # ConcurrentEvalError would otherwise null out the in-flight
         # eval's state and orphan its bridge calls.
         prev_ptc_state = self._ptc_state
+        ptc_eval_token = self._ptc_eval_context.set(
+            _PTCEvalContext(runtime=outer_runtime, outer_loop=outer_loop)
+        )
         self._ptc_state = _PTCState(remaining_calls=self._max_ptc_calls)
         try:
             value = await ctx.eval_async(code, timeout=self._per_call_timeout)
@@ -660,6 +698,7 @@ class _ThreadREPL:
             await self._record_eval_error(outcome, error=e, code=code)
         finally:
             self._ptc_state = prev_ptc_state
+            self._ptc_eval_context.reset(ptc_eval_token)
             outcome.stdout, outcome.stdout_truncated_chars = self._console.drain()
         return outcome
 

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -4,6 +4,7 @@ State persists across tool calls within a LangGraph thread (each thread
 gets its own QuickJS context).
 """
 
+import asyncio
 import contextlib
 import logging
 import uuid
@@ -254,21 +255,16 @@ class REPLMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
         ) -> ToolMessage:
             repl = registry.get(_resolve_thread_id(fallback_id))
             skills = middleware._skills_for_eval(runtime)
-            # The sync path doesn't support PTC (host-fn bridges are
-            # async); set_outer_runtime is a no-op here.
-            repl.set_outer_runtime(runtime)
-            try:
-                return _run(
-                    lambda c: repl.eval_sync(
-                        c,
-                        skills=skills,
-                        skills_backend=middleware._skills_backend,
-                    ),
-                    code,
-                    runtime.tool_call_id,
-                )
-            finally:
-                repl.set_outer_runtime(None)
+            return _run(
+                lambda c: repl.eval_sync(
+                    c,
+                    skills=skills,
+                    skills_backend=middleware._skills_backend,
+                    outer_runtime=runtime,
+                ),
+                code,
+                runtime.tool_call_id,
+            )
 
         async def async_eval(
             runtime: ToolRuntime[None, Any],
@@ -276,20 +272,13 @@ class REPLMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
         ) -> ToolMessage:
             repl = registry.get(_resolve_thread_id(fallback_id))
             skills = middleware._skills_for_eval(runtime)
-            # Capture the outer runtime so PTC bridges can forward
-            # state/store/context into tool calls during this eval. Clear
-            # after so a stale runtime can't bleed into a later call on
-            # the same thread — the lock serialises, but the closure
-            # would otherwise retain a reference past the call.
-            repl.set_outer_runtime(runtime)
-            try:
-                outcome = await repl.eval_async(
-                    code,
-                    skills=skills,
-                    skills_backend=middleware._skills_backend,
-                )
-            finally:
-                repl.set_outer_runtime(None)
+            outcome = await repl.eval_async(
+                code,
+                skills=skills,
+                skills_backend=middleware._skills_backend,
+                outer_runtime=runtime,
+                outer_loop=asyncio.get_running_loop(),
+            )
             return ToolMessage(
                 content=format_outcome(outcome, max_result_chars=max_chars),
                 tool_call_id=runtime.tool_call_id,

--- a/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
@@ -1,0 +1,157 @@
+"""Thread/loop-affinity regression tests for QuickJS PTC async dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import (
+    Iterator,  # noqa: TC003 — pydantic resolves annotations at runtime
+)
+from typing import Any
+
+from deepagents import create_deep_agent
+from deepagents.middleware.subagents import SubAgentMiddleware
+from langchain.agents import create_agent
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import tool
+from pydantic import Field
+
+from langchain_quickjs import REPLMiddleware
+
+
+class _FakeChatModel(GenericFakeChatModel):
+    """GenericFakeChatModel whose bind_tools returns self."""
+
+    messages: Iterator[AIMessage | str] = Field(exclude=True)
+
+    def bind_tools(self, tools: list[Any], **_: Any) -> _FakeChatModel:
+        del tools
+        return self
+
+
+def _script(code: str, *, final_message: str = "done") -> Iterator[AIMessage]:
+    return iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "eval",
+                        "args": {"code": code},
+                        "id": "call_1",
+                        "type": "tool_call",
+                    },
+                ],
+            ),
+            AIMessage(content=final_message),
+        ]
+    )
+
+
+def _eval_tool_message(result: dict[str, Any]) -> ToolMessage:
+    messages = [
+        m for m in result["messages"] if isinstance(m, ToolMessage) and m.name == "eval"
+    ]
+    assert messages, "expected at least one eval ToolMessage"
+    return messages[-1]
+
+
+def _assert_result_contains(content: str, expected: str) -> None:
+    assert "<error" not in content, content
+    assert "<result" in content, content
+    assert expected in content, content
+
+
+def _make_agent(
+    code: str,
+    middleware: REPLMiddleware,
+    *,
+    final_message: str = "done",
+) -> Any:
+    return create_deep_agent(
+        model=_FakeChatModel(messages=_script(code, final_message=final_message)),
+        middleware=[middleware],
+    )
+
+
+@tool("current_loop_id")
+async def current_loop_id() -> str:
+    """Return the running loop id for loop-affinity assertions."""
+    await asyncio.sleep(0)
+    return str(id(asyncio.get_running_loop()))
+
+
+async def test_quickjs_async_ptc_runs_tools_on_outer_loop() -> None:
+    """PTC tool coroutines run on the caller loop, not the worker loop."""
+    outer_loop_id = str(id(asyncio.get_running_loop()))
+    result = await _make_agent(
+        "await tools.currentLoopId({})",
+        REPLMiddleware(ptc=[current_loop_id]),
+    ).ainvoke(
+        {
+            "messages": [
+                HumanMessage(
+                    content="Use the eval tool and call currentLoopId via PTC."
+                )
+            ]
+        }
+    )
+
+    tool_message = _eval_tool_message(result)
+    _assert_result_contains(tool_message.content, outer_loop_id)
+
+
+async def test_quickjs_async_ptc_task_subagent_loop_affinity_e2e() -> None:
+    """E2E: PTC `task` runs compiled subagents on the caller loop."""
+    outer_loop_id = id(asyncio.get_running_loop())
+    owner_loop = asyncio.get_running_loop()
+    subagent_loop_ids: list[int] = []
+
+    def _subagent_sync(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        return {"messages": [AIMessage(content="subagent-ok")]}
+
+    async def _subagent_async(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        subagent_loop_ids.append(id(asyncio.get_running_loop()))
+        # Affine guard: awaiting this from a different loop raises the
+        # same "Future attached to a different loop" runtime error.
+        future = owner_loop.create_future()
+        owner_loop.call_soon_threadsafe(future.set_result, None)
+        await future
+        return {"messages": [AIMessage(content="subagent-ok")]}
+
+    subagent_runnable = RunnableLambda(_subagent_sync, afunc=_subagent_async)
+    agent = create_agent(
+        model=_FakeChatModel(
+            messages=_script(
+                "await tools.task({"
+                "description: 'say hi', subagent_type: 'researcher'"
+                "})",
+                final_message="done",
+            )
+        ),
+        middleware=[
+            SubAgentMiddleware(
+                backend=None,
+                subagents=[
+                    {
+                        "name": "researcher",
+                        "description": "returns one short answer",
+                        "runnable": subagent_runnable,
+                    }
+                ],
+            ),
+            REPLMiddleware(ptc=["task"]),
+        ],
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage(content="Use eval and call task for researcher")]},
+        config={"configurable": {"thread_id": "ptc-task-loop-affinity"}},
+    )
+    tool_message = _eval_tool_message(result)
+    _assert_result_contains(tool_message.content, "subagent-ok")
+    assert subagent_loop_ids
+    assert all(loop_id == outer_loop_id for loop_id in subagent_loop_ids)


### PR DESCRIPTION
This PR fixes an async loop-affinity bug in `langchain-quickjs` where PTC tool calls could execute on the QuickJS worker loop instead of the outer LangGraph loop. In real subagent flows (`tools.task(...)`), this could surface as `RuntimeError: ... got Future ... attached to a different loop` during checkpoint/background execution.

### Changes

- `langchain_quickjs._repl`:
  - Added per-eval PTC dispatch context (`_PTCEvalContext`) stored in a task-local `ContextVar`.
  - Added `_ainvoke_tool_on_outer_loop(...)` to route `tool.ainvoke(...)` to the outer loop when available.
  - Updated PTC bridge invocation to read eval-scoped runtime/loop context and inject runtime args from that context.
  - Extended `eval_sync` / `eval_async` / `_aeval_async` signatures to accept `outer_runtime` and `outer_loop` so loop affinity is explicit at eval boundaries.
- `langchain_quickjs.middleware`:
  - Removed shared `set_outer_runtime(...)` mutation pattern.
  - Now passes `outer_runtime` and `asyncio.get_running_loop()` directly per eval call.
- Tests:
  - Added `tests/unit_tests/test_thread_affinity.py` with dedicated async loop-affinity regression coverage:
    - `test_quickjs_async_ptc_runs_tools_on_outer_loop`
    - `test_quickjs_async_ptc_task_subagent_loop_affinity_e2e` (full `eval -> tools.task -> SubAgentMiddleware -> subagent.ainvoke` path).

### Why this approach

The fix keeps QuickJS evaluation thread-affine while making tool execution loop-affine to the caller graph. That matches LangGraph expectations for async orchestration and removes cross-loop `Future` attachment failures in nested PTC/subagent scenarios.
