### PR TITLE
fix(ci): hyperlink branch name in evals step summary

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -256,7 +256,7 @@ jobs:
           {
             echo "### 🌳 Source tree"
             echo ""
-            echo "Run fired from [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}) on \`${GITHUB_REF_NAME}\`."
+            echo "Run fired from [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}) on [\`${GITHUB_REF_NAME}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_REF})."
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
           echo "### 📊 Eval dispatch inputs" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The branch name in the evals workflow step summary was rendered as plain inline code, while the commit SHA next to it was already a hyperlink. Make `GITHUB_REF_NAME` a clickable link to the branch tree, matching the SHA link pattern.