### PR TITLE
feat(cli): add splash tips visibility env var

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -76,6 +76,9 @@ HIDE_GIT_BRANCH = "DEEPAGENTS_CLI_HIDE_GIT_BRANCH"
 HIDE_LANGSMITH_TRACING = "DEEPAGENTS_CLI_HIDE_LANGSMITH_TRACING"
 """Hide LangSmith tracing project/thread info in the startup splash when enabled."""
 
+HIDE_SPLASH_TIPS = "DEEPAGENTS_CLI_HIDE_SPLASH_TIPS"
+"""Hide rotating tips in the startup splash when enabled."""
+
 HIDE_SPLASH_VERSION = "DEEPAGENTS_CLI_HIDE_SPLASH_VERSION"
 """Hide version and local-install details in the splash screen when enabled."""
 

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -21,6 +21,7 @@ from deepagents_cli._env_vars import (
     DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER,
     HIDE_CWD,
     HIDE_LANGSMITH_TRACING,
+    HIDE_SPLASH_TIPS,
     HIDE_SPLASH_VERSION,
     is_env_truthy,
 )
@@ -151,11 +152,12 @@ class WelcomeBanner(Static):
         self._defer_connecting_display = defer_connecting_display and connecting
         self._defer_timer: Timer | None = None
         self._hide_langsmith_tracing = is_env_truthy(HIDE_LANGSMITH_TRACING)
+        self._hide_splash_tips = is_env_truthy(HIDE_SPLASH_TIPS)
         self._project_name: str | None = (
             None if self._hide_langsmith_tracing else get_langsmith_project_name()
         )
         self._project_url: str | None = None
-        self._tip: str = _pick_tip()
+        self._tip: str | None = None if self._hide_splash_tips else _pick_tip()
 
         super().__init__(self._build_banner(), **kwargs)
 
@@ -412,7 +414,13 @@ class WelcomeBanner(Static):
             )
         elif not self._idle:
             ready_color = "bold" if ansi else colors.primary
-            parts.append(build_welcome_footer(primary_color=ready_color, tip=self._tip))
+            parts.append(
+                build_welcome_footer(
+                    primary_color=ready_color,
+                    tip=self._tip,
+                    show_tip=not self._hide_splash_tips,
+                )
+            )
         # `_idle` ⇒ no footer; chat-surface owns the failure message.
         return Content.assemble(*parts)
 
@@ -441,11 +449,14 @@ def build_connecting_footer(
 
 
 def build_welcome_footer(
-    *, primary_color: str = theme.PRIMARY, tip: str | None = None
+    *,
+    primary_color: str = theme.PRIMARY,
+    tip: str | None = None,
+    show_tip: bool | None = None,
 ) -> Content:
     """Build the footer shown at the bottom of the welcome banner.
 
-    Includes a tip to help users discover features.
+    Includes a tip to help users discover features unless tips are disabled.
 
     Args:
         primary_color: Color string for the ready prompt.
@@ -455,17 +466,21 @@ def build_welcome_footer(
         tip: Tip text to display. When `None`, a random tip is selected.
 
             Pass an explicit value to keep the tip stable across re-renders.
+        show_tip: Whether to show the tip. When `None`, the startup splash tips
+            env var controls visibility.
 
     Returns:
-        Content with the ready prompt and a tip.
+        Content with the ready prompt and, when enabled, a tip.
     """
-    if tip is None:
+    if show_tip is None:
+        show_tip = not is_env_truthy(HIDE_SPLASH_TIPS)
+    if show_tip and tip is None:
         tip = _pick_tip()
     subheader = (
         os.environ.get(DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER)
         or "Ready to code! What would you like to build?"
     )
-    return Content.assemble(
-        (f"\n{subheader}\n", primary_color),
-        (f"Tip: {tip}", "dim italic"),
-    )
+    parts: list[tuple[str, str]] = [(f"\n{subheader}", primary_color)]
+    if show_tip and tip is not None:
+        parts.append((f"\nTip: {tip}", "dim italic"))
+    return Content.assemble(*parts)

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -11,6 +11,7 @@ from deepagents_cli._env_vars import (
     DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER,
     HIDE_CWD,
     HIDE_LANGSMITH_TRACING,
+    HIDE_SPLASH_TIPS,
     HIDE_SPLASH_VERSION,
 )
 from deepagents_cli._version import __version__
@@ -23,9 +24,10 @@ from deepagents_cli.widgets.welcome import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_startup_subheader_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prevent local startup subheader overrides from affecting tests."""
+def _clear_startup_splash_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent local startup splash overrides from affecting tests."""
     monkeypatch.delenv(DANGEROUSLY_OVERRIDE_STARTUP_SUBHEADER, raising=False)
+    monkeypatch.delenv(HIDE_SPLASH_TIPS, raising=False)
 
 
 def _extract_links(banner: Content, text_start: int, text_end: int) -> list[str]:
@@ -393,6 +395,33 @@ class TestBuildWelcomeFooter:
         assert "Tip: " in plain
         assert any(tip in plain for tip in _TIPS)
 
+    def test_hide_splash_tips_env_var_hides_tip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Splash tips should hide when the env var is enabled."""
+        monkeypatch.setenv(HIDE_SPLASH_TIPS, "1")
+
+        plain = build_welcome_footer(tip="Use /help").plain
+
+        assert "Ready to code! What would you like to build?" in plain
+        assert "Tip: " not in plain
+        assert "Use /help" not in plain
+        assert plain.split("\n") == [
+            "",
+            "Ready to code! What would you like to build?",
+        ]
+
+    def test_hide_splash_tips_env_var_skips_random_tip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Disabling splash tips should avoid selecting a random tip."""
+        monkeypatch.setenv(HIDE_SPLASH_TIPS, "1")
+
+        with patch("deepagents_cli.widgets.welcome._pick_tip") as pick_tip:
+            build_welcome_footer()
+
+        pick_tip.assert_not_called()
+
     def test_startup_cmd_tip_registered(self) -> None:
         """New `--startup-cmd` flag must have a discoverability tip."""
         assert any("--startup-cmd" in tip for tip in _TIPS)
@@ -436,6 +465,15 @@ class TestBannerFooterPosition:
         lines = widget._build_banner().plain.strip().splitlines()
         assert "Ready to code" in lines[-2]
         assert lines[-1].strip().startswith("Tip: ")
+
+    def test_hide_splash_tips_env_var_hides_tip_in_banner(self) -> None:
+        """Full startup banner should omit tips when the env var is enabled."""
+        with patch.dict("os.environ", {HIDE_SPLASH_TIPS: "1"}, clear=True):
+            widget = WelcomeBanner()
+        plain = widget._build_banner().plain
+        lines = plain.strip().splitlines()
+        assert "Ready to code" in lines[-1]
+        assert "Tip: " not in plain
 
     def test_footer_is_last_with_thread_id(self) -> None:
         """Footer remains last when a thread ID is displayed."""


### PR DESCRIPTION
Custom or embedded CLI sessions can now suppress rotating startup tips while keeping the splash banner and ready prompt intact. The visibility toggle follows the existing splash env-var pattern and avoids picking a random tip when tips are hidden.