### PR TITLE
docs(sdk): add mkdocs cross-reference links to docstrings

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -557,7 +557,8 @@ class CompositeBackend(BackendProtocol):
 
         Raises:
             NotImplementedError: If the default backend is not a
-                `SandboxBackendProtocol` (i.e., it doesn't support execution).
+                [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol]
+                (i.e., it doesn't support execution).
         """
         if isinstance(self.default, SandboxBackendProtocol):
             if timeout is not None and execute_accepts_timeout(type(self.default)):

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -46,7 +46,7 @@ def _binary_read_result(file_path: str, raw: bytes) -> ReadResult:
 
 
 class LangSmithSandbox(BaseSandbox):
-    """LangSmith sandbox implementation conforming to `SandboxBackendProtocol`."""
+    """LangSmith sandbox implementation conforming to [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol]."""
 
     def __init__(self, sandbox: Sandbox) -> None:
         """Create a backend wrapping an existing LangSmith sandbox.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -829,7 +829,8 @@ def execute_accepts_timeout(cls: type[SandboxBackendProtocol]) -> bool:
     """Check whether a backend class's `execute` accepts a `timeout` kwarg.
 
     Older backend packages didn't lower-bound their SDK dependency, so they
-    may not accept the `timeout` keyword added to `SandboxBackendProtocol`.
+    may not accept the `timeout` keyword added to
+    [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
 
     Results are cached per class to avoid repeated introspection overhead.
     """

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -1,4 +1,7 @@
-"""Base sandbox implementation (`BaseSandbox`) implementing `SandboxBackendProtocol`.
+"""Base sandbox implementation.
+
+[`BaseSandbox`][deepagents.backends.sandbox.BaseSandbox] implements
+[`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
 
 File listing, grep, glob, and read use shell commands via `execute()`. Write
 delegates content transfer to `upload_files()`. Edit uses server-side `execute()`

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -162,7 +162,7 @@ def get_default_model() -> ChatAnthropic:
 
     Used as a fallback when `model=None` is passed to `create_deep_agent`.
 
-    Requires `ANTHROPIC_API_KEY` to be set in the environment if used.
+    Requires `ANTHROPIC_API_KEY` to be set in the environment.
 
     Returns:
         `ChatAnthropic` instance configured with `claude-sonnet-4-6`.
@@ -320,9 +320,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             `AgentMiddleware.name` exactly (e.g. `"SummarizationMiddleware"`
             drops the summarization middleware via its public alias).
             Entries that match nothing in the assembled stack raise
-            `ValueError`, as does excluding scaffolding classes
-            ([`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware],
-            [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]).
+            `ValueError`, as does excluding any class in the harness's
+            protected scaffolding set (e.g.,
+            [`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware]
+            or [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]).
 
             To run without the `task` tool, set
             `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
@@ -445,8 +446,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         ImportError: If a required provider package is missing or below the
             minimum supported version (e.g., `langchain-openrouter`).
         ValueError: If the active `HarnessProfile.excluded_middleware`
-            references required scaffolding
-            ([`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware],
+            references a class in the harness's protected scaffolding set
+            (e.g.,
+            [`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware]
+            or
             [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]),
             uses a private (underscore-prefixed) name, collides with multiple
             distinct middleware classes, or matches no entry in the assembled

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -1,8 +1,8 @@
 """Primary graph assembly module for Deep Agents.
 
-Provides `create_deep_agent`, the main entry point for constructing a fully
-configured deep agent with planning, filesystem, subagent, and summarization
-middleware.
+Provides [`create_deep_agent`][deepagents.graph.create_deep_agent], the main entry
+point for constructing a fully configured deep agent with planning, filesystem,
+subagent, and summarization middleware.
 """
 
 import logging
@@ -162,7 +162,7 @@ def get_default_model() -> ChatAnthropic:
 
     Used as a fallback when `model=None` is passed to `create_deep_agent`.
 
-    Requires `ANTHROPIC_API_KEY` to be set in the environment.
+    Requires `ANTHROPIC_API_KEY` to be set in the environment if used.
 
     Returns:
         `ChatAnthropic` instance configured with `claude-sonnet-4-6`.
@@ -231,15 +231,25 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     - `execute`: run shell commands
     - `task`: call subagents
 
-    The `execute` tool allows running shell commands if the backend implements `SandboxBackendProtocol`.
+    The `execute` tool allows running shell commands if the backend implements
+    [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
     For non-sandbox backends, the `execute` tool will return an error message.
 
     Args:
         model: The model to use.
 
-            Defaults to `claude-sonnet-4-6`.
+            !!! deprecated
 
-            Accepts a `provider:model` string (e.g., `openai:gpt-5`); see
+                Specify a model explicitly.
+
+                Passing `model=None` (relying on the default
+                `claude-sonnet-4-6`) is deprecated since `0.5.3` and will
+                be removed in `deepagents==1.0.0`. The parameter type
+                will change from `BaseChatModel | str | None` to
+                `BaseChatModel | str`. See
+                [Models](https://docs.langchain.com/oss/python/deepagents/models).
+
+            Accepts a `provider:model` string (e.g., `openai:gpt-5.5`); see
             [`init_chat_model`][langchain.chat_models.init_chat_model(model_provider)]
             for supported values. You can also pass a pre-initialized
             [`BaseChatModel`][langchain.chat_models.BaseChatModel] instance directly.
@@ -281,13 +291,17 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             Base stack:
 
-            - `TodoListMiddleware`
-            - `SkillsMiddleware` (if `skills` is provided)
-            - `FilesystemMiddleware`
-            - `SubAgentMiddleware` (if any inline subagents — declarative `SubAgent` or `CompiledSubAgent` — are available)
-            - `SummarizationMiddleware`
-            - `PatchToolCallsMiddleware`
-            - `AsyncSubAgentMiddleware` (if async `subagents` are provided)
+            - [`TodoListMiddleware`][langchain.agents.middleware.TodoListMiddleware]
+            - [`SkillsMiddleware`][deepagents.middleware.skills.SkillsMiddleware] (if `skills` is provided)
+            - [`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware]
+            - [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]
+                (if any inline subagents — declarative
+                [`SubAgent`][deepagents.middleware.subagents.SubAgent] or
+                [`CompiledSubAgent`][deepagents.middleware.subagents.CompiledSubAgent]
+                — are available)
+            - [`SummarizationMiddleware`][langchain.agents.middleware.SummarizationMiddleware]
+            - [`PatchToolCallsMiddleware`][deepagents.middleware.patch_tool_calls.PatchToolCallsMiddleware]
+            - [`AsyncSubAgentMiddleware`][deepagents.middleware.async_subagents.AsyncSubAgentMiddleware] (if async `subagents` are provided)
 
             *User middleware is inserted here.*
 
@@ -295,10 +309,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             - Harness profile `extra_middleware` (if any)
             - `_ToolExclusionMiddleware` (if profile has `excluded_tools`)
-            - `AnthropicPromptCachingMiddleware` (unconditional; no-ops for
+            - [`AnthropicPromptCachingMiddleware`][langchain_anthropic.middleware.AnthropicPromptCachingMiddleware] (unconditional; no-ops for
                 non-Anthropic models)
-            - `MemoryMiddleware` (if `memory` is provided)
-            - `HumanInTheLoopMiddleware` (if `interrupt_on` is provided)
+            - [`MemoryMiddleware`][deepagents.middleware.memory.MemoryMiddleware] (if `memory` is provided)
+            - [`HumanInTheLoopMiddleware`][langchain.agents.middleware.HumanInTheLoopMiddleware] (if `interrupt_on` is provided)
 
             After assembly, any entries in the profile's
             `excluded_middleware` are filtered from the final stack. Class
@@ -307,7 +321,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             drops the summarization middleware via its public alias).
             Entries that match nothing in the assembled stack raise
             `ValueError`, as does excluding scaffolding classes
-            (`FilesystemMiddleware`, `SubAgentMiddleware`).
+            ([`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware],
+            [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]).
 
             To run without the `task` tool, set
             `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
@@ -378,7 +393,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             Pass a `Backend` instance (e.g. `StateBackend()`).
 
             For execution support, use a backend that
-            implements `SandboxBackendProtocol`.
+            implements [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
         interrupt_on: Mapping of tool names to interrupt configs.
 
             Pass to pause agent execution at specified tool calls for human
@@ -429,6 +444,13 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     Raises:
         ImportError: If a required provider package is missing or below the
             minimum supported version (e.g., `langchain-openrouter`).
+        ValueError: If the active `HarnessProfile.excluded_middleware`
+            references required scaffolding
+            ([`FilesystemMiddleware`][deepagents.middleware.filesystem.FilesystemMiddleware],
+            [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware]),
+            uses a private (underscore-prefixed) name, collides with multiple
+            distinct middleware classes, or matches no entry in the assembled
+            stack.
     """
     _model_spec: str | None = model if isinstance(model, str) else None
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -453,8 +453,10 @@ Use this tool to run commands, scripts, tests, builds, and other shell operation
 def supports_execution(backend: BackendProtocol) -> bool:
     """Check if a backend supports command execution.
 
-    For CompositeBackend, checks if the default backend supports execution.
-    For other backends, checks if they implement SandboxBackendProtocol.
+    For [`CompositeBackend`][deepagents.backends.composite.CompositeBackend],
+    checks if the default backend supports execution.
+    For other backends, checks if they implement
+    [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
 
     Args:
         backend: The backend to check.
@@ -645,10 +647,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
     This middleware adds filesystem tools to the agent: `ls`, `read_file`, `write_file`,
     `edit_file`, `glob`, and `grep`.
 
-    Files can be stored using any backend that implements the `BackendProtocol`.
+    Files can be stored using any backend that implements the
+    [`BackendProtocol`][deepagents.backends.protocol.BackendProtocol].
 
-    If the backend implements `SandboxBackendProtocol`, an `execute` tool is also added
-    for running shell commands.
+    If the backend implements
+    [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol],
+    an `execute` tool is also added for running shell commands.
 
     This middleware also automatically evicts large tool results to the file system when
     they exceed a token threshold, preventing context window saturation.
@@ -656,11 +660,16 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
     Args:
         backend: Backend for file storage and optional execution.
 
-            If not provided, defaults to `StateBackend` (ephemeral storage in agent state).
+            If not provided, defaults to
+            [`StateBackend`][deepagents.backends.state.StateBackend]
+            (ephemeral storage in agent state).
 
-            For persistent storage or hybrid setups, use `CompositeBackend` with custom routes.
+            For persistent storage or hybrid setups, use
+            [`CompositeBackend`][deepagents.backends.composite.CompositeBackend]
+            with custom routes.
 
-            For execution support, use a backend that implements `SandboxBackendProtocol`.
+            For execution support, use a backend that implements
+            [`SandboxBackendProtocol`][deepagents.backends.protocol.SandboxBackendProtocol].
         system_prompt: Optional custom system prompt override.
         custom_tool_descriptions: Optional custom tool descriptions override.
         tool_token_limit_before_evict: Token limit before evicting a tool result to the


### PR DESCRIPTION
Cross-references API symbols in docstrings across the backend and graph modules so generated docs link directly to referenced types and classes. Also documents the deprecation of `model=None` in `create_deep_agent` and clarifies when `ANTHROPIC_API_KEY` is required.