### PR TITLE
feat(evals): support multi-provider OpenRouter allowlist and `openrouter_allow_fallbacks` toggle

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -42,10 +42,15 @@ on:
         default: "anthropic:claude-haiku-4-5-20251001"
         type: string
       openrouter_provider:
-        description: "Pin OpenRouter to a single provider."
+        description: "Pin OpenRouter to one or more providers (comma-separated allowlist)."
         required: false
         default: ""
         type: string
+      openrouter_allow_fallbacks:
+        description: "Allow OpenRouter to fall back outside `openrouter_provider`. Default is strict (no fallbacks)."
+        required: false
+        default: false
+        type: boolean
       openai_reasoning_effort:
         description: "Reasoning effort for OpenAI models (minimal | low | medium | high | xhigh)."
         required: false
@@ -170,9 +175,14 @@ jobs:
         if: inputs.openrouter_provider != '' && inputs.provider == 'openrouter'
         env:
           OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
+          OPENROUTER_ALLOW_FALLBACKS: ${{ inputs.openrouter_allow_fallbacks }}
         run: |
           provider=$(echo "$OPENROUTER_PROVIDER" | xargs)
-          printf 'PYTEST_ADDOPTS=%s --openrouter-provider %s\n' "${PYTEST_ADDOPTS}" "${provider}" >> "$GITHUB_ENV"
+          extra=""
+          if [ "${OPENROUTER_ALLOW_FALLBACKS}" = "true" ]; then
+            extra=" --openrouter-allow-fallbacks"
+          fi
+          printf 'PYTEST_ADDOPTS=%s --openrouter-provider %s%s\n' "${PYTEST_ADDOPTS}" "${provider}" "${extra}" >> "$GITHUB_ENV"
 
       - name: "🧠 Apply OpenAI reasoning effort"
         if: inputs.openai_reasoning_effort != '' && inputs.provider == 'openai'

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -178,10 +178,24 @@ jobs:
           OPENROUTER_ALLOW_FALLBACKS: ${{ inputs.openrouter_allow_fallbacks }}
         run: |
           provider=$(echo "$OPENROUTER_PROVIDER" | xargs)
+          # Defense in depth: GitHub serializes typed `boolean` inputs as
+          # lowercase "true"/"false", but if this workflow is ever wired to
+          # a string-valued source (workflow_run payload, matrix string,
+          # caller-side env literal) the value could arrive as "True"/"1"/
+          # "yes". Normalize and fail loudly on anything unrecognized so a
+          # silent strict-pin never masquerades as a soft preference.
           extra=""
-          if [ "${OPENROUTER_ALLOW_FALLBACKS}" = "true" ]; then
-            extra=" --openrouter-allow-fallbacks"
-          fi
+          case "${OPENROUTER_ALLOW_FALLBACKS,,}" in
+            true|1|yes)
+              extra=" --openrouter-allow-fallbacks"
+              ;;
+            false|0|no|"")
+              ;;
+            *)
+              echo "::error::Unrecognized openrouter_allow_fallbacks=${OPENROUTER_ALLOW_FALLBACKS}; expected true/false."
+              exit 1
+              ;;
+          esac
           printf 'PYTEST_ADDOPTS=%s --openrouter-provider %s%s\n' "${PYTEST_ADDOPTS}" "${provider}" "${extra}" >> "$GITHUB_ENV"
 
       - name: "🧠 Apply OpenAI reasoning effort"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -303,11 +303,21 @@ jobs:
           fi
           if [ -n "${OPENROUTER_PROVIDER}" ]; then
             echo "| \`openrouter_provider\` | \`${OPENROUTER_PROVIDER}\` |" >> "$GITHUB_STEP_SUMMARY"
-            if [ "${OPENROUTER_ALLOW_FALLBACKS}" = "true" ]; then
-              echo "| \`openrouter_allow_fallbacks\` | ✅ soft (preferred + fallback) |" >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "| \`openrouter_allow_fallbacks\` | 🔒 strict (no fallback) |" >> "$GITHUB_STEP_SUMMARY"
-            fi
+            # Mirror `_eval.yml` boolean parsing: accept the GitHub-typed
+            # lowercase `true`/`false` plus common variants so a non-typed
+            # caller can't silently render the wrong badge here.
+            case "${OPENROUTER_ALLOW_FALLBACKS,,}" in
+              true|1|yes)
+                echo "| \`openrouter_allow_fallbacks\` | ✅ soft (preferred + fallback) |" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              false|0|no|"")
+                echo "| \`openrouter_allow_fallbacks\` | 🔒 strict (no fallback) |" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              *)
+                echo "::error::Unrecognized openrouter_allow_fallbacks=${OPENROUTER_ALLOW_FALLBACKS}; expected true/false."
+                exit 1
+                ;;
+            esac
           fi
           if [ -n "${OPENAI_REASONING_EFFORT}" ]; then
             echo "| \`openai_reasoning_effort\` | \`${OPENAI_REASONING_EFFORT}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -174,10 +174,15 @@ on:
           - "google_genai:gemini-3-flash-preview"
           - "google_genai:gemini-3.1-flash-lite-preview"
       openrouter_provider:
-        description: "Pin OpenRouter to a single provider (solo routing). E.g. 'MiniMax'. Only applies to openrouter: models."
+        description: "Pin OpenRouter to one or more providers (comma-separated allowlist). E.g. 'MiniMax' or 'MiniMax,Fireworks'. Only applies to openrouter: models."
         required: false
         default: ""
         type: string
+      openrouter_allow_fallbacks:
+        description: "Soft allowlist: prefer the providers in `openrouter_provider` but allow OpenRouter to fall back to any other provider hosting the model. Off (default) = strict pin."
+        required: false
+        default: false
+        type: boolean
       openai_reasoning_effort:
         description: "Reasoning effort for OpenAI models (applied as the `reasoning_effort` model kwarg). Only applies to openai: models."
         required: false
@@ -244,6 +249,7 @@ jobs:
           EVAL_CATEGORIES: ${{ inputs.eval_categories_override || inputs.eval_categories || '(all)' }}
           EVAL_TIERS: ${{ inputs.eval_tiers_override || inputs.eval_tiers || '(all)' }}
           OPENROUTER_PROVIDER: ${{ inputs.openrouter_provider }}
+          OPENROUTER_ALLOW_FALLBACKS: ${{ inputs.openrouter_allow_fallbacks }}
           OPENAI_REASONING_EFFORT: ${{ inputs.openai_reasoning_effort }}
           REPL: ${{ inputs.repl }}
           ANALYZE_FAILURES: ${{ inputs.analyze_failures }}
@@ -297,6 +303,11 @@ jobs:
           fi
           if [ -n "${OPENROUTER_PROVIDER}" ]; then
             echo "| \`openrouter_provider\` | \`${OPENROUTER_PROVIDER}\` |" >> "$GITHUB_STEP_SUMMARY"
+            if [ "${OPENROUTER_ALLOW_FALLBACKS}" = "true" ]; then
+              echo "| \`openrouter_allow_fallbacks\` | ✅ soft (preferred + fallback) |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| \`openrouter_allow_fallbacks\` | 🔒 strict (no fallback) |" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           if [ -n "${OPENAI_REASONING_EFFORT}" ]; then
             echo "| \`openai_reasoning_effort\` | \`${OPENAI_REASONING_EFFORT}\` |" >> "$GITHUB_STEP_SUMMARY"
@@ -353,6 +364,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -375,6 +387,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -397,6 +410,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -419,6 +433,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -441,6 +456,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -463,6 +479,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -485,6 +502,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -507,6 +525,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -529,6 +548,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -551,6 +571,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -573,6 +594,7 @@ jobs:
       analyze_failures: ${{ inputs.analyze_failures }}
       analysis_model: ${{ inputs.analysis_model }}
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit

--- a/.github/workflows/evals_trials.yml
+++ b/.github/workflows/evals_trials.yml
@@ -45,10 +45,15 @@ on:
         default: ""
         type: string
       openrouter_provider:
-        description: "Pin OpenRouter to a specific provider (e.g. `MiniMax`)."
+        description: "Pin OpenRouter to one or more providers (comma-separated allowlist), e.g. `MiniMax` or `MiniMax,Fireworks`."
         required: false
         default: ""
         type: string
+      openrouter_allow_fallbacks:
+        description: "Soft allowlist: prefer the listed providers but allow OpenRouter to fall back. Off (default) = strict pin."
+        required: false
+        default: false
+        type: boolean
       openai_reasoning_effort:
         description: "Reasoning effort for OpenAI models."
         required: false
@@ -129,13 +134,15 @@ jobs:
 
           # Defense in depth: these flow through to `_eval.yml` as shell
           # arguments. Reject anything outside a comma-separated identifier
-          # list before we hand them off.
+          # list before we hand them off. `openrouter_provider` accepts a
+          # comma-separated allowlist (e.g. `MiniMax,Fireworks`) so it uses
+          # the CSV pattern; `repl` is single-valued so it stays on SLUG.
           _CSV_RE = re.compile(r"^[a-zA-Z0-9_\-,]*$")
           _SLUG_RE = re.compile(r"^[a-zA-Z0-9_\-]*$")
           for name, value, pattern in (
               ("eval_categories", os.environ.get("EVAL_CATEGORIES", ""), _CSV_RE),
               ("eval_tiers", os.environ.get("EVAL_TIERS", ""), _CSV_RE),
-              ("openrouter_provider", os.environ.get("OPENROUTER_PROVIDER", ""), _SLUG_RE),
+              ("openrouter_provider", os.environ.get("OPENROUTER_PROVIDER", ""), _CSV_RE),
               ("repl", os.environ.get("REPL", ""), _SLUG_RE),
           ):
               if not pattern.match(value):
@@ -186,6 +193,7 @@ jobs:
       eval_tiers: ${{ inputs.eval_tiers }}
       analyze_failures: false
       openrouter_provider: ${{ inputs.openrouter_provider }}
+      openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
     secrets: inherit
@@ -328,6 +336,29 @@ jobs:
                           md=fmt(t.get("median_duration_s")),
                       )
                   )
+
+          # Per-trial × per-category matrix: lets you see whether a regression
+          # is concentrated in one category or spread across all of them — info
+          # the across-trial mean/stdev table above hides.
+          cat_keys = sorted(cats.keys())
+          if trials and cat_keys:
+              labels_path = Path(os.environ["GITHUB_WORKSPACE"]) / "libs/evals/deepagents_evals/categories.json"
+              labels = {}
+              try:
+                  labels = json.loads(labels_path.read_text()).get("labels", {})
+              except (FileNotFoundError, json.JSONDecodeError) as exc:
+                  print(f"::warning::Could not load category labels from {labels_path}: {exc}")
+              def esc(s): return str(s).replace("|", "\\|")
+              header = "| # | " + " | ".join(esc(labels.get(c, c)) for c in cat_keys) + " |"
+              sep = "|---:|" + "|".join("---:" for _ in cat_keys) + "|"
+              lines += ["", "### Per-trial correctness by category", "", header, sep]
+              for t in trials:
+                  scores = t.get("category_scores") or {}
+                  cells = [
+                      "-" if scores.get(c) is None else fmt(scores.get(c), 3)
+                      for c in cat_keys
+                  ]
+                  lines.append(f"| {t.get('trial_index')} | " + " | ".join(cells) + " |")
 
           out = os.environ.get("GITHUB_STEP_SUMMARY")
           if out:

--- a/.github/workflows/evals_trials.yml
+++ b/.github/workflows/evals_trials.yml
@@ -340,25 +340,20 @@ jobs:
           # Per-trial × per-category matrix: lets you see whether a regression
           # is concentrated in one category or spread across all of them — info
           # the across-trial mean/stdev table above hides.
+          from deepagents_evals.trial_summary import render_per_trial_category_matrix
+
           cat_keys = sorted(cats.keys())
-          if trials and cat_keys:
-              labels_path = Path(os.environ["GITHUB_WORKSPACE"]) / "libs/evals/deepagents_evals/categories.json"
-              labels = {}
-              try:
-                  labels = json.loads(labels_path.read_text()).get("labels", {})
-              except (FileNotFoundError, json.JSONDecodeError) as exc:
-                  print(f"::warning::Could not load category labels from {labels_path}: {exc}")
-              def esc(s): return str(s).replace("|", "\\|")
-              header = "| # | " + " | ".join(esc(labels.get(c, c)) for c in cat_keys) + " |"
-              sep = "|---:|" + "|".join("---:" for _ in cat_keys) + "|"
-              lines += ["", "### Per-trial correctness by category", "", header, sep]
-              for t in trials:
-                  scores = t.get("category_scores") or {}
-                  cells = [
-                      "-" if scores.get(c) is None else fmt(scores.get(c), 3)
-                      for c in cat_keys
-                  ]
-                  lines.append(f"| {t.get('trial_index')} | " + " | ".join(cells) + " |")
+          labels_path = Path(os.environ["GITHUB_WORKSPACE"]) / "libs/evals/deepagents_evals/categories.json"
+          labels: dict[str, str] = {}
+          try:
+              parsed = json.loads(labels_path.read_text())
+              if isinstance(parsed, dict):
+                  labels = parsed.get("labels") or {}
+              else:
+                  print(f"::warning::categories.json at {labels_path} is not a JSON object; rendering raw category keys")
+          except (FileNotFoundError, json.JSONDecodeError) as exc:
+              print(f"::warning::Could not load category labels from {labels_path}: {exc}")
+          lines += render_per_trial_category_matrix(trials, cat_keys, labels)
 
           out = os.environ.get("GITHUB_STEP_SUMMARY")
           if out:

--- a/libs/evals/CONTRIBUTING.md
+++ b/libs/evals/CONTRIBUTING.md
@@ -248,7 +248,7 @@ Dispatch the **📊 Eval trials - GHA** workflow (`evals_trials.yml`).
 | `model` | Single spec, e.g. `openai:gpt-5.5`. No presets — trials are single-model only |
 | `trials` | 1–20 (the local CLI accepts up to 50; the workflow caps lower since a runaway runner pool is harder to recover than a stuck terminal) |
 | `parallel` | Off (default): trials run sequentially. On: all trials run concurrently |
-| `eval_categories`, `eval_tiers`, `openai_reasoning_effort`, `openrouter_provider` | Same semantics as `evals.yml` |
+| `eval_categories`, `eval_tiers`, `openai_reasoning_effort`, `openrouter_provider`, `openrouter_allow_fallbacks` | Same semantics as `evals.yml` (the OpenRouter pin accepts a comma-separated allowlist; `openrouter_allow_fallbacks` toggles strict pin vs. soft preference) |
 
 The `parallel` toggle exists to trade time for API burst pressure. Sequential mode keeps the per-second call rate equivalent to a single eval run, so it is safe for any provider; parallel mode finishes ~N× faster but bursts every trial's traffic at once and should only be used when the provider can absorb the load.
 

--- a/libs/evals/deepagents_evals/trial_summary.py
+++ b/libs/evals/deepagents_evals/trial_summary.py
@@ -1,0 +1,65 @@
+"""Helpers for rendering trial summary tables in the GHA step summary."""
+
+from __future__ import annotations
+
+
+def _esc(value: object) -> str:
+    """Escape characters that would break a markdown table row.
+
+    Pipes terminate cells, backslashes need to be doubled before pipe
+    escapes survive a second pass, and newlines split a row in two —
+    none of which the renderer notices until the table is already broken.
+    """
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .strip()
+    )
+
+
+def _fmt(value: float | None, places: int) -> str:
+    return "-" if value is None else f"{value:.{places}f}"
+
+
+def render_per_trial_category_matrix(
+    trials: list[dict],
+    cat_keys: list[str],
+    labels: dict[str, str] | None = None,
+    *,
+    places: int = 3,
+) -> list[str]:
+    """Build the per-trial-by-per-category correctness table as markdown lines.
+
+    Each row is one trial; each column is one category. Cells are
+    correctness scores formatted to `places` decimals; categories that
+    did not run in a given trial render as `-` so a missing column is
+    visually distinct from a 0.0 score.
+
+    Args:
+        trials: Per-trial summary dicts (each must carry `trial_index`
+            and optionally `category_scores`).
+        cat_keys: Category keys to render as columns, in display order.
+        labels: Optional human-friendly labels keyed by category. Falls
+            back to the raw key when a label is missing.
+        places: Decimal places for score cells.
+
+    Returns:
+        Markdown lines (blank line, heading, blank line, header row,
+        separator, data rows). An empty list when `trials` or `cat_keys`
+        is empty so callers can unconditionally extend a buffer.
+    """
+    if not trials or not cat_keys:
+        return []
+
+    labels = labels or {}
+    header = "| # | " + " | ".join(_esc(labels.get(c, c)) for c in cat_keys) + " |"
+    sep = "|---:|" + "|".join("---:" for _ in cat_keys) + "|"
+    lines = ["", "### Per-trial correctness by category", "", header, sep]
+    for trial in trials:
+        scores = trial.get("category_scores") or {}
+        cells = [_fmt(scores.get(c), places) for c in cat_keys]
+        lines.append(f"| {trial.get('trial_index')} | " + " | ".join(cells) + " |")
+    return lines

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -46,6 +46,23 @@ load_dotenv()
 
 _MAX_FILE_LISTING = 10  # maximum files shown in the system prompt directory context
 
+
+def _parse_openrouter_providers(value: str) -> list[str]:
+    """Split a comma-separated provider spec into OpenRouter's `only` list.
+
+    Empty tokens (e.g. trailing commas, double commas, whitespace-only
+    entries) are dropped silently; the result must contain at least one
+    provider name or `ValueError` is raised so a typo can't silently
+    relax the routing pin to "any provider".
+    """
+    parts = [p.strip() for p in value.split(",")]
+    providers = [p for p in parts if p]
+    if not providers:
+        msg = "openrouter_provider must contain at least one non-empty provider name"
+        raise ValueError(msg)
+    return providers
+
+
 SYSTEM_MESSAGE = """
 You are an autonomous agent executing tasks in a sandboxed environment. Follow these instructions carefully.
 
@@ -79,6 +96,7 @@ class DeepAgentsWrapper(BaseAgent):
         verbose: bool = True,
         use_cli_agent: bool = True,
         openrouter_provider: str | None = None,
+        openrouter_allow_fallbacks: bool = False,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -92,14 +110,23 @@ class DeepAgentsWrapper(BaseAgent):
             use_cli_agent: If `True`, use `create_cli_agent` from
                 `deepagents-cli` (default). If `False`, use
                 `create_deep_agent` from the SDK.
-            openrouter_provider: Pin OpenRouter routing to a single provider
-                (e.g. `"MiniMax"`).
+            openrouter_provider: Pin OpenRouter routing to one or more
+                providers. Accepts a single name (e.g. `"MiniMax"`) or a
+                comma-separated allowlist (e.g. `"MiniMax,Fireworks"`),
+                fed into OpenRouter's `provider.only` field.
 
                 Requires an `openrouter:` model prefix.
+            openrouter_allow_fallbacks: When `False` (default), OpenRouter
+                will only route to a provider in `openrouter_provider` and
+                hard-fail otherwise (strict allowlist). When `True`, the
+                listed providers are preferred but OpenRouter may fall
+                back to any other provider hosting the model.
 
         Raises:
-            ValueError: If `model_name` is empty/whitespace, or if
-                `openrouter_provider` is set without an `openrouter:` prefix.
+            ValueError: If `model_name` is empty/whitespace, if
+                `openrouter_provider` is set without an `openrouter:`
+                prefix, or if `openrouter_provider` parses to an empty
+                list.
         """
         if not model_name or not model_name.strip():
             msg = "model_name must be a non-empty string"
@@ -114,9 +141,10 @@ class DeepAgentsWrapper(BaseAgent):
         self._model_name = model_name
         model_kwargs: dict[str, Any] = {}
         if openrouter_provider:
+            providers = _parse_openrouter_providers(openrouter_provider)
             model_kwargs["openrouter_provider"] = {
-                "only": [openrouter_provider],
-                "allow_fallbacks": False,
+                "only": providers,
+                "allow_fallbacks": openrouter_allow_fallbacks,
             }
         self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
 

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -96,8 +96,8 @@ class DeepAgentsWrapper(BaseAgent):
         verbose: bool = True,
         use_cli_agent: bool = True,
         openrouter_provider: str | None = None,
-        openrouter_allow_fallbacks: bool = False,
         *args: Any,
+        openrouter_allow_fallbacks: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize Deep AgentsWrapper.
@@ -120,16 +120,24 @@ class DeepAgentsWrapper(BaseAgent):
                 will only route to a provider in `openrouter_provider` and
                 hard-fail otherwise (strict allowlist). When `True`, the
                 listed providers are preferred but OpenRouter may fall
-                back to any other provider hosting the model.
+                back to any other provider hosting the model. Has no
+                effect on its own and requires `openrouter_provider` to
+                be set.
 
         Raises:
             ValueError: If `model_name` is empty/whitespace, if
                 `openrouter_provider` is set without an `openrouter:`
-                prefix, or if `openrouter_provider` parses to an empty
-                list.
+                prefix, if `openrouter_provider` is non-empty but
+                contains no provider names (e.g. only commas/whitespace),
+                or if `openrouter_allow_fallbacks` is `True` without
+                `openrouter_provider`.
         """
         if not model_name or not model_name.strip():
             msg = "model_name must be a non-empty string"
+            raise ValueError(msg)
+
+        if openrouter_allow_fallbacks and not openrouter_provider:
+            msg = "openrouter_allow_fallbacks requires openrouter_provider"
             raise ValueError(msg)
 
         super().__init__(logs_dir, model_name, *args, **kwargs)

--- a/libs/evals/scripts/run_trials.py
+++ b/libs/evals/scripts/run_trials.py
@@ -282,6 +282,8 @@ def _build_pytest_args(args: argparse.Namespace, report_path: Path) -> list[str]
         cmd.extend(["--openai-reasoning-effort", args.openai_reasoning_effort])
     if args.openrouter_provider:
         cmd.extend(["--openrouter-provider", args.openrouter_provider])
+    if args.openrouter_allow_fallbacks:
+        cmd.append("--openrouter-allow-fallbacks")
     if args.repl:
         cmd.extend(["--repl", args.repl])
     cmd.extend(args.pytest_extra)
@@ -493,7 +495,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--openrouter-provider",
         default=None,
-        help="Pin OpenRouter to a specific provider (e.g. MiniMax).",
+        help=(
+            "Pin OpenRouter to one or more providers (comma-separated allowlist), "
+            "e.g. MiniMax or MiniMax,Fireworks."
+        ),
+    )
+    parser.add_argument(
+        "--openrouter-allow-fallbacks",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow OpenRouter to fall back outside --openrouter-provider when the "
+            "listed providers are unavailable. Default is strict (no fallbacks)."
+        ),
     )
     parser.add_argument(
         "--repl",

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -85,7 +85,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--openrouter-provider",
         action="store",
         default=None,
-        help="Pin OpenRouter to a specific provider. E.g. --openrouter-provider MiniMax",
+        help=(
+            "Pin OpenRouter to one or more providers (comma-separated allowlist). "
+            "E.g. --openrouter-provider MiniMax or --openrouter-provider MiniMax,Fireworks"
+        ),
+    )
+    parser.addoption(
+        "--openrouter-allow-fallbacks",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow OpenRouter to fall back outside --openrouter-provider when the "
+            "listed providers are unavailable. Default is strict (no fallbacks)."
+        ),
     )
     parser.addoption(
         "--openai-reasoning-effort",
@@ -196,14 +208,22 @@ def langsmith_experiment_metadata(request: pytest.FixtureRequest) -> dict[str, A
 def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
     kwargs: dict[str, Any] = {}
     provider = request.config.getoption("--openrouter-provider")
+    allow_fallbacks = bool(request.config.getoption("--openrouter-allow-fallbacks"))
     if provider:
         if not model_name.startswith("openrouter:"):
             msg = "--openrouter-provider requires an openrouter: model prefix"
             raise ValueError(msg)
+        providers = [p.strip() for p in provider.split(",") if p.strip()]
+        if not providers:
+            msg = "--openrouter-provider must contain at least one provider name"
+            raise ValueError(msg)
         kwargs["openrouter_provider"] = {
-            "only": [provider],
-            "allow_fallbacks": False,
+            "only": providers,
+            "allow_fallbacks": allow_fallbacks,
         }
+    elif allow_fallbacks:
+        msg = "--openrouter-allow-fallbacks requires --openrouter-provider"
+        raise ValueError(msg)
     if model_name.startswith("openrouter:"):
         # OpenRouter SDK passes timeout=None to httpx, disabling its default
         # 5s read timeout. This causes indefinite hangs on TCP stalls.

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 from deepagents import __version__ as deepagents_version
 
+from deepagents_harbor.deepagents_wrapper import _parse_openrouter_providers
+
 pytest_plugins = ["tests.evals.pytest_reporter"]
 
 
@@ -213,12 +215,8 @@ def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
         if not model_name.startswith("openrouter:"):
             msg = "--openrouter-provider requires an openrouter: model prefix"
             raise ValueError(msg)
-        providers = [p.strip() for p in provider.split(",") if p.strip()]
-        if not providers:
-            msg = "--openrouter-provider must contain at least one provider name"
-            raise ValueError(msg)
         kwargs["openrouter_provider"] = {
-            "only": providers,
+            "only": _parse_openrouter_providers(provider),
             "allow_fallbacks": allow_fallbacks,
         }
     elif allow_fallbacks:

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from deepagents_harbor.deepagents_wrapper import DeepAgentsWrapper
+from deepagents_harbor.deepagents_wrapper import (
+    DeepAgentsWrapper,
+    _parse_openrouter_providers,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -51,3 +54,113 @@ class TestHappyPathConstruction:
         assert wrapper._model_name == "claude-sonnet-4-6"
         assert wrapper._model is not None
         assert wrapper._temperature == 0.0
+
+
+class TestParseOpenrouterProviders:
+    """The comma-separated provider parser drops empty tokens and rejects empty input."""
+
+    def test_single_value(self) -> None:
+        assert _parse_openrouter_providers("MiniMax") == ["MiniMax"]
+
+    def test_comma_separated_list(self) -> None:
+        assert _parse_openrouter_providers("MiniMax,Fireworks") == ["MiniMax", "Fireworks"]
+
+    def test_strips_whitespace_around_each_token(self) -> None:
+        assert _parse_openrouter_providers("  MiniMax , Fireworks  ") == [
+            "MiniMax",
+            "Fireworks",
+        ]
+
+    def test_drops_empty_tokens(self) -> None:
+        assert _parse_openrouter_providers("MiniMax,,Fireworks,") == ["MiniMax", "Fireworks"]
+
+    def test_all_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one non-empty provider name"):
+            _parse_openrouter_providers(" , , ")
+
+
+class TestOpenRouterRoutingKwargs:
+    """`openrouter_provider` + `openrouter_allow_fallbacks` shape `init_chat_model` kwargs.
+
+    These tests capture what gets handed to `init_chat_model` so we can assert
+    on the routing config (`only` list + `allow_fallbacks` flag) without
+    spinning up a real model client.
+    """
+
+    @staticmethod
+    def _capture_init(
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> list[dict[str, object]]:
+        captured: list[dict[str, object]] = []
+
+        def fake_init(model: str, **kwargs: object) -> object:  # noqa: ARG001
+            captured.append(kwargs)
+            return object()
+
+        monkeypatch.setattr(
+            "deepagents_harbor.deepagents_wrapper.init_chat_model",
+            fake_init,
+        )
+        return captured
+
+    def test_strict_pin_with_single_provider(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_init(monkeypatch)
+        DeepAgentsWrapper(
+            logs_dir=tmp_path,
+            model_name="openrouter:minimax/minimax-m2",
+            openrouter_provider="MiniMax",
+        )
+        assert captured[0]["openrouter_provider"] == {
+            "only": ["MiniMax"],
+            "allow_fallbacks": False,
+        }
+
+    def test_allowlist_with_fallbacks_disabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_init(monkeypatch)
+        DeepAgentsWrapper(
+            logs_dir=tmp_path,
+            model_name="openrouter:minimax/minimax-m2",
+            openrouter_provider="MiniMax,Fireworks",
+            openrouter_allow_fallbacks=False,
+        )
+        assert captured[0]["openrouter_provider"] == {
+            "only": ["MiniMax", "Fireworks"],
+            "allow_fallbacks": False,
+        }
+
+    def test_allowlist_with_fallbacks_enabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_init(monkeypatch)
+        DeepAgentsWrapper(
+            logs_dir=tmp_path,
+            model_name="openrouter:minimax/minimax-m2",
+            openrouter_provider="MiniMax,Fireworks",
+            openrouter_allow_fallbacks=True,
+        )
+        assert captured[0]["openrouter_provider"] == {
+            "only": ["MiniMax", "Fireworks"],
+            "allow_fallbacks": True,
+        }
+
+    def test_no_routing_kwargs_when_provider_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_init(monkeypatch)
+        DeepAgentsWrapper(
+            logs_dir=tmp_path,
+            model_name="openrouter:minimax/minimax-m2",
+        )
+        assert "openrouter_provider" not in captured[0]
+
+    def test_empty_provider_list_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="at least one non-empty provider name"):
+            DeepAgentsWrapper(
+                logs_dir=tmp_path,
+                model_name="openrouter:minimax/minimax-m2",
+                openrouter_provider=" , , ",
+            )

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING
 
 import pytest
@@ -73,6 +74,14 @@ class TestParseOpenrouterProviders:
 
     def test_drops_empty_tokens(self) -> None:
         assert _parse_openrouter_providers("MiniMax,,Fireworks,") == ["MiniMax", "Fireworks"]
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one non-empty provider name"):
+            _parse_openrouter_providers("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one non-empty provider name"):
+            _parse_openrouter_providers("   ")
 
     def test_all_empty_raises(self) -> None:
         with pytest.raises(ValueError, match="at least one non-empty provider name"):
@@ -164,3 +173,18 @@ class TestOpenRouterRoutingKwargs:
                 model_name="openrouter:minimax/minimax-m2",
                 openrouter_provider=" , , ",
             )
+
+    def test_allow_fallbacks_without_provider_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(
+            ValueError, match="openrouter_allow_fallbacks requires openrouter_provider"
+        ):
+            DeepAgentsWrapper(
+                logs_dir=tmp_path,
+                model_name="openrouter:minimax/minimax-m2",
+                openrouter_allow_fallbacks=True,
+            )
+
+    def test_allow_fallbacks_is_keyword_only(self) -> None:
+        sig = inspect.signature(DeepAgentsWrapper.__init__)
+        param = sig.parameters["openrouter_allow_fallbacks"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY

--- a/libs/evals/tests/unit_tests/test_run_trials.py
+++ b/libs/evals/tests/unit_tests/test_run_trials.py
@@ -321,6 +321,7 @@ def _make_args(**overrides: Any) -> argparse.Namespace:
         "eval_tier": [],
         "openai_reasoning_effort": None,
         "openrouter_provider": None,
+        "openrouter_allow_fallbacks": False,
         "repl": None,
         "out_dir": Path("/tmp/out"),
         "pytest_extra": [],
@@ -361,8 +362,23 @@ class TestBuildPytestArgs:
         assert cmd[cmd.index("--openai-reasoning-effort") + 1] == "medium"
         assert "--openrouter-provider" in cmd
         assert cmd[cmd.index("--openrouter-provider") + 1] == "MiniMax"
+        assert "--openrouter-allow-fallbacks" not in cmd
         assert "--repl" in cmd
         assert cmd[cmd.index("--repl") + 1] == "quickjs"
+
+    def test_openrouter_provider_accepts_comma_separated_allowlist(self) -> None:
+        args = _make_args(openrouter_provider="MiniMax,Fireworks")
+        cmd = run_trials._build_pytest_args(args, Path("/tmp/r.json"))
+        # Pytest does the parsing; the script just forwards the string verbatim.
+        assert cmd[cmd.index("--openrouter-provider") + 1] == "MiniMax,Fireworks"
+
+    def test_openrouter_allow_fallbacks_passed_as_bare_flag(self) -> None:
+        args = _make_args(
+            openrouter_provider="MiniMax,Fireworks",
+            openrouter_allow_fallbacks=True,
+        )
+        cmd = run_trials._build_pytest_args(args, Path("/tmp/r.json"))
+        assert "--openrouter-allow-fallbacks" in cmd
 
     def test_pytest_extra_forwarded(self) -> None:
         args = _make_args(pytest_extra=["-k", "smoke"])

--- a/libs/evals/tests/unit_tests/test_trial_summary.py
+++ b/libs/evals/tests/unit_tests/test_trial_summary.py
@@ -1,0 +1,95 @@
+"""Unit tests for `deepagents_evals.trial_summary`."""
+
+from __future__ import annotations
+
+from deepagents_evals.trial_summary import render_per_trial_category_matrix
+
+
+class TestRenderPerTrialCategoryMatrix:
+    """The matrix renders one row per trial and one column per category."""
+
+    def test_returns_empty_when_no_trials(self) -> None:
+        assert render_per_trial_category_matrix([], ["memory"], {}) == []
+
+    def test_returns_empty_when_no_categories(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": {"memory": 1.0}}]
+        assert render_per_trial_category_matrix(trials, [], {}) == []
+
+    def test_renders_header_separator_and_rows(self) -> None:
+        trials = [
+            {"trial_index": 0, "category_scores": {"memory": 0.875, "tool_use": 0.5}},
+            {"trial_index": 1, "category_scores": {"memory": 1.0, "tool_use": 0.25}},
+        ]
+        cat_keys = ["memory", "tool_use"]
+        labels = {"memory": "Memory", "tool_use": "Tool use"}
+
+        lines = render_per_trial_category_matrix(trials, cat_keys, labels)
+
+        assert lines == [
+            "",
+            "### Per-trial correctness by category",
+            "",
+            "| # | Memory | Tool use |",
+            "|---:|---:|---:|",
+            "| 0 | 0.875 | 0.500 |",
+            "| 1 | 1.000 | 0.250 |",
+        ]
+
+    def test_falls_back_to_raw_key_when_label_missing(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": {"memory": 1.0}}]
+        lines = render_per_trial_category_matrix(trials, ["memory"], labels=None)
+        # Header uses the raw key when no label dict is provided.
+        assert "| memory |" in lines[3]
+
+    def test_renders_dash_for_missing_score(self) -> None:
+        # `None` distinguishes "category did not run for this trial" from
+        # an actual 0.0 score — pytest_reporter only emits a category when
+        # at least one test ran.
+        trials = [
+            {"trial_index": 0, "category_scores": {"memory": 0.0}},
+            {"trial_index": 1, "category_scores": {}},
+        ]
+        lines = render_per_trial_category_matrix(trials, ["memory"], {})
+        assert lines[-2] == "| 0 | 0.000 |"
+        assert lines[-1] == "| 1 | - |"
+
+    def test_renders_dash_when_category_scores_is_none(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": None}]
+        lines = render_per_trial_category_matrix(trials, ["memory"], {})
+        assert lines[-1] == "| 0 | - |"
+
+    def test_escapes_pipe_in_label(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": {"weird": 1.0}}]
+        labels = {"weird": "Has | pipe"}
+        lines = render_per_trial_category_matrix(trials, ["weird"], labels)
+        assert "Has \\| pipe" in lines[3]
+
+    def test_escapes_newline_in_label(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": {"weird": 1.0}}]
+        labels = {"weird": "Line one\nline two"}
+        lines = render_per_trial_category_matrix(trials, ["weird"], labels)
+        # Newline collapsed to a single space; the row stays one line.
+        assert "Line one line two" in lines[3]
+        assert "\n" not in lines[3]
+
+    def test_escapes_backslash_in_label(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": {"weird": 1.0}}]
+        labels = {"weird": "back\\slash"}
+        lines = render_per_trial_category_matrix(trials, ["weird"], labels)
+        # Backslash is doubled before the pipe escape pass so a malicious
+        # label can't smuggle a real `\|` through.
+        assert "back\\\\slash" in lines[3]
+
+    def test_places_parameter_controls_precision(self) -> None:
+        trials = [{"trial_index": 0, "category_scores": {"memory": 0.123456}}]
+        lines = render_per_trial_category_matrix(trials, ["memory"], {}, places=2)
+        assert lines[-1] == "| 0 | 0.12 |"
+
+    def test_columns_render_in_provided_order(self) -> None:
+        # The caller controls column order via `cat_keys`; the helper must
+        # not re-sort or it would break alignment with the header.
+        trials = [{"trial_index": 0, "category_scores": {"a": 0.1, "b": 0.2}}]
+        forward = render_per_trial_category_matrix(trials, ["a", "b"], {})
+        reverse = render_per_trial_category_matrix(trials, ["b", "a"], {})
+        assert forward[-1] == "| 0 | 0.100 | 0.200 |"
+        assert reverse[-1] == "| 0 | 0.200 | 0.100 |"


### PR DESCRIPTION
Expand OpenRouter provider pinning from a single provider to a comma-separated allowlist, and add an `openrouter_allow_fallbacks` toggle to switch between strict pinning (no fallback) and soft preference (allow OpenRouter to route outside the listed providers). Also adds a per-trial × per-category correctness table to the trials workflow summary.