### PR TITLE
fix(cli): suppress noisy network warnings from interrupt cleanup

### DIFF
--- a/libs/cli/deepagents_cli/remote_client.py
+++ b/libs/cli/deepagents_cli/remote_client.py
@@ -225,7 +225,8 @@ class RemoteAgent:
         """Update the state of a thread.
 
         Exceptions from the underlying graph (server/network errors) are logged
-        at WARNING level and then re-raised so callers can handle them.
+        at DEBUG level and then re-raised so callers can decide how to surface
+        them (callers typically log at WARNING with a friendlier message).
 
         Args:
             config: Config with `configurable.thread_id`.
@@ -240,7 +241,7 @@ class RemoteAgent:
         try:
             await graph.aupdate_state(_prepare_config(config), values)
         except Exception:
-            logger.warning(
+            logger.debug(
                 "Failed to update state for thread %s", thread_id, exc_info=True
             )
             raise

--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -10,6 +10,8 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
+import httpx
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from pathlib import Path
@@ -1329,6 +1331,8 @@ async def _handle_interrupt_cleanup(
             "Previous operation was cancelled."
         )
         await agent.aupdate_state(config, {"messages": [cancellation_msg]})
+    except (httpx.TransportError, httpx.TimeoutException) as e:
+        logger.warning("Could not save interrupted state (network): %s", e)
     except Exception:
         logger.warning("Failed to save interrupted state", exc_info=True)
 
@@ -1367,6 +1371,13 @@ async def _persist_context_tokens(
     """
     try:
         await agent.aupdate_state(config, {"_context_tokens": tokens})
+    except (httpx.TransportError, httpx.TimeoutException) as e:
+        logger.warning(
+            "Could not persist _context_tokens=%d (network): %s; "
+            "token count may be stale on resume",
+            tokens,
+            e,
+        )
     except Exception:  # non-critical; stale count on resume is acceptable
         logger.warning(
             "Failed to persist _context_tokens=%d; token count may be stale on resume",


### PR DESCRIPTION
Downgrades `aupdate_state` failure logging in `RemoteAgent` from `WARNING` to `DEBUG`, so the CLI no longer emits low-value stack traces for routine network hiccups. Callers like interrupt cleanup and token persistence now explicitly catch `httpx` transport and timeout errors and surface a single, user-friendly warning line instead.