### PR TITLE
release(deepagents-cli): 0.0.52a1

### DIFF
--- a/libs/cli/deepagents_cli/_version.py
+++ b/libs/cli/deepagents_cli/_version.py
@@ -1,6 +1,6 @@
 """Version information and lightweight constants for `deepagents-cli`."""
 
-__version__ = "0.0.47"  # x-release-please-version
+__version__ = "0.0.52a1"  # x-release-please-version
 
 DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
 """URL for `deepagents-cli` documentation."""

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deepagents-cli"
-version = "0.0.47"
+version = "0.0.52a1"
 description = "Terminal interface for Deep Agents - interactive AI agent with file operations, shell access, and sub-agent capabilities."
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -1026,7 +1026,7 @@ wheels = [
 
 [[package]]
 name = "deepagents-cli"
-version = "0.0.47"
+version = "0.0.52a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "deepagents-cli"
-version = "0.0.47"
+version = "0.0.52a1"
 source = { directory = "../cli" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Bumps `deepagents-cli` from `0.0.47` → `0.0.52a1` on the `v0.6` branch, bundling the langgraph 1.2 delta-channel work merged via #3143.

Versioning rationale: `0.0.52a1` is strictly newer than the latest `0.0.51` stable on `main`, so PyPI/installers will prefer it under `--pre`, and the `aN` suffix signals pre-release for users who haven't opted in.

## Test plan

- [ ] CI green (lockfiles, lint, tests)
- [ ] Verify PyPI publish picks up `0.0.52a1` as a pre-release