### PR TITLE
feat(cli): add startup splash env var overrides

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -33,6 +33,11 @@ import os
 AUTO_UPDATE = "DEEPAGENTS_CLI_AUTO_UPDATE"
 """Enable automatic CLI updates ('1', 'true', or 'yes')."""
 
+DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER = (
+    "DEEPAGENTS_CLI_DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER"
+)
+"""Override the startup splash subheader text when set."""
+
 DEBUG = "DEEPAGENTS_CLI_DEBUG"
 """Enable verbose debug logging and preserve the server subprocess log.
 
@@ -63,10 +68,13 @@ EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
 """Colon-separated paths added to the skill containment allowlist."""
 
 HIDE_CWD = "DEEPAGENTS_CLI_HIDE_CWD"
-"""Hide the current working directory in the TUI footer when enabled."""
+"""Hide local path displays in the TUI footer and startup splash when enabled."""
 
 HIDE_GIT_BRANCH = "DEEPAGENTS_CLI_HIDE_GIT_BRANCH"
 """Hide the current git branch in the TUI footer when enabled."""
+
+HIDE_LANGSMITH_TRACING = "DEEPAGENTS_CLI_HIDE_LANGSMITH_TRACING"
+"""Hide LangSmith tracing project/thread info in the startup splash when enabled."""
 
 HIDE_SPLASH_VERSION = "DEEPAGENTS_CLI_HIDE_SPLASH_VERSION"
 """Hide version and local-install details in the splash screen when enabled."""

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import random
 from typing import TYPE_CHECKING, Any
 
@@ -16,7 +17,13 @@ if TYPE_CHECKING:
     from textual.timer import Timer
 
 from deepagents_cli import theme
-from deepagents_cli._env_vars import HIDE_SPLASH_VERSION, is_env_truthy
+from deepagents_cli._env_vars import (
+    DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER,
+    HIDE_CWD,
+    HIDE_LANGSMITH_TRACING,
+    HIDE_SPLASH_VERSION,
+    is_env_truthy,
+)
 from deepagents_cli._version import __version__
 from deepagents_cli.config import (
     _get_editable_install_path,
@@ -143,7 +150,10 @@ class WelcomeBanner(Static):
         self._idle = False
         self._defer_connecting_display = defer_connecting_display and connecting
         self._defer_timer: Timer | None = None
-        self._project_name: str | None = get_langsmith_project_name()
+        self._hide_langsmith_tracing = is_env_truthy(HIDE_LANGSMITH_TRACING)
+        self._project_name: str | None = (
+            None if self._hide_langsmith_tracing else get_langsmith_project_name()
+        )
         self._project_url: str | None = None
         self._tip: str = _pick_tip()
 
@@ -318,7 +328,8 @@ class WelcomeBanner(Static):
         accent: str | TStyle = "bold" if ansi else colors.primary
         success_color: str = "bold green" if ansi else colors.success
 
-        editable_path = None if hide_version else _get_editable_install_path()
+        hide_editable_path = hide_version or is_env_truthy(HIDE_CWD)
+        editable_path = None if hide_editable_path else _get_editable_install_path()
         if editable_path:
             parts.extend([("Installed from: ", "dim"), (editable_path, "dim"), "\n"])
 
@@ -344,7 +355,7 @@ class WelcomeBanner(Static):
                 parts.append((f"'{self._project_name}'", accent))
             parts.append("\n")
 
-        if self._cli_thread_id:
+        if self._cli_thread_id and not self._hide_langsmith_tracing:
             if project_url:
                 thread_url = (
                     f"{project_url.rstrip('/')}/t/{self._cli_thread_id}"
@@ -450,7 +461,11 @@ def build_welcome_footer(
     """
     if tip is None:
         tip = _pick_tip()
+    subheader = (
+        os.environ.get(DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER)
+        or "Ready to code! What would you like to build?"
+    )
     return Content.assemble(
-        ("\nReady to code! What would you like to build?\n", primary_color),
+        (f"\n{subheader}\n", primary_color),
         (f"Tip: {tip}", "dim italic"),
     )

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -2,11 +2,17 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from rich.style import Style
 from textual.content import Content
 from textual.style import Style as TStyle
 
-from deepagents_cli._env_vars import HIDE_SPLASH_VERSION
+from deepagents_cli._env_vars import (
+    DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER,
+    HIDE_CWD,
+    HIDE_LANGSMITH_TRACING,
+    HIDE_SPLASH_VERSION,
+)
 from deepagents_cli._version import __version__
 from deepagents_cli.widgets.welcome import (
     _TIPS,
@@ -14,6 +20,12 @@ from deepagents_cli.widgets.welcome import (
     build_connecting_footer,
     build_welcome_footer,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_startup_subheader_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent local startup subheader overrides from affecting tests."""
+    monkeypatch.delenv(DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER, raising=False)
 
 
 def _extract_links(banner: Content, text_start: int, text_end: int) -> list[str]:
@@ -43,12 +55,15 @@ def _extract_links(banner: Content, text_start: int, text_end: int) -> list[str]
 def _make_banner(
     thread_id: str | None = None,
     project_name: str | None = None,
+    *,
+    hide_langsmith_tracing: bool = False,
 ) -> WelcomeBanner:
     """Create a `WelcomeBanner` with all env vars cleared.
 
     Args:
         thread_id: Optional thread ID to display.
         project_name: If set, simulates LangSmith being configured.
+        hide_langsmith_tracing: Whether to hide tracing info from the splash.
 
     Returns:
         A `WelcomeBanner` instance ready for testing.
@@ -61,6 +76,8 @@ def _make_banner(
         env["LANGSMITH_TRACING"] = "true"
         env["LANGSMITH_PROJECT"] = project_name
         env["DEEPAGENTS_CLI_LANGSMITH_PROJECT"] = project_name
+    if hide_langsmith_tracing:
+        env[HIDE_LANGSMITH_TRACING] = "1"
 
     # Temporarily clear the cached settings singleton so _get_settings()
     # re-creates it from the patched env vars inside the context manager.
@@ -151,6 +168,22 @@ class TestBuildBannerThreadLink:
         links = _extract_links(banner, thread_id_start, thread_id_end)
         assert links
         assert links[0] == f"{project_url}/t/77777?utm_source=deepagents-cli"
+
+    def test_hide_langsmith_tracing_env_var_hides_project_and_thread(self) -> None:
+        """Tracing splash frontmatter should hide when the env var is enabled."""
+        widget = _make_banner(
+            thread_id="77777",
+            project_name="my-project",
+            hide_langsmith_tracing=True,
+        )
+        banner = widget._build_banner(
+            project_url="https://smith.langchain.com/o/org/projects/p/abc123"
+        )
+
+        assert "LangSmith tracing:" not in banner.plain
+        assert "my-project" not in banner.plain
+        assert "Thread:" not in banner.plain
+        assert "77777" not in banner.plain
 
 
 class TestUpdateThreadId:
@@ -247,6 +280,26 @@ class TestBuildBannerEditableInstall:
         assert "(local)" not in banner.plain
         assert "Installed from:" not in banner.plain
 
+    def test_hide_cwd_env_var_hides_editable_install_path(self) -> None:
+        """Cwd privacy override should hide the local editable install path."""
+        with (
+            patch.dict("os.environ", {HIDE_CWD: "1"}, clear=True),
+            patch(
+                "deepagents_cli.widgets.welcome._is_editable_install",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_cli.widgets.welcome._get_editable_install_path",
+                return_value="~/oss/deepagents/libs/cli",
+            ) as editable_path,
+        ):
+            widget = WelcomeBanner()
+            banner = widget._build_banner()
+        editable_path.assert_not_called()
+        assert f"v{__version__}" in banner.plain
+        assert "Installed from:" not in banner.plain
+        assert "~/oss/deepagents/libs/cli" not in banner.plain
+
 
 class TestBuildBannerReturnType:
     """Tests for `_build_banner` return value."""
@@ -321,6 +374,18 @@ class TestBuildWelcomeFooter:
             "Ready to code! What would you like to build?"
             in build_welcome_footer().plain
         )
+
+    def test_startup_subheader_env_var_overrides_ready_prompt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Startup subheader override should replace the default ready prompt."""
+        monkeypatch.setenv(DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER, "Ship it.")
+
+        plain = build_welcome_footer(tip="Use /help").plain
+
+        assert "Ship it." in plain
+        assert "Ready to code! What would you like to build?" not in plain
+        assert "Tip: Use /help" in plain
 
     def test_contains_tip(self) -> None:
         """Footer should include a tip from the rotating tips list."""


### PR DESCRIPTION
Startup splash metadata can now be hidden or customized with explicit `DEEPAGENTS_CLI_*` env vars. The defaults stay unchanged, but users can suppress local-path and LangSmith frontmatter or replace the ready prompt when embedding/customizing the CLI.