### PR TITLE
fix(filesystem): execute tool sets status='error' on non-zero exit code

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1532,11 +1532,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if result.truncated:
                 parts.append("\n[Output was truncated due to size limits]")
 
+            is_error = result.exit_code is not None and result.exit_code != 0
             return ToolMessage(
                 content="".join(parts),
                 name="execute",
                 tool_call_id=runtime.tool_call_id,
-                status="success",
+                status="error" if is_error else "success",
             )
 
         async def async_execute(  # noqa: PLR0911 - early returns for distinct error conditions
@@ -1621,11 +1622,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if result.truncated:
                 parts.append("\n[Output was truncated due to size limits]")
 
+            is_error = result.exit_code is not None and result.exit_code != 0
             return ToolMessage(
                 content="".join(parts),
                 name="execute",
                 tool_call_id=runtime.tool_call_id,
-                status="success",
+                status="error" if is_error else "success",
             )
 
         return StructuredTool.from_function(


### PR DESCRIPTION
Fixes #3205

The execute tool's final `ToolMessage` return hardcoded `status="success"` even when the command failed (`exit_code != 0`). All other error paths in `sync_execute` and `async_execute` already correctly set `status="error"` — only the post-execution return was missing it.

## Changes

- `sync_execute`: derive `status` from `result.exit_code` instead of hardcoding `"success"`
- `async_execute`: same

## Why

Failed commands appeared as successful in LangSmith traces, preventing operators from filtering for errors. Agents couldn't distinguish success from failure at the `ToolMessage` level, leading to unbounded retry loops on persistent errors (638 LLM turns / 8.8M tokens in our production case).

## Test

A command returning non-zero exit code now produces `ToolMessage(status="error")`. Commands returning exit code 0 continue to produce `ToolMessage(status="success")`. No behavior change for successful commands.