### PR TITLE
feat(cli): surface MCP config discovery paths and format in help screens

### DIFF
--- a/libs/cli/deepagents_cli/mcp_commands.py
+++ b/libs/cli/deepagents_cli/mcp_commands.py
@@ -113,7 +113,9 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
         found = discover_mcp_configs()
         if not found:
             print(  # noqa: T201
-                "No MCP config file found. Pass --config <path>.",
+                "No MCP config file found in any auto-discovered location. "
+                "Pass --config <path>, or run `deepagents mcp login --help` "
+                "to see the search paths and config format.",
                 file=sys.stderr,
             )
             return 2

--- a/libs/cli/deepagents_cli/mcp_tools.py
+++ b/libs/cli/deepagents_cli/mcp_tools.py
@@ -640,16 +640,27 @@ def _resolve_project_config_base(project_context: ProjectContext | None) -> Path
     return find_project_root() or Path.cwd()
 
 
+MCP_CONFIG_DISCOVERY_PATHS: tuple[tuple[str, str], ...] = (
+    ("~/.deepagents/.mcp.json", "user-level"),
+    ("<project-root>/.deepagents/.mcp.json", "project subdir"),
+    ("<project-root>/.mcp.json", "project root"),
+)
+"""Display strings for the auto-discovered MCP config paths.
+
+Ordered from lowest to highest precedence. Each entry is `(path, label)`
+suitable for rendering in help screens and error messages. The runtime
+discovery in `discover_mcp_configs` builds the same paths from
+`Path.home()` and `_resolve_project_config_base()`.
+"""
+
+
 def discover_mcp_configs(
     *, project_context: ProjectContext | None = None
 ) -> list[Path]:
     """Find MCP config files from standard locations.
 
-    Checks three paths in precedence order (lowest to highest):
-
-    1. `~/.deepagents/.mcp.json` (user-level global)
-    2. `<project-root>/.deepagents/.mcp.json` (project subdir)
-    3. `<project-root>/.mcp.json` (project root, Claude Code compat)
+    Checks the paths listed in `MCP_CONFIG_DISCOVERY_PATHS`, lowest to
+    highest precedence.
 
     Args:
         project_context: Explicit project path context, if available.

--- a/libs/cli/deepagents_cli/ui.py
+++ b/libs/cli/deepagents_cli/ui.py
@@ -403,6 +403,35 @@ def show_update_help() -> None:
     console.print()
 
 
+def _print_mcp_discovery_paths() -> None:
+    """Print the auto-discovered MCP config paths in precedence order."""
+    from deepagents_cli.mcp_tools import MCP_CONFIG_DISCOVERY_PATHS
+
+    console.print(
+        "[bold]Auto-discovered config paths (precedence order):[/bold]",
+        style=theme.PRIMARY,
+    )
+    width = max(len(path) for path, _ in MCP_CONFIG_DISCOVERY_PATHS)
+    for path, label in MCP_CONFIG_DISCOVERY_PATHS:
+        console.print(f"  {path:<{width}}  ({label})")
+    console.print(
+        "  <project-root> = nearest ancestor with a `.git` entry, else CWD.",
+        style=theme.MUTED,
+    )
+
+
+_MCP_CONFIG_FORMAT_EXAMPLE = """\
+  {
+    "mcpServers": {
+      "notion": {
+        "transport": "http",
+        "url": "https://mcp.notion.com/mcp",
+        "auth": "oauth"
+      }
+    }
+  }"""
+
+
 def show_mcp_help() -> None:
     """Show help information for the `mcp` subcommand."""
     console.print()
@@ -413,6 +442,13 @@ def show_mcp_help() -> None:
     console.print("  login <server>    Run the OAuth login flow for an MCP server")
     console.print()
     _print_option_section()
+    console.print()
+    _print_mcp_discovery_paths()
+    console.print()
+    console.print(
+        "  Pass --config <path> to any subcommand to bypass discovery.",
+        style=theme.MUTED,
+    )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  deepagents mcp login notion")
@@ -430,6 +466,11 @@ def show_mcp_login_help() -> None:
         "  --config PATH           Path to an MCP config JSON file "
         "(default: auto-discovered)",
     )
+    console.print()
+    _print_mcp_discovery_paths()
+    console.print()
+    console.print("[bold]Config format:[/bold]", style=theme.PRIMARY)
+    console.print(_MCP_CONFIG_FORMAT_EXAMPLE, style=theme.MUTED)
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  deepagents mcp login notion")


### PR DESCRIPTION
Surface the MCP config discovery paths and format in the `mcp` and `mcp login` help screens, replacing the previously opaque error message when no config is found. Extract display-ready path strings into `MCP_CONFIG_DISCOVERY_PATHS` so both the help UI and error messages can reference the same source of truth.