### PR TITLE
chore(examples): remove unused tavily dependency from text-to-sql agent

### DIFF
--- a/examples/text-to-sql-agent/.env.example
+++ b/examples/text-to-sql-agent/.env.example
@@ -6,6 +6,3 @@ LANGCHAIN_TRACING_V2=true
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 LANGCHAIN_API_KEY=your_langsmith_api_key_here
 LANGCHAIN_PROJECT=text2sql-deepagent
-
-# Tavily API (optional - for web search capabilities)
-TAVILY_API_KEY=your_tavily_api_key_here

--- a/examples/text-to-sql-agent/pyproject.toml
+++ b/examples/text-to-sql-agent/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "langgraph>=1.0.6",
     "sqlalchemy>=2.0.0",
     "python-dotenv>=1.0.0",
-    "tavily-python>=0.5.0",
     "rich>=13.0.0",
 ]
 


### PR DESCRIPTION
Removes the unused `tavily-python` dependency from the `text-to-sql-agent` example's `pyproject.toml` and `.env.example` files to prevent confusion for users starting out with the example.