### PR TITLE
feat(cli): add TUI footer visibility env vars

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -62,6 +62,12 @@ real PyPI release. Any non-empty value enables the flag (including `"0"` or
 EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
 """Colon-separated paths added to the skill containment allowlist."""
 
+HIDE_CWD = "DEEPAGENTS_CLI_HIDE_CWD"
+"""Hide the current working directory in the TUI footer when enabled."""
+
+HIDE_GIT_BRANCH = "DEEPAGENTS_CLI_HIDE_GIT_BRANCH"
+"""Hide the current git branch in the TUI footer when enabled."""
+
 KITTY_KEYBOARD = "DEEPAGENTS_CLI_KITTY_KEYBOARD"
 """Override kitty-keyboard detection (`1` forces on, `0` forces off)."""
 

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -14,6 +14,7 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from deepagents_cli._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
 from deepagents_cli.config import get_glyphs
 
 logger = logging.getLogger(__name__)
@@ -175,6 +176,8 @@ class StatusBar(Horizontal):
         super().__init__(**kwargs)
         # Store initial cwd - will be used in compose()
         self._initial_cwd = str(cwd) if cwd else str(Path.cwd())
+        self._hide_cwd = is_env_truthy(HIDE_CWD)
+        self._hide_git_branch = is_env_truthy(HIDE_GIT_BRANCH)
 
     def compose(self) -> ComposeResult:  # noqa: PLR6301 — Textual widget method
         """Compose the status bar layout.
@@ -207,13 +210,18 @@ class StatusBar(Horizontal):
         Priority (highest first): model, cwd, git branch.
         """
         width = event.size.width
+        branch_threshold = (
+            self._CWD_WIDTH_THRESHOLD
+            if self._hide_cwd
+            else self._BRANCH_WIDTH_THRESHOLD
+        )
         with suppress(NoMatches):
             self.query_one("#branch-display", Static).display = (
-                width >= self._BRANCH_WIDTH_THRESHOLD
+                not self._hide_git_branch and width >= branch_threshold
             )
         with suppress(NoMatches):
             self.query_one("#cwd-display", Static).display = (
-                width >= self._CWD_WIDTH_THRESHOLD
+                not self._hide_cwd and width >= self._CWD_WIDTH_THRESHOLD
             )
 
     def on_mount(self) -> None:
@@ -221,6 +229,12 @@ class StatusBar(Horizontal):
         from deepagents_cli.config import settings
 
         self.cwd = self._initial_cwd
+        if self._hide_cwd:
+            with suppress(NoMatches):
+                self.query_one("#cwd-display", Static).display = False
+        if self._hide_git_branch:
+            with suppress(NoMatches):
+                self.query_one("#branch-display", Static).display = False
         # Set initial model display
         label = self.query_one("#model-display", ModelLabel)
         label.provider = settings.model_provider or ""

--- a/libs/cli/tests/unit_tests/test_status.py
+++ b/libs/cli/tests/unit_tests/test_status.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from textual import events
 from textual.app import App, ComposeResult
 from textual.geometry import Size
 
+from deepagents_cli._env_vars import HIDE_CWD, HIDE_GIT_BRANCH
 from deepagents_cli.widgets.status import StatusBar
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class StatusBarApp(App):
@@ -16,8 +22,53 @@ class StatusBarApp(App):
         yield StatusBar(id="status-bar")
 
 
+class TestCwdDisplay:
+    """Tests for the cwd display in the status bar."""
+
+    async def test_hide_cwd_env_var_hides_display(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cwd display should stay hidden when the env var override is enabled."""
+        monkeypatch.setenv(HIDE_CWD, "1")
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            cwd = pilot.app.query_one("#cwd-display")
+            assert cwd.display is False
+            await pilot.resize_terminal(120, 24)
+            await pilot.pause()
+            assert cwd.display is False
+
+    async def test_hide_cwd_env_var_keeps_branch_visible_at_medium_width(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hiding cwd should not hide the branch when there is enough space."""
+        monkeypatch.setenv(HIDE_CWD, "1")
+        async with StatusBarApp().run_test(size=(85, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.branch = "main"
+            await pilot.pause()
+            cwd = pilot.app.query_one("#cwd-display")
+            branch = pilot.app.query_one("#branch-display")
+            assert cwd.display is False
+            assert branch.display is True
+
+
 class TestBranchDisplay:
     """Tests for the git branch display in the status bar."""
+
+    async def test_hide_git_branch_env_var_hides_display(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Branch display should stay hidden when the env var override is enabled."""
+        monkeypatch.setenv(HIDE_GIT_BRANCH, "1")
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.branch = "main"
+            await pilot.pause()
+            branch = pilot.app.query_one("#branch-display")
+            assert branch.display is False
+            await pilot.resize_terminal(120, 24)
+            await pilot.pause()
+            assert branch.display is False
 
     async def test_branch_display_empty_by_default(self) -> None:
         """Branch display should be empty when no branch is set."""


### PR DESCRIPTION
The CLI TUI status bar can now suppress cwd and git branch display via explicit environment flags. The responsive layout treats a hidden cwd as freeing space for branch display instead of hiding both footer fields at medium widths.