### PR TITLE
feat(evals): add unified `deepagents-evals` CLI

### DIFF
--- a/libs/evals/AGENTS.md
+++ b/libs/evals/AGENTS.md
@@ -1,0 +1,178 @@
+# `libs/evals` agent guide
+
+Quick reference for agents (and humans) running the Deep Agents eval suite.
+The canonical interface is the `deepagents-evals` console script, installed with this package. The `Makefile` targets remain available for parity with CI.
+
+## Canonical entry point
+
+```sh
+deepagents-evals --help
+deepagents-evals <subcommand> --help
+```
+
+Subcommands:
+
+| Subcommand     | Purpose                                                           |
+| -------------- | ----------------------------------------------------------------- |
+| `run`          | Run the eval suite once (single trial).                           |
+| `trials`       | Run the eval suite N times and aggregate metrics.                 |
+| `aggregate`    | Aggregate previously-written trial reports.                       |
+| `radar`        | Generate a radar chart from results.                              |
+| `catalog`      | Regenerate or check `EVAL_CATALOG.md`.                            |
+| `model-groups` | Regenerate or check `MODEL_GROUPS.md`.                            |
+| `list`         | Discover categories / tiers / models / evals.                     |
+
+Most subcommands accept:
+
+- `--json` — emit machine-readable JSON on stdout.
+- `--dry-run` — print the underlying invocation without executing.
+
+## Discovery
+
+Before kicking off a run, ask the CLI what's available — no source-grepping required:
+
+```sh
+deepagents-evals list categories                  # eval categories
+deepagents-evals list tiers                       # e.g. baseline | hillclimb
+deepagents-evals list models --json               # full eval-tagged registry
+deepagents-evals list models --group set0         # one preset
+deepagents-evals list models --provider anthropic # one provider
+deepagents-evals list evals --category memory     # eval functions in a category
+```
+
+## Common workflows
+
+```sh
+# Single trial against one model.
+deepagents-evals run --model claude-opus-4-7
+
+# Restrict to a category and tier, and write a JSON report.
+deepagents-evals run \
+    --model openai:gpt-5.5 \
+    --eval-category memory \
+    --eval-tier baseline \
+    --report evals_report.json
+
+# Three trials with stats aggregation.
+deepagents-evals trials --model openai:gpt-5.5 --trials 3
+
+# Re-run only the failures from a prior trial sweep.
+deepagents-evals trials \
+    --model openai:gpt-5.5 \
+    --trials 1 \
+    --retry-failed trial_runs/trials_summary.json
+
+# Aggregate CI artifacts after a fan-out workflow.
+deepagents-evals aggregate ./downloaded-artifacts --summary-out summary.json
+```
+
+## Default model env var
+
+Set `DEEPAGENTS_EVALS_MODEL` once and omit `--model`:
+
+```sh
+export DEEPAGENTS_EVALS_MODEL=claude-sonnet-4-6
+deepagents-evals run
+deepagents-evals trials --trials 3
+```
+
+`scripts/run_trials.py` honors the same env var when invoked directly,
+and supports its own `--json` flag for compact stdout output.
+
+## Exit codes
+
+| Code | Meaning                                                                                                                                                                                                                          |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success.                                                                                                                                                                                                                         |
+| `1`  | Eval failures. `run` saw a non-zero `pytest` exit; `trials` / `aggregate` produced a summary whose aggregated `counts.failed.mean` is greater than zero; `radar` failed.                                                         |
+| `2`  | Configuration error: missing `--model`, model-registry import failed, or a `--check` drift detector (`catalog --check`, `model-groups --check`) found that a generated file is stale. `argparse` usage errors also exit `2`.     |
+| `3`  | No usable reports: `trials` / `aggregate` produced no summary, or `--retry-failed` could not parse any prior reports.                                                                                                            |
+
+Use these codes to drive automation; do not parse human-readable output.
+
+The `pytest_reporter` plugin rewrites the per-trial pytest exit status to `0` even when individual evals fail (so a CI shell step doesn't fail the workflow). The CLI therefore reads `trials_summary.json`'s aggregated `counts.failed.mean` to decide whether to return `1`, not the per-trial `pytest_returncode` field.
+
+## Required environment
+
+The eval suite refuses to start without LangSmith tracing enabled:
+
+```sh
+export LANGSMITH_TRACING=true
+export LANGSMITH_API_KEY=...
+```
+
+Provider keys (any of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, ...) are required to match the chosen `--model`.
+
+## `trials_summary.json` schema
+
+`deepagents-evals trials` and `deepagents-evals aggregate` write a summary
+file with this shape:
+
+```jsonc
+{
+  "n_trials": 3,
+  "model": "openai:gpt-5.5",
+  "sdk_version": "0.5.7",
+  "metrics": {
+    "correctness":       {"n": 3, "mean": 0.84, "median": 0.85, "stdev": 0.02, "min": 0.82, "max": 0.86},
+    "solve_rate":        {"n": 3, "mean": 0.71, "median": 0.70, "stdev": 0.03, "min": 0.68, "max": 0.74},
+    "step_ratio":        {"n": 3, "mean": 1.10, "median": 1.10, "stdev": 0.01, "min": 1.09, "max": 1.11},
+    "tool_call_ratio":   {"n": 3, "mean": 1.05, "median": 1.05, "stdev": 0.01, "min": 1.04, "max": 1.06},
+    "median_duration_s": {"n": 3, "mean": 4.30, "median": 4.31, "stdev": 0.05, "min": 4.25, "max": 4.34}
+  },
+  "counts": {
+    "passed":  {"n": 3, "mean": 17.0, "median": 17, "stdev": 0.0, "min": 17, "max": 17},
+    "failed":  {"n": 3, "mean":  3.0, "median":  3, "stdev": 0.0, "min":  3, "max":  3},
+    "skipped": {"n": 3, "mean":  0.0, "median":  0, "stdev": 0.0, "min":  0, "max":  0},
+    "total":   {"n": 3, "mean": 20.0, "median": 20, "stdev": 0.0, "min": 20, "max": 20}
+  },
+  "category_scores": {
+    "memory":          {"n": 3, "mean": 0.83, "median": 0.83, "stdev": 0.0, "min": 0.83, "max": 0.83},
+    "tool_use":        {"n": 3, "mean": 0.90, "median": 0.90, "stdev": 0.0, "min": 0.90, "max": 0.90},
+    "file_operations": {"n": 3, "mean": 0.78, "median": 0.78, "stdev": 0.0, "min": 0.78, "max": 0.78}
+  },
+  "trials": [
+    {
+      "trial_index": 1,
+      "created_at": "2026-05-06T14:23:11+00:00",
+      "passed": 17, "failed": 3, "skipped": 0, "total": 20,
+      "correctness": 0.85,
+      "solve_rate": 0.70,
+      "step_ratio": 1.10,
+      "tool_call_ratio": 1.05,
+      "median_duration_s": 4.31,
+      "category_scores": {"memory": 0.83, "tool_use": 0.90, "file_operations": 0.78},
+      "experiment_urls": ["https://smith.langchain.com/..."],
+      "pytest_returncode": 0
+    }
+  ]
+}
+```
+
+Notes on the per-trial entries:
+
+- `pytest_returncode` is populated by the trial runner only on the
+  live-execution path. It is **not** written by `pytest_reporter`, so it
+  may be missing from individual `evals_report_trial_NNN.json` files and
+  from summaries produced via `--aggregate-only`.
+- `pytest_reporter` rewrites pytest's session exit status to `0` even when
+  tests fail, so `pytest_returncode` is not a reliable failure signal —
+  use `counts.failed.mean` instead.
+
+Per-trial `evals_report_trial_NNN.json` files written by `pytest_reporter` contain the metrics shown above and additionally carry a `failures` array used by `--retry-failed`:
+
+```jsonc
+{
+  "failures": [
+    {
+      "test_name": "tests/evals/test_memory.py::test_memory_recall[claude-sonnet-4-6]",
+      "category": "memory",
+      "failure_message": "AssertionError: ..."
+    }
+  ]
+}
+```
+
+## Relationship to the `Makefile`
+
+`make evals MODEL=...` and `make evals-trials MODEL=... TRIALS=...` still work and remain the form CI invokes. The console script is a strict superset — every flag the Makefile passes through to pytest is exposed as a first-class option on `deepagents-evals run` / `trials`, plus the discovery and JSON-output features the Makefile cannot offer.

--- a/libs/evals/deepagents_evals/cli.py
+++ b/libs/evals/deepagents_evals/cli.py
@@ -1,0 +1,725 @@
+"""Unified, agent-friendly CLI for the Deep Agents evaluation suite.
+
+Wraps the scattered `Makefile` targets and `scripts/*.py` entry points behind
+a single `deepagents-evals` console script with discoverable subcommands and
+machine-readable output.
+
+Subcommands:
+    run            Run the eval suite once (single trial).
+    trials         Run the eval suite N times and aggregate metrics.
+    aggregate      Aggregate previously-written trial reports.
+    radar          Generate a radar chart from results.
+    catalog        Regenerate or check `EVAL_CATALOG.md`.
+    model-groups   Regenerate or check `MODEL_GROUPS.md`.
+    list           Discover categories / tiers / models / evals.
+
+Exit codes:
+    0   Success.
+    1   Eval failures: `run` saw a non-zero pytest exit, or `trials` /
+        `aggregate` produced a summary whose aggregated `counts.failed.mean`
+        is greater than zero. `radar` non-zero exits also map here.
+    2   Configuration error: missing `--model`, registry-load failure, or
+        a `--check` drift detector found that a generated file is stale.
+    3   No usable reports: `trials` / `aggregate` produced no summary,
+        or `--retry-failed` could not parse any prior reports.
+
+Most subcommands accept `--json` for structured stdout and `--dry-run` for
+preview-only execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+EXIT_OK = 0
+"""Successful run."""
+
+EXIT_EVAL_FAILURES = 1
+"""At least one test failed in this run.
+
+For `run`, set when `pytest` exited non-zero. For `trials` / `aggregate`,
+set when the aggregated summary's `counts.failed.mean` is greater than
+zero — `pytest_reporter` rewrites `session.exitstatus` to 0 even on test
+failures, so the per-trial returncodes are not a reliable signal.
+"""
+
+EXIT_CONFIG = 2
+"""Bad CLI arguments, missing env vars, or unknown discovery values."""
+
+EXIT_NO_REPORTS = 3
+"""No readable reports were produced; nothing to aggregate."""
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+"""`libs/evals/deepagents_evals/`."""
+
+_EVALS_DIR = _PACKAGE_DIR.parent
+"""`libs/evals/`."""
+
+_REPO_ROOT = _EVALS_DIR.parent.parent
+"""Monorepo root."""
+
+_CATEGORIES_JSON = _PACKAGE_DIR / "categories.json"
+"""Source of truth for eval categories."""
+
+_KNOWN_TIERS = ("baseline", "hillclimb")
+"""Eval tier marker values recognized by `--eval-tier` / `pytest.mark.eval_tier`."""
+
+_MODEL_ENV_VAR = "DEEPAGENTS_EVALS_MODEL"
+"""When set, used as the default value for `--model` on `run` and `trials`."""
+
+
+def _load_categories() -> list[str]:
+    """Return the canonical list of eval categories from `categories.json`."""
+    data = json.loads(_CATEGORIES_JSON.read_text(encoding="utf-8"))
+    return list(data.get("categories", []))
+
+
+def _load_module_by_path(name: str, path: Path) -> Any:
+    """Import a Python file by absolute path, caching it in `sys.modules`.
+
+    Registering the module before `exec_module` runs is required because
+    classes defined in the loaded file resolve `cls.__module__` via
+    `sys.modules[name]` during construction. Without it, `@dataclass`
+    decorators (used in `scripts/run_trials.py`) fail with `AttributeError`.
+
+    Subsequent calls return the cached module so monkeypatched attributes
+    survive across `_import_*` helpers (the helpers are called on every
+    subcommand invocation; without caching, a fresh module would be loaded
+    each time and tests' patches would silently miss).
+    """
+    cached = sys.modules.get(name)
+    if cached is not None:
+        return cached
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        msg = f"could not import {path}"
+        raise RuntimeError(msg)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _import_models_module() -> Any:
+    """Import the registry module from `.github/scripts/models.py` lazily.
+
+    Kept lazy because the module isn't installable as a package and importing
+    it requires a `spec_from_file_location` dance — we only pay the cost when
+    `list models` is actually invoked.
+    """
+    return _load_module_by_path(
+        "_deepagents_evals_models", _REPO_ROOT / ".github" / "scripts" / "models.py"
+    )
+
+
+def _list_known_models() -> list[dict[str, Any]]:
+    """Return all eval-tagged models with their groups and provider labels."""
+    mod = _import_models_module()
+    out: list[dict[str, Any]] = []
+    for m in mod.REGISTRY:
+        eval_groups = sorted(g.split(":", 1)[1] for g in m.groups if g.startswith("eval:"))
+        if not eval_groups:
+            continue
+        out.append(
+            {
+                "spec": m.spec,
+                "display_name": m.display_name,
+                "provider_label": m.provider_label,
+                "groups": eval_groups,
+            }
+        )
+    out.sort(key=lambda r: r["spec"])
+    return out
+
+
+def _list_known_evals() -> list[dict[str, Any]]:
+    """Return all discovered eval functions with their categories.
+
+    Reuses the AST walker from `scripts/generate_eval_catalog.py` rather than
+    importing the test modules (which would require LangSmith env config and
+    the full eval dependency graph).
+    """
+    mod = _load_module_by_path(
+        "_deepagents_eval_catalog", _EVALS_DIR / "scripts" / "generate_eval_catalog.py"
+    )
+    catalog: dict[str, list[tuple[str, str, int]]] = mod._collect_evals()  # noqa: SLF001
+    out: list[dict[str, Any]] = []
+    for category, entries in catalog.items():
+        for name, path, line in entries:
+            out.append(
+                {
+                    "name": name,
+                    "category": category,
+                    "path": path,
+                    "line": line,
+                }
+            )
+    out.sort(key=lambda r: (r["category"], r["path"], r["line"]))
+    return out
+
+
+def _emit_json(payload: object) -> None:
+    """Print `payload` as compact JSON on a single line."""
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _emit_table(rows: list[dict[str, Any]], columns: Sequence[str]) -> None:
+    """Render `rows` as a fixed-width table on stdout."""
+    if not rows:
+        return
+    widths = {col: max(len(col), *(len(str(r.get(col, ""))) for r in rows)) for col in columns}
+    header = "  ".join(col.ljust(widths[col]) for col in columns)
+    print(header)
+    print("  ".join("-" * widths[col] for col in columns))
+    for r in rows:
+        print("  ".join(str(r.get(col, "")).ljust(widths[col]) for col in columns))
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    """Discover available categories / tiers / models / evals."""
+    if args.target == "categories":
+        cats = _load_categories()
+        if args.json:
+            _emit_json(cats)
+        else:
+            print("\n".join(cats))
+        return EXIT_OK
+
+    if args.target == "tiers":
+        if args.json:
+            _emit_json(list(_KNOWN_TIERS))
+        else:
+            print("\n".join(_KNOWN_TIERS))
+        return EXIT_OK
+
+    if args.target == "models":
+        try:
+            models = _list_known_models()
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"error: failed to load model registry from .github/scripts/models.py: {exc}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG
+        if args.group:
+            models = [m for m in models if args.group in m["groups"]]
+        if args.provider:
+            models = [m for m in models if m["spec"].split(":", 1)[0] == args.provider]
+        if args.json:
+            _emit_json(models)
+        else:
+            _emit_table(models, ("spec", "display_name", "provider_label", "groups"))
+        return EXIT_OK
+
+    if args.target == "evals":
+        try:
+            evals = _list_known_evals()
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"error: failed to discover evals from tests/evals/: {exc}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG
+        if args.category:
+            evals = [e for e in evals if e["category"] == args.category]
+        if args.json:
+            _emit_json(evals)
+        else:
+            _emit_table(evals, ("category", "name", "path", "line"))
+        return EXIT_OK
+
+    msg = f"unknown list target: {args.target!r}"
+    raise AssertionError(msg)
+
+
+def _build_single_trial_argv(args: argparse.Namespace) -> list[str]:
+    """Build the `pytest tests/evals` argv for a single-trial run.
+
+    Mirrors `make evals` but adds optional report path and lets every flag from
+    `tests/evals/conftest.py:pytest_addoption` flow through.
+    """
+    cmd: list[str] = [
+        "uv",
+        "run",
+        "--group",
+        "test",
+        "pytest",
+        "tests/evals",
+        "-v",
+        "--tb=short",
+        "--model",
+        args.model,
+    ]
+    if args.report:
+        cmd.extend(["--evals-report-file", str(args.report)])
+    for cat in args.eval_category or []:
+        cmd.extend(["--eval-category", cat])
+    for cat in args.eval_category_exclude or []:
+        cmd.extend(["--eval-category-exclude", cat])
+    for tier in args.eval_tier or []:
+        cmd.extend(["--eval-tier", tier])
+    if args.openai_reasoning_effort:
+        cmd.extend(["--openai-reasoning-effort", args.openai_reasoning_effort])
+    if args.openrouter_provider:
+        cmd.extend(["--openrouter-provider", args.openrouter_provider])
+    if args.openrouter_allow_fallbacks:
+        cmd.append("--openrouter-allow-fallbacks")
+    if args.repl:
+        cmd.extend(["--repl", args.repl])
+    cmd.extend(args.pytest_extra)
+    return cmd
+
+
+def _validate_model(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Resolve `--model` from args / env, exit-2 on failure with a helpful message."""
+    if args.model:
+        return
+    env_model = os.environ.get(_MODEL_ENV_VAR)
+    if env_model:
+        args.model = env_model
+        return
+    sample_groups: list[str] = []
+    try:
+        models = _list_known_models()
+        all_groups = sorted({g for m in models for g in m["groups"]})
+        sample_groups = all_groups[:8]
+    except Exception as exc:  # noqa: BLE001
+        # Discovery is best-effort, but a failing registry probe is itself
+        # worth surfacing — silent regressions in `.github/scripts/models.py`
+        # would otherwise rot until someone runs `list models` directly.
+        print(
+            f"warning: could not enumerate model groups for help text: {exc}",
+            file=sys.stderr,
+        )
+    extra = (
+        f"\n  Known model groups (run `deepagents-evals list models --group <name>`): "
+        f"{', '.join(sample_groups)}"
+        if sample_groups
+        else ""
+    )
+    parser.exit(
+        EXIT_CONFIG,
+        f"error: --model is required (or set {_MODEL_ENV_VAR}). "
+        f"Example: --model claude-sonnet-4-6{extra}\n",
+    )
+
+
+def _cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
+    """Run the eval suite once via `pytest tests/evals`."""
+    _validate_model(args, parser)
+    cmd = _build_single_trial_argv(args)
+    if args.dry_run:
+        if args.json:
+            _emit_json({"dry_run": True, "argv": cmd, "cwd": str(_EVALS_DIR)})
+        else:
+            print("$ " + " ".join(cmd))
+        return EXIT_OK
+    env = os.environ.copy()
+    env.setdefault("LANGSMITH_TEST_SUITE", "deepagents-evals")
+    result = subprocess.run(cmd, cwd=_EVALS_DIR, env=env, check=False)
+    if args.json:
+        _emit_json(
+            {
+                "model": args.model,
+                "returncode": result.returncode,
+                "report": str(args.report) if args.report else None,
+            }
+        )
+    if result.returncode == 0:
+        return EXIT_OK
+    return EXIT_EVAL_FAILURES
+
+
+def _import_run_trials() -> Any:
+    """Import `scripts/run_trials.py` lazily (the script lives outside the package)."""
+    return _load_module_by_path("_deepagents_run_trials", _EVALS_DIR / "scripts" / "run_trials.py")
+
+
+def _collect_failed_nodeids(summary_or_dir: Path) -> tuple[list[str], int, int]:
+    """Read failure node IDs from per-trial reports.
+
+    `summary_or_dir` may be a `trials_summary.json` file (its parent directory
+    is searched) or a directory containing `evals_report_trial_*.json` files.
+    Per-trial reports each carry a `failures` array of
+    `{test_name, category, failure_message}` dicts; node IDs are deduped
+    across trials so a flake that failed once is retried once.
+
+    Returns:
+        A tuple `(nodeids, n_total, n_loaded)` where `n_total` is the number
+            of report files discovered and `n_loaded` is the subset that parsed
+            successfully. Callers use the difference to distinguish "every trial
+            passed" from "every report was unreadable".
+    """
+    rt = _import_run_trials()
+    root = summary_or_dir.parent if summary_or_dir.is_file() else summary_or_dir
+    nodeids: set[str] = set()
+    paths = rt._discover_reports(root)  # noqa: SLF001
+    n_loaded = 0
+    for path in paths:
+        data = rt._load_report(path)  # noqa: SLF001
+        if not data:
+            continue
+        n_loaded += 1
+        failures = data.get("failures")
+        if failures is None:
+            continue
+        if not isinstance(failures, list):
+            print(
+                f"warning: ignoring non-list `failures` in {path}: {type(failures).__name__}",
+                file=sys.stderr,
+            )
+            continue
+        for failure in failures:
+            if not isinstance(failure, dict):
+                continue
+            nodeid = failure.get("test_name")
+            if isinstance(nodeid, str) and nodeid:
+                nodeids.add(nodeid)
+    return sorted(nodeids), len(paths), n_loaded
+
+
+def _cmd_trials(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
+    """Run N trials and aggregate, delegating to `scripts/run_trials.py`."""
+    _validate_model(args, parser)
+    rt = _import_run_trials()
+
+    rt_argv: list[str] = ["--model", args.model, "--trials", str(args.trials)]
+    for cat in args.eval_category or []:
+        rt_argv.extend(["--eval-category", cat])
+    for tier in args.eval_tier or []:
+        rt_argv.extend(["--eval-tier", tier])
+    if args.openai_reasoning_effort:
+        rt_argv.extend(["--openai-reasoning-effort", args.openai_reasoning_effort])
+    if args.openrouter_provider:
+        rt_argv.extend(["--openrouter-provider", args.openrouter_provider])
+    if args.openrouter_allow_fallbacks:
+        rt_argv.append("--openrouter-allow-fallbacks")
+    if args.repl:
+        rt_argv.extend(["--repl", args.repl])
+    if args.out_dir:
+        rt_argv.extend(["--out-dir", str(args.out_dir)])
+    if args.summary_out:
+        rt_argv.extend(["--summary-out", str(args.summary_out)])
+
+    if args.retry_failed:
+        nodeids, n_total, n_loaded = _collect_failed_nodeids(args.retry_failed)
+        if not nodeids:
+            if n_total > 0 and n_loaded == 0:
+                print(
+                    f"error: discovered {n_total} report(s) under {args.retry_failed} "
+                    f"but none parsed; see warnings above",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"error: no failed test node IDs found under {args.retry_failed}",
+                    file=sys.stderr,
+                )
+            return EXIT_NO_REPORTS
+        if args.dry_run:
+            payload = {"retry_failed": nodeids, "trials": args.trials, "model": args.model}
+            if args.json:
+                _emit_json(payload)
+            else:
+                print(f"would retry {len(nodeids)} failed test(s):\n  " + "\n  ".join(nodeids))
+            return EXIT_OK
+        rt_argv.extend(["--", *nodeids])
+    else:
+        rt_argv.extend(args.pytest_extra or [])
+
+    if args.dry_run:
+        # Show the argv that would be passed to run_trials.main().
+        msg = {"argv": rt_argv, "script": str(_EVALS_DIR / "scripts" / "run_trials.py")}
+        if args.json:
+            _emit_json(msg)
+        else:
+            print("would run: scripts/run_trials.py " + " ".join(rt_argv))
+        return EXIT_OK
+
+    rc = rt.main(rt_argv)
+    if rc != 0:
+        # `run_trials.main` only returns 0 (aggregation done) or 1 (no reports).
+        return EXIT_NO_REPORTS
+    summary_path = _resolve_summary_path(args)
+    return _exit_code_from_summary(summary_path)
+
+
+def _cmd_aggregate(args: argparse.Namespace) -> int:
+    """Aggregate existing reports under a directory."""
+    rt = _import_run_trials()
+    rt_argv = ["--aggregate-only", str(args.directory)]
+    if args.summary_out:
+        rt_argv.extend(["--summary-out", str(args.summary_out)])
+    if args.json:
+        rt_argv.append("--json")
+    rc = rt.main(rt_argv)
+    if rc != 0:
+        return EXIT_NO_REPORTS
+    summary_path = args.summary_out or (args.directory / "trials_summary.json")
+    return _exit_code_from_summary(summary_path)
+
+
+def _resolve_summary_path(args: argparse.Namespace) -> Path:
+    """Compute where `run_trials.main()` wrote its `trials_summary.json`.
+
+    Mirrors `scripts/run_trials.py` defaults: `--summary-out` wins, otherwise
+    `<--out-dir or trial_runs>/trials_summary.json` next to the per-trial
+    reports.
+    """
+    if args.summary_out:
+        return args.summary_out
+    out_dir = args.out_dir or (_EVALS_DIR / "trial_runs")
+    return out_dir / "trials_summary.json"
+
+
+def _exit_code_from_summary(summary_path: Path) -> int:
+    """Map an aggregated `trials_summary.json` to a CLI exit code.
+
+    `pytest_reporter` rewrites the per-trial `session.exitstatus` to 0 when
+    tests fail (so CI doesn't fail the workflow shell), which means the
+    aggregated `pytest_returncode` is also 0 for failure-laden runs. The
+    only reliable signal is the aggregated `counts.failed.mean` produced by
+    `aggregate_trials`. A non-zero failed mean ⇒ at least one test failed
+    in at least one trial.
+    """
+    try:
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"warning: could not read {summary_path}: {exc}", file=sys.stderr)
+        return EXIT_OK
+    failed = data.get("counts", {}).get("failed", {}).get("mean")
+    if isinstance(failed, (int, float)) and failed > 0:
+        return EXIT_EVAL_FAILURES
+    return EXIT_OK
+
+
+def _shell_out(
+    cmd: list[str],
+    *,
+    dry_run: bool,
+    json_mode: bool,
+    nonzero_exit: int = EXIT_EVAL_FAILURES,
+) -> int:
+    """Run an external command from `_EVALS_DIR`, honoring dry-run / JSON modes.
+
+    `nonzero_exit` controls how a non-zero subprocess return is mapped to a
+    CLI exit code; defaults to `EXIT_EVAL_FAILURES` for the eval-running
+    paths and is overridden to `EXIT_CONFIG` for `--check` drift detectors,
+    where a non-zero exit means "files are out of date", not "evals failed".
+    """
+    if dry_run:
+        if json_mode:
+            _emit_json({"dry_run": True, "argv": cmd, "cwd": str(_EVALS_DIR)})
+        else:
+            print("$ " + " ".join(cmd))
+        return EXIT_OK
+    result = subprocess.run(cmd, cwd=_EVALS_DIR, check=False)
+    return EXIT_OK if result.returncode == 0 else nonzero_exit
+
+
+def _cmd_radar(args: argparse.Namespace) -> int:
+    """Generate a radar chart by delegating to `scripts/generate_radar.py`."""
+    cmd = ["uv", "run", "--extra", "charts", "python", "scripts/generate_radar.py"]
+    if args.toy:
+        cmd.append("--toy")
+    if args.summary:
+        cmd.extend(["--summary", str(args.summary)])
+    if args.results:
+        cmd.extend(["--results", str(args.results)])
+    if args.output:
+        cmd.extend(["-o", str(args.output)])
+    cmd.extend(args.extra or [])
+    return _shell_out(cmd, dry_run=args.dry_run, json_mode=args.json)
+
+
+def _cmd_catalog(args: argparse.Namespace) -> int:
+    """Regenerate or check `EVAL_CATALOG.md`."""
+    cmd = ["uv", "run", "python", "scripts/generate_eval_catalog.py"]
+    if args.check:
+        cmd.append("--check")
+    # `--check` non-zero means drift, which is a configuration condition
+    # (the file is stale), not an eval failure.
+    nonzero = EXIT_CONFIG if args.check else EXIT_EVAL_FAILURES
+    return _shell_out(cmd, dry_run=args.dry_run, json_mode=args.json, nonzero_exit=nonzero)
+
+
+def _cmd_model_groups(args: argparse.Namespace) -> int:
+    """Regenerate or check `MODEL_GROUPS.md`."""
+    cmd = ["uv", "run", "python", "scripts/generate_model_groups.py"]
+    if args.check:
+        cmd.append("--check")
+    nonzero = EXIT_CONFIG if args.check else EXIT_EVAL_FAILURES
+    return _shell_out(cmd, dry_run=args.dry_run, json_mode=args.json, nonzero_exit=nonzero)
+
+
+def _add_run_options(p: argparse.ArgumentParser) -> None:
+    """Attach the shared `--model` / category / tier / provider flags."""
+    p.add_argument(
+        "--model",
+        default=None,
+        help=(
+            f"Model identifier. Defaults to ${_MODEL_ENV_VAR} when --model is omitted; "
+            f"the explicit flag wins when both are set."
+        ),
+    )
+    p.add_argument(
+        "--eval-category",
+        action="append",
+        default=[],
+        help="Restrict to one eval category (repeatable).",
+    )
+    p.add_argument(
+        "--eval-category-exclude",
+        action="append",
+        default=[],
+        help="Exclude one eval category (repeatable).",
+    )
+    p.add_argument(
+        "--eval-tier",
+        action="append",
+        default=[],
+        choices=_KNOWN_TIERS,
+        help="Restrict to one eval tier (repeatable).",
+    )
+    p.add_argument(
+        "--openai-reasoning-effort",
+        choices=("minimal", "low", "medium", "high", "xhigh"),
+        default=None,
+    )
+    p.add_argument("--openrouter-provider", default=None)
+    p.add_argument("--openrouter-allow-fallbacks", action="store_true", default=False)
+    p.add_argument("--repl", choices=("quickjs", "langchain"), default=None)
+    p.add_argument("--dry-run", action="store_true", help="Print the command instead of running.")
+    p.add_argument("--json", action="store_true", help="Emit machine-readable JSON on stdout.")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the top-level argparse parser for `deepagents-evals`."""
+    parser = argparse.ArgumentParser(
+        prog="deepagents-evals",
+        description=(
+            "Unified, agent-friendly CLI for the Deep Agents evaluation suite. "
+            "See `deepagents-evals <subcommand> --help` for details."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True, metavar="<subcommand>")
+
+    # run
+    p_run = sub.add_parser("run", help="Run the eval suite once.")
+    _add_run_options(p_run)
+    p_run.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Where to write the per-run JSON report (passes --evals-report-file to pytest).",
+    )
+    p_run.add_argument(
+        "pytest_extra",
+        nargs=argparse.REMAINDER,
+        help="Extra pytest args (use `--` to separate).",
+    )
+    p_run.set_defaults(func=lambda a: _cmd_run(a, p_run))
+
+    # trials
+    p_trials = sub.add_parser("trials", help="Run the eval suite N times and aggregate.")
+    _add_run_options(p_trials)
+    p_trials.add_argument("--trials", type=int, default=None)
+    p_trials.add_argument("--out-dir", type=Path, default=None)
+    p_trials.add_argument("--summary-out", type=Path, default=None)
+    p_trials.add_argument(
+        "--retry-failed",
+        type=Path,
+        default=None,
+        help=(
+            "Re-run only the failing tests from a prior run. PATH may be a "
+            "trials_summary.json file or a directory containing per-trial reports."
+        ),
+    )
+    p_trials.add_argument("pytest_extra", nargs=argparse.REMAINDER)
+    p_trials.set_defaults(func=lambda a: _cmd_trials(a, p_trials))
+
+    # aggregate
+    p_agg = sub.add_parser("aggregate", help="Aggregate existing trial reports.")
+    p_agg.add_argument("directory", type=Path, help="Directory to recursively scan for reports.")
+    p_agg.add_argument("--summary-out", type=Path, default=None)
+    p_agg.add_argument("--json", action="store_true")
+    p_agg.set_defaults(func=_cmd_aggregate)
+
+    # radar
+    p_radar = sub.add_parser("radar", help="Generate a radar chart.")
+    p_radar.add_argument("--toy", action="store_true")
+    p_radar.add_argument("--summary", type=Path, default=None)
+    p_radar.add_argument("--results", type=Path, default=None)
+    p_radar.add_argument("-o", "--output", type=Path, default=None)
+    p_radar.add_argument("--dry-run", action="store_true")
+    p_radar.add_argument("--json", action="store_true")
+    p_radar.add_argument("extra", nargs=argparse.REMAINDER)
+    p_radar.set_defaults(func=_cmd_radar)
+
+    # catalog
+    p_cat = sub.add_parser("catalog", help="Regenerate or check EVAL_CATALOG.md.")
+    p_cat.add_argument("--check", action="store_true")
+    p_cat.add_argument("--dry-run", action="store_true")
+    p_cat.add_argument("--json", action="store_true")
+    p_cat.set_defaults(func=_cmd_catalog)
+
+    # model-groups
+    p_mg = sub.add_parser("model-groups", help="Regenerate or check MODEL_GROUPS.md.")
+    p_mg.add_argument("--check", action="store_true")
+    p_mg.add_argument("--dry-run", action="store_true")
+    p_mg.add_argument("--json", action="store_true")
+    p_mg.set_defaults(func=_cmd_model_groups)
+
+    # list
+    p_list = sub.add_parser("list", help="Discover categories / tiers / models / evals.")
+    list_sub = p_list.add_subparsers(dest="target", required=True, metavar="<target>")
+    p_list_cat = list_sub.add_parser("categories", help="List eval categories.")
+    p_list_cat.add_argument("--json", action="store_true")
+    p_list_tiers = list_sub.add_parser("tiers", help="List eval tiers.")
+    p_list_tiers.add_argument("--json", action="store_true")
+    p_list_models = list_sub.add_parser("models", help="List eval-tagged models.")
+    p_list_models.add_argument("--group", default=None, help="Filter by group (e.g. set0).")
+    p_list_models.add_argument("--provider", default=None, help="Filter by provider prefix.")
+    p_list_models.add_argument("--json", action="store_true")
+    p_list_evals = list_sub.add_parser("evals", help="List discovered eval functions.")
+    p_list_evals.add_argument("--category", default=None, help="Filter by category.")
+    p_list_evals.add_argument("--json", action="store_true")
+    p_list.set_defaults(func=_cmd_list)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the `deepagents-evals` console script.
+
+    Args:
+        argv: Optional argv override (mostly for tests). When `None`,
+            `argparse` reads from `sys.argv`.
+
+    Returns:
+        One of the `EXIT_*` constants.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "trials" and args.trials is None:
+        parser.error("--trials is required")
+    # `argparse.REMAINDER` keeps a leading `--`; downstream callers don't want it.
+    if hasattr(args, "pytest_extra") and args.pytest_extra and args.pytest_extra[0] == "--":
+        args.pytest_extra = args.pytest_extra[1:]
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -50,6 +50,9 @@ dependencies = [
     "langchain-quickjs",
 ]
 
+[project.scripts]
+deepagents-evals = "deepagents_evals.cli:main"
+
 [project.optional-dependencies]
 charts = [
     "matplotlib>=3.9.0",
@@ -170,6 +173,12 @@ ban-relative-imports = "all"
     "INP001",  # Missing `__init__.py` — scripts are standalone
     "T201",    # `print` found — scripts use print for output
     "S",       # Security warnings — not applicable to scripts
+]
+"deepagents_evals/cli.py" = [
+    "T201",    # `print` is the CLI's stdout output mechanism
+    "S",       # subprocess invocations are the CLI's purpose
+    "PLC0415", # Lazy imports keep startup fast and isolate optional deps
+    "ANN401",  # Lazy-imported scripts have no static type
 ]
 "deepagents_harbor/langsmith.py" = [
     "T201",    # `print` found — CI-facing integration layer, print is the expected output

--- a/libs/evals/scripts/run_trials.py
+++ b/libs/evals/scripts/run_trials.py
@@ -52,6 +52,9 @@ _COUNT_FIELDS = ("passed", "failed", "skipped", "total")
 _MIN_SAMPLES_FOR_STDEV = 2
 """`statistics.stdev` requires at least two samples; below that we report None."""
 
+_MODEL_ENV_VAR = "DEEPAGENTS_EVALS_MODEL"
+"""When set, used as the default value for `--model` if the flag is omitted."""
+
 
 def _warn(message: str) -> None:
     """Emit a warning to stderr, prefixed with `::warning::` under GitHub Actions.
@@ -467,7 +470,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--model",
         required=False,
-        help="Model identifier, e.g. openai:gpt-5.5 (passed through to pytest). Required unless --aggregate-only is set.",
+        default=os.environ.get(_MODEL_ENV_VAR),
+        help=(
+            "Model identifier, e.g. openai:gpt-5.5 (passed through to pytest). "
+            f"Required unless --aggregate-only is set. Defaults to ${_MODEL_ENV_VAR} when set."
+        ),
     )
     parser.add_argument(
         "--trials",
@@ -521,6 +528,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=f"Where per-trial reports and the summary are written (default: {_DEFAULT_OUT_DIR}).",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help=(
+            "Emit the aggregated summary as compact JSON on stdout (in addition "
+            "to writing trials_summary.json). Useful for downstream agents."
+        ),
+    )
+    parser.add_argument(
         "pytest_extra",
         nargs=argparse.REMAINDER,
         help="Extra args to forward to pytest (use `--` to separate).",
@@ -529,7 +545,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     if args.aggregate_only is None:
         if not args.model:
-            parser.error("--model is required (unless --aggregate-only is set)")
+            parser.error(
+                f"--model is required (unless --aggregate-only is set). "
+                f"Set ${_MODEL_ENV_VAR} or pass --model. "
+                f"Run `deepagents-evals list models` for known specs."
+            )
         if args.trials is None:
             parser.error("--trials is required (unless --aggregate-only is set)")
         if not 1 <= args.trials <= _MAX_TRIALS:
@@ -603,8 +623,15 @@ def main(argv: list[str] | None = None) -> int:
     summary_path = args.summary_out or (out_dir / "trials_summary.json")
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    _print_summary(summary)
-    print(f"\nwrote {summary_path}")
+    if args.json:
+        # Compact single-line JSON keeps stdout machine-parseable; the human
+        # summary still goes to the on-disk `trials_summary.json` and to
+        # stderr below for terminal users.
+        print(json.dumps(summary, sort_keys=True))
+        print(f"wrote {summary_path}", file=sys.stderr)
+    else:
+        _print_summary(summary)
+        print(f"\nwrote {summary_path}")
     return 0
 
 

--- a/libs/evals/tests/unit_tests/test_cli.py
+++ b/libs/evals/tests/unit_tests/test_cli.py
@@ -1,0 +1,407 @@
+"""Tests for the unified `deepagents-evals` CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_evals import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts without the default-model env var leaking from the host.
+
+    `monkeypatch` handles teardown automatically; no `yield` needed.
+    """
+    monkeypatch.delenv(cli._MODEL_ENV_VAR, raising=False)
+
+
+class TestListSubcommand:
+    def test_categories_text(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["list", "categories"])
+        out = capsys.readouterr().out
+        assert rc == cli.EXIT_OK
+        assert "memory" in out
+        assert "tool_use" in out
+
+    def test_categories_json_is_valid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["list", "categories", "--json"])
+        assert rc == cli.EXIT_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert "memory" in payload
+        assert payload == sorted(payload) or "memory" in payload
+
+    def test_tiers_text(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["list", "tiers"])
+        out = capsys.readouterr().out.splitlines()
+        assert rc == cli.EXIT_OK
+        assert "baseline" in out
+        assert "hillclimb" in out
+
+    def test_evals_filtered_by_category(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["list", "evals", "--category", "memory", "--json"])
+        assert rc == cli.EXIT_OK
+        evals = json.loads(capsys.readouterr().out)
+        assert isinstance(evals, list)
+        assert evals, "expected at least one memory eval"
+        assert all(e["category"] == "memory" for e in evals)
+
+    def test_models_lists_eval_tagged(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["list", "models", "--json"])
+        assert rc == cli.EXIT_OK
+        models = json.loads(capsys.readouterr().out)
+        assert isinstance(models, list)
+        assert any(m["spec"].startswith("anthropic:") for m in models)
+        assert all("groups" in m for m in models)
+
+    def test_models_filtered_by_provider(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["list", "models", "--provider", "anthropic", "--json"])
+        assert rc == cli.EXIT_OK
+        models = json.loads(capsys.readouterr().out)
+        assert models
+        assert all(m["spec"].startswith("anthropic:") for m in models)
+
+
+class TestRunSubcommand:
+    def test_dry_run_prints_argv(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(
+            [
+                "run",
+                "--model",
+                "openai:gpt-5.5",
+                "--eval-category",
+                "memory",
+                "--eval-tier",
+                "baseline",
+                "--report",
+                "/tmp/x.json",
+                "--dry-run",
+                "--json",
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is True
+        argv = payload["argv"]
+        assert "pytest" in argv
+        assert "tests/evals" in argv
+        assert "--model" in argv
+        assert "openai:gpt-5.5" in argv
+        assert "--eval-category" in argv
+        assert "memory" in argv
+        assert "--eval-tier" in argv
+        assert "baseline" in argv
+        assert "--evals-report-file" in argv
+
+    def test_missing_model_is_config_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # `parser.exit` raises SystemExit with the configured code.
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(["run", "--dry-run"])
+        assert excinfo.value.code == cli.EXIT_CONFIG
+        err = capsys.readouterr().err
+        assert "--model is required" in err
+        assert cli._MODEL_ENV_VAR in err
+
+    def test_env_var_supplies_model(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(cli._MODEL_ENV_VAR, "anthropic:claude-sonnet-4-6")
+        rc = cli.main(["run", "--dry-run", "--json"])
+        assert rc == cli.EXIT_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert "anthropic:claude-sonnet-4-6" in payload["argv"]
+
+
+class TestTrialsSubcommand:
+    def test_dry_run_emits_argv(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--eval-category",
+                "tool_use",
+                "--dry-run",
+                "--json",
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        payload = json.loads(capsys.readouterr().out)
+        argv = payload["argv"]
+        assert "--model" in argv
+        assert "openai:gpt-5.5" in argv
+        assert "--trials" in argv
+        assert "2" in argv
+        assert "--eval-category" in argv
+        assert "tool_use" in argv
+
+    def test_retry_failed_collects_nodeids(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Seed a trial-report file with two failures.
+        report = {
+            "model": "openai:gpt-5.5",
+            "passed": 1,
+            "failed": 2,
+            "skipped": 0,
+            "total": 3,
+            "failures": [
+                {
+                    "test_name": "tests/evals/test_memory.py::test_a",
+                    "category": "memory",
+                    "failure_message": "boom",
+                },
+                {
+                    "test_name": "tests/evals/test_tool.py::test_b",
+                    "category": "tool_use",
+                    "failure_message": "boom",
+                },
+            ],
+        }
+        (tmp_path / "evals_report_trial_001.json").write_text(json.dumps(report))
+
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "1",
+                "--retry-failed",
+                str(tmp_path),
+                "--dry-run",
+                "--json",
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["model"] == "openai:gpt-5.5"
+        assert sorted(payload["retry_failed"]) == [
+            "tests/evals/test_memory.py::test_a",
+            "tests/evals/test_tool.py::test_b",
+        ]
+
+    def test_retry_failed_no_failures_returns_no_reports(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "1",
+                "--retry-failed",
+                str(tmp_path),
+                "--dry-run",
+            ]
+        )
+        assert rc == cli.EXIT_NO_REPORTS
+        assert "no failed test node IDs" in capsys.readouterr().err
+
+    def test_retry_failed_unreadable_reports_distinct_message(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Seed a corrupted report so `_load_report` discards it.
+        (tmp_path / "evals_report_trial_001.json").write_text("not valid json")
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "1",
+                "--retry-failed",
+                str(tmp_path),
+                "--dry-run",
+            ]
+        )
+        err = capsys.readouterr().err
+        assert rc == cli.EXIT_NO_REPORTS
+        assert "discovered" in err
+        assert "but none parsed" in err
+
+    def test_retry_failed_forwards_separator_to_run_trials(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Capture the argv passed to run_trials.main when the dry-run shortcut
+        # is bypassed (no --dry-run flag).
+        report = {
+            "failures": [{"test_name": "tests/evals/test_x.py::test_a"}],
+        }
+        (tmp_path / "evals_report_trial_001.json").write_text(json.dumps(report))
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_main(argv: list[str]) -> int:
+            captured["argv"] = list(argv)
+            # Write a passing summary so post-hoc resolution returns EXIT_OK.
+            summary_path = tmp_path / "trials_summary.json"
+            summary_path.write_text(json.dumps({"counts": {"failed": {"mean": 0}}}))
+            return 0
+
+        rt = cli._import_run_trials()
+        monkeypatch.setattr(rt, "main", fake_main)
+        # Force the summary path the CLI computes to land in tmp_path.
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "1",
+                "--retry-failed",
+                str(tmp_path),
+                "--summary-out",
+                str(tmp_path / "trials_summary.json"),
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        argv = captured["argv"]
+        # The `--` must precede any node ID forwarded to pytest, otherwise
+        # `argparse.REMAINDER` parses node IDs as run_trials flags.
+        sep_idx = argv.index("--")
+        assert argv[sep_idx + 1] == "tests/evals/test_x.py::test_a"
+
+
+class TestExitCodeMapping:
+    def _summary_with_failures(self, path: Path, *, failed_mean: float) -> None:
+        path.write_text(json.dumps({"counts": {"failed": {"mean": failed_mean}}}))
+
+    def test_run_subprocess_zero_returns_ok(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        def fake_run(cmd: list[str], **_kw: object) -> subprocess.CompletedProcess[bytes]:
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        rc = cli.main(["run", "--model", "openai:gpt-5.5", "--json"])
+        assert rc == cli.EXIT_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["returncode"] == 0
+
+    def test_run_subprocess_nonzero_maps_to_eval_failures(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            cli.subprocess,
+            "run",
+            lambda cmd, **_kw: subprocess.CompletedProcess(args=cmd, returncode=1),
+        )
+        rc = cli.main(["run", "--model", "openai:gpt-5.5"])
+        assert rc == cli.EXIT_EVAL_FAILURES
+
+    def test_trials_failures_in_summary_returns_eval_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary = tmp_path / "trials_summary.json"
+        self._summary_with_failures(summary, failed_mean=2.5)
+        rt = cli._import_run_trials()
+        monkeypatch.setattr(rt, "main", lambda _argv: 0)
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--summary-out",
+                str(summary),
+            ]
+        )
+        assert rc == cli.EXIT_EVAL_FAILURES
+
+    def test_trials_no_failures_returns_ok(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        summary = tmp_path / "trials_summary.json"
+        self._summary_with_failures(summary, failed_mean=0)
+        rt = cli._import_run_trials()
+        monkeypatch.setattr(rt, "main", lambda _argv: 0)
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--summary-out",
+                str(summary),
+            ]
+        )
+        assert rc == cli.EXIT_OK
+
+    def test_trials_no_reports_maps_to_exit_no_reports(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rt = cli._import_run_trials()
+        monkeypatch.setattr(rt, "main", lambda _argv: 1)
+        rc = cli.main(["trials", "--model", "openai:gpt-5.5", "--trials", "2"])
+        assert rc == cli.EXIT_NO_REPORTS
+
+    def test_aggregate_forwards_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, list[str]] = {}
+
+        def fake_main(argv: list[str]) -> int:
+            captured["argv"] = list(argv)
+            (tmp_path / "trials_summary.json").write_text(
+                json.dumps({"counts": {"failed": {"mean": 0}}})
+            )
+            return 0
+
+        rt = cli._import_run_trials()
+        monkeypatch.setattr(rt, "main", fake_main)
+        rc = cli.main(["aggregate", str(tmp_path), "--json"])
+        assert rc == cli.EXIT_OK
+        assert "--json" in captured["argv"]
+
+    def test_catalog_check_drift_maps_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            cli.subprocess,
+            "run",
+            lambda cmd, **_kw: subprocess.CompletedProcess(args=cmd, returncode=1),
+        )
+        rc = cli.main(["catalog", "--check"])
+        assert rc == cli.EXIT_CONFIG
+
+    def test_model_groups_check_drift_maps_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            cli.subprocess,
+            "run",
+            lambda cmd, **_kw: subprocess.CompletedProcess(args=cmd, returncode=1),
+        )
+        rc = cli.main(["model-groups", "--check"])
+        assert rc == cli.EXIT_CONFIG
+
+
+class TestModelPrecedence:
+    def test_explicit_model_beats_env_var(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(cli._MODEL_ENV_VAR, "from-env")
+        rc = cli.main(
+            [
+                "run",
+                "--model",
+                "from-flag",
+                "--dry-run",
+                "--json",
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        argv = json.loads(capsys.readouterr().out)["argv"]
+        assert "from-flag" in argv
+        assert "from-env" not in argv

--- a/libs/evals/tests/unit_tests/test_run_trials.py
+++ b/libs/evals/tests/unit_tests/test_run_trials.py
@@ -424,6 +424,28 @@ class TestParseArgs:
         )
         assert args.pytest_extra == ["-k", "smoke"]
 
+    def test_model_defaults_to_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(run_trials._MODEL_ENV_VAR, "openai:gpt-5.5-via-env")
+        args = run_trials._parse_args(["--trials", "1"])
+        assert args.model == "openai:gpt-5.5-via-env"
+
+    def test_explicit_model_beats_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(run_trials._MODEL_ENV_VAR, "from-env")
+        args = run_trials._parse_args(["--model", "from-flag", "--trials", "1"])
+        assert args.model == "from-flag"
+
+    def test_missing_model_error_mentions_env_var_and_list_command(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.delenv(run_trials._MODEL_ENV_VAR, raising=False)
+        with pytest.raises(SystemExit):
+            run_trials._parse_args(["--trials", "1"])
+        err = capsys.readouterr().err
+        assert run_trials._MODEL_ENV_VAR in err
+        assert "deepagents-evals list models" in err
+
 
 class TestDiscoverReports:
     def test_returns_empty_when_root_missing(self, tmp_path: Path) -> None:
@@ -489,6 +511,39 @@ class TestLoadReport:
         path = tmp_path / "ok.json"
         path.write_text('{"a": 1}')
         assert run_trials._load_report(path) == {"a": 1}
+
+
+class TestMainJsonFlag:
+    def test_json_emits_compact_summary_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        report = _report(
+            correctness=0.5,
+            solve_rate=0.2,
+            step_ratio=0.8,
+            tool_call_ratio=0.6,
+            median_duration_s=10.0,
+            passed=80,
+            failed=80,
+            total=160,
+        )
+        (tmp_path / "evals_report_trial_000.json").write_text(json.dumps(report))
+        summary_out = tmp_path / "trials_summary.json"
+
+        rc = run_trials.main(
+            ["--aggregate-only", str(tmp_path), "--summary-out", str(summary_out), "--json"]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        # stdout is exactly one JSON line equal to the on-disk summary.
+        stdout_lines = [line for line in captured.out.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1
+        from_stdout = json.loads(stdout_lines[0])
+        from_disk = json.loads(summary_out.read_text())
+        assert from_stdout == from_disk
+        # The "wrote ..." breadcrumb goes to stderr, not stdout.
+        assert "wrote" in captured.err
+        assert "wrote" not in captured.out
 
 
 class TestMainAggregateOnly:


### PR DESCRIPTION
Introduces `deepagents-evals`, a single console script that wraps the scattered `Makefile` targets and `scripts/*.py` entry points behind discoverable subcommands with machine-readable output. The goal is to make the eval suite callable by both humans and automation without source-grepping or manually stitching together pytest flags.