### PR TITLE
fix(filesystem): use `file_path=` in `read_file` description examples to match schema

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -318,10 +318,10 @@ Assume this tool is able to read all files. If the User provides a path to a fil
 Usage:
 - By default, it reads up to 100 lines starting from the beginning of the file
 - **IMPORTANT for large files and codebase exploration**: Use pagination with offset and limit parameters to avoid context overflow
-  - First scan: read_file(path, limit=100) to see file structure
-  - Read more sections: read_file(path, offset=100, limit=200) for next 200 lines
+  - First scan: read_file(file_path=..., limit=100) to see file structure
+  - Read more sections: read_file(file_path=..., offset=100, limit=200) for next 200 lines
   - Only omit limit (read full file) when necessary for editing
-- Specify offset and limit: read_file(path, offset=0, limit=100) reads first 100 lines
+- Specify offset and limit: read_file(file_path=..., offset=0, limit=100) reads first 100 lines
 - Results are returned using cat -n format, with line numbers starting at 1
 - Lines longer than 5,000 characters will be split into multiple lines with continuation markers (e.g., 5.1, 5.2, etc.). When you specify a limit, these continuation lines count towards the limit.
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.


### PR DESCRIPTION
Closes #3185.

## Problem

`READ_FILE_TOOL_DESCRIPTION` in `libs/deepagents/deepagents/middleware/filesystem.py` contains three worked-example call sites using `path` as the kwarg name, but the actual tool schema declares the field as `file_path`. The model follows the worked examples in the description literally, emits `read_file(path=...)`, and trips Pydantic with `Field required: file_path` — wasting a turn on the retry every time the agent reads a file.

The bug is reproducible across every release I checked (0.4.1, 0.4.12, 0.5.7, 0.6.0a1) and on `main`.

## Repro

```python
from deepagents.middleware.filesystem import FilesystemMiddleware
from deepagents.backends.state import StateBackend
from langchain_core.utils.function_calling import convert_to_openai_tool

mw = FilesystemMiddleware(backend=StateBackend)
read_tool = next(t for t in mw.tools if t.name == "read_file")
spec = convert_to_openai_tool(read_tool)

# Schema correctly declares file_path:
print(list(spec["function"]["parameters"]["properties"].keys()))
# -> ['file_path', 'offset', 'limit']

# Description examples (before this PR) say `path`:
for line in spec["function"]["description"].splitlines():
    if "read_file(" in line:
        print(line.strip())
# -> - First scan: read_file(path, limit=100) to see file structure
# -> - Read more sections: read_file(path, offset=100, limit=200) for next 200 lines
# -> - Specify offset and limit: read_file(path, offset=0, limit=100) reads first 100 lines
# -> - Use `read_file(file_path=...)`
```

## Fix

Three-line description-only change. Lines 321/322/324 of `READ_FILE_TOOL_DESCRIPTION` are rewritten to use `file_path=` so they match the schema and align with the existing multimodal example at line 332.

```diff
-  - First scan: read_file(path, limit=100) to see file structure
-  - Read more sections: read_file(path, offset=100, limit=200) for next 200 lines
+  - First scan: read_file(file_path=..., limit=100) to see file structure
+  - Read more sections: read_file(file_path=..., offset=100, limit=200) for next 200 lines
   - Only omit limit (read full file) when necessary for editing
-- Specify offset and limit: read_file(path, offset=0, limit=100) reads first 100 lines
+- Specify offset and limit: read_file(file_path=..., offset=0, limit=100) reads first 100 lines
```

No behavioral change. The tool's signature, schema, and runtime behavior are untouched; only the documentation text the LLM sees alongside the schema changes.

## Verification

After applying:

```python
for line in spec["function"]["description"].splitlines():
    if "read_file(" in line:
        print(line.strip())
# -> - First scan: read_file(file_path=..., limit=100) to see file structure
# -> - Read more sections: read_file(file_path=..., offset=100, limit=200) for next 200 lines
# -> - Specify offset and limit: read_file(file_path=..., offset=0, limit=100) reads first 100 lines
# -> - Use `read_file(file_path=...)`
```

All four worked examples now consistently use `file_path=`.