### PR TITLE
feat(ci): add repl workflow input for evals

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -51,6 +51,11 @@ on:
         required: false
         default: ""
         type: string
+      repl:
+        description: "REPL middleware to use for `@pytest.mark.repl` tests (`quickjs` | `langchain`). Empty = bind tools directly."
+        required: false
+        default: ""
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -176,6 +181,25 @@ jobs:
         run: |
           effort=$(echo "$OPENAI_REASONING_EFFORT" | xargs)
           printf 'PYTEST_ADDOPTS=%s --openai-reasoning-effort %s\n' "${PYTEST_ADDOPTS}" "${effort}" >> "$GITHUB_ENV"
+
+      - name: "🧪 Apply REPL middleware"
+        # `repl` is `type: string` so a `workflow_call` caller could pass any
+        # value; the case below is the source of truth for accepted values.
+        # Keep the `repl` choice enums in `evals.yml` and `evals_trials.yml`
+        # in sync with this list.
+        if: inputs.repl != ''
+        env:
+          REPL: ${{ inputs.repl }}
+        run: |
+          repl=$(echo "$REPL" | xargs)
+          case "$repl" in
+            quickjs|langchain) ;;
+            *)
+              echo "::error::Unsupported repl value: ${repl}. Allowed: quickjs, langchain."
+              exit 1
+              ;;
+          esac
+          printf 'PYTEST_ADDOPTS=%s --repl %s\n' "${PYTEST_ADDOPTS}" "${repl}" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
         env:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -20,7 +20,7 @@
 
 name: "📊 Evals - GHA"
 run-name: >-
-  📊 Evals - GHA — ${{ inputs.models_override && (contains(inputs.models_override, ',') && 'custom models' || inputs.models_override) || inputs.models || 'all' }}${{ (inputs.eval_categories_override || inputs.eval_categories) && format(' [{0}]', inputs.eval_categories_override || inputs.eval_categories) || '' }}${{ (inputs.eval_tiers_override || inputs.eval_tiers) && format(' tier:{0}', inputs.eval_tiers_override || inputs.eval_tiers) || '' }}${{ inputs.openai_reasoning_effort && format(' reasoning:{0}', inputs.openai_reasoning_effort) || '' }}
+  📊 Evals - GHA — ${{ inputs.models_override && (contains(inputs.models_override, ',') && 'custom models' || inputs.models_override) || inputs.models || 'all' }}${{ (inputs.eval_categories_override || inputs.eval_categories) && format(' [{0}]', inputs.eval_categories_override || inputs.eval_categories) || '' }}${{ (inputs.eval_tiers_override || inputs.eval_tiers) && format(' tier:{0}', inputs.eval_tiers_override || inputs.eval_tiers) || '' }}${{ inputs.openai_reasoning_effort && format(' reasoning:{0}', inputs.openai_reasoning_effort) || '' }}${{ inputs.repl && format(' repl:{0}', inputs.repl) || '' }}
 
 on:
   workflow_dispatch:
@@ -190,6 +190,15 @@ on:
           - medium
           - high
           - xhigh
+      repl:
+        description: "REPL middleware for tests marked with @pytest.mark.repl. Empty = bind tools directly (native tool calling)."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - quickjs
+          - langchain
 
 permissions:
   contents: write
@@ -236,6 +245,7 @@ jobs:
           EVAL_TIERS: ${{ inputs.eval_tiers_override || inputs.eval_tiers || '(all)' }}
           OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
           OPENAI_REASONING_EFFORT: ${{ inputs.openai_reasoning_effort }}
+          REPL: ${{ inputs.repl }}
           ANALYZE_FAILURES: ${{ inputs.analyze_failures }}
           ANALYSIS_MODEL: ${{ inputs.analysis_model || 'anthropic:claude-haiku-4-5-20251001' }}
         run: |
@@ -291,6 +301,9 @@ jobs:
           if [ -n "${OPENAI_REASONING_EFFORT}" ]; then
             echo "| \`openai_reasoning_effort\` | \`${OPENAI_REASONING_EFFORT}\` |" >> "$GITHUB_STEP_SUMMARY"
           fi
+          if [ -n "${REPL}" ]; then
+            echo "| \`repl\` | \`${REPL}\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "${ANALYZE_FAILURES}" = "true" ]; then
             echo "| \`analyze_failures\` | ✅ enabled (\`${ANALYSIS_MODEL}\`) |" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -341,6 +354,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-baseten:
@@ -362,6 +376,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-fireworks:
@@ -383,6 +398,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-google-genai:
@@ -404,6 +420,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-groq:
@@ -425,6 +442,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-nvidia:
@@ -446,6 +464,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-ollama:
@@ -467,6 +486,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-openai:
@@ -488,6 +508,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-openrouter:
@@ -509,6 +530,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-xai:
@@ -530,6 +552,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   eval-other:
@@ -551,6 +574,7 @@ jobs:
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   aggregate:

--- a/.github/workflows/evals_trials.yml
+++ b/.github/workflows/evals_trials.yml
@@ -15,7 +15,7 @@
 
 name: "📊 Eval trials - GHA"
 run-name: >-
-  📊 Eval trials — ${{ inputs.model }} × ${{ inputs.trials }} trials${{ inputs.parallel && ' (parallel)' || ' (sequential)' }}${{ inputs.openai_reasoning_effort && format(' reasoning:{0}', inputs.openai_reasoning_effort) || '' }}
+  📊 Eval trials — ${{ inputs.model }} × ${{ inputs.trials }} trials${{ inputs.parallel && ' (parallel)' || ' (sequential)' }}${{ inputs.openai_reasoning_effort && format(' reasoning:{0}', inputs.openai_reasoning_effort) || '' }}${{ inputs.repl && format(' repl:{0}', inputs.repl) || '' }}
 
 on:
   workflow_dispatch:
@@ -61,6 +61,15 @@ on:
           - medium
           - high
           - xhigh
+      repl:
+        description: "REPL middleware for `@pytest.mark.repl` tests. Empty = bind tools directly."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - quickjs
+          - langchain
 
 permissions:
   contents: read
@@ -88,6 +97,7 @@ jobs:
           EVAL_CATEGORIES: ${{ inputs.eval_categories }}
           EVAL_TIERS: ${{ inputs.eval_tiers }}
           OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
+          REPL: ${{ inputs.repl }}
         run: |
           python3 << 'PYEOF'
           import json, os, re, sys
@@ -126,6 +136,7 @@ jobs:
               ("eval_categories", os.environ.get("EVAL_CATEGORIES", ""), _CSV_RE),
               ("eval_tiers", os.environ.get("EVAL_TIERS", ""), _CSV_RE),
               ("openrouter_provider", os.environ.get("OPENROUTER_PROVIDER", ""), _SLUG_RE),
+              ("repl", os.environ.get("REPL", ""), _SLUG_RE),
           ):
               if not pattern.match(value):
                   print(f"::error::Unsafe `{name}` value: {value!r}")
@@ -176,6 +187,7 @@ jobs:
       analyze_failures: false
       openrouter_provider: ${{ inputs.openrouter_provider }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
+      repl: ${{ inputs.repl }}
     secrets: inherit
 
   aggregate-trials:
@@ -229,6 +241,7 @@ jobs:
           N: ${{ inputs.trials }}
           PARALLEL: ${{ inputs.parallel }}
           REASONING: ${{ inputs.openai_reasoning_effort }}
+          REPL: ${{ inputs.repl }}
         run: |
           python3 << 'PYEOF'
           import json, os, sys
@@ -272,6 +285,8 @@ jobs:
               lines.append(missing_banner)
           if os.environ.get("REASONING"):
               lines.append(f"- reasoning_effort: `{os.environ['REASONING']}`")
+          if os.environ.get("REPL"):
+              lines.append(f"- repl: `{os.environ['REPL']}`")
 
           lines += [
               "",


### PR DESCRIPTION
Add a `repl` input to the eval and eval-trials workflows so callers can choose which REPL middleware (`quickjs` or `langchain`) to use for tests marked with `@pytest.mark.repl`. When empty, tools are bound directly (native tool calling) as before.