### PR TITLE
feat(cli): add per-terminal theme mapping via `[ui.terminal_themes]`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -187,6 +187,13 @@ if _IS_ITERM:
 def _load_theme_preference() -> str:
     """Load the forced or saved theme name, or return the default.
 
+    Resolution order:
+
+    1. ``DEEPAGENTS_CLI_THEME`` env var (explicit override).
+    2. ``[ui].theme`` in ``~/.deepagents/config.toml`` (saved preference).
+    3. ``[ui.terminal_themes]`` mapping keyed by ``TERM_PROGRAM`` (smart default).
+    4. :data:`theme.DEFAULT_THEME`.
+
     Returns:
         A Textual theme name (e.g., `'langchain'`, `'langchain-light'`).
     """
@@ -236,6 +243,22 @@ def _load_theme_preference() -> str:
             "Unknown theme '%s' in config; falling back to default",
             name,
         )
+
+    terminal_themes = data.get("ui", {}).get("terminal_themes")
+    if isinstance(terminal_themes, dict):
+        term_program = os.environ.get("TERM_PROGRAM")
+        if term_program is not None:
+            mapped = terminal_themes.get(term_program)
+            if isinstance(mapped, str) and mapped in theme.get_registry():
+                return mapped
+            if isinstance(mapped, str):
+                logger.warning(
+                    "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
+                    "in [ui.terminal_themes]; ignoring",
+                    mapped,
+                    term_program,
+                )
+
     return theme.DEFAULT_THEME
 
 

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -514,6 +514,120 @@ class TestLoadThemePreference:
         assert _load_theme_preference() == DEFAULT_THEME
 
 
+class TestTerminalThemeMapping:
+    """_load_theme_preference respects [ui.terminal_themes] mapping."""
+
+    def test_terminal_mapping_resolves_theme(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == "langchain-light"
+
+    def test_saved_theme_overrides_terminal_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui]\ntheme = "langchain"\n'
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == "langchain"
+
+    def test_env_theme_overrides_terminal_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.setenv(THEME, "langchain")
+
+        assert _load_theme_preference() == "langchain"
+
+    def test_unknown_terminal_falls_through_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "SomeUnknownTerminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_unknown_mapped_theme_warns_and_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "nonexistent-theme"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_missing_term_program_falls_through_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_no_terminal_themes_section_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[model]\nname = "gpt-4"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+
 class TestSaveThemePreference:
     """save_theme_preference writes config.toml correctly."""
 


### PR DESCRIPTION
Ref #2146                                                                                                         
                                                                                                             
  ---                                                                                                                

Users can now map `TERM_PROGRAM` values to theme names in `~/.deepagents/config.toml` under `[ui.terminal_themes]`, giving terminals that can't report their color scheme (`Apple Terminal`,`iTerm2`, `WezTerm`) a smart default. 

The mapping sits between the saved preference and the hardcoded default in the resolution chain — it never overrides an explicit  `[ui].theme` or `DEEPAGENTS_CLI_THEME`.                                                                            
                                                                                                                     
PR 1 of 2 — system dark/light auto-detection will follow once Textualize/textual#6151 lands upstream. 