### PR TITLE
refactor(evals): backport harbor async factory API adapter to v0.6

### DIFF
--- a/libs/evals/deepagents_harbor/langsmith.py
+++ b/libs/evals/deepagents_harbor/langsmith.py
@@ -11,6 +11,7 @@ Provides functions for:
 import asyncio
 import datetime
 import hashlib
+import inspect
 import json
 import os
 import subprocess
@@ -18,14 +19,15 @@ import sys
 import tempfile
 import urllib.parse
 import uuid
+from collections.abc import Awaitable
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, cast
 
 import aiohttp
 import toml
 from harbor.models.dataset_item import DownloadedDatasetItem
 from harbor.registry.client import (
-    RegistryClient,  # ty: ignore[unresolved-import]  # harbor API drift, tracked separately
+    RegistryClientFactory,
 )
 from langsmith import Client
 from langsmith.utils import LangSmithError, LangSmithNotFoundError
@@ -35,6 +37,19 @@ LANGSMITH_API_URL = os.getenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain
 
 _API_KEY_ENV_VARS = ("LANGSMITH_SANDBOX_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_API_KEY")
 """Environment variables checked (in priority order) when resolving an API key."""
+
+
+class _RegistryClient(Protocol):
+    """Subset of Harbor registry client behavior used by this module."""
+
+    def download_dataset(
+        self,
+        name: str,
+        *,
+        overwrite: bool = False,
+        output_dir: Path | None = None,
+    ) -> list[DownloadedDatasetItem] | Awaitable[list[DownloadedDatasetItem]]:
+        """Download Harbor dataset tasks."""
 
 
 def resolve_langsmith_api_key() -> tuple[str, str] | None:
@@ -206,6 +221,62 @@ def _scan_downloaded_tasks(
     return examples
 
 
+def _dataset_ref(dataset_name: str, version: str) -> str:
+    """Return the Harbor dataset reference accepted by current registry clients.
+
+    Args:
+        dataset_name: Harbor dataset name, with or without an embedded version.
+        version: Harbor dataset version to append when `dataset_name` is unversioned.
+
+    Returns:
+        A Harbor dataset reference in `name@version` form when needed.
+    """
+    if "@" in dataset_name or not version:
+        return dataset_name
+    return f"{dataset_name}@{version}"
+
+
+async def _await_download_result(
+    result: Awaitable[list[DownloadedDatasetItem]],
+) -> list[DownloadedDatasetItem]:
+    """Await a Harbor download result."""
+    return await result
+
+
+def _download_dataset(
+    dataset_name: str,
+    *,
+    version: str,
+    overwrite: bool,
+    output_dir: Path,
+) -> list[DownloadedDatasetItem]:
+    """Download a Harbor dataset through the current registry client API.
+
+    Harbor's registry client is now factory-created and its `download_dataset`
+    method is async. The surrounding LangSmith CLI remains synchronous, so this
+    boundary keeps the rest of the module unchanged.
+
+    Args:
+        dataset_name: Harbor dataset name.
+        version: Harbor dataset version.
+        overwrite: Whether to overwrite cached remote tasks.
+        output_dir: Directory where Harbor should download tasks.
+
+    Returns:
+        Downloaded Harbor dataset items.
+    """
+    registry_client = cast("_RegistryClient", RegistryClientFactory.create())
+    result = registry_client.download_dataset(
+        _dataset_ref(dataset_name, version),
+        overwrite=overwrite,
+        output_dir=output_dir,
+    )
+    if inspect.isawaitable(result):
+        awaitable = cast("Awaitable[list[DownloadedDatasetItem]]", result)
+        return asyncio.run(_await_download_result(awaitable))
+    return result
+
+
 def create_dataset(dataset_name: str, version: str = "head", overwrite: bool = False) -> None:
     """Create a LangSmith dataset from Harbor tasks.
 
@@ -220,9 +291,8 @@ def create_dataset(dataset_name: str, version: str = "head", overwrite: bool = F
     print(f"Using temporary directory: {output_dir}")
 
     print(f"Downloading dataset '{dataset_name}@{version}' from Harbor registry...")
-    registry_client = RegistryClient()
-    downloaded_tasks = registry_client.download_dataset(
-        name=dataset_name,
+    downloaded_tasks = _download_dataset(
+        dataset_name,
         version=version,
         overwrite=overwrite,
         output_dir=output_dir,

--- a/libs/evals/tests/unit_tests/test_langsmith.py
+++ b/libs/evals/tests/unit_tests/test_langsmith.py
@@ -8,12 +8,15 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from deepagents_harbor.langsmith import (
+    _dataset_ref,
+    _download_dataset,
     _extract_reward,
     _headers,
     resolve_langsmith_api_key,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from pathlib import Path
 
 
@@ -25,6 +28,28 @@ def trial_dir(tmp_path: Path) -> Path:
 
 def _write_result(trial_dir: Path, data: dict[str, Any]) -> None:
     (trial_dir / "result.json").write_text(json.dumps(data))
+
+
+class _FakeRegistryClient:
+    """Offline fake for Harbor registry client behavior."""
+
+    def __init__(
+        self,
+        result: list[Any] | Awaitable[list[Any]],
+    ) -> None:
+        self.result = result
+        self.calls: list[tuple[str, bool, Path | None]] = []
+
+    def download_dataset(
+        self,
+        name: str,
+        *,
+        overwrite: bool = False,
+        output_dir: Path | None = None,
+    ) -> list[Any] | Awaitable[list[Any]]:
+        """Record the call and return the configured result."""
+        self.calls.append((name, overwrite, output_dir))
+        return self.result
 
 
 class TestResolveLangsmithApiKey:
@@ -84,6 +109,58 @@ class TestHeaders:
         monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
         with pytest.raises(ValueError, match="No LangSmith API key found"):
             _headers()
+
+
+class TestDownloadDataset:
+    """Tests for Harbor registry client compatibility helpers."""
+
+    def test_dataset_ref_appends_version_to_unversioned_name(self) -> None:
+        assert _dataset_ref("terminal-bench", "2.0") == "terminal-bench@2.0"
+
+    def test_dataset_ref_preserves_explicit_version(self) -> None:
+        assert _dataset_ref("terminal-bench@2.0", "head") == "terminal-bench@2.0"
+
+    def test_download_dataset_uses_factory_client(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeRegistryClient(result=[])
+
+        monkeypatch.setattr(
+            "deepagents_harbor.langsmith.RegistryClientFactory.create",
+            lambda: fake,
+        )
+
+        result = _download_dataset(
+            "terminal-bench",
+            version="2.0",
+            overwrite=True,
+            output_dir=tmp_path,
+        )
+
+        assert result == []
+        assert fake.calls == [("terminal-bench@2.0", True, tmp_path)]
+
+    def test_download_dataset_unwraps_async_result(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _result() -> list[Any]:
+            return ["downloaded"]
+
+        fake = _FakeRegistryClient(result=_result())
+
+        monkeypatch.setattr(
+            "deepagents_harbor.langsmith.RegistryClientFactory.create",
+            lambda: fake,
+        )
+
+        result = _download_dataset(
+            "terminal-bench",
+            version="2.0",
+            overwrite=False,
+            output_dir=tmp_path,
+        )
+
+        assert result == ["downloaded"]
 
 
 class TestExtractReward:


### PR DESCRIPTION
## Summary

- Cherry-picks #3197 (`6b8d3926`) onto `v0.6`. v0.6's evals + quickjs CI have been red since harbor 0.6.4 dropped the synchronous `RegistryClient` constructor in favor of `RegistryClientFactory.create()` returning an async client.
- No code changes from the original PR — straight cherry-pick that applies cleanly.

## Why this is needed

v0.6's `libs/evals/deepagents_harbor/langsmith.py` still imports the removed `RegistryClient` symbol, so any test module that imports `deepagents_harbor` fails at collection with `ImportError: cannot import name 'RegistryClient' from 'harbor.registry.client'`. Confirmed broken on `119f5d7a` (latest v0.6) and on PRs branching from v0.6 (e.g. #3192).

## Test plan

- [x] `make test` in `libs/evals` — 344 passed locally on this branch
- [ ] CI green on v0.6 evals + quickjs jobs