### PR TITLE
feat(quickjs): propagate return types

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_format.py
+++ b/libs/partners/quickjs/langchain_quickjs/_format.py
@@ -82,6 +82,56 @@ def coerce_tool_output(value: Any) -> str:
     return _coerce_message_content(value)
 
 
+# Types the quickjs_rs binding marshals natively from Python to JS without
+# information loss. Anything else gets JSON-encoded so the JS side at least
+# sees a stable string (rather than a Python repr).
+_NATIVE_JS_TYPES = (str, bool, int, float, type(None), list, dict)
+
+
+def coerce_tool_output_for_ptc(value: Any) -> Any:
+    """Coerce a tool result for the PTC bridge, preserving native types.
+
+    The quickjs_rs ``register`` bridge marshals Python primitives, ``list``,
+    and ``dict`` directly to native JS values, so the model can use them
+    without an explicit ``JSON.parse``. This helper unwraps LangChain's
+    ``ToolMessage`` / ``Command`` envelopes (matching ``coerce_tool_output``'s
+    selection rules) and returns the underlying value typed.
+
+    For values the binding cannot marshal natively (Pydantic models, custom
+    classes, etc.), fall back to a JSON-encoded string so the JS side still
+    receives a usable representation.
+    """
+    if isinstance(value, Command):
+        return coerce_tool_output_for_ptc(_extract_command_content(value))
+    if isinstance(value, ToolMessage):
+        return coerce_tool_output_for_ptc(value.content)
+    if isinstance(value, list):
+        for entry in reversed(value):
+            if isinstance(entry, ToolMessage):
+                return coerce_tool_output_for_ptc(entry.content)
+            if isinstance(entry, Command):
+                return coerce_tool_output_for_ptc(_extract_command_content(entry))
+    if isinstance(value, _NATIVE_JS_TYPES):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _extract_command_content(command: Command) -> Any:
+    """Return the trailing message content from a ``Command`` update, if any."""
+    update = command.update
+    if isinstance(update, dict):
+        messages = update.get("messages")
+        if isinstance(messages, list):
+            for entry in reversed(messages):
+                content = getattr(entry, "content", None)
+                if content is not None:
+                    return content
+    return str(update)
+
+
 def _coerce_message_content(content: Any) -> str:
     if isinstance(content, str):
         return content

--- a/libs/partners/quickjs/langchain_quickjs/_format.py
+++ b/libs/partners/quickjs/langchain_quickjs/_format.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
+from pydantic import BaseModel
 from quickjs_rs import UNDEFINED
 
 if TYPE_CHECKING:
@@ -126,6 +127,11 @@ def _coerce_for_marshal(value: Any) -> Any:
         return {str(k): _coerce_for_marshal(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_coerce_for_marshal(v) for v in value]
+    # Pydantic models are dumped to a plain dict so the JS side sees the
+    # field shape its return-type signature advertises (rather than
+    # ``str(model)``). Nested models / datetimes are handled by recursion.
+    if isinstance(value, BaseModel):
+        return _coerce_for_marshal(value.model_dump())
     return str(value)
 
 

--- a/libs/partners/quickjs/langchain_quickjs/_format.py
+++ b/libs/partners/quickjs/langchain_quickjs/_format.py
@@ -82,10 +82,11 @@ def coerce_tool_output(value: Any) -> str:
     return _coerce_message_content(value)
 
 
-# Types the quickjs_rs binding marshals natively from Python to JS without
-# information loss. Anything else gets JSON-encoded so the JS side at least
-# sees a stable string (rather than a Python repr).
-_NATIVE_JS_TYPES = (str, bool, int, float, type(None), list, dict)
+# Scalar types the quickjs_rs binding marshals natively. Compound shapes
+# (``dict`` / ``list`` / ``tuple``) are walked recursively in
+# ``_coerce_for_marshal``; anything else becomes ``str(value)`` so the JS
+# side can still see a usable value.
+_NATIVE_JS_SCALARS = (str, bool, int, float, type(None))
 
 
 def coerce_tool_output_for_ptc(value: Any) -> Any:
@@ -97,9 +98,12 @@ def coerce_tool_output_for_ptc(value: Any) -> Any:
     ``ToolMessage`` / ``Command`` envelopes (matching ``coerce_tool_output``'s
     selection rules) and returns the underlying value typed.
 
-    For values the binding cannot marshal natively (Pydantic models, custom
-    classes, etc.), fall back to a JSON-encoded string so the JS side still
-    receives a usable representation.
+    Compound returns are walked recursively: nested values that the binding
+    cannot marshal natively (``datetime``, Pydantic models, custom classes)
+    are stringified in place via ``str(value)`` so the surrounding object
+    structure remains navigable from JS. Cyclic structures hit Python's
+    recursion limit and surface as a host error in the eval — same outcome
+    as ``json.dumps`` on a self-referencing dict.
     """
     if isinstance(value, Command):
         return coerce_tool_output_for_ptc(_extract_command_content(value))
@@ -111,12 +115,18 @@ def coerce_tool_output_for_ptc(value: Any) -> Any:
                 return coerce_tool_output_for_ptc(entry.content)
             if isinstance(entry, Command):
                 return coerce_tool_output_for_ptc(_extract_command_content(entry))
-    if isinstance(value, _NATIVE_JS_TYPES):
+    return _coerce_for_marshal(value)
+
+
+def _coerce_for_marshal(value: Any) -> Any:
+    """Convert *value* into a shape the quickjs_rs bridge can marshal."""
+    if isinstance(value, _NATIVE_JS_SCALARS):
         return value
-    try:
-        return json.dumps(value, default=str)
-    except (TypeError, ValueError):
-        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _coerce_for_marshal(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_coerce_for_marshal(v) for v in value]
+    return str(value)
 
 
 def _extract_command_content(command: Command) -> Any:

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -84,8 +84,10 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
         "### API Reference — `tools` namespace\n\n"
         "The agent tools listed below are exposed on the global object at "
         "`globalThis.tools` (also reachable as `tools`). Each takes a single "
-        "object argument and returns a Promise that resolves to a string "
-        "(structured return values are JSON-serialized).\n\n"
+        "object argument and returns a Promise that resolves to the tool's "
+        "native value: strings as strings, numbers as numbers, lists as "
+        "arrays, dicts as objects, and `None` as `null`. You do NOT need to "
+        "`JSON.parse` results — they are already typed.\n\n"
         "Invocation pattern: `await tools.<name>({ ... })`.\n\n"
         "- Use `await` to get tool results; combine with `Promise.all` for "
         "independent calls so they run concurrently.\n"
@@ -107,8 +109,8 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
         "model reasoning or user input.\n\n"
         "Example shape — substitute real tool names:\n\n"
         "```typescript\n"
-        'const usersJson = await tools.findUsers({ name: "Ada" });\n'
-        "const userId = JSON.parse(usersJson)[0].id;\n"
+        'const users = await tools.findUsers({ name: "Ada" });\n'
+        "const userId = users[0].id;\n"
         "const [city, normalized] = await Promise.all([\n"
         "  tools.cityForUser({ user_id: userId }),\n"
         '  tools.normalize({ name: "Ada" }),\n'
@@ -135,7 +137,7 @@ def _safe_json_schema(tool: BaseTool) -> dict[str, Any] | None:
 
 def _render_signature(fn_name: str, schema: dict[str, Any] | None) -> str:
     default_signature = f"async function {fn_name}"
-    default_signature += "(input: Record<string, unknown>): Promise<string>"
+    default_signature += "(input: Record<string, unknown>): Promise<unknown>"
     if not schema or not isinstance(schema.get("properties"), dict):
         return default_signature
     props: dict[str, Any] = schema["properties"]
@@ -150,7 +152,7 @@ def _render_signature(fn_name: str, schema: dict[str, Any] | None) -> str:
     body = "\n".join(fields) if fields else ""
     if not body:
         return default_signature
-    return f"async function {fn_name}(input: {{\n{body}\n}}): Promise<string>"
+    return f"async function {fn_name}(input: {{\n{body}\n}}): Promise<unknown>"
 
 
 def _json_schema_to_ts(prop: dict[str, Any]) -> str:

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -65,7 +65,7 @@ def is_valid_ptc_tool_name(name: str) -> bool:
     return is_valid_js_identifier(to_camel_case(name))
 
 
-def render_ptc_prompt(tools: Sequence[BaseTool]) -> str:
+def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> str:
     """Build the `tools` namespace section of the system prompt."""
     if not tools:
         return ""
@@ -83,10 +83,38 @@ def render_ptc_prompt(tools: Sequence[BaseTool]) -> str:
         "\n\n"
         "### API Reference — `tools` namespace\n\n"
         "The agent tools listed below are exposed on the global object at "
-        "`globalThis.tools` (also reachable as `tools`). Each takes a single object "
-        "argument and returns a Promise that resolves to a string.\n\n"
-        "Invocation pattern: `await tools.<name>({ ... })`).\n\n"
-        "Use `await`; combine with `Promise.all` for concurrent calls.\n\n"
+        "`globalThis.tools` (also reachable as `tools`). Each takes a single "
+        "object argument and returns a Promise that resolves to a string "
+        "(structured return values are JSON-serialized).\n\n"
+        "Invocation pattern: `await tools.<name>({ ... })`.\n\n"
+        "- Use `await` to get tool results; combine with `Promise.all` for "
+        "independent calls so they run concurrently.\n"
+        f"- If the task needs multiple tool calls, prefer one `{tool_name}` "
+        "invocation that performs all of them rather than splitting the work "
+        f"across multiple `{tool_name}` calls — each round-trip costs a model "
+        "turn.\n"
+        "- Pipeline dependent calls within a single program. If a result from "
+        "one tool is needed as input to a later tool, chain them in one "
+        "program instead of returning the intermediate value to the model.\n"
+        "- If a tool returns an ID or other value that can be passed directly "
+        "into the next tool, trust it and chain the calls instead of stopping "
+        "to double-check it.\n"
+        "- To inspect an intermediate value, `console.log` it inside the same "
+        "program; otherwise, fetch as much information as possible in one "
+        "call.\n"
+        f"- Only split work across multiple `{tool_name}` invocations when "
+        "you genuinely cannot determine what to do next without additional "
+        "model reasoning or user input.\n\n"
+        "Example shape — substitute real tool names:\n\n"
+        "```typescript\n"
+        'const usersJson = await tools.findUsers({ name: "Ada" });\n'
+        "const userId = JSON.parse(usersJson)[0].id;\n"
+        "const [city, normalized] = await Promise.all([\n"
+        "  tools.cityForUser({ user_id: userId }),\n"
+        '  tools.normalize({ name: "Ada" }),\n'
+        "]);\n"
+        "console.log({ city, normalized });\n"
+        "```\n\n"
         "```typescript\n"
         f"{body}\n"
         "```"

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import contextlib
+import inspect
 import json
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin, get_type_hints
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from langchain_core.tools import BaseTool
-
 
 _CAMEL_SEP = re.compile(r"[-_]([a-z])")
 _JS_IDENTIFIER = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
@@ -73,12 +74,22 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
     for tool in tools:
         camel = to_camel_case(tool.name)
         schema = _safe_json_schema(tool)
-        signature = _render_signature(camel, schema)
+        return_type = _render_return_type(tool)
+        signature = _render_signature(camel, schema, return_type=return_type)
         description = (
             (tool.description or "").strip().splitlines()[0] if tool.description else ""
         )
         blocks.append(f"/** {description} */\n{signature}")
     body = "\n\n".join(blocks)
+    referenced_types = _collect_referenced_typed_dicts(tools)
+    referenced_block = ""
+    if referenced_types:
+        type_definitions = "\n\n".join(
+            _render_typed_dict_definition(t) for t in referenced_types
+        )
+        referenced_block = (
+            f"\n\nReferenced types:\n\n```typescript\n{type_definitions}\n```"
+        )
     return (
         "\n\n"
         "### API Reference — `tools` namespace\n\n"
@@ -120,6 +131,7 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
         "```typescript\n"
         f"{body}\n"
         "```"
+        f"{referenced_block}"
     )
 
 
@@ -135,9 +147,16 @@ def _safe_json_schema(tool: BaseTool) -> dict[str, Any] | None:
     return None
 
 
-def _render_signature(fn_name: str, schema: dict[str, Any] | None) -> str:
-    default_signature = f"async function {fn_name}"
-    default_signature += "(input: Record<string, unknown>): Promise<unknown>"
+def _render_signature(
+    fn_name: str,
+    schema: dict[str, Any] | None,
+    *,
+    return_type: str = "unknown",
+) -> str:
+    return_clause = f"Promise<{return_type}>"
+    default_signature = (
+        f"async function {fn_name}(input: Record<string, unknown>): {return_clause}"
+    )
     if not schema or not isinstance(schema.get("properties"), dict):
         return default_signature
     props: dict[str, Any] = schema["properties"]
@@ -152,7 +171,152 @@ def _render_signature(fn_name: str, schema: dict[str, Any] | None) -> str:
     body = "\n".join(fields) if fields else ""
     if not body:
         return default_signature
-    return f"async function {fn_name}(input: {{\n{body}\n}}): Promise<unknown>"
+    return f"async function {fn_name}(input: {{\n{body}\n}}): {return_clause}"
+
+
+# ---------------------------------------------------------------------------
+# Return-type rendering
+#
+# Inputs come from the tool's args_schema (Pydantic JSON Schema) so we get
+# Field descriptions and required/optional handling. Return types do NOT have
+# a JSON Schema source — only the function's Python annotation — so we render
+# them directly. Intentionally narrow scope: primitives, list[T], dict[str, V],
+# Optional[T], Literal[...], TypedDict (via referenced-type block), and bare
+# class names. Anything richer (Union, generics, BaseModel field expansion)
+# renders as ``unknown``.
+# ---------------------------------------------------------------------------
+
+
+def _is_typed_dict(annotation: Any) -> bool:
+    return (
+        isinstance(annotation, type)
+        and hasattr(annotation, "__annotations__")
+        and hasattr(annotation, "__required_keys__")
+    )
+
+
+def _is_optional_union(origin: Any, args: tuple[Any, ...]) -> bool:
+    """Return whether *origin*/*args* describe ``T | None`` exactly."""
+    origin_name = getattr(origin, "__name__", None)
+    if origin_name not in {"Union", "UnionType"}:
+        return False
+    non_none = [a for a in args if a is not type(None)]
+    return len(non_none) == 1 and len(args) == len(non_none) + 1
+
+
+def _format_return_annotation(annotation: Any) -> str:  # noqa: C901, PLR0912 — flat dispatch over a small fixed set of annotation shapes; splitting hurts readability
+    """Render a Python return annotation as a compact TS-ish string."""
+    dict_arg_count = 2
+    # Empty / Any → unknown.
+    if annotation is inspect.Signature.empty or annotation is Any:
+        return "unknown"
+
+    # Primitives.
+    if annotation is type(None):
+        return "null"
+    if annotation in (int, float):
+        return "number"
+    if annotation is str:
+        return "string"
+    if annotation is bool:
+        return "boolean"
+    # Bare ``dict`` / ``list`` (no parameters) render as their parameterised
+    # equivalents so the model sees standard TS types instead of "dict"/"list".
+    if annotation is dict:
+        return "Record<string, unknown>"
+    if annotation is list:
+        return "unknown[]"
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    # Optional[T] / T | None — render as ``T | null``. Other unions → unknown.
+    if _is_optional_union(origin, args):
+        non_none = next(a for a in args if a is not type(None))
+        return f"{_format_return_annotation(non_none)} | null"
+
+    # Literal["a", "b", 1] — quoted union of literal values.
+    if origin is Literal:
+        return " | ".join(json.dumps(arg) for arg in args)
+
+    # Containers: list[T], dict[str, V]. Other generics → unknown.
+    if origin in (list, set, frozenset):
+        inner = _format_return_annotation(args[0]) if args else "unknown"
+        return f"{inner}[]"
+    if origin is dict:
+        if len(args) == dict_arg_count and args[0] is str:
+            return f"Record<string, {_format_return_annotation(args[1])}>"
+        return "unknown"
+
+    # TypedDict / bare class → render its name. TypedDicts get a definition
+    # block emitted separately by `_collect_referenced_typed_dicts`.
+    if isinstance(annotation, type):
+        return annotation.__name__
+
+    return "unknown"
+
+
+def _get_tool_doc_target(tool: BaseTool) -> Callable[..., Any] | None:
+    target = getattr(tool, "func", None)
+    if callable(target):
+        return target
+    target = getattr(tool, "coroutine", None)
+    if callable(target):
+        return target
+    return None
+
+
+def _get_return_annotation(target: Callable[..., Any]) -> Any:
+    """Resolve the return annotation for a callable, ``Signature.empty`` if absent."""
+    with contextlib.suppress(TypeError, ValueError, NameError):
+        signature = inspect.signature(target)
+        resolved = get_type_hints(target)
+        return resolved.get("return", signature.return_annotation)
+    return inspect.Signature.empty
+
+
+def _render_return_type(tool: BaseTool) -> str:
+    target = _get_tool_doc_target(tool)
+    if target is None:
+        return "unknown"
+    return _format_return_annotation(_get_return_annotation(target))
+
+
+def _render_typed_dict_definition(annotation: type[Any]) -> str:
+    optional_keys = frozenset(getattr(annotation, "__optional_keys__", frozenset()))
+    try:
+        field_types = get_type_hints(annotation)
+    except (TypeError, NameError):
+        field_types = getattr(annotation, "__annotations__", {})
+    lines = [f"type {annotation.__name__} = {{"]
+    for key, value in field_types.items():
+        field_name = f"{key}?" if key in optional_keys else key
+        lines.append(f"  {field_name}: {_format_return_annotation(value)};")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _collect_referenced_typed_dicts(tools: Sequence[BaseTool]) -> list[type[Any]]:
+    """Return TypedDicts referenced by tools' return types, first-seen order."""
+    collected: list[type[Any]] = []
+    seen: set[type[Any]] = set()
+    for tool in tools:
+        target = _get_tool_doc_target(tool)
+        if target is None:
+            continue
+        annotation = _get_return_annotation(target)
+        # Surface the inner element of a one-level container: e.g.
+        # ``list[ServiceSearchResult]`` should pull ServiceSearchResult.
+        origin = get_origin(annotation)
+        if origin in (list, set, frozenset):
+            inner = get_args(annotation)
+            if inner:
+                annotation = inner[0]
+        if not _is_typed_dict(annotation) or annotation in seen:
+            continue
+        seen.add(annotation)
+        collected.append(annotation)
+    return collected
 
 
 def _json_schema_to_ts(prop: dict[str, Any]) -> str:

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -6,10 +6,12 @@ import contextlib
 import inspect
 import json
 import re
-from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, get_type_hints
+
+from pydantic import TypeAdapter
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
 
     from langchain_core.tools import BaseTool
 
@@ -81,15 +83,6 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
         )
         blocks.append(f"/** {description} */\n{signature}")
     body = "\n\n".join(blocks)
-    referenced_types = _collect_referenced_typed_dicts(tools)
-    referenced_block = ""
-    if referenced_types:
-        type_definitions = "\n\n".join(
-            _render_typed_dict_definition(t) for t in referenced_types
-        )
-        referenced_block = (
-            f"\n\nReferenced types:\n\n```typescript\n{type_definitions}\n```"
-        )
     return (
         "\n\n"
         "### API Reference — `tools` namespace\n\n"
@@ -131,7 +124,6 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
         "```typescript\n"
         f"{body}\n"
         "```"
-        f"{referenced_block}"
     )
 
 
@@ -174,159 +166,32 @@ def _render_signature(
     return f"async function {fn_name}(input: {{\n{body}\n}}): {return_clause}"
 
 
-# ---------------------------------------------------------------------------
-# Return-type rendering
-#
-# Inputs come from the tool's args_schema (Pydantic JSON Schema) so we get
-# Field descriptions and required/optional handling. Return types do NOT have
-# a JSON Schema source — only the function's Python annotation — so we render
-# them directly. Intentionally narrow scope: primitives, list[T], dict[str, V],
-# Optional[T], Literal[...], TypedDict (via referenced-type block), and bare
-# class names. Anything richer (Union, generics, BaseModel field expansion)
-# renders as ``unknown``.
-# ---------------------------------------------------------------------------
-
-
-def _is_typed_dict(annotation: Any) -> bool:
-    return (
-        isinstance(annotation, type)
-        and hasattr(annotation, "__annotations__")
-        and hasattr(annotation, "__required_keys__")
-    )
-
-
-def _is_optional_union(origin: Any, args: tuple[Any, ...]) -> bool:
-    """Return whether *origin*/*args* describe ``T | None`` exactly."""
-    origin_name = getattr(origin, "__name__", None)
-    if origin_name not in {"Union", "UnionType"}:
-        return False
-    non_none = [a for a in args if a is not type(None)]
-    return len(non_none) == 1 and len(args) == len(non_none) + 1
-
-
-def _format_return_annotation(annotation: Any) -> str:  # noqa: C901, PLR0912 — flat dispatch over a small fixed set of annotation shapes; splitting hurts readability
-    """Render a Python return annotation as a compact TS-ish string."""
-    dict_arg_count = 2
-    # Empty / Any → unknown.
-    if annotation is inspect.Signature.empty or annotation is Any:
-        return "unknown"
-
-    # Primitives.
-    if annotation is type(None):
-        return "null"
-    if annotation in (int, float):
-        return "number"
-    if annotation is str:
-        return "string"
-    if annotation is bool:
-        return "boolean"
-    # Bare ``dict`` / ``list`` (no parameters) render as their parameterised
-    # equivalents so the model sees standard TS types instead of "dict"/"list".
-    if annotation is dict:
-        return "Record<string, unknown>"
-    if annotation is list:
-        return "unknown[]"
-
-    origin = get_origin(annotation)
-    args = get_args(annotation)
-
-    # Optional[T] / T | None — render as ``T | null``. Other unions → unknown.
-    if _is_optional_union(origin, args):
-        non_none = next(a for a in args if a is not type(None))
-        return f"{_format_return_annotation(non_none)} | null"
-
-    # Literal["a", "b", 1] — quoted union of literal values.
-    if origin is Literal:
-        return " | ".join(json.dumps(arg) for arg in args)
-
-    # Containers: list[T], dict[str, V]. Other generics → unknown.
-    if origin in (list, set, frozenset):
-        inner = _format_return_annotation(args[0]) if args else "unknown"
-        return f"{inner}[]"
-    if origin is dict:
-        if len(args) == dict_arg_count and args[0] is str:
-            return f"Record<string, {_format_return_annotation(args[1])}>"
-        return "unknown"
-
-    # TypedDicts get their own name (definitions are emitted separately by
-    # `_collect_referenced_typed_dicts`). Subclasses of the standard
-    # containers render as the equivalent TS shape. Everything else
-    # (Pydantic models, dataclasses, custom classes) hits ``str(value)`` at
-    # the bridge, so advertise it as ``string`` — the historical default
-    # before native marshaling, and an honest description of what arrives.
-    if _is_typed_dict(annotation):
-        return annotation.__name__
-    if isinstance(annotation, type):
-        if issubclass(annotation, dict):
-            return "Record<string, unknown>"
-        if issubclass(annotation, (list, tuple)):
-            return "unknown[]"
-        return "string"
-
-    return "unknown"
-
-
-def _get_tool_doc_target(tool: BaseTool) -> Callable[..., Any] | None:
-    target = getattr(tool, "func", None)
-    if callable(target):
-        return target
-    target = getattr(tool, "coroutine", None)
-    if callable(target):
-        return target
-    return None
-
-
-def _get_return_annotation(target: Callable[..., Any]) -> Any:
-    """Resolve the return annotation for a callable, ``Signature.empty`` if absent."""
-    with contextlib.suppress(TypeError, ValueError, NameError):
-        signature = inspect.signature(target)
-        resolved = get_type_hints(target)
-        return resolved.get("return", signature.return_annotation)
-    return inspect.Signature.empty
+# Return types come from the tool's underlying function annotation. We feed
+# the annotation through ``pydantic.TypeAdapter`` to get a JSON Schema and
+# render it through the same ``_json_schema_to_ts`` we use for input args.
+# Compound shapes (TypedDict, BaseModel, recursive types) end up as ``$ref``
+# in the schema and currently render as ``unknown`` — same behaviour as
+# nested-model input args. Until that path resolves ``$ref`` / ``$defs``,
+# the simpler unified renderer is the right trade-off here.
 
 
 def _render_return_type(tool: BaseTool) -> str:
-    target = _get_tool_doc_target(tool)
+    """Render the return annotation as a TS type, defaulting to ``unknown``."""
+    target = getattr(tool, "func", None) or getattr(tool, "coroutine", None)
     if target is None:
         return "unknown"
-    return _format_return_annotation(_get_return_annotation(target))
-
-
-def _render_typed_dict_definition(annotation: type[Any]) -> str:
-    optional_keys = frozenset(getattr(annotation, "__optional_keys__", frozenset()))
+    annotation = inspect.Signature.empty
+    with contextlib.suppress(TypeError, ValueError, NameError):
+        signature = inspect.signature(target)
+        resolved = get_type_hints(target)
+        annotation = resolved.get("return", signature.return_annotation)
+    if annotation is inspect.Signature.empty or annotation is Any:
+        return "unknown"
     try:
-        field_types = get_type_hints(annotation)
-    except (TypeError, NameError):
-        field_types = getattr(annotation, "__annotations__", {})
-    lines = [f"type {annotation.__name__} = {{"]
-    for key, value in field_types.items():
-        field_name = f"{key}?" if key in optional_keys else key
-        lines.append(f"  {field_name}: {_format_return_annotation(value)};")
-    lines.append("}")
-    return "\n".join(lines)
-
-
-def _collect_referenced_typed_dicts(tools: Sequence[BaseTool]) -> list[type[Any]]:
-    """Return TypedDicts referenced by tools' return types, first-seen order."""
-    collected: list[type[Any]] = []
-    seen: set[type[Any]] = set()
-    for tool in tools:
-        target = _get_tool_doc_target(tool)
-        if target is None:
-            continue
-        annotation = _get_return_annotation(target)
-        # Surface the inner element of a one-level container: e.g.
-        # ``list[ServiceSearchResult]`` should pull ServiceSearchResult.
-        origin = get_origin(annotation)
-        if origin in (list, set, frozenset):
-            inner = get_args(annotation)
-            if inner:
-                annotation = inner[0]
-        if not _is_typed_dict(annotation) or annotation in seen:
-            continue
-        seen.add(annotation)
-        collected.append(annotation)
-    return collected
+        schema = TypeAdapter(annotation).json_schema()
+    except Exception:  # noqa: BLE001 — schema generation is best-effort
+        return "unknown"
+    return _json_schema_to_ts(schema)
 
 
 def _json_schema_to_ts(prop: dict[str, Any]) -> str:

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -248,10 +248,20 @@ def _format_return_annotation(annotation: Any) -> str:  # noqa: C901, PLR0912 �
             return f"Record<string, {_format_return_annotation(args[1])}>"
         return "unknown"
 
-    # TypedDict / bare class → render its name. TypedDicts get a definition
-    # block emitted separately by `_collect_referenced_typed_dicts`.
-    if isinstance(annotation, type):
+    # TypedDicts get their own name (definitions are emitted separately by
+    # `_collect_referenced_typed_dicts`). Subclasses of the standard
+    # containers render as the equivalent TS shape. Everything else
+    # (Pydantic models, dataclasses, custom classes) hits ``str(value)`` at
+    # the bridge, so advertise it as ``string`` — the historical default
+    # before native marshaling, and an honest description of what arrives.
+    if _is_typed_dict(annotation):
         return annotation.__name__
+    if isinstance(annotation, type):
+        if issubclass(annotation, dict):
+            return "Record<string, unknown>"
+        if issubclass(annotation, (list, tuple)):
+            return "unknown[]"
+        return "string"
 
     return "unknown"
 

--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -125,9 +125,9 @@ def _raise_on_invalid_ptc_tools(tools: Sequence[BaseTool]) -> None:
         raise ValueError(msg)
 
 
-def render_ptc_prompt(tools: Sequence[BaseTool]) -> str:
+def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> str:
     """Build the `tools` namespace section of the system prompt."""
     if not tools:
         return ""
     _raise_on_invalid_ptc_tools(tools)
-    return _prompt.render_ptc_prompt(tools)
+    return _prompt.render_ptc_prompt(tools, tool_name=tool_name)

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -210,15 +210,14 @@ def _inject_tool_args_for_ptc(
     """Mirror LangGraph's ``ToolNode._inject_tool_args`` for PTC calls.
 
     LangChain tools that declare ``ToolRuntime`` / ``InjectedState`` /
-    ``InjectedStore`` / ``InjectedToolCallId`` only see those values when
-    a real ``ToolNode`` (or the ``BaseTool`` tool-call envelope path)
-    wires them in. PTC calls bypass both, so we replicate the detection
-    logic here. The outer runtime (captured from the active ``eval`` tool
-    invocation) provides state/store/context/config; ``tool_call_id`` is
-    freshly minted per sub-call.
+    ``InjectedStore`` only see those values when a real ``ToolNode`` wires
+    them in. PTC calls bypass it, so we replicate the detection logic here.
+    The outer runtime (captured from the active ``eval`` tool invocation)
+    provides state/store/context/config; ``tool_call_id`` is freshly minted
+    per sub-call. ``InjectedToolCallId`` is handled separately via
+    ``BaseTool.arun(..., tool_call_id=...)`` at the bridge site.
     """
     enriched = dict(payload)
-    enriched.update(_collect_tool_call_id_args(tool, tool_call_id))
 
     try:
         from langgraph.prebuilt.tool_node import (  # noqa: PLC0415 — optional dep, imported here so ImportError is catchable
@@ -264,14 +263,20 @@ def _inject_tool_args_for_ptc(
     return enriched
 
 
-def _collect_tool_call_id_args(tool: Any, tool_call_id: str) -> dict[str, str]:
-    """Return ``{arg_name: tool_call_id}`` for each ``InjectedToolCallId`` field.
+def _tool_uses_injected_tool_call_id(tool: Any) -> bool:
+    """Return whether *tool* declares an ``InjectedToolCallId`` parameter.
 
-    PTC calls invoke tools with an args dict (not a ``tool_call`` envelope),
-    so ``BaseTool._parse_input``'s built-in injection of ``InjectedToolCallId``
-    does not run. Detect those params using the same combination of schema
-    annotations and ``get_type_hints`` that langgraph's
-    ``_get_all_injected_args`` uses, then populate the args dict ourselves.
+    PTC invokes tools with an args dict via ``BaseTool.arun``. Tools that
+    declare ``InjectedToolCallId`` need ``tool_call_id`` passed as a kwarg
+    so ``BaseTool._parse_input``'s built-in injection runs. Detect via the
+    same combination of schema annotations and ``get_type_hints`` that
+    langgraph's ``_get_all_injected_args`` uses.
+
+    Trade-off: passing ``tool_call_id`` as a kwarg makes
+    ``BaseTool._format_output`` wrap the result in a ``ToolMessage`` with
+    string-coerced ``.content`` (unless the tool returns a ``ToolOutputMixin``
+    such as ``Command``). For tools without this annotation we pass
+    ``tool_call_id=None`` and recover the native return value.
     """
     try:
         from typing import get_type_hints  # noqa: PLC0415
@@ -282,7 +287,7 @@ def _collect_tool_call_id_args(tool: Any, tool_call_id: str) -> dict[str, str]:
             get_all_basemodel_annotations,
         )
     except ImportError:  # pragma: no cover — both deps are required at runtime
-        return {}
+        return False
 
     try:
         schema_annotations = get_all_basemodel_annotations(tool.get_input_schema())
@@ -298,12 +303,10 @@ def _collect_tool_call_id_args(tool: Any, tool_call_id: str) -> dict[str, str]:
 
     # Match langgraph's merge order: schema annotations override func ones.
     all_annotations = {**func_annotations, **schema_annotations}
-
-    return {
-        name: tool_call_id
-        for name, type_ in all_annotations.items()
-        if _is_injected_arg_type(type_, injected_type=InjectedToolCallId)
-    }
+    return any(
+        _is_injected_arg_type(type_, injected_type=InjectedToolCallId)
+        for type_ in all_annotations.values()
+    )
 
 
 def _bridge_symbol_name(tool_name: str) -> str:
@@ -494,13 +497,28 @@ class _ThreadREPL:
         *,
         outer_loop: asyncio.AbstractEventLoop | None,
     ) -> Any:
-        """Run ``tool.ainvoke`` on the outer runtime's loop when available."""
+        """Run the tool on the outer runtime's loop when available.
+
+        Uses ``BaseTool.arun(args, tool_call_id=...)`` rather than
+        ``ainvoke(envelope)`` so the result is the tool's native return
+        value rather than a string-coerced ``ToolMessage``. We only pass
+        ``tool_call_id`` when the tool declares ``InjectedToolCallId`` —
+        otherwise ``_format_output`` would wrap the result anyway.
+        """
+        args = tool_call["args"]
+        tool_call_id = (
+            tool_call.get("id") if _tool_uses_injected_tool_call_id(tool) else None
+        )
+
+        async def _call() -> Any:
+            return await tool.arun(args, tool_call_id=tool_call_id)
+
         if outer_loop is None:
-            return await tool.ainvoke(tool_call)
+            return await _call()
         current_loop = asyncio.get_running_loop()
         if current_loop is outer_loop:
-            return await tool.ainvoke(tool_call)
-        future = asyncio.run_coroutine_threadsafe(tool.ainvoke(tool_call), outer_loop)
+            return await _call()
+        future = asyncio.run_coroutine_threadsafe(_call(), outer_loop)
         try:
             return await asyncio.wrap_future(future)
         except asyncio.CancelledError:
@@ -537,17 +555,19 @@ class _ThreadREPL:
             self._ptc_state = state
             payload = _normalize_tool_input(raw_input)
             call_id = _synth_tool_call_id(tool.name)
-            # Inject runtime/state/store/tool_call_id ourselves so we can
-            # invoke with a plain args dict. The tool-call envelope path
-            # would auto-inject these, but it also wraps the return in a
-            # ToolMessage and string-coerces ``.content``, which destroys
-            # native return types (lists, dicts, numbers) before the JS
-            # side can see them.
+            # Inject runtime/state/store ourselves; ``InjectedToolCallId``
+            # is handled inside ``_ainvoke_tool_on_outer_loop`` via
+            # ``tool.arun(..., tool_call_id=...)``. The bridge intentionally
+            # avoids the tool-call envelope path because it wraps the
+            # result in a ``ToolMessage`` and string-coerces ``.content``,
+            # destroying native return types (lists, dicts, numbers).
             args = _inject_tool_args_for_ptc(
                 tool, payload, state.outer_runtime, call_id
             )
             result = await self._ainvoke_tool_on_outer_loop(
-                tool, args, outer_loop=state.outer_loop
+                tool,
+                {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
+                outer_loop=state.outer_loop,
             )
             return coerce_tool_output_for_ptc(result)
 

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -35,7 +35,7 @@ from quickjs_rs import (
 )
 
 from langchain_quickjs._format import (
-    coerce_tool_output,
+    coerce_tool_output_for_ptc,
     format_handle,
     stringify,
 )
@@ -210,22 +210,26 @@ def _inject_tool_args_for_ptc(
     """Mirror LangGraph's ``ToolNode._inject_tool_args`` for PTC calls.
 
     LangChain tools that declare ``ToolRuntime`` / ``InjectedState`` /
-    ``InjectedStore`` only see those values when a real ``ToolNode``
-    wires them in. PTC calls bypass the ToolNode, so we replicate the
-    detection logic here. The outer runtime (captured from the active
-    ``eval`` tool invocation) provides state/store/context/config;
-    ``tool_call_id`` is freshly minted per sub-call.
+    ``InjectedStore`` / ``InjectedToolCallId`` only see those values when
+    a real ``ToolNode`` (or the ``BaseTool`` tool-call envelope path)
+    wires them in. PTC calls bypass both, so we replicate the detection
+    logic here. The outer runtime (captured from the active ``eval`` tool
+    invocation) provides state/store/context/config; ``tool_call_id`` is
+    freshly minted per sub-call.
     """
+    enriched = dict(payload)
+    enriched.update(_collect_tool_call_id_args(tool, tool_call_id))
+
     try:
         from langgraph.prebuilt.tool_node import (  # noqa: PLC0415 — optional dep, imported here so ImportError is catchable
             _get_all_injected_args,
         )
     except ImportError:  # pragma: no cover — langgraph always present
-        return payload
+        return enriched
 
     injected = _get_all_injected_args(tool)
     if not injected or outer_runtime is None:
-        return payload
+        return enriched
 
     # Build a ToolRuntime matching the outer one but with a fresh
     # tool_call_id. ``type(outer_runtime)`` rather than a literal import
@@ -242,7 +246,6 @@ def _inject_tool_args_for_ptc(
         server_info=getattr(outer_runtime, "server_info", None),
     )
 
-    enriched = dict(payload)
     if injected.runtime:
         enriched[injected.runtime] = derived
     # InjectedState: state can be injected under one or more arg names.
@@ -259,6 +262,48 @@ def _inject_tool_args_for_ptc(
     if injected.store and outer_runtime.store is not None:
         enriched[injected.store] = outer_runtime.store
     return enriched
+
+
+def _collect_tool_call_id_args(tool: Any, tool_call_id: str) -> dict[str, str]:
+    """Return ``{arg_name: tool_call_id}`` for each ``InjectedToolCallId`` field.
+
+    PTC calls invoke tools with an args dict (not a ``tool_call`` envelope),
+    so ``BaseTool._parse_input``'s built-in injection of ``InjectedToolCallId``
+    does not run. Detect those params using the same combination of schema
+    annotations and ``get_type_hints`` that langgraph's
+    ``_get_all_injected_args`` uses, then populate the args dict ourselves.
+    """
+    try:
+        from typing import get_type_hints  # noqa: PLC0415
+
+        from langchain_core.tools.base import (  # noqa: PLC0415
+            InjectedToolCallId,
+            _is_injected_arg_type,
+            get_all_basemodel_annotations,
+        )
+    except ImportError:  # pragma: no cover — both deps are required at runtime
+        return {}
+
+    try:
+        schema_annotations = get_all_basemodel_annotations(tool.get_input_schema())
+    except Exception:  # noqa: BLE001 — schema introspection is best-effort
+        schema_annotations = {}
+    func = getattr(tool, "func", None) or getattr(tool, "coroutine", None)
+    try:
+        func_annotations = (
+            get_type_hints(func, include_extras=True) if func is not None else {}
+        )
+    except Exception:  # noqa: BLE001 — type-hint resolution is best-effort
+        func_annotations = {}
+
+    # Match langgraph's merge order: schema annotations override func ones.
+    all_annotations = {**func_annotations, **schema_annotations}
+
+    return {
+        name: tool_call_id
+        for name, type_ in all_annotations.items()
+        if _is_injected_arg_type(type_, injected_type=InjectedToolCallId)
+    }
 
 
 def _bridge_symbol_name(tool_name: str) -> str:
@@ -474,7 +519,7 @@ class _ThreadREPL:
         ctx = self._require_ctx()
         registered = self._registered_tools
 
-        async def _bridge(raw_input: Any = None) -> str:
+        async def _bridge(raw_input: Any = None) -> Any:
             tool = registered.get(camel)
             if tool is None:
                 # Shouldn't happen — we only rewrite ``globalThis.tools``
@@ -492,17 +537,19 @@ class _ThreadREPL:
             self._ptc_state = state
             payload = _normalize_tool_input(raw_input)
             call_id = _synth_tool_call_id(tool.name)
-            # Build a ToolCall-shaped input so InjectedToolCallId and the
-            # runtime-arg injection in _inject_tool_args_for_ptc fire.
+            # Inject runtime/state/store/tool_call_id ourselves so we can
+            # invoke with a plain args dict. The tool-call envelope path
+            # would auto-inject these, but it also wraps the return in a
+            # ToolMessage and string-coerces ``.content``, which destroys
+            # native return types (lists, dicts, numbers) before the JS
+            # side can see them.
             args = _inject_tool_args_for_ptc(
                 tool, payload, state.outer_runtime, call_id
             )
             result = await self._ainvoke_tool_on_outer_loop(
-                tool,
-                {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
-                outer_loop=state.outer_loop,
+                tool, args, outer_loop=state.outer_loop
             )
-            return coerce_tool_output(result)
+            return coerce_tool_output_for_ptc(result)
 
         bridge_symbol = _bridge_symbol_name(camel)
         ctx.register(bridge_symbol, _bridge, is_async=True)

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -421,7 +421,10 @@ class REPLMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
         # Same tradeoff the TS package accepts; see the module docstring.
         exposed_names = frozenset(t.name for t in exposed)
         if self._ptc_prompt_cache is None or self._ptc_prompt_cache[0] != exposed_names:
-            self._ptc_prompt_cache = (exposed_names, render_ptc_prompt(exposed))
+            self._ptc_prompt_cache = (
+                exposed_names,
+                render_ptc_prompt(exposed, tool_name=self._tool_name),
+            )
         return self._base_system_prompt + self._ptc_prompt_cache[1]
 
     def _extend(

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
@@ -149,7 +149,7 @@ console.log({ city, normalized });
 /** Find users with the given name. */
 async function findUsersByName(input: {
   name: string;
-}): Promise<UserLookup[]>
+}): Promise<unknown[]>
 
 /** Get the location id for a user. */
 async function getUserLocation(input: {
@@ -170,13 +170,4 @@ async function normalizeName(input: {
 async function fetchWeather(input: {
   city: string;
 }): Promise<string>
-```
-
-Referenced types:
-
-```typescript
-type UserLookup = {
-  id: number;
-  name: string;
-}
 ```

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
@@ -122,22 +122,39 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 
 ### API Reference — `tools` namespace
 
-The agent tools listed below are exposed on the global object at `globalThis.tools` (also reachable as `tools`). Each takes a single object argument and returns a Promise that resolves to a string.
+The agent tools listed below are exposed on the global object at `globalThis.tools` (also reachable as `tools`). Each takes a single object argument and returns a Promise that resolves to the tool's native value: strings as strings, numbers as numbers, lists as arrays, dicts as objects, and `None` as `null`. You do NOT need to `JSON.parse` results — they are already typed.
 
-Invocation pattern: `await tools.<name>({ ... })`).
+Invocation pattern: `await tools.<name>({ ... })`.
 
-Use `await`; combine with `Promise.all` for concurrent calls.
+- Use `await` to get tool results; combine with `Promise.all` for independent calls so they run concurrently.
+- If the task needs multiple tool calls, prefer one `eval` invocation that performs all of them rather than splitting the work across multiple `eval` calls — each round-trip costs a model turn.
+- Pipeline dependent calls within a single program. If a result from one tool is needed as input to a later tool, chain them in one program instead of returning the intermediate value to the model.
+- If a tool returns an ID or other value that can be passed directly into the next tool, trust it and chain the calls instead of stopping to double-check it.
+- To inspect an intermediate value, `console.log` it inside the same program; otherwise, fetch as much information as possible in one call.
+- Only split work across multiple `eval` invocations when you genuinely cannot determine what to do next without additional model reasoning or user input.
+
+Example shape — substitute real tool names:
+
+```typescript
+const users = await tools.findUsers({ name: "Ada" });
+const userId = users[0].id;
+const [city, normalized] = await Promise.all([
+  tools.cityForUser({ user_id: userId }),
+  tools.normalize({ name: "Ada" }),
+]);
+console.log({ city, normalized });
+```
 
 ```typescript
 /** Find users with the given name. */
 async function findUsersByName(input: {
   name: string;
-}): Promise<string>
+}): Promise<UserLookup[]>
 
 /** Get the location id for a user. */
 async function getUserLocation(input: {
   user_id: number;
-}): Promise<string>
+}): Promise<number>
 
 /** Get the city for a location. */
 async function getCityForLocation(input: {
@@ -153,4 +170,13 @@ async function normalizeName(input: {
 async function fetchWeather(input: {
   city: string;
 }): Promise<string>
+```
+
+Referenced types:
+
+```typescript
+type UserLookup = {
+  id: number;
+  name: string;
+}
 ```

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -141,13 +141,9 @@ def test_deepagent_with_quickjs_interpreter_sync() -> None:
     assert result["messages"][-1].content == "The answer is 42."
 
 
-def test_deepagent_with_quickjs_json_roundtrip_foreign_function_sync() -> None:
-    """Verify sync eval can parse JSON strings returned from PTC tool calls."""
-    code = (
-        "const idsJson = await tools.listUserIds({});\n"
-        "const ids = JSON.parse(idsJson);\n"
-        "ids.join(',');"
-    )
+def test_deepagent_with_quickjs_list_returning_foreign_function_sync() -> None:
+    """A PTC tool returning a Python ``list`` surfaces as a native JS Array."""
+    code = "const ids = await tools.listUserIds({});\nids.join(',');"
     result = _make_agent(code, REPLMiddleware(ptc=[list_user_ids])).invoke(
         {
             "messages": [

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -20,7 +20,7 @@ from collections.abc import (
     Iterator,  # noqa: TC003 — pydantic resolves field annotations at runtime
 )
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import Annotated, Any
 
 import pytest
 from deepagents import create_deep_agent
@@ -28,7 +28,7 @@ from langchain.tools import (
     ToolRuntime,  # noqa: TC002  # tool decorator resolves type hints at import time
 )
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langchain_core.tools import tool
+from langchain_core.tools import InjectedToolCallId, tool
 
 from langchain_quickjs import REPLMiddleware
 from tests._common import FakeChatModel
@@ -74,6 +74,33 @@ async def always_fails(value: str) -> str:
 def echo_foo(foo: str) -> str:
     """Echo the value of `foo`."""
     return f"got {foo}"
+
+
+@tool
+def get_user_count() -> int:
+    """Return a count of users."""
+    return 7
+
+
+@tool
+def get_user_profile() -> dict[str, Any]:
+    """Return a small user profile object."""
+    return {"id": 21, "name": "Bob", "tags": ["admin", "ops"]}
+
+
+@tool
+def get_user_email_or_none(user_id: int) -> str | None:
+    """Return an email if the user has one, otherwise None."""
+    return None if user_id < 0 else "alice@example.com"
+
+
+@tool
+def echo_call_id(
+    value: str,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+) -> str:
+    """Return the synthetic tool_call_id back to the caller."""
+    return f"{value}|{tool_call_id}"
 
 
 def _script(code: str, *, final_message: str = "Done.") -> Iterator[AIMessage]:
@@ -156,6 +183,49 @@ def test_deepagent_with_quickjs_list_returning_foreign_function_sync() -> None:
 
     tool_message = _eval_tool_message(result)
     _assert_result_contains(tool_message.content, "1,21,35,41,42,43")
+
+
+def test_ptc_int_return_is_native_js_number() -> None:
+    """A PTC tool returning a Python ``int`` surfaces as a JS ``number``."""
+    code = "const n = await tools.getUserCount({});\n`${typeof n}:${n + 1}`;"
+    result = _make_agent(code, REPLMiddleware(ptc=[get_user_count])).invoke(
+        {"messages": [HumanMessage(content="go")]}
+    )
+    _assert_result_contains(_eval_tool_message(result).content, "number:8")
+
+
+def test_ptc_dict_return_is_native_js_object() -> None:
+    """A PTC tool returning a Python ``dict`` surfaces as a JS object."""
+    code = (
+        "const u = await tools.getUserProfile({});\n"
+        "`${u.id}:${u.name}:${u.tags.join(',')}`;"
+    )
+    result = _make_agent(code, REPLMiddleware(ptc=[get_user_profile])).invoke(
+        {"messages": [HumanMessage(content="go")]}
+    )
+    _assert_result_contains(_eval_tool_message(result).content, "21:Bob:admin,ops")
+
+
+def test_ptc_none_return_is_js_null() -> None:
+    """A PTC tool returning ``None`` surfaces as JS ``null``."""
+    code = "const r = await tools.getUserEmailOrNone({user_id: -1});\n`${r === null}`;"
+    result = _make_agent(code, REPLMiddleware(ptc=[get_user_email_or_none])).invoke(
+        {"messages": [HumanMessage(content="go")]}
+    )
+    _assert_result_contains(_eval_tool_message(result).content, "true")
+
+
+def test_ptc_injects_tool_call_id_per_call() -> None:
+    """``InjectedToolCallId`` receives a fresh id on each PTC sub-call."""
+    code = (
+        "const a = await tools.echoCallId({value: 'a'});\n"
+        "const b = await tools.echoCallId({value: 'b'});\n"
+        "`${a !== b}:${a.startsWith('a|')}:${b.startsWith('b|')}`;"
+    )
+    result = _make_agent(code, REPLMiddleware(ptc=[echo_call_id])).invoke(
+        {"messages": [HumanMessage(content="go")]}
+    )
+    _assert_result_contains(_eval_tool_message(result).content, "true:true:true")
 
 
 def test_deepagent_with_quickjs_mixed_foreign_function_sync() -> None:

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -20,6 +20,7 @@ from collections.abc import (
     Iterator,  # noqa: TC003 — pydantic resolves field annotations at runtime
 )
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from typing import Annotated, Any
 
 import pytest
@@ -86,6 +87,18 @@ def get_user_count() -> int:
 def get_user_profile() -> dict[str, Any]:
     """Return a small user profile object."""
     return {"id": 21, "name": "Bob", "tags": ["admin", "ops"]}
+
+
+@tool
+def get_user_profile_with_dates() -> dict[str, Any]:
+    """Return a user profile containing nested datetimes (non JS-native values)."""
+    return {
+        "id": 21,
+        "created_at": datetime(2024, 1, 1, 12, 30),  # noqa: DTZ001 — fixture
+        "events": [
+            {"seen_at": datetime(2024, 1, 2, 15, 45)}  # noqa: DTZ001 — fixture
+        ],
+    }
 
 
 @tool
@@ -204,6 +217,23 @@ def test_ptc_dict_return_is_native_js_object() -> None:
         {"messages": [HumanMessage(content="go")]}
     )
     _assert_result_contains(_eval_tool_message(result).content, "21:Bob:admin,ops")
+
+
+def test_ptc_dict_with_nested_non_native_values_does_not_break_eval() -> None:
+    """A PTC tool returning nested non-native values should not break eval."""
+    code = (
+        "const u = await tools.getUserProfileWithDates({});\n"
+        "`${u.id}:${u.created_at}:${u.events[0].seen_at}`;"
+    )
+    result = _make_agent(
+        code,
+        REPLMiddleware(ptc=[get_user_profile_with_dates]),
+    ).invoke({"messages": [HumanMessage(content="go")]})
+
+    _assert_result_contains(
+        _eval_tool_message(result).content,
+        "21:2024-01-01 12:30:00:2024-01-02 15:45:00",
+    )
 
 
 def test_ptc_none_return_is_js_null() -> None:

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
@@ -118,13 +118,9 @@ async def test_deepagent_with_quickjs_interpreter() -> None:
     assert result["messages"][-1].content == "The answer is 42."
 
 
-async def test_deepagent_with_quickjs_json_roundtrip_foreign_function() -> None:
-    """Verify async eval can parse JSON strings returned from PTC tool calls."""
-    code = (
-        "const idsJson = await tools.listUserIds({});\n"
-        "const ids = JSON.parse(idsJson);\n"
-        "ids.join(',');"
-    )
+async def test_deepagent_with_quickjs_list_returning_foreign_function() -> None:
+    """A PTC tool returning a Python ``list`` surfaces as a native JS Array."""
+    code = "const ids = await tools.listUserIds({});\nids.join(',');"
     result = await _make_agent(code, REPLMiddleware(ptc=[list_user_ids])).ainvoke(
         {
             "messages": [

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -18,7 +18,6 @@ from quickjs_rs import Runtime, ThreadWorker
 from typing_extensions import TypedDict
 
 from langchain_quickjs import REPLMiddleware
-from langchain_quickjs._prompt import _format_return_annotation
 from langchain_quickjs._ptc import (
     filter_tools_for_ptc,
     render_ptc_prompt,
@@ -34,6 +33,20 @@ from langchain_quickjs._repl import _ThreadREPL
 class _GreetInput(BaseModel):
     name: str = Field(description="Who to greet")
     times: int = Field(default=1, description="Repeat count")
+
+
+class _Status(BaseModel):
+    """Module-scope BaseModel used as a return annotation in PTC tests."""
+
+    status: str
+    count: int
+
+
+class _UserLookup(TypedDict):
+    """Module-scope TypedDict used as a return annotation in PTC tests."""
+
+    id: int
+    name: str
 
 
 def _greet_tool(record: list[dict] | None = None) -> BaseTool:
@@ -659,58 +672,20 @@ def test_middleware_rejects_dict_ptc_config_during_prepare() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _StatusRecord(BaseModel):
-    """Pydantic model used as a "bare class" return type."""
-
-    status: str
-
-
-class _ServiceLookup(TypedDict):
-    id: int
-    name: str
-
-
-@pytest.mark.parametrize(
-    ("annotation", "expected"),
-    [
-        (int, "number"),
-        (float, "number"),
-        (str, "string"),
-        (bool, "boolean"),
-        (type(None), "null"),
-        (Any, "unknown"),
-        (list[int], "number[]"),
-        (list, "unknown[]"),
-        (dict[str, int], "Record<string, number>"),
-        (dict, "Record<string, unknown>"),
-        (str | None, "string | null"),
-        (Literal["active", "resolved"], '"active" | "resolved"'),
-        (_ServiceLookup, "_ServiceLookup"),
-        # Pydantic / dataclass / custom-class returns stringify at the bridge,
-        # so the prompt advertises them as ``string`` rather than the bare
-        # class name.
-        (_StatusRecord, "string"),
-        # Things outside our trimmed scope render as ``unknown``:
-        (int | str, "unknown"),
-        (tuple[int, str], "unknown"),
-    ],
-)
-def test_format_return_annotation_covers_supported_branches(
-    annotation: Any, expected: str
-) -> None:
-    assert _format_return_annotation(annotation) == expected
-
-
-def test_render_ptc_prompt_uses_concrete_return_types_and_typed_dict_block() -> None:
-    """``render_ptc_prompt`` renders ``Promise<T>`` and a referenced-type block."""
+def test_render_ptc_prompt_renders_concrete_primitive_return_types() -> None:
+    """`render_ptc_prompt` renders Promise<T> from primitive annotations."""
 
     def get_service_id() -> int:
         """Return a service id."""
         return 1
 
-    async def list_services(name: str) -> list[_ServiceLookup]:
-        """List services with a similar name."""
-        return [{"id": 1, "name": name}]
+    def get_service_name() -> str:
+        """Return a service name."""
+        return "svc"
+
+    async def list_ids() -> list[int]:
+        """List ids."""
+        return [1, 2, 3]
 
     tools = [
         StructuredTool.from_function(
@@ -719,17 +694,118 @@ def test_render_ptc_prompt_uses_concrete_return_types_and_typed_dict_block() -> 
             func=get_service_id,
         ),
         StructuredTool.from_function(
-            name="list_services",
-            description="List services with a similar name.",
-            coroutine=list_services,
+            name="get_service_name",
+            description="Return a service name.",
+            func=get_service_name,
+        ),
+        StructuredTool.from_function(
+            name="list_ids",
+            description="List ids.",
+            coroutine=list_ids,
         ),
     ]
     prompt = render_ptc_prompt(tools)
-    # Concrete return types appear in the signatures.
-    assert "Promise<number>" in prompt
-    assert "Promise<_ServiceLookup[]>" in prompt
-    # The referenced TypedDict gets pulled into its own block at the bottom.
-    assert "Referenced types:" in prompt
-    assert "type _ServiceLookup = {" in prompt
-    assert "id: number;" in prompt
-    assert "name: string;" in prompt
+    assert "Promise<integer>" in prompt or "Promise<number>" in prompt
+    assert "Promise<string>" in prompt
+    assert "Promise<integer[]>" in prompt or "Promise<number[]>" in prompt
+
+
+def test_render_ptc_prompt_falls_back_to_unknown_for_unannotated_returns() -> None:
+    """Tools without a return annotation render as ``Promise<unknown>``."""
+
+    def no_annotation():
+        """Return something."""
+        return 1
+
+    tool = StructuredTool.from_function(
+        name="no_annotation",
+        description="Return something.",
+        func=no_annotation,
+    )
+    prompt = render_ptc_prompt([tool])
+    assert "Promise<unknown>" in prompt
+
+
+def _stub() -> None:
+    """Stub function used as a tool callable in parametrized return-type tests."""
+    return
+
+
+@pytest.mark.parametrize(
+    ("annotation", "expected"),
+    [
+        # Primitives.
+        (int, "Promise<number>"),
+        (float, "Promise<number>"),
+        (str, "Promise<string>"),
+        (bool, "Promise<boolean>"),
+        (type(None), "Promise<null>"),
+        # Containers of primitives.
+        (list[int], "Promise<number[]>"),
+        # ``dict[str, V]`` uses ``additionalProperties`` in the schema, which
+        # ``_json_schema_to_ts`` doesn't currently read — value type collapses
+        # to ``unknown``.
+        (dict[str, int], "Promise<Record<string, unknown>>"),
+        # Optional / Literal / unions all flow through ``anyOf`` or ``enum``.
+        (int | None, "Promise<number | null>"),
+        (Literal["active", "resolved"], 'Promise<"active" | "resolved">'),
+        (int | str, "Promise<number | string>"),
+        # Top-level TypedDict / BaseModel — Pydantic inlines the schema.
+        (_UserLookup, "Promise<{ id: number; name: string }>"),
+        (_Status, "Promise<{ status: string; count: number }>"),
+        # Compound types that hit ``$ref`` (collections of TypedDict /
+        # BaseModel) — we don't resolve refs, so they collapse to ``unknown``.
+        (list[_UserLookup], "Promise<unknown[]>"),
+        (list[_Status], "Promise<unknown[]>"),
+    ],
+)
+def test_render_ptc_prompt_return_types(annotation: Any, expected: str) -> None:
+    """Return-type rendering covers each supported annotation shape."""
+
+    # Build a fresh callable so the parametrized annotation is bound at runtime
+    # rather than at import (``from __future__ import annotations`` would
+    # otherwise leave the annotation as a string).
+    def _fn() -> None:
+        """Tool stub."""
+        return
+
+    _fn.__annotations__["return"] = annotation
+    tool = StructuredTool.from_function(
+        name="t",
+        description="Stub tool.",
+        func=_fn,
+    )
+    prompt = render_ptc_prompt([tool])
+    assert expected in prompt, prompt
+
+
+def _get_status_record() -> _Status:
+    """Module-level helper.
+
+    Defined at module scope so ``get_type_hints`` can resolve the return
+    annotation under ``from __future__ import annotations``.
+    """
+    return _Status(status="ok", count=3)
+
+
+async def test_pydantic_return_arrives_as_object_matching_schema(
+    repl: _ThreadREPL,
+) -> None:
+    """BaseModel returns are dumped at the bridge so the JS shape matches the schema."""
+    tool = StructuredTool.from_function(
+        name="get_status",
+        description="Return a status record.",
+        func=_get_status_record,
+    )
+    # The prompt advertises a structured object (Pydantic JSON Schema inlined).
+    prompt = render_ptc_prompt([tool])
+    assert "status: string" in prompt
+    assert "count: number" in prompt
+
+    # And the bridge delivers an object with those fields, not a string.
+    repl.install_tools([tool])
+    outcome = await repl.eval_async(
+        "const r = await tools.getStatus({});\n`${typeof r}:${r.status}:${r.count}`"
+    )
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result == "object:ok:3"

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -7,6 +7,7 @@ the REPL so one ``eval`` can orchestrate many tool invocations.
 from __future__ import annotations
 
 import json
+from typing import Any, Literal
 
 import pytest
 from langchain_core.messages import ToolMessage
@@ -14,8 +15,10 @@ from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 from quickjs_rs import Runtime, ThreadWorker
+from typing_extensions import TypedDict
 
 from langchain_quickjs import REPLMiddleware
+from langchain_quickjs._prompt import _format_return_annotation
 from langchain_quickjs._ptc import (
     filter_tools_for_ptc,
     render_ptc_prompt,
@@ -649,3 +652,81 @@ def test_middleware_rejects_dict_ptc_config_during_prepare() -> None:
     mw = REPLMiddleware(ptc={"include": ["greet"]})  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
         mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))
+
+
+# ---------------------------------------------------------------------------
+# Return-type rendering
+# ---------------------------------------------------------------------------
+
+
+class _StatusRecord(BaseModel):
+    """Pydantic model used as a "bare class" return type."""
+
+    status: str
+
+
+class _ServiceLookup(TypedDict):
+    id: int
+    name: str
+
+
+@pytest.mark.parametrize(
+    ("annotation", "expected"),
+    [
+        (int, "number"),
+        (float, "number"),
+        (str, "string"),
+        (bool, "boolean"),
+        (type(None), "null"),
+        (Any, "unknown"),
+        (list[int], "number[]"),
+        (list, "unknown[]"),
+        (dict[str, int], "Record<string, number>"),
+        (dict, "Record<string, unknown>"),
+        (str | None, "string | null"),
+        (Literal["active", "resolved"], '"active" | "resolved"'),
+        (_ServiceLookup, "_ServiceLookup"),
+        (_StatusRecord, "_StatusRecord"),
+        # Things outside our trimmed scope render as ``unknown``:
+        (int | str, "unknown"),
+        (tuple[int, str], "unknown"),
+    ],
+)
+def test_format_return_annotation_covers_supported_branches(
+    annotation: Any, expected: str
+) -> None:
+    assert _format_return_annotation(annotation) == expected
+
+
+def test_render_ptc_prompt_uses_concrete_return_types_and_typed_dict_block() -> None:
+    """``render_ptc_prompt`` renders ``Promise<T>`` and a referenced-type block."""
+
+    def get_service_id() -> int:
+        """Return a service id."""
+        return 1
+
+    async def list_services(name: str) -> list[_ServiceLookup]:
+        """List services with a similar name."""
+        return [{"id": 1, "name": name}]
+
+    tools = [
+        StructuredTool.from_function(
+            name="get_service_id",
+            description="Return a service id.",
+            func=get_service_id,
+        ),
+        StructuredTool.from_function(
+            name="list_services",
+            description="List services with a similar name.",
+            coroutine=list_services,
+        ),
+    ]
+    prompt = render_ptc_prompt(tools)
+    # Concrete return types appear in the signatures.
+    assert "Promise<number>" in prompt
+    assert "Promise<_ServiceLookup[]>" in prompt
+    # The referenced TypedDict gets pulled into its own block at the bottom.
+    assert "Referenced types:" in prompt
+    assert "type _ServiceLookup = {" in prompt
+    assert "id: number;" in prompt
+    assert "name: string;" in prompt

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -686,7 +686,10 @@ class _ServiceLookup(TypedDict):
         (str | None, "string | null"),
         (Literal["active", "resolved"], '"active" | "resolved"'),
         (_ServiceLookup, "_ServiceLookup"),
-        (_StatusRecord, "_StatusRecord"),
+        # Pydantic / dataclass / custom-class returns stringify at the bridge,
+        # so the prompt advertises them as ``string`` rather than the bare
+        # class name.
+        (_StatusRecord, "string"),
         # Things outside our trimmed scope render as ``unknown``:
         (int | str, "unknown"),
         (tuple[int, str], "unknown"),


### PR DESCRIPTION
separate commits here:
1. update the prompt to encourage more efficient use of repl (this is independent / extraneous)
2. deliver raw types from foreign functions, bypass ToolNode stringification (also adds support for injected tool IDs along the way)
3. inspect return types from tool callables, translate to JS and propagate to the prompt.