### PR TITLE
fix: skip skills loading only when skills_metadata is non-empty

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -1013,8 +1013,11 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         Returns:
             State update with `skills_metadata` populated, or `None` if already present.
         """
-        # Skip if skills_metadata is already present in state (even if empty)
-        if "skills_metadata" in state:
+        # Skip if skills_metadata is already loaded (non-empty list).
+        # PrivateStateAttr initialises the key to [] by default, so we
+        # must also check the list is non-empty to avoid skipping the
+        # initial load on the first turn.
+        if "skills_metadata" in state and state["skills_metadata"]:
             return None
 
         # Resolve backend (supports both direct instances and factory functions)
@@ -1055,8 +1058,11 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         Returns:
             State update with `skills_metadata` populated, or `None` if already present.
         """
-        # Skip if skills_metadata is already present in state (even if empty)
-        if "skills_metadata" in state:
+        # Skip if skills_metadata is already loaded (non-empty list).
+        # PrivateStateAttr initialises the key to [] by default, so we
+        # must also check the list is non-empty to avoid skipping the
+        # initial load on the first turn.
+        if "skills_metadata" in state and state["skills_metadata"]:
             return None
 
         # Resolve backend (supports both direct instances and factory functions)


### PR DESCRIPTION
Fixes #3233

## Problem

`SkillsMiddleware.before_agent` (and `abefore_agent`) skip loading skills when `"skills_metadata" in state` — but `PrivateStateAttr` initialises this field to `[]` by default in the graph state. This means the initial load is **always skipped on the first turn**, and the system prompt shows "(No skills available yet)" even when valid skills exist.

## Root cause

```python
# before_agent, ~line 1017
if "skills_metadata" in state:
    return None
```

The key exists (value is `[]`), so the guard fires and the middleware never reads the skill files.

## Fix

Check that the metadata list is non-empty before skipping:

```python
if "skills_metadata" in state and state["skills_metadata"]:
    return None
```

Applied to both `before_agent` and `abefore_agent`.