### PR TITLE
feat(cli): per-terminal theme selection

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -214,11 +214,11 @@ def _load_theme_preference() -> str:
     Resolution order:
 
     1. `DEEPAGENTS_CLI_THEME` env var (explicit override).
-    2. `[ui].theme` in `~/.deepagents/config.toml` (saved preference). An
-        invalid value here returns the default — the user's explicit choice is
-        not silently overridden by the terminal mapping.
-    3. `[ui.terminal_themes]` mapping keyed by `TERM_PROGRAM` (smart default,
-        consulted only when no `[ui].theme` is set).
+    2. `[ui.terminal_themes]` mapping keyed by `TERM_PROGRAM` — wins over the
+        saved preference so a user moving between terminals (e.g. dark iTerm,
+        light Apple Terminal) gets the right theme automatically.
+    3. `[ui].theme` in `~/.deepagents/config.toml` (saved preference, used
+        when no terminal mapping matches).
     4. `theme.DEFAULT_THEME`.
 
     Returns:
@@ -261,17 +261,6 @@ def _load_theme_preference() -> str:
 
     ui = data.get("ui", {})
 
-    saved = ui.get("theme")
-    resolved = _resolve_config_theme(saved)
-    if resolved is not None:
-        return resolved
-    if isinstance(saved, str):
-        logger.warning(
-            "Unknown theme '%s' in config; falling back to default",
-            saved,
-        )
-        return theme.DEFAULT_THEME
-
     terminal_themes = ui.get("terminal_themes")
     if isinstance(terminal_themes, dict):
         term_program = os.environ.get("TERM_PROGRAM")
@@ -299,6 +288,16 @@ def _load_theme_preference() -> str:
             "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
             "values to theme names; got %s",
             type(terminal_themes).__name__,
+        )
+
+    saved = ui.get("theme")
+    resolved = _resolve_config_theme(saved)
+    if resolved is not None:
+        return resolved
+    if isinstance(saved, str):
+        logger.warning(
+            "Unknown theme '%s' in config; falling back to default",
+            saved,
         )
 
     return theme.DEFAULT_THEME

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -216,6 +216,41 @@ def _resolve_theme_name(value: object) -> str | None:
     return None
 
 
+def _load_terminal_default() -> str | None:
+    """Return the saved default theme for the current `TERM_PROGRAM`.
+
+    Reads `[ui.terminal_themes][TERM_PROGRAM]` from `config.toml` and
+    resolves the value via `_resolve_theme_name`, so labels and case variants
+    are accepted. Used by `ThemeSelectorScreen` to badge the matching option
+    with `(terminal default)`.
+
+    Returns:
+        The canonical registry key, or `None` if `TERM_PROGRAM` is unset,
+            the file is missing or unreadable, no mapping is set, or the mapped
+            value doesn't match a registered theme.
+    """
+    term_program = os.environ.get("TERM_PROGRAM", "").strip()
+    if not term_program:
+        return None
+
+    import tomllib
+
+    try:
+        from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
+
+        if not DEFAULT_CONFIG_PATH.exists():
+            return None
+        with DEFAULT_CONFIG_PATH.open("rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, PermissionError, OSError):
+        return None
+
+    terminal_themes = data.get("ui", {}).get("terminal_themes")
+    if not isinstance(terminal_themes, dict):
+        return None
+    return _resolve_theme_name(terminal_themes.get(term_program))
+
+
 def _load_theme_preference() -> str:
     """Load the forced or saved theme name, or return the default.
 
@@ -6596,7 +6631,10 @@ class DeepAgentsApp(App):
             if self._chat_input:
                 self._chat_input.focus_input()
 
-        screen = ThemeSelectorScreen(current_theme=self.theme)
+        screen = ThemeSelectorScreen(
+            current_theme=self.theme,
+            terminal_default=_load_terminal_default(),
+        )
         self.push_screen(screen, handle_result)
 
     async def _show_agent_selector(self) -> None:

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -184,15 +184,42 @@ if _IS_ITERM:
     atexit.register(_restore_cursor_guide)
 
 
+def _resolve_config_theme(value: object) -> str | None:
+    """Resolve a theme name read from `config.toml`.
+
+    Applies the legacy `textual-ansi` migration (pre-Textual 8.2.5) and
+    requires an exact registry-key match. Config-file values are written by the
+    CLI itself, so case/label tolerance is intentionally narrower than the
+    `DEEPAGENTS_CLI_THEME` env-var path.
+
+    Args:
+        value: Raw value read from TOML.
+
+    Returns:
+        The canonical registry key, or `None` if the value is not a string or
+        does not match a registered theme.
+    """
+    if not isinstance(value, str):
+        return None
+    if value == "textual-ansi":
+        value = "ansi-light"
+    if value in theme.get_registry():
+        return value
+    return None
+
+
 def _load_theme_preference() -> str:
     """Load the forced or saved theme name, or return the default.
 
     Resolution order:
 
-    1. ``DEEPAGENTS_CLI_THEME`` env var (explicit override).
-    2. ``[ui].theme`` in ``~/.deepagents/config.toml`` (saved preference).
-    3. ``[ui.terminal_themes]`` mapping keyed by ``TERM_PROGRAM`` (smart default).
-    4. :data:`theme.DEFAULT_THEME`.
+    1. `DEEPAGENTS_CLI_THEME` env var (explicit override).
+    2. `[ui].theme` in `~/.deepagents/config.toml` (saved preference). An
+        invalid value here returns the default — the user's explicit choice is
+        not silently overridden by the terminal mapping.
+    3. `[ui.terminal_themes]` mapping keyed by `TERM_PROGRAM` (smart default,
+        consulted only when no `[ui].theme` is set).
+    4. `theme.DEFAULT_THEME`.
 
     Returns:
         A Textual theme name (e.g., `'langchain'`, `'langchain-light'`).
@@ -232,25 +259,27 @@ def _load_theme_preference() -> str:
         logger.warning("Could not read config for theme preference: %s", exc)
         return theme.DEFAULT_THEME
 
-    name = data.get("ui", {}).get("theme")
-    # Migrate legacy `textual-ansi` preference (pre-Textual 8.2.5) to `ansi-light`.
-    if name == "textual-ansi":
-        name = "ansi-light"
-    if isinstance(name, str) and name in theme.get_registry():
-        return name
-    if isinstance(name, str):
+    ui = data.get("ui", {})
+
+    saved = ui.get("theme")
+    resolved = _resolve_config_theme(saved)
+    if resolved is not None:
+        return resolved
+    if isinstance(saved, str):
         logger.warning(
             "Unknown theme '%s' in config; falling back to default",
-            name,
+            saved,
         )
+        return theme.DEFAULT_THEME
 
-    terminal_themes = data.get("ui", {}).get("terminal_themes")
+    terminal_themes = ui.get("terminal_themes")
     if isinstance(terminal_themes, dict):
         term_program = os.environ.get("TERM_PROGRAM")
-        if term_program is not None:
+        if term_program:
             mapped = terminal_themes.get(term_program)
-            if isinstance(mapped, str) and mapped in theme.get_registry():
-                return mapped
+            resolved = _resolve_config_theme(mapped)
+            if resolved is not None:
+                return resolved
             if isinstance(mapped, str):
                 logger.warning(
                     "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
@@ -258,6 +287,19 @@ def _load_theme_preference() -> str:
                     mapped,
                     term_program,
                 )
+            elif mapped is not None:
+                logger.warning(
+                    "Expected string theme name for TERM_PROGRAM='%s' in "
+                    "[ui.terminal_themes], got %s; ignoring",
+                    term_program,
+                    type(mapped).__name__,
+                )
+    elif terminal_themes is not None:
+        logger.warning(
+            "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
+            "values to theme names; got %s",
+            type(terminal_themes).__name__,
+        )
 
     return theme.DEFAULT_THEME
 
@@ -5560,7 +5602,7 @@ class DeepAgentsApp(App):
         This method also stores the message data and handles pruning
         when the widget count exceeds the maximum.
 
-        If the ``#messages`` container is not present (e.g. the screen has
+        If the `#messages` container is not present (e.g. the screen has
         been torn down during an interruption), the call is silently skipped
         to avoid cascading `NoMatches` errors.
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -187,6 +187,13 @@ if _IS_ITERM:
 def _load_theme_preference() -> str:
     """Load the forced or saved theme name, or return the default.
 
+    Resolution order:
+
+    1. ``DEEPAGENTS_CLI_THEME`` env var (explicit override).
+    2. ``[ui].theme`` in ``~/.deepagents/config.toml`` (saved preference).
+    3. ``[ui.terminal_themes]`` mapping keyed by ``TERM_PROGRAM`` (smart default).
+    4. :data:`theme.DEFAULT_THEME`.
+
     Returns:
         A Textual theme name (e.g., `'langchain'`, `'langchain-light'`).
     """
@@ -236,6 +243,22 @@ def _load_theme_preference() -> str:
             "Unknown theme '%s' in config; falling back to default",
             name,
         )
+
+    terminal_themes = data.get("ui", {}).get("terminal_themes")
+    if isinstance(terminal_themes, dict):
+        term_program = os.environ.get("TERM_PROGRAM")
+        if term_program is not None:
+            mapped = terminal_themes.get(term_program)
+            if isinstance(mapped, str) and mapped in theme.get_registry():
+                return mapped
+            if isinstance(mapped, str):
+                logger.warning(
+                    "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
+                    "in [ui.terminal_themes]; ignoring",
+                    mapped,
+                    term_program,
+                )
+
     return theme.DEFAULT_THEME
 
 

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -92,18 +92,30 @@ from deepagents_cli.widgets.welcome import WelcomeBanner
 logger = logging.getLogger(__name__)
 _monotonic = time.monotonic
 
-# Serializes read-modify-write of `~/.deepagents/config.toml` between
-# `save_theme_preference` and `save_terminal_theme_mapping`. Without this,
-# pressing `t` (per-terminal mapping) and Enter (global theme) in quick
-# succession would race two writers over the same file: each reads the
-# pre-mutation state, then the second writer's dump clobbers the first
-# writer's keys.
+# Serializes process-local read-modify-write operations for `config.toml`.
+# Without this, overlapping global-theme and per-terminal-theme saves can each
+# read the same pre-mutation state and then clobber the other's keys.
 _CONFIG_WRITE_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _ConfigWriteResult:
+    """Result of a config write with TUI-facing failure context."""
+
+    ok: bool
+    """Whether the write completed successfully."""
+
+    message: str | None = None
+    """Optional user-facing detail for repairs or failures."""
+
+    severity: Literal["warning", "error"] = "warning"
+    """Toast severity to use when `message` is shown."""
+
 
 ScreenResultT = TypeVar("ScreenResultT")
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Mapping
 
     from deepagents.backends import CompositeBackend
     from langchain_core.runnables import RunnableConfig
@@ -169,7 +181,19 @@ def _resolve_theme_name(value: object) -> str | None:
     return None
 
 
-def _resolve_terminal_mapping(ui: dict[str, Any]) -> str | None:
+def _as_toml_table(value: object) -> dict[str, object] | None:
+    """Return `value` as a TOML table when it has the expected runtime shape."""
+    if not isinstance(value, dict):
+        return None
+    # `tomllib` parses TOML tables as string-keyed dicts; `ty` cannot infer
+    # that from a runtime `dict` check. Keep the cast at this boundary so it
+    # does not become a general-purpose escape hatch.
+    from typing import cast
+
+    return cast("dict[str, object]", value)
+
+
+def _resolve_terminal_mapping(ui: Mapping[str, object]) -> str | None:
     """Resolve `[ui.terminal_themes][TERM_PROGRAM]` to a registered theme.
 
     Centralizes both the lookup and the misconfiguration warnings shared by
@@ -187,7 +211,8 @@ def _resolve_terminal_mapping(ui: dict[str, Any]) -> str | None:
     terminal_themes = ui.get("terminal_themes")
     if terminal_themes is None:
         return None
-    if not isinstance(terminal_themes, dict):
+    terminal_themes_table = _as_toml_table(terminal_themes)
+    if terminal_themes_table is None:
         logger.warning(
             "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
             "values to theme names; got %s",
@@ -196,13 +221,13 @@ def _resolve_terminal_mapping(ui: dict[str, Any]) -> str | None:
         return None
     term_program = os.environ.get("TERM_PROGRAM", "").strip()
     if not term_program:
-        if terminal_themes:
+        if terminal_themes_table:
             logger.warning(
                 "[ui.terminal_themes] is configured but TERM_PROGRAM is unset; "
                 "no per-terminal theme will be applied",
             )
         return None
-    mapped = terminal_themes.get(term_program)
+    mapped = terminal_themes_table.get(term_program)
     resolved = _resolve_theme_name(mapped)
     if resolved is not None:
         return resolved
@@ -255,6 +280,11 @@ def _load_terminal_default() -> str | None:
 
     ui = data.get("ui")
     if not isinstance(ui, dict):
+        if ui is not None:
+            logger.warning(
+                "[ui] should be a table; got %s while loading terminal theme default",
+                type(ui).__name__,
+            )
         return None
     return _resolve_terminal_mapping(ui)
 
@@ -264,7 +294,8 @@ def _load_theme_preference() -> str:
 
     Resolution order:
 
-    1. `DEEPAGENTS_CLI_THEME` env var (explicit override).
+    1. `DEEPAGENTS_CLI_THEME` env var (explicit override). If it is set but
+        cannot be resolved, the default theme is used immediately.
     2. `[ui.terminal_themes]` mapping keyed by `TERM_PROGRAM` — wins over the
         saved preference so a user moving between terminals (e.g. dark iTerm,
         light Apple Terminal) gets the right theme automatically.
@@ -304,6 +335,10 @@ def _load_theme_preference() -> str:
 
     ui = data.get("ui", {})
     if not isinstance(ui, dict):
+        logger.warning(
+            "[ui] should be a table; got %s while loading theme preference",
+            type(ui).__name__,
+        )
         return theme.DEFAULT_THEME
 
     resolved = _resolve_terminal_mapping(ui)
@@ -323,18 +358,40 @@ def _load_theme_preference() -> str:
     return theme.DEFAULT_THEME
 
 
-def save_theme_preference(name: str) -> bool:
-    """Persist theme preference to `~/.deepagents/config.toml`.
+def _replace_malformed_ui(
+    data: dict[str, object],
+) -> tuple[dict[str, object], str | None]:
+    """Return a writable `[ui]` table, replacing malformed values if needed."""
+    ui = data.get("ui")
+    table = _as_toml_table(ui)
+    if table is not None:
+        return table, None
+    replaced_malformed = ui is not None
+    if ui is not None:
+        logger.warning(
+            "Existing [ui] is not a table (got %r); replacing with a fresh table",
+            ui,
+        )
+    ui = {}
+    data["ui"] = ui
+    return ui, (
+        "Existing [ui] was not a table and was replaced while saving the theme "
+        "configuration."
+        if replaced_malformed
+        else None
+    )
 
-    Args:
-        name: Textual theme name to save.
+
+def _save_theme_preference_result(name: str) -> _ConfigWriteResult:
+    """Persist theme preference and return TUI-facing status details.
 
     Returns:
-        `True` if the preference was saved, `False` if any error occurred.
+        Write status and a message suitable for a toast when the user needs to
+            know about a repair or failure.
     """
     if name not in theme.get_registry():
         logger.warning("Refusing to save unknown theme '%s'", name)
-        return False
+        return _ConfigWriteResult(False, f"Unknown theme '{name}' was not saved.")
 
     import contextlib
     import tempfile
@@ -353,9 +410,8 @@ def save_theme_preference(name: str) -> bool:
             else:
                 data = {}
 
-            if "ui" not in data:
-                data["ui"] = {}
-            data["ui"]["theme"] = name
+            ui, repair_message = _replace_malformed_ui(data)
+            ui["theme"] = name
 
             fd, tmp_path = tempfile.mkstemp(
                 dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp"
@@ -368,10 +424,118 @@ def save_theme_preference(name: str) -> bool:
                 with contextlib.suppress(OSError):
                     Path(tmp_path).unlink()
                 raise
-    except (OSError, tomllib.TOMLDecodeError, ImportError, TypeError, ValueError):
+    except (
+        OSError,
+        tomllib.TOMLDecodeError,
+        ImportError,
+        TypeError,
+        ValueError,
+    ) as exc:
         logger.exception("Could not save theme preference")
-        return False
-    return True
+        return _ConfigWriteResult(
+            False,
+            f"Theme applied for this session but could not be saved "
+            f"({type(exc).__name__}).",
+            "error",
+        )
+    return _ConfigWriteResult(True, repair_message)
+
+
+def save_theme_preference(name: str) -> bool:
+    """Persist theme preference to `~/.deepagents/config.toml`.
+
+    Args:
+        name: Textual theme name to save.
+
+    Returns:
+        `True` if the preference was saved, `False` if any error occurred.
+    """
+    return _save_theme_preference_result(name).ok
+
+
+def _save_terminal_theme_mapping_result(
+    term_program: str, name: str
+) -> _ConfigWriteResult:
+    """Persist a terminal theme mapping and return TUI-facing status details.
+
+    Returns:
+        Write status and a message suitable for a toast when the user needs to
+            know about a repair or failure.
+    """
+    if name not in theme.get_registry():
+        logger.warning("Refusing to map unknown theme '%s'", name)
+        return _ConfigWriteResult(False, f"Unknown theme '{name}' was not saved.")
+    term_program = term_program.strip()
+    if not term_program:
+        logger.warning("Refusing to save terminal mapping with empty TERM_PROGRAM")
+        return _ConfigWriteResult(
+            False,
+            "TERM_PROGRAM is unset; can't set a per-terminal default.",
+        )
+
+    import contextlib
+    import tempfile
+    import tomllib
+
+    try:
+        import tomli_w
+
+        from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
+
+        DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        repair_messages: list[str] = []
+        with _CONFIG_WRITE_LOCK:
+            if DEFAULT_CONFIG_PATH.exists():
+                with DEFAULT_CONFIG_PATH.open("rb") as f:
+                    data = tomllib.load(f)
+            else:
+                data = {}
+
+            ui, repair_message = _replace_malformed_ui(data)
+            if repair_message is not None:
+                repair_messages.append(repair_message)
+            terminal_themes = ui.get("terminal_themes")
+            terminal_themes_table = _as_toml_table(terminal_themes)
+            if terminal_themes_table is None:
+                if terminal_themes is not None:
+                    logger.warning(
+                        "Existing [ui.terminal_themes] is not a table (got %r); "
+                        "replacing with a fresh table",
+                        terminal_themes,
+                    )
+                    repair_messages.append(
+                        "Existing [ui.terminal_themes] was not a table and was "
+                        "replaced while saving this terminal default."
+                    )
+                terminal_themes_table = {}
+                ui["terminal_themes"] = terminal_themes_table
+            terminal_themes_table[term_program] = name
+
+            fd, tmp_path = tempfile.mkstemp(
+                dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    tomli_w.dump(data, f)
+                Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    Path(tmp_path).unlink()
+                raise
+    except (
+        OSError,
+        tomllib.TOMLDecodeError,
+        ImportError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        logger.exception("Could not save terminal theme mapping")
+        return _ConfigWriteResult(
+            False,
+            f"Could not save terminal mapping ({type(exc).__name__}).",
+            "error",
+        )
+    return _ConfigWriteResult(True, " ".join(repair_messages) or None)
 
 
 def save_terminal_theme_mapping(term_program: str, name: str) -> bool:
@@ -393,59 +557,7 @@ def save_terminal_theme_mapping(term_program: str, name: str) -> bool:
             theme, `term_program` is empty after stripping, or any error
             occurred.
     """
-    if name not in theme.get_registry():
-        logger.warning("Refusing to map unknown theme '%s'", name)
-        return False
-    term_program = term_program.strip()
-    if not term_program:
-        logger.warning("Refusing to save terminal mapping with empty TERM_PROGRAM")
-        return False
-
-    import contextlib
-    import tempfile
-    import tomllib
-
-    try:
-        import tomli_w
-
-        from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
-
-        DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with _CONFIG_WRITE_LOCK:
-            if DEFAULT_CONFIG_PATH.exists():
-                with DEFAULT_CONFIG_PATH.open("rb") as f:
-                    data = tomllib.load(f)
-            else:
-                data = {}
-
-            ui = data.setdefault("ui", {})
-            terminal_themes = ui.get("terminal_themes")
-            if not isinstance(terminal_themes, dict):
-                if terminal_themes is not None:
-                    logger.warning(
-                        "Existing [ui.terminal_themes] is not a table (got %r); "
-                        "replacing with a fresh table",
-                        terminal_themes,
-                    )
-                terminal_themes = {}
-                ui["terminal_themes"] = terminal_themes
-            terminal_themes[term_program] = name
-
-            fd, tmp_path = tempfile.mkstemp(
-                dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp"
-            )
-            try:
-                with os.fdopen(fd, "wb") as f:
-                    tomli_w.dump(data, f)
-                Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
-            except BaseException:
-                with contextlib.suppress(OSError):
-                    Path(tmp_path).unlink()
-                raise
-    except (OSError, tomllib.TOMLDecodeError, ImportError, TypeError, ValueError):
-        logger.exception("Could not save terminal theme mapping")
-        return False
-    return True
+    return _save_terminal_theme_mapping_result(term_program, name).ok
 
 
 def _extract_model_params_flag(raw_arg: str) -> tuple[str, dict[str, Any] | None]:
@@ -6708,12 +6820,13 @@ class DeepAgentsApp(App):
 
                 async def _persist() -> None:
                     try:
-                        ok = await asyncio.to_thread(save_theme_preference, result)
-                        if not ok:
+                        status = await asyncio.to_thread(
+                            _save_theme_preference_result, result
+                        )
+                        if status.message is not None:
                             self.notify(
-                                "Theme applied for this session but could not"
-                                " be saved. Check logs for details.",
-                                severity="warning",
+                                status.message,
+                                severity=status.severity,
                                 timeout=6,
                                 markup=False,
                             )
@@ -6723,8 +6836,7 @@ class DeepAgentsApp(App):
                             exc_info=True,
                         )
                         self.notify(
-                            "Theme applied for this session but could not"
-                            " be saved. Check logs for details.",
+                            "Theme applied for this session but could not be saved.",
                             severity="warning",
                             timeout=6,
                             markup=False,

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import signal
 import sys
+import threading
 import time
 import uuid
 import webbrowser
@@ -89,6 +90,14 @@ from deepagents_cli.widgets.welcome import WelcomeBanner
 
 logger = logging.getLogger(__name__)
 _monotonic = time.monotonic
+
+# Serializes read-modify-write of `~/.deepagents/config.toml` between
+# `save_theme_preference` and `save_terminal_theme_mapping`. Without this,
+# pressing `t` (per-terminal mapping) and Enter (global theme) in quick
+# succession would race two writers over the same file: each reads the
+# pre-mutation state, then the second writer's dump clobbers the first
+# writer's keys.
+_CONFIG_WRITE_LOCK = threading.Lock()
 
 ScreenResultT = TypeVar("ScreenResultT")
 
@@ -198,8 +207,8 @@ def _resolve_theme_name(value: object) -> str | None:
 
     Returns:
         The canonical registry key, or `None` if the value is not a string or
-        does not match any registered theme by key or label
-        (case-insensitive).
+            does not match any registered theme by key or label
+            (case-insensitive).
     """
     if not isinstance(value, str):
         return None
@@ -216,39 +225,94 @@ def _resolve_theme_name(value: object) -> str | None:
     return None
 
 
+def _resolve_terminal_mapping(ui: dict[str, Any]) -> str | None:
+    """Resolve `[ui.terminal_themes][TERM_PROGRAM]` to a registered theme.
+
+    Centralizes both the lookup and the misconfiguration warnings shared by
+    `_load_theme_preference` (startup) and `_load_terminal_default` (picker
+    badge). Misconfiguration is logged exactly once per call.
+
+    Args:
+        ui: The `[ui]` table parsed from `config.toml`.
+
+    Returns:
+        The canonical registry key, or `None` if `terminal_themes` is absent,
+            malformed, references an unknown theme, or `TERM_PROGRAM` is unset
+            despite a non-empty mapping.
+    """
+    terminal_themes = ui.get("terminal_themes")
+    if terminal_themes is None:
+        return None
+    if not isinstance(terminal_themes, dict):
+        logger.warning(
+            "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
+            "values to theme names; got %s",
+            type(terminal_themes).__name__,
+        )
+        return None
+    term_program = os.environ.get("TERM_PROGRAM", "").strip()
+    if not term_program:
+        if terminal_themes:
+            logger.warning(
+                "[ui.terminal_themes] is configured but TERM_PROGRAM is unset; "
+                "no per-terminal theme will be applied",
+            )
+        return None
+    mapped = terminal_themes.get(term_program)
+    resolved = _resolve_theme_name(mapped)
+    if resolved is not None:
+        return resolved
+    if isinstance(mapped, str):
+        logger.warning(
+            "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
+            "in [ui.terminal_themes]; ignoring",
+            mapped,
+            term_program,
+        )
+    elif mapped is not None:
+        logger.warning(
+            "Expected string theme name for TERM_PROGRAM='%s' in "
+            "[ui.terminal_themes], got %s; ignoring",
+            term_program,
+            type(mapped).__name__,
+        )
+    return None
+
+
 def _load_terminal_default() -> str | None:
     """Return the saved default theme for the current `TERM_PROGRAM`.
 
     Reads `[ui.terminal_themes][TERM_PROGRAM]` from `config.toml` and
     resolves the value via `_resolve_theme_name`, so labels and case variants
     are accepted. Used by `ThemeSelectorScreen` to badge the matching option
-    with `(terminal default)`.
+    with `(default)`.
 
     Returns:
-        The canonical registry key, or `None` if `TERM_PROGRAM` is unset,
-            the file is missing or unreadable, no mapping is set, or the mapped
-            value doesn't match a registered theme.
+        The canonical registry key, or `None` if `TERM_PROGRAM` is unset, the
+            file is missing/unreadable, no mapping is set, or the mapped value
+            doesn't match a registered theme. Read errors and misconfigurations
+            are logged at WARNING.
     """
-    term_program = os.environ.get("TERM_PROGRAM", "").strip()
-    if not term_program:
+    if not os.environ.get("TERM_PROGRAM", "").strip():
         return None
 
     import tomllib
 
-    try:
-        from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
+    from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
 
-        if not DEFAULT_CONFIG_PATH.exists():
-            return None
+    if not DEFAULT_CONFIG_PATH.exists():
+        return None
+    try:
         with DEFAULT_CONFIG_PATH.open("rb") as f:
             data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError):
+    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
+        logger.warning("Could not read config for terminal theme default: %s", exc)
         return None
 
-    terminal_themes = data.get("ui", {}).get("terminal_themes")
-    if not isinstance(terminal_themes, dict):
+    ui = data.get("ui")
+    if not isinstance(ui, dict):
         return None
-    return _resolve_theme_name(terminal_themes.get(term_program))
+    return _resolve_terminal_mapping(ui)
 
 
 def _load_theme_preference() -> str:
@@ -283,12 +347,11 @@ def _load_theme_preference() -> str:
 
     import tomllib
 
+    from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        return theme.DEFAULT_THEME
     try:
-        from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
-
-        if not DEFAULT_CONFIG_PATH.exists():
-            return theme.DEFAULT_THEME
-
         with DEFAULT_CONFIG_PATH.open("rb") as f:
             data = tomllib.load(f)
     except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
@@ -296,35 +359,12 @@ def _load_theme_preference() -> str:
         return theme.DEFAULT_THEME
 
     ui = data.get("ui", {})
+    if not isinstance(ui, dict):
+        return theme.DEFAULT_THEME
 
-    terminal_themes = ui.get("terminal_themes")
-    if isinstance(terminal_themes, dict):
-        term_program = os.environ.get("TERM_PROGRAM")
-        if term_program:
-            mapped = terminal_themes.get(term_program)
-            resolved = _resolve_theme_name(mapped)
-            if resolved is not None:
-                return resolved
-            if isinstance(mapped, str):
-                logger.warning(
-                    "Unknown theme '%s' mapped to TERM_PROGRAM='%s' "
-                    "in [ui.terminal_themes]; ignoring",
-                    mapped,
-                    term_program,
-                )
-            elif mapped is not None:
-                logger.warning(
-                    "Expected string theme name for TERM_PROGRAM='%s' in "
-                    "[ui.terminal_themes], got %s; ignoring",
-                    term_program,
-                    type(mapped).__name__,
-                )
-    elif terminal_themes is not None:
-        logger.warning(
-            "[ui.terminal_themes] should be a table mapping TERM_PROGRAM "
-            "values to theme names; got %s",
-            type(terminal_themes).__name__,
-        )
+    resolved = _resolve_terminal_mapping(ui)
+    if resolved is not None:
+        return resolved
 
     saved = ui.get("theme")
     resolved = _resolve_theme_name(saved)
@@ -354,35 +394,37 @@ def save_theme_preference(name: str) -> bool:
 
     import contextlib
     import tempfile
+    import tomllib
 
     try:
-        import tomllib
-
         import tomli_w
 
         from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
 
         DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        if DEFAULT_CONFIG_PATH.exists():
-            with DEFAULT_CONFIG_PATH.open("rb") as f:
-                data = tomllib.load(f)
-        else:
-            data = {}
+        with _CONFIG_WRITE_LOCK:
+            if DEFAULT_CONFIG_PATH.exists():
+                with DEFAULT_CONFIG_PATH.open("rb") as f:
+                    data = tomllib.load(f)
+            else:
+                data = {}
 
-        if "ui" not in data:
-            data["ui"] = {}
-        data["ui"]["theme"] = name
+            if "ui" not in data:
+                data["ui"] = {}
+            data["ui"]["theme"] = name
 
-        fd, tmp_path = tempfile.mkstemp(dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp")
-        try:
-            with os.fdopen(fd, "wb") as f:
-                tomli_w.dump(data, f)
-            Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                Path(tmp_path).unlink()
-            raise
-    except Exception:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    tomli_w.dump(data, f)
+                Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    Path(tmp_path).unlink()
+                raise
+    except (OSError, tomllib.TOMLDecodeError, ImportError, TypeError, ValueError):
         logger.exception("Could not save theme preference")
         return False
     return True
@@ -417,45 +459,46 @@ def save_terminal_theme_mapping(term_program: str, name: str) -> bool:
 
     import contextlib
     import tempfile
+    import tomllib
 
     try:
-        import tomllib
-
         import tomli_w
 
         from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
 
         DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        if DEFAULT_CONFIG_PATH.exists():
-            with DEFAULT_CONFIG_PATH.open("rb") as f:
-                data = tomllib.load(f)
-        else:
-            data = {}
+        with _CONFIG_WRITE_LOCK:
+            if DEFAULT_CONFIG_PATH.exists():
+                with DEFAULT_CONFIG_PATH.open("rb") as f:
+                    data = tomllib.load(f)
+            else:
+                data = {}
 
-        ui = data.setdefault("ui", {})
-        terminal_themes = ui.get("terminal_themes")
-        if not isinstance(terminal_themes, dict):
-            if terminal_themes is not None:
-                logger.warning(
-                    "Existing [ui.terminal_themes] is not a table (got %r); "
-                    "replacing with a fresh table",
-                    terminal_themes,
-                )
-            terminal_themes = {}
-            ui["terminal_themes"] = terminal_themes
-        terminal_themes[term_program] = name
+            ui = data.setdefault("ui", {})
+            terminal_themes = ui.get("terminal_themes")
+            if not isinstance(terminal_themes, dict):
+                if terminal_themes is not None:
+                    logger.warning(
+                        "Existing [ui.terminal_themes] is not a table (got %r); "
+                        "replacing with a fresh table",
+                        terminal_themes,
+                    )
+                terminal_themes = {}
+                ui["terminal_themes"] = terminal_themes
+            terminal_themes[term_program] = name
 
-        # Atomic write: dump to a temp file in the same dir, then rename.
-        fd, tmp_path = tempfile.mkstemp(dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp")
-        try:
-            with os.fdopen(fd, "wb") as f:
-                tomli_w.dump(data, f)
-            Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                Path(tmp_path).unlink()
-            raise
-    except Exception:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    tomli_w.dump(data, f)
+                Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    Path(tmp_path).unlink()
+                raise
+    except (OSError, tomllib.TOMLDecodeError, ImportError, TypeError, ValueError):
         logger.exception("Could not save terminal theme mapping")
         return False
     return True

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -184,27 +184,35 @@ if _IS_ITERM:
     atexit.register(_restore_cursor_guide)
 
 
-def _resolve_config_theme(value: object) -> str | None:
-    """Resolve a theme name read from `config.toml`.
+def _resolve_theme_name(value: object) -> str | None:
+    """Resolve a user-supplied theme name to a canonical registry key.
 
-    Applies the legacy `textual-ansi` migration (pre-Textual 8.2.5) and
-    requires an exact registry-key match. Config-file values are written by the
-    CLI itself, so case/label tolerance is intentionally narrower than the
-    `DEEPAGENTS_CLI_THEME` env-var path.
+    Accepts the registry key or the human-readable label, case-insensitive
+    on both, with surrounding whitespace stripped — config values
+    (especially `[ui.terminal_themes]`) and the `DEEPAGENTS_CLI_THEME`
+    env var are commonly hand-edited. Also applies the legacy
+    `textual-ansi` → `ansi-light` migration (pre-Textual 8.2.5).
 
     Args:
-        value: Raw value read from TOML.
+        value: Raw value read from TOML or an environment variable.
 
     Returns:
         The canonical registry key, or `None` if the value is not a string or
-        does not match a registered theme.
+        does not match any registered theme by key or label
+        (case-insensitive).
     """
     if not isinstance(value, str):
         return None
-    if value == "textual-ansi":
-        value = "ansi-light"
-    if value in theme.get_registry():
-        return value
+    name = value.strip()
+    if name == "textual-ansi":
+        name = "ansi-light"
+    registry = theme.get_registry()
+    if name in registry:
+        return name
+    folded = name.casefold()
+    for registered, entry in registry.items():
+        if registered.casefold() == folded or entry.label.casefold() == folded:
+            return registered
     return None
 
 
@@ -228,16 +236,9 @@ def _load_theme_preference() -> str:
 
     env_name = os.environ.get(THEME)
     if env_name is not None:
-        name = env_name.strip()
-        registry = theme.get_registry()
-        if name in registry:
-            return name
-        for registered, entry in registry.items():
-            if (
-                registered.casefold() == name.casefold()
-                or entry.label.casefold() == name.casefold()
-            ):
-                return registered
+        resolved = _resolve_theme_name(env_name)
+        if resolved is not None:
+            return resolved
         logger.warning(
             "Unknown theme '%s' in %s; falling back to default",
             env_name,
@@ -266,7 +267,7 @@ def _load_theme_preference() -> str:
         term_program = os.environ.get("TERM_PROGRAM")
         if term_program:
             mapped = terminal_themes.get(term_program)
-            resolved = _resolve_config_theme(mapped)
+            resolved = _resolve_theme_name(mapped)
             if resolved is not None:
                 return resolved
             if isinstance(mapped, str):
@@ -291,7 +292,7 @@ def _load_theme_preference() -> str:
         )
 
     saved = ui.get("theme")
-    resolved = _resolve_config_theme(saved)
+    resolved = _resolve_theme_name(saved)
     if resolved is not None:
         return resolved
     if isinstance(saved, str):
@@ -348,6 +349,79 @@ def save_theme_preference(name: str) -> bool:
             raise
     except Exception:
         logger.exception("Could not save theme preference")
+        return False
+    return True
+
+
+def save_terminal_theme_mapping(term_program: str, name: str) -> bool:
+    """Persist a `[ui.terminal_themes][term_program] = name` entry.
+
+    The write is atomic (temp file + `Path.replace`) to avoid corrupting
+    `config.toml` on crash or SIGINT. Mirrors `save_theme_preference`.
+
+    Args:
+        term_program: Value of the `TERM_PROGRAM` environment variable to key
+            on. Whitespace is stripped; the trimmed value is matched verbatim
+            against `os.environ["TERM_PROGRAM"]` at lookup time.
+        name: Theme name to map. Validated as an exact registry-key match —
+            labels and case variants are rejected here because the picker
+            writes canonical keys.
+
+    Returns:
+        `True` if the mapping was saved, `False` if `name` isn't a registered
+            theme, `term_program` is empty after stripping, or any error
+            occurred.
+    """
+    if name not in theme.get_registry():
+        logger.warning("Refusing to map unknown theme '%s'", name)
+        return False
+    term_program = term_program.strip()
+    if not term_program:
+        logger.warning("Refusing to save terminal mapping with empty TERM_PROGRAM")
+        return False
+
+    import contextlib
+    import tempfile
+
+    try:
+        import tomllib
+
+        import tomli_w
+
+        from deepagents_cli.model_config import DEFAULT_CONFIG_PATH
+
+        DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        if DEFAULT_CONFIG_PATH.exists():
+            with DEFAULT_CONFIG_PATH.open("rb") as f:
+                data = tomllib.load(f)
+        else:
+            data = {}
+
+        ui = data.setdefault("ui", {})
+        terminal_themes = ui.get("terminal_themes")
+        if not isinstance(terminal_themes, dict):
+            if terminal_themes is not None:
+                logger.warning(
+                    "Existing [ui.terminal_themes] is not a table (got %r); "
+                    "replacing with a fresh table",
+                    terminal_themes,
+                )
+            terminal_themes = {}
+            ui["terminal_themes"] = terminal_themes
+        terminal_themes[term_program] = name
+
+        # Atomic write: dump to a temp file in the same dir, then rename.
+        fd, tmp_path = tempfile.mkstemp(dir=DEFAULT_CONFIG_PATH.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(DEFAULT_CONFIG_PATH)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except Exception:
+        logger.exception("Could not save terminal theme mapping")
         return False
     return True
 

--- a/libs/cli/deepagents_cli/widgets/theme_selector.py
+++ b/libs/cli/deepagents_cli/widgets/theme_selector.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding, BindingType
@@ -32,6 +34,8 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         Binding("escape", "cancel", "Cancel", show=False),
         Binding("tab", "cursor_down", "Next", show=False, priority=True),
         Binding("shift+tab", "cursor_up", "Previous", show=False, priority=True),
+        Binding("n", "toggle_names", "Names", show=False),
+        Binding("t", "set_for_terminal", "Set for terminal", show=False),
     ]
     """Key bindings for the selector.
 
@@ -39,6 +43,14 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     handled natively by the embedded `OptionList`; Tab / Shift+Tab are bound
     here to advance the option list cursor for consistency with other
     selector screens (where Tab cycles focus across multiple widgets).
+    `n` toggles between human-readable labels and canonical registry keys —
+    the registry key is what `[ui.terminal_themes]` and `[ui].theme` accept,
+    so users editing config by hand can copy the exact value. `t` writes the
+    highlighted theme into `[ui.terminal_themes]` keyed on the current
+    `TERM_PROGRAM`, then closes the picker with the live preview committed —
+    `[ui].theme` is left untouched so the per-terminal mapping is the only
+    thing persisted (avoiding a concurrent-write race against the standard
+    Enter-to-save path).
     """
 
     CSS = """
@@ -71,7 +83,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     }
 
     ThemeSelectorScreen .theme-selector-help {
-        height: 1;
+        height: auto;
         color: $text-muted;
         text-style: italic;
         margin-top: 1;
@@ -89,6 +101,23 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         super().__init__()
         self._current_theme = current_theme
         self._original_theme = current_theme
+        self._show_keys = False
+
+    def _format_option(self, name: str, entry: theme.ThemeEntry) -> str:
+        """Render the option text for a theme entry.
+
+        Args:
+            name: Registry key.
+            entry: Registry entry.
+
+        Returns:
+            Either the human label or the registry key, with a `(current)`
+            suffix on the active theme.
+        """
+        text = name if self._show_keys else entry.label
+        if name == self._current_theme:
+            text = f"{text} (current)"
+        return text
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout.
@@ -101,23 +130,22 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         highlight_index = 0
 
         for i, (name, entry) in enumerate(theme.get_registry().items()):
-            label = entry.label
+            options.append(Option(self._format_option(name, entry), id=name))
             if name == self._current_theme:
-                label = f"{label} (current)"
                 highlight_index = i
-            options.append(Option(label, id=name))
 
         with Vertical():
             yield Static("Select Theme", classes="theme-selector-title")
             option_list = OptionList(*options, id="theme-options")
             option_list.highlighted = highlight_index
             yield option_list
-            help_text = (
+            nav_line = (
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} or Tab switch"
                 f" {glyphs.bullet} Enter select"
                 f" {glyphs.bullet} Esc cancel"
             )
-            yield Static(help_text, classes="theme-selector-help")
+            action_line = "N labels/keys  •  T set for this terminal"
+            yield Static(f"{nav_line}\n{action_line}", classes="theme-selector-help")
 
     def on_mount(self) -> None:
         """Apply ASCII border if needed."""
@@ -180,3 +208,93 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     def action_cursor_up(self) -> None:
         """Move the option list cursor up (Shift+Tab)."""
         self.query_one(OptionList).action_cursor_up()
+
+    def action_set_for_terminal(self) -> None:
+        """Persist the highlighted theme as the default for `TERM_PROGRAM`.
+
+        Writes `[ui.terminal_themes][TERM_PROGRAM] = name`, dismisses the
+        picker with `None`, and leaves the live preview applied. `[ui].theme`
+        is intentionally not touched — pressing `t` is "save for this
+        terminal", not "save as my global default". Dismissing with `None`
+        also avoids racing the parent app's save-on-Enter writer against this
+        action's writer over the same `config.toml`.
+
+        No-ops with a warning toast if `TERM_PROGRAM` is unset, or silently
+        if nothing is highlighted / the highlighted id isn't a registered
+        theme (defensive guards — both branches are unreachable in practice).
+        """
+        term_program = os.environ.get("TERM_PROGRAM", "").strip()
+        if not term_program:
+            self.app.notify(
+                "TERM_PROGRAM is unset; can't set a per-terminal default. "
+                "Set the [ui].theme directly with Enter.",
+                severity="warning",
+                markup=False,
+                timeout=6,
+            )
+            return
+
+        option_list = self.query_one(OptionList)
+        if option_list.highlighted is None:
+            return
+        option = option_list.get_option_at_index(option_list.highlighted)
+        name = option.id
+        if name is None or name not in theme.get_registry():
+            return
+
+        # Dismiss synchronously so the worker can't race a later Esc/Enter.
+        self.dismiss(None)
+
+        async def _persist() -> None:
+            try:
+                from deepagents_cli.app import save_terminal_theme_mapping
+
+                ok = await asyncio.to_thread(
+                    save_terminal_theme_mapping, term_program, name
+                )
+            except Exception:
+                logger.exception("Failed to persist terminal theme mapping")
+                self.app.notify(
+                    "Could not save terminal mapping; check logs.",
+                    severity="error",
+                    markup=False,
+                    timeout=6,
+                )
+                return
+            if ok:
+                self.app.notify(
+                    f"Set '{name}' as the default for {term_program}.",
+                    severity="information",
+                    markup=False,
+                    timeout=4,
+                )
+            else:
+                self.app.notify(
+                    "Could not save terminal mapping; check logs.",
+                    severity="warning",
+                    markup=False,
+                    timeout=6,
+                )
+
+        # Anchor the worker on the app, not this screen — the screen is
+        # being dismissed and would tear down its own workers mid-flight.
+        self.app.run_worker(_persist(), exclusive=False)
+
+    def action_toggle_names(self) -> None:
+        """Toggle between human labels and registry keys in the option list.
+
+        Useful for copying the canonical key into `[ui.terminal_themes]` or
+        `[ui].theme` without leaving the picker.
+        """
+        self._show_keys = not self._show_keys
+        option_list = self.query_one(OptionList)
+        cursor = option_list.highlighted
+        registry = theme.get_registry()
+        new_options = [
+            Option(self._format_option(name, entry), id=name)
+            for name, entry in registry.items()
+        ]
+        option_list.clear_options()
+        option_list.add_options(new_options)
+        if cursor is not None:
+            option_list.highlighted = cursor

--- a/libs/cli/deepagents_cli/widgets/theme_selector.py
+++ b/libs/cli/deepagents_cli/widgets/theme_selector.py
@@ -92,15 +92,19 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     """
     """Styling for the centered modal shell, title, option list, and help footer."""
 
-    def __init__(self, current_theme: str) -> None:
+    def __init__(self, current_theme: str, terminal_default: str | None = None) -> None:
         """Initialize the ThemeSelectorScreen.
 
         Args:
             current_theme: The currently active theme name (to highlight).
+            terminal_default: The theme saved in `[ui.terminal_themes]` for
+                the current `TERM_PROGRAM`, if any. Badged with
+                `(terminal default)` in the option list.
         """
         super().__init__()
         self._current_theme = current_theme
         self._original_theme = current_theme
+        self._terminal_default = terminal_default
         self._show_keys = False
 
     def _format_option(self, name: str, entry: theme.ThemeEntry) -> str:
@@ -111,12 +115,18 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             entry: Registry entry.
 
         Returns:
-            Either the human label or the registry key, with a `(current)`
-            suffix on the active theme.
+            Either the human label or the registry key, with `(current)`
+                and/or `(terminal default)` suffixes — combined as
+                `(current, terminal default)` when both apply to the same theme.
         """
         text = name if self._show_keys else entry.label
+        suffixes: list[str] = []
         if name == self._current_theme:
-            text = f"{text} (current)"
+            suffixes.append("current")
+        if name == self._terminal_default:
+            suffixes.append("terminal default")
+        if suffixes:
+            text = f"{text} ({', '.join(suffixes)})"
         return text
 
     def compose(self) -> ComposeResult:

--- a/libs/cli/deepagents_cli/widgets/theme_selector.py
+++ b/libs/cli/deepagents_cli/widgets/theme_selector.py
@@ -43,11 +43,10 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     handled natively by the embedded `OptionList`; Tab / Shift+Tab are bound
     here to advance the option list cursor for consistency with other
     selector screens (where Tab cycles focus across multiple widgets).
-    `n` toggles between human-readable labels and canonical registry keys —
-    the registry key is what `[ui.terminal_themes]` and `[ui].theme` accept,
-    so users editing config by hand can copy the exact value. `t` saves the
-    highlighted theme as the per-terminal default and updates the `(default)`
-    badge in place without closing the picker, so the user can keep browsing.
+    `action_toggle_names` toggles between human-readable labels and canonical
+    registry keys, which are accepted by the theme config. The terminal-default
+    action saves the highlighted theme for the current terminal and updates
+    the `(default)` badge in place without closing the picker.
     """
 
     CSS = """
@@ -151,7 +150,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 f" {glyphs.bullet} Enter select"
                 f" {glyphs.bullet} Esc cancel"
             )
-            action_line = "N labels/keys  •  T set for this terminal"
+            action_line = f"N labels/keys  {glyphs.bullet}  T set for this terminal"
             yield Static(f"{nav_line}\n{action_line}", classes="theme-selector-help")
 
     def on_mount(self) -> None:
@@ -222,10 +221,10 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         Writes `[ui.terminal_themes][TERM_PROGRAM] = name` and updates the
         `(default)` badge in the option list without closing the picker, so
         the user can confirm the change and keep browsing. `[ui].theme` is
-        intentionally not touched — pressing `t` is "save for this terminal",
-        not "save as my global default". The two save paths share a
-        `threading.Lock` (`_CONFIG_WRITE_LOCK` in `app.py`) so a quick
-        `t`-then-`Enter` can't race two writers over the same `config.toml`.
+        intentionally not touched because this action saves only the current
+        terminal default. Config writes are serialized in `app.py`, so
+        overlapping global-theme and per-terminal-theme saves cannot clobber
+        each other's keys.
 
         No-ops with a warning toast if `TERM_PROGRAM` is unset, or silently
         if the option list has no highlighted entry / the highlighted id
@@ -256,29 +255,35 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
 
         async def _persist() -> None:
             try:
-                from deepagents_cli.app import save_terminal_theme_mapping
+                from deepagents_cli.app import _save_terminal_theme_mapping_result
 
-                ok = await asyncio.to_thread(
-                    save_terminal_theme_mapping, term_program, name
+                status = await asyncio.to_thread(
+                    _save_terminal_theme_mapping_result, term_program, name
                 )
-            except (OSError, ImportError) as exc:
+            except Exception as exc:
                 logger.exception("Failed to persist terminal theme mapping")
                 self.app.notify(
-                    f"Could not save terminal mapping ({type(exc).__name__}); "
-                    "see logs in ~/.deepagents/logs/.",
+                    f"Could not save terminal mapping ({type(exc).__name__}).",
                     severity="error",
                     markup=False,
                     timeout=6,
                 )
                 return
-            if not ok:
+            if not status.ok:
                 self.app.notify(
-                    "Could not save terminal mapping; see logs in ~/.deepagents/logs/.",
-                    severity="warning",
+                    status.message or "Could not save terminal mapping.",
+                    severity=status.severity,
                     markup=False,
                     timeout=6,
                 )
                 return
+            if status.message is not None:
+                self.app.notify(
+                    status.message,
+                    severity=status.severity,
+                    markup=False,
+                    timeout=6,
+                )
             # Update the badge in place if the screen is still mounted.
             # The user may have dismissed the picker (Esc/Enter) while the
             # write was in flight; `is_mounted` guards the widget tree.

--- a/libs/cli/deepagents_cli/widgets/theme_selector.py
+++ b/libs/cli/deepagents_cli/widgets/theme_selector.py
@@ -45,12 +45,9 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     selector screens (where Tab cycles focus across multiple widgets).
     `n` toggles between human-readable labels and canonical registry keys —
     the registry key is what `[ui.terminal_themes]` and `[ui].theme` accept,
-    so users editing config by hand can copy the exact value. `t` writes the
-    highlighted theme into `[ui.terminal_themes]` keyed on the current
-    `TERM_PROGRAM`, then closes the picker with the live preview committed —
-    `[ui].theme` is left untouched so the per-terminal mapping is the only
-    thing persisted (avoiding a concurrent-write race against the standard
-    Enter-to-save path).
+    so users editing config by hand can copy the exact value. `t` saves the
+    highlighted theme as the per-terminal default and updates the `(default)`
+    badge in place without closing the picker, so the user can keep browsing.
     """
 
     CSS = """
@@ -98,8 +95,8 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         Args:
             current_theme: The currently active theme name (to highlight).
             terminal_default: The theme saved in `[ui.terminal_themes]` for
-                the current `TERM_PROGRAM`, if any. Badged with
-                `(terminal default)` in the option list.
+                the current `TERM_PROGRAM`, if any. Badged with `(default)`
+                in the option list.
         """
         super().__init__()
         self._current_theme = current_theme
@@ -116,15 +113,15 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
 
         Returns:
             Either the human label or the registry key, with `(current)`
-                and/or `(terminal default)` suffixes — combined as
-                `(current, terminal default)` when both apply to the same theme.
+                and/or `(default)` suffixes — combined as
+                `(current, default)` when both apply to the same theme.
         """
         text = name if self._show_keys else entry.label
         suffixes: list[str] = []
         if name == self._current_theme:
             suffixes.append("current")
         if name == self._terminal_default:
-            suffixes.append("terminal default")
+            suffixes.append("default")
         if suffixes:
             text = f"{text} ({', '.join(suffixes)})"
         return text
@@ -222,16 +219,17 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     def action_set_for_terminal(self) -> None:
         """Persist the highlighted theme as the default for `TERM_PROGRAM`.
 
-        Writes `[ui.terminal_themes][TERM_PROGRAM] = name`, dismisses the
-        picker with `None`, and leaves the live preview applied. `[ui].theme`
-        is intentionally not touched — pressing `t` is "save for this
-        terminal", not "save as my global default". Dismissing with `None`
-        also avoids racing the parent app's save-on-Enter writer against this
-        action's writer over the same `config.toml`.
+        Writes `[ui.terminal_themes][TERM_PROGRAM] = name` and updates the
+        `(default)` badge in the option list without closing the picker, so
+        the user can confirm the change and keep browsing. `[ui].theme` is
+        intentionally not touched — pressing `t` is "save for this terminal",
+        not "save as my global default". The two save paths share a
+        `threading.Lock` (`_CONFIG_WRITE_LOCK` in `app.py`) so a quick
+        `t`-then-`Enter` can't race two writers over the same `config.toml`.
 
         No-ops with a warning toast if `TERM_PROGRAM` is unset, or silently
-        if nothing is highlighted / the highlighted id isn't a registered
-        theme (defensive guards — both branches are unreachable in practice).
+        if the option list has no highlighted entry / the highlighted id
+        isn't a registered theme.
         """
         term_program = os.environ.get("TERM_PROGRAM", "").strip()
         if not term_program:
@@ -246,14 +244,15 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
 
         option_list = self.query_one(OptionList)
         if option_list.highlighted is None:
+            logger.warning("action_set_for_terminal invoked with no highlighted option")
             return
         option = option_list.get_option_at_index(option_list.highlighted)
         name = option.id
         if name is None or name not in theme.get_registry():
+            logger.warning(
+                "action_set_for_terminal got unregistered option id '%s'", name
+            )
             return
-
-        # Dismiss synchronously so the worker can't race a later Esc/Enter.
-        self.dismiss(None)
 
         async def _persist() -> None:
             try:
@@ -262,32 +261,40 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 ok = await asyncio.to_thread(
                     save_terminal_theme_mapping, term_program, name
                 )
-            except Exception:
+            except (OSError, ImportError) as exc:
                 logger.exception("Failed to persist terminal theme mapping")
                 self.app.notify(
-                    "Could not save terminal mapping; check logs.",
+                    f"Could not save terminal mapping ({type(exc).__name__}); "
+                    "see logs in ~/.deepagents/logs/.",
                     severity="error",
                     markup=False,
                     timeout=6,
                 )
                 return
-            if ok:
+            if not ok:
                 self.app.notify(
-                    f"Set '{name}' as the default for {term_program}.",
-                    severity="information",
-                    markup=False,
-                    timeout=4,
-                )
-            else:
-                self.app.notify(
-                    "Could not save terminal mapping; check logs.",
+                    "Could not save terminal mapping; see logs in ~/.deepagents/logs/.",
                     severity="warning",
                     markup=False,
                     timeout=6,
                 )
+                return
+            # Update the badge in place if the screen is still mounted.
+            # The user may have dismissed the picker (Esc/Enter) while the
+            # write was in flight; `is_mounted` guards the widget tree.
+            if self.is_mounted:
+                self._terminal_default = name
+                self._rerender_options()
+            self.app.notify(
+                f"Set '{name}' as the default for {term_program}.",
+                severity="information",
+                markup=False,
+                timeout=4,
+            )
 
-        # Anchor the worker on the app, not this screen — the screen is
-        # being dismissed and would tear down its own workers mid-flight.
+        # Anchor the worker on the app, not this screen — if the user
+        # dismisses the picker mid-flight, the screen tears down its own
+        # workers but the write should still complete and toast.
         self.app.run_worker(_persist(), exclusive=False)
 
     def action_toggle_names(self) -> None:
@@ -297,6 +304,15 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         `[ui].theme` without leaving the picker.
         """
         self._show_keys = not self._show_keys
+        self._rerender_options()
+
+    def _rerender_options(self) -> None:
+        """Rebuild the option list, preserving the cursor position.
+
+        Used when the badge text or label/key mode changes — Textual's
+        `OptionList` doesn't expose a way to mutate a rendered prompt, so
+        we recreate the options.
+        """
         option_list = self.query_one(OptionList)
         cursor = option_list.highlighted
         registry = theme.get_registry()

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -48,6 +48,7 @@ _TIPS: dict[str, int] = {
     "Use /skill:<name> to invoke a skill directly": 1,
     "Type /update to check for and install updates": 1,
     "Use /theme to customize the CLI colors and style": 1,
+    "In /theme, press N to toggle labels/keys, T to set for the current terminal": 1,
     "Use /skill-creator to build reusable agent skills": 1,
     "Use /auto-update to toggle automatic CLI updates": 1,
     "Use /agents to browse and switch between your available agents": 2,

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -549,6 +549,23 @@ class TestTerminalThemeMapping:
 
         assert _load_theme_preference() == "langchain"
 
+    def test_unknown_saved_theme_returns_default_before_terminal_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui]\ntheme = "nonexistent-theme"\n'
+            "[ui.terminal_themes]\n"
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
     def test_env_theme_overrides_terminal_mapping(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -580,7 +597,10 @@ class TestTerminalThemeMapping:
         assert _load_theme_preference() == DEFAULT_THEME
 
     def test_unknown_mapped_theme_warns_and_falls_through(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         from deepagents_cli.app import _load_theme_preference
 
@@ -592,7 +612,16 @@ class TestTerminalThemeMapping:
         monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
         monkeypatch.delenv(THEME, raising=False)
 
-        assert _load_theme_preference() == DEFAULT_THEME
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == DEFAULT_THEME
+
+        # The warning must surface both the bad theme name and the terminal so
+        # users have enough context to fix their config.
+        assert any(
+            "nonexistent-theme" in record.getMessage()
+            and "Apple_Terminal" in record.getMessage()
+            for record in caplog.records
+        )
 
     def test_missing_term_program_falls_through_to_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -621,6 +650,120 @@ class TestTerminalThemeMapping:
         monkeypatch.delenv(THEME, raising=False)
 
         assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_non_string_mapped_value_warns_and_falls_through(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-string mapped value warns rather than silently falling through.
+
+        E.g., user thought they could list fallbacks — that's a TOML mistake
+        worth surfacing.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            "[ui.terminal_themes]\n"
+            '"Apple_Terminal" = ["langchain-light", "langchain"]\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == DEFAULT_THEME
+
+        assert any(
+            "Apple_Terminal" in record.getMessage() and "list" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_non_dict_terminal_themes_warns_and_falls_through(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A scalar `terminal_themes` value warns instead of silently no-oping.
+
+        Writing `terminal_themes = "..."` instead of `[ui.terminal_themes]`
+        is a structural mistake that should surface to the user.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\nterminal_themes = "langchain-light"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == DEFAULT_THEME
+
+        assert any(
+            "[ui.terminal_themes]" in record.getMessage() for record in caplog.records
+        )
+
+    def test_empty_term_program_falls_through_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty-string `TERM_PROGRAM` is treated as unset.
+
+        Some shells export `TERM_PROGRAM=""`; falling back to `dict.get("")`
+        would be surprising.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n"" = "langchain-light"\n'
+            '"Apple_Terminal" = "langchain"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_terminal_mapping_is_case_sensitive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`TERM_PROGRAM` keys are matched verbatim, no case folding.
+
+        Config-file values are written by the user, so we don't second-guess
+        casing.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n"apple_terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_terminal_mapping_migrates_legacy_textual_ansi(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Legacy `textual-ansi` is migrated to `ansi-light` via the mapping.
+
+        Mirrors the migration in the saved-theme branch (pre-Textual 8.2.5).
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui.terminal_themes]\n"Apple_Terminal" = "textual-ansi"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == "ansi-light"
 
 
 class TestSaveThemePreference:

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -384,6 +384,54 @@ class TestGetThemeColors:
 # ---------------------------------------------------------------------------
 
 
+class TestResolveThemeName:
+    """Direct unit tests for the shared theme-name resolver."""
+
+    def test_exact_registry_key_round_trips(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("langchain") == "langchain"
+
+    def test_human_label_resolves(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("LangChain Dark") == "langchain"
+
+    def test_casefolded_key_resolves(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("LANGCHAIN-LIGHT") == "langchain-light"
+
+    def test_casefolded_label_resolves(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("langchain dark") == "langchain"
+
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        """Hand-edited TOML / env vars routinely pick up trailing whitespace."""
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("  langchain  ") == "langchain"
+        assert _resolve_theme_name("\tLangChain Dark\n") == "langchain"
+
+    def test_legacy_textual_ansi_migrates(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("textual-ansi") == "ansi-light"
+
+    def test_unknown_returns_none(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name("nonexistent-theme") is None
+
+    def test_non_string_returns_none(self) -> None:
+        from deepagents_cli.app import _resolve_theme_name
+
+        assert _resolve_theme_name(None) is None
+        assert _resolve_theme_name(42) is None
+        assert _resolve_theme_name(["langchain"]) is None
+
+
 class TestLoadThemePreference:
     """_load_theme_preference reads config.toml correctly."""
 
@@ -755,13 +803,14 @@ class TestTerminalThemeMapping:
 
         assert _load_theme_preference() == DEFAULT_THEME
 
-    def test_terminal_mapping_is_case_sensitive(
+    def test_term_program_keys_are_matched_verbatim(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`TERM_PROGRAM` keys are matched verbatim, no case folding.
+        """`TERM_PROGRAM` table keys are looked up by exact match.
 
-        Config-file values are written by the user, so we don't second-guess
-        casing.
+        The shells that set `TERM_PROGRAM` use a stable canonical casing, so
+        we match it verbatim — looser matching would risk mapping the wrong
+        terminal.
         """
         from deepagents_cli.app import _load_theme_preference
 
@@ -774,6 +823,47 @@ class TestTerminalThemeMapping:
         monkeypatch.delenv(THEME, raising=False)
 
         assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_terminal_mapping_accepts_theme_label(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Theme values accept the human label, not just the registry key.
+
+        `[ui.terminal_themes]` is hand-edited, so a user copying the label
+        from the `/theme` picker (e.g. `LangChain Dark`) should still resolve
+        to the registered theme without a warning.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui.terminal_themes]\n"iTerm.app" = "LangChain Dark"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+        monkeypatch.delenv(THEME, raising=False)
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == "langchain"
+
+        assert not caplog.records, "label match should not warn"
+
+    def test_terminal_mapping_accepts_casefolded_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Theme values are matched case-insensitively against registry keys."""
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n"Apple_Terminal" = "LANGCHAIN-LIGHT"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == "langchain-light"
 
     def test_terminal_mapping_migrates_legacy_textual_ansi(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1297,6 +1387,107 @@ class TestSaveThemePreferenceOverwrite:
         assert data["ui"]["theme"] == "langchain-light"
 
 
+class TestSaveTerminalThemeMapping:
+    """save_terminal_theme_mapping writes [ui.terminal_themes] correctly."""
+
+    def test_creates_section_from_scratch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tomllib
+
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        assert save_terminal_theme_mapping("Apple_Terminal", "langchain-light") is True
+        data = tomllib.loads(config.read_text())
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain-light"
+
+    def test_preserves_other_terminal_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tomllib
+
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui]\ntheme = "langchain"\n'
+            "[ui.terminal_themes]\n"
+            '"iTerm.app" = "langchain"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        assert save_terminal_theme_mapping("Apple_Terminal", "langchain-light") is True
+        data = tomllib.loads(config.read_text())
+        assert data["ui"]["theme"] == "langchain"
+        assert data["ui"]["terminal_themes"]["iTerm.app"] == "langchain"
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain-light"
+
+    def test_overwrites_existing_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tomllib
+
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        assert save_terminal_theme_mapping("Apple_Terminal", "langchain") is True
+        assert save_terminal_theme_mapping("Apple_Terminal", "langchain-light") is True
+        data = tomllib.loads(config.read_text())
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain-light"
+
+    def test_repairs_non_dict_terminal_themes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A scalar `terminal_themes` value is replaced with a fresh table.
+
+        We can't merge into a malformed value, so the user's mistake is
+        overwritten — the saved-by-the-CLI invariant trumps preserving it.
+        The discarded value is logged so it remains recoverable.
+        """
+        import tomllib
+
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\nterminal_themes = "junk"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert save_terminal_theme_mapping("Apple_Terminal", "langchain") is True
+        data = tomllib.loads(config.read_text())
+        assert isinstance(data["ui"]["terminal_themes"], dict)
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain"
+        assert any(
+            "junk" in record.getMessage() and "replacing" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_rejects_unknown_theme(self) -> None:
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        assert save_terminal_theme_mapping("Apple_Terminal", "nonexistent") is False
+
+    def test_rejects_empty_term_program(self) -> None:
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        assert save_terminal_theme_mapping("", "langchain") is False
+
+    def test_rejects_whitespace_only_term_program(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A whitespace-only key would write a junk entry — reject it."""
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        assert save_terminal_theme_mapping("   ", "langchain") is False
+        assert not config.exists()
+
+
 # ---------------------------------------------------------------------------
 # ThemeSelectorScreen
 # ---------------------------------------------------------------------------
@@ -1405,3 +1596,206 @@ class TestThemeSelectorScreen:
             assert len(results) == 1
             assert results[0] is not None
             assert results[0] in theme.get_registry()
+
+    async def test_t_writes_terminal_mapping_for_current_term_program(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`t` persists the highlighted theme to `[ui.terminal_themes]` only.
+
+        Dismisses with `None` so the parent's save-theme-preference path
+        does not also write `[ui].theme` — that would race this writer over
+        the same `config.toml`.
+        """
+        import tomllib
+
+        from textual.app import App
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        results: list[str | None] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+
+            def on_result(result: str | None) -> None:
+                results.append(result)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen, on_result)
+            await pilot.pause()
+
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+        assert results == [None]
+        data = tomllib.loads(config.read_text())
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain"
+        # `[ui].theme` must NOT be written by the `t` action — otherwise we'd
+        # race the parent's save-theme-preference path.
+        assert "theme" not in data.get("ui", {})
+
+    async def test_t_persists_moved_cursor_not_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`t` saves the *highlighted* theme, not the originally-current one."""
+        import tomllib
+
+        from textual.app import App
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            registry_keys = list(theme.get_registry())
+            lc_index = registry_keys.index("langchain")
+            target_index = lc_index + 1
+            target_key = registry_keys[target_index]
+
+            await pilot.press("down")
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+        data = tomllib.loads(config.read_text())
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == target_key
+
+    async def test_t_no_op_when_term_program_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without `TERM_PROGRAM`, `t` warns instead of writing a bad mapping."""
+        from textual.app import App
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+
+        results: list[str | None] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+
+            def on_result(result: str | None) -> None:
+                results.append(result)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen, on_result)
+            await pilot.pause()
+
+            await pilot.press("t")
+            await pilot.pause()
+
+        assert results == []
+        assert not config.exists()
+
+    async def test_t_no_op_when_term_program_whitespace_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A whitespace-only `TERM_PROGRAM` is treated as unset."""
+        from textual.app import App
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "   ")
+
+        results: list[str | None] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+
+            def on_result(result: str | None) -> None:
+                results.append(result)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen, on_result)
+            await pilot.pause()
+
+            await pilot.press("t")
+            await pilot.pause()
+
+        assert results == []
+        assert not config.exists()
+
+    async def test_n_toggles_between_labels_and_registry_keys(self) -> None:
+        """`n` swaps the option list between display labels and canonical keys.
+
+        Lets users copy the exact registry key into `[ui.terminal_themes]`
+        or `[ui].theme` without leaving the picker. Also verifies that
+        non-current rows render without a `(current)` suffix and that the
+        cursor is preserved across a toggle even when moved off the default
+        position.
+        """
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            registry = theme.get_registry()
+            keys = list(registry)
+            lc_index = keys.index("langchain")
+            lc_label = registry["langchain"].label
+            other_index = lc_index + 1
+            other_key = keys[other_index]
+            other_label = registry[other_key].label
+
+            assert str(option_list.get_option_at_index(lc_index).prompt) == (
+                f"{lc_label} (current)"
+            )
+            assert (
+                str(option_list.get_option_at_index(other_index).prompt) == other_label
+            )
+
+            # Move the cursor so the post-toggle highlighted index is not the
+            # default — otherwise the cursor-preservation branch is untested.
+            await pilot.press("down")
+            await pilot.pause()
+            assert option_list.highlighted == other_index
+
+            await pilot.press("n")
+            await pilot.pause()
+
+            assert str(option_list.get_option_at_index(lc_index).prompt) == (
+                "langchain (current)"
+            )
+            assert str(option_list.get_option_at_index(other_index).prompt) == other_key
+            assert option_list.highlighted == other_index
+
+            await pilot.press("n")
+            await pilot.pause()
+
+            assert str(option_list.get_option_at_index(lc_index).prompt) == (
+                f"{lc_label} (current)"
+            )
+            assert (
+                str(option_list.get_option_at_index(other_index).prompt) == other_label
+            )
+            assert option_list.highlighted == other_index

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -13,6 +13,8 @@ from deepagents_cli._env_vars import THEME
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from _typeshed import SupportsRead
+
 from deepagents_cli import theme
 from deepagents_cli.theme import (
     DARK_COLORS,
@@ -551,6 +553,26 @@ class TestLoadTerminalDefault:
             for record in caplog.records
         )
 
+    def test_warns_on_non_dict_ui(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text('ui = "junk"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_terminal_default() is None
+        assert any(
+            "[ui]" in record.getMessage() and "table" in record.getMessage()
+            for record in caplog.records
+        )
+
     def test_warns_on_unknown_mapped_theme(
         self,
         tmp_path: Path,
@@ -701,6 +723,25 @@ class TestLoadThemePreference:
         config.write_text('[model]\nname = "gpt-4"\n')
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_warns_on_non_dict_ui(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('ui = "junk"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == DEFAULT_THEME
+        assert any(
+            "[ui]" in record.getMessage() and "table" in record.getMessage()
+            for record in caplog.records
+        )
 
 
 class TestTerminalThemeMapping:
@@ -1646,6 +1687,80 @@ class TestSaveTerminalThemeMapping:
             for record in caplog.records
         )
 
+    def test_repairs_non_dict_ui(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A scalar top-level `ui` value is replaced with a fresh table."""
+        import tomllib
+
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        config.write_text('ui = "junk"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert save_terminal_theme_mapping("Apple_Terminal", "langchain") is True
+        data = tomllib.loads(config.read_text())
+        assert isinstance(data["ui"], dict)
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain"
+        assert any(
+            "[ui]" in record.getMessage() and "replacing" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_concurrent_global_and_terminal_writes_preserve_both_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Overlapping config saves keep both read-modify-write mutations."""
+        import contextlib
+        import threading
+        import tomllib
+
+        from deepagents_cli.app import (
+            save_terminal_theme_mapping,
+            save_theme_preference,
+        )
+
+        config = tmp_path / "config.toml"
+        config.write_text('[model]\nname = "existing"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+
+        original_load = tomllib.load
+        barrier = threading.Barrier(2)
+
+        def slow_load(fp: SupportsRead[bytes]) -> dict[str, object]:
+            data = original_load(fp)
+            with contextlib.suppress(threading.BrokenBarrierError):
+                barrier.wait(timeout=0.2)
+            return data
+
+        monkeypatch.setattr(tomllib, "load", slow_load)
+
+        results: list[bool] = []
+
+        def save_global() -> None:
+            results.append(save_theme_preference("langchain-light"))
+
+        def save_terminal() -> None:
+            results.append(save_terminal_theme_mapping("Apple_Terminal", "langchain"))
+
+        threads = [
+            threading.Thread(target=save_global),
+            threading.Thread(target=save_terminal),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        data = tomllib.loads(config.read_text())
+        assert results == [True, True]
+        assert data["ui"]["theme"] == "langchain-light"
+        assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain"
+
     def test_rejects_unknown_theme(self) -> None:
         from deepagents_cli.app import save_terminal_theme_mapping
 
@@ -1833,6 +1948,7 @@ class TestThemeSelectorScreen:
         import tomllib
 
         from textual.app import App
+        from textual.widgets import OptionList
 
         from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
 
@@ -1874,6 +1990,7 @@ class TestThemeSelectorScreen:
         import tomllib
 
         from textual.app import App
+        from textual.widgets import OptionList
 
         from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
 
@@ -1889,11 +2006,11 @@ class TestThemeSelectorScreen:
             await pilot.pause()
 
             registry_keys = list(theme.get_registry())
-            lc_index = registry_keys.index("langchain")
-            target_index = lc_index + 1
-            target_key = registry_keys[target_index]
+            target_key = next(key for key in registry_keys if key != "langchain")
+            target_index = registry_keys.index(target_key)
 
-            await pilot.press("down")
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = target_index
             await pilot.pause()
             await pilot.press("t")
             await app.workers.wait_for_complete()
@@ -2011,6 +2128,7 @@ class TestThemeSelectorScreen:
         """
         from textual.app import App
 
+        from deepagents_cli.app import _ConfigWriteResult
         from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
 
         config = tmp_path / "config.toml"
@@ -2019,8 +2137,10 @@ class TestThemeSelectorScreen:
         # Force the writer to report failure without actually raising —
         # exercises the `if ok:` else-branch in `_persist`.
         monkeypatch.setattr(
-            "deepagents_cli.app.save_terminal_theme_mapping",
-            lambda *_args, **_kwargs: False,
+            "deepagents_cli.app._save_terminal_theme_mapping_result",
+            lambda *_args, **_kwargs: _ConfigWriteResult(
+                False, "Could not save terminal mapping.", "error"
+            ),
         )
 
         notifications: list[tuple[str, str]] = []
@@ -2044,7 +2164,7 @@ class TestThemeSelectorScreen:
             await pilot.pause()
 
         assert any(
-            sev == "warning" and "terminal mapping" in msg for sev, msg in notifications
+            sev == "error" and "terminal mapping" in msg for sev, msg in notifications
         )
 
     async def test_t_notifies_on_save_exception(
@@ -2067,7 +2187,9 @@ class TestThemeSelectorScreen:
             msg = "simulated"
             raise OSError(msg)
 
-        monkeypatch.setattr("deepagents_cli.app.save_terminal_theme_mapping", _boom)
+        monkeypatch.setattr(
+            "deepagents_cli.app._save_terminal_theme_mapping_result", _boom
+        )
 
         notifications: list[tuple[str, str]] = []
 
@@ -2090,6 +2212,48 @@ class TestThemeSelectorScreen:
             await pilot.pause()
 
         assert any(sev == "error" and "OSError" in msg for sev, msg in notifications)
+
+    async def test_t_write_skips_rerender_after_screen_unmount(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The background terminal save tolerates the picker unmounting mid-write."""
+        import asyncio
+        import threading
+
+        from textual.app import App
+
+        from deepagents_cli.app import _ConfigWriteResult
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _slow_save(*_args: object, **_kwargs: object) -> _ConfigWriteResult:
+            started.set()
+            release.wait(timeout=1)
+            return _ConfigWriteResult(True)
+
+        monkeypatch.setattr(
+            "deepagents_cli.app._save_terminal_theme_mapping_result", _slow_save
+        )
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await pilot.press("t")
+            assert await asyncio.to_thread(started.wait, 1)
+            screen._is_mounted = False  # simulate mid-write teardown
+            release.set()
+            await app.workers.wait_for_complete()
+            screen._is_mounted = True  # keep Textual teardown normal
 
     async def test_terminal_default_badge_renders(self) -> None:
         """The `terminal_default` row renders with a `(default)` suffix."""

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -432,6 +432,85 @@ class TestResolveThemeName:
         assert _resolve_theme_name(["langchain"]) is None
 
 
+class TestLoadTerminalDefault:
+    """Direct unit tests for `_load_terminal_default`."""
+
+    def test_returns_mapped_theme(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        assert _load_terminal_default() == "langchain-light"
+
+    def test_resolves_label_via_resolve_theme_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui.terminal_themes]\n"Apple_Terminal" = "LangChain Dark"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        assert _load_terminal_default() == "langchain"
+
+    def test_returns_none_when_term_program_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+
+        assert _load_terminal_default() is None
+
+    def test_returns_none_when_no_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui.terminal_themes]\n"iTerm.app" = "langchain"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        assert _load_terminal_default() is None
+
+    def test_returns_none_when_mapped_theme_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui.terminal_themes]\n"Apple_Terminal" = "nonexistent"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        assert _load_terminal_default() is None
+
+    def test_returns_none_when_config_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        assert _load_terminal_default() is None
+
+
 class TestLoadThemePreference:
     """_load_theme_preference reads config.toml correctly."""
 
@@ -1736,6 +1815,78 @@ class TestThemeSelectorScreen:
 
         assert results == []
         assert not config.exists()
+
+    async def test_terminal_default_badge_renders(self) -> None:
+        """The `terminal_default` row renders with a `(terminal default)` suffix."""
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(
+                current_theme="langchain", terminal_default="langchain-light"
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            registry = theme.get_registry()
+            keys = list(registry)
+            current_idx = keys.index("langchain")
+            default_idx = keys.index("langchain-light")
+
+            assert str(option_list.get_option_at_index(current_idx).prompt) == (
+                f"{registry['langchain'].label} (current)"
+            )
+            assert str(option_list.get_option_at_index(default_idx).prompt) == (
+                f"{registry['langchain-light'].label} (terminal default)"
+            )
+
+    async def test_terminal_default_combines_with_current_badge(self) -> None:
+        """A theme that's both current and the terminal default renders both."""
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(
+                current_theme="langchain", terminal_default="langchain"
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            registry = theme.get_registry()
+            lc_index = list(registry).index("langchain")
+
+            assert str(option_list.get_option_at_index(lc_index).prompt) == (
+                f"{registry['langchain'].label} (current, terminal default)"
+            )
+
+    async def test_no_default_badge_when_terminal_default_is_none(self) -> None:
+        """Without a terminal mapping, no row gets a `(terminal default)` suffix."""
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            for i in range(option_list.option_count):
+                prompt = str(option_list.get_option_at_index(i).prompt)
+                assert "terminal default" not in prompt, prompt
 
     async def test_n_toggles_between_labels_and_registry_keys(self) -> None:
         """`n` swaps the option list between display labels and canonical keys.

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -510,6 +510,68 @@ class TestLoadTerminalDefault:
 
         assert _load_terminal_default() is None
 
+    def test_returns_none_and_logs_on_corrupt_toml(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Corrupt config returns `None` and logs a warning so the user can debug."""
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text("this is not valid toml [[[")
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_terminal_default() is None
+        assert any(
+            "terminal theme default" in record.getMessage() for record in caplog.records
+        )
+
+    def test_warns_on_non_dict_terminal_themes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\nterminal_themes = "not-a-table"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_terminal_default() is None
+        assert any(
+            "[ui.terminal_themes]" in record.getMessage()
+            and "table" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_warns_on_unknown_mapped_theme(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from deepagents_cli.app import _load_terminal_default
+
+        config = tmp_path / "config.toml"
+        config.write_text('[ui.terminal_themes]\n"Apple_Terminal" = "nonexistent"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_terminal_default() is None
+        assert any(
+            "nonexistent" in record.getMessage()
+            and "Apple_Terminal" in record.getMessage()
+            for record in caplog.records
+        )
+
 
 class TestLoadThemePreference:
     """_load_theme_preference reads config.toml correctly."""
@@ -778,8 +840,16 @@ class TestTerminalThemeMapping:
         )
 
     def test_missing_term_program_falls_through_to_default(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        """Warn when mapping is non-empty but `TERM_PROGRAM` is unset.
+
+        Non-`TERM_PROGRAM` terminals (Windows Terminal, tmux without
+        passthrough, ssh, Linux console) shouldn't silently no-op.
+        """
         from deepagents_cli.app import _load_theme_preference
 
         config = tmp_path / "config.toml"
@@ -790,7 +860,38 @@ class TestTerminalThemeMapping:
         monkeypatch.delenv("TERM_PROGRAM", raising=False)
         monkeypatch.delenv(THEME, raising=False)
 
-        assert _load_theme_preference() == DEFAULT_THEME
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == DEFAULT_THEME
+
+        assert any(
+            "TERM_PROGRAM is unset" in record.getMessage() for record in caplog.records
+        )
+
+    def test_empty_terminal_themes_with_unset_term_program_no_warn(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No warning for an empty `[ui.terminal_themes]` table.
+
+        When `TERM_PROGRAM` is unset and the table is empty there's nothing
+        for the user to fix.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text("[ui.terminal_themes]\n")
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv(THEME, raising=False)
+
+        with caplog.at_level("WARNING", logger="deepagents_cli.app"):
+            assert _load_theme_preference() == DEFAULT_THEME
+
+        assert not any(
+            "TERM_PROGRAM is unset" in record.getMessage() for record in caplog.records
+        )
 
     def test_no_terminal_themes_section_falls_through(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1566,6 +1667,49 @@ class TestSaveTerminalThemeMapping:
         assert save_terminal_theme_mapping("   ", "langchain") is False
         assert not config.exists()
 
+    def test_returns_false_on_write_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mirror of `TestSaveThemePreference::test_returns_false_on_write_error`.
+
+        A read-only parent dir means `mkdir(exist_ok=True)` raises `OSError`,
+        which the function should catch and return `False` from.
+        """
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "readonly" / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        (tmp_path / "readonly").mkdir()
+        (tmp_path / "readonly").chmod(0o444)
+        try:
+            result = save_terminal_theme_mapping("Apple_Terminal", "langchain")
+        finally:
+            (tmp_path / "readonly").chmod(0o755)
+        assert result is False
+
+    def test_returns_false_on_atomic_write_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clean up the temp file and return `False` on mid-write failure.
+
+        If `tomli_w.dump` raises, the temp file is unlinked. A stray
+        `.tmp` file in `~/.deepagents/` after a crash would be hard to
+        diagnose.
+        """
+        from deepagents_cli.app import save_terminal_theme_mapping
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            msg = "simulated dump failure"
+            raise OSError(msg)
+
+        monkeypatch.setattr("tomli_w.dump", _boom)
+        assert save_terminal_theme_mapping("Apple_Terminal", "langchain") is False
+        # Temp file (`*.tmp` sibling of the target) must not be left behind.
+        assert not list(tmp_path.glob("*.tmp"))
+
 
 # ---------------------------------------------------------------------------
 # ThemeSelectorScreen
@@ -1681,9 +1825,10 @@ class TestThemeSelectorScreen:
     ) -> None:
         """`t` persists the highlighted theme to `[ui.terminal_themes]` only.
 
-        Dismisses with `None` so the parent's save-theme-preference path
-        does not also write `[ui].theme` — that would race this writer over
-        the same `config.toml`.
+        Leaves the picker open so the user can confirm and keep browsing.
+        `[ui].theme` is intentionally untouched — pressing `t` is "save for
+        this terminal", not "save as my global default". The shared
+        `_CONFIG_WRITE_LOCK` prevents racing the parent's Enter writer.
         """
         import tomllib
 
@@ -1712,7 +1857,10 @@ class TestThemeSelectorScreen:
             await app.workers.wait_for_complete()
             await pilot.pause()
 
-        assert results == [None]
+            # Picker stays open after `t`.
+            assert results == []
+            assert app.screen is screen
+
         data = tomllib.loads(config.read_text())
         assert data["ui"]["terminal_themes"]["Apple_Terminal"] == "langchain"
         # `[ui].theme` must NOT be written by the `t` action — otherwise we'd
@@ -1753,6 +1901,43 @@ class TestThemeSelectorScreen:
 
         data = tomllib.loads(config.read_text())
         assert data["ui"]["terminal_themes"]["Apple_Terminal"] == target_key
+
+    async def test_t_updates_default_badge_in_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After `t`, the picker stays open and the saved row gains `(default)`.
+
+        Confirms the user's action visually so they don't need to reopen the
+        picker to verify what was saved.
+        """
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            registry = theme.get_registry()
+            keys = list(registry)
+            lc_index = keys.index("langchain")
+            option_list = screen.query_one("#theme-options", OptionList)
+            prompt = str(option_list.get_option_at_index(lc_index).prompt)
+            # `langchain` is both current and now the saved default.
+            assert "(current, default)" in prompt
+            # Cursor stays on the saved row.
+            assert option_list.highlighted == lc_index
 
     async def test_t_no_op_when_term_program_unset(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1816,8 +2001,98 @@ class TestThemeSelectorScreen:
         assert results == []
         assert not config.exists()
 
+    async def test_t_notifies_on_save_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Warn the user when `save_terminal_theme_mapping` returns `False`.
+
+        Surfaces a warning toast pointing at the log location instead of a
+        silent no-op.
+        """
+        from textual.app import App
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        # Force the writer to report failure without actually raising —
+        # exercises the `if ok:` else-branch in `_persist`.
+        monkeypatch.setattr(
+            "deepagents_cli.app.save_terminal_theme_mapping",
+            lambda *_args, **_kwargs: False,
+        )
+
+        notifications: list[tuple[str, str]] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+
+            def _capture(
+                message: str, *, severity: str = "information", **_kwargs: object
+            ) -> None:
+                notifications.append((severity, message))
+
+            monkeypatch.setattr(app, "notify", _capture)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+        assert any(
+            sev == "warning" and "terminal mapping" in msg for sev, msg in notifications
+        )
+
+    async def test_t_notifies_on_save_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Surface the exception class name in a toast on raise.
+
+        A generic 'check logs' message hides the failure mode; the class
+        name (e.g., `OSError`) tells the user where to look.
+        """
+        from textual.app import App
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            msg = "simulated"
+            raise OSError(msg)
+
+        monkeypatch.setattr("deepagents_cli.app.save_terminal_theme_mapping", _boom)
+
+        notifications: list[tuple[str, str]] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+
+            def _capture(
+                message: str, *, severity: str = "information", **_kwargs: object
+            ) -> None:
+                notifications.append((severity, message))
+
+            monkeypatch.setattr(app, "notify", _capture)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+        assert any(sev == "error" and "OSError" in msg for sev, msg in notifications)
+
     async def test_terminal_default_badge_renders(self) -> None:
-        """The `terminal_default` row renders with a `(terminal default)` suffix."""
+        """The `terminal_default` row renders with a `(default)` suffix."""
         from textual.app import App
         from textual.widgets import OptionList
 
@@ -1842,11 +2117,11 @@ class TestThemeSelectorScreen:
                 f"{registry['langchain'].label} (current)"
             )
             assert str(option_list.get_option_at_index(default_idx).prompt) == (
-                f"{registry['langchain-light'].label} (terminal default)"
+                f"{registry['langchain-light'].label} (default)"
             )
 
     async def test_terminal_default_combines_with_current_badge(self) -> None:
-        """A theme that's both current and the terminal default renders both."""
+        """A theme that's both current and the saved default renders both."""
         from textual.app import App
         from textual.widgets import OptionList
 
@@ -1866,11 +2141,11 @@ class TestThemeSelectorScreen:
             lc_index = list(registry).index("langchain")
 
             assert str(option_list.get_option_at_index(lc_index).prompt) == (
-                f"{registry['langchain'].label} (current, terminal default)"
+                f"{registry['langchain'].label} (current, default)"
             )
 
     async def test_no_default_badge_when_terminal_default_is_none(self) -> None:
-        """Without a terminal mapping, no row gets a `(terminal default)` suffix."""
+        """Without a terminal mapping, no row gets a `(default)` suffix."""
         from textual.app import App
         from textual.widgets import OptionList
 
@@ -1886,7 +2161,10 @@ class TestThemeSelectorScreen:
             option_list = screen.query_one("#theme-options", OptionList)
             for i in range(option_list.option_count):
                 prompt = str(option_list.get_option_at_index(i).prompt)
-                assert "terminal default" not in prompt, prompt
+                # Match "(default)" as a whole token to avoid false positives
+                # from "(current)" rows.
+                assert "(default)" not in prompt, prompt
+                assert ", default)" not in prompt, prompt
 
     async def test_n_toggles_between_labels_and_registry_keys(self) -> None:
         """`n` swaps the option list between display labels and canonical keys.

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -514,6 +514,120 @@ class TestLoadThemePreference:
         assert _load_theme_preference() == DEFAULT_THEME
 
 
+class TestTerminalThemeMapping:
+    """_load_theme_preference respects [ui.terminal_themes] mapping."""
+
+    def test_terminal_mapping_resolves_theme(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == "langchain-light"
+
+    def test_saved_theme_overrides_terminal_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui]\ntheme = "langchain"\n'
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == "langchain"
+
+    def test_env_theme_overrides_terminal_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.setenv(THEME, "langchain")
+
+        assert _load_theme_preference() == "langchain"
+
+    def test_unknown_terminal_falls_through_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "SomeUnknownTerminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_unknown_mapped_theme_warns_and_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "nonexistent-theme"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_missing_term_program_falls_through_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui.terminal_themes]\n'
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+    def test_no_terminal_themes_section_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text('[model]\nname = "gpt-4"\n')
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.delenv(THEME, raising=False)
+
+        assert _load_theme_preference() == DEFAULT_THEME
+
+
 class TestSaveThemePreference:
     """save_theme_preference writes config.toml correctly."""
 

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -524,8 +524,7 @@ class TestTerminalThemeMapping:
 
         config = tmp_path / "config.toml"
         config.write_text(
-            '[ui.terminal_themes]\n'
-            '"Apple_Terminal" = "langchain-light"\n'
+            '[ui.terminal_themes]\n"Apple_Terminal" = "langchain-light"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
@@ -541,7 +540,7 @@ class TestTerminalThemeMapping:
         config = tmp_path / "config.toml"
         config.write_text(
             '[ui]\ntheme = "langchain"\n'
-            '[ui.terminal_themes]\n'
+            "[ui.terminal_themes]\n"
             '"Apple_Terminal" = "langchain-light"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
@@ -557,8 +556,7 @@ class TestTerminalThemeMapping:
 
         config = tmp_path / "config.toml"
         config.write_text(
-            '[ui.terminal_themes]\n'
-            '"Apple_Terminal" = "langchain-light"\n'
+            '[ui.terminal_themes]\n"Apple_Terminal" = "langchain-light"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
@@ -573,8 +571,7 @@ class TestTerminalThemeMapping:
 
         config = tmp_path / "config.toml"
         config.write_text(
-            '[ui.terminal_themes]\n'
-            '"Apple_Terminal" = "langchain-light"\n'
+            '[ui.terminal_themes]\n"Apple_Terminal" = "langchain-light"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.setenv("TERM_PROGRAM", "SomeUnknownTerminal")
@@ -589,8 +586,7 @@ class TestTerminalThemeMapping:
 
         config = tmp_path / "config.toml"
         config.write_text(
-            '[ui.terminal_themes]\n'
-            '"Apple_Terminal" = "nonexistent-theme"\n'
+            '[ui.terminal_themes]\n"Apple_Terminal" = "nonexistent-theme"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
@@ -605,8 +601,7 @@ class TestTerminalThemeMapping:
 
         config = tmp_path / "config.toml"
         config.write_text(
-            '[ui.terminal_themes]\n'
-            '"Apple_Terminal" = "langchain-light"\n'
+            '[ui.terminal_themes]\n"Apple_Terminal" = "langchain-light"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
         monkeypatch.delenv("TERM_PROGRAM", raising=False)

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -532,9 +532,14 @@ class TestTerminalThemeMapping:
 
         assert _load_theme_preference() == "langchain-light"
 
-    def test_saved_theme_overrides_terminal_mapping(
+    def test_terminal_mapping_overrides_saved_theme(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Mapping wins over saved theme.
+
+        Users moving between terminals (e.g. dark iTerm vs light Apple
+        Terminal) get the right theme without re-picking each time.
+        """
         from deepagents_cli.app import _load_theme_preference
 
         config = tmp_path / "config.toml"
@@ -547,9 +552,31 @@ class TestTerminalThemeMapping:
         monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
         monkeypatch.delenv(THEME, raising=False)
 
+        assert _load_theme_preference() == "langchain-light"
+
+    def test_saved_theme_used_when_no_terminal_mapping_match(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mapping miss falls through to the saved preference, not default.
+
+        When the current terminal isn't in the mapping table, the user's
+        saved preference still applies.
+        """
+        from deepagents_cli.app import _load_theme_preference
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            '[ui]\ntheme = "langchain"\n'
+            "[ui.terminal_themes]\n"
+            '"Apple_Terminal" = "langchain-light"\n'
+        )
+        monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "SomeOtherTerminal")
+        monkeypatch.delenv(THEME, raising=False)
+
         assert _load_theme_preference() == "langchain"
 
-    def test_unknown_saved_theme_returns_default_before_terminal_mapping(
+    def test_unknown_saved_theme_falls_through_to_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from deepagents_cli.app import _load_theme_preference
@@ -561,7 +588,7 @@ class TestTerminalThemeMapping:
             '"Apple_Terminal" = "langchain-light"\n'
         )
         monkeypatch.setattr("deepagents_cli.model_config.DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+        monkeypatch.setenv("TERM_PROGRAM", "SomeOtherTerminal")
         monkeypatch.delenv(THEME, raising=False)
 
         assert _load_theme_preference() == DEFAULT_THEME


### PR DESCRIPTION
Fixes part 1 of #2146

---

Add per-terminal theme mapping so users switching between terminals (e.g. dark iTerm vs. light Apple Terminal) get the right theme automatically without re-picking each time.

## Changes
- Add `[ui.terminal_themes]` config table keyed on `TERM_PROGRAM` — looked up before the saved global preference in `_load_theme_preference`, after the `DEEPAGENTS_CLI_THEME` env var override
- Introduce `_resolve_theme_name` to canonicalize theme values (registry key, human label, case-insensitive, whitespace-tolerant, plus `textual-ansi` → `ansi-light` legacy migration) shared across env var, terminal mapping, and saved-preference resolution paths
- Add `save_terminal_theme_mapping` for atomic TOML writes to `[ui.terminal_themes]`; preserves existing table entries and repairs malformed scalar values with a warning
- Extend `ThemeSelectorScreen` with `n` to toggle between human-readable labels and canonical registry keys, and `t` to persist the highlighted theme for the current `TERM_PROGRAM` without touching `[ui].theme` — the picker stays open and the `(default)` badge updates in place, so users can keep browsing
- Badge the option list with `(default)` when a theme matches the current terminal's saved mapping; combine with `(current)` as `(current, default)` when both apply
- Serialize `config.toml` writes with a process-local lock so a quick `t`-then-Enter sequence can't clobber either mutation

PR 1 of 2 — system dark/light auto-detection will follow once Textualize/textual#6151 lands upstream.
