### PR TITLE
feat(cli): add splash version visibility env var

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -68,6 +68,9 @@ HIDE_CWD = "DEEPAGENTS_CLI_HIDE_CWD"
 HIDE_GIT_BRANCH = "DEEPAGENTS_CLI_HIDE_GIT_BRANCH"
 """Hide the current git branch in the TUI footer when enabled."""
 
+HIDE_SPLASH_VERSION = "DEEPAGENTS_CLI_HIDE_SPLASH_VERSION"
+"""Hide version and local-install details in the splash screen when enabled."""
+
 KITTY_KEYBOARD = "DEEPAGENTS_CLI_KITTY_KEYBOARD"
 """Override kitty-keyboard detection (`1` forces on, `0` forces off)."""
 

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
 
+from deepagents_cli._env_vars import HIDE_SPLASH_VERSION, is_env_truthy
 from deepagents_cli._git import resolve_git_branch
 from deepagents_cli._version import __version__
 
@@ -561,6 +562,9 @@ def get_banner() -> str:
         banner = _ASCII_BANNER
     else:
         banner = _UNICODE_BANNER
+
+    if is_env_truthy(HIDE_SPLASH_VERSION):
+        return banner.replace(f"v{__version__}", "")
 
     if _is_editable_install():
         banner = banner.replace(f"v{__version__}", f"v{__version__} (local)")

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from textual.timer import Timer
 
 from deepagents_cli import theme
+from deepagents_cli._env_vars import HIDE_SPLASH_VERSION, is_env_truthy
 from deepagents_cli._version import __version__
 from deepagents_cli.config import (
     _get_editable_install_path,
@@ -294,7 +295,8 @@ class WelcomeBanner(Static):
             else TStyle(foreground=TColor.parse(colors.primary), bold=True)
         )
 
-        if not ansi and _is_editable_install():
+        hide_version = is_env_truthy(HIDE_SPLASH_VERSION)
+        if not hide_version and not ansi and _is_editable_install():
             # Highlight local-install version tag with tool accent; art stays primary.
             dev_style = TStyle(foreground=TColor.parse(colors.tool), bold=True)
             version_tag = f"v{__version__} (local)"
@@ -316,7 +318,7 @@ class WelcomeBanner(Static):
         accent: str | TStyle = "bold" if ansi else colors.primary
         success_color: str = "bold green" if ansi else colors.success
 
-        editable_path = _get_editable_install_path()
+        editable_path = None if hide_version else _get_editable_install_path()
         if editable_path:
             parts.extend([("Installed from: ", "dim"), (editable_path, "dim"), "\n"])
 

--- a/libs/cli/tests/unit_tests/test_charset.py
+++ b/libs/cli/tests/unit_tests/test_charset.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from deepagents_cli._env_vars import HIDE_SPLASH_VERSION
 from deepagents_cli.config import (
     _ASCII_BANNER,
     _UNICODE_BANNER,
@@ -315,6 +316,19 @@ class TestGetBanner:
             banner = get_banner()
         assert "(local)" in banner
         assert f"v{__version__} (local)" in banner
+
+    @patch.dict(
+        "os.environ",
+        {"UI_CHARSET_MODE": "unicode", HIDE_SPLASH_VERSION: "1"},
+        clear=False,
+    )
+    def test_get_banner_hides_version_and_local_suffix(self) -> None:
+        """Splash version override should hide version and skip local detection."""
+        with patch("deepagents_cli.config._is_editable_install") as editable:
+            banner = get_banner()
+        editable.assert_not_called()
+        assert f"v{__version__}" not in banner
+        assert "(local)" not in banner
 
     def test_unicode_banner_contains_box_drawing_chars(self) -> None:
         """Test that Unicode banner contains non-ASCII box drawing characters."""

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -6,6 +6,8 @@ from rich.style import Style
 from textual.content import Content
 from textual.style import Style as TStyle
 
+from deepagents_cli._env_vars import HIDE_SPLASH_VERSION
+from deepagents_cli._version import __version__
 from deepagents_cli.widgets.welcome import (
     _TIPS,
     WelcomeBanner,
@@ -222,6 +224,27 @@ class TestBuildBannerEditableInstall:
         ):
             widget = WelcomeBanner()
             banner = widget._build_banner()
+        assert "Installed from:" not in banner.plain
+
+    def test_hide_splash_version_env_var_hides_local_install_details(self) -> None:
+        """Splash version override should hide version and local install details."""
+        with (
+            patch.dict("os.environ", {HIDE_SPLASH_VERSION: "1"}, clear=True),
+            patch(
+                "deepagents_cli.widgets.welcome._is_editable_install",
+                return_value=True,
+            ) as editable,
+            patch(
+                "deepagents_cli.widgets.welcome._get_editable_install_path",
+                return_value="~/dev/deepagents",
+            ) as editable_path,
+        ):
+            widget = WelcomeBanner()
+            banner = widget._build_banner()
+        editable.assert_not_called()
+        editable_path.assert_not_called()
+        assert f"v{__version__}" not in banner.plain
+        assert "(local)" not in banner.plain
         assert "Installed from:" not in banner.plain
 
 


### PR DESCRIPTION
Add an opt-in splash screen override for environments that want to hide install-specific metadata. The flag suppresses both the rendered CLI version and local editable-install indicators without changing `/version` or other version reporting paths.