### PR TITLE
fix(cli): show detached HEAD commit in local context

### DIFF
--- a/libs/cli/deepagents_cli/local_context.py
+++ b/libs/cli/deepagents_cli/local_context.py
@@ -229,7 +229,7 @@ fi
 
 
 def _section_git() -> str:
-    """Git branch, main branches, uncommitted changes.
+    """Git branch or detached HEAD commit, main branches, uncommitted changes.
 
     Returns:
         Bash snippet (requires `IN_GIT` from header).
@@ -237,7 +237,12 @@ def _section_git() -> str:
     return r"""# --- Git ---
 if $IN_GIT; then
   BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
-  GT="**Git**: Current branch \`${BRANCH}\`"
+  if [ "$BRANCH" = "HEAD" ]; then
+    COMMIT="$(git rev-parse --short HEAD 2>/dev/null)"
+    GT="**Git**: Detached HEAD at \`${COMMIT}\`"
+  else
+    GT="**Git**: Current branch \`${BRANCH}\`"
+  fi
 
   MAINS=""
   for b in $(git branch 2>/dev/null | sed 's/^[* ]*//'); do

--- a/libs/cli/tests/unit_tests/test_local_context.py
+++ b/libs/cli/tests/unit_tests/test_local_context.py
@@ -1054,6 +1054,27 @@ class TestSectionGit:
         out = _run_section(_section_git(), tmp_path, with_header=True)
         assert "Current branch `feat-x`" in out
 
+    def test_detached_head_includes_commit_hash(self, tmp_path: Path) -> None:
+        _git_init_commit(tmp_path, branch="main")
+        commit = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "checkout", "--detach", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+
+        out = _run_section(_section_git(), tmp_path, with_header=True)
+
+        assert f"Detached HEAD at `{commit}`" in out
+        assert "Current branch `HEAD`" not in out
+
     def test_main_branch_listed(self, tmp_path: Path) -> None:
         _git_init_commit(tmp_path, branch="main")
         out = _run_section(_section_git(), tmp_path, with_header=True)


### PR DESCRIPTION
Handle detached HEAD state in the local context git section. Previously, `git rev-parse --abbrev-ref HEAD` would return "HEAD" in detached state, resulting in the misleading "Current branch `HEAD`" output.

## Changes
- Add conditional in `_section_git()` to detect detached HEAD (`BRANCH == "HEAD"`) and show "Detached HEAD at `<short-commit>`" instead of the branch name
- Update docstring to reflect the either/or nature of the output

**Before**: `` **Git**: Current branch `HEAD` ``  
**After**: `` **Git**: Detached HEAD at `abc1234` ``
