### PR TITLE
ci(evals): fix skipped eval job names

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -84,7 +84,12 @@ env:
 
 jobs:
   eval:
-    name: "Run"
+    # Carries the per-run detail (model · categories · tiers) so it appears in
+    # the matrix-job breadcrumb when the job actually runs. The outer caller
+    # in `evals.yml` is intentionally static — GHA does not evaluate `name:`
+    # expressions for jobs skipped via `if:`, so referencing `${{ matrix.* }}`
+    # there would render as raw template text in the UI.
+    name: "📊 ${{ inputs.model }} · ${{ inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers || 'all tiers' }}"
     runs-on: ubuntu-latest
     environment: evals
     timeout-minutes: 360

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -315,8 +315,15 @@ jobs:
   # GHA has no built-in "queue per matrix value", so the partition is encoded
   # as separate jobs whose matrices come from `prep`'s per-provider outputs;
   # see _EVAL_PROVIDER_OUTPUTS in .github/scripts/models.py for the source set.
+  #
+  # Each per-provider `name:` below is intentionally a static string. GHA does
+  # not evaluate `name:` expressions for jobs skipped via `if:`, so any
+  # `${{ matrix.* }}` or `${{ inputs.* }}` references would render as raw
+  # template text in the UI for skipped providers. Per-run detail (model,
+  # categories, tiers) lives on the inner `_eval.yml` job name, which only
+  # renders when the job actually runs.
   eval-anthropic:
-    name: "📊 Anthropic · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Anthropic"
     needs: prep
     if: ${{ needs.prep.outputs.anthropic_has_models == 'true' }}
     strategy:
@@ -337,7 +344,7 @@ jobs:
     secrets: inherit
 
   eval-baseten:
-    name: "📊 Baseten · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Baseten"
     needs: prep
     if: ${{ needs.prep.outputs.baseten_has_models == 'true' }}
     strategy:
@@ -358,7 +365,7 @@ jobs:
     secrets: inherit
 
   eval-fireworks:
-    name: "📊 Fireworks · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Fireworks"
     needs: prep
     if: ${{ needs.prep.outputs.fireworks_has_models == 'true' }}
     strategy:
@@ -379,7 +386,7 @@ jobs:
     secrets: inherit
 
   eval-google-genai:
-    name: "📊 Google GenAI · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Google GenAI"
     needs: prep
     if: ${{ needs.prep.outputs.google_genai_has_models == 'true' }}
     strategy:
@@ -400,7 +407,7 @@ jobs:
     secrets: inherit
 
   eval-groq:
-    name: "📊 Groq · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Groq"
     needs: prep
     if: ${{ needs.prep.outputs.groq_has_models == 'true' }}
     strategy:
@@ -421,7 +428,7 @@ jobs:
     secrets: inherit
 
   eval-nvidia:
-    name: "📊 NVIDIA · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 NVIDIA"
     needs: prep
     if: ${{ needs.prep.outputs.nvidia_has_models == 'true' }}
     strategy:
@@ -442,7 +449,7 @@ jobs:
     secrets: inherit
 
   eval-ollama:
-    name: "📊 Ollama · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Ollama"
     needs: prep
     if: ${{ needs.prep.outputs.ollama_has_models == 'true' }}
     strategy:
@@ -463,7 +470,7 @@ jobs:
     secrets: inherit
 
   eval-openai:
-    name: "📊 OpenAI · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 OpenAI"
     needs: prep
     if: ${{ needs.prep.outputs.openai_has_models == 'true' }}
     strategy:
@@ -484,7 +491,7 @@ jobs:
     secrets: inherit
 
   eval-openrouter:
-    name: "📊 OpenRouter · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 OpenRouter"
     needs: prep
     if: ${{ needs.prep.outputs.openrouter_has_models == 'true' }}
     strategy:
@@ -505,7 +512,7 @@ jobs:
     secrets: inherit
 
   eval-xai:
-    name: "📊 xAI · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 xAI"
     needs: prep
     if: ${{ needs.prep.outputs.xai_has_models == 'true' }}
     strategy:
@@ -526,7 +533,7 @@ jobs:
     secrets: inherit
 
   eval-other:
-    name: "📊 Other · ${{ matrix.model }} · ${{ inputs.eval_categories_override || inputs.eval_categories || 'all categories' }} · ${{ inputs.eval_tiers_override || inputs.eval_tiers || 'all tiers' }}"
+    name: "📊 Other"
     needs: prep
     if: ${{ needs.prep.outputs.other_has_models == 'true' }}
     strategy:


### PR DESCRIPTION
Fix eval workflow job labels so skipped provider jobs show clean static names in GitHub Actions. Per-model detail still appears where it is actually evaluated: on the reusable `_eval.yml` job that runs for each matrix entry.