### PR TITLE
style(cli): clarify onboarding name persistence

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3486,7 +3486,7 @@ class DeepAgentsApp(App):
         """Persist the optional onboarding name into agent memory.
 
         Surfaces a user-visible toast when the memory write fails so the
-        promise made in `LaunchNameScreen` ("can be remembered for future
+        promise made in `LaunchNameScreen` ("will be remembered for future
         sessions") does not silently break.
         """
         from deepagents_cli.onboarding import write_onboarding_name_memory

--- a/libs/cli/deepagents_cli/widgets/launch_init.py
+++ b/libs/cli/deepagents_cli/widgets/launch_init.py
@@ -115,7 +115,7 @@ class LaunchNameScreen(ModalScreen[str | None]):
             yield Static(
                 Content.assemble(
                     "What should Deep Agents call you? This is optional and "
-                    "can be remembered for future sessions."
+                    "will be remembered for future sessions."
                 ),
                 classes="launch-init-copy",
             )


### PR DESCRIPTION
Clarify the first-launch name prompt so it matches the behavior implemented by the onboarding memory writer. The copy now tells users their optional name will be remembered rather than suggesting persistence is uncertain.