### PR TITLE
feat(evals,ci): multi-trial eval runner with aggregate stats and GHA workflow

### DIFF
--- a/.github/workflows/evals_trials.yml
+++ b/.github/workflows/evals_trials.yml
@@ -1,0 +1,326 @@
+# N-trial eval workflow.
+#
+# Runs the eval suite N times for the same model/config (each trial as its
+# own GHA job, getting its own 6h budget) and aggregates per-trial reports
+# into a single trials_summary.json.
+#
+# By default trials run sequentially (max-parallel: 1), which is rate-limit
+# safe for any provider. Setting `parallel: true` runs all trials at once —
+# only flip it on when the provider can comfortably absorb the burst.
+#
+# Reuses `_eval.yml` for the actual eval run (same checkout, install, pytest
+# invocation, summary, and artifact upload). Each trial uploads under a
+# unique `evals-report-trial-NNN-<slug>` artifact name; the aggregate job
+# downloads them all and runs `scripts/run_trials.py --aggregate-only`.
+
+name: "📊 Eval trials - GHA"
+run-name: >-
+  📊 Eval trials — ${{ inputs.model }} × ${{ inputs.trials }} trials${{ inputs.parallel && ' (parallel)' || ' (sequential)' }}${{ inputs.openai_reasoning_effort && format(' reasoning:{0}', inputs.openai_reasoning_effort) || '' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model to evaluate, e.g. `openai:gpt-5.5` (single spec, no presets)."
+        required: true
+        type: string
+      trials:
+        description: "Number of trials to run (1..20)."
+        required: true
+        default: "5"
+        type: string
+      parallel:
+        description: "Run trials in parallel (faster, but bursts API calls). Off → sequential."
+        required: false
+        default: false
+        type: boolean
+      eval_categories:
+        description: "Comma-separated eval categories. Empty = all."
+        required: false
+        default: ""
+        type: string
+      eval_tiers:
+        description: "Comma-separated eval tiers (baseline | hillclimb). Empty = all."
+        required: false
+        default: ""
+        type: string
+      openrouter_provider:
+        description: "Pin OpenRouter to a specific provider (e.g. `MiniMax`)."
+        required: false
+        default: ""
+        type: string
+      openai_reasoning_effort:
+        description: "Reasoning effort for OpenAI models."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - minimal
+          - low
+          - medium
+          - high
+          - xhigh
+
+permissions:
+  contents: read
+
+env:
+  UV_NO_SYNC: "true"
+  UV_FROZEN: "true"
+
+jobs:
+  prep:
+    name: "🔧 Prepare trial matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      max_parallel: ${{ steps.build.outputs.max_parallel }}
+      provider: ${{ steps.build.outputs.provider }}
+      slug: ${{ steps.build.outputs.slug }}
+    steps:
+      - name: "🐍 Build trial matrix"
+        id: build
+        env:
+          MODEL: ${{ inputs.model }}
+          TRIALS: ${{ inputs.trials }}
+          PARALLEL: ${{ inputs.parallel }}
+          EVAL_CATEGORIES: ${{ inputs.eval_categories }}
+          EVAL_TIERS: ${{ inputs.eval_tiers }}
+          OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
+        run: |
+          python3 << 'PYEOF'
+          import json, os, re, sys
+
+          # Per-CI cap: stricter than run_trials.py's `_MAX_TRIALS = 50` so a
+          # typo in the dispatch form can't burn a whole runner pool. If you
+          # raise this, leave the script's higher cap alone — local runs are
+          # cheaper to abort.
+          MAX_TRIALS = 20
+          model = os.environ["MODEL"].strip()
+          trials_raw = os.environ["TRIALS"].strip()
+          parallel = os.environ["PARALLEL"].strip().lower() == "true"
+
+          # Require non-empty provider AND non-empty model name; allow `/`
+          # and `.` only on the model side (provider names don't use them).
+          if not re.match(r"^[a-zA-Z0-9_\-.]+:[a-zA-Z0-9_\-./]+$", model):
+              print(f"::error::Model must be `provider:name` with non-empty parts, got {model!r}")
+              sys.exit(1)
+          provider = model.split(":", 1)[0]
+
+          try:
+              n = int(trials_raw)
+          except ValueError:
+              print(f"::error::trials must be an integer, got {trials_raw!r}")
+              sys.exit(1)
+          if not 1 <= n <= MAX_TRIALS:
+              print(f"::error::trials must be in 1..{MAX_TRIALS}, got {n}")
+              sys.exit(1)
+
+          # Defense in depth: these flow through to `_eval.yml` as shell
+          # arguments. Reject anything outside a comma-separated identifier
+          # list before we hand them off.
+          _CSV_RE = re.compile(r"^[a-zA-Z0-9_\-,]*$")
+          _SLUG_RE = re.compile(r"^[a-zA-Z0-9_\-]*$")
+          for name, value, pattern in (
+              ("eval_categories", os.environ.get("EVAL_CATEGORIES", ""), _CSV_RE),
+              ("eval_tiers", os.environ.get("EVAL_TIERS", ""), _CSV_RE),
+              ("openrouter_provider", os.environ.get("OPENROUTER_PROVIDER", ""), _SLUG_RE),
+          ):
+              if not pattern.match(value):
+                  print(f"::error::Unsafe `{name}` value: {value!r}")
+                  sys.exit(1)
+
+          slug = re.sub(r"[^a-zA-Z0-9_\-]", "-", model).strip("-")
+
+          entries = [
+              {
+                  "trial_index": i,
+                  "artifact_key": f"trial-{i:03d}-{slug}",
+              }
+              for i in range(n)
+          ]
+          matrix = {"include": entries}
+          max_parallel = n if parallel else 1
+
+          out = os.environ["GITHUB_OUTPUT"]
+          with open(out, "a") as f:
+              f.write(f"matrix={json.dumps(matrix)}\n")
+              f.write(f"max_parallel={max_parallel}\n")
+              f.write(f"provider={provider}\n")
+              f.write(f"slug={slug}\n")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a") as f:
+                  f.write("### Trial dispatch\n\n")
+                  f.write(f"- model: `{model}`\n")
+                  f.write(f"- trials: {n}\n")
+                  f.write(f"- parallelism: {'parallel' if parallel else 'sequential'} (max-parallel={max_parallel})\n")
+          PYEOF
+
+  eval-trial:
+    name: "📊 Trial ${{ matrix.trial_index }}"
+    needs: prep
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJson(needs.prep.outputs.max_parallel) }}
+      matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
+    uses: ./.github/workflows/_eval.yml
+    with:
+      model: ${{ inputs.model }}
+      provider: ${{ needs.prep.outputs.provider }}
+      artifact_key: ${{ matrix.artifact_key }}
+      eval_categories: ${{ inputs.eval_categories }}
+      eval_tiers: ${{ inputs.eval_tiers }}
+      analyze_failures: false
+      openrouter_provider: ${{ inputs.openrouter_provider }}
+      openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+    secrets: inherit
+
+  aggregate-trials:
+    name: "📋 Aggregate trials"
+    runs-on: ubuntu-latest
+    needs:
+      - prep
+      - eval-trial
+    if: always() && needs.prep.result == 'success'
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "📥 Download trial artifacts"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: trial_artifacts
+          pattern: evals-report-trial-*
+
+      - name: "🐍 Set up Python + UV"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.12"
+          cache-suffix: evals-trials
+          working-directory: libs/evals
+
+      - name: "📦 Install evals package"
+        working-directory: libs/evals
+        run: uv sync --group test
+
+      - name: "📊 Aggregate trial reports"
+        working-directory: libs/evals
+        env:
+          ARTIFACTS_DIR: ${{ github.workspace }}/trial_artifacts
+        run: |
+          uv run python scripts/run_trials.py \
+            --aggregate-only "$ARTIFACTS_DIR" \
+            --summary-out "$GITHUB_WORKSPACE/trials_summary.json"
+
+      - name: "📤 Upload trials summary"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: trials-summary
+          path: trials_summary.json
+          if-no-files-found: error
+
+      - name: "📊 Post summary"
+        if: always()
+        env:
+          MODEL: ${{ inputs.model }}
+          N: ${{ inputs.trials }}
+          PARALLEL: ${{ inputs.parallel }}
+          REASONING: ${{ inputs.openai_reasoning_effort }}
+        run: |
+          python3 << 'PYEOF'
+          import json, os, sys
+          from pathlib import Path
+
+          summary_path = Path(os.environ["GITHUB_WORKSPACE"]) / "trials_summary.json"
+          if not summary_path.exists():
+              # The previous aggregate step succeeded iff this file exists;
+              # missing it here means something earlier broke in a way that
+              # wasn't already fatal (race, disk error, wrong path). Don't
+              # mask it with a green checkmark.
+              print(
+                  "::error::trials_summary.json missing; aggregation step did not produce output",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          summary = json.loads(summary_path.read_text())
+          metrics = summary["metrics"]
+
+          # Loud signal when fewer trials made it to aggregation than were
+          # dispatched — a green check on a half-empty sample size is a trap.
+          requested = int(os.environ["N"])
+          actual = int(summary.get("n_trials", 0))
+          missing = requested - actual
+          missing_banner = ""
+          if missing > 0:
+              msg = f"{missing} of {requested} trial(s) failed to produce a usable report"
+              print(f"::error::{msg}")
+              missing_banner = f"\n> :warning: **{msg}** — stats below cover only the {actual} surviving trial(s).\n"
+
+          def fmt(v, places=4):
+              return "n/a" if v is None else f"{v:.{places}f}"
+
+          lines = [
+              "## Trial summary",
+              "",
+              f"- model: `{summary.get('model') or os.environ['MODEL']}`",
+              f"- trials: {actual}/{requested} ({'parallel' if os.environ['PARALLEL']=='true' else 'sequential'})",
+          ]
+          if missing_banner:
+              lines.append(missing_banner)
+          if os.environ.get("REASONING"):
+              lines.append(f"- reasoning_effort: `{os.environ['REASONING']}`")
+
+          lines += [
+              "",
+              "| metric | mean | median | stdev | min | max | n |",
+              "|---|---:|---:|---:|---:|---:|---:|",
+          ]
+          for key in ("correctness","solve_rate","step_ratio","tool_call_ratio","median_duration_s"):
+              s = metrics.get(key, {})
+              lines.append(
+                  f"| `{key}` | {fmt(s.get('mean'))} | {fmt(s.get('median'))} | {fmt(s.get('stdev'))} | {fmt(s.get('min'))} | {fmt(s.get('max'))} | {s.get('n', 0)} |"
+              )
+
+          cats = summary.get("category_scores") or {}
+          if cats:
+              lines += ["", "### Per-category correctness (across trials)", "", "| category | mean | stdev | n |", "|---|---:|---:|---:|"]
+              for cat, s in sorted(cats.items()):
+                  lines.append(f"| `{cat}` | {fmt(s.get('mean'), 3)} | {fmt(s.get('stdev'), 3)} | {s.get('n', 0)} |")
+
+          trials = summary.get("trials") or []
+          if trials:
+              lines += [
+                  "",
+                  "### Per-trial",
+                  "",
+                  "| # | passed | failed | total | correctness | solve_rate | step_ratio | tool_call_ratio | median_duration_s |",
+                  "|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+              ]
+              for t in trials:
+                  lines.append(
+                      "| {idx} | {p} | {f} | {tot} | {c} | {sr} | {step} | {tc} | {md} |".format(
+                          idx=t.get("trial_index"),
+                          p=t.get("passed"),
+                          f=t.get("failed"),
+                          tot=t.get("total"),
+                          c=fmt(t.get("correctness"), 3),
+                          sr=fmt(t.get("solve_rate")),
+                          step=fmt(t.get("step_ratio")),
+                          tc=fmt(t.get("tool_call_ratio")),
+                          md=fmt(t.get("median_duration_s")),
+                      )
+                  )
+
+          out = os.environ.get("GITHUB_STEP_SUMMARY")
+          if out:
+              with open(out, "a") as fh:
+                  fh.write("\n".join(lines) + "\n")
+          print("\n".join(lines))
+          # Render the markdown summary first, then exit non-zero so the
+          # job is marked failed when trials are missing.
+          if missing > 0:
+              sys.exit(1)
+          PYEOF

--- a/libs/evals/CONTRIBUTING.md
+++ b/libs/evals/CONTRIBUTING.md
@@ -206,6 +206,104 @@ A drift test (`tests/unit_tests/test_eval_catalog.py`) fails CI if the file is s
 3. Add the category to `EXPECTED_CATEGORY_MODULES` in `tests/unit_tests/test_category_tagging.py`
 4. Run `make test` — drift tests will catch any mismatch
 
+## Multi-trial runs
+
+When you need to tell signal from noise — "did this prompt change actually move correctness, or am I looking at run-to-run variance?" — run the suite N times under the same config and look at the spread.
+
+### Why two eval workflows
+
+| Workflow | Question it answers | Shape |
+|---|---|---|
+| `evals.yml` | How do *these models* compare on this dataset? | trials = 1, models = many (presets, fan-out across providers) |
+| `evals_trials.yml` | Is *this model's* number stable under the same config? | trials = N, models = exactly one |
+
+They are kept separate because folding trials into `evals.yml` would produce a *trials × models × providers* fan-out (rarely useful) and would require a second aggregate shape (per-trial stats vs. per-model comparison) in one workflow. The trials workflow also needs a per-trial GHA job so each trial gets its own 6h budget — a 5-trial sequential run on a slow model can take 10–15h wall time and cannot fit in a single job.
+
+### Running locally
+
+```bash
+make evals-trials MODEL=openai:gpt-5.5 TRIALS=5
+```
+
+Forward extra flags through `TRIAL_ARGS`:
+
+```bash
+make evals-trials MODEL=openai:gpt-5.5 TRIALS=3 \
+    TRIAL_ARGS="--openai-reasoning-effort medium --eval-category memory"
+```
+
+Trials run sequentially. Outputs land under `libs/evals/trial_runs/`:
+
+- `evals_report_trial_NNN.json` — one per trial, same schema as the single-run report described in [Report output](#report-output)
+- `trials_summary.json` — aggregate across trials (schema below)
+
+Each trial creates its own LangSmith experiment.
+
+### Running in CI
+
+Dispatch the **📊 Eval trials - GHA** workflow (`evals_trials.yml`).
+
+| Input | Notes |
+|---|---|
+| `model` | Single spec, e.g. `openai:gpt-5.5`. No presets — trials are single-model only |
+| `trials` | 1–20 (the local CLI accepts up to 50; the workflow caps lower since a runaway runner pool is harder to recover than a stuck terminal) |
+| `parallel` | Off (default): trials run sequentially. On: all trials run concurrently |
+| `eval_categories`, `eval_tiers`, `openai_reasoning_effort`, `openrouter_provider` | Same semantics as `evals.yml` |
+
+The `parallel` toggle exists to trade time for API burst pressure. Sequential mode keeps the per-second call rate equivalent to a single eval run, so it is safe for any provider; parallel mode finishes ~N× faster but bursts every trial's traffic at once and should only be used when the provider can absorb the load.
+
+**Job structure:**
+
+1. `prep` — validates inputs and emits the trial matrix (`include` array of `{trial_index, artifact_key}`) plus a `max_parallel` value (1 for sequential, N for parallel).
+2. `eval-trial` — matrix job that calls the existing `_eval.yml` reusable workflow once per trial. Each trial runs on its own GHA runner with its own 6h budget; `strategy.max-parallel` controls sequential vs. parallel. Each trial uploads its report under a unique `evals-report-trial-NNN-<slug>` artifact name.
+3. `aggregate-trials` — runs even when individual trials fail. Downloads every trial's report artifact, runs `scripts/run_trials.py --aggregate-only`, uploads `trials-summary` as an artifact, and posts a markdown table to the workflow summary (overall metrics, per-category breakdown, per-trial rows). If fewer reports than the requested trial count made it through, the summary banners the gap loudly and the job exits non-zero — a green check on a partial sample size is a trap.
+
+### `trials_summary.json` schema
+
+```jsonc
+{
+  "n_trials": 5,
+  "model": "openai:gpt-5.5",
+  "sdk_version": "0.5.6",
+  "metrics": {
+    // One block per scalar metric
+    "correctness":       {"n": 5, "mean": 0.49, "median": 0.49, "stdev": 0.012, "min": 0.47, "max": 0.51},
+    "solve_rate":        {"n": 5, "mean": ..., ...},
+    "step_ratio":        {"n": 5, "mean": ..., ...},
+    "tool_call_ratio":   {"n": 5, "mean": ..., ...},
+    "median_duration_s": {"n": 5, "mean": ..., ...}
+  },
+  "counts": {
+    // Pass/fail/skip/total stats across trials
+    "passed":  {"n": 5, "mean": 81.6, ...},
+    "failed":  {...},
+    "skipped": {...},
+    "total":   {...}
+  },
+  "category_scores": {
+    // Per-category correctness across trials
+    "memory":   {"n": 5, "mean": 0.62, "stdev": 0.018, ...},
+    "tool_use": {"n": 5, ...}
+  },
+  "trials": [
+    // Per-trial records preserved in dispatch order
+    {"trial_index": 0, "passed": 81, "correctness": 0.47, "category_scores": {...}, "experiment_urls": [...]},
+    ...
+  ]
+}
+```
+
+`stdev` is `null` for n < 2 (sample stdev needs n ≥ 2). Metrics some trials reported as `null` (e.g. `solve_rate` when nothing passed) are silently dropped from that metric's stats — `n` reflects how many trials actually contributed, not the trial count. Non-`null` values that aren't numeric (a sign the upstream reporter shape changed) are excluded *with* a warning so the regression surfaces.
+
+### Interpreting the spread
+
+Trial stdev tells you what change sizes are real:
+
+- **stdev ≪ candidate delta** → the change is signal; ship the conclusion.
+- **stdev ≈ candidate delta** → run more trials, or treat the result as noise.
+
+For context: a 2-task pass-count swing on a 170-test suite is Δcorrectness ≈ 0.012, which is comparable to typical single-trial stdev on this benchmark. Single-run deltas in that range should not be reported as model differences without trial backing.
+
 ## Harbor / Terminal Bench 2.0
 
 ### What is Harbor?

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format type typecheck test help test_integration test_watch run-hello-world run-terminal-bench-modal run-terminal-bench-docker run-terminal-bench-daytona run-terminal-bench-runloop evals format_unsafe radar radar-from-summary model-groups eval-catalog
+.PHONY: lint format type typecheck test help test_integration test_watch run-hello-world run-terminal-bench-modal run-terminal-bench-docker run-terminal-bench-daytona run-terminal-bench-runloop evals evals-trials format_unsafe radar radar-from-summary model-groups eval-catalog
 
 .DEFAULT_GOAL := help
 
@@ -19,6 +19,21 @@ evals: ## Run evals (set MODEL=<id>; required)
 		exit 1; \
 	fi
 	LANGSMITH_TEST_SUITE=deepagents-evals uv run --group test pytest tests/evals -v --tb=short --model $(MODEL) $(PYTEST_EXTRA)
+
+# Run the eval suite N times for the same MODEL/config and aggregate metrics
+# (mean / median / stdev / min / max). See scripts/run_trials.py for full options.
+TRIALS ?=
+TRIAL_ARGS ?=
+evals-trials: ## Run evals N times (set MODEL=<id> TRIALS=<n>; both required)
+	@if [ -z "$(MODEL)" ]; then \
+		echo "ERROR: MODEL is required. Example: make evals-trials MODEL=openai:gpt-5.5 TRIALS=5" >&2; \
+		exit 1; \
+	fi
+	@if [ -z "$(TRIALS)" ]; then \
+		echo "ERROR: TRIALS is required. Example: make evals-trials MODEL=openai:gpt-5.5 TRIALS=5" >&2; \
+		exit 1; \
+	fi
+	uv run --group test python scripts/run_trials.py --model $(MODEL) --trials $(TRIALS) $(TRIAL_ARGS)
 
 test_watch: ## Run tests in watch mode
 	uv run --group test ptw . -- $(TEST_FILE)

--- a/libs/evals/scripts/run_trials.py
+++ b/libs/evals/scripts/run_trials.py
@@ -1,0 +1,598 @@
+"""Run the eval suite N times for the same model/config and aggregate stats.
+
+Each trial invokes `pytest tests/evals` with the same flags as `make evals`,
+writes its own per-trial report to `--out-dir`, and creates its own LangSmith
+experiment. After all trials complete, per-metric mean / median / stdev / min /
+max are computed across trials and written to `<out-dir>/trials_summary.json`.
+
+Usage:
+    python scripts/run_trials.py --model openai:gpt-5.5 --trials 5
+    python scripts/run_trials.py --model openai:gpt-5.5 --trials 3 \
+        --eval-category memory --openai-reasoning-effort medium
+
+Within a single CLI invocation, trials run sequentially in-process — LangSmith
+experiment creation and provider rate-limits make in-process parallelism
+unsafe. CI achieves parallelism by running each trial as a separate GHA job
+and then calling this script with `--aggregate-only` to merge their reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_EVALS_DIR = Path(__file__).resolve().parents[1]
+"""Root of the evals package (libs/evals/)."""
+
+_DEFAULT_OUT_DIR = _EVALS_DIR / "trial_runs"
+"""Default location for per-trial reports and the aggregated summary."""
+
+_MAX_TRIALS = 50
+"""Hard cap on `--trials` to bound runtime / cost from a typo."""
+
+_SCALAR_METRICS = (
+    "correctness",
+    "solve_rate",
+    "step_ratio",
+    "tool_call_ratio",
+    "median_duration_s",
+)
+"""Top-level numeric metrics aggregated across trials."""
+
+_COUNT_FIELDS = ("passed", "failed", "skipped", "total")
+"""Per-run counts surfaced alongside the scalar metrics."""
+
+_MIN_SAMPLES_FOR_STDEV = 2
+"""`statistics.stdev` requires at least two samples; below that we report None."""
+
+
+def _warn(message: str) -> None:
+    """Emit a warning to stderr, prefixed with `::warning::` under GitHub Actions.
+
+    The annotation prefix surfaces the message in the workflow run's annotations
+    panel; locally it just prints as a plain line.
+    """
+    prefix = "::warning::" if os.environ.get("GITHUB_ACTIONS") == "true" else "warning: "
+    print(f"{prefix}{message}", file=sys.stderr)
+
+
+@dataclass(frozen=True)
+class _Stats:
+    """Summary statistics for a metric across trials.
+
+    `n` is the count of trials that reported a non-null value for the metric.
+    """
+
+    n: int
+    mean: float | None
+    median: float | None
+    stdev: float | None
+    min: float | None
+    max: float | None
+
+    def to_dict(self) -> dict[str, float | int | None]:
+        return {
+            "n": self.n,
+            "mean": self.mean,
+            "median": self.median,
+            "stdev": self.stdev,
+            "min": self.min,
+            "max": self.max,
+        }
+
+
+def _summarize(values: list[float]) -> _Stats:
+    """Compute mean / median / stdev / min / max for a list of metric values.
+
+    `stdev` is `None` for fewer than two samples; sample stdev (Bessel-corrected,
+    which is what `statistics.stdev` returns) requires n >= 2.
+
+    Args:
+        values: Per-trial metric values; callers should filter out `None`s
+            before passing.
+
+    Returns:
+        An `_Stats` record. All numeric fields are `None` when `values` is
+        empty.
+    """
+    if not values:
+        return _Stats(n=0, mean=None, median=None, stdev=None, min=None, max=None)
+    return _Stats(
+        n=len(values),
+        mean=round(statistics.mean(values), 6),
+        median=round(statistics.median(values), 6),
+        stdev=(
+            round(statistics.stdev(values), 6) if len(values) >= _MIN_SAMPLES_FOR_STDEV else None
+        ),
+        min=round(min(values), 6),
+        max=round(max(values), 6),
+    )
+
+
+def _collect_numeric_values(
+    reports: list[dict[str, Any]],
+    key: str,
+    *,
+    nested_under: str | None = None,
+) -> list[float]:
+    """Collect a metric's values across reports, warning on type regressions.
+
+    `None` is silently treated as "this trial didn't report it" — that's a
+    legitimate schema variant (e.g. `solve_rate` is `null` when no test passed).
+    Anything else that isn't numeric is a sign the upstream reporter shape
+    changed; warn loudly so it doesn't get silently dropped from the stats.
+
+    Args:
+        reports: Per-trial report dicts.
+        key: Metric name to extract.
+        nested_under: If set, look up `report[nested_under][key]` instead of
+            `report[key]` (used for `category_scores`).
+
+    Returns:
+        A list of `float`-coerced values from reports that supplied a real
+        number; `None` and missing entries are skipped silently, all other
+        types are skipped with a warning.
+    """
+    values: list[float] = []
+    for idx, r in enumerate(reports):
+        if nested_under is not None:
+            container = r.get(nested_under) or {}
+            if key not in container:
+                continue
+            raw = container[key]
+        else:
+            if key not in r:
+                continue
+            raw = r[key]
+        if raw is None:
+            continue
+        # Exact-type check: JSON only produces int / float / bool / str / list /
+        # dict / None, and `bool` is a subclass of `int`, so an `isinstance`
+        # check would silently coerce `True` / `False` to 1.0 / 0.0.
+        if type(raw) not in (int, float):
+            location = f"{nested_under}.{key}" if nested_under else key
+            _warn(
+                f"trial {idx}: non-numeric value for {location!r}: {raw!r} "
+                f"(type {type(raw).__name__}); excluded from stats"
+            )
+            continue
+        values.append(float(raw))
+    return values
+
+
+def aggregate_trials(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-trial eval reports into a single summary dict.
+
+    Args:
+        reports: Per-trial report dicts as written by the eval pytest reporter
+            (one dict per `evals_report_trial_*.json`).
+
+    Returns:
+        A dict containing `trials` (list of per-trial input reports trimmed to
+        the fields that matter for cross-trial comparison), `metrics` (mean /
+        median / stdev / min / max for each scalar metric), `counts` (same
+        stats for pass/fail/skip/total), and `category_scores` (per-category
+        stats across trials).
+
+    Raises:
+        ValueError: If `reports` is empty.
+    """
+    if not reports:
+        msg = "aggregate_trials requires at least one report"
+        raise ValueError(msg)
+
+    # Reports are expected to share model + sdk_version. Mismatches usually
+    # mean the user mixed runs from two campaigns; the summary picks the
+    # first report's values regardless, so warn before that becomes silent.
+    models: set[str] = {str(r["model"]) for r in reports if r.get("model") is not None}
+    if len(models) > 1:
+        _warn(
+            f"reports disagree on `model` ({sorted(models)!r}); "
+            f"summary will use {reports[0].get('model')!r}"
+        )
+    sdks: set[str] = {
+        str(r["sdk_version"]) for r in reports if r.get("sdk_version") is not None
+    }
+    if len(sdks) > 1:
+        _warn(
+            f"reports disagree on `sdk_version` ({sorted(sdks)!r}); "
+            f"summary will use {reports[0].get('sdk_version')!r}"
+        )
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for key in _SCALAR_METRICS:
+        metrics[key] = _summarize(_collect_numeric_values(reports, key)).to_dict()
+
+    counts: dict[str, dict[str, Any]] = {}
+    for key in _COUNT_FIELDS:
+        counts[key] = _summarize(_collect_numeric_values(reports, key)).to_dict()
+
+    all_categories = sorted({cat for r in reports for cat in (r.get("category_scores") or {})})
+    category_stats: dict[str, dict[str, Any]] = {}
+    for cat in all_categories:
+        category_stats[cat] = _summarize(
+            _collect_numeric_values(reports, cat, nested_under="category_scores")
+        ).to_dict()
+
+    return {
+        "n_trials": len(reports),
+        "model": reports[0].get("model"),
+        "sdk_version": reports[0].get("sdk_version"),
+        "metrics": metrics,
+        "counts": counts,
+        "category_scores": category_stats,
+        "trials": [
+            {
+                "trial_index": idx,
+                "created_at": r.get("created_at"),
+                "passed": r.get("passed"),
+                "failed": r.get("failed"),
+                "skipped": r.get("skipped"),
+                "total": r.get("total"),
+                "correctness": r.get("correctness"),
+                "solve_rate": r.get("solve_rate"),
+                "step_ratio": r.get("step_ratio"),
+                "tool_call_ratio": r.get("tool_call_ratio"),
+                "median_duration_s": r.get("median_duration_s"),
+                "category_scores": r.get("category_scores", {}),
+                "experiment_urls": r.get("experiment_urls", []),
+                "pytest_returncode": r.get("pytest_returncode"),
+            }
+            for idx, r in enumerate(reports)
+        ],
+    }
+
+
+def _build_pytest_args(args: argparse.Namespace, report_path: Path) -> list[str]:
+    """Build the `uv run ... pytest tests/evals` argv for one trial.
+
+    Args:
+        args: Parsed CLI arguments for the trial runner.
+        report_path: Path the trial should write its JSON report to.
+
+    Returns:
+        The full argv list passed to `subprocess.run`.
+    """
+    cmd: list[str] = [
+        "uv",
+        "run",
+        "--group",
+        "test",
+        "pytest",
+        "tests/evals",
+        "-v",
+        "--tb=short",
+        "--model",
+        args.model,
+        "--evals-report-file",
+        str(report_path),
+    ]
+    for cat in args.eval_category or []:
+        cmd.extend(["--eval-category", cat])
+    for tier in args.eval_tier or []:
+        cmd.extend(["--eval-tier", tier])
+    if args.openai_reasoning_effort:
+        cmd.extend(["--openai-reasoning-effort", args.openai_reasoning_effort])
+    if args.openrouter_provider:
+        cmd.extend(["--openrouter-provider", args.openrouter_provider])
+    if args.repl:
+        cmd.extend(["--repl", args.repl])
+    cmd.extend(args.pytest_extra)
+    return cmd
+
+
+@dataclass(frozen=True)
+class _TrialOutcome:
+    """Result of running one trial.
+
+    `report_path` is `None` when pytest exited without writing a report.
+    `returncode` is the pytest process exit code; non-zero values can occur
+    *with* a usable report (e.g. session-scoped teardown crashed after the
+    reporter wrote) and should be surfaced rather than silently ignored.
+    """
+
+    report_path: Path | None
+    returncode: int
+
+
+def _run_trial(
+    *,
+    trial_index: int,
+    n_trials: int,
+    args: argparse.Namespace,
+    out_dir: Path,
+) -> _TrialOutcome:
+    """Execute a single trial.
+
+    Args:
+        trial_index: Zero-based index of this trial in the sweep.
+        n_trials: Total number of trials being run; only used for logging.
+        args: Parsed CLI arguments (forwarded to `_build_pytest_args`).
+        out_dir: Directory the trial's report file is written under.
+
+    Returns:
+        A `_TrialOutcome` with the report path (`None` if not produced) and
+        the pytest exit code.
+    """
+    report_path = out_dir / f"evals_report_trial_{trial_index:03d}.json"
+    cmd = _build_pytest_args(args, report_path)
+
+    env = os.environ.copy()
+    env.setdefault("LANGSMITH_TEST_SUITE", "deepagents-evals")
+    env["DEEPAGENTS_TRIAL_INDEX"] = str(trial_index)
+    env["DEEPAGENTS_TRIAL_TOTAL"] = str(n_trials)
+
+    print(
+        f"\n=== trial {trial_index + 1}/{n_trials} === model={args.model} report={report_path}",
+        flush=True,
+    )
+    print(f"$ {' '.join(cmd)}", flush=True)
+
+    # `check=False`: a failing trial may still write a partial report we want
+    # to aggregate; the caller inspects the returncode to decide what to do.
+    result = subprocess.run(
+        cmd,
+        cwd=_EVALS_DIR,
+        env=env,
+        check=False,
+    )
+
+    if not report_path.is_file():
+        _warn(
+            f"trial {trial_index} produced no report at {report_path} "
+            f"(pytest exit code {result.returncode}); skipping in aggregation"
+        )
+        return _TrialOutcome(report_path=None, returncode=result.returncode)
+    if result.returncode != 0:
+        _warn(
+            f"trial {trial_index} pytest exited non-zero ({result.returncode}); "
+            f"report at {report_path} will be aggregated but flagged"
+        )
+    return _TrialOutcome(report_path=report_path, returncode=result.returncode)
+
+
+def _discover_reports(root: Path) -> list[Path]:
+    """Recursively find eval report JSON files under `root`.
+
+    Matches both `evals_report_trial_*.json` (written by this script when
+    running locally) and `evals_report.json` (written directly by the eval
+    pytest reporter, which is the filename inside each `_eval.yml` artifact
+    bundle). Sorted for deterministic ordering; the set-union dedupes the
+    rare case of both patterns matching the same path.
+    """
+    if not root.is_dir():
+        return []
+    matches = {
+        *root.rglob("evals_report.json"),
+        *root.rglob("evals_report_trial_*.json"),
+    }
+    return sorted(matches)
+
+
+def _load_report(path: Path) -> dict[str, Any] | None:
+    """Read a per-trial report file.
+
+    Returns `None` on filesystem errors (`OSError`), encoding errors
+    (`UnicodeDecodeError`), JSON syntax errors, or when the top-level value is
+    not a dict. Each failure mode emits a warning so a single bad file in an
+    aggregate sweep doesn't get silently dropped.
+    """
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        _warn(f"could not read {path}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        _warn(f"{path} is not a JSON object; skipping")
+        return None
+    return data
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    """Pretty-print the aggregate summary to stdout."""
+    print()
+    header = f"=== {summary['n_trials']} trials · model={summary.get('model')} ==="
+    nonzero = [
+        t["trial_index"]
+        for t in summary.get("trials", [])
+        if isinstance(t.get("pytest_returncode"), int) and t["pytest_returncode"] != 0
+    ]
+    if nonzero:
+        header += f" ({len(nonzero)} had non-zero pytest exit: {nonzero})"
+    print(header)
+    metrics = summary["metrics"]
+    width = max(len(k) for k in (*_SCALAR_METRICS, *_COUNT_FIELDS))
+    for key in _SCALAR_METRICS:
+        s = metrics[key]
+        if s["n"] == 0:
+            print(f"  {key:<{width}}  (no data)")
+            continue
+        stdev = "n/a" if s["stdev"] is None else f"{s['stdev']:.4f}"
+        print(
+            f"  {key:<{width}}  mean={s['mean']:.4f}  median={s['median']:.4f}  "
+            f"stdev={stdev}  min={s['min']:.4f}  max={s['max']:.4f}  (n={s['n']})"
+        )
+    for key in _COUNT_FIELDS:
+        s = summary["counts"][key]
+        if s["n"] == 0:
+            continue
+        stdev = "n/a" if s["stdev"] is None else f"{s['stdev']:.2f}"
+        print(
+            f"  {key:<{width}}  mean={s['mean']:.2f}  median={s['median']:.2f}  "
+            f"stdev={stdev}  min={s['min']:.0f}  max={s['max']:.0f}"
+        )
+    if summary.get("category_scores"):
+        print("\n  per-category correctness (mean ± stdev across trials):")
+        for cat, s in sorted(summary["category_scores"].items()):
+            if s["n"] == 0:
+                continue
+            stdev = "n/a" if s["stdev"] is None else f"±{s['stdev']:.3f}"
+            print(f"    {cat}: {s['mean']:.3f} {stdev}  (n={s['n']})")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse argv into a Namespace.
+
+    Enforces `--model` and `--trials` (with bounds) unless `--aggregate-only`
+    is set, in which case the script just merges existing reports.
+    """
+    parser = argparse.ArgumentParser(
+        description="Run the eval suite N times and aggregate metrics."
+    )
+    parser.add_argument(
+        "--aggregate-only",
+        type=Path,
+        default=None,
+        help=(
+            "Skip trial execution; aggregate existing reports under DIR (recursive "
+            "search for evals_report*.json). Used by CI after artifacts are downloaded."
+        ),
+    )
+    parser.add_argument(
+        "--summary-out",
+        type=Path,
+        default=None,
+        help="Where to write trials_summary.json (default: <out-dir>/trials_summary.json).",
+    )
+    parser.add_argument(
+        "--model",
+        required=False,
+        help="Model identifier, e.g. openai:gpt-5.5 (passed through to pytest). Required unless --aggregate-only is set.",
+    )
+    parser.add_argument(
+        "--trials",
+        type=int,
+        required=False,
+        help=f"Number of trials to run (1..{_MAX_TRIALS}). Required unless --aggregate-only is set.",
+    )
+    parser.add_argument(
+        "--eval-category",
+        action="append",
+        default=[],
+        help="Restrict to one eval category (repeatable).",
+    )
+    parser.add_argument(
+        "--eval-tier",
+        action="append",
+        default=[],
+        help="Restrict to one eval tier (repeatable: baseline | hillclimb).",
+    )
+    parser.add_argument(
+        "--openai-reasoning-effort",
+        choices=("minimal", "low", "medium", "high", "xhigh"),
+        default=None,
+    )
+    parser.add_argument(
+        "--openrouter-provider",
+        default=None,
+        help="Pin OpenRouter to a specific provider (e.g. MiniMax).",
+    )
+    parser.add_argument(
+        "--repl",
+        choices=("quickjs", "langchain"),
+        default=None,
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=_DEFAULT_OUT_DIR,
+        help=f"Where per-trial reports and the summary are written (default: {_DEFAULT_OUT_DIR}).",
+    )
+    parser.add_argument(
+        "pytest_extra",
+        nargs=argparse.REMAINDER,
+        help="Extra args to forward to pytest (use `--` to separate).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.aggregate_only is None:
+        if not args.model:
+            parser.error("--model is required (unless --aggregate-only is set)")
+        if args.trials is None:
+            parser.error("--trials is required (unless --aggregate-only is set)")
+        if not 1 <= args.trials <= _MAX_TRIALS:
+            parser.error(f"--trials must be between 1 and {_MAX_TRIALS}")
+    if args.pytest_extra and args.pytest_extra[0] == "--":
+        args.pytest_extra = args.pytest_extra[1:]
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run N eval trials and write `<out-dir>/trials_summary.json`.
+
+    With `--aggregate-only DIR`, skip trial execution and aggregate report
+    files already on disk (e.g. CI artifacts).
+
+    Returns:
+        Process exit code: `0` on success, `1` when no usable reports were
+        found (either no trial produced one, or every produced file was
+        unreadable).
+    """
+    args = _parse_args(argv)
+
+    # Maps a report path to the pytest exit code that produced it; only
+    # populated for the live-execution path so partial failures can be
+    # surfaced in the summary header and per-trial JSON.
+    returncodes: dict[Path, int] = {}
+
+    if args.aggregate_only is not None:
+        report_paths = _discover_reports(args.aggregate_only)
+        if not report_paths:
+            print(
+                f"error: no eval report JSON files found under {args.aggregate_only}",
+                file=sys.stderr,
+            )
+            return 1
+        out_dir = args.aggregate_only
+    else:
+        out_dir = args.out_dir
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        report_paths = []
+        for i in range(args.trials):
+            outcome = _run_trial(
+                trial_index=i,
+                n_trials=args.trials,
+                args=args,
+                out_dir=out_dir,
+            )
+            if outcome.report_path is not None:
+                report_paths.append(outcome.report_path)
+                returncodes[outcome.report_path] = outcome.returncode
+
+        if not report_paths:
+            print("error: no trial produced a report; nothing to aggregate", file=sys.stderr)
+            return 1
+
+    reports: list[dict[str, Any]] = []
+    for p in report_paths:
+        data = _load_report(p)
+        if data is None:
+            continue
+        if p in returncodes:
+            data.setdefault("pytest_returncode", returncodes[p])
+        reports.append(data)
+
+    if not reports:
+        print("error: no readable trial reports found", file=sys.stderr)
+        return 1
+
+    summary = aggregate_trials(reports)
+    summary_path = args.summary_out or (out_dir / "trials_summary.json")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _print_summary(summary)
+    print(f"\nwrote {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libs/evals/tests/unit_tests/test_run_trials.py
+++ b/libs/evals/tests/unit_tests/test_run_trials.py
@@ -1,0 +1,601 @@
+"""Tests for the multi-trial eval runner aggregator."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "run_trials.py"
+_MODULE_NAME = "_run_trials_under_test"
+
+
+def _load_run_trials() -> ModuleType:
+    """Import scripts/run_trials.py as a module without polluting sys.path.
+
+    Registers the module in `sys.modules` before `exec_module` so dataclass
+    forward-reference resolution (which looks the module up by name) works on
+    Python 3.14+.
+    """
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SCRIPT)
+    if spec is None or spec.loader is None:
+        msg = f"could not load spec for {_SCRIPT}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+run_trials = _load_run_trials()
+
+
+def _report(
+    *,
+    correctness: float,
+    solve_rate: float | None,
+    step_ratio: float | None,
+    tool_call_ratio: float | None,
+    median_duration_s: float,
+    passed: int,
+    failed: int,
+    total: int,
+    category_scores: dict[str, float] | None = None,
+    skipped: int = 0,
+) -> dict[str, Any]:
+    """Build a fake per-trial report matching the pytest reporter schema."""
+    return {
+        "model": "openai:gpt-5.5",
+        "sdk_version": "0.5.6",
+        "created_at": "2026-05-04T00:00:00+00:00",
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "total": total,
+        "correctness": correctness,
+        "solve_rate": solve_rate,
+        "step_ratio": step_ratio,
+        "tool_call_ratio": tool_call_ratio,
+        "median_duration_s": median_duration_s,
+        "category_scores": category_scores or {},
+        "experiment_urls": [],
+    }
+
+
+class TestAggregateTrials:
+    def test_empty_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one report"):
+            run_trials.aggregate_trials([])
+
+    def test_single_trial_has_no_stdev(self) -> None:
+        summary = run_trials.aggregate_trials(
+            [
+                _report(
+                    correctness=0.5,
+                    solve_rate=0.2,
+                    step_ratio=0.8,
+                    tool_call_ratio=0.6,
+                    median_duration_s=10.0,
+                    passed=80,
+                    failed=80,
+                    total=160,
+                ),
+            ]
+        )
+        assert summary["n_trials"] == 1
+        assert summary["metrics"]["correctness"]["mean"] == pytest.approx(0.5)
+        assert summary["metrics"]["correctness"]["stdev"] is None
+        assert summary["metrics"]["correctness"]["min"] == pytest.approx(0.5)
+        assert summary["metrics"]["correctness"]["max"] == pytest.approx(0.5)
+
+    def test_multi_trial_stats_match_statistics_module(self) -> None:
+        correctness_values = [0.47, 0.49, 0.51]
+        reports = [
+            _report(
+                correctness=c,
+                solve_rate=0.20 + i * 0.01,
+                step_ratio=0.80 + i * 0.01,
+                tool_call_ratio=0.50 + i * 0.05,
+                median_duration_s=8.0 + i,
+                passed=80 + i,
+                failed=80 - i,
+                total=160,
+            )
+            for i, c in enumerate(correctness_values)
+        ]
+        summary = run_trials.aggregate_trials(reports)
+
+        c_stats = summary["metrics"]["correctness"]
+        assert c_stats["n"] == 3
+        assert c_stats["mean"] == pytest.approx(statistics.mean(correctness_values))
+        assert c_stats["median"] == pytest.approx(statistics.median(correctness_values))
+        assert c_stats["stdev"] == pytest.approx(statistics.stdev(correctness_values))
+        assert c_stats["min"] == pytest.approx(min(correctness_values))
+        assert c_stats["max"] == pytest.approx(max(correctness_values))
+
+        passed_stats = summary["counts"]["passed"]
+        assert passed_stats["mean"] == pytest.approx(81.0)
+        assert passed_stats["min"] == 80
+        assert passed_stats["max"] == 82
+
+    def test_null_metric_values_are_skipped(self) -> None:
+        reports = [
+            _report(
+                correctness=0.5,
+                solve_rate=None,
+                step_ratio=0.8,
+                tool_call_ratio=None,
+                median_duration_s=10.0,
+                passed=80,
+                failed=80,
+                total=160,
+            ),
+            _report(
+                correctness=0.6,
+                solve_rate=0.25,
+                step_ratio=None,
+                tool_call_ratio=0.7,
+                median_duration_s=12.0,
+                passed=90,
+                failed=70,
+                total=160,
+            ),
+        ]
+        summary = run_trials.aggregate_trials(reports)
+        assert summary["metrics"]["solve_rate"]["n"] == 1
+        assert summary["metrics"]["solve_rate"]["mean"] == pytest.approx(0.25)
+        assert summary["metrics"]["solve_rate"]["stdev"] is None
+        assert summary["metrics"]["step_ratio"]["n"] == 1
+        assert summary["metrics"]["tool_call_ratio"]["n"] == 1
+        assert summary["metrics"]["correctness"]["n"] == 2
+
+    def test_category_scores_aggregated_across_trials(self) -> None:
+        reports = [
+            _report(
+                correctness=0.5,
+                solve_rate=0.2,
+                step_ratio=0.8,
+                tool_call_ratio=0.6,
+                median_duration_s=10.0,
+                passed=80,
+                failed=80,
+                total=160,
+                category_scores={"memory": 0.6, "tool_use": 0.2},
+            ),
+            _report(
+                correctness=0.55,
+                solve_rate=0.21,
+                step_ratio=0.82,
+                tool_call_ratio=0.65,
+                median_duration_s=11.0,
+                passed=85,
+                failed=75,
+                total=160,
+                category_scores={"memory": 0.7, "tool_use": 0.18, "retrieval": 1.0},
+            ),
+        ]
+        summary = run_trials.aggregate_trials(reports)
+        cats = summary["category_scores"]
+        assert cats["memory"]["n"] == 2
+        assert cats["memory"]["mean"] == pytest.approx(0.65)
+        # `retrieval` only appears in one trial; n=1, stdev=None
+        assert cats["retrieval"]["n"] == 1
+        assert cats["retrieval"]["stdev"] is None
+
+    def test_per_trial_records_preserved_in_order(self) -> None:
+        reports = [
+            _report(
+                correctness=0.4 + i * 0.05,
+                solve_rate=0.2,
+                step_ratio=0.8,
+                tool_call_ratio=0.5,
+                median_duration_s=10.0,
+                passed=10 * i,
+                failed=0,
+                total=10 * i,
+            )
+            for i in range(3)
+        ]
+        summary = run_trials.aggregate_trials(reports)
+        assert [t["trial_index"] for t in summary["trials"]] == [0, 1, 2]
+        assert [t["correctness"] for t in summary["trials"]] == pytest.approx([0.4, 0.45, 0.5])
+
+    def test_non_numeric_metric_value_is_excluded_with_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        reports = [
+            _report(
+                correctness=0.5,
+                solve_rate=0.2,
+                step_ratio=0.8,
+                tool_call_ratio=0.6,
+                median_duration_s=10.0,
+                passed=80,
+                failed=80,
+                total=160,
+            ),
+        ]
+        # Bad upstream schema: correctness arrived as a string.
+        reports[0]["correctness"] = "0.5"
+        summary = run_trials.aggregate_trials(reports)
+        assert summary["metrics"]["correctness"]["n"] == 0
+        captured = capsys.readouterr()
+        assert "non-numeric value for 'correctness'" in captured.err
+
+    def test_bool_values_are_not_aggregated_as_ints(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        reports = [
+            _report(
+                correctness=0.5,
+                solve_rate=0.2,
+                step_ratio=0.8,
+                tool_call_ratio=0.6,
+                median_duration_s=10.0,
+                passed=80,
+                failed=80,
+                total=160,
+            ),
+        ]
+        # `True` is `isinstance(_, int)` but should not be aggregated as 1.
+        reports[0]["passed"] = True
+        summary = run_trials.aggregate_trials(reports)
+        assert summary["counts"]["passed"]["n"] == 0
+        assert "non-numeric value for 'passed'" in capsys.readouterr().err
+
+    def test_divergent_model_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
+        a = _report(
+            correctness=0.5,
+            solve_rate=0.2,
+            step_ratio=0.8,
+            tool_call_ratio=0.6,
+            median_duration_s=10.0,
+            passed=80,
+            failed=80,
+            total=160,
+        )
+        b = _report(
+            correctness=0.6,
+            solve_rate=0.2,
+            step_ratio=0.8,
+            tool_call_ratio=0.6,
+            median_duration_s=10.0,
+            passed=80,
+            failed=80,
+            total=160,
+        )
+        b["model"] = "anthropic:claude-4.6"
+        summary = run_trials.aggregate_trials([a, b])
+        assert summary["model"] == "openai:gpt-5.5"
+        assert "disagree on `model`" in capsys.readouterr().err
+
+    def test_pytest_returncode_passes_through_to_per_trial(self) -> None:
+        r = _report(
+            correctness=0.5,
+            solve_rate=0.2,
+            step_ratio=0.8,
+            tool_call_ratio=0.6,
+            median_duration_s=10.0,
+            passed=80,
+            failed=80,
+            total=160,
+        )
+        r["pytest_returncode"] = 2
+        summary = run_trials.aggregate_trials([r])
+        assert summary["trials"][0]["pytest_returncode"] == 2
+
+
+class TestSummarize:
+    def test_empty_input_returns_all_none(self) -> None:
+        stats = run_trials._summarize([]).to_dict()
+        assert stats == {
+            "n": 0,
+            "mean": None,
+            "median": None,
+            "stdev": None,
+            "min": None,
+            "max": None,
+        }
+
+    def test_single_value_has_no_stdev(self) -> None:
+        stats = run_trials._summarize([0.5]).to_dict()
+        assert stats["n"] == 1
+        assert stats["stdev"] is None
+        assert stats["mean"] == pytest.approx(0.5)
+
+
+def _make_args(**overrides: Any) -> argparse.Namespace:
+    base: dict[str, Any] = {
+        "model": "openai:gpt-5.5",
+        "trials": 1,
+        "eval_category": [],
+        "eval_tier": [],
+        "openai_reasoning_effort": None,
+        "openrouter_provider": None,
+        "repl": None,
+        "out_dir": Path("/tmp/out"),
+        "pytest_extra": [],
+        "aggregate_only": None,
+        "summary_out": None,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestBuildPytestArgs:
+    def test_minimal_args(self) -> None:
+        cmd = run_trials._build_pytest_args(_make_args(), Path("/tmp/r.json"))
+        assert cmd[:6] == ["uv", "run", "--group", "test", "pytest", "tests/evals"]
+        assert "--model" in cmd
+        assert cmd[cmd.index("--model") + 1] == "openai:gpt-5.5"
+        assert "--evals-report-file" in cmd
+        assert cmd[cmd.index("--evals-report-file") + 1] == "/tmp/r.json"
+
+    def test_repeated_categories_and_tiers(self) -> None:
+        args = _make_args(eval_category=["memory", "tool_use"], eval_tier=["baseline"])
+        cmd = run_trials._build_pytest_args(args, Path("/tmp/r.json"))
+        # Each repeated value should show up as its own --eval-category flag.
+        assert cmd.count("--eval-category") == 2
+        assert "memory" in cmd
+        assert "tool_use" in cmd
+        assert cmd.count("--eval-tier") == 1
+        assert "baseline" in cmd
+
+    def test_optional_flags_pass_through(self) -> None:
+        args = _make_args(
+            openai_reasoning_effort="medium",
+            openrouter_provider="MiniMax",
+            repl="quickjs",
+        )
+        cmd = run_trials._build_pytest_args(args, Path("/tmp/r.json"))
+        assert "--openai-reasoning-effort" in cmd
+        assert cmd[cmd.index("--openai-reasoning-effort") + 1] == "medium"
+        assert "--openrouter-provider" in cmd
+        assert cmd[cmd.index("--openrouter-provider") + 1] == "MiniMax"
+        assert "--repl" in cmd
+        assert cmd[cmd.index("--repl") + 1] == "quickjs"
+
+    def test_pytest_extra_forwarded(self) -> None:
+        args = _make_args(pytest_extra=["-k", "smoke"])
+        cmd = run_trials._build_pytest_args(args, Path("/tmp/r.json"))
+        assert cmd[-2:] == ["-k", "smoke"]
+
+
+class TestParseArgs:
+    def test_requires_model_when_not_aggregate_only(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            run_trials._parse_args(["--trials", "3"])
+        assert "--model is required" in capsys.readouterr().err
+
+    def test_requires_trials_when_not_aggregate_only(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            run_trials._parse_args(["--model", "openai:gpt-5.5"])
+        assert "--trials is required" in capsys.readouterr().err
+
+    def test_rejects_trials_below_one(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            run_trials._parse_args(["--model", "openai:gpt-5.5", "--trials", "0"])
+        assert "between 1 and" in capsys.readouterr().err
+
+    def test_rejects_trials_above_max(self, capsys: pytest.CaptureFixture[str]) -> None:
+        too_many = run_trials._MAX_TRIALS + 1
+        with pytest.raises(SystemExit):
+            run_trials._parse_args(["--model", "openai:gpt-5.5", "--trials", str(too_many)])
+        assert "between 1 and" in capsys.readouterr().err
+
+    def test_aggregate_only_skips_model_and_trials_validation(self, tmp_path: Path) -> None:
+        args = run_trials._parse_args(["--aggregate-only", str(tmp_path)])
+        assert args.aggregate_only == tmp_path
+        assert args.model is None
+        assert args.trials is None
+
+    def test_strips_leading_double_dash_from_pytest_extra(self) -> None:
+        args = run_trials._parse_args(
+            ["--model", "openai:gpt-5.5", "--trials", "1", "--", "-k", "smoke"]
+        )
+        assert args.pytest_extra == ["-k", "smoke"]
+
+
+class TestDiscoverReports:
+    def test_returns_empty_when_root_missing(self, tmp_path: Path) -> None:
+        assert run_trials._discover_reports(tmp_path / "does_not_exist") == []
+
+    def test_finds_per_trial_files(self, tmp_path: Path) -> None:
+        (tmp_path / "evals_report_trial_000.json").write_text("{}")
+        (tmp_path / "evals_report_trial_001.json").write_text("{}")
+        found = run_trials._discover_reports(tmp_path)
+        assert [p.name for p in found] == [
+            "evals_report_trial_000.json",
+            "evals_report_trial_001.json",
+        ]
+
+    def test_finds_ci_artifact_layout(self, tmp_path: Path) -> None:
+        # `_eval.yml` writes `evals_report.json` inside each artifact dir.
+        for i in range(2):
+            d = tmp_path / f"evals-report-trial-{i:03d}-slug"
+            d.mkdir()
+            (d / "evals_report.json").write_text("{}")
+        found = run_trials._discover_reports(tmp_path)
+        assert len(found) == 2
+        assert all(p.name == "evals_report.json" for p in found)
+
+    def test_dedupes_when_a_file_matches_both_patterns(self, tmp_path: Path) -> None:
+        # Implausible but valid: a file matching both globs should appear once.
+        (tmp_path / "evals_report.json").write_text("{}")
+        (tmp_path / "evals_report_trial_000.json").write_text("{}")
+        found = run_trials._discover_reports(tmp_path)
+        assert len(found) == 2
+
+    def test_returns_sorted(self, tmp_path: Path) -> None:
+        for name in ("evals_report_trial_002.json", "evals_report_trial_000.json"):
+            (tmp_path / name).write_text("{}")
+        found = run_trials._discover_reports(tmp_path)
+        assert [p.name for p in found] == sorted(p.name for p in found)
+
+
+class TestLoadReport:
+    def test_returns_none_for_missing_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert run_trials._load_report(tmp_path / "nope.json") is None
+        assert "could not read" in capsys.readouterr().err
+
+    def test_returns_none_for_invalid_json(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("not json{")
+        assert run_trials._load_report(path) is None
+        assert "could not read" in capsys.readouterr().err
+
+    def test_returns_none_for_non_dict_top_level(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "list.json"
+        path.write_text("[1, 2, 3]")
+        assert run_trials._load_report(path) is None
+        assert "not a JSON object" in capsys.readouterr().err
+
+    def test_returns_dict_on_success(self, tmp_path: Path) -> None:
+        path = tmp_path / "ok.json"
+        path.write_text('{"a": 1}')
+        assert run_trials._load_report(path) == {"a": 1}
+
+
+class TestMainAggregateOnly:
+    def test_writes_summary_from_existing_reports(self, tmp_path: Path) -> None:
+        report = _report(
+            correctness=0.5,
+            solve_rate=0.2,
+            step_ratio=0.8,
+            tool_call_ratio=0.6,
+            median_duration_s=10.0,
+            passed=80,
+            failed=80,
+            total=160,
+        )
+        (tmp_path / "evals_report_trial_000.json").write_text(json.dumps(report))
+        summary_out = tmp_path / "trials_summary.json"
+
+        rc = run_trials.main(["--aggregate-only", str(tmp_path), "--summary-out", str(summary_out)])
+        assert rc == 0
+        assert summary_out.is_file()
+        summary = json.loads(summary_out.read_text())
+        assert summary["n_trials"] == 1
+        assert summary["metrics"]["correctness"]["mean"] == pytest.approx(0.5)
+
+    def test_returns_1_when_dir_empty(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = run_trials.main(["--aggregate-only", str(tmp_path)])
+        assert rc == 1
+        assert "no eval report JSON files found" in capsys.readouterr().err
+
+    def test_returns_1_when_all_reports_unreadable(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / "evals_report_trial_000.json").write_text("not json")
+        rc = run_trials.main(["--aggregate-only", str(tmp_path)])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "no readable trial reports found" in captured.err
+
+    def test_default_summary_path_is_under_aggregate_dir(self, tmp_path: Path) -> None:
+        report = _report(
+            correctness=0.5,
+            solve_rate=0.2,
+            step_ratio=0.8,
+            tool_call_ratio=0.6,
+            median_duration_s=10.0,
+            passed=80,
+            failed=80,
+            total=160,
+        )
+        (tmp_path / "evals_report_trial_000.json").write_text(json.dumps(report))
+        rc = run_trials.main(["--aggregate-only", str(tmp_path)])
+        assert rc == 0
+        assert (tmp_path / "trials_summary.json").is_file()
+
+
+class TestMain:
+    def test_returns_1_when_no_trial_produces_a_report(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def fail(**_: object) -> object:
+            return run_trials._TrialOutcome(report_path=None, returncode=1)
+
+        monkeypatch.setattr(run_trials, "_run_trial", fail)
+        rc = run_trials.main(
+            [
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--out-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 1
+        assert "no trial produced a report" in capsys.readouterr().err
+
+    def test_main_aggregates_when_run_trial_succeeds(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fake_run_trial(
+            *,
+            trial_index: int,
+            n_trials: int,  # noqa: ARG001
+            args: argparse.Namespace,  # noqa: ARG001
+            out_dir: Path,
+        ) -> object:
+            path = out_dir / f"evals_report_trial_{trial_index:03d}.json"
+            path.write_text(
+                json.dumps(
+                    _report(
+                        correctness=0.5 + 0.1 * trial_index,
+                        solve_rate=0.2,
+                        step_ratio=0.8,
+                        tool_call_ratio=0.6,
+                        median_duration_s=10.0,
+                        passed=80,
+                        failed=80,
+                        total=160,
+                    )
+                )
+            )
+            return run_trials._TrialOutcome(report_path=path, returncode=0)
+
+        monkeypatch.setattr(run_trials, "_run_trial", fake_run_trial)
+        rc = run_trials.main(
+            [
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--out-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        summary = json.loads((tmp_path / "trials_summary.json").read_text())
+        assert summary["n_trials"] == 2
+        # Returncode passthrough on the live-execution path.
+        assert summary["trials"][0]["pytest_returncode"] == 0


### PR DESCRIPTION
Run the eval suite N times under the same model/config and aggregate per-trial results into mean/median/stdev/min/max — useful for distinguishing real model improvements from run-to-run variance. A dedicated `evals_trials.yml` workflow runs each trial as its own GHA job (each getting a 6h budget) and aggregates the reports, since multi-hour sequential runs don't fit in a single job.