### PR TITLE
refactor(ci): drop numeric prefix from, enforce uniqueness via dedupe and collision detection

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -677,25 +677,24 @@ def _provider(model_spec: str) -> str:
     return model_spec.split(":", 1)[0]
 
 
-def _artifact_key(index: int, model_spec: str) -> str:
-    """Build a stable, artifact-safe key for one model matrix entry.
+def _artifact_key(model_spec: str) -> str:
+    """Build an artifact-safe key for one model matrix entry.
 
     GitHub Actions artifact names disallow several characters that appear in
-    model specs (e.g., `:` and `/`), and two artifacts cannot share a name
-    within a workflow run. The numeric `index` prefix guarantees uniqueness
-    even if two specs collapse to the same slug; the regex replaces every
-    disallowed character with `-`.
+    model specs (e.g., `:` and `/`), so the regex replaces every disallowed
+    character with `-`. Uniqueness across a workflow run is enforced by
+    `_resolve_models` (dedupe) and `_matrix_outputs` (assertion); see those
+    callers.
     """
-    slug = _ARTIFACT_KEY_RE.sub("-", model_spec).strip("-")
-    return f"{index:03d}-{slug}"
+    return _ARTIFACT_KEY_RE.sub("-", model_spec).strip("-")
 
 
-def _matrix_entry(index: int, model_spec: str) -> dict[str, str]:
+def _matrix_entry(model_spec: str) -> dict[str, str]:
     """Build one GitHub Actions matrix entry for a model."""
     return {
         "model": model_spec,
         "provider": _provider(model_spec),
-        "artifact_key": _artifact_key(index, model_spec),
+        "artifact_key": _artifact_key(model_spec),
     }
 
 
@@ -716,7 +715,19 @@ def _matrix_outputs(workflow: str, models: list[str]) -> dict[str, object]:
     Returns:
         Mapping of GitHub output names to JSON-serializable values.
     """
-    entries = [_matrix_entry(index, model) for index, model in enumerate(models)]
+    entries = [_matrix_entry(model) for model in models]
+    # Tripwire: `_resolve_models` dedupes raw specs, and our `provider:model`
+    # convention plus the registry's canonical specs make it effectively
+    # impossible for two distinct specs to collapse to the same slug. If this
+    # ever fires, reintroduce a disambiguating prefix in `_artifact_key`.
+    by_key: dict[str, list[str]] = {}
+    for entry in entries:
+        by_key.setdefault(entry["artifact_key"], []).append(entry["model"])
+    collisions = {key: specs for key, specs in by_key.items() if len(specs) > 1}
+    if collisions:
+        details = "; ".join(f"{key!r} <- {specs}" for key, specs in collisions.items())
+        msg = f"Duplicate artifact_key(s) in matrix: {details}"
+        raise ValueError(msg)
     outputs: dict[str, object] = {"matrix": {"include": entries}}
 
     if workflow != "eval":
@@ -758,21 +769,24 @@ def _resolve_models(workflow: str, selection: str) -> list[str]:
     normalized = selection.strip()
 
     if normalized in presets:
-        return _filter_by_tag(f"{workflow}:", presets[normalized])
-
-    specs = [s.strip() for s in normalized.split(",") if s.strip()]
-    if not specs:
-        msg = f"No models resolved from {env_var} (got empty or whitespace-only input)"
-        raise ValueError(msg)
-    invalid = [s for s in specs if ":" not in s]
-    if invalid:
-        msg = f"Invalid model spec(s) (expected 'provider:model'): {', '.join(repr(s) for s in invalid)}"
-        raise ValueError(msg)
-    unsafe = [s for s in specs if not _SAFE_SPEC_RE.match(s)]
-    if unsafe:
-        msg = f"Model spec(s) contain disallowed characters: {', '.join(repr(s) for s in unsafe)}"
-        raise ValueError(msg)
-    return specs
+        specs = _filter_by_tag(f"{workflow}:", presets[normalized])
+    else:
+        specs = [s.strip() for s in normalized.split(",") if s.strip()]
+        if not specs:
+            msg = f"No models resolved from {env_var} (got empty or whitespace-only input)"
+            raise ValueError(msg)
+        invalid = [s for s in specs if ":" not in s]
+        if invalid:
+            msg = f"Invalid model spec(s) (expected 'provider:model'): {', '.join(repr(s) for s in invalid)}"
+            raise ValueError(msg)
+        unsafe = [s for s in specs if not _SAFE_SPEC_RE.match(s)]
+        if unsafe:
+            msg = f"Model spec(s) contain disallowed characters: {', '.join(repr(s) for s in unsafe)}"
+            raise ValueError(msg)
+    # Order-preserving dedupe so duplicate entries (typo'd `models_override`,
+    # or a future REGISTRY edit that accidentally repeats a spec) cannot
+    # collide on `artifact_key` downstream.
+    return list(dict.fromkeys(specs))
 
 
 def main() -> None:

--- a/.github/scripts/test_models.py
+++ b/.github/scripts/test_models.py
@@ -57,7 +57,7 @@ def test_eval_matrix_outputs_are_partitioned_by_provider(models: ModuleType) -> 
             {
                 "model": "anthropic:claude-sonnet-4-6",
                 "provider": "anthropic",
-                "artifact_key": "000-anthropic-claude-sonnet-4-6",
+                "artifact_key": "anthropic-claude-sonnet-4-6",
             }
         ]
     }
@@ -66,7 +66,7 @@ def test_eval_matrix_outputs_are_partitioned_by_provider(models: ModuleType) -> 
             {
                 "model": "openrouter:moonshotai/kimi-k2.6",
                 "provider": "openrouter",
-                "artifact_key": "001-openrouter-moonshotai-kimi-k2.6",
+                "artifact_key": "openrouter-moonshotai-kimi-k2.6",
             }
         ]
     }
@@ -75,7 +75,7 @@ def test_eval_matrix_outputs_are_partitioned_by_provider(models: ModuleType) -> 
             {
                 "model": "new_provider:model-1",
                 "provider": "new_provider",
-                "artifact_key": "002-new_provider-model-1",
+                "artifact_key": "new_provider-model-1",
             }
         ]
     }
@@ -91,7 +91,7 @@ def test_harbor_matrix_output_stays_flat(models: ModuleType) -> None:
                 {
                     "model": "openai:gpt-5.4",
                     "provider": "openai",
-                    "artifact_key": "000-openai-gpt-5.4",
+                    "artifact_key": "openai-gpt-5.4",
                 }
             ]
         }
@@ -174,28 +174,106 @@ def test_has_models_serializes_to_lowercase_bool(models: ModuleType) -> None:
 
 
 @pytest.mark.parametrize(
-    ("index", "spec", "expected"),
+    ("spec", "expected"),
     [
-        (0, "openrouter:moonshotai/kimi-k2.6", "000-openrouter-moonshotai-kimi-k2.6"),
-        (5, "openrouter:foo//bar", "005-openrouter-foo-bar"),
-        (12, ":leading-colon", "012-leading-colon"),
-        (99, "trailing-slash/", "099-trailing-slash"),
-        (7, "anthropic:claude-opus-4-7", "007-anthropic-claude-opus-4-7"),
+        ("openrouter:moonshotai/kimi-k2.6", "openrouter-moonshotai-kimi-k2.6"),
+        ("openrouter:foo//bar", "openrouter-foo-bar"),
+        (":leading-colon", "leading-colon"),
+        ("trailing-slash/", "trailing-slash"),
+        ("anthropic:claude-opus-4-7", "anthropic-claude-opus-4-7"),
     ],
 )
 def test_artifact_key_handles_disallowed_characters(
-    models: ModuleType, index: int, spec: str, expected: str
+    models: ModuleType, spec: str, expected: str
 ) -> None:
     """`_artifact_key` strips/collapses every char outside `[a-zA-Z0-9._-]`."""
-    assert models._artifact_key(index, spec) == expected
+    assert models._artifact_key(spec) == expected
 
 
-def test_artifact_key_index_disambiguates_identical_slugs(
+def test_resolve_models_dedupes_repeated_specs(models: ModuleType) -> None:
+    """`_resolve_models` deduplicates so `artifact_key` cannot collide downstream.
+
+    Without this, a typo'd `models_override` like `openai:gpt-5.5,openai:gpt-5.5`
+    would produce two matrix rows that race to upload artifacts under the same
+    name and fail mid-run.
+    """
+    resolved = models._resolve_models(
+        "eval", "anthropic:claude-sonnet-4-6,anthropic:claude-sonnet-4-6"
+    )
+    assert resolved == ["anthropic:claude-sonnet-4-6"]
+
+
+def test_resolve_models_preserves_first_occurrence_order(
     models: ModuleType,
 ) -> None:
-    """Same spec at different indexes still produces unique keys."""
-    spec = "anthropic:claude-sonnet-4-6"
-    assert models._artifact_key(0, spec) != models._artifact_key(1, spec)
+    """Dedupe keeps each spec at its first position — guards against `set()`.
+
+    A future "simplification" to `list(set(specs))` would silently scramble
+    the matrix order; this test pins the `dict.fromkeys` contract.
+    """
+    resolved = models._resolve_models(
+        "eval",
+        "anthropic:claude-sonnet-4-6,openai:gpt-5.5,anthropic:claude-sonnet-4-6,"
+        "openai:gpt-5.5,google_genai:gemini-3.1-pro",
+    )
+    assert resolved == [
+        "anthropic:claude-sonnet-4-6",
+        "openai:gpt-5.5",
+        "google_genai:gemini-3.1-pro",
+    ]
+
+
+def test_resolve_models_dedupes_preset_branch(models: ModuleType) -> None:
+    """Dedupe applies to preset resolution too, not just manual `models_override`.
+
+    The `_artifact_key` docstring promises uniqueness is enforced by
+    `_resolve_models`; this test pins that promise across both code paths so
+    a future REGISTRY edit that accidentally duplicates a spec won't blow up
+    the matrix mid-run.
+    """
+    resolved = models._resolve_models("eval", "all")
+    assert len(resolved) == len(set(resolved))
+
+
+def test_matrix_outputs_rejects_colliding_artifact_keys(
+    models: ModuleType,
+) -> None:
+    """Defense-in-depth: if dedupe is ever bypassed, `_matrix_outputs` raises.
+
+    Bypasses `_resolve_models` to feed two distinct specs that slugify to the
+    same key (`foo:a/b` and `foo:a-b` both become `foo-a-b`) — the actual
+    failure mode the tripwire defends against. Asserts both the slug and the
+    raw model specs appear in the message so a CI failure is self-diagnosing.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        models._matrix_outputs("eval", ["foo:a/b", "foo:a-b"])
+    msg = str(excinfo.value)
+    assert "Duplicate artifact_key" in msg
+    assert "foo-a-b" in msg
+    assert "foo:a/b" in msg
+    assert "foo:a-b" in msg
+
+
+def test_matrix_outputs_rejects_three_way_collision(
+    models: ModuleType,
+) -> None:
+    """Three-way collision lists the offending key once, with all three specs.
+
+    Exercises the `len(specs) > 1` branch in the collision detector — the
+    list-of-models grouping must not split a 3+ collision into separate
+    entries or duplicate the slug in the message.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        models._matrix_outputs(
+            "eval",
+            ["foo:a/b", "foo:a-b", "foo:a:b"],
+        )
+    msg = str(excinfo.value)
+    # Slug appears exactly once; all three offending specs are named.
+    assert msg.count("'foo-a-b'") == 1
+    assert "foo:a/b" in msg
+    assert "foo:a-b" in msg
+    assert "foo:a:b" in msg
 
 
 def test_provider_returns_whole_string_when_no_colon(models: ModuleType) -> None:


### PR DESCRIPTION
Drop the numeric index prefix from `_artifact_key` and enforce uniqueness through dedupe + collision detection instead. The old zero-padded index (`000-`, `001-`, ...) was a blunt disambiguator that made artifact names harder to scan — since `_resolve_models` already controls what specs enter the matrix, uniqueness is better guaranteed at the source.

## Changes
- Remove the `index` parameter from `_artifact_key` and `_matrix_entry`, dropping the `{index:03d}-` prefix so artifact keys are just the slugified spec (e.g., `anthropic-claude-sonnet-4-6` instead of `000-anthropic-claude-sonnet-4-6`)
- Add order-preserving dedupe (`dict.fromkeys`) to `_resolve_models` across both the preset and manual code paths, preventing duplicate specs from ever reaching `_matrix_outputs`
- Add a collision-detection tripwire in `_matrix_outputs` that raises `ValueError` with the offending slug and specs if two distinct specs slugify to the same key — defense-in-depth in case dedupe is ever bypassed