### PR TITLE
refactor(evals,ci): make `trial_index` 1-indexed in n-trials

### DIFF
--- a/.github/workflows/evals_trials.yml
+++ b/.github/workflows/evals_trials.yml
@@ -200,7 +200,7 @@ jobs:
                   "trial_index": i,
                   "artifact_key": f"trial-{i:03d}-{slug}",
               }
-              for i in range(n)
+              for i in range(1, n + 1)
           ]
           matrix = {"include": entries}
           max_parallel = n if parallel else 1

--- a/libs/evals/CONTRIBUTING.md
+++ b/libs/evals/CONTRIBUTING.md
@@ -340,7 +340,7 @@ The `parallel` toggle exists to trade time for API burst pressure. Sequential mo
   },
   "trials": [
     // Per-trial records preserved in dispatch order
-    {"trial_index": 0, "passed": 81, "correctness": 0.47, "category_scores": {...}, "experiment_urls": [...]},
+    {"trial_index": 1, "passed": 81, "correctness": 0.47, "category_scores": {...}, "experiment_urls": [...]},
     ...
   ]
 }

--- a/libs/evals/scripts/run_trials.py
+++ b/libs/evals/scripts/run_trials.py
@@ -159,7 +159,7 @@ def _collect_numeric_values(
         if type(raw) not in (int, float):
             location = f"{nested_under}.{key}" if nested_under else key
             _warn(
-                f"trial {idx}: non-numeric value for {location!r}: {raw!r} "
+                f"trial {idx + 1}: non-numeric value for {location!r}: {raw!r} "
                 f"(type {type(raw).__name__}); excluded from stats"
             )
             continue
@@ -230,7 +230,7 @@ def aggregate_trials(reports: list[dict[str, Any]]) -> dict[str, Any]:
         "category_scores": category_stats,
         "trials": [
             {
-                "trial_index": idx,
+                "trial_index": idx + 1,
                 "created_at": r.get("created_at"),
                 "passed": r.get("passed"),
                 "failed": r.get("failed"),
@@ -314,7 +314,7 @@ def _run_trial(
     """Execute a single trial.
 
     Args:
-        trial_index: Zero-based index of this trial in the sweep.
+        trial_index: One-based index of this trial in the sweep.
         n_trials: Total number of trials being run; only used for logging.
         args: Parsed CLI arguments (forwarded to `_build_pytest_args`).
         out_dir: Directory the trial's report file is written under.
@@ -332,7 +332,7 @@ def _run_trial(
     env["DEEPAGENTS_TRIAL_TOTAL"] = str(n_trials)
 
     print(
-        f"\n=== trial {trial_index + 1}/{n_trials} === model={args.model} report={report_path}",
+        f"\n=== trial {trial_index}/{n_trials} === model={args.model} report={report_path}",
         flush=True,
     )
     print(f"$ {' '.join(cmd)}", flush=True)
@@ -573,7 +573,7 @@ def main(argv: list[str] | None = None) -> int:
         report_paths = []
         for i in range(args.trials):
             outcome = _run_trial(
-                trial_index=i,
+                trial_index=i + 1,
                 n_trials=args.trials,
                 args=args,
                 out_dir=out_dir,

--- a/libs/evals/tests/unit_tests/test_run_trials.py
+++ b/libs/evals/tests/unit_tests/test_run_trials.py
@@ -206,7 +206,7 @@ class TestAggregateTrials:
             for i in range(3)
         ]
         summary = run_trials.aggregate_trials(reports)
-        assert [t["trial_index"] for t in summary["trials"]] == [0, 1, 2]
+        assert [t["trial_index"] for t in summary["trials"]] == [1, 2, 3]
         assert [t["correctness"] for t in summary["trials"]] == pytest.approx([0.4, 0.45, 0.5])
 
     def test_non_numeric_metric_value_is_excluded_with_warning(
@@ -229,7 +229,7 @@ class TestAggregateTrials:
         summary = run_trials.aggregate_trials(reports)
         assert summary["metrics"]["correctness"]["n"] == 0
         captured = capsys.readouterr()
-        assert "non-numeric value for 'correctness'" in captured.err
+        assert "trial 1: non-numeric value for 'correctness'" in captured.err
 
     def test_bool_values_are_not_aggregated_as_ints(
         self, capsys: pytest.CaptureFixture[str]
@@ -250,7 +250,7 @@ class TestAggregateTrials:
         reports[0]["passed"] = True
         summary = run_trials.aggregate_trials(reports)
         assert summary["counts"]["passed"]["n"] == 0
-        assert "non-numeric value for 'passed'" in capsys.readouterr().err
+        assert "trial 1: non-numeric value for 'passed'" in capsys.readouterr().err
 
     def test_divergent_model_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
         a = _report(

--- a/libs/evals/tests/unit_tests/test_trial_summary.py
+++ b/libs/evals/tests/unit_tests/test_trial_summary.py
@@ -12,13 +12,13 @@ class TestRenderPerTrialCategoryMatrix:
         assert render_per_trial_category_matrix([], ["memory"], {}) == []
 
     def test_returns_empty_when_no_categories(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": {"memory": 1.0}}]
+        trials = [{"trial_index": 1, "category_scores": {"memory": 1.0}}]
         assert render_per_trial_category_matrix(trials, [], {}) == []
 
     def test_renders_header_separator_and_rows(self) -> None:
         trials = [
-            {"trial_index": 0, "category_scores": {"memory": 0.875, "tool_use": 0.5}},
-            {"trial_index": 1, "category_scores": {"memory": 1.0, "tool_use": 0.25}},
+            {"trial_index": 1, "category_scores": {"memory": 0.875, "tool_use": 0.5}},
+            {"trial_index": 2, "category_scores": {"memory": 1.0, "tool_use": 0.25}},
         ]
         cat_keys = ["memory", "tool_use"]
         labels = {"memory": "Memory", "tool_use": "Tool use"}
@@ -31,12 +31,12 @@ class TestRenderPerTrialCategoryMatrix:
             "",
             "| # | Memory | Tool use |",
             "|---:|---:|---:|",
-            "| 0 | 0.875 | 0.500 |",
-            "| 1 | 1.000 | 0.250 |",
+            "| 1 | 0.875 | 0.500 |",
+            "| 2 | 1.000 | 0.250 |",
         ]
 
     def test_falls_back_to_raw_key_when_label_missing(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": {"memory": 1.0}}]
+        trials = [{"trial_index": 1, "category_scores": {"memory": 1.0}}]
         lines = render_per_trial_category_matrix(trials, ["memory"], labels=None)
         # Header uses the raw key when no label dict is provided.
         assert "| memory |" in lines[3]
@@ -46,26 +46,26 @@ class TestRenderPerTrialCategoryMatrix:
         # an actual 0.0 score — pytest_reporter only emits a category when
         # at least one test ran.
         trials = [
-            {"trial_index": 0, "category_scores": {"memory": 0.0}},
-            {"trial_index": 1, "category_scores": {}},
+            {"trial_index": 1, "category_scores": {"memory": 0.0}},
+            {"trial_index": 2, "category_scores": {}},
         ]
         lines = render_per_trial_category_matrix(trials, ["memory"], {})
-        assert lines[-2] == "| 0 | 0.000 |"
-        assert lines[-1] == "| 1 | - |"
+        assert lines[-2] == "| 1 | 0.000 |"
+        assert lines[-1] == "| 2 | - |"
 
     def test_renders_dash_when_category_scores_is_none(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": None}]
+        trials = [{"trial_index": 1, "category_scores": None}]
         lines = render_per_trial_category_matrix(trials, ["memory"], {})
-        assert lines[-1] == "| 0 | - |"
+        assert lines[-1] == "| 1 | - |"
 
     def test_escapes_pipe_in_label(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": {"weird": 1.0}}]
+        trials = [{"trial_index": 1, "category_scores": {"weird": 1.0}}]
         labels = {"weird": "Has | pipe"}
         lines = render_per_trial_category_matrix(trials, ["weird"], labels)
         assert "Has \\| pipe" in lines[3]
 
     def test_escapes_newline_in_label(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": {"weird": 1.0}}]
+        trials = [{"trial_index": 1, "category_scores": {"weird": 1.0}}]
         labels = {"weird": "Line one\nline two"}
         lines = render_per_trial_category_matrix(trials, ["weird"], labels)
         # Newline collapsed to a single space; the row stays one line.
@@ -73,7 +73,7 @@ class TestRenderPerTrialCategoryMatrix:
         assert "\n" not in lines[3]
 
     def test_escapes_backslash_in_label(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": {"weird": 1.0}}]
+        trials = [{"trial_index": 1, "category_scores": {"weird": 1.0}}]
         labels = {"weird": "back\\slash"}
         lines = render_per_trial_category_matrix(trials, ["weird"], labels)
         # Backslash is doubled before the pipe escape pass so a malicious
@@ -81,15 +81,15 @@ class TestRenderPerTrialCategoryMatrix:
         assert "back\\\\slash" in lines[3]
 
     def test_places_parameter_controls_precision(self) -> None:
-        trials = [{"trial_index": 0, "category_scores": {"memory": 0.123456}}]
+        trials = [{"trial_index": 1, "category_scores": {"memory": 0.123456}}]
         lines = render_per_trial_category_matrix(trials, ["memory"], {}, places=2)
-        assert lines[-1] == "| 0 | 0.12 |"
+        assert lines[-1] == "| 1 | 0.12 |"
 
     def test_columns_render_in_provided_order(self) -> None:
         # The caller controls column order via `cat_keys`; the helper must
         # not re-sort or it would break alignment with the header.
-        trials = [{"trial_index": 0, "category_scores": {"a": 0.1, "b": 0.2}}]
+        trials = [{"trial_index": 1, "category_scores": {"a": 0.1, "b": 0.2}}]
         forward = render_per_trial_category_matrix(trials, ["a", "b"], {})
         reverse = render_per_trial_category_matrix(trials, ["b", "a"], {})
-        assert forward[-1] == "| 0 | 0.100 | 0.200 |"
-        assert reverse[-1] == "| 0 | 0.200 | 0.100 |"
+        assert forward[-1] == "| 1 | 0.100 | 0.200 |"
+        assert reverse[-1] == "| 1 | 0.200 | 0.100 |"


### PR DESCRIPTION
Switch `trial_index` from 0-based to 1-based across the n-trials eval pipeline so that trial numbers in reports, summaries, log output, and the GHA matrix match how humans naturally count (trial 1, trial 2, ... instead of trial 0, trial 1, ...).