### PR TITLE
feat(cli): emit `user.name.set` hook during onboarding

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3374,6 +3374,7 @@ class DeepAgentsApp(App):
 
             if name:
                 self._launch_user_name = name
+                self._dispatch_launch_name_hook(name)
                 name_memory_task = asyncio.create_task(
                     self._write_launch_name_memory(name)
                 )
@@ -3471,6 +3472,23 @@ class DeepAgentsApp(App):
         """Mount the personalized onboarding welcome message."""
         await self._mount_message(
             AppMessage(Content.from_markup("Welcome, $name.", name=name))
+        )
+
+    def _dispatch_launch_name_hook(self, name: str) -> None:
+        """Fire the onboarding name hook for external integrations.
+
+        Args:
+            name: Submitted user name.
+        """
+        from deepagents_cli.hooks import dispatch_hook_fire_and_forget
+
+        assistant_id = self._assistant_id or DEFAULT_ASSISTANT_ID
+        dispatch_hook_fire_and_forget(
+            "user.name.set",
+            {
+                "name": name,
+                "assistant_id": assistant_id,
+            },
         )
 
     async def _mark_onboarding_complete(self) -> None:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -829,6 +829,11 @@ class DeepAgentsApp(App):
         during background startup.
         """
 
+        self._resume_thread_resolved_event = asyncio.Event()
+        """Set once `-r` resume resolution has completed or is unnecessary."""
+        if resume_thread is None:
+            self._resume_thread_resolved_event.set()
+
         self._initial_prompt = initial_prompt
         """Prompt to auto-submit after first paint (from `-m`)."""
 
@@ -1728,15 +1733,15 @@ class DeepAgentsApp(App):
             thread_exists,
         )
 
-        resume = self._resume_thread_intent
-        self._resume_thread_intent = None  # consumed
-
-        if not resume:
-            return
-
-        default_agent = DEFAULT_ASSISTANT_ID
-
         try:
+            resume = self._resume_thread_intent
+            self._resume_thread_intent = None  # consumed
+
+            if not resume:
+                return
+
+            default_agent = DEFAULT_ASSISTANT_ID
+
             if resume == "__MOST_RECENT__":
                 agent_filter = (
                     self._assistant_id if self._assistant_id != default_agent else None
@@ -1779,6 +1784,8 @@ class DeepAgentsApp(App):
                 "Could not look up thread history. Starting new session.",
                 severity="warning",
             )
+        finally:
+            self._resume_thread_resolved_event.set()
 
         # Update session state if ready (may still be initializing in a
         # concurrent worker)
@@ -3374,7 +3381,6 @@ class DeepAgentsApp(App):
 
             if name:
                 self._launch_user_name = name
-                self._dispatch_launch_name_hook(name)
                 name_memory_task = asyncio.create_task(
                     self._write_launch_name_memory(name)
                 )
@@ -3474,15 +3480,16 @@ class DeepAgentsApp(App):
             AppMessage(Content.from_markup("Welcome, $name.", name=name))
         )
 
-    def _dispatch_launch_name_hook(self, name: str) -> None:
+    @staticmethod
+    def _dispatch_launch_name_hook(name: str, assistant_id: str) -> None:
         """Fire the onboarding name hook for external integrations.
 
         Args:
             name: Submitted user name.
+            assistant_id: Agent identifier associated with the submitted name.
         """
         from deepagents_cli.hooks import dispatch_hook_fire_and_forget
 
-        assistant_id = self._assistant_id or DEFAULT_ASSISTANT_ID
         dispatch_hook_fire_and_forget(
             "user.name.set",
             {
@@ -3517,7 +3524,9 @@ class DeepAgentsApp(App):
         """
         from deepagents_cli.onboarding import write_onboarding_name_memory
 
+        await self._resume_thread_resolved_event.wait()
         assistant_id = self._assistant_id or DEFAULT_ASSISTANT_ID
+        self._dispatch_launch_name_hook(name, assistant_id)
         ok = await asyncio.to_thread(write_onboarding_name_memory, name, assistant_id)
         if not ok:
             self.notify(

--- a/libs/cli/deepagents_cli/hooks.py
+++ b/libs/cli/deepagents_cli/hooks.py
@@ -12,6 +12,9 @@ Config format (`~/.deepagents/hooks.json`):
 ```
 
 If `events` is omitted or empty the hook receives **all** events.
+
+Onboarding emits `user.name.set` with `{"name": "...", "assistant_id": "..."}`
+after the user submits a non-empty preferred name.
 """
 
 from __future__ import annotations

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -567,7 +567,7 @@ class TestStartupSequence:
             await app._run_launch_init_sequence()
 
         assert app._launch_user_name == "Ada"
-        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada", "coder")  # type: ignore[attr-defined]
         prompt_flow_mock.assert_awaited_once_with()
         write_name.assert_called_once_with("Ada", "coder")
         switch_model_mock.assert_awaited_once_with(
@@ -614,7 +614,6 @@ class TestStartupSequence:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
         app._push_screen_wait = AsyncMock(return_value="Ada")  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
-        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
 
         model_prompted = asyncio.Event()
         release_write = asyncio.Event()
@@ -641,7 +640,6 @@ class TestStartupSequence:
             await asyncio.wait_for(task, timeout=1)
 
         app._write_launch_name_memory.assert_awaited_once_with("Ada")  # type: ignore[attr-defined]
-        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
         app._prompt_launch_dependencies_then_model.assert_awaited_once_with()  # type: ignore[attr-defined]
         mark_complete.assert_called_once_with()
 
@@ -699,7 +697,7 @@ class TestStartupSequence:
             await app._run_launch_init_sequence()
 
         write_name.assert_called_once_with("Ada", "coder")
-        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada", "coder")  # type: ignore[attr-defined]
         prompt_flow_mock.assert_awaited_once_with()
         switch_model_mock.assert_not_awaited()
         app._mount_message.assert_awaited_once()  # type: ignore[attr-defined]
@@ -734,7 +732,7 @@ class TestStartupSequence:
             await app._run_launch_init_sequence()
 
         write_name.assert_called_once_with("Ada", "coder")
-        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada", "coder")  # type: ignore[attr-defined]
         switch_model_mock.assert_not_awaited()
         app._mount_message.assert_awaited_once()  # type: ignore[attr-defined]
         mark_complete.assert_called_once_with()
@@ -804,8 +802,45 @@ class TestStartupSequence:
         with patch(
             "deepagents_cli.hooks.dispatch_hook_fire_and_forget"
         ) as dispatch_hook:
-            app._dispatch_launch_name_hook("Ada")
+            app._dispatch_launch_name_hook("Ada", "coder")
 
+        dispatch_hook.assert_called_once_with(
+            "user.name.set",
+            {
+                "name": "Ada",
+                "assistant_id": "coder",
+            },
+        )
+
+    async def test_write_launch_name_waits_for_resume_agent_resolution(self) -> None:
+        """The name hook should use the agent resolved from a resumed thread."""
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            assistant_id=None,
+            resume_thread="thread-from-coder",
+            thread_id="thread-123",
+        )
+
+        with (
+            patch(
+                "deepagents_cli.onboarding.write_onboarding_name_memory",
+                return_value=True,
+            ) as write_name,
+            patch(
+                "deepagents_cli.hooks.dispatch_hook_fire_and_forget"
+            ) as dispatch_hook,
+        ):
+            task = asyncio.create_task(app._write_launch_name_memory("Ada"))
+            await asyncio.sleep(0)
+
+            write_name.assert_not_called()
+            dispatch_hook.assert_not_called()
+
+            app._assistant_id = "coder"
+            app._resume_thread_resolved_event.set()
+            await asyncio.wait_for(task, timeout=1)
+
+        write_name.assert_called_once_with("Ada", "coder")
         dispatch_hook.assert_called_once_with(
             "user.name.set",
             {

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -552,6 +552,7 @@ class TestStartupSequence:
 
         app._switch_model = switch_model_mock  # type: ignore[assignment]
         app._mount_message = track_mount_message  # type: ignore[assignment]
+        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
 
         with (
             patch(
@@ -566,6 +567,7 @@ class TestStartupSequence:
             await app._run_launch_init_sequence()
 
         assert app._launch_user_name == "Ada"
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
         prompt_flow_mock.assert_awaited_once_with()
         write_name.assert_called_once_with("Ada", "coder")
         switch_model_mock.assert_awaited_once_with(
@@ -612,6 +614,7 @@ class TestStartupSequence:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
         app._push_screen_wait = AsyncMock(return_value="Ada")  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
+        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
 
         model_prompted = asyncio.Event()
         release_write = asyncio.Event()
@@ -638,6 +641,7 @@ class TestStartupSequence:
             await asyncio.wait_for(task, timeout=1)
 
         app._write_launch_name_memory.assert_awaited_once_with("Ada")  # type: ignore[attr-defined]
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
         app._prompt_launch_dependencies_then_model.assert_awaited_once_with()  # type: ignore[attr-defined]
         mark_complete.assert_called_once_with()
 
@@ -680,6 +684,7 @@ class TestStartupSequence:
         app._prompt_launch_dependencies_then_model = prompt_flow_mock  # type: ignore[assignment]
         app._switch_model = switch_model_mock  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
+        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
 
         with (
             patch(
@@ -694,6 +699,7 @@ class TestStartupSequence:
             await app._run_launch_init_sequence()
 
         write_name.assert_called_once_with("Ada", "coder")
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
         prompt_flow_mock.assert_awaited_once_with()
         switch_model_mock.assert_not_awaited()
         app._mount_message.assert_awaited_once()  # type: ignore[attr-defined]
@@ -713,6 +719,7 @@ class TestStartupSequence:
         switch_model_mock = AsyncMock()
         app._switch_model = switch_model_mock  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
+        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
 
         with (
             patch(
@@ -727,6 +734,7 @@ class TestStartupSequence:
             await app._run_launch_init_sequence()
 
         write_name.assert_called_once_with("Ada", "coder")
+        app._dispatch_launch_name_hook.assert_called_once_with("Ada")  # type: ignore[attr-defined]
         switch_model_mock.assert_not_awaited()
         app._mount_message.assert_awaited_once()  # type: ignore[attr-defined]
         mark_complete.assert_called_once_with()
@@ -741,6 +749,7 @@ class TestStartupSequence:
         switch_failure = RuntimeError("missing credentials")
         app._switch_model = AsyncMock(side_effect=switch_failure)  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
+        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
         notify_mock = MagicMock()
         app.notify = notify_mock  # type: ignore[method-assign]
 
@@ -784,6 +793,27 @@ class TestStartupSequence:
         assert notify_kwargs.get("severity") == "warning"
         assert notify_kwargs.get("markup") is False
 
+    def test_dispatch_launch_name_hook_sends_name_payload(self) -> None:
+        """The onboarding name hook should include the submitted name."""
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            assistant_id="coder",
+            thread_id="thread-123",
+        )
+
+        with patch(
+            "deepagents_cli.hooks.dispatch_hook_fire_and_forget"
+        ) as dispatch_hook:
+            app._dispatch_launch_name_hook("Ada")
+
+        dispatch_hook.assert_called_once_with(
+            "user.name.set",
+            {
+                "name": "Ada",
+                "assistant_id": "coder",
+            },
+        )
+
     async def test_launch_init_sequence_times_out_waiting_for_server(self) -> None:
         """A stuck server should not trap onboarding past the timeout."""
         from deepagents_cli import app as app_module
@@ -796,6 +826,7 @@ class TestStartupSequence:
         app._switch_model = AsyncMock()  # type: ignore[assignment]
         app._mount_message = AsyncMock()  # type: ignore[assignment]
         app._connecting = True
+        app._dispatch_launch_name_hook = MagicMock()  # type: ignore[method-assign]
         # Constructor pre-sets the readiness event when no server is configured;
         # clear it so the wait_for actually has to time out.
         app._connection_ready_event.clear()


### PR DESCRIPTION
Fire a `user.name.set` hook when the user submits their preferred name during the first-run onboarding flow, allowing external integrations to react to name submission without polling or patching.

Event `"user.name.set"` and payload:

  ```json
  {"name": "<str>", "assistant_id": "<str>"}
  ```
