### PR TITLE
refactor(ci): move source tree recording from `_eval` to `evals` workflow

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -153,15 +153,6 @@ jobs:
         # combining that environment variable with `--locked`.
         run: uv sync --group test
 
-      - name: "🌳 Record source tree"
-        run: |
-          {
-            echo "### 🌳 Source tree"
-            echo ""
-            echo "Run fired from [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}) on \`${GITHUB_REF_NAME}\`."
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: "🔖 Record resolved versions"
         run: |
           {

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -253,6 +253,12 @@ jobs:
           ANALYZE_FAILURES: ${{ inputs.analyze_failures }}
           ANALYSIS_MODEL: ${{ inputs.analysis_model || 'anthropic:claude-haiku-4-5-20251001' }}
         run: |
+          {
+            echo "### 🌳 Source tree"
+            echo ""
+            echo "Run fired from [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}) on \`${GITHUB_REF_NAME}\`."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
           echo "### 📊 Eval dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Input | Value |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Move the "🌳 Source tree" step out of the reusable `_eval.yml` workflow and inline it into the caller `evals.yml`, right before the dispatch-inputs summary table. The source tree context is a dispatch concern — it belongs alongside the other run metadata that `evals.yml` already logs, not buried in the reusable workflow's setup steps.