### PR TITLE
feat(cli): auto-wire issues board with context hub repo handle

### DIFF
--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -9,7 +9,6 @@ import argparse
 import os
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -583,28 +582,22 @@ def _resolve_langsmith_endpoint() -> str:
 def _resolve_tracer_session_id_by_project_name(
     *, project_name: str, api_key: str
 ) -> str | None:
-    """Resolve tracing project id (session id) by name with short retries."""
+    """Resolve tracing project id (session id) by name."""
     from langsmith import Client
     from langsmith.utils import LangSmithNotFoundError
 
     api_url = _resolve_langsmith_endpoint()
-    last_error: Exception | None = None
-    for delay in (0.0, 1.0, 2.0, 4.0):
-        if delay:
-            time.sleep(delay)
-        try:
-            client = Client(api_url=api_url, api_key=api_key)
-            project = client.read_project(project_name=project_name)
-            return str(project.id)
-        except LangSmithNotFoundError as exc:
-            last_error = exc
-            continue
-        except Exception as exc:
-            last_error = exc
-            continue
-    if last_error is not None:
+    try:
+        client = Client(api_url=api_url, api_key=api_key)
+        project = client.read_project(project_name=project_name)
+        return str(project.id)
+    except LangSmithNotFoundError as exc:
         print(
-            f"Warning: Failed to resolve tracing project '{project_name}': {last_error}"
+            f"Warning: Failed to resolve tracing project '{project_name}': {exc}"
+        )
+    except Exception as exc:
+        print(
+            f"Warning: Failed to resolve tracing project '{project_name}': {exc}"
         )
     return None
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -673,12 +673,32 @@ def _upsert_issues_board_config(
         print(f"Warning: Issues board auto-wire failed: {exc}")
 
 
+def _resolve_context_hub_identifier(config: Any) -> str:  # noqa: ANN401
+    return config.memories.identifier or f"-/{config.agent.name}"
+
+
+def _resolve_context_hub_repo_handle_for_issues_board(
+    config: Any,  # noqa: ANN401
+) -> str | None:
+    identifier = _resolve_context_hub_identifier(config)
+    owner, sep, repo_handle = identifier.partition("/")
+    if sep == "" or not owner or not repo_handle:
+        print(
+            "Warning: Invalid memories identifier for hub-backed deploy: "
+            f"{identifier!r}; skipping issues board auto-wire."
+        )
+        return None
+    return repo_handle
+
+
 def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
     """Best-effort issues-board wiring after deploy for hub-backed memories."""
     if getattr(config.memories, "backend", "") != "hub":
         return
 
-    context_hub_repo_handle = config.memories.identifier or f"-/{config.agent.name}"
+    context_hub_repo_handle = _resolve_context_hub_repo_handle_for_issues_board(config)
+    if context_hub_repo_handle is None:
+        return
     api_key = _resolve_langsmith_api_key()
     if api_key is None:
         print(

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -560,47 +560,11 @@ def _run_langgraph_deploy(build_dir: Path, *, name: str) -> None:
     print("\nDeployment complete!")
 
 
-def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
-    """Best-effort issues-board wiring after deploy for hub-backed memories.
-
-    This is intentionally non-fatal: deploy success should not be blocked by
-    optional post-deploy wiring.
-    """
-    if getattr(config.memories, "backend", "") != "hub":
-        return
-
-    context_hub_identifier = config.memories.identifier or f"-/{config.agent.name}"
-    api_key = _resolve_langsmith_api_key()
-    if not api_key:
-        print(
-            "Warning: LANGSMITH/LANGCHAIN API key not found; skipping issues board auto-wire."
-        )
-        return
-
-    session_id = _resolve_tracer_session_id_by_project_name(
-        project_name=config.agent.name,
-        api_key=api_key,
-    )
-    if not session_id:
-        print(
-            "Warning: Could not resolve tracing project after deploy; "
-            "skipping issues board auto-wire."
-        )
-        return
-
-    _upsert_issues_board_config(
-        session_id=session_id,
-        api_key=api_key,
-        context_hub_identifier=context_hub_identifier,
-    )
-
-
-def _resolve_langsmith_api_key() -> str:
+def _resolve_langsmith_api_key() -> str | None:
     return (
         os.environ.get("LANGSMITH_API_KEY")
         or os.environ.get("LANGCHAIN_API_KEY")
         or os.environ.get("LANGGRAPH_HOST_API_KEY")
-        or ""
     )
 
 
@@ -612,7 +576,9 @@ def _resolve_langsmith_endpoint() -> str:
     ).rstrip("/")
 
 
-def _resolve_tracer_session_id_by_project_name(*, project_name: str, api_key: str) -> str:
+def _resolve_tracer_session_id_by_project_name(
+    *, project_name: str, api_key: str
+) -> str | None:
     """Resolve tracing project id (session id) by name with short retries."""
     from langsmith import Client
     from langsmith.utils import LangSmithNotFoundError
@@ -634,7 +600,7 @@ def _resolve_tracer_session_id_by_project_name(*, project_name: str, api_key: st
             continue
     if last_error is not None:
         print(f"Warning: Failed to resolve tracing project '{project_name}': {last_error}")
-    return ""
+    return None
 
 
 def _upsert_issues_board_config(
@@ -695,3 +661,34 @@ def _upsert_issues_board_config(
             )
     except Exception as exc:  # noqa: BLE001
         print(f"Warning: Issues board auto-wire failed: {exc}")
+
+
+def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
+    """Best-effort issues-board wiring after deploy for hub-backed memories."""
+    if getattr(config.memories, "backend", "") != "hub":
+        return
+
+    context_hub_identifier = config.memories.identifier or f"-/{config.agent.name}"
+    api_key = _resolve_langsmith_api_key()
+    if api_key is None:
+        print(
+            "Warning: LANGSMITH/LANGCHAIN API key not found; skipping issues board auto-wire."
+        )
+        return
+
+    session_id = _resolve_tracer_session_id_by_project_name(
+        project_name=config.agent.name,
+        api_key=api_key,
+    )
+    if session_id is None:
+        print(
+            "Warning: Could not resolve tracing project after deploy; "
+            "skipping issues board auto-wire."
+        )
+        return
+
+    _upsert_issues_board_config(
+        session_id=session_id,
+        api_key=api_key,
+        context_hub_identifier=context_hub_identifier,
+    )

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -565,7 +565,6 @@ def _resolve_langsmith_api_key() -> str | None:
     return (
         resolve_env_var("LANGSMITH_API_KEY")
         or resolve_env_var("LANGCHAIN_API_KEY")
-        or resolve_env_var("LANGGRAPH_HOST_API_KEY")
     )
 
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -595,11 +595,14 @@ def _resolve_tracer_session_id_by_project_name(
         except LangSmithNotFoundError as exc:
             last_error = exc
             continue
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             last_error = exc
             continue
     if last_error is not None:
-        print(f"Warning: Failed to resolve tracing project '{project_name}': {last_error}")
+        print(
+            f"Warning: Failed to resolve tracing project '{project_name}': "
+            f"{last_error}"
+        )
     return None
 
 
@@ -612,6 +615,8 @@ def _upsert_issues_board_config(
     """Best-effort create or patch board config for a deployed agent."""
     import httpx
 
+    success_codes = {200, 201}
+    http_conflict = 409
     endpoint = _resolve_langsmith_endpoint()
     url = f"{endpoint}/v1/platform/sessions/{session_id}/issues-agent"
     headers = {
@@ -632,19 +637,19 @@ def _upsert_issues_board_config(
     try:
         with httpx.Client(timeout=20.0) as client:
             create_resp = client.post(url, headers=headers, json=create_payload)
-            if create_resp.status_code in (200, 201):
+            if create_resp.status_code in success_codes:
                 print(
                     f"Issues board auto-wired for tracing project {session_id} "
                     f"({context_hub_identifier})."
                 )
                 return
-            if create_resp.status_code == 409:
+            if create_resp.status_code == http_conflict:
                 patch_resp = client.patch(
                     url,
                     headers=headers,
                     json={"context_hub_identifier": context_hub_identifier},
                 )
-                if patch_resp.status_code in (200, 201):
+                if patch_resp.status_code in success_codes:
                     print(
                         f"Issues board already existed; updated context hub "
                         f"identifier to {context_hub_identifier}."
@@ -659,7 +664,7 @@ def _upsert_issues_board_config(
                 "Warning: Failed to create issues board config: "
                 f"HTTP {create_resp.status_code} — {create_resp.text[:300]}"
             )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         print(f"Warning: Issues board auto-wire failed: {exc}")
 
 
@@ -672,7 +677,8 @@ def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
     api_key = _resolve_langsmith_api_key()
     if api_key is None:
         print(
-            "Warning: LANGSMITH/LANGCHAIN API key not found; skipping issues board auto-wire."
+            "Warning: LANGSMITH/LANGCHAIN API key not found; "
+            "skipping issues board auto-wire."
         )
         return
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -561,17 +561,21 @@ def _run_langgraph_deploy(build_dir: Path, *, name: str) -> None:
 
 
 def _resolve_langsmith_api_key() -> str | None:
+    from deepagents_cli.model_config import resolve_env_var
+
     return (
-        os.environ.get("LANGSMITH_API_KEY")
-        or os.environ.get("LANGCHAIN_API_KEY")
-        or os.environ.get("LANGGRAPH_HOST_API_KEY")
+        resolve_env_var("LANGSMITH_API_KEY")
+        or resolve_env_var("LANGCHAIN_API_KEY")
+        or resolve_env_var("LANGGRAPH_HOST_API_KEY")
     )
 
 
 def _resolve_langsmith_endpoint() -> str:
+    from deepagents_cli.model_config import resolve_env_var
+
     return (
-        os.environ.get("LANGSMITH_ENDPOINT")
-        or os.environ.get("LANGCHAIN_ENDPOINT")
+        resolve_env_var("LANGSMITH_ENDPOINT")
+        or resolve_env_var("LANGCHAIN_ENDPOINT")
         or "https://api.smith.langchain.com"
     ).rstrip("/")
 
@@ -614,6 +618,8 @@ def _upsert_issues_board_config(
     """Best-effort create or patch board config for a deployed agent."""
     import httpx
 
+    from deepagents_cli.model_config import resolve_env_var
+
     success_codes = {200, 201}
     http_conflict = 409
     endpoint = _resolve_langsmith_endpoint()
@@ -622,7 +628,7 @@ def _upsert_issues_board_config(
         "x-api-key": api_key,
         "Content-Type": "application/json",
     }
-    tenant_id = os.environ.get("LANGSMITH_TENANT_ID")
+    tenant_id = resolve_env_var("LANGSMITH_TENANT_ID")
     if tenant_id:
         headers["x-tenant-id"] = tenant_id
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -600,8 +600,7 @@ def _resolve_tracer_session_id_by_project_name(
             continue
     if last_error is not None:
         print(
-            f"Warning: Failed to resolve tracing project '{project_name}': "
-            f"{last_error}"
+            f"Warning: Failed to resolve tracing project '{project_name}': {last_error}"
         )
     return None
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -613,7 +613,7 @@ def _upsert_issues_board_config(
     *,
     session_id: str,
     api_key: str,
-    context_hub_id: str,
+    context_hub_repo_handle: str,
 ) -> None:
     """Best-effort create or patch board config for a deployed agent."""
     import httpx
@@ -636,7 +636,7 @@ def _upsert_issues_board_config(
         "cron_schedule": "0 */6 * * *",
         "heavy_model": "anthropic:issues-agent-heavy",
         "light_model": "anthropic:issues-agent-light",
-        "context_hub_id": context_hub_id,
+        "context_hub_repo_handle": context_hub_repo_handle,
     }
 
     try:
@@ -645,19 +645,19 @@ def _upsert_issues_board_config(
             if create_resp.status_code in success_codes:
                 print(
                     f"Issues board auto-wired for tracing project {session_id} "
-                    f"({context_hub_id})."
+                    f"({context_hub_repo_handle})."
                 )
                 return
             if create_resp.status_code == http_conflict:
                 patch_resp = client.patch(
                     url,
                     headers=headers,
-                    json={"context_hub_id": context_hub_id},
+                    json={"context_hub_repo_handle": context_hub_repo_handle},
                 )
                 if patch_resp.status_code in success_codes:
                     print(
                         "Issues board already existed; updated context hub id "
-                        f"to {context_hub_id}."
+                        f"to {context_hub_repo_handle}."
                     )
                     return
                 print(
@@ -678,7 +678,7 @@ def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
     if getattr(config.memories, "backend", "") != "hub":
         return
 
-    context_hub_id = config.memories.identifier or f"-/{config.agent.name}"
+    context_hub_repo_handle = config.memories.identifier or f"-/{config.agent.name}"
     api_key = _resolve_langsmith_api_key()
     if api_key is None:
         print(
@@ -701,5 +701,5 @@ def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
     _upsert_issues_board_config(
         session_id=session_id,
         api_key=api_key,
-        context_hub_id=context_hub_id,
+        context_hub_repo_handle=context_hub_repo_handle,
     )

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -613,7 +613,7 @@ def _upsert_issues_board_config(
     *,
     session_id: str,
     api_key: str,
-    context_hub_identifier: str,
+    context_hub_id: str,
 ) -> None:
     """Best-effort create or patch board config for a deployed agent."""
     import httpx
@@ -636,7 +636,7 @@ def _upsert_issues_board_config(
         "cron_schedule": "0 */6 * * *",
         "heavy_model": "anthropic:issues-agent-heavy",
         "light_model": "anthropic:issues-agent-light",
-        "context_hub_identifier": context_hub_identifier,
+        "context_hub_id": context_hub_id,
     }
 
     try:
@@ -645,19 +645,19 @@ def _upsert_issues_board_config(
             if create_resp.status_code in success_codes:
                 print(
                     f"Issues board auto-wired for tracing project {session_id} "
-                    f"({context_hub_identifier})."
+                    f"({context_hub_id})."
                 )
                 return
             if create_resp.status_code == http_conflict:
                 patch_resp = client.patch(
                     url,
                     headers=headers,
-                    json={"context_hub_identifier": context_hub_identifier},
+                    json={"context_hub_id": context_hub_id},
                 )
                 if patch_resp.status_code in success_codes:
                     print(
-                        f"Issues board already existed; updated context hub "
-                        f"identifier to {context_hub_identifier}."
+                        "Issues board already existed; updated context hub id "
+                        f"to {context_hub_id}."
                     )
                     return
                 print(
@@ -678,7 +678,7 @@ def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
     if getattr(config.memories, "backend", "") != "hub":
         return
 
-    context_hub_identifier = config.memories.identifier or f"-/{config.agent.name}"
+    context_hub_id = config.memories.identifier or f"-/{config.agent.name}"
     api_key = _resolve_langsmith_api_key()
     if api_key is None:
         print(
@@ -701,5 +701,5 @@ def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
     _upsert_issues_board_config(
         session_id=session_id,
         api_key=api_key,
-        context_hub_identifier=context_hub_identifier,
+        context_hub_id=context_hub_id,
     )

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -562,10 +562,7 @@ def _run_langgraph_deploy(build_dir: Path, *, name: str) -> None:
 def _resolve_langsmith_api_key() -> str | None:
     from deepagents_cli.model_config import resolve_env_var
 
-    return (
-        resolve_env_var("LANGSMITH_API_KEY")
-        or resolve_env_var("LANGCHAIN_API_KEY")
-    )
+    return resolve_env_var("LANGSMITH_API_KEY") or resolve_env_var("LANGCHAIN_API_KEY")
 
 
 def _resolve_langsmith_endpoint() -> str:
@@ -591,13 +588,9 @@ def _resolve_tracer_session_id_by_project_name(
         project = client.read_project(project_name=project_name)
         return str(project.id)
     except LangSmithNotFoundError as exc:
-        print(
-            f"Warning: Failed to resolve tracing project '{project_name}': {exc}"
-        )
+        print(f"Warning: Failed to resolve tracing project '{project_name}': {exc}")
     except Exception as exc:
-        print(
-            f"Warning: Failed to resolve tracing project '{project_name}': {exc}"
-        )
+        print(f"Warning: Failed to resolve tracing project '{project_name}': {exc}")
     return None
 
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -673,12 +673,12 @@ def _upsert_issues_board_config(
         print(f"Warning: Issues board auto-wire failed: {exc}")
 
 
-def _resolve_context_hub_identifier(config: Any) -> str:  # noqa: ANN401
+def _resolve_context_hub_identifier(config: DeployConfig) -> str:
     return config.memories.identifier or f"-/{config.agent.name}"
 
 
 def _resolve_context_hub_repo_handle_for_issues_board(
-    config: Any,  # noqa: ANN401
+    config: DeployConfig,
 ) -> str | None:
     identifier = _resolve_context_hub_identifier(config)
     owner, sep, repo_handle = identifier.partition("/")
@@ -691,9 +691,9 @@ def _resolve_context_hub_repo_handle_for_issues_board(
     return repo_handle
 
 
-def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
+def _auto_wire_issues_board_if_hub(config: DeployConfig) -> None:
     """Best-effort issues-board wiring after deploy for hub-backed memories."""
-    if getattr(config.memories, "backend", "") != "hub":
+    if config.memories.backend != "hub":
         return
 
     context_hub_repo_handle = _resolve_context_hub_repo_handle_for_issues_board(config)

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -9,6 +9,7 @@ import argparse
 import os
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -328,6 +329,7 @@ def _deploy(
 
         # Deploy via langgraph CLI.
         _run_langgraph_deploy(build_dir, name=config.agent.name)
+        _auto_wire_issues_board_if_hub(config)
     finally:
         if not dry_run:
             import shutil
@@ -556,3 +558,140 @@ def _run_langgraph_deploy(build_dir: Path, *, name: str) -> None:
         raise SystemExit(result.returncode)
 
     print("\nDeployment complete!")
+
+
+def _auto_wire_issues_board_if_hub(config: Any) -> None:  # noqa: ANN401
+    """Best-effort issues-board wiring after deploy for hub-backed memories.
+
+    This is intentionally non-fatal: deploy success should not be blocked by
+    optional post-deploy wiring.
+    """
+    if getattr(config.memories, "backend", "") != "hub":
+        return
+
+    context_hub_identifier = config.memories.identifier or f"-/{config.agent.name}"
+    api_key = _resolve_langsmith_api_key()
+    if not api_key:
+        print(
+            "Warning: LANGSMITH/LANGCHAIN API key not found; skipping issues board auto-wire."
+        )
+        return
+
+    session_id = _resolve_tracer_session_id_by_project_name(
+        project_name=config.agent.name,
+        api_key=api_key,
+    )
+    if not session_id:
+        print(
+            "Warning: Could not resolve tracing project after deploy; "
+            "skipping issues board auto-wire."
+        )
+        return
+
+    _upsert_issues_board_config(
+        session_id=session_id,
+        api_key=api_key,
+        context_hub_identifier=context_hub_identifier,
+    )
+
+
+def _resolve_langsmith_api_key() -> str:
+    return (
+        os.environ.get("LANGSMITH_API_KEY")
+        or os.environ.get("LANGCHAIN_API_KEY")
+        or os.environ.get("LANGGRAPH_HOST_API_KEY")
+        or ""
+    )
+
+
+def _resolve_langsmith_endpoint() -> str:
+    return (
+        os.environ.get("LANGSMITH_ENDPOINT")
+        or os.environ.get("LANGCHAIN_ENDPOINT")
+        or "https://api.smith.langchain.com"
+    ).rstrip("/")
+
+
+def _resolve_tracer_session_id_by_project_name(*, project_name: str, api_key: str) -> str:
+    """Resolve tracing project id (session id) by name with short retries."""
+    from langsmith import Client
+    from langsmith.utils import LangSmithNotFoundError
+
+    api_url = _resolve_langsmith_endpoint()
+    last_error: Exception | None = None
+    for delay in (0.0, 1.0, 2.0, 4.0):
+        if delay:
+            time.sleep(delay)
+        try:
+            client = Client(api_url=api_url, api_key=api_key)
+            project = client.read_project(project_name=project_name)
+            return str(project.id)
+        except LangSmithNotFoundError as exc:
+            last_error = exc
+            continue
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            continue
+    if last_error is not None:
+        print(f"Warning: Failed to resolve tracing project '{project_name}': {last_error}")
+    return ""
+
+
+def _upsert_issues_board_config(
+    *,
+    session_id: str,
+    api_key: str,
+    context_hub_identifier: str,
+) -> None:
+    """Best-effort create or patch board config for a deployed agent."""
+    import httpx
+
+    endpoint = _resolve_langsmith_endpoint()
+    url = f"{endpoint}/v1/platform/sessions/{session_id}/issues-agent"
+    headers = {
+        "x-api-key": api_key,
+        "Content-Type": "application/json",
+    }
+    tenant_id = os.environ.get("LANGSMITH_TENANT_ID")
+    if tenant_id:
+        headers["x-tenant-id"] = tenant_id
+
+    create_payload = {
+        "cron_schedule": "0 */6 * * *",
+        "heavy_model": "anthropic:issues-agent-heavy",
+        "light_model": "anthropic:issues-agent-light",
+        "context_hub_identifier": context_hub_identifier,
+    }
+
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            create_resp = client.post(url, headers=headers, json=create_payload)
+            if create_resp.status_code in (200, 201):
+                print(
+                    f"Issues board auto-wired for tracing project {session_id} "
+                    f"({context_hub_identifier})."
+                )
+                return
+            if create_resp.status_code == 409:
+                patch_resp = client.patch(
+                    url,
+                    headers=headers,
+                    json={"context_hub_identifier": context_hub_identifier},
+                )
+                if patch_resp.status_code in (200, 201):
+                    print(
+                        f"Issues board already existed; updated context hub "
+                        f"identifier to {context_hub_identifier}."
+                    )
+                    return
+                print(
+                    "Warning: Failed to patch existing issues board: "
+                    f"HTTP {patch_resp.status_code} — {patch_resp.text[:300]}"
+                )
+                return
+            print(
+                "Warning: Failed to create issues board config: "
+                f"HTTP {create_resp.status_code} — {create_resp.text[:300]}"
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: Issues board auto-wire failed: {exc}")

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -682,7 +682,7 @@ def _resolve_context_hub_repo_handle_for_issues_board(
 ) -> str | None:
     identifier = _resolve_context_hub_identifier(config)
     owner, sep, repo_handle = identifier.partition("/")
-    if sep == "" or not owner or not repo_handle:
+    if not sep or not owner or not repo_handle:
         print(
             "Warning: Invalid memories identifier for hub-backed deploy: "
             f"{identifier!r}; skipping issues board auto-wire."

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -73,3 +74,91 @@ class TestInitProject:
 
         _init_project(name="proj", force=True)
         assert (tmp_path / "proj" / DEFAULT_CONFIG_FILENAME).is_file()
+
+
+class TestAutoWireIssuesBoard:
+    def test_skips_when_memories_not_hub(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from deepagents_cli.deploy.commands import _auto_wire_issues_board_if_hub
+
+        called = {"upsert": False}
+
+        def _upsert(**_: object) -> None:
+            called["upsert"] = True
+
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._upsert_issues_board_config",
+            _upsert,
+        )
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(name="my-agent"),
+            memories=SimpleNamespace(backend="store", identifier=""),
+        )
+
+        _auto_wire_issues_board_if_hub(cfg)
+        assert called["upsert"] is False
+
+    def test_skips_when_api_key_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from deepagents_cli.deploy.commands import _auto_wire_issues_board_if_hub
+
+        called = {"lookup": False}
+
+        def _lookup(**_: object) -> str:
+            called["lookup"] = True
+            return ""
+
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._resolve_langsmith_api_key",
+            lambda: "",
+        )
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._resolve_tracer_session_id_by_project_name",
+            _lookup,
+        )
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(name="my-agent"),
+            memories=SimpleNamespace(backend="hub", identifier=""),
+        )
+
+        _auto_wire_issues_board_if_hub(cfg)
+        assert called["lookup"] is False
+
+    def test_hub_wires_board_with_default_identifier(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from deepagents_cli.deploy.commands import _auto_wire_issues_board_if_hub
+
+        observed: dict[str, str] = {}
+
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._resolve_langsmith_api_key",
+            lambda: "test-key",
+        )
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._resolve_tracer_session_id_by_project_name",
+            lambda **_: "session-123",
+        )
+
+        def _upsert(**kwargs: str) -> None:
+            observed.update(kwargs)
+
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._upsert_issues_board_config",
+            _upsert,
+        )
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(name="my-agent"),
+            memories=SimpleNamespace(backend="hub", identifier=""),
+        )
+
+        _auto_wire_issues_board_if_hub(cfg)
+
+        assert observed["session_id"] == "session-123"
+        assert observed["api_key"] == "test-key"
+        assert observed["context_hub_identifier"] == "-/my-agent"

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -17,6 +17,8 @@ from deepagents_cli.deploy.config import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from deepagents_cli.deploy.commands import DeployConfig
 
 
 class TestInitProject:
@@ -97,7 +99,7 @@ class TestAutoWireIssuesBoard:
             memories=SimpleNamespace(backend="store", identifier=""),
         )
 
-        _auto_wire_issues_board_if_hub(cfg)
+        _auto_wire_issues_board_if_hub(cast("DeployConfig", cfg))
         assert called["upsert"] is False
 
     def test_skips_when_api_key_missing(
@@ -125,7 +127,7 @@ class TestAutoWireIssuesBoard:
             memories=SimpleNamespace(backend="hub", identifier=""),
         )
 
-        _auto_wire_issues_board_if_hub(cfg)
+        _auto_wire_issues_board_if_hub(cast("DeployConfig", cfg))
         assert called["lookup"] is False
 
     def test_hub_wires_board_with_default_identifier(
@@ -157,7 +159,7 @@ class TestAutoWireIssuesBoard:
             memories=SimpleNamespace(backend="hub", identifier=""),
         )
 
-        _auto_wire_issues_board_if_hub(cfg)
+        _auto_wire_issues_board_if_hub(cast("DeployConfig", cfg))
 
         assert observed["session_id"] == "session-123"
         assert observed["api_key"] == "test-key"
@@ -192,6 +194,6 @@ class TestAutoWireIssuesBoard:
             memories=SimpleNamespace(backend="hub", identifier="acme/custom-agent"),
         )
 
-        _auto_wire_issues_board_if_hub(cfg)
+        _auto_wire_issues_board_if_hub(cast("DeployConfig", cfg))
 
         assert observed["context_hub_repo_handle"] == "custom-agent"

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -161,4 +161,37 @@ class TestAutoWireIssuesBoard:
 
         assert observed["session_id"] == "session-123"
         assert observed["api_key"] == "test-key"
-        assert observed["context_hub_repo_handle"] == "-/my-agent"
+        assert observed["context_hub_repo_handle"] == "my-agent"
+
+    def test_hub_wires_board_with_explicit_identifier(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from deepagents_cli.deploy.commands import _auto_wire_issues_board_if_hub
+
+        observed: dict[str, str] = {}
+
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._resolve_langsmith_api_key",
+            lambda: "test-key",
+        )
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._resolve_tracer_session_id_by_project_name",
+            lambda **_: "session-123",
+        )
+
+        def _upsert(**kwargs: str) -> None:
+            observed.update(kwargs)
+
+        monkeypatch.setattr(
+            "deepagents_cli.deploy.commands._upsert_issues_board_config",
+            _upsert,
+        )
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(name="my-agent"),
+            memories=SimpleNamespace(backend="hub", identifier="acme/custom-agent"),
+        )
+
+        _auto_wire_issues_board_if_hub(cfg)
+
+        assert observed["context_hub_repo_handle"] == "custom-agent"

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -108,13 +108,13 @@ class TestAutoWireIssuesBoard:
 
         called = {"lookup": False}
 
-        def _lookup(**_: object) -> str:
+        def _lookup(**_: object) -> str | None:
             called["lookup"] = True
-            return ""
+            return None
 
         monkeypatch.setattr(
             "deepagents_cli.deploy.commands._resolve_langsmith_api_key",
-            lambda: "",
+            lambda: None,
         )
         monkeypatch.setattr(
             "deepagents_cli.deploy.commands._resolve_tracer_session_id_by_project_name",

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -161,4 +161,4 @@ class TestAutoWireIssuesBoard:
 
         assert observed["session_id"] == "session-123"
         assert observed["api_key"] == "test-key"
-        assert observed["context_hub_identifier"] == "-/my-agent"
+        assert observed["context_hub_id"] == "-/my-agent"

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -161,4 +161,4 @@ class TestAutoWireIssuesBoard:
 
         assert observed["session_id"] == "session-123"
         assert observed["api_key"] == "test-key"
-        assert observed["context_hub_id"] == "-/my-agent"
+        assert observed["context_hub_repo_handle"] == "-/my-agent"


### PR DESCRIPTION
## Summary
- auto-wire an issues board after successful `deepagents deploy` when memories backend is `hub`
- resolve tracing session by deployed project name and call `POST /v1/platform/sessions/{session_id}/issues-agent`
- derive `context_hub_repo_handle` from the hub identifier (`memories.identifier` or `-/{agent.name}`) and send only the repo-handle segment
- on `409`, patch the existing board with the same `context_hub_repo_handle`
- add unit tests for default and explicit identifier -> repo-handle mapping

## Verification
- `uv run --project libs/cli --group test pytest libs/cli/tests/unit_tests/deploy/test_commands.py -q`
