### PR TITLE
chore(cli): disable click-to-show-timestamp toast

### DIFF
--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -710,7 +710,7 @@ class _AgentCoreProvider(SandboxProvider):
 
         # Validate AWS credentials early for a clear error message.
         try:
-            import boto3
+            import boto3  # ty: ignore[unresolved-import, unused-ignore-comment]
 
             session = boto3.Session()
             credentials = session.get_credentials()

--- a/libs/cli/deepagents_cli/integrations/sandbox_factory.py
+++ b/libs/cli/deepagents_cli/integrations/sandbox_factory.py
@@ -710,7 +710,7 @@ class _AgentCoreProvider(SandboxProvider):
 
         # Validate AWS credentials early for a clear error message.
         try:
-            import boto3  # ty: ignore[unresolved-import]
+            import boto3
 
             session = boto3.Session()
             credentials = session.get_credentials()

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _show_timestamp_toast(widget: Static | Vertical) -> None:
+def _show_timestamp_toast(widget: Static | Vertical) -> None:  # noqa: ARG001  # temporarily disabled
     """Show a toast with the message's creation timestamp.
 
     No-ops silently if the widget is not mounted or has no associated message
@@ -50,21 +50,23 @@ def _show_timestamp_toast(widget: Static | Vertical) -> None:
     Args:
         widget: The message widget whose timestamp to display.
     """
-    from datetime import UTC, datetime
-
-    try:
-        app = widget.app
-    except Exception:  # noqa: BLE001  # Textual raises when widget has no app
-        return
-    if not widget.id:
-        return
-    store = app._message_store  # type: ignore[attr-defined]
-    data = store.get_message(widget.id)
-    if not data:
-        return
-    dt = datetime.fromtimestamp(data.timestamp, tz=UTC).astimezone()
-    label = f"{dt:%b} {dt.day}, {dt.hour % 12 or 12}:{dt:%M:%S} {dt:%p}"
-    app.notify(label, timeout=3)
+    # TODO: temporarily disabled — uncomment to restore click-to-show-timestamp
+    return  # early return while feature is disabled
+    # from datetime import UTC, datetime  # noqa: ERA001
+    #
+    # try:  # noqa: ERA001
+    #     app = widget.app  # noqa: ERA001
+    # except Exception:  # Textual raises when widget has no app  # noqa: ERA001
+    #     return  # noqa: ERA001
+    # if not widget.id:
+    #     return  # noqa: ERA001
+    # store = app._message_store  # type: ignore[attr-defined]  # noqa: ERA001
+    # data = store.get_message(widget.id)  # noqa: ERA001
+    # if not data:
+    #     return  # noqa: ERA001
+    # dt = datetime.fromtimestamp(data.timestamp, tz=UTC).astimezone()  # noqa: ERA001
+    # label = f"{dt:%b} {dt.day}, {dt.hour % 12 or 12}:{dt:%M:%S} {dt:%p}"  # noqa: ERA001, E501
+    # app.notify(label, timeout=3)  # noqa: ERA001
 
 
 class _TimestampClickMixin:

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -60,7 +60,7 @@ def _show_timestamp_toast(widget: Static | Vertical) -> None:  # noqa: ARG001  #
     #     return  # noqa: ERA001
     # if not widget.id:
     #     return  # noqa: ERA001
-    # store = app._message_store  # type: ignore[attr-defined]  # noqa: ERA001
+    # store = app._message_store  # noqa: ERA001
     # data = store.get_message(widget.id)  # noqa: ERA001
     # if not data:
     #     return  # noqa: ERA001

--- a/libs/cli/tests/unit_tests/test_mcp_tools.py
+++ b/libs/cli/tests/unit_tests/test_mcp_tools.py
@@ -92,10 +92,23 @@ def write_config(tmp_path: Path) -> Callable[..., str]:
 
 @pytest.fixture
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect `Path.home()` to a temp directory."""
+    """Redirect `Path.home()` and `DEFAULT_STATE_DIR` into a temp directory.
+
+    `Path.home` is patched for code that resolves it at call time;
+    `DEFAULT_STATE_DIR` is patched for code (like `mcp_auth._tokens_dir`)
+    that pulls from the import-time-frozen constant in `model_config`.
+    Without the second patch, `FileTokenStorage` reads/writes the real
+    `~/.deepagents/.state/mcp-tokens/` directory, which leaks token state
+    across tests and causes flakes (e.g. one test's `set_tokens` makes a
+    later test's `get_tokens` return non-`None`).
+    """
     fake = tmp_path / "home"
     fake.mkdir()
     monkeypatch.setattr(Path, "home", staticmethod(lambda: fake))
+    monkeypatch.setattr(
+        "deepagents_cli.model_config.DEFAULT_STATE_DIR",
+        fake / ".deepagents" / ".state",
+    )
     return fake
 
 

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -624,60 +624,6 @@ class TestAppMessageOnClickOpensLink:
 _MSG_STORE_PATH = "deepagents_cli.widgets.messages"
 
 
-class TestShowTimestampToast:
-    """Tests for `_show_timestamp_toast` helper."""
-
-    def test_noop_when_widget_not_mounted(self) -> None:
-        """Should not raise when widget has no app."""
-        widget = MagicMock(spec=["app", "id"])
-        # Simulate unmounted widget: .app property raises
-        type(widget).app = property(
-            lambda _: (_ for _ in ()).throw(RuntimeError("no app"))
-        )
-        widget.id = "msg-abc"
-        _show_timestamp_toast(widget)  # should not raise
-
-    def test_noop_when_widget_id_is_none(self) -> None:
-        """Should return early when widget.id is None."""
-        widget = MagicMock()
-        widget.id = None
-        widget.app = MagicMock()
-        _show_timestamp_toast(widget)
-        widget.app.notify.assert_not_called()
-
-    def test_noop_when_message_not_in_store(self) -> None:
-        """Should return early when message is not found in the store."""
-        widget = MagicMock()
-        widget.id = "msg-missing"
-        widget.app._message_store.get_message.return_value = None
-        _show_timestamp_toast(widget)
-        widget.app.notify.assert_not_called()
-
-    def test_shows_toast_with_formatted_timestamp(self) -> None:
-        """Should call notify with a human-readable timestamp."""
-        from deepagents_cli.widgets.message_store import MessageData, MessageType
-
-        data = MessageData(
-            type=MessageType.USER,
-            content="hello",
-            id="msg-test123",
-            timestamp=1709744055.0,  # 2024-03-06 17:14:15 UTC
-        )
-        widget = MagicMock()
-        widget.id = "msg-test123"
-        widget.app._message_store.get_message.return_value = data
-
-        _show_timestamp_toast(widget)
-
-        widget.app.notify.assert_called_once()
-        call_args = widget.app.notify.call_args
-        label = call_args[0][0]
-        # Should contain month abbreviation and time components
-        assert "Mar" in label
-        assert ":" in label
-        assert call_args[1]["timeout"] == 3
-
-
 class TestTimestampClickMixin:
     """Tests for `_TimestampClickMixin` on message widgets."""
 


### PR DESCRIPTION
Noisy, don't think it was actually that useful. Mostly useful for demonstration of a callback from clicking a message. Keeping around for now commented out, as it will likely be useful for later.