### PR TITLE
ci(evals): show filters in job names

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -84,7 +84,7 @@ env:
 
 jobs:
   eval:
-    name: "📊 Eval (${{ inputs.model }})"
+    name: "Run"
     runs-on: ubuntu-latest
     environment: evals
     timeout-minutes: 360

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -316,7 +316,7 @@ jobs:
   # as separate jobs whose matrices come from `prep`'s per-provider outputs;
   # see _EVAL_PROVIDER_OUTPUTS in .github/scripts/models.py for the source set.
   eval-anthropic:
-    name: "📊 Eval Anthropic (${{ matrix.model }})"
+    name: "📊 Anthropic · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.anthropic_has_models == 'true' }}
     strategy:
@@ -337,7 +337,7 @@ jobs:
     secrets: inherit
 
   eval-baseten:
-    name: "📊 Eval Baseten (${{ matrix.model }})"
+    name: "📊 Baseten · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.baseten_has_models == 'true' }}
     strategy:
@@ -358,7 +358,7 @@ jobs:
     secrets: inherit
 
   eval-fireworks:
-    name: "📊 Eval Fireworks (${{ matrix.model }})"
+    name: "📊 Fireworks · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.fireworks_has_models == 'true' }}
     strategy:
@@ -379,7 +379,7 @@ jobs:
     secrets: inherit
 
   eval-google-genai:
-    name: "📊 Eval Google GenAI (${{ matrix.model }})"
+    name: "📊 Google GenAI · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.google_genai_has_models == 'true' }}
     strategy:
@@ -400,7 +400,7 @@ jobs:
     secrets: inherit
 
   eval-groq:
-    name: "📊 Eval Groq (${{ matrix.model }})"
+    name: "📊 Groq · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.groq_has_models == 'true' }}
     strategy:
@@ -421,7 +421,7 @@ jobs:
     secrets: inherit
 
   eval-nvidia:
-    name: "📊 Eval NVIDIA (${{ matrix.model }})"
+    name: "📊 NVIDIA · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.nvidia_has_models == 'true' }}
     strategy:
@@ -442,7 +442,7 @@ jobs:
     secrets: inherit
 
   eval-ollama:
-    name: "📊 Eval Ollama (${{ matrix.model }})"
+    name: "📊 Ollama · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.ollama_has_models == 'true' }}
     strategy:
@@ -463,7 +463,7 @@ jobs:
     secrets: inherit
 
   eval-openai:
-    name: "📊 Eval OpenAI (${{ matrix.model }})"
+    name: "📊 OpenAI · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.openai_has_models == 'true' }}
     strategy:
@@ -484,7 +484,7 @@ jobs:
     secrets: inherit
 
   eval-openrouter:
-    name: "📊 Eval OpenRouter (${{ matrix.model }})"
+    name: "📊 OpenRouter · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.openrouter_has_models == 'true' }}
     strategy:
@@ -505,7 +505,7 @@ jobs:
     secrets: inherit
 
   eval-xai:
-    name: "📊 Eval xAI (${{ matrix.model }})"
+    name: "📊 xAI · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.xai_has_models == 'true' }}
     strategy:
@@ -526,7 +526,7 @@ jobs:
     secrets: inherit
 
   eval-other:
-    name: "📊 Eval Other (${{ matrix.model }})"
+    name: "📊 Other · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
     needs: prep
     if: ${{ needs.prep.outputs.other_has_models == 'true' }}
     strategy:


### PR DESCRIPTION
Eval workflow runs now surface provider, model, category, and tier selections directly in the GitHub Actions job list. The reusable `_eval.yml` job uses a generic `Run` label so the caller-defined matrix names carry the useful context instead of repeating a generic eval label.