### PR TITLE
style(cli): render `ask_user` interrupts as toggleable tool rows

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -6080,6 +6080,17 @@ class DeepAgentsApp(App):
 
     def action_toggle_tool_output(self) -> None:
         """Toggle expand/collapse of the most recent tool output or skill body."""
+        if self._pending_ask_user_widget is not None:
+            with suppress(NoMatches):
+                tool_messages = list(self.query(ToolCallMessage))
+                for tool_msg in reversed(tool_messages):
+                    if (
+                        tool_msg._tool_name == "ask_user"
+                        and tool_msg.has_expandable_args
+                    ):
+                        tool_msg.toggle_args()
+                        return
+
         # Try skill messages first (most recent collapsible content)
         with suppress(NoMatches):
             skill_messages = list(self.query(SkillMessage))
@@ -6091,7 +6102,7 @@ class DeepAgentsApp(App):
         with suppress(NoMatches):
             tool_messages = list(self.query(ToolCallMessage))
             for tool_msg in reversed(tool_messages):
-                if tool_msg.has_output:
+                if tool_msg.has_output or tool_msg.has_expandable_args:
                     tool_msg.toggle_output()
                     return
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -6080,31 +6080,39 @@ class DeepAgentsApp(App):
 
     def action_toggle_tool_output(self) -> None:
         """Toggle expand/collapse of the most recent tool output or skill body."""
+        # Pending ask_user takes precedence so Ctrl+O toggles the question card.
         if self._pending_ask_user_widget is not None:
-            with suppress(NoMatches):
+            try:
                 tool_messages = list(self.query(ToolCallMessage))
-                for tool_msg in reversed(tool_messages):
-                    if (
-                        tool_msg._tool_name == "ask_user"
-                        and tool_msg.has_expandable_args
-                    ):
-                        tool_msg.toggle_args()
-                        return
+            except NoMatches:
+                tool_messages = []
+            for tool_msg in reversed(tool_messages):
+                if tool_msg.has_expandable_args:
+                    tool_msg.toggle_args()
+                    return
 
         # Try skill messages first (most recent collapsible content)
-        with suppress(NoMatches):
+        try:
             skill_messages = list(self.query(SkillMessage))
-            for skill_msg in reversed(skill_messages):
-                if skill_msg._stripped_body.strip():
-                    skill_msg.toggle_body()
-                    return
-        # Fall back to tool messages with output
-        with suppress(NoMatches):
+        except NoMatches:
+            skill_messages = []
+        for skill_msg in reversed(skill_messages):
+            if skill_msg._stripped_body.strip():
+                skill_msg.toggle_body()
+                return
+
+        # Fall back to tool messages with output or expandable args
+        try:
             tool_messages = list(self.query(ToolCallMessage))
-            for tool_msg in reversed(tool_messages):
-                if tool_msg.has_output or tool_msg.has_expandable_args:
-                    tool_msg.toggle_output()
-                    return
+        except NoMatches:
+            tool_messages = []
+        for tool_msg in reversed(tool_messages):
+            if tool_msg.has_output:
+                tool_msg.toggle_output()
+                return
+            if tool_msg.has_expandable_args:
+                tool_msg.toggle_args()
+                return
 
     # Approval menu action handlers (delegated from App-level bindings)
     # NOTE: These only activate when approval widget is pending

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -570,6 +570,23 @@ async def execute_task_textual(
                                         pending_ask_user[interrupt_obj.id] = (
                                             validated_ask_user
                                         )
+                                        tool_id = validated_ask_user["tool_call_id"]
+                                        if tool_id not in displayed_tool_ids:
+                                            displayed_tool_ids.add(tool_id)
+                                            if adapter._set_spinner:
+                                                await adapter._set_spinner(None)
+                                            tool_msg = ToolCallMessage(
+                                                "ask_user",
+                                                {
+                                                    "questions": validated_ask_user[
+                                                        "questions"
+                                                    ]
+                                                },
+                                            )
+                                            await adapter._mount_message(tool_msg)
+                                            adapter._current_tool_messages[tool_id] = (
+                                                tool_msg
+                                            )
                                         interrupt_occurred = True
                                         await dispatch_hook("input.required", {})
                                     except ValidationError:
@@ -1006,11 +1023,11 @@ async def execute_task_textual(
                                 }
 
                         result_type = result.get("type")
+                        tool_id = ask_req["tool_call_id"]
                         if result_type == "answered":
                             answers = result.get("answers", [])
                             if isinstance(answers, list):
                                 resume_payload[interrupt_id] = {"answers": answers}
-                                tool_id = ask_req["tool_call_id"]
                                 if tool_id in adapter._current_tool_messages:
                                     tool_msg = adapter._current_tool_messages[tool_id]
                                     tool_msg.set_success("User answered")
@@ -1027,12 +1044,22 @@ async def execute_task_textual(
                                     "answers": ["" for _ in questions],
                                 }
                                 any_rejected = True
+                                if tool_id in adapter._current_tool_messages:
+                                    tool_msg = adapter._current_tool_messages[tool_id]
+                                    tool_msg.set_error(
+                                        "invalid ask_user answers payload"
+                                    )
+                                    adapter._current_tool_messages.pop(tool_id, None)
                         elif result_type == "cancelled":
                             resume_payload[interrupt_id] = {
                                 "status": "cancelled",
                                 "answers": ["" for _ in questions],
                             }
                             any_rejected = True
+                            if tool_id in adapter._current_tool_messages:
+                                tool_msg = adapter._current_tool_messages[tool_id]
+                                tool_msg.set_rejected()
+                                adapter._current_tool_messages.pop(tool_id, None)
                         else:
                             error_text = result.get("error")
                             if not isinstance(error_text, str) or not error_text:
@@ -1043,6 +1070,10 @@ async def execute_task_textual(
                                 "answers": ["" for _ in questions],
                             }
                             any_rejected = True
+                            if tool_id in adapter._current_tool_messages:
+                                tool_msg = adapter._current_tool_messages[tool_id]
+                                tool_msg.set_error(error_text)
+                                adapter._current_tool_messages.pop(tool_id, None)
                     else:
                         logger.warning(
                             "ask_user interrupt received but no UI callback is "
@@ -1053,6 +1084,11 @@ async def execute_task_textual(
                             "error": "ask_user not supported by this UI",
                             "answers": ["" for _ in questions],
                         }
+                        tool_id = ask_req["tool_call_id"]
+                        if tool_id in adapter._current_tool_messages:
+                            tool_msg = adapter._current_tool_messages[tool_id]
+                            tool_msg.set_error("ask_user not supported by this UI")
+                            adapter._current_tool_messages.pop(tool_id, None)
 
                 for interrupt_id, hitl_request in list(pending_interrupts.items()):
                     action_requests = hitl_request["action_requests"]

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -73,6 +73,8 @@ configure_debug_logging(logger)
 _hitl_adapter_cache: TypeAdapter | None = None
 """Lazy singleton for the HITL request validator."""
 
+_ASK_USER_UNSUPPORTED_ERROR = "ask_user not supported by this UI"
+
 
 def _get_hitl_request_adapter(hitl_request_type: type) -> TypeAdapter:
     """Return a cached `TypeAdapter(HITLRequest)`.
@@ -572,7 +574,6 @@ async def execute_task_textual(
                                         )
                                         tool_id = validated_ask_user["tool_call_id"]
                                         if tool_id not in displayed_tool_ids:
-                                            displayed_tool_ids.add(tool_id)
                                             if adapter._set_spinner:
                                                 await adapter._set_spinner(None)
                                             tool_msg = ToolCallMessage(
@@ -583,10 +584,19 @@ async def execute_task_textual(
                                                     ]
                                                 },
                                             )
-                                            await adapter._mount_message(tool_msg)
-                                            adapter._current_tool_messages[tool_id] = (
-                                                tool_msg
-                                            )
+                                            try:
+                                                await adapter._mount_message(tool_msg)
+                                            except Exception:
+                                                logger.exception(
+                                                    "Failed to mount ask_user "
+                                                    "tool row for %s",
+                                                    tool_id,
+                                                )
+                                            else:
+                                                displayed_tool_ids.add(tool_id)
+                                                adapter._current_tool_messages[
+                                                    tool_id
+                                                ] = tool_msg
                                         interrupt_occurred = True
                                         await dispatch_hook("input.required", {})
                                     except ValidationError:
@@ -1028,10 +1038,17 @@ async def execute_task_textual(
                             answers = result.get("answers", [])
                             if isinstance(answers, list):
                                 resume_payload[interrupt_id] = {"answers": answers}
-                                if tool_id in adapter._current_tool_messages:
-                                    tool_msg = adapter._current_tool_messages[tool_id]
+                                tool_msg = adapter._current_tool_messages.pop(
+                                    tool_id, None
+                                )
+                                if tool_msg is not None:
                                     tool_msg.set_success("User answered")
-                                    adapter._current_tool_messages.pop(tool_id, None)
+                                else:
+                                    logger.warning(
+                                        "ask_user tool_id %s missing from "
+                                        "_current_tool_messages on answered",
+                                        tool_id,
+                                    )
                             else:
                                 logger.error(
                                     "ask_user answered payload had non-list "
@@ -1044,22 +1061,28 @@ async def execute_task_textual(
                                     "answers": ["" for _ in questions],
                                 }
                                 any_rejected = True
-                                if tool_id in adapter._current_tool_messages:
-                                    tool_msg = adapter._current_tool_messages[tool_id]
+                                tool_msg = adapter._current_tool_messages.pop(
+                                    tool_id, None
+                                )
+                                if tool_msg is not None:
                                     tool_msg.set_error(
                                         "invalid ask_user answers payload"
                                     )
-                                    adapter._current_tool_messages.pop(tool_id, None)
                         elif result_type == "cancelled":
                             resume_payload[interrupt_id] = {
                                 "status": "cancelled",
                                 "answers": ["" for _ in questions],
                             }
                             any_rejected = True
-                            if tool_id in adapter._current_tool_messages:
-                                tool_msg = adapter._current_tool_messages[tool_id]
+                            tool_msg = adapter._current_tool_messages.pop(tool_id, None)
+                            if tool_msg is not None:
                                 tool_msg.set_rejected()
-                                adapter._current_tool_messages.pop(tool_id, None)
+                            else:
+                                logger.warning(
+                                    "ask_user tool_id %s missing from "
+                                    "_current_tool_messages on cancelled",
+                                    tool_id,
+                                )
                         else:
                             error_text = result.get("error")
                             if not isinstance(error_text, str) or not error_text:
@@ -1070,10 +1093,9 @@ async def execute_task_textual(
                                 "answers": ["" for _ in questions],
                             }
                             any_rejected = True
-                            if tool_id in adapter._current_tool_messages:
-                                tool_msg = adapter._current_tool_messages[tool_id]
+                            tool_msg = adapter._current_tool_messages.pop(tool_id, None)
+                            if tool_msg is not None:
                                 tool_msg.set_error(error_text)
-                                adapter._current_tool_messages.pop(tool_id, None)
                     else:
                         logger.warning(
                             "ask_user interrupt received but no UI callback is "
@@ -1081,14 +1103,13 @@ async def execute_task_textual(
                         )
                         resume_payload[interrupt_id] = {
                             "status": "error",
-                            "error": "ask_user not supported by this UI",
+                            "error": _ASK_USER_UNSUPPORTED_ERROR,
                             "answers": ["" for _ in questions],
                         }
                         tool_id = ask_req["tool_call_id"]
-                        if tool_id in adapter._current_tool_messages:
-                            tool_msg = adapter._current_tool_messages[tool_id]
-                            tool_msg.set_error("ask_user not supported by this UI")
-                            adapter._current_tool_messages.pop(tool_id, None)
+                        tool_msg = adapter._current_tool_messages.pop(tool_id, None)
+                        if tool_msg is not None:
+                            tool_msg.set_error(_ASK_USER_UNSUPPORTED_ERROR)
 
                 for interrupt_id, hitl_request in list(pending_interrupts.items()):
                     action_requests = hitl_request["action_requests"]

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -138,6 +138,7 @@ _TOOLS_WITH_HEADER_INFO: set[str] = {
     # Web tools
     "web_search",
     "fetch_url",
+    "ask_user",
     # Agent tools
     "task",
     "write_todos",
@@ -787,8 +788,11 @@ class ToolCallMessage(Vertical):
         self._status = "pending"  # Waiting for approval or auto-approve
         self._output: str = ""
         self._expanded: bool = False
+        self._args_expanded: bool = False
         # Widget references (set in on_mount)
         self._status_widget: Static | None = None
+        self._args_widget: Static | None = None
+        self._args_hint_widget: Static | None = None
         self._preview_widget: Static | None = None
         self._hint_widget: Static | None = None
         self._full_widget: Static | None = None
@@ -833,6 +837,9 @@ class ToolCallMessage(Vertical):
                     Content.from_markup("[dim]($args)[/dim]", args=args_str),
                     classes="tool-args",
                 )
+        # Collapsed argument detail for tools whose args are too noisy inline.
+        yield Static("", classes="tool-args", id="args-full")
+        yield Static("", classes="tool-output-hint", id="args-hint")
         # Status - shows running animation while pending, then final status
         yield Static("", classes="tool-status", id="status")
         # Output area - hidden initially, shown when output is set
@@ -846,14 +853,19 @@ class ToolCallMessage(Vertical):
             self.add_class("-ascii")
 
         self._status_widget = self.query_one("#status", Static)
+        self._args_widget = self.query_one("#args-full", Static)
+        self._args_hint_widget = self.query_one("#args-hint", Static)
         self._preview_widget = self.query_one("#output-preview", Static)
         self._hint_widget = self.query_one("#output-hint", Static)
         self._full_widget = self.query_one("#output-full", Static)
         # Hide everything initially - status only shown when running or on error/reject
         self._status_widget.display = False
+        self._args_widget.display = False
+        self._args_hint_widget.display = False
         self._preview_widget.display = False
         self._hint_widget.display = False
         self._full_widget.display = False
+        self._update_args_display()
 
         # Restore deferred state if this widget was hydrated from data
         self._restore_deferred_state()
@@ -1032,17 +1044,28 @@ class ToolCallMessage(Vertical):
             self._status_widget.display = True
 
     def toggle_output(self) -> None:
-        """Toggle between preview and full output display."""
+        """Toggle output expansion, or tool argument detail when there is no output."""
         if not self._output:
+            if self.has_expandable_args:
+                self.toggle_args()
             return
         self._expanded = not self._expanded
         self._update_output_display()
 
+    def toggle_args(self) -> None:
+        """Toggle display of collapsed tool arguments."""
+        if not self.has_expandable_args:
+            return
+        self._args_expanded = not self._args_expanded
+        self._update_args_display()
+
     def on_click(self, event: Click) -> None:
-        """Toggle output expansion, or show timestamp if no output."""
+        """Toggle output/argument expansion, or show timestamp if nothing expands."""
         event.stop()  # Prevent click from bubbling up and scrolling
         if self._output:
             self.toggle_output()
+        elif self.has_expandable_args:
+            self.toggle_args()
         else:
             _show_timestamp_toast(self)
 
@@ -1554,6 +1577,51 @@ class ToolCallMessage(Vertical):
             True if there is output content, False otherwise.
         """
         return bool(self._output)
+
+    @property
+    def has_expandable_args(self) -> bool:
+        """Check if this tool message has collapsed arguments available.
+
+        Returns:
+            True when arguments can be expanded, False otherwise.
+        """
+        return self._tool_name == "ask_user" and bool(self._args)
+
+    def _format_args_detail(self) -> Content:
+        """Format tool arguments for expanded display.
+
+        Returns:
+            Literal `Content` containing pretty-printed arguments.
+        """
+        try:
+            text = json.dumps(self._args, ensure_ascii=False, indent=2, default=str)
+        except (TypeError, ValueError):
+            text = str(self._args)
+        lines = Content(text).split("\n")
+        return Content("\n").join(Content.assemble("  ", line) for line in lines)
+
+    def _update_args_display(self) -> None:
+        """Update the collapsed/expanded argument display."""
+        if not self._args_widget or not self._args_hint_widget:
+            return
+
+        if not self.has_expandable_args:
+            self._args_widget.display = False
+            self._args_hint_widget.display = False
+            return
+
+        if self._args_expanded:
+            self._args_widget.update(self._format_args_detail())
+            self._args_widget.display = True
+            self._args_hint_widget.update(
+                Content.styled("click or Ctrl+O to hide arguments", "dim italic")
+            )
+        else:
+            self._args_widget.display = False
+            self._args_hint_widget.update(
+                Content.styled("click or Ctrl+O to show arguments", "dim italic")
+            )
+        self._args_hint_widget.display = True
 
     def _filtered_args(self) -> dict[str, Any]:
         """Filter large tool args for display.

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -838,6 +838,7 @@ class ToolCallMessage(Vertical):
                     classes="tool-args",
                 )
         # Collapsed argument detail for tools whose args are too noisy inline.
+        # Mounted for every tool but only populated when `has_expandable_args` is True.
         yield Static("", classes="tool-args", id="args-full")
         yield Static("", classes="tool-output-hint", id="args-hint")
         # Status - shows running animation while pending, then final status
@@ -1044,10 +1045,8 @@ class ToolCallMessage(Vertical):
             self._status_widget.display = True
 
     def toggle_output(self) -> None:
-        """Toggle output expansion, or tool argument detail when there is no output."""
+        """Toggle expansion of the tool's preview/full output."""
         if not self._output:
-            if self.has_expandable_args:
-                self.toggle_args()
             return
         self._expanded = not self._expanded
         self._update_output_display()
@@ -1579,30 +1578,46 @@ class ToolCallMessage(Vertical):
         return bool(self._output)
 
     @property
-    def has_expandable_args(self) -> bool:
-        """Check if this tool message has collapsed arguments available.
+    def tool_name(self) -> str:
+        """Public read-only accessor for the underlying tool name."""
+        return self._tool_name
 
-        Returns:
-            True when arguments can be expanded, False otherwise.
+    @property
+    def has_expandable_args(self) -> bool:
+        """Whether the tool's args are large enough to deserve a collapsible block.
+
+        Only `ask_user` qualifies today: its `questions` payload is too noisy to
+        render inline, but users still need a way to inspect it.
         """
         return self._tool_name == "ask_user" and bool(self._args)
 
     def _format_args_detail(self) -> Content:
-        """Format tool arguments for expanded display.
+        """Render tool arguments as an indented `Content` block.
+
+        Falls back to `str(self._args)` (with a visible marker) when JSON
+        serialization fails — `default=str` already handles most non-serializable
+        values, so reaching the fallback indicates a deeper issue worth logging.
 
         Returns:
-            Literal `Content` containing pretty-printed arguments.
+            Indented `Content` containing JSON-pretty-printed arguments, or a
+            marked fallback rendering on serialization failure.
         """
         try:
             text = json.dumps(self._args, ensure_ascii=False, indent=2, default=str)
-        except (TypeError, ValueError):
-            text = str(self._args)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "ask_user args not JSON-serializable; using repr fallback: %r", exc
+            )
+            text = f"# (fallback rendering)\n{self._args!s}"
         lines = Content(text).split("\n")
         return Content("\n").join(Content.assemble("  ", line) for line in lines)
 
     def _update_args_display(self) -> None:
         """Update the collapsed/expanded argument display."""
-        if not self._args_widget or not self._args_hint_widget:
+        if self._args_widget is None or self._args_hint_widget is None:
+            # Toggle invoked before on_mount cached the refs; log so a regression
+            # that nulls them out post-mount doesn't appear as a silent no-op.
+            logger.debug("_update_args_display called before widget refs are cached")
             return
 
         if not self.has_expandable_args:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2109,13 +2109,68 @@ class TestAskUserLifecycle:
         app = DeepAgentsApp(agent=MagicMock())
         app._pending_ask_user_widget = MagicMock()
         tool = MagicMock()
-        tool._tool_name = "ask_user"
         tool.has_expandable_args = True
 
         with patch.object(app, "query", return_value=[tool]):
             app.action_toggle_tool_output()
 
         tool.toggle_args.assert_called_once_with()
+
+    def test_ctrl_o_falls_back_to_tool_with_expandable_args(self) -> None:
+        """When no ask_user is pending, Ctrl+O still expands an ask_user-like row."""
+        app = DeepAgentsApp(agent=MagicMock())
+        app._pending_ask_user_widget = None
+        tool = MagicMock()
+        tool.has_output = False
+        tool.has_expandable_args = True
+
+        def fake_query(query_type: object) -> list[object]:
+            from deepagents_cli.widgets.messages import (
+                SkillMessage,
+                ToolCallMessage,
+            )
+
+            if query_type is ToolCallMessage:
+                return [tool]
+            if query_type is SkillMessage:
+                return []
+            return []
+
+        with patch.object(app, "query", side_effect=fake_query):
+            app.action_toggle_tool_output()
+
+        tool.toggle_args.assert_called_once_with()
+        tool.toggle_output.assert_not_called()
+
+    def test_ctrl_o_prefers_tool_with_output_over_expandable_args(self) -> None:
+        """Tool with real output wins over a later one with only expandable args."""
+        app = DeepAgentsApp(agent=MagicMock())
+        app._pending_ask_user_widget = None
+        older = MagicMock()
+        older.has_output = True
+        older.has_expandable_args = False
+        newer = MagicMock()
+        newer.has_output = False
+        newer.has_expandable_args = True
+
+        def fake_query(query_type: object) -> list[object]:
+            from deepagents_cli.widgets.messages import (
+                SkillMessage,
+                ToolCallMessage,
+            )
+
+            if query_type is ToolCallMessage:
+                return [older, newer]
+            if query_type is SkillMessage:
+                return []
+            return []
+
+        with patch.object(app, "query", side_effect=fake_query):
+            app.action_toggle_tool_output()
+
+        # Iterates in reverse, so newer (expandable args) is hit first.
+        newer.toggle_args.assert_called_once_with()
+        older.toggle_output.assert_not_called()
 
     async def test_request_ask_user_timeout_cleans_old_widget(self) -> None:
         """Timeout cleanup should cancel then remove the previous widget."""

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2104,6 +2104,19 @@ class TestMessageQueue:
 class TestAskUserLifecycle:
     """Tests for ask_user widget cleanup flows."""
 
+    def test_ctrl_o_targets_pending_ask_user_tool_row(self) -> None:
+        """App-level Ctrl+O should toggle the active ask_user tool row."""
+        app = DeepAgentsApp(agent=MagicMock())
+        app._pending_ask_user_widget = MagicMock()
+        tool = MagicMock()
+        tool._tool_name = "ask_user"
+        tool.has_expandable_args = True
+
+        with patch.object(app, "query", return_value=[tool]):
+            app.action_toggle_tool_output()
+
+        tool.toggle_args.assert_called_once_with()
+
     async def test_request_ask_user_timeout_cleans_old_widget(self) -> None:
         """Timeout cleanup should cancel then remove the previous widget."""
         app = DeepAgentsApp()

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -347,6 +347,120 @@ class TestToolCallMessageMarkupSafety:
         assert msg.has_expandable_args is True
 
 
+class TestToolCallMessageExpandableArgs:
+    """Tests for the `ask_user` expandable-arguments toggle."""
+
+    def test_has_expandable_args_false_for_non_ask_user(self) -> None:
+        """Only `ask_user` should expose expandable args."""
+        msg = ToolCallMessage("read_file", {"path": "/tmp/x"})
+        assert msg.has_expandable_args is False
+
+    def test_has_expandable_args_false_for_ask_user_without_args(self) -> None:
+        """Empty args dict should not be expandable."""
+        msg = ToolCallMessage("ask_user", {})
+        assert msg.has_expandable_args is False
+
+    def test_tool_name_property_exposes_underlying_name(self) -> None:
+        """Public `tool_name` property should mirror the constructor arg."""
+        msg = ToolCallMessage("ask_user", {"questions": []})
+        assert msg.tool_name == "ask_user"
+
+    def test_toggle_args_no_op_before_mount(self) -> None:
+        """Calling `toggle_args` before mount should not flip state."""
+        msg = ToolCallMessage("ask_user", {"questions": [{"question": "?"}]})
+        # Without `on_mount`, widget refs are None — `_update_args_display`
+        # short-circuits and the expanded flag should not be flipped either,
+        # since the user can't possibly see the result.
+        msg.toggle_args()
+        assert msg._args_expanded is True  # state flips
+        # but rendering is a no-op:
+        assert msg._args_widget is None
+
+    async def test_toggle_args_swaps_display_state(self) -> None:
+        """`toggle_args` should flip the args widget's display after mount."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage(
+                    "ask_user",
+                    {"questions": [{"question": "Name?", "type": "text"}]},
+                )
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+
+            # Initial state: hint visible, full args hidden.
+            assert msg._args_widget is not None
+            assert msg._args_hint_widget is not None
+            assert msg._args_widget.display is False
+            assert msg._args_hint_widget.display is True
+
+            msg.toggle_args()
+            await pilot.pause()
+            assert msg._args_expanded is True
+            assert msg._args_widget.display is True
+
+            msg.toggle_args()
+            await pilot.pause()
+            assert msg._args_expanded is False
+            assert msg._args_widget.display is False
+
+    async def test_on_click_routes_ask_user_to_toggle_args(self) -> None:
+        """Clicking an `ask_user` row (no output) should expand args."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage(
+                    "ask_user",
+                    {"questions": [{"question": "?"}]},
+                )
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+            event = MagicMock()
+            msg.on_click(event)
+            await pilot.pause()
+            event.stop.assert_called_once()
+            assert msg._args_expanded is True
+
+    async def test_toggle_output_does_not_fall_through_to_args(self) -> None:
+        """`toggle_output` is strictly about output; args stay collapsed."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage(
+                    "ask_user",
+                    {"questions": [{"question": "?"}]},
+                )
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+            msg.toggle_output()
+            await pilot.pause()
+            assert msg._args_expanded is False
+
+
 class TestToolCallMessageShellCommand:
     """Test ToolCallMessage shows full shell command for errors.
 

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -320,6 +320,32 @@ class TestToolCallMessageMarkupSafety:
         assert "[foo]" in content.plain
         assert "[/dim]" in content.plain
 
+    def test_ask_user_args_are_collapsed_by_default(self) -> None:
+        """`ask_user` should show compact header without inline raw args."""
+        msg = ToolCallMessage(
+            "ask_user",
+            {
+                "questions": [
+                    {
+                        "question": 'Your prompt is just "hi" - what should I build?',
+                        "type": "text",
+                    }
+                    for _ in range(4)
+                ]
+            },
+        )
+
+        widgets = list(msg.compose())
+        visible = []
+        for widget in widgets[:3]:
+            content = widget._Static__content  # type: ignore[attr-defined]
+            visible.append(content.plain if isinstance(content, Content) else content)
+        visible_plain = "\n".join(visible)
+
+        assert "ask_user(4 questions)" in visible_plain
+        assert "Your prompt is just" not in visible_plain
+        assert msg.has_expandable_args is True
+
 
 class TestToolCallMessageShellCommand:
     """Test ToolCallMessage shows full shell command for errors.

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -1129,8 +1129,269 @@ class TestExecuteTaskTextualAskUser:
         ]
         assert len(tool_rows) == 1
         tool_row = tool_rows[0]
-        assert tool_row._tool_name == "ask_user"
+        assert tool_row.tool_name == "ask_user"
         assert tool_row.has_expandable_args is True
+        # Answered cleanup pops the row from `_current_tool_messages`.
+        assert "tool-1" not in adapter._current_tool_messages
+
+    async def test_ask_user_mount_failure_does_not_register_tool_id(self) -> None:
+        """Mount failure should not poison `displayed_tool_ids` on the adapter."""
+
+        async def mount_message(_widget: object) -> None:
+            await asyncio.sleep(0)
+            msg = "mount failed"
+            raise RuntimeError(msg)
+
+        future: asyncio.Future[object] = asyncio.Future()
+        future.set_result({"type": "answered", "answers": ["Alice"]})
+
+        async def request_ask_user(
+            _questions: list[Any],
+        ) -> asyncio.Future[object] | None:
+            await asyncio.sleep(0)
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(
+                        {
+                            "type": "ask_user",
+                            "questions": [{"question": "Name?", "type": "text"}],
+                            "tool_call_id": "tool-1",
+                        }
+                    )
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=request_ask_user,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        # The flow continued, resumed with the answer, and never registered the
+        # broken tool row.
+        assert "tool-1" not in adapter._current_tool_messages
+
+    async def test_ask_user_duplicate_interrupt_only_mounts_once(self) -> None:
+        """Re-emitting the same `tool_call_id` should not double-mount."""
+        mounted: list[object] = []
+        future: asyncio.Future[object] = asyncio.Future()
+        future.set_result({"type": "answered", "answers": ["Alice"]})
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            mounted.append(widget)
+
+        async def request_ask_user(
+            _questions: list[Any],
+        ) -> asyncio.Future[object] | None:
+            await asyncio.sleep(0)
+            return future
+
+        payload = {
+            "type": "ask_user",
+            "questions": [{"question": "Name?", "type": "text"}],
+            "tool_call_id": "tool-dedup",
+        }
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(payload),
+                    _ask_user_interrupt_chunk(payload),
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=request_ask_user,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        tool_rows = [w for w in mounted if isinstance(w, ToolCallMessage)]
+        assert len(tool_rows) == 1
+
+    async def test_ask_user_cancelled_marks_row_rejected(self) -> None:
+        """Cancelled result should call `set_rejected` and pop the tool row."""
+        future: asyncio.Future[object] = asyncio.Future()
+        future.set_result({"type": "cancelled"})
+
+        async def request_ask_user(
+            _questions: list[Any],
+        ) -> asyncio.Future[object] | None:
+            await asyncio.sleep(0)
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(
+                        {
+                            "type": "ask_user",
+                            "questions": [{"question": "Name?", "type": "text"}],
+                            "tool_call_id": "tool-1",
+                        }
+                    )
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=request_ask_user,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        resume_cmd = agent.stream_inputs[1]
+        assert isinstance(resume_cmd, Command)
+        resume_payload = cast("dict[str, dict[str, Any]]", resume_cmd.resume)
+        assert resume_payload["interrupt-1"]["status"] == "cancelled"
+        assert "tool-1" not in adapter._current_tool_messages
+
+    async def test_ask_user_invalid_answers_payload_marks_row_error(self) -> None:
+        """Non-list answers should mark row as error and pop it."""
+        mounted: list[ToolCallMessage] = []
+        error_calls: list[str] = []
+        future: asyncio.Future[object] = asyncio.Future()
+        future.set_result({"type": "answered", "answers": "not-a-list"})
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                original = widget.set_error
+
+                def _capture(error: str) -> None:
+                    error_calls.append(error)
+                    original(error)
+
+                widget.set_error = _capture  # type: ignore[method-assign]
+                mounted.append(widget)
+
+        async def request_ask_user(
+            _questions: list[Any],
+        ) -> asyncio.Future[object] | None:
+            await asyncio.sleep(0)
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(
+                        {
+                            "type": "ask_user",
+                            "questions": [{"question": "Name?", "type": "text"}],
+                            "tool_call_id": "tool-1",
+                        }
+                    )
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=request_ask_user,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        resume_cmd = agent.stream_inputs[1]
+        assert isinstance(resume_cmd, Command)
+        resume_payload = cast("dict[str, dict[str, Any]]", resume_cmd.resume)
+        assert resume_payload["interrupt-1"]["status"] == "error"
+        assert (
+            resume_payload["interrupt-1"]["error"] == "invalid ask_user answers payload"
+        )
+        assert len(mounted) == 1
+        assert "invalid ask_user answers payload" in error_calls
+        assert "tool-1" not in adapter._current_tool_messages
+
+    async def test_ask_user_unsupported_marks_row_error(self) -> None:
+        """When no callback is registered, the mounted row gets an error."""
+        mounted: list[ToolCallMessage] = []
+        error_calls: list[str] = []
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                original = widget.set_error
+
+                def _capture(error: str) -> None:
+                    error_calls.append(error)
+                    original(error)
+
+                widget.set_error = _capture  # type: ignore[method-assign]
+                mounted.append(widget)
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(
+                        {
+                            "type": "ask_user",
+                            "questions": [{"question": "Name?", "type": "text"}],
+                            "tool_call_id": "tool-1",
+                        }
+                    )
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=None,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert len(mounted) == 1
+        assert "ask_user not supported by this UI" in error_calls
+        assert "tool-1" not in adapter._current_tool_messages
 
     async def test_request_ask_user_returning_none_is_reported_as_error(self) -> None:
         """A `None` callback result should resume with explicit error status."""

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -29,7 +29,7 @@ from deepagents_cli.textual_adapter import (
     format_token_count,
     print_usage_table,
 )
-from deepagents_cli.widgets.messages import SummarizationMessage
+from deepagents_cli.widgets.messages import SummarizationMessage, ToolCallMessage
 
 
 async def _mock_mount(widget: object) -> None:
@@ -1078,6 +1078,59 @@ class TestExecuteTaskTextualTextThenToolSpinner:
 
 class TestExecuteTaskTextualAskUser:
     """Tests for ask_user interrupt handling in the Textual adapter."""
+
+    async def test_ask_user_interrupt_mounts_tool_call_row(self) -> None:
+        """ask_user interrupts should mount the tool row before the prompt."""
+        mounted: list[object] = []
+        future: asyncio.Future[object] = asyncio.Future()
+        future.set_result({"type": "answered", "answers": ["Alice"]})
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            mounted.append(widget)
+
+        async def request_ask_user(
+            _questions: list[Any],
+        ) -> asyncio.Future[object] | None:
+            await asyncio.sleep(0)
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    _ask_user_interrupt_chunk(
+                        {
+                            "type": "ask_user",
+                            "questions": [{"question": "Name?", "type": "text"}],
+                            "tool_call_id": "tool-1",
+                        }
+                    )
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            request_ask_user=request_ask_user,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        tool_rows = [
+            widget for widget in mounted if isinstance(widget, ToolCallMessage)
+        ]
+        assert len(tool_rows) == 1
+        tool_row = tool_rows[0]
+        assert tool_row._tool_name == "ask_user"
+        assert tool_row.has_expandable_args is True
 
     async def test_request_ask_user_returning_none_is_reported_as_error(self) -> None:
         """A `None` callback result should resume with explicit error status."""


### PR DESCRIPTION
The `ask_user` tool call is now displayed as a first-class `ToolCallMessage` widget in the TUI instead of appearing inline with the chat stream. This keeps long question lists from cluttering the main transcript and lets users collapse or expand the arguments with a click or `Ctrl+O`, matching the behavior of other tool calls.