### PR TITLE
feat(cli): add env var for launch theme

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -94,6 +94,9 @@ SERVER_ENV_PREFIX = "DEEPAGENTS_CLI_SERVER_"
 SHELL_ALLOW_LIST = "DEEPAGENTS_CLI_SHELL_ALLOW_LIST"
 """Comma-separated shell commands to allow (or 'recommended'/'all')."""
 
+THEME = "DEEPAGENTS_CLI_THEME"
+"""Force the CLI to launch with this theme name when set."""
+
 USER_ID = "DEEPAGENTS_CLI_USER_ID"
 """Attach a user identifier to LangSmith trace metadata."""
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -182,11 +182,32 @@ if _IS_ITERM:
 
 
 def _load_theme_preference() -> str:
-    """Load the saved theme name from config, or return the default.
+    """Load the forced or saved theme name, or return the default.
 
     Returns:
         A Textual theme name (e.g., `'langchain'`, `'langchain-light'`).
     """
+    from deepagents_cli._env_vars import THEME
+
+    env_name = os.environ.get(THEME)
+    if env_name is not None:
+        name = env_name.strip()
+        registry = theme.get_registry()
+        if name in registry:
+            return name
+        for registered, entry in registry.items():
+            if (
+                registered.casefold() == name.casefold()
+                or entry.label.casefold() == name.casefold()
+            ):
+                return registered
+        logger.warning(
+            "Unknown theme '%s' in %s; falling back to default",
+            env_name,
+            THEME,
+        )
+        return theme.DEFAULT_THEME
+
     import tomllib
 
     try:

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from deepagents_cli._env_vars import THEME
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -404,6 +406,82 @@ class TestLoadThemePreference:
         config.write_text('[ui]\ntheme = "langchain-light"\n')
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_theme_preference() == "langchain-light"
+
+    def test_env_theme_overrides_saved_theme(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\ntheme = "langchain"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(THEME, "langchain-light")
+
+        assert _load_theme_preference() == "langchain-light"
+
+    def test_env_theme_supports_spaces_in_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\ntheme = "langchain"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(THEME, "my theme")
+        monkeypatch.setattr(
+            "deepagents_cli.app.theme.get_registry",
+            lambda: {"my theme": object()},
+        )
+
+        assert _load_theme_preference() == "my theme"
+
+    def test_env_theme_is_case_insensitive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\ntheme = "langchain"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(THEME, "LANGCHAIN-LIGHT")
+
+        assert _load_theme_preference() == "langchain-light"
+
+    def test_env_theme_accepts_display_label(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\ntheme = "langchain-light"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(THEME, "LangChain Dark")
+
+        assert _load_theme_preference() == "langchain"
+
+    def test_unknown_env_theme_returns_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\ntheme = "langchain-light"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(THEME, "nonexistent-theme")
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_env_theme_does_not_create_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(THEME, "langchain-light")
+
+        assert _load_theme_preference() == "langchain-light"
+        assert not config.exists()
 
     def test_returns_default_for_unknown_theme(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
CLI startup can now force a theme with `DEEPAGENTS_CLI_THEME` without writing that choice back to `config.toml`. The override accepts the registered theme key or the picker label, so values like `langchain`, `LANGCHAIN-LIGHT`, and `LangChain Dark` resolve to the correct Textual theme.