### PR TITLE
fix(sdk): avoid deprecated-use warnings in `CompositeBackend` path mutation

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -18,7 +18,6 @@ Examples:
 """
 
 from collections import defaultdict
-from dataclasses import replace
 from typing import cast
 
 from deepagents.backends.protocol import (
@@ -482,7 +481,7 @@ class CompositeBackend(BackendProtocol):
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = backend.write(stripped_key, content)
         if res.path is not None:
-            res = replace(res, path=file_path)
+            res.path = file_path
         return res
 
     async def awrite(
@@ -494,7 +493,7 @@ class CompositeBackend(BackendProtocol):
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.awrite(stripped_key, content)
         if res.path is not None:
-            res = replace(res, path=file_path)
+            res.path = file_path
         return res
 
     def edit(
@@ -518,7 +517,7 @@ class CompositeBackend(BackendProtocol):
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = backend.edit(stripped_key, old_string, new_string, replace_all=replace_all)
         if res.path is not None:
-            res = replace(res, path=file_path)
+            res.path = file_path
         return res
 
     async def aedit(
@@ -532,7 +531,7 @@ class CompositeBackend(BackendProtocol):
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.aedit(stripped_key, old_string, new_string, replace_all=replace_all)
         if res.path is not None:
-            res = replace(res, path=file_path)
+            res.path = file_path
         return res
 
     def execute(

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -199,6 +199,7 @@ def _normalize_files_update(
 
     # `stacklevel=3` lifts attribution past `__init__` and this helper to the
     # user's `WriteResult(...)` / `EditResult(...)` call site.
+    # TODO(mdrxy): remove `files_update` fields in 0.7.0. https://github.com/langchain-ai/deepagents/issues/3220  # noqa: FIX002
     warn_deprecated(
         since="0.5.0",
         removal="0.7.0",


### PR DESCRIPTION
Fixes #3220

---

`CompositeBackend.write`, `awrite`, `edit`, and `aedit` were using `dataclasses.replace()` to update the `path` field on `WriteResult`/`EditResult` objects. Since these dataclasses have custom `__init__` methods that emit deprecation warnings for the `files_update` parameter, `replace()` was triggering those warnings during routine internal path mutation.