### PR TITLE
feat(cli): external event listener via Unix domain socket

### DIFF
--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -65,10 +65,13 @@ real PyPI release. Any non-empty value enables the flag (including `"0"` or
 `"false"`)."""
 
 EXTERNAL_EVENT_SOCKET = "DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET"
-"""Enable the alpha local Unix-socket external event listener."""
+"""Enable the local Unix-socket external event listener.
+
+Parsed by `is_env_truthy`; off by default. Wire format and behavior are
+considered experimental until the listener is documented in the CLI README."""
 
 EXTERNAL_EVENT_SOCKET_PATH = "DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET_PATH"
-"""Explicit path for the alpha local Unix-socket external event listener."""
+"""Override the default Unix-socket path for the external event listener."""
 
 EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
 """Colon-separated paths added to the skill containment allowlist."""

--- a/libs/cli/deepagents_cli/_env_vars.py
+++ b/libs/cli/deepagents_cli/_env_vars.py
@@ -64,6 +64,12 @@ at launch so the update-available flow can be exercised without waiting for a
 real PyPI release. Any non-empty value enables the flag (including `"0"` or
 `"false"`)."""
 
+EXTERNAL_EVENT_SOCKET = "DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET"
+"""Enable the alpha local Unix-socket external event listener."""
+
+EXTERNAL_EVENT_SOCKET_PATH = "DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET_PATH"
+"""Explicit path for the alpha local Unix-socket external event listener."""
+
 EXTRA_SKILLS_DIRS = "DEEPAGENTS_CLI_EXTRA_SKILLS_DIRS"
 """Colon-separated paths added to the skill containment allowlist."""
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
     from textual.worker import Worker
 
     from deepagents_cli._ask_user_types import AskUserWidgetResult, Question
+    from deepagents_cli.event_bus import EventSource, ExternalEvent
     from deepagents_cli.mcp_tools import MCPServerInfo
     from deepagents_cli.remote_client import RemoteAgent
     from deepagents_cli.server import ServerProcess
@@ -419,6 +420,19 @@ class QueuedMessage:
 
     mode: InputMode
     """The input mode that determines message routing."""
+
+
+class ExternalInput(Message):
+    """Textual message carrying an external prompt or command."""
+
+    def __init__(self, event: ExternalEvent) -> None:
+        """Create an external input message.
+
+        Args:
+            event: Transport-independent external event.
+        """
+        super().__init__()
+        self.event = event
 
 
 DeferredActionKind = Literal[
@@ -1164,6 +1178,12 @@ class DeepAgentsApp(App):
         self._startup_task: asyncio.Task[None] | None = None
         """Startup task reference (set in on_mount)."""
 
+        self._external_event_source: EventSource | None = None
+        """Optional alpha external event source, enabled by environment."""
+
+        self._external_event_source_task: asyncio.Task[None] | None = None
+        """Background task that owns the external event source lifecycle."""
+
         self._git_branch_refresh_task: asyncio.Task[None] | None = None
         """Latest background git-branch refresh task, if one is running."""
 
@@ -1402,6 +1422,50 @@ class DeepAgentsApp(App):
         self._startup_task = asyncio.create_task(
             self._resolve_git_branch_and_continue()
         )
+        self._maybe_start_external_event_source()
+
+    def _maybe_start_external_event_source(self) -> None:
+        """Start the alpha external event listener when explicitly enabled."""
+        from deepagents_cli._env_vars import (
+            EXTERNAL_EVENT_SOCKET,
+            EXTERNAL_EVENT_SOCKET_PATH,
+            is_env_truthy,
+        )
+
+        if not is_env_truthy(EXTERNAL_EVENT_SOCKET):
+            return
+
+        from deepagents_cli.event_bus import UnixSocketEventSource
+
+        raw_path = os.environ.get(EXTERNAL_EVENT_SOCKET_PATH)
+        path = Path(raw_path).expanduser() if raw_path else None
+        source = UnixSocketEventSource(path)
+        self._external_event_source = source
+        self._external_event_source_task = asyncio.create_task(
+            self._run_external_event_source(source)
+        )
+
+    async def _run_external_event_source(self, source: EventSource) -> None:
+        """Run the configured external event source until app shutdown.
+
+        Raises:
+            asyncio.CancelledError: When the app is exiting.
+        """
+
+        async def sink(event: ExternalEvent) -> None:
+            await asyncio.sleep(0)
+            self.post_message(ExternalInput(event))
+
+        try:
+            await source.start(sink)
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("External event source failed")
+        finally:
+            with suppress(Exception):
+                await source.stop()
 
     async def _refresh_git_branch(self) -> None:
         """Resolve the current git branch and update the status bar.
@@ -3704,23 +3768,17 @@ class DeepAgentsApp(App):
             return value == cmd
         return cmd in SIDE_EFFECT_FREE
 
-    async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
-        """Handle submitted input from ChatInput widget."""
-        value = event.value
-        mode: InputMode = event.mode  # type: ignore[assignment]  # Textual event mode is str at type level but InputMode at runtime
+    async def _submit_input(self, value: str, mode: InputMode) -> None:
+        """Submit input through the normal queue and bypass policy.
 
-        # Reset quit pending state on any input
-        self._quit_pending = False
-
-        from deepagents_cli.hooks import dispatch_hook
-
-        await dispatch_hook("user.prompt", {})
-
-        # /quit and /q always execute immediately, even mid-thread-switch.
+        Args:
+            value: Message or command text.
+            mode: Input routing mode.
+        """
         from deepagents_cli.command_registry import ALWAYS_IMMEDIATE
 
         if mode == "command" and value.lower().strip() in ALWAYS_IMMEDIATE:
-            self.exit()
+            await self._process_message(value, mode)
             return
 
         # Prevent message handling while a thread switch is in-flight.
@@ -3759,6 +3817,40 @@ class DeepAgentsApp(App):
             return
 
         await self._process_message(value, mode)
+
+    async def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
+        """Handle submitted input from ChatInput widget."""
+        value = event.value
+        mode: InputMode = event.mode  # type: ignore[assignment]  # Textual event mode is str at type level but InputMode at runtime
+
+        # Reset quit pending state on any input
+        self._quit_pending = False
+
+        from deepagents_cli.hooks import dispatch_hook
+
+        await dispatch_hook("user.prompt", {})
+
+        await self._submit_input(value, mode)
+
+    async def on_external_input(self, event: ExternalInput) -> None:
+        """Route external prompt and command events through the app queue."""
+        external = event.event
+        if external.kind == "signal":
+            await self._handle_external_signal(external.payload)
+            return
+
+        mode: InputMode = "command" if external.kind == "command" else "normal"
+        await self._submit_input(external.payload, mode)
+
+    async def _handle_external_signal(self, payload: str) -> None:
+        """Handle a small alpha set of generic external signals."""
+        signal_name = payload.strip().lower()
+        if signal_name == "interrupt":
+            self.action_interrupt()
+        elif signal_name == "force-clear":
+            await self._submit_input("/force-clear", "command")
+        else:
+            logger.warning("Ignoring unknown external signal %r", payload)
 
     def on_chat_input_mode_changed(self, event: ChatInput.ModeChanged) -> None:
         """Update status bar when input mode changes."""
@@ -4134,7 +4226,8 @@ class DeepAgentsApp(App):
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))
             help_body = (
-                "Commands: /quit, /agents, /auth, /clear, /offload, /editor, "
+                "Commands: /quit, /agents, /auth, /clear, /force-clear, "
+                "/offload, /editor, "
                 "/mcp, /model [--model-params JSON] [--default], "
                 "/notifications, /reload, /skill:<name>, /remember, "
                 "/skill-creator, /theme, /tokens, /threads, /trace, "
@@ -4163,7 +4256,9 @@ class DeepAgentsApp(App):
             await self._handle_version_command()
         elif cmd == "/agents":
             await self._show_agent_selector()
-        elif cmd == "/clear":
+        elif cmd in {"/clear", "/force-clear"}:
+            if cmd == "/force-clear":
+                self._force_interrupt_active_work()
             self._pending_messages.clear()
             self._queued_widgets.clear()
             await self._clear_messages()
@@ -5543,6 +5638,20 @@ class DeepAgentsApp(App):
         self._queued_widgets.clear()
         self._deferred_actions.clear()
 
+    def _force_interrupt_active_work(self) -> None:
+        """Best-effort interruption used by `/force-clear` before clearing UI."""
+        if self._pending_approval_widget:
+            with suppress(Exception):
+                self._pending_approval_widget.action_select_reject()
+        if self._pending_ask_user_widget:
+            with suppress(Exception):
+                self._pending_ask_user_widget.action_cancel()
+        if self._shell_running and self._shell_worker:
+            self._shell_worker.cancel()
+        if self._agent_running and self._agent_worker:
+            self._agent_worker.cancel()
+        self._discard_queue()
+
     def _defer_action(self, action: DeferredAction) -> None:
         """Queue a deferred action, replacing any existing action of the same kind.
 
@@ -5791,6 +5900,8 @@ class DeepAgentsApp(App):
             self._agent_worker.cancel()
         if self._git_branch_refresh_task is not None:
             self._git_branch_refresh_task.cancel()
+        if self._external_event_source_task is not None:
+            self._external_event_source_task.cancel()
 
         # Dispatch synchronously — the event loop is about to be torn down by
         # super().exit(), so an async task would never complete.

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1179,10 +1179,14 @@ class DeepAgentsApp(App):
         """Startup task reference (set in on_mount)."""
 
         self._external_event_source: EventSource | None = None
-        """Optional alpha external event source, enabled by environment."""
+        """External event source created when its env var is enabled.
+
+        Cleared back to `None` if the listener fails to start so callers can
+        distinguish a configured-and-running listener from a no-op.
+        """
 
         self._external_event_source_task: asyncio.Task[None] | None = None
-        """Background task that owns the external event source lifecycle."""
+        """Lifecycle task for `_external_event_source`; cleared together."""
 
         self._git_branch_refresh_task: asyncio.Task[None] | None = None
         """Latest background git-branch refresh task, if one is running."""
@@ -1425,7 +1429,7 @@ class DeepAgentsApp(App):
         self._maybe_start_external_event_source()
 
     def _maybe_start_external_event_source(self) -> None:
-        """Start the alpha external event listener when explicitly enabled."""
+        """Start the external event listener when explicitly enabled."""
         from deepagents_cli._env_vars import (
             EXTERNAL_EVENT_SOCKET,
             EXTERNAL_EVENT_SOCKET_PATH,
@@ -1446,26 +1450,39 @@ class DeepAgentsApp(App):
         )
 
     async def _run_external_event_source(self, source: EventSource) -> None:
-        """Run the configured external event source until app shutdown.
+        """Drive `source` from start to shutdown, surfacing failures to the user.
+
+        Args:
+            source: External event source whose lifecycle this task owns.
 
         Raises:
-            asyncio.CancelledError: When the app is exiting.
+            asyncio.CancelledError: Re-raised when the task is cancelled
+                during app shutdown so the cleanup path runs to completion.
         """
 
-        async def sink(event: ExternalEvent) -> None:
-            await asyncio.sleep(0)
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029  # protocol requires async callable; post_message is sync
             self.post_message(ExternalInput(event))
 
         try:
             await source.start(sink)
-            await asyncio.Event().wait()
+            await source.serve_forever()
         except asyncio.CancelledError:
             raise
-        except Exception:
-            logger.exception("External event source failed")
-        finally:
+        except (OSError, RuntimeError, ValueError) as exc:
+            logger.exception("External event source failed to start")
+            self._external_event_source = None
             with suppress(Exception):
+                self.notify(
+                    f"External event listener failed: {exc}",
+                    severity="error",
+                    timeout=8,
+                    markup=False,
+                )
+        finally:
+            try:
                 await source.stop()
+            except Exception:
+                logger.exception("Error while stopping external event source")
 
     async def _refresh_git_branch(self) -> None:
         """Resolve the current git branch and update the status bar.
@@ -3768,16 +3785,32 @@ class DeepAgentsApp(App):
             return value == cmd
         return cmd in SIDE_EFFECT_FREE
 
-    async def _submit_input(self, value: str, mode: InputMode) -> None:
-        """Submit input through the normal queue and bypass policy.
+    async def _submit_input(
+        self,
+        value: str,
+        mode: InputMode,
+        *,
+        force_bypass: bool = False,
+    ) -> None:
+        """Submit input, fast-pathing always-immediate commands.
+
+        For commands in `ALWAYS_IMMEDIATE` (or whenever `force_bypass` is set
+        by an external caller), the value is processed directly. Otherwise
+        the standard queue and per-tier bypass policy applies.
 
         Args:
-            value: Message or command text.
+            value: Raw text submitted by the user or external source.
             mode: Input routing mode.
+            force_bypass: When `True`, skip queueing and process the value
+                immediately. External callers use this to mirror the
+                `ALWAYS_IMMEDIATE` fast path for commands they classify as
+                urgent.
         """
         from deepagents_cli.command_registry import ALWAYS_IMMEDIATE
 
-        if mode == "command" and value.lower().strip() in ALWAYS_IMMEDIATE:
+        if force_bypass or (
+            mode == "command" and value.lower().strip() in ALWAYS_IMMEDIATE
+        ):
             await self._process_message(value, mode)
             return
 
@@ -3833,22 +3866,36 @@ class DeepAgentsApp(App):
         await self._submit_input(value, mode)
 
     async def on_external_input(self, event: ExternalInput) -> None:
-        """Route external prompt and command events through the app queue."""
+        """Route external prompt and command events through the app queue.
+
+        Honors `event.bypass`: when an external caller supplies any tier
+        other than `QUEUED`, the event skips the queue regardless of normal
+        per-command policy. This is the documented escape hatch for
+        scripted callers that need to inject high-priority work.
+        """
+        from deepagents_cli.command_registry import BypassTier
+
         external = event.event
         if external.kind == "signal":
             await self._handle_external_signal(external.payload)
             return
 
         mode: InputMode = "command" if external.kind == "command" else "normal"
-        await self._submit_input(external.payload, mode)
+        force_bypass = external.bypass is not BypassTier.QUEUED
+        await self._submit_input(external.payload, mode, force_bypass=force_bypass)
 
     async def _handle_external_signal(self, payload: str) -> None:
-        """Handle a small alpha set of generic external signals."""
+        """Dispatch an external signal payload to the corresponding action.
+
+        The wire-protocol decoder rejects unknown signal names before they
+        reach this method, so the `else` branch only fires when callers
+        construct an `ExternalEvent` directly with an unvalidated payload.
+        """
         signal_name = payload.strip().lower()
         if signal_name == "interrupt":
             self.action_interrupt()
         elif signal_name == "force-clear":
-            await self._submit_input("/force-clear", "command")
+            await self._submit_input("/force-clear", "command", force_bypass=True)
         else:
             logger.warning("Ignoring unknown external signal %r", payload)
 
@@ -5630,6 +5677,42 @@ class DeepAgentsApp(App):
         else:
             self.notify("Queued message discarded (input not empty)", timeout=3)
 
+    def _cleanup_external_event_source_sync(self) -> None:
+        """Synchronously close the external event listener and unlink its socket.
+
+        Called from `exit()` because the event loop is about to be torn
+        down and the task's async `finally` would never complete. Close
+        the asyncio server (releases the file descriptor) and unlink the
+        socket path so we never leave stale entries on disk.
+        """
+        source = self._external_event_source
+        if source is None:
+            return
+        from deepagents_cli.event_bus import UnixSocketEventSource
+
+        if isinstance(source, UnixSocketEventSource):
+            server = source._server  # synchronous teardown peer
+            source._server = None
+            if server is not None:
+                with suppress(Exception):
+                    server.close()
+            with suppress(FileNotFoundError):
+                from deepagents_cli.event_bus import _unlink_existing_socket
+
+                try:
+                    _unlink_existing_socket(source.path)
+                except FileExistsError:
+                    logger.warning(
+                        "Leaving non-socket entry at %s during exit",
+                        source.path,
+                    )
+                except OSError as exc:
+                    logger.warning(
+                        "Failed to unlink event socket %s: %s",
+                        source.path,
+                        exc,
+                    )
+
     def _discard_queue(self) -> None:
         """Clear pending messages, deferred actions, and queued widgets."""
         self._pending_messages.clear()
@@ -5639,13 +5722,25 @@ class DeepAgentsApp(App):
         self._deferred_actions.clear()
 
     def _force_interrupt_active_work(self) -> None:
-        """Best-effort interruption used by `/force-clear` before clearing UI."""
+        """Cancel in-flight work before the standard `/clear` path runs.
+
+        Rejects pending approvals, cancels pending ask-user prompts, kills
+        the shell worker, kills the agent worker, and drops the queued
+        message backlog. UI clearing itself happens in the calling
+        `/clear` handler. Each widget interaction is best-effort: a torn-
+        down widget should not abort the interrupt sequence, but the
+        underlying error is logged so regressions are visible.
+        """
         if self._pending_approval_widget:
-            with suppress(Exception):
+            try:
                 self._pending_approval_widget.action_select_reject()
+            except (AttributeError, RuntimeError):
+                logger.exception("force-clear: failed to reject pending approval")
         if self._pending_ask_user_widget:
-            with suppress(Exception):
+            try:
                 self._pending_ask_user_widget.action_cancel()
+            except (AttributeError, RuntimeError):
+                logger.exception("force-clear: failed to cancel pending ask-user")
         if self._shell_running and self._shell_worker:
             self._shell_worker.cancel()
         if self._agent_running and self._agent_worker:
@@ -5902,6 +5997,13 @@ class DeepAgentsApp(App):
             self._git_branch_refresh_task.cancel()
         if self._external_event_source_task is not None:
             self._external_event_source_task.cancel()
+        # Cancellation alone is not enough: the task's `finally` block runs
+        # asynchronously, and the event loop is about to be torn down by
+        # `super().exit()`. Synchronously close the server and unlink the
+        # socket file so we never leave a stale entry on disk.
+        if self._external_event_source is not None:
+            self._cleanup_external_event_source_sync()
+            self._external_event_source = None
 
         # Dispatch synchronously — the event loop is about to be torn down by
         # super().exit(), so an async task would never complete.

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -91,6 +91,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="reset",
     ),
     SlashCommand(
+        name="/force-clear",
+        description="Interrupt active work, clear chat, and start new thread",
+        bypass_tier=BypassTier.ALWAYS,
+        hidden_keywords="reset interrupt",
+    ),
+    SlashCommand(
         name="/editor",
         description="Open prompt in external editor ($EDITOR)",
         bypass_tier=BypassTier.QUEUED,

--- a/libs/cli/deepagents_cli/event_bus.py
+++ b/libs/cli/deepagents_cli/event_bus.py
@@ -1,0 +1,181 @@
+"""Alpha external event ingress for the Textual CLI app."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from deepagents_cli.command_registry import BypassTier
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+ExternalEventKind = Literal["command", "prompt", "signal"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ExternalEvent:
+    """A transport-independent event delivered from outside the TUI."""
+
+    kind: ExternalEventKind
+    payload: str
+    source: str
+    bypass: BypassTier = BypassTier.QUEUED
+    correlation_id: str | None = None
+
+
+class EventSource(Protocol):
+    """Source of external events for the CLI app."""
+
+    async def start(
+        self,
+        sink: Callable[[ExternalEvent], Awaitable[None]],
+    ) -> None:
+        """Start forwarding events to `sink`.
+
+        Args:
+            sink: Async callback that receives parsed external events.
+        """
+
+    async def stop(self) -> None:
+        """Stop forwarding events and release transport resources."""
+
+
+class UnixSocketEventSource:
+    """Line-delimited JSON event source over a local Unix domain socket."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        """Create a Unix-socket event source.
+
+        Args:
+            path: Socket path. When omitted, a per-process path under the
+                runtime or temp directory is used.
+        """
+        self.path = path or default_unix_socket_path()
+        self._server: asyncio.AbstractServer | None = None
+        self._sink: Callable[[ExternalEvent], Awaitable[None]] | None = None
+
+    async def start(
+        self,
+        sink: Callable[[ExternalEvent], Awaitable[None]],
+    ) -> None:
+        """Start listening for newline-delimited JSON events."""
+        self._sink = sink
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with contextlib.suppress(FileNotFoundError):
+            _unlink_existing_socket(self.path)
+        self._server = await asyncio.start_unix_server(
+            self._handle_client,
+            path=str(self.path),
+        )
+        self.path.chmod(0o600)
+
+    async def stop(self) -> None:
+        """Close the listener and remove the socket path."""
+        server = self._server
+        self._server = None
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        with contextlib.suppress(FileNotFoundError, FileExistsError):
+            _unlink_existing_socket(self.path)
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            while line := await reader.readline():
+                event = decode_external_event(line, source=f"unix:{self.path}")
+                if self._sink is not None:
+                    await self._sink(event)
+                writer.write(b'{"ok":true}\n')
+                await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+def default_unix_socket_path() -> Path:
+    """Return the default per-process Unix socket path."""
+    root = os.environ.get("XDG_RUNTIME_DIR")
+    base = Path(root) if root else Path(tempfile.gettempdir())
+    return base / "deepagents" / f"events-{os.getpid()}.sock"
+
+
+def _unlink_existing_socket(path: Path) -> None:
+    """Remove a stale Unix socket without touching other filesystem entries.
+
+    Args:
+        path: Candidate socket path to remove.
+
+    Raises:
+        FileExistsError: If `path` exists but is not a Unix socket.
+    """
+    info = path.stat(follow_symlinks=False)
+    if not stat.S_ISSOCK(info.st_mode):
+        msg = f"Refusing to remove non-socket external event path: {path}"
+        raise FileExistsError(msg)
+    path.unlink()
+
+
+def decode_external_event(data: bytes, *, source: str) -> ExternalEvent:
+    """Decode one newline-delimited JSON external event.
+
+    Args:
+        data: Raw JSON line.
+        source: Transport-specific source label attached to the event.
+
+    Returns:
+        Parsed external event.
+
+    Raises:
+        TypeError: If the envelope is not a JSON object.
+        ValueError: If the event envelope is invalid.
+    """
+    try:
+        raw = json.loads(data)
+    except json.JSONDecodeError as exc:
+        msg = "External event must be valid JSON"
+        raise ValueError(msg) from exc
+    if not isinstance(raw, dict):
+        msg = "External event must be a JSON object"
+        raise TypeError(msg)
+
+    kind = raw.get("kind")
+    if kind not in {"command", "prompt", "signal"}:
+        msg = "External event kind must be command, prompt, or signal"
+        raise ValueError(msg)
+
+    payload = raw.get("payload")
+    if not isinstance(payload, str) or not payload.strip():
+        msg = "External event payload must be a non-empty string"
+        raise ValueError(msg)
+
+    bypass = raw.get("bypass", BypassTier.QUEUED.value)
+    try:
+        bypass_tier = BypassTier(bypass)
+    except ValueError as exc:
+        msg = "External event bypass must be a valid bypass tier"
+        raise ValueError(msg) from exc
+
+    correlation_id = raw.get("correlation_id")
+    if correlation_id is not None and not isinstance(correlation_id, str):
+        msg = "External event correlation_id must be a string when present"
+        raise ValueError(msg)
+
+    return ExternalEvent(
+        kind=kind,
+        payload=payload,
+        source=source,
+        bypass=bypass_tier,
+        correlation_id=correlation_id,
+    )

--- a/libs/cli/deepagents_cli/event_bus.py
+++ b/libs/cli/deepagents_cli/event_bus.py
@@ -1,23 +1,55 @@
-"""Alpha external event ingress for the Textual CLI app."""
+"""External event ingress for the Textual CLI app.
+
+Exposes a small `EventSource` protocol plus a Unix-domain-socket implementation
+that lets local processes push commands, prompts, and signals into a running
+CLI session over a newline-delimited JSON wire protocol.
+
+!!! warning "Experimental"
+
+    The wire format and configuration env vars may change without semver
+    guarantees while this surface stabilizes.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
 import json
+import logging
 import os
 import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol, get_args
 
 from deepagents_cli.command_registry import BypassTier
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+logger = logging.getLogger(__name__)
+
 ExternalEventKind = Literal["command", "prompt", "signal"]
+"""Top-level event kinds carried by the wire protocol."""
+
+ExternalSignal = Literal["interrupt", "force-clear"]
+"""Closed vocabulary of `kind="signal"` payloads accepted by the listener."""
+
+EventSink = "Callable[[ExternalEvent], Awaitable[None]]"
+"""Type alias for the async callback that receives parsed events."""
+
+_VALID_KINDS: frozenset[str] = frozenset(get_args(ExternalEventKind))
+_VALID_SIGNALS: frozenset[str] = frozenset(get_args(ExternalSignal))
+
+_ACK = b'{"ok":true}\n'
+"""Wire-level acknowledgement returned for an accepted event."""
+
+_MAX_LINE_BYTES = 64 * 1024
+"""Per-line read limit; an oversized line is rejected with a NACK."""
+
+_CLIENT_IDLE_TIMEOUT_SECONDS = 60.0
+"""Maximum idle time on a client connection before the server closes it."""
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -30,9 +62,34 @@ class ExternalEvent:
     bypass: BypassTier = BypassTier.QUEUED
     correlation_id: str | None = None
 
+    def __post_init__(self) -> None:
+        """Validate invariants for direct construction.
+
+        Raises:
+            ValueError: If `kind` is not a known kind, the payload is empty
+                or whitespace-only, or the kind is `"signal"` but the payload
+                is not a recognized signal name.
+        """
+        if self.kind not in _VALID_KINDS:
+            msg = f"Unknown external event kind: {self.kind!r}"
+            raise ValueError(msg)
+        if not self.payload or not self.payload.strip():
+            msg = "External event payload must be a non-empty string"
+            raise ValueError(msg)
+        if self.kind == "signal" and self.payload.strip().lower() not in _VALID_SIGNALS:
+            msg = (
+                f"Unknown external signal: {self.payload!r}; "
+                f"expected one of {sorted(_VALID_SIGNALS)}"
+            )
+            raise ValueError(msg)
+
 
 class EventSource(Protocol):
-    """Source of external events for the CLI app."""
+    """Source of external events for the CLI app.
+
+    Implementations must be safe to `stop()` even when `start()` failed
+    partway through; the app always invokes `stop()` from a `finally` block.
+    """
 
     async def start(
         self,
@@ -44,12 +101,28 @@ class EventSource(Protocol):
             sink: Async callback that receives parsed external events.
         """
 
+    async def serve_forever(self) -> None:
+        """Park until the source is cancelled or its transport dies.
+
+        Implementations should re-raise `CancelledError` and propagate
+        unexpected transport-layer failures so the lifecycle owner can
+        notice and surface them.
+        """
+
     async def stop(self) -> None:
         """Stop forwarding events and release transport resources."""
 
 
 class UnixSocketEventSource:
-    """Line-delimited JSON event source over a local Unix domain socket."""
+    """Line-delimited JSON event source over a local Unix domain socket.
+
+    The listener creates its parent directory with mode `0o700` and binds the
+    socket inside it under a transient `umask(0o077)` so the socket inherits
+    `0o600` from the moment of `bind()`. Stale sockets at the configured path
+    are removed on start, but only after a `stat` confirms the path is a
+    socket — a regular file or directory at that path is left untouched and
+    causes start to fail loudly.
+    """
 
     def __init__(self, path: Path | None = None) -> None:
         """Create a Unix-socket event source.
@@ -66,46 +139,200 @@ class UnixSocketEventSource:
         self,
         sink: Callable[[ExternalEvent], Awaitable[None]],
     ) -> None:
-        """Start listening for newline-delimited JSON events."""
+        """Start listening for newline-delimited JSON events.
+
+        Args:
+            sink: Async callback invoked with each decoded event.
+
+        Raises:
+            RuntimeError: If `start()` has already been called on this
+                instance without a subsequent `stop()`.
+            FileExistsError: If the socket path is occupied by a non-socket
+                filesystem entry.
+            OSError: If the socket cannot be bound (e.g. permission denied,
+                path too long).
+        """  # noqa: DOC502  # FileExistsError/OSError propagate from helpers
+        if self._server is not None:
+            msg = "UnixSocketEventSource is already started"
+            raise RuntimeError(msg)
+
         self._sink = sink
         self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         with contextlib.suppress(FileNotFoundError):
             _unlink_existing_socket(self.path)
-        self._server = await asyncio.start_unix_server(
-            self._handle_client,
-            path=str(self.path),
-        )
-        self.path.chmod(0o600)
+
+        previous_umask = os.umask(0o077)
+        try:
+            self._server = await asyncio.start_unix_server(
+                self._handle_client,
+                path=str(self.path),
+                limit=_MAX_LINE_BYTES,
+            )
+        finally:
+            os.umask(previous_umask)
+
+        # Defense in depth: even if `start_unix_server` somehow ignored the
+        # umask (different libc, mocked socket layer), force-tighten the mode.
+        with contextlib.suppress(OSError):
+            self.path.chmod(0o600)
+        logger.debug("External event listener bound at %s", self.path)
+
+    async def serve_forever(self) -> None:
+        """Park until the underlying server is cancelled or fails.
+
+        `asyncio.start_unix_server` already begins accepting connections,
+        so this delegates to the server's own `serve_forever`. A fatal
+        error inside the accept loop propagates here, letting the
+        lifecycle owner notice and react.
+
+        Raises:
+            RuntimeError: If invoked before `start()`.
+        """
+        if self._server is None:
+            msg = "UnixSocketEventSource.serve_forever called before start()"
+            raise RuntimeError(msg)
+        await self._server.serve_forever()
 
     async def stop(self) -> None:
-        """Close the listener and remove the socket path."""
+        """Close the listener and remove the socket path.
+
+        Idempotent: safe to call after a failed or never-started `start()`.
+        """
         server = self._server
         self._server = None
         if server is not None:
             server.close()
-            await server.wait_closed()
-        with contextlib.suppress(FileNotFoundError, FileExistsError):
+            with contextlib.suppress(Exception):
+                await server.wait_closed()
+        try:
             _unlink_existing_socket(self.path)
+        except FileNotFoundError:
+            pass
+        except FileExistsError as exc:
+            logger.warning(
+                "Leaving non-socket entry at %s during shutdown: %s",
+                self.path,
+                exc,
+            )
+        except OSError as exc:
+            logger.warning("Failed to unlink event socket %s: %s", self.path, exc)
 
     async def _handle_client(
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
+        r"""Read newline-delimited JSON envelopes from one client.
+
+        Each accepted line yields an event to the configured sink and is
+        acked with `{"ok":true}\n` (plus `correlation_id` when present).
+        Rejected lines (oversized, malformed, sink unconfigured, sink
+        raised) are answered with `{"ok":false,"error":...}\n` and the
+        loop continues so a single bad caller cannot kill the connection.
+        """
+        peer = writer.get_extra_info("peername") or "<unknown>"
+        logger.debug("External event client connected: %s", peer)
         try:
-            while line := await reader.readline():
-                event = decode_external_event(line, source=f"unix:{self.path}")
-                if self._sink is not None:
-                    await self._sink(event)
-                writer.write(b'{"ok":true}\n')
-                await writer.drain()
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        reader.readline(),
+                        timeout=_CLIENT_IDLE_TIMEOUT_SECONDS,
+                    )
+                except TimeoutError:
+                    logger.debug("Closing idle external event client %s", peer)
+                    break
+                except (ValueError, asyncio.LimitOverrunError) as exc:
+                    logger.warning("External event line exceeded read limit: %s", exc)
+                    await _write_nack(writer, "line exceeds read limit", None)
+                    break
+
+                if not line:
+                    break
+
+                await self._handle_one_line(line, writer)
+        except (BrokenPipeError, ConnectionResetError) as exc:
+            logger.debug("External event client %s disconnected: %s", peer, exc)
         finally:
             writer.close()
-            await writer.wait_closed()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+            logger.debug("External event client closed: %s", peer)
+
+    async def _handle_one_line(
+        self,
+        line: bytes,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Decode and dispatch one envelope, replying with ACK or NACK."""
+        correlation_id: str | None = None
+        try:
+            event = decode_external_event(line, source=f"unix:{self.path}")
+        except (ValueError, TypeError) as exc:
+            logger.warning("Rejected malformed external event: %s", exc)
+            with contextlib.suppress(ValueError, TypeError, json.JSONDecodeError):
+                parsed = json.loads(line)
+                if isinstance(parsed, dict):
+                    candidate = parsed.get("correlation_id")
+                    if isinstance(candidate, str):
+                        correlation_id = candidate
+            await _write_nack(writer, str(exc), correlation_id)
+            return
+
+        correlation_id = event.correlation_id
+
+        if self._sink is None:
+            logger.warning("External event arrived before sink was set; dropping")
+            await _write_nack(writer, "listener not ready", correlation_id)
+            return
+
+        try:
+            await self._sink(event)
+        except Exception as exc:
+            logger.exception("External event sink raised")
+            await _write_nack(writer, f"sink failed: {exc}", correlation_id)
+            return
+
+        await _write_ack(writer, correlation_id)
+
+
+async def _write_ack(
+    writer: asyncio.StreamWriter,
+    correlation_id: str | None,
+) -> None:
+    """Write the success acknowledgement frame, echoing `correlation_id`."""
+    if correlation_id is None:
+        writer.write(_ACK)
+    else:
+        body = json.dumps({"ok": True, "correlation_id": correlation_id})
+        writer.write(body.encode("utf-8") + b"\n")
+    with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+        await writer.drain()
+
+
+async def _write_nack(
+    writer: asyncio.StreamWriter,
+    error: str,
+    correlation_id: str | None,
+) -> None:
+    """Write a failure response frame; never raises on a closed socket."""
+    body: dict[str, object] = {"ok": False, "error": error}
+    if correlation_id is not None:
+        body["correlation_id"] = correlation_id
+    try:
+        writer.write(json.dumps(body).encode("utf-8") + b"\n")
+        await writer.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        pass
 
 
 def default_unix_socket_path() -> Path:
-    """Return the default per-process Unix socket path."""
+    """Return the default per-process Unix socket path.
+
+    Prefers `XDG_RUNTIME_DIR` (per-user, tmpfs-backed, auto-cleaned on
+    logout) and falls back to the system temp dir when the runtime
+    directory is unset.
+    """
     root = os.environ.get("XDG_RUNTIME_DIR")
     base = Path(root) if root else Path(tempfile.gettempdir())
     return base / "deepagents" / f"events-{os.getpid()}.sock"
@@ -118,8 +345,10 @@ def _unlink_existing_socket(path: Path) -> None:
         path: Candidate socket path to remove.
 
     Raises:
+        FileNotFoundError: If `path` does not exist.
         FileExistsError: If `path` exists but is not a Unix socket.
-    """
+        OSError: If the entry exists but cannot be removed.
+    """  # noqa: DOC502  # FileNotFoundError/OSError propagate from stat/unlink
     info = path.stat(follow_symlinks=False)
     if not stat.S_ISSOCK(info.st_mode):
         msg = f"Refusing to remove non-socket external event path: {path}"
@@ -139,20 +368,21 @@ def decode_external_event(data: bytes, *, source: str) -> ExternalEvent:
 
     Raises:
         TypeError: If the envelope is not a JSON object.
-        ValueError: If the event envelope is invalid.
+        ValueError: If any envelope field is missing, of the wrong type, or
+            otherwise invalid.
     """
     try:
         raw = json.loads(data)
     except json.JSONDecodeError as exc:
-        msg = "External event must be valid JSON"
+        msg = f"External event must be valid JSON: {exc.msg}"
         raise ValueError(msg) from exc
     if not isinstance(raw, dict):
         msg = "External event must be a JSON object"
         raise TypeError(msg)
 
     kind = raw.get("kind")
-    if kind not in {"command", "prompt", "signal"}:
-        msg = "External event kind must be command, prompt, or signal"
+    if kind not in _VALID_KINDS:
+        msg = f"External event kind must be one of {sorted(_VALID_KINDS)}; got {kind!r}"
         raise ValueError(msg)
 
     payload = raw.get("payload")
@@ -164,7 +394,7 @@ def decode_external_event(data: bytes, *, source: str) -> ExternalEvent:
     try:
         bypass_tier = BypassTier(bypass)
     except ValueError as exc:
-        msg = "External event bypass must be a valid bypass tier"
+        msg = f"External event bypass must be a valid bypass tier: {exc}"
         raise ValueError(msg) from exc
 
     correlation_id = raw.get("correlation_id")

--- a/libs/cli/tests/unit_tests/conftest.py
+++ b/libs/cli/tests/unit_tests/conftest.py
@@ -66,6 +66,13 @@ def _clear_onboarding_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _clear_external_event_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent local alpha event-listener env vars from affecting tests."""
+    monkeypatch.delenv("DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET_PATH", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _register_theme_variables(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make app-specific CSS variables available to all test `App` instances.
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -36,10 +36,12 @@ from deepagents_cli.app import (
     _TYPING_IDLE_THRESHOLD_SECONDS,
     DeepAgentsApp,
     DeferredAction,
+    ExternalInput,
     QueuedMessage,
     TextualSessionState,
     _write_iterm_escape,
 )
+from deepagents_cli.event_bus import ExternalEvent
 from deepagents_cli.widgets.chat_input import ChatInput
 from deepagents_cli.widgets.launch_init import LaunchNameScreen
 from deepagents_cli.widgets.messages import (
@@ -3925,6 +3927,60 @@ class TestSlashCommandBypass:
 
             exit_mock.assert_called_once()
             assert len(app._pending_messages) == 0
+
+    async def test_force_clear_bypasses_queue_when_agent_running(self) -> None:
+        """/force-clear should process immediately when agent is running."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            with patch.object(app, "_process_message", new_callable=AsyncMock) as pm:
+                app.post_message(ChatInput.Submitted("/force-clear", "command"))
+                await pilot.pause()
+
+            pm.assert_called_once_with("/force-clear", "command")
+            assert len(app._pending_messages) == 0
+
+    async def test_external_command_uses_same_bypass_policy(self) -> None:
+        """External command events should route through normal command policy."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            with patch.object(app, "_process_message", new_callable=AsyncMock) as pm:
+                app.post_message(
+                    ExternalInput(
+                        ExternalEvent(
+                            kind="command",
+                            payload="/force-clear",
+                            source="test",
+                        )
+                    )
+                )
+                await pilot.pause()
+
+            pm.assert_called_once_with("/force-clear", "command")
+            assert len(app._pending_messages) == 0
+
+    async def test_external_prompt_queues_when_agent_running(self) -> None:
+        """External prompt events should queue while the agent is busy."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            app.post_message(
+                ExternalInput(
+                    ExternalEvent(kind="prompt", payload="next task", source="test")
+                )
+            )
+            await pilot.pause()
+
+            assert list(app._pending_messages) == [
+                QueuedMessage(text="next task", mode="normal")
+            ]
 
     async def test_version_executes_during_connecting(self) -> None:
         """/version should process immediately when only connecting."""

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -6934,3 +6934,197 @@ class TestHeaderAndTitle:
         async with app.run_test() as pilot:
             await pilot.pause()
             assert not app.query(Header)
+
+
+class TestHandleExternalSignal:
+    """Verify routing of `kind=signal` external events."""
+
+    async def test_interrupt_calls_action_interrupt(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with patch.object(app, "action_interrupt") as action:
+                await app._handle_external_signal("interrupt")
+            action.assert_called_once_with()
+
+    async def test_force_clear_routes_to_command_with_force_bypass(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with patch.object(app, "_submit_input", new_callable=AsyncMock) as submit:
+                await app._handle_external_signal("force-clear")
+            submit.assert_called_once_with("/force-clear", "command", force_bypass=True)
+
+    async def test_unknown_signal_is_no_op(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch.object(app, "action_interrupt") as action,
+                patch.object(app, "_submit_input", new_callable=AsyncMock) as submit,
+            ):
+                # Bypasses ExternalEvent's __post_init__ guard which would
+                # otherwise reject this payload at the wire boundary.
+                await app._handle_external_signal("intrupt")
+            action.assert_not_called()
+            submit.assert_not_called()
+
+
+class TestExternalEventEnvGating:
+    """`_maybe_start_external_event_source` env-var contract."""
+
+    async def test_off_by_default(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._external_event_source is None
+            assert app._external_event_source_task is None
+
+    async def test_falsy_value_does_not_start(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET", "0")
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._external_event_source is None
+
+    async def test_truthy_value_starts_listener(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import shutil
+        import tempfile
+
+        # Use short-path tmp to avoid AF_UNIX path-length limit on macOS.
+        socket_dir = tempfile.mkdtemp(dir="/tmp")
+        try:
+            monkeypatch.setenv("DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET", "1")
+            monkeypatch.setenv(
+                "DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET_PATH",
+                f"{socket_dir}/events.sock",
+            )
+            app = DeepAgentsApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._external_event_source is not None
+                assert app._external_event_source_task is not None
+        finally:
+            shutil.rmtree(socket_dir, ignore_errors=True)
+        del tmp_path
+
+    async def test_socket_file_removed_on_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import shutil
+        import tempfile
+        from pathlib import Path as _Path
+
+        socket_dir = tempfile.mkdtemp(dir="/tmp")
+        socket_path = _Path(socket_dir) / "events.sock"
+        try:
+            monkeypatch.setenv("DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET", "1")
+            monkeypatch.setenv(
+                "DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET_PATH",
+                str(socket_path),
+            )
+            app = DeepAgentsApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                for _ in range(50):
+                    if socket_path.exists():
+                        break
+                    await asyncio.sleep(0.01)
+                assert socket_path.exists()
+                app.exit()
+                await pilot.pause()
+            assert not socket_path.exists()
+        finally:
+            shutil.rmtree(socket_dir, ignore_errors=True)
+
+
+class TestForceInterruptActiveWork:
+    """Verify `_force_interrupt_active_work` cancels in-flight work."""
+
+    async def test_cancels_agent_worker(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            worker = MagicMock()
+            app._agent_worker = worker
+            app._force_interrupt_active_work()
+            worker.cancel.assert_called_once()
+
+    async def test_cancels_shell_worker(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._shell_running = True
+            worker = MagicMock()
+            app._shell_worker = worker
+            app._force_interrupt_active_work()
+            worker.cancel.assert_called_once()
+
+    async def test_rejects_pending_approval(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            widget = MagicMock()
+            app._pending_approval_widget = widget
+            app._force_interrupt_active_work()
+            widget.action_select_reject.assert_called_once()
+
+    async def test_cancels_pending_ask_user(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            widget = MagicMock()
+            app._pending_ask_user_widget = widget
+            app._force_interrupt_active_work()
+            widget.action_cancel.assert_called_once()
+
+    async def test_drops_queued_messages(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_messages.append(QueuedMessage(text="x", mode="normal"))
+            app._force_interrupt_active_work()
+            assert len(app._pending_messages) == 0
+
+    async def test_widget_failure_is_logged_not_raised(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            widget = MagicMock()
+            widget.action_select_reject.side_effect = AttributeError("boom")
+            app._pending_approval_widget = widget
+            # Must not raise: best-effort interruption.
+            app._force_interrupt_active_work()
+
+
+class TestExternalBypassFieldHonored:
+    """`event.bypass` overrides queue when set on a prompt event."""
+
+    async def test_prompt_with_bypass_skips_queue(self) -> None:
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            with patch.object(app, "_process_message", new_callable=AsyncMock) as pm:
+                app.post_message(
+                    ExternalInput(
+                        ExternalEvent(
+                            kind="prompt",
+                            payload="urgent",
+                            source="test",
+                            bypass=BypassTier.ALWAYS,
+                        )
+                    )
+                )
+                await pilot.pause()
+            pm.assert_called_once_with("urgent", "normal")
+            assert len(app._pending_messages) == 0
+
+
+# Local import for BypassTier in TestExternalBypassFieldHonored.
+from deepagents_cli.command_registry import BypassTier  # noqa: E402

--- a/libs/cli/tests/unit_tests/test_event_bus.py
+++ b/libs/cli/tests/unit_tests/test_event_bus.py
@@ -1,8 +1,10 @@
-"""Unit tests for alpha external event ingress."""
+"""Unit tests for the external event ingress."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 import socket
 import tempfile
 from pathlib import Path
@@ -11,47 +13,152 @@ import pytest
 
 from deepagents_cli.command_registry import BypassTier
 from deepagents_cli.event_bus import (
+    _MAX_LINE_BYTES,
     ExternalEvent,
     UnixSocketEventSource,
     decode_external_event,
+    default_unix_socket_path,
 )
+
+# Unix socket paths are capped at ~104 bytes on macOS / ~108 on Linux. Pytest's
+# default `tmp_path` lives under `/var/folders/...` on macOS which routinely
+# exceeds that limit. The helper below binds the socket inside a short-path
+# temp dir while still letting the test's other artifacts use `tmp_path`.
+_SHORT_TMP_ROOT = "/tmp"  # short path required for AF_UNIX limit
+
+
+def _short_tmp_dir() -> tempfile.TemporaryDirectory[str]:
+    return tempfile.TemporaryDirectory(dir=_SHORT_TMP_ROOT)
+
+
+class TestExternalEventInvariants:
+    """Direct construction must enforce envelope invariants."""
+
+    def test_rejects_unknown_kind(self) -> None:
+        with pytest.raises(ValueError, match="Unknown external event kind"):
+            ExternalEvent(kind="reboot", payload="x", source="t")  # type: ignore[arg-type]
+
+    def test_rejects_empty_payload(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ExternalEvent(kind="prompt", payload="   ", source="t")
+
+    def test_rejects_unknown_signal_payload(self) -> None:
+        with pytest.raises(ValueError, match="Unknown external signal"):
+            ExternalEvent(kind="signal", payload="reboot", source="t")
+
+    def test_accepts_known_signal(self) -> None:
+        event = ExternalEvent(kind="signal", payload="interrupt", source="t")
+        assert event.payload == "interrupt"
+
+    def test_accepts_force_clear_signal(self) -> None:
+        event = ExternalEvent(kind="signal", payload="force-clear", source="t")
+        assert event.payload == "force-clear"
 
 
 class TestDecodeExternalEvent:
     """Validate the JSON-lines external event envelope."""
 
     def test_decodes_command_event(self) -> None:
-        """Command events should parse into typed external events."""
         event = decode_external_event(
             b'{"kind":"command","payload":"/force-clear","bypass":"always"}\n',
             source="test",
         )
-
         assert event.kind == "command"
         assert event.payload == "/force-clear"
         assert event.bypass is BypassTier.ALWAYS
         assert event.source == "test"
+        assert event.correlation_id is None
+
+    def test_decodes_correlation_id_round_trip(self) -> None:
+        event = decode_external_event(
+            b'{"kind":"prompt","payload":"hi","correlation_id":"req-1"}\n',
+            source="test",
+        )
+        assert event.correlation_id == "req-1"
+
+    def test_rejects_invalid_json(self) -> None:
+        with pytest.raises(ValueError, match="valid JSON"):
+            decode_external_event(b"not json\n", source="t")
+
+    def test_rejects_json_array(self) -> None:
+        with pytest.raises(TypeError, match="JSON object"):
+            decode_external_event(b"[1, 2, 3]\n", source="t")
+
+    def test_rejects_missing_kind(self) -> None:
+        with pytest.raises(ValueError, match="kind must be one of"):
+            decode_external_event(b'{"payload":"x"}\n', source="t")
+
+    def test_rejects_unknown_kind(self) -> None:
+        with pytest.raises(ValueError, match="kind must be one of"):
+            decode_external_event(b'{"kind":"reboot","payload":"x"}\n', source="t")
+
+    def test_rejects_non_string_payload(self) -> None:
+        with pytest.raises(ValueError, match="payload"):
+            decode_external_event(b'{"kind":"prompt","payload":123}\n', source="t")
 
     def test_rejects_empty_payload(self) -> None:
-        """Payload must contain command or prompt text."""
         with pytest.raises(ValueError, match="payload"):
-            decode_external_event(b'{"kind":"prompt","payload":" "}\n', source="test")
+            decode_external_event(b'{"kind":"prompt","payload":" "}\n', source="t")
+
+    def test_rejects_invalid_bypass(self) -> None:
+        with pytest.raises(ValueError, match="bypass"):
+            decode_external_event(
+                b'{"kind":"prompt","payload":"x","bypass":"nope"}\n',
+                source="t",
+            )
+
+    def test_rejects_non_string_correlation_id(self) -> None:
+        with pytest.raises(ValueError, match="correlation_id"):
+            decode_external_event(
+                b'{"kind":"prompt","payload":"x","correlation_id":42}\n',
+                source="t",
+            )
+
+    def test_rejects_unknown_signal_payload(self) -> None:
+        with pytest.raises(ValueError, match="Unknown external signal"):
+            decode_external_event(
+                b'{"kind":"signal","payload":"reboot"}\n',
+                source="t",
+            )
+
+    def test_accepts_known_signal(self) -> None:
+        event = decode_external_event(
+            b'{"kind":"signal","payload":"interrupt"}\n',
+            source="t",
+        )
+        assert event.kind == "signal"
+        assert event.payload == "interrupt"
+
+
+class TestDefaultUnixSocketPath:
+    """`default_unix_socket_path` resolution."""
+
+    def test_uses_xdg_runtime_dir_when_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        path = default_unix_socket_path()
+        assert path.parent == tmp_path / "deepagents"
+        assert path.name == f"events-{os.getpid()}.sock"
+
+    def test_falls_back_to_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        path = default_unix_socket_path()
+        assert path.parent.name == "deepagents"
+        assert path.parent.parent == Path(tempfile.gettempdir())
 
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="requires Unix sockets")
 class TestUnixSocketEventSource:
-    """Exercise the alpha local socket source."""
+    """Exercise the local socket source end-to-end."""
 
-    async def test_forwards_json_lines_to_sink(self, tmp_path: Path) -> None:
-        """Events sent over the socket should reach the configured sink."""
-        del tmp_path
-        tmp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+    async def test_forwards_json_lines_to_sink(self) -> None:
+        tmp_dir = _short_tmp_dir()
         path = Path(tmp_dir.name) / "events.sock"
         source = UnixSocketEventSource(path)
         received: list[ExternalEvent] = []
 
-        async def sink(event: ExternalEvent) -> None:
-            await asyncio.sleep(0)
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
             received.append(event)
 
         await source.start(sink)
@@ -69,20 +176,270 @@ class TestUnixSocketEventSource:
             tmp_dir.cleanup()
 
         assert response == b'{"ok":true}\n'
-        assert [event.payload for event in received] == ["/force-clear"]
+        assert [e.payload for e in received] == ["/force-clear"]
         assert not path.exists()
 
+    async def test_socket_has_restrictive_permissions(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+
+        await source.start(sink)
+        try:
+            mode = path.stat().st_mode & 0o777
+            assert mode == 0o600, f"socket mode is {oct(mode)}, expected 0o600"
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+    async def test_echoes_correlation_id_in_ack(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            writer.write(b'{"kind":"prompt","payload":"hi","correlation_id":"req-7"}\n')
+            await writer.drain()
+            response = json.loads(await reader.readline())
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert response == {"ok": True, "correlation_id": "req-7"}
+
+    async def test_nacks_malformed_envelope_and_keeps_listening(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+        received: list[ExternalEvent] = []
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            received.append(event)
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            writer.write(b"not json\n")
+            await writer.drain()
+            nack = json.loads(await reader.readline())
+            assert nack["ok"] is False
+            assert "JSON" in nack["error"]
+
+            writer.write(b'{"kind":"prompt","payload":"valid"}\n')
+            await writer.drain()
+            ack = json.loads(await reader.readline())
+            assert ack == {"ok": True}
+
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert [e.payload for e in received] == ["valid"]
+
+    async def test_nack_includes_correlation_id_when_present(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            writer.write(b'{"kind":"reboot","payload":"x","correlation_id":"r-9"}\n')
+            await writer.drain()
+            nack = json.loads(await reader.readline())
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert nack["ok"] is False
+        assert nack["correlation_id"] == "r-9"
+
+    async def test_sink_failure_responds_with_nack(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            writer.write(b'{"kind":"prompt","payload":"x"}\n')
+            await writer.drain()
+            response = json.loads(await reader.readline())
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert response["ok"] is False
+        assert "boom" in response["error"]
+
+    async def test_oversized_line_responds_with_nack(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+        received: list[ExternalEvent] = []
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            received.append(event)
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            writer.write(b"x" * (_MAX_LINE_BYTES + 1) + b"\n")
+            await writer.drain()
+            response = json.loads(await reader.readline())
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert response == {"ok": False, "error": "line exceeds read limit"}
+        assert received == []
+
+    async def test_handles_multiple_events_per_connection(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+        received: list[str] = []
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            received.append(event.payload)
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            for payload in ("first", "second", "third"):
+                writer.write(
+                    json.dumps({"kind": "prompt", "payload": payload}).encode() + b"\n"
+                )
+                await writer.drain()
+                ack = json.loads(await reader.readline())
+                assert ack["ok"] is True
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert received == ["first", "second", "third"]
+
+    async def test_handles_concurrent_clients(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+        received: list[str] = []
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            received.append(event.payload)
+
+        await source.start(sink)
+
+        async def send(payload: str) -> dict[str, object]:
+            r, w = await asyncio.open_unix_connection(str(path))
+            w.write(json.dumps({"kind": "prompt", "payload": payload}).encode() + b"\n")
+            await w.drain()
+            ack = json.loads(await r.readline())
+            w.close()
+            await w.wait_closed()
+            return ack
+
+        try:
+            results = await asyncio.gather(send("a"), send("b"), send("c"))
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert all(r["ok"] is True for r in results)
+        assert sorted(received) == ["a", "b", "c"]
+
+    async def test_recovers_from_stale_socket_file(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        # Pre-create a real socket at the path to simulate a previous crash.
+        stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            stale.bind(str(path))
+        finally:
+            stale.close()
+
+        assert path.exists()
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+
+        try:
+            await source.start(sink)
+            assert path.exists()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
     async def test_start_refuses_existing_regular_file(self, tmp_path: Path) -> None:
-        """Startup must not delete a non-socket file at the configured path."""
         path = tmp_path / "events.sock"
         path.write_text("do not delete")
         source = UnixSocketEventSource(path)
 
-        async def sink(event: ExternalEvent) -> None:
-            await asyncio.sleep(0)
-            raise AssertionError(event)
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+            msg = "should not reach sink"
+            raise AssertionError(msg)
 
         with pytest.raises(FileExistsError, match="non-socket"):
             await source.start(sink)
 
         assert path.read_text() == "do not delete"
+
+    async def test_start_twice_raises(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:  # noqa: RUF029
+            del event
+
+        await source.start(sink)
+        try:
+            with pytest.raises(RuntimeError, match="already started"):
+                await source.start(sink)
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+    async def test_stop_is_idempotent_without_start(self, tmp_path: Path) -> None:
+        source = UnixSocketEventSource(tmp_path / "events.sock")
+        await source.stop()
+        await source.stop()  # second call must not raise
+
+    async def test_serve_forever_requires_start(self) -> None:
+        tmp_dir = _short_tmp_dir()
+        source = UnixSocketEventSource(Path(tmp_dir.name) / "events.sock")
+        try:
+            with pytest.raises(RuntimeError, match="before start"):
+                await source.serve_forever()
+        finally:
+            tmp_dir.cleanup()

--- a/libs/cli/tests/unit_tests/test_event_bus.py
+++ b/libs/cli/tests/unit_tests/test_event_bus.py
@@ -1,0 +1,88 @@
+"""Unit tests for alpha external event ingress."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from deepagents_cli.command_registry import BypassTier
+from deepagents_cli.event_bus import (
+    ExternalEvent,
+    UnixSocketEventSource,
+    decode_external_event,
+)
+
+
+class TestDecodeExternalEvent:
+    """Validate the JSON-lines external event envelope."""
+
+    def test_decodes_command_event(self) -> None:
+        """Command events should parse into typed external events."""
+        event = decode_external_event(
+            b'{"kind":"command","payload":"/force-clear","bypass":"always"}\n',
+            source="test",
+        )
+
+        assert event.kind == "command"
+        assert event.payload == "/force-clear"
+        assert event.bypass is BypassTier.ALWAYS
+        assert event.source == "test"
+
+    def test_rejects_empty_payload(self) -> None:
+        """Payload must contain command or prompt text."""
+        with pytest.raises(ValueError, match="payload"):
+            decode_external_event(b'{"kind":"prompt","payload":" "}\n', source="test")
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="requires Unix sockets")
+class TestUnixSocketEventSource:
+    """Exercise the alpha local socket source."""
+
+    async def test_forwards_json_lines_to_sink(self, tmp_path: Path) -> None:
+        """Events sent over the socket should reach the configured sink."""
+        del tmp_path
+        tmp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+        path = Path(tmp_dir.name) / "events.sock"
+        source = UnixSocketEventSource(path)
+        received: list[ExternalEvent] = []
+
+        async def sink(event: ExternalEvent) -> None:
+            await asyncio.sleep(0)
+            received.append(event)
+
+        await source.start(sink)
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(path))
+            writer.write(b'{"kind":"command","payload":"/force-clear"}\n')
+            await writer.drain()
+
+            response = await reader.readline()
+
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            await source.stop()
+            tmp_dir.cleanup()
+
+        assert response == b'{"ok":true}\n'
+        assert [event.payload for event in received] == ["/force-clear"]
+        assert not path.exists()
+
+    async def test_start_refuses_existing_regular_file(self, tmp_path: Path) -> None:
+        """Startup must not delete a non-socket file at the configured path."""
+        path = tmp_path / "events.sock"
+        path.write_text("do not delete")
+        source = UnixSocketEventSource(path)
+
+        async def sink(event: ExternalEvent) -> None:
+            await asyncio.sleep(0)
+            raise AssertionError(event)
+
+        with pytest.raises(FileExistsError, match="non-socket"):
+            await source.start(sink)
+
+        assert path.read_text() == "do not delete"


### PR DESCRIPTION
> [!WARNING]
> This feature is in alpha. Do not rely on it in production code as its signature and behavior may change (including removal.

Adds an alpha local Unix-socket ingress path so external processes can submit prompts, commands, and signals to a running CLI session, and introduces `/force-clear` as an always-immediate command that interrupts active work before clearing the chat.

## Changes
- **New `event_bus` module** with `ExternalEvent` dataclass, `EventSource` protocol, and `UnixSocketEventSource` — a line-delimited JSON server over a Unix domain socket. Supports `command`, `prompt`, and `signal` event kinds with optional `bypass` tier and `correlation_id`. Gated behind `DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET` and `DEEPAGENTS_CLI_EXTERNAL_EVENT_SOCKET_PATH` env vars.
- **`/force-clear` slash command** (always-immediate bypass tier) that calls `_force_interrupt_active_work()` to cancel any in-flight agent/shell worker and dismiss pending approval/ask-user widgets before clearing the UI — unlike `/clear` which only clears the message queue.
- **Refactored input submission** into `_submit_input()` shared by both `on_chat_input_submitted` and the new `on_external_input` handler, so external events and interactive input follow the same bypass/queue policy.
- **Signal handling** via `on_external_input`: `interrupt` dispatches `action_interrupt()`, `force-clear` routes to the `/force-clear` path, and unknown signals are logged.