### PR TITLE
ci(evals): per-shard uv cache scope to avoid parallel save races

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -142,7 +142,10 @@ jobs:
         uses: "./.github/actions/uv_setup"
         with:
           python-version: "3.12"
-          cache-suffix: evals
+          # Per-shard scope so parallel matrix jobs don't race on the same
+          # cache key. `artifact_key` is enforced unique by the matrix
+          # builder (`_artifact_key` in `.github/scripts/models.py`).
+          cache-suffix: evals-${{ inputs.artifact_key }}
           working-directory: libs/evals
 
       - name: "📦 Install Dependencies"


### PR DESCRIPTION
The matrix shards in the eval workflow all called `uv_setup` with `cache-suffix: evals`, producing an identical `setup-uv-…-evals` cache key across every parallel provider. Only one shard wins the save reservation per run, so every other shard emits a benign-but-noisy `Failed to save: another job may be creating this cache` annotation. Switching the suffix to include the per-shard `artifact_key` gives each job its own slot — guaranteed unique by `_artifact_key` in `.github/scripts/models.py` — so saves never collide.