### PR TITLE
test(quickjs): consolidate fake test model helpers across quickjs tests

### DIFF
--- a/libs/partners/quickjs/tests/_common.py
+++ b/libs/partners/quickjs/tests/_common.py
@@ -1,0 +1,29 @@
+"""Shared test helpers for QuickJS test suites."""
+
+from __future__ import annotations
+
+from collections.abc import (
+    Iterator,  # noqa: TC003 — pydantic resolves field annotations at runtime
+    Sequence,  # noqa: TC003 — pydantic resolves field annotations at runtime
+)
+from typing import Any
+
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import (
+    AIMessage,  # noqa: TC002 — pydantic resolves field annotations at runtime
+)
+from pydantic import Field
+
+
+class FakeChatModel(GenericFakeChatModel):
+    """GenericFakeChatModel whose ``bind_tools`` returns self.
+
+    Without this override, ``create_deep_agent``/``create_agent`` wraps the model in
+    a binding that no longer reads from the scripted message iterator.
+    """
+
+    messages: Iterator[AIMessage | str] = Field(exclude=True)
+
+    def bind_tools(self, tools: Sequence[Any], **_: Any) -> FakeChatModel:
+        del tools
+        return self

--- a/libs/partners/quickjs/tests/benchmarks/_common.py
+++ b/libs/partners/quickjs/tests/benchmarks/_common.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 from collections.abc import (
     Iterator,  # noqa: TC003  # pydantic resolves this annotation at runtime
-    Sequence,  # noqa: TC003  # used in runtime-accessed annotations
 )
 from typing import TYPE_CHECKING, Any
 
 from deepagents import create_deep_agent
-from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
-from pydantic import Field
 
 from langchain_quickjs import REPLMiddleware
+from tests._common import FakeChatModel
 
 if TYPE_CHECKING:
     from langchain_quickjs.middleware import REPLState
@@ -41,15 +39,6 @@ PTC_AND_CONSOLE_CODE = (
 COUNTER_INIT_CODE = "let counter = 0; String(counter);"
 COUNTER_NEXT_CODE = 'typeof counter === "number" ? String(counter += 1) : "missing";'
 THROUGHPUT_ITERATIONS = 200
-
-
-class FakeChatModel(GenericFakeChatModel):
-    """Generic fake chat model whose ``bind_tools`` keeps scripted messages."""
-
-    messages: Iterator[AIMessage | str] = Field(exclude=True)
-
-    def bind_tools(self, tools: Sequence[Any], **_: Any) -> FakeChatModel:
-        return self
 
 
 @tool("echo_payload")

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -20,39 +20,21 @@ from collections.abc import (
     Iterator,  # noqa: TC003 — pydantic resolves field annotations at runtime
 )
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 from deepagents import create_deep_agent
 from langchain.tools import (
     ToolRuntime,  # noqa: TC002  # tool decorator resolves type hints at import time
 )
-from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
-from pydantic import Field
 
 from langchain_quickjs import REPLMiddleware
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
+from tests._common import FakeChatModel
 
 # The exact snippet a model produced in production when this regressed.
 _EVAL_CODE = "var result = tools.listUserIds({}); result;"
-
-
-class _FakeChatModel(GenericFakeChatModel):
-    """GenericFakeChatModel whose bind_tools returns self.
-
-    Without the override, ``create_deep_agent``'s bind_tools call replaces
-    the model with a RunnableBinding whose ``_generate`` no longer reads
-    from our pre-scripted iterator.
-    """
-
-    messages: Iterator[AIMessage | str] = Field(exclude=True)
-
-    def bind_tools(self, tools: Sequence[Any], **_: Any) -> _FakeChatModel:
-        return self
 
 
 @tool
@@ -120,7 +102,7 @@ def _make_agent(
     final_message: str = "Done.",
 ) -> Any:
     return create_deep_agent(
-        model=_FakeChatModel(messages=_script(code, final_message=final_message)),
+        model=FakeChatModel(messages=_script(code, final_message=final_message)),
         middleware=[middleware],
     )
 
@@ -325,7 +307,7 @@ async def test_async_ptc_eval_through_repl() -> None:
 def test_wrong_arg_name_surfaces_to_model() -> None:
     """Document what the model sees when JS calls a tool with a misspelled arg."""
     agent = create_deep_agent(
-        model=_FakeChatModel(
+        model=FakeChatModel(
             messages=iter(
                 [
                     AIMessage(

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
@@ -11,36 +11,18 @@ import asyncio
 from collections.abc import (
     Iterator,  # noqa: TC003 — pydantic resolves field annotations at runtime
 )
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 from deepagents import create_deep_agent
 from langchain.tools import (
     ToolRuntime,  # noqa: TC002  # tool decorator resolves type hints at import time
 )
-from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
-from pydantic import Field
 
 from langchain_quickjs import REPLMiddleware
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-
-class _FakeChatModel(GenericFakeChatModel):
-    """GenericFakeChatModel whose bind_tools returns self.
-
-    Without the override, ``create_deep_agent``'s bind_tools call replaces
-    the model with a RunnableBinding whose ``_generate`` no longer reads
-    from the pre-scripted iterator.
-    """
-
-    messages: Iterator[AIMessage | str] = Field(exclude=True)
-
-    def bind_tools(self, tools: Sequence[Any], **_: Any) -> _FakeChatModel:
-        return self
+from tests._common import FakeChatModel
 
 
 @tool
@@ -102,7 +84,7 @@ def _make_agent(
     final_message: str = "done",
 ) -> Any:
     return create_deep_agent(
-        model=_FakeChatModel(messages=_script(code, final_message=final_message)),
+        model=FakeChatModel(messages=_script(code, final_message=final_message)),
         middleware=[middleware],
     )
 

--- a/libs/partners/quickjs/tests/unit_tests/test_snapshot_persistence.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_snapshot_persistence.py
@@ -8,24 +8,13 @@ from typing import Any, Literal
 import pytest
 from deepagents import create_deep_agent
 from deepagents.backends.state import StateBackend
-from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.memory import InMemorySaver
-from pydantic import Field
 
 from langchain_quickjs import REPLMiddleware
+from tests._common import FakeChatModel
 
 InvokeMode = Literal["invoke", "ainvoke"]
-
-
-class _FakeChatModel(GenericFakeChatModel):
-    """GenericFakeChatModel whose ``bind_tools`` returns self."""
-
-    messages: Any = Field(exclude=True)
-
-    def bind_tools(self, tools, **_: Any) -> _FakeChatModel:
-        del tools
-        return self
 
 
 def _script_two_turns() -> list[AIMessage]:
@@ -148,7 +137,7 @@ async def test_repl_snapshot_persists_state_between_turns(
 ) -> None:
     """REPL state survives across turns on the same thread_id."""
     agent = create_deep_agent(
-        model=_FakeChatModel(messages=iter(_script_two_turns())),
+        model=FakeChatModel(messages=iter(_script_two_turns())),
         middleware=[REPLMiddleware()],
         checkpointer=InMemorySaver(),
     )
@@ -184,7 +173,7 @@ async def test_repl_without_snapshots_resets_state_between_turns(
 ) -> None:
     """When snapshots are disabled, turn-2 eval starts with a fresh context."""
     agent = create_deep_agent(
-        model=_FakeChatModel(messages=iter(_script_two_turns_without_snapshots())),
+        model=FakeChatModel(messages=iter(_script_two_turns_without_snapshots())),
         middleware=[REPLMiddleware(snapshot_between_turns=False)],
         checkpointer=InMemorySaver(),
     )
@@ -243,7 +232,7 @@ async def test_repl_snapshot_persists_skill_usage_between_turns(
     }
 
     agent = create_deep_agent(
-        model=_FakeChatModel(messages=iter(_script_two_turns_with_skill())),
+        model=FakeChatModel(messages=iter(_script_two_turns_with_skill())),
         backend=backend,
         skills=["/skills"],
         middleware=[REPLMiddleware(skills_backend=backend)],


### PR DESCRIPTION
## Summary

Reduces duplication across the QuickJS test suite by centralizing the scripted fake chat model used to keep `bind_tools` from replacing the message iterator-driven model behavior.
