### PR TITLE
fix(cli): catch `WorkerCancelled` in `await_prewarm_imports`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2090,15 +2090,24 @@ class DeepAgentsApp(App):
         LangChain from the event-loop thread while it's still running can
         race on partially-initialized module locks.
 
-        `CancelledError` propagates so app shutdown isn't silently absorbed.
+        `asyncio.CancelledError` propagates so app shutdown isn't silently
+        absorbed. `WorkerCancelled` and `WorkerFailed` (both `Exception`
+        subclasses, distinct from `CancelledError`) are caught: prewarm is a
+        cache optimization, so a cancelled or failed worker just means the
+        next inline import is a cold load instead of a dict lookup.
         """
-        from textual.worker import WorkerFailed
+        from textual.worker import WorkerCancelled, WorkerFailed
 
         worker = self._prewarm_worker
         if worker is None:
             return
         try:
             await worker.wait()
+        except WorkerCancelled:
+            # Cancellation is benign here: app shutdown or another exclusive
+            # worker in the same group displaced the prewarm. The subsequent
+            # inline imports will still succeed — just without the warm-up.
+            logger.debug("Import prewarm worker was cancelled", exc_info=True)
         except WorkerFailed:
             # Prewarm body best-efforts third-party imports and already
             # warns; logging at WARNING here surfaces unexpected failures

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -6580,6 +6580,25 @@ class TestPrewarmAwait:
 
         worker.wait.assert_awaited_once()
 
+    async def test_await_prewarm_imports_swallows_worker_cancelled(self) -> None:
+        """`WorkerCancelled` is non-fatal; prewarm is a cache optimization.
+
+        Distinct from `asyncio.CancelledError`: Textual's `Worker.wait()`
+        raises `WorkerCancelled` (a plain `Exception`) when the awaited
+        worker was cancelled. The caller — typically `_start_server_background`
+        — must not propagate that and crash startup.
+        """
+        from textual.worker import WorkerCancelled
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        worker = MagicMock()
+        worker.wait = AsyncMock(side_effect=WorkerCancelled("cancelled"))
+        app._prewarm_worker = worker
+
+        await app._await_prewarm_imports()  # must not raise
+
+        worker.wait.assert_awaited_once()
+
     async def test_await_prewarm_imports_propagates_cancellation(self) -> None:
         """`CancelledError` MUST propagate so app shutdown isn't absorbed."""
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")


### PR DESCRIPTION
`_await_prewarm_imports` already handled `WorkerFailed` but let `WorkerCancelled` escape. Textual raises `WorkerCancelled` (a plain `Exception`, distinct from `asyncio.CancelledError`) when a worker is cancelled — e.g. during app shutdown or when an exclusive worker displaces the prewarm. Since prewarm is a cache optimization, a cancelled worker should not crash startup.