### PR TITLE
fix(cli): scroll tall `ask_user prompts` to top of viewport

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -3228,7 +3228,7 @@ class DeepAgentsApp(App):
         try:
             messages = self.query_one("#messages", Container)
             await self._mount_before_queued(messages, menu)
-            self.call_after_refresh(menu.scroll_visible)
+            self.call_after_refresh(lambda: self._scroll_ask_user_into_view(menu))
             self.call_after_refresh(menu.focus_active)
         except Exception as e:
             logger.exception(
@@ -3240,6 +3240,19 @@ class DeepAgentsApp(App):
                 result_future.set_exception(e)
 
         return result_future
+
+    def _scroll_ask_user_into_view(self, menu: AskUserMenu) -> None:
+        """Scroll mounted ask_user prompts into view.
+
+        Oversized prompts should start at the top of the viewport so the first
+        question and menu border are visible, instead of only exposing the
+        bottom edge of the widget.
+        """
+        chat = self.query_one("#chat", VerticalScroll)
+        if menu.outer_size.height > chat.size.height:
+            menu.scroll_visible(animate=False, top=True)
+            return
+        menu.scroll_visible()
 
     async def on_ask_user_menu_answered(
         self,

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -10,6 +10,7 @@ import os
 import signal
 import time
 import webbrowser
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -2103,6 +2104,32 @@ class TestMessageQueue:
 
 class TestAskUserLifecycle:
     """Tests for ask_user widget cleanup flows."""
+
+    def test_tall_ask_user_scrolls_to_widget_top(self) -> None:
+        """Tall ask_user menus should align their top border with the viewport."""
+        app = DeepAgentsApp(agent=MagicMock())
+        menu = MagicMock()
+        menu.outer_size = SimpleNamespace(height=30)
+        chat = MagicMock()
+        chat.size = SimpleNamespace(height=20)
+
+        with patch.object(app, "query_one", return_value=chat):
+            app._scroll_ask_user_into_view(menu)
+
+        menu.scroll_visible.assert_called_once_with(animate=False, top=True)
+
+    def test_short_ask_user_uses_default_scroll_visible(self) -> None:
+        """Short ask_user menus should keep the existing scroll behavior."""
+        app = DeepAgentsApp(agent=MagicMock())
+        menu = MagicMock()
+        menu.outer_size = SimpleNamespace(height=10)
+        chat = MagicMock()
+        chat.size = SimpleNamespace(height=20)
+
+        with patch.object(app, "query_one", return_value=chat):
+            app._scroll_ask_user_into_view(menu)
+
+        menu.scroll_visible.assert_called_once_with()
 
     def test_ctrl_o_targets_pending_ask_user_tool_row(self) -> None:
         """App-level Ctrl+O should toggle the active ask_user tool row."""


### PR DESCRIPTION
Tall `ask_user` prompts in the chat UI were mounting with only their bottom edge visible, hiding the first question and menu border from the user. Added `_scroll_ask_user_into_view` in `DeepAgentsApp` to detect oversized prompts and align them to the top of the viewport with `scroll_visible(animate=False, top=True)`, while preserving default scroll behavior for shorter menus.