### PR TITLE
fix(cli): pause input cursor blink when terminal loses OS focus

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -6236,7 +6236,7 @@ class DeepAgentsApp(App):
         (requires a terminal that supports FocusIn events). Re-focusing the chat
         input here keeps it ready for typing.
         """
-        if not self._chat_input:
+        if self._chat_input is None:
             return
         self._chat_input.set_cursor_blink(blink=True)
         if isinstance(self.screen, ModalScreen):
@@ -6248,8 +6248,9 @@ class DeepAgentsApp(App):
     def on_app_blur(self) -> None:
         """Pause the chat input cursor blink when the terminal loses OS focus.
 
-        `TextArea` pauses its own blink in `_watch_has_focus`, but `AppBlur`
-        does not change widget focus, so we toggle `cursor_blink` here.
+        `TextArea` pauses its own blink when its `has_focus` flips, but
+        `AppBlur` does not change widget focus, so we toggle `cursor_blink`
+        manually.
         """
         if self._chat_input is None:
             return

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -6229,7 +6229,7 @@ class DeepAgentsApp(App):
             event.stop()
 
     def on_app_focus(self) -> None:
-        """Restore chat input focus when the terminal regains OS focus.
+        """Restore chat input focus and resume cursor blink on terminal focus regain.
 
         When the user opens a link via `webbrowser.open`, OS focus shifts to
         the browser. On returning to the terminal, Textual fires `AppFocus`
@@ -6238,11 +6238,22 @@ class DeepAgentsApp(App):
         """
         if not self._chat_input:
             return
+        self._chat_input.set_cursor_blink(blink=True)
         if isinstance(self.screen, ModalScreen):
             return
         if self._pending_approval_widget or self._pending_ask_user_widget:
             return
         self._chat_input.focus_input()
+
+    def on_app_blur(self) -> None:
+        """Pause the chat input cursor blink when the terminal loses OS focus.
+
+        `TextArea` pauses its own blink in `_watch_has_focus`, but `AppBlur`
+        does not change widget focus, so we toggle `cursor_blink` here.
+        """
+        if self._chat_input is None:
+            return
+        self._chat_input.set_cursor_blink(blink=False)
 
     def on_click(self, event: Click) -> None:
         """Handle clicks anywhere in the terminal.

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -1943,6 +1943,15 @@ class ChatInput(Vertical):
         if self._text_area:
             self._text_area.set_app_focus(has_focus=active)
 
+    def set_cursor_blink(self, *, blink: bool) -> None:
+        """Toggle the input's cursor blink without changing focus.
+
+        Args:
+            blink: Whether the cursor should blink.
+        """
+        if self._text_area is not None:
+            self._text_area.cursor_blink = blink
+
     def exit_mode(self) -> bool:
         """Exit the current input mode (command/shell) back to normal.
 

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2682,6 +2682,84 @@ class TestAppFocusRestoresChatInput:
 
             mock_focus.assert_not_called()
 
+    async def test_app_focus_resumes_blink_with_modal_open(self) -> None:
+        """Blink should resume on focus regain even when a modal blocks refocus."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            assert app._chat_input._text_area is not None
+
+            from deepagents_cli.widgets.thread_selector import ThreadSelectorScreen
+
+            app.push_screen(ThreadSelectorScreen(current_thread=None))
+            await pilot.pause()
+            assert isinstance(app.screen, ModalScreen)
+
+            app._chat_input._text_area.cursor_blink = False
+            app.on_app_focus()
+            await pilot.pause()
+
+            assert app._chat_input._text_area.cursor_blink is True
+
+    async def test_app_focus_resumes_blink_with_approval_pending(self) -> None:
+        """Blink should resume on focus regain even when an approval is pending."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            assert app._chat_input._text_area is not None
+
+            app._pending_approval_widget = MagicMock()
+            app._chat_input._text_area.cursor_blink = False
+
+            app.on_app_focus()
+            await pilot.pause()
+
+            assert app._chat_input._text_area.cursor_blink is True
+
+
+class TestAppBlurPausesCursorBlink:
+    """Test `on_app_blur` pauses cursor blink without changing widget focus."""
+
+    async def test_app_blur_pauses_blink(self) -> None:
+        """Losing terminal focus should pause the chat input cursor blink."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            assert app._chat_input._text_area is not None
+            assert app._chat_input._text_area.cursor_blink is True
+
+            app.on_app_blur()
+            await pilot.pause()
+
+            assert app._chat_input._text_area.cursor_blink is False
+
+    async def test_app_blur_preserves_widget_focus(self) -> None:
+        """Pausing blink must not blur the chat input widget."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            assert app._chat_input._text_area is not None
+            app._chat_input._text_area.focus()
+            await pilot.pause()
+
+            app.on_app_blur()
+            await pilot.pause()
+
+            assert app._chat_input._text_area.has_focus is True
+
+    async def test_app_blur_noop_before_mount(self) -> None:
+        """`on_app_blur` should silently ignore blur events before mount."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._chat_input = None
+
+            app.on_app_blur()
+
 
 class TestPasteRouting:
     """Tests app-level paste routing when chat input focus lags."""

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -2579,3 +2579,37 @@ class TestScrollCursorVisibleDesync:
                 result = text_area.scroll_cursor_visible()
 
             assert result == Offset(0, 0)
+
+
+class TestSetCursorBlink:
+    """`ChatInput.set_cursor_blink` toggles cursor blink without changing focus."""
+
+    async def test_toggles_reactive(self) -> None:
+        """Pause flips `cursor_blink` to False; resume flips it back to True."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+            assert chat._text_area.cursor_blink is True
+
+            chat.set_cursor_blink(blink=False)
+            await pilot.pause()
+            assert chat._text_area.cursor_blink is False
+
+            chat.set_cursor_blink(blink=True)
+            await pilot.pause()
+            assert chat._text_area.cursor_blink is True
+
+    async def test_preserves_widget_focus(self) -> None:
+        """Pausing must not blur the widget."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+            chat._text_area.focus()
+            await pilot.pause()
+
+            chat.set_cursor_blink(blink=False)
+            await pilot.pause()
+
+            assert chat._text_area.has_focus is True


### PR DESCRIPTION
Fixes #3166

---

`AppBlur` is an OS-level event that doesn't change widget focus, so Textual's `TextArea._watch_has_focus`-based blink pause never triggered when the terminal window lost focus. Adds an `on_app_blur` handler symmetric to `on_app_focus` plus a `ChatInput.set_cursor_blink` mediator that toggles the public `cursor_blink` reactive without blurring the widget, so key events keep flowing while the cursor is paused.

Verified by reproducing in terminal (cursor freezes on window switch, resumes on return). Added two unit tests covering the reactive toggle and focus preservation.