### PR TITLE
test(evals): align HITL `allowed_decisions` assertions with `respond` decision

### DIFF
--- a/libs/evals/tests/evals/test_hitl.py
+++ b/libs/evals/tests/evals/test_hitl.py
@@ -96,7 +96,7 @@ def test_hitl_agent(model: BaseChatModel) -> None:
     review_configs = interrupt_value["review_configs"]
     assert any(
         review_config["action_name"] == "sample_tool"
-        and review_config["allowed_decisions"] == ["approve", "edit", "reject"]
+        and review_config["allowed_decisions"] == ["approve", "edit", "reject", "respond"]
         for review_config in review_configs
     )
     assert any(
@@ -159,7 +159,7 @@ def test_subagent_with_hitl(model: BaseChatModel) -> None:
     review_configs = interrupt_value["review_configs"]
     assert any(
         review_config["action_name"] == "sample_tool"
-        and review_config["allowed_decisions"] == ["approve", "edit", "reject"]
+        and review_config["allowed_decisions"] == ["approve", "edit", "reject", "respond"]
         for review_config in review_configs
     )
     assert any(
@@ -236,12 +236,12 @@ def test_subagent_with_custom_interrupt_on(model: BaseChatModel) -> None:
     review_configs = interrupt_value["review_configs"]
     assert any(
         review_config["action_name"] == "get_weather"
-        and review_config["allowed_decisions"] == ["approve", "edit", "reject"]
+        and review_config["allowed_decisions"] == ["approve", "edit", "reject", "respond"]
         for review_config in review_configs
     )
     assert any(
         review_config["action_name"] == "get_soccer_scores"
-        and review_config["allowed_decisions"] == ["approve", "edit", "reject"]
+        and review_config["allowed_decisions"] == ["approve", "edit", "reject", "respond"]
         for review_config in review_configs
     )
 


### PR DESCRIPTION
The HITL trio (`test_hitl_agent`, `test_subagent_with_hitl`, `test_subagent_with_custom_interrupt_on`) had been failing on every model eval, because the `review_configs` assertions pinned the pre-`respond` contract. Upstream [langchain-ai/langchain#37095](https://github.com/langchain-ai/langchain/pull/37095) (in `langchain` 1.2.x) added a fourth `respond` decision and now resolves `interrupt_on[tool] = True` to `["approve", "edit", "reject", "respond"]`.