### PR TITLE
fix(sdk): default OpenRouter routing to ignore Azure upstream

### DIFF
--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1956,6 +1956,22 @@ app_categories = ["cloud-agent"]
         assert "app_url" not in call_kwargs
         assert "app_title" not in call_kwargs
         assert "app_categories" not in call_kwargs
+        assert "openrouter_provider" not in call_kwargs
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_sdk_provider_routing_flows_through_cli_profile(
+        self, mock_init: Mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SDK's Azure-ignore default survives CLI profile chaining."""
+        from deepagents.profiles.provider._openrouter import _OPENROUTER_ALLOW_AZURE_ENV
+
+        monkeypatch.delenv(_OPENROUTER_ALLOW_AZURE_ENV, raising=False)
+        mock_init.return_value = _make_init_chat_model_mock()
+
+        create_model("openrouter:deepseek/deepseek-chat")
+
+        _, call_kwargs = mock_init.call_args
+        assert call_kwargs["openrouter_provider"] == {"ignore": ["azure"]}
 
 
 class TestCreateModelForwardsProviderProfile:

--- a/libs/deepagents/deepagents/profiles/provider/_openrouter.py
+++ b/libs/deepagents/deepagents/profiles/provider/_openrouter.py
@@ -39,9 +39,23 @@ See https://openrouter.ai/docs/app-attribution for details.
 _OPENROUTER_APP_TITLE = "Deep Agents"
 """Default `app_title` (maps to `X-Title`) for OpenRouter attribution."""
 
+_OPENROUTER_ALLOW_AZURE_ENV = "DEEPAGENTS_OPENROUTER_ALLOW_AZURE"
+"""Env var that opts back into Azure as an OpenRouter upstream provider.
+
+By default the SDK injects `openrouter_provider={"ignore": ["azure"]}` to keep
+OpenRouter from routing reasoning-model calls through Azure. Azure's Responses
+API support is fine in isolation, but OpenRouter's `/responses` beta is
+documented stateless — it does not propagate `store=true` or `previous_response_id`
+plumbing — so any prior `rs_*` reasoning item the client replays cannot be looked
+up upstream and the request fails with `"Item with id 'rs_...' not found"`.
+Set this var to a truthy value (`1`, `true`, `yes`, `on`) to allow Azure back
+into the provider pool, accepting the multi-turn reasoning breakage as the
+trade-off.
+"""
+
 
 def _openrouter_attribution_kwargs() -> dict[str, Any]:
-    """Build OpenRouter attribution kwargs, deferring to env var overrides.
+    """Build default OpenRouter kwargs, deferring to env var overrides.
 
     `ChatOpenRouter` reads `OPENROUTER_APP_URL` and `OPENROUTER_APP_TITLE` via
     `from_env()` defaults. Explicit kwargs passed to the constructor take
@@ -53,14 +67,22 @@ def _openrouter_attribution_kwargs() -> dict[str, Any]:
     and suppresses the SDK default. This lets a caller opt out of app
     attribution without unsetting the variable.
 
+    Also injects `openrouter_provider={"ignore": ["azure"]}` so OpenRouter never
+    routes to Azure as the upstream provider. Opt out by setting
+    `DEEPAGENTS_OPENROUTER_ALLOW_AZURE` to a truthy value. The ignore is a
+    no-op for non-OpenAI models (Azure is not a candidate provider for them),
+    so the rule is safe to apply globally.
+
     Returns:
-        Dictionary of attribution kwargs to spread into `init_chat_model`.
+        Dictionary of kwargs to spread into `init_chat_model`.
     """
     kwargs: dict[str, Any] = {}
     if os.environ.get("OPENROUTER_APP_URL") is None:
         kwargs["app_url"] = _OPENROUTER_APP_URL
     if os.environ.get("OPENROUTER_APP_TITLE") is None:
         kwargs["app_title"] = _OPENROUTER_APP_TITLE
+    if os.environ.get(_OPENROUTER_ALLOW_AZURE_ENV, "").strip().lower() not in {"1", "true", "yes", "on"}:
+        kwargs["openrouter_provider"] = {"ignore": ["azure"]}
     return kwargs
 
 

--- a/libs/deepagents/tests/unit_tests/test_models.py
+++ b/libs/deepagents/tests/unit_tests/test_models.py
@@ -31,6 +31,7 @@ from deepagents.profiles.harness.harness_profiles import (
     _merge_profiles,
 )
 from deepagents.profiles.provider._openrouter import (
+    _OPENROUTER_ALLOW_AZURE_ENV,
     _OPENROUTER_APP_TITLE,
     _OPENROUTER_APP_URL,
     OPENROUTER_MIN_VERSION,
@@ -43,6 +44,20 @@ from deepagents.profiles.provider.provider_profiles import (
     apply_provider_profile,
     get_provider_profile,
 )
+
+_OPENROUTER_AZURE_IGNORE = {"ignore": ["azure"]}
+"""Expected default value of `openrouter_provider` injected by the SDK profile."""
+
+
+@pytest.fixture(autouse=True)
+def _scrub_openrouter_allow_azure_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pop `DEEPAGENTS_OPENROUTER_ALLOW_AZURE` before each test.
+
+    Otherwise an ambient `DEEPAGENTS_OPENROUTER_ALLOW_AZURE=1` in the
+    developer's shell or CI environment would suppress the `openrouter_provider`
+    kwarg the SDK profile injects, silently breaking assertions that expect it.
+    """
+    monkeypatch.delenv(_OPENROUTER_ALLOW_AZURE_ENV, raising=False)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -103,6 +118,7 @@ class TestResolveModel:
             "openrouter:anthropic/claude-sonnet-4-6",
             app_url=_OPENROUTER_APP_URL,
             app_title=_OPENROUTER_APP_TITLE,
+            openrouter_provider=_OPENROUTER_AZURE_IGNORE,
         )
         assert result is mock.return_value
 
@@ -118,6 +134,7 @@ class TestResolveModel:
         _, kwargs = mock.call_args
         assert "app_url" not in kwargs
         assert kwargs["app_title"] == _OPENROUTER_APP_TITLE
+        assert kwargs["openrouter_provider"] == _OPENROUTER_AZURE_IGNORE
 
     def test_openrouter_env_var_overrides_app_title(self) -> None:
         env = {"OPENROUTER_APP_TITLE": "My Custom App"}
@@ -131,11 +148,30 @@ class TestResolveModel:
         _, kwargs = mock.call_args
         assert kwargs["app_url"] == _OPENROUTER_APP_URL
         assert "app_title" not in kwargs
+        assert kwargs["openrouter_provider"] == _OPENROUTER_AZURE_IGNORE
 
     def test_openrouter_env_vars_override_both(self) -> None:
         env = {
             "OPENROUTER_APP_URL": "https://custom.app",
             "OPENROUTER_APP_TITLE": "My Custom App",
+        }
+        with (
+            patch("deepagents._models.init_chat_model") as mock,
+            patch.dict("os.environ", env),
+        ):
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            resolve_model("openrouter:anthropic/claude-sonnet-4-6")
+
+        mock.assert_called_once_with(
+            "openrouter:anthropic/claude-sonnet-4-6",
+            openrouter_provider=_OPENROUTER_AZURE_IGNORE,
+        )
+
+    def test_openrouter_allow_azure_env_drops_provider_kwarg(self) -> None:
+        env = {
+            "OPENROUTER_APP_URL": "https://custom.app",
+            "OPENROUTER_APP_TITLE": "My Custom App",
+            _OPENROUTER_ALLOW_AZURE_ENV: "1",
         }
         with (
             patch("deepagents._models.init_chat_model") as mock,
@@ -292,6 +328,7 @@ class TestOpenRouterAttributionKwargs:
         assert result == {
             "app_url": _OPENROUTER_APP_URL,
             "app_title": _OPENROUTER_APP_TITLE,
+            "openrouter_provider": _OPENROUTER_AZURE_IGNORE,
         }
 
     def test_omits_app_url_when_env_set(self) -> None:
@@ -300,6 +337,7 @@ class TestOpenRouterAttributionKwargs:
 
         assert "app_url" not in result
         assert result["app_title"] == _OPENROUTER_APP_TITLE
+        assert result["openrouter_provider"] == _OPENROUTER_AZURE_IGNORE
 
     def test_omits_app_title_when_env_set(self) -> None:
         with patch.dict("os.environ", {"OPENROUTER_APP_TITLE": "Custom"}):
@@ -307,8 +345,9 @@ class TestOpenRouterAttributionKwargs:
 
         assert result["app_url"] == _OPENROUTER_APP_URL
         assert "app_title" not in result
+        assert result["openrouter_provider"] == _OPENROUTER_AZURE_IGNORE
 
-    def test_empty_when_both_env_set(self) -> None:
+    def test_only_provider_kwarg_when_both_attribution_env_set(self) -> None:
         env = {
             "OPENROUTER_APP_URL": "https://example.com",
             "OPENROUTER_APP_TITLE": "Custom",
@@ -316,7 +355,39 @@ class TestOpenRouterAttributionKwargs:
         with patch.dict("os.environ", env):
             result = _openrouter_attribution_kwargs()
 
+        assert result == {"openrouter_provider": _OPENROUTER_AZURE_IGNORE}
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "YES", "on", "ON", " yes "])
+    def test_allow_azure_env_truthy_drops_provider_kwarg(self, value: str) -> None:
+        with patch.dict("os.environ", {_OPENROUTER_ALLOW_AZURE_ENV: value}):
+            result = _openrouter_attribution_kwargs()
+
+        assert "openrouter_provider" not in result
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "anything-else"])
+    def test_allow_azure_env_non_truthy_keeps_provider_kwarg(self, value: str) -> None:
+        with patch.dict("os.environ", {_OPENROUTER_ALLOW_AZURE_ENV: value}):
+            result = _openrouter_attribution_kwargs()
+
+        assert result["openrouter_provider"] == _OPENROUTER_AZURE_IGNORE
+
+    def test_empty_when_all_env_set_and_azure_allowed(self) -> None:
+        env = {
+            "OPENROUTER_APP_URL": "https://example.com",
+            "OPENROUTER_APP_TITLE": "Custom",
+            _OPENROUTER_ALLOW_AZURE_ENV: "1",
+        }
+        with patch.dict("os.environ", env):
+            result = _openrouter_attribution_kwargs()
+
         assert result == {}
+
+    def test_caller_openrouter_provider_wins_over_default(self) -> None:
+        """User-supplied `openrouter_provider` overrides the SDK Azure-ignore default."""
+        caller = {"openrouter_provider": {"order": ["fireworks"]}}
+        result = apply_provider_profile("openrouter:openai/gpt-5", caller, run_pre_init=False)
+
+        assert result["openrouter_provider"] == {"order": ["fireworks"]}
 
 
 class TestProviderProfile:


### PR DESCRIPTION
OpenRouter sometimes routes reasoning-model traffic to Azure as the upstream provider. That path breaks multi-turn calls because OpenRouter's `/responses` beta is documented stateless — it doesn't propagate `store=true` or `previous_response_id`, so any prior `rs_*` reasoning item the client replays cannot be looked up upstream and the request fails with `"Item with id 'rs_...' not found"`. The fix excludes Azure from OpenRouter's provider pool by default; the rule is a no-op on non-OpenAI models since Azure isn't a candidate provider for them.

## Changes
- The SDK's built-in OpenRouter profile factory now injects `openrouter_provider={"ignore": ["azure"]}` into `init_chat_model` calls, alongside the existing app-attribution kwargs.
- New env var `DEEPAGENTS_OPENROUTER_ALLOW_AZURE` restores Azure as a candidate provider for callers who explicitly want the failover.
- Caller-supplied `openrouter_provider=...` to `init_chat_model` still wins over the SDK default