### PR TITLE
[do not review] feat(middleware): named, addressable system-prompt sections

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -35,6 +35,7 @@ from deepagents._tools import _apply_tool_description_overrides
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
+from deepagents.middleware._system_prompt import SystemPromptAssemblerMiddleware
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
@@ -677,6 +678,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 add_cache_control=True,
             )
         )
+    deepagent_middleware.append(SystemPromptAssemblerMiddleware())
     if interrupt_on is not None:
         deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
     deepagent_middleware = _apply_excluded_middleware(

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -47,6 +47,12 @@ Use a **plain tool** when:
 * The tool is specific to a single consumer (e.g. CLI-only)
 """
 
+from deepagents.middleware._utils import (
+    BUILTIN_SECTION_ORDER,
+    SystemSection,
+    get_system_section,
+    set_system_section,
+)
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.memory import MemoryMiddleware
@@ -59,6 +65,7 @@ from deepagents.middleware.summarization import (
 )
 
 __all__ = [
+    "BUILTIN_SECTION_ORDER",
     "AsyncSubAgent",
     "AsyncSubAgentMiddleware",
     "CompiledSubAgent",
@@ -66,6 +73,9 @@ __all__ = [
     "FilesystemPermission",
     "MemoryMiddleware",
     "SkillsMiddleware",
+    "SystemSection",
+    "get_system_section",
+    "set_system_section",
     "SubAgent",
     "SubAgentMiddleware",
     "SummarizationMiddleware",

--- a/libs/deepagents/deepagents/middleware/_system_prompt.py
+++ b/libs/deepagents/deepagents/middleware/_system_prompt.py
@@ -1,0 +1,64 @@
+"""SystemPromptAssemblerMiddleware — final assembly of named system-prompt sections."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage
+
+from deepagents.middleware._utils import (
+    _BASE_SYSTEM_MESSAGE_KEY,
+    _SYSTEM_SECTIONS_KEY,
+    assemble_system_message,
+)
+
+
+class SystemPromptAssemblerMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Innermost tail middleware that finalises the system prompt.
+
+    Middleware earlier in the stack contribute named sections via
+    :func:`~deepagents.middleware._utils.set_system_section`.  This middleware
+    reads those sections from ``request.model_settings``, assembles them into
+    the final ``SystemMessage`` in deterministic order, strips the internal
+    ``_deepagents_system_sections`` key so it never reaches the LLM API, and
+    calls the next handler with the clean request.
+
+    Assembly order
+    --------------
+    1. Base ``system_message`` blocks (user-supplied prompt, if any).
+    2. Named sections sorted by ``(section.order, section.key)``.
+
+    ``cache_control`` ephemeral breakpoints are applied to any section where
+    ``cache_control=True`` when the active model is an Anthropic model.
+    """
+
+    def _assemble(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        sections: dict[str, Any] | None = request.model_settings.get(_SYSTEM_SECTIONS_KEY)
+        if not sections:
+            return request
+        # Rebuild from the original base (saved before any set_system_section calls)
+        # so sections are ordered correctly instead of in registration order.
+        base = request.model_settings.get(_BASE_SYSTEM_MESSAGE_KEY)
+        clean_settings = {
+            k: v
+            for k, v in request.model_settings.items()
+            if k not in (_SYSTEM_SECTIONS_KEY, _BASE_SYSTEM_MESSAGE_KEY)
+        }
+        assembled = assemble_system_message(base, sections, model=request.model)
+        return request.override(system_message=assembled, model_settings=clean_settings)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any] | AIMessage:
+        return handler(self._assemble(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any] | AIMessage:
+        return await handler(self._assemble(request))

--- a/libs/deepagents/deepagents/middleware/_utils.py
+++ b/libs/deepagents/deepagents/middleware/_utils.py
@@ -1,6 +1,174 @@
 """Utility functions for middleware."""
 
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
 from langchain_core.messages import ContentBlock, SystemMessage
+
+if TYPE_CHECKING:
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain.agents.middleware.types import ModelRequest
+
+_SYSTEM_SECTIONS_KEY = "_deepagents_system_sections"
+_BASE_SYSTEM_MESSAGE_KEY = "_deepagents_base_system_message"
+
+# Lower order → assembled earlier in the final system prompt.
+# Sections not listed here default to order 100.
+BUILTIN_SECTION_ORDER: dict[str, int] = {
+    "filesystem": 10,
+    "subagents": 20,
+    "async_subagents": 25,
+    "skills": 30,
+    "memory": 40,
+}
+
+
+@dataclass
+class SystemSection:
+    """A named section of the system prompt contributed by one middleware.
+
+    Sections are assembled in ascending ``order`` order (ties broken by key
+    name) into the final ``SystemMessage`` by
+    :class:`SystemPromptAssemblerMiddleware`.
+    """
+
+    key: str
+    content: str
+    cache_control: bool = False
+    order: int = 100
+
+
+def set_system_section(
+    request: ModelRequest[Any],
+    key: str,
+    content: str,
+    *,
+    cache_control: bool = False,
+    order: int | None = None,
+) -> ModelRequest[Any]:
+    """Store a named system-prompt section on the request.
+
+    Replaces any existing section for ``key``.  The actual assembly into
+    ``SystemMessage`` is deferred to :class:`SystemPromptAssemblerMiddleware`
+    (the innermost tail middleware), so sections set by outer middleware are
+    visible to inner middleware via :func:`get_system_section` but do not yet
+    appear in ``request.system_message``.
+
+    Args:
+        request: The current model request.
+        key: Section identifier (e.g. ``"memory"``, ``"skills"``).
+        content: Section text.
+        cache_control: If ``True`` and the active model is Anthropic, the
+            assembler will attach a ``cache_control`` ephemeral breakpoint to
+            this content block.
+        order: Assembly order.  Defaults to ``BUILTIN_SECTION_ORDER[key]``
+            when the key is recognised, otherwise ``100``.
+
+    Returns:
+        New ``ModelRequest`` with the section stored in ``model_settings``.
+    """
+    resolved_order = order if order is not None else BUILTIN_SECTION_ORDER.get(key, 100)
+    sections: dict[str, SystemSection] = dict(
+        request.model_settings.get(_SYSTEM_SECTIONS_KEY, {})
+    )
+    sections[key] = SystemSection(
+        key=key,
+        content=content,
+        cache_control=cache_control,
+        order=resolved_order,
+    )
+
+    # Save the original base system_message on the first set_system_section call so that
+    # SystemPromptAssemblerMiddleware can later rebuild from the unmodified base.
+    new_settings: dict[str, Any] = {**request.model_settings, _SYSTEM_SECTIONS_KEY: sections}
+    if _BASE_SYSTEM_MESSAGE_KEY not in request.model_settings:
+        new_settings[_BASE_SYSTEM_MESSAGE_KEY] = request.system_message
+
+    # Also append directly to system_message so that middleware works correctly
+    # when SystemPromptAssemblerMiddleware is not in the stack (e.g. vanilla
+    # create_agent usage).  The assembler overrides this with a properly-ordered
+    # rebuild when it is present.
+    existing = request.system_message
+    existing_blocks: list[ContentBlock] = list(existing.content_blocks) if existing else []
+    text = f"\n\n{content}" if existing_blocks else content
+    block: ContentBlock = {"type": "text", "text": text}
+    if cache_control:
+        try:
+            from langchain_anthropic import ChatAnthropic
+
+            if isinstance(request.model, ChatAnthropic):
+                block = {**block, "cache_control": {"type": "ephemeral"}}  # ty: ignore[invalid-assignment]
+        except ImportError:
+            pass
+    new_blocks = [*existing_blocks, block]
+    new_system_message = SystemMessage(content_blocks=new_blocks)
+
+    return request.override(system_message=new_system_message, model_settings=new_settings)
+
+
+def get_system_section(request: ModelRequest[Any], key: str) -> str | None:
+    """Return the content of a named system-prompt section, or ``None``.
+
+    Args:
+        request: The current model request.
+        key: Section identifier.
+
+    Returns:
+        Section content string, or ``None`` if not set.
+    """
+    sections: dict[str, SystemSection] = request.model_settings.get(_SYSTEM_SECTIONS_KEY, {})
+    section = sections.get(key)
+    return section.content if section is not None else None
+
+
+def assemble_system_message(
+    base: SystemMessage | None,
+    sections: dict[str, SystemSection],
+    model: BaseChatModel | None = None,
+) -> SystemMessage | None:
+    """Assemble a base ``SystemMessage`` and named sections into a final message.
+
+    The base message's blocks come first (preserving any existing
+    ``cache_control`` markers), followed by the sections sorted by
+    ``(order, key)``.  Adjacent blocks are separated by a ``\\n\\n`` prefix on
+    each section's text — matching the historical behaviour of
+    ``append_to_system_message``.
+
+    Args:
+        base: Existing system message (the user-supplied system prompt).
+        sections: Named sections from :func:`set_system_section` calls.
+        model: Active chat model; used to gate ``cache_control`` application
+            (only added for Anthropic models).
+
+    Returns:
+        A new ``SystemMessage``, or ``None`` when there is nothing to assemble.
+    """
+    try:
+        from langchain_anthropic import ChatAnthropic
+
+        is_anthropic = model is not None and isinstance(model, ChatAnthropic)
+    except ImportError:
+        is_anthropic = False
+
+    base_blocks: list[ContentBlock] = list(base.content_blocks) if base else []
+    sorted_sections = sorted(sections.values(), key=lambda s: (s.order, s.key))
+
+    final_blocks: list[ContentBlock] = list(base_blocks)
+    for section in sorted_sections:
+        if not section.content:
+            continue
+        text = f"\n\n{section.content}" if final_blocks else section.content
+        block: ContentBlock = {"type": "text", "text": text}
+        if section.cache_control and is_anthropic:
+            block = {**block, "cache_control": {"type": "ephemeral"}}  # ty: ignore[invalid-assignment]
+        final_blocks.append(block)
+
+    if not final_blocks:
+        return None
+    return SystemMessage(content_blocks=final_blocks)
 
 
 def append_to_system_message(
@@ -9,13 +177,24 @@ def append_to_system_message(
 ) -> SystemMessage:
     """Append text to a system message.
 
+    .. deprecated::
+        Use :func:`set_system_section` to contribute named, addressable
+        sections that assemble in deterministic order.
+
     Args:
         system_message: Existing system message or None.
         text: Text to add to the system message.
 
     Returns:
-        New SystemMessage with the text appended.
+        New ``SystemMessage`` with the text appended.
     """
+    warnings.warn(
+        "append_to_system_message is deprecated. "
+        "Use set_system_section() to contribute named sections that can be "
+        "replaced and assembled in deterministic order.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     new_content: list[ContentBlock] = list(system_message.content_blocks) if system_message else []
     if new_content:
         text = f"\n\n{text}"

--- a/libs/deepagents/deepagents/middleware/async_subagents.py
+++ b/libs/deepagents/deepagents/middleware/async_subagents.py
@@ -26,7 +26,7 @@ from langgraph_sdk.client import LangGraphClient, SyncLangGraphClient
 from langgraph_sdk.schema import Run
 from pydantic import BaseModel, Field
 
-from deepagents.middleware._utils import append_to_system_message
+from deepagents.middleware._utils import set_system_section
 
 logger = logging.getLogger(__name__)
 
@@ -934,8 +934,7 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     ) -> ModelResponse[ResponseT]:
         """Update the system message to include async subagent instructions."""
         if self.system_prompt is not None:
-            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
-            return handler(request.override(system_message=new_system_message))
+            return handler(set_system_section(request, "async_subagents", self.system_prompt))
         return handler(request)
 
     async def awrap_model_call(
@@ -945,6 +944,5 @@ class AsyncSubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     ) -> ModelResponse[ResponseT]:
         """(async) Update the system message to include async subagent instructions."""
         if self.system_prompt is not None:
-            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
-            return await handler(request.override(system_message=new_system_message))
+            return await handler(set_system_section(request, "async_subagents", self.system_prompt))
         return await handler(request)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -56,7 +56,7 @@ from deepagents.backends.utils import (
     truncate_if_too_long,
     validate_path,
 )
-from deepagents.middleware._utils import append_to_system_message
+from deepagents.middleware._utils import set_system_section
 
 _FS_WCMATCH_FLAGS = wcglob.BRACE | wcglob.GLOBSTAR
 
@@ -1695,8 +1695,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             system_prompt = "\n\n".join(prompt_parts).strip()
 
         if system_prompt:
-            new_system_message = append_to_system_message(request.system_message, system_prompt)
-            request = request.override(system_message=new_system_message)
+            request = set_system_section(request, "filesystem", system_prompt)
 
         eviction_result = self._evict_and_truncate_messages(request)
         if eviction_result is not None:
@@ -1760,8 +1759,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             system_prompt = "\n\n".join(prompt_parts).strip()
 
         if system_prompt:
-            new_system_message = append_to_system_message(request.system_message, system_prompt)
-            request = request.override(system_message=new_system_message)
+            request = set_system_section(request, "filesystem", system_prompt)
 
         eviction_result = await self._aevict_and_truncate_messages(request)
         if eviction_result is not None:

--- a/libs/deepagents/deepagents/middleware/memory.py
+++ b/libs/deepagents/deepagents/middleware/memory.py
@@ -71,10 +71,7 @@ from langchain.agents.middleware.types import (
     ResponseT,
 )
 from langchain.tools import ToolRuntime
-from langchain_anthropic import ChatAnthropic
-from langchain_core.messages import ContentBlock, SystemMessage
-
-from deepagents.middleware._utils import append_to_system_message
+from deepagents.middleware._utils import set_system_section
 
 logger = logging.getLogger(__name__)
 
@@ -332,21 +329,11 @@ class MemoryMiddleware(AgentMiddleware[MemoryState, ContextT, ResponseT]):
         """
         contents = request.state.get("memory_contents", {})
         agent_memory = self._format_agent_memory(contents)
-
-        new_system_message = append_to_system_message(request.system_message, agent_memory)
-
-        # Runtime check uses `request.model` (not a flag captured at init) so
-        # the breakpoint correctly follows middleware-level model overrides.
-        if self._add_cache_control and isinstance(request.model, ChatAnthropic) and new_system_message.content_blocks:
-            blocks: list[ContentBlock] = list(new_system_message.content_blocks)
-            last = blocks[-1]
-            base = last if isinstance(last, dict) else {}
-            # Merged dict is structurally a ContentBlock with an extra
-            # provider-specific key; ty can't discriminate the union.
-            blocks[-1] = {**base, "cache_control": {"type": "ephemeral"}}  # ty: ignore[invalid-assignment]
-            new_system_message = SystemMessage(content_blocks=blocks)
-
-        return request.override(system_message=new_system_message)
+        # cache_control placement and Anthropic model detection are delegated to
+        # SystemPromptAssemblerMiddleware, which applies them at assembly time.
+        return set_system_section(
+            request, "memory", agent_memory, cache_control=self._add_cache_control
+        )
 
     def wrap_model_call(
         self,

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -131,7 +131,7 @@ from langgraph.prebuilt import ToolRuntime
 
 from deepagents.backends.protocol import FILE_NOT_FOUND, FileDownloadResponse, LsResult
 from deepagents.backends.utils import to_posix_path
-from deepagents.middleware._utils import append_to_system_message
+from deepagents.middleware._utils import set_system_section
 
 logger = logging.getLogger(__name__)
 
@@ -991,9 +991,7 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
             skills_list=skills_list,
         )
 
-        new_system_message = append_to_system_message(request.system_message, skills_section)
-
-        return request.override(system_message=new_system_message)
+        return set_system_section(request, "skills", skills_section)
 
     def before_agent(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> SkillsStateUpdate | None:  # ty: ignore[invalid-method-override]
         """Load skills metadata before agent execution (synchronous).

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -18,7 +18,7 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
-from deepagents.middleware._utils import append_to_system_message
+from deepagents.middleware._utils import set_system_section
 from deepagents.middleware.filesystem import FilesystemPermission
 
 
@@ -608,8 +608,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     ) -> ModelResponse[ResponseT]:
         """Update the system message to include instructions on using subagents."""
         if self.system_prompt is not None:
-            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
-            return handler(request.override(system_message=new_system_message))
+            return handler(set_system_section(request, "subagents", self.system_prompt))
         return handler(request)
 
     async def awrap_model_call(
@@ -619,6 +618,5 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     ) -> ModelResponse[ResponseT]:
         """(async) Update the system message to include instructions on using subagents."""
         if self.system_prompt is not None:
-            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
-            return await handler(request.override(system_message=new_system_message))
+            return await handler(set_system_section(request, "subagents", self.system_prompt))
         return await handler(request)

--- a/libs/deepagents/tests/unit_tests/middleware/test_system_prompt_sections.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_system_prompt_sections.py
@@ -1,0 +1,338 @@
+"""Unit tests for the named system-prompt sections API."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, SystemMessage
+
+from deepagents.middleware._system_prompt import SystemPromptAssemblerMiddleware
+from deepagents.middleware._utils import (
+    BUILTIN_SECTION_ORDER,
+    SystemSection,
+    _BASE_SYSTEM_MESSAGE_KEY,
+    _SYSTEM_SECTIONS_KEY,
+    append_to_system_message,
+    assemble_system_message,
+    get_system_section,
+    set_system_section,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model() -> MagicMock:
+    model = MagicMock()
+    model.__class__ = MagicMock  # not ChatAnthropic
+    return model
+
+
+def _make_request(
+    *,
+    system_message: SystemMessage | None = None,
+    model_settings: dict[str, Any] | None = None,
+) -> ModelRequest[None]:
+    return ModelRequest(
+        model=_make_model(),
+        messages=[],
+        system_message=system_message,
+        tools=[],
+        runtime=None,  # type: ignore[arg-type]
+        state={"messages": []},
+        model_settings=model_settings or {},
+    )
+
+
+def _fake_handler(captured: list[ModelRequest[Any]]) -> Callable[[ModelRequest[Any]], ModelResponse[Any]]:
+    def handler(req: ModelRequest[Any]) -> ModelResponse[Any]:
+        captured.append(req)
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# set_system_section / get_system_section
+# ---------------------------------------------------------------------------
+
+
+class TestSetGetSystemSection:
+    def test_set_stores_section(self) -> None:
+        req = _make_request()
+        req2 = set_system_section(req, "memory", "My memory content")
+
+        sections: dict[str, SystemSection] = req2.model_settings[_SYSTEM_SECTIONS_KEY]
+        assert "memory" in sections
+        assert sections["memory"].content == "My memory content"
+
+    def test_set_does_not_mutate_original(self) -> None:
+        req = _make_request()
+        set_system_section(req, "memory", "content")
+        assert _SYSTEM_SECTIONS_KEY not in req.model_settings
+
+    def test_set_replaces_existing_section(self) -> None:
+        req = _make_request()
+        req = set_system_section(req, "skills", "old content")
+        req = set_system_section(req, "skills", "new content")
+
+        sections: dict[str, SystemSection] = req.model_settings[_SYSTEM_SECTIONS_KEY]
+        assert sections["skills"].content == "new content"
+
+    def test_set_preserves_other_sections(self) -> None:
+        req = _make_request()
+        req = set_system_section(req, "filesystem", "fs content")
+        req = set_system_section(req, "memory", "memory content")
+
+        sections: dict[str, SystemSection] = req.model_settings[_SYSTEM_SECTIONS_KEY]
+        assert "filesystem" in sections
+        assert "memory" in sections
+
+    def test_set_preserves_other_model_settings(self) -> None:
+        req = _make_request(model_settings={"existing_key": 42})
+        req = set_system_section(req, "memory", "content")
+
+        assert req.model_settings["existing_key"] == 42
+
+    def test_builtin_section_order_applied(self) -> None:
+        req = _make_request()
+        req = set_system_section(req, "memory", "content")
+        sections: dict[str, SystemSection] = req.model_settings[_SYSTEM_SECTIONS_KEY]
+        assert sections["memory"].order == BUILTIN_SECTION_ORDER["memory"]
+
+    def test_unknown_key_defaults_order_100(self) -> None:
+        req = _make_request()
+        req = set_system_section(req, "custom_section", "content")
+        sections: dict[str, SystemSection] = req.model_settings[_SYSTEM_SECTIONS_KEY]
+        assert sections["custom_section"].order == 100
+
+    def test_explicit_order_overrides_builtin(self) -> None:
+        req = _make_request()
+        req = set_system_section(req, "memory", "content", order=5)
+        sections: dict[str, SystemSection] = req.model_settings[_SYSTEM_SECTIONS_KEY]
+        assert sections["memory"].order == 5
+
+    def test_get_returns_content(self) -> None:
+        req = _make_request()
+        req = set_system_section(req, "skills", "Skills text")
+        assert get_system_section(req, "skills") == "Skills text"
+
+    def test_get_returns_none_when_absent(self) -> None:
+        req = _make_request()
+        assert get_system_section(req, "memory") is None
+
+
+# ---------------------------------------------------------------------------
+# assemble_system_message
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleSystemMessage:
+    def test_returns_none_when_nothing(self) -> None:
+        result = assemble_system_message(base=None, sections={})
+        assert result is None
+
+    def test_base_only(self) -> None:
+        base = SystemMessage(content="Base prompt")
+        result = assemble_system_message(base=base, sections={})
+        assert result is not None
+        texts = [b["text"] for b in result.content_blocks if isinstance(b, dict)]  # type: ignore[index]
+        assert any("Base prompt" in t for t in texts)
+
+    def test_section_only(self) -> None:
+        sections = {"memory": SystemSection(key="memory", content="Memory stuff", order=40)}
+        result = assemble_system_message(base=None, sections=sections)
+        assert result is not None
+        texts = [b["text"] for b in result.content_blocks if isinstance(b, dict)]  # type: ignore[index]
+        assert any("Memory stuff" in t for t in texts)
+
+    def test_sections_sorted_by_order(self) -> None:
+        sections = {
+            "memory": SystemSection(key="memory", content="MEMORY", order=40),
+            "filesystem": SystemSection(key="filesystem", content="FILESYSTEM", order=10),
+            "skills": SystemSection(key="skills", content="SKILLS", order=30),
+        }
+        result = assemble_system_message(base=None, sections=sections)
+        assert result is not None
+        texts = [b["text"] for b in result.content_blocks if isinstance(b, dict)]  # type: ignore[index]
+        combined = "\n".join(texts)
+        assert combined.index("FILESYSTEM") < combined.index("SKILLS") < combined.index("MEMORY")
+
+    def test_sections_after_base(self) -> None:
+        base = SystemMessage(content="BASE")
+        sections = {"memory": SystemSection(key="memory", content="MEMORY", order=40)}
+        result = assemble_system_message(base=base, sections=sections)
+        assert result is not None
+        texts = [b["text"] for b in result.content_blocks if isinstance(b, dict)]  # type: ignore[index]
+        combined = "\n".join(texts)
+        assert combined.index("BASE") < combined.index("MEMORY")
+
+    def test_separator_between_blocks(self) -> None:
+        base = SystemMessage(content="BASE")
+        sections = {"memory": SystemSection(key="memory", content="MEMORY", order=40)}
+        result = assemble_system_message(base=base, sections=sections)
+        assert result is not None
+        section_block = result.content_blocks[-1]
+        assert isinstance(section_block, dict)
+        assert section_block["text"].startswith("\n\n")  # type: ignore[index]
+
+    def test_empty_section_skipped(self) -> None:
+        sections = {
+            "memory": SystemSection(key="memory", content="", order=40),
+            "skills": SystemSection(key="skills", content="SKILLS", order=30),
+        }
+        result = assemble_system_message(base=None, sections=sections)
+        assert result is not None
+        assert len(result.content_blocks) == 1
+
+    def test_cache_control_not_added_for_non_anthropic(self) -> None:
+        sections = {"memory": SystemSection(key="memory", content="MEMORY", cache_control=True, order=40)}
+        result = assemble_system_message(base=None, sections=sections, model=_make_model())
+        assert result is not None
+        block = result.content_blocks[-1]
+        assert isinstance(block, dict)
+        assert "cache_control" not in block
+
+    def test_no_cache_control_when_flag_false(self) -> None:
+        sections = {"memory": SystemSection(key="memory", content="MEMORY", cache_control=False, order=40)}
+        result = assemble_system_message(base=None, sections=sections, model=None)
+        assert result is not None
+        block = result.content_blocks[-1]
+        assert isinstance(block, dict)
+        assert "cache_control" not in block
+
+
+# ---------------------------------------------------------------------------
+# SystemPromptAssemblerMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptAssemblerMiddleware:
+    def _middleware(self) -> SystemPromptAssemblerMiddleware:
+        return SystemPromptAssemblerMiddleware()
+
+    def test_passthrough_when_no_sections(self) -> None:
+        mw = self._middleware()
+        req = _make_request(system_message=SystemMessage(content="Base"))
+        captured: list[ModelRequest[Any]] = []
+        mw.wrap_model_call(req, _fake_handler(captured))
+
+        passed = captured[0]
+        # system_message unchanged when no sections are present
+        assert passed.system_message is not None
+        assert _SYSTEM_SECTIONS_KEY not in passed.model_settings
+        assert _BASE_SYSTEM_MESSAGE_KEY not in passed.model_settings
+
+    def test_assembles_sections_into_system_message(self) -> None:
+        mw = self._middleware()
+        req = _make_request()
+        req = set_system_section(req, "filesystem", "FS content")
+        req = set_system_section(req, "memory", "Memory content")
+
+        captured: list[ModelRequest[Any]] = []
+        mw.wrap_model_call(req, _fake_handler(captured))
+
+        passed = captured[0]
+        assert passed.system_message is not None
+        full_text = " ".join(
+            b["text"]  # type: ignore[index]
+            for b in passed.system_message.content_blocks
+            if isinstance(b, dict)
+        )
+        assert "FS content" in full_text
+        assert "Memory content" in full_text
+
+    def test_uses_saved_base_for_ordering(self) -> None:
+        """Assembler rebuilds from original base, not the direct-appended system_message."""
+        mw = self._middleware()
+        req = _make_request()
+        # Set memory first (order=40), then filesystem (order=10) — registration order reversed.
+        req = set_system_section(req, "memory", "MEMORY")
+        req = set_system_section(req, "filesystem", "FILESYSTEM")
+
+        captured: list[ModelRequest[Any]] = []
+        mw.wrap_model_call(req, _fake_handler(captured))
+
+        passed = captured[0]
+        texts = [b["text"] for b in passed.system_message.content_blocks if isinstance(b, dict)]  # type: ignore[index, union-attr]
+        combined = "\n".join(texts)
+        # filesystem (order=10) should come before memory (order=40)
+        assert combined.index("FILESYSTEM") < combined.index("MEMORY")
+
+    def test_strips_sections_key_from_model_settings(self) -> None:
+        mw = self._middleware()
+        req = _make_request(model_settings={"other": "value"})
+        req = set_system_section(req, "skills", "Skills text")
+
+        captured: list[ModelRequest[Any]] = []
+        mw.wrap_model_call(req, _fake_handler(captured))
+
+        passed = captured[0]
+        assert _SYSTEM_SECTIONS_KEY not in passed.model_settings
+        assert passed.model_settings.get("other") == "value"
+
+    def test_preserves_base_system_message(self) -> None:
+        mw = self._middleware()
+        base = SystemMessage(content="User base prompt")
+        req = _make_request(system_message=base)
+        req = set_system_section(req, "memory", "Memory")
+
+        captured: list[ModelRequest[Any]] = []
+        mw.wrap_model_call(req, _fake_handler(captured))
+
+        passed = captured[0]
+        full_text = " ".join(
+            b["text"]  # type: ignore[index]
+            for b in passed.system_message.content_blocks  # type: ignore[union-attr]
+            if isinstance(b, dict)
+        )
+        assert "User base prompt" in full_text
+        assert "Memory" in full_text
+
+    @pytest.mark.asyncio
+    async def test_async_assembles_sections(self) -> None:
+        mw = self._middleware()
+        req = _make_request()
+        req = set_system_section(req, "filesystem", "FS async content")
+
+        captured: list[ModelRequest[Any]] = []
+
+        async def async_handler(r: ModelRequest[Any]) -> ModelResponse[Any]:
+            captured.append(r)
+            return ModelResponse(result=[AIMessage(content="ok")])
+
+        await mw.awrap_model_call(req, async_handler)
+
+        passed = captured[0]
+        assert _SYSTEM_SECTIONS_KEY not in passed.model_settings
+        assert passed.system_message is not None
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: append_to_system_message deprecation
+# ---------------------------------------------------------------------------
+
+
+class TestAppendToSystemMessageDeprecation:
+    def test_emits_deprecation_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = append_to_system_message(None, "some text")
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        assert result.content_blocks[-1]["text"] == "some text"  # type: ignore[index]
+
+    def test_still_works_with_existing_content(self) -> None:
+        existing = SystemMessage(content="Existing")
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = append_to_system_message(existing, "Appended")
+        texts = [b["text"] for b in result.content_blocks if isinstance(b, dict)]  # type: ignore[index]
+        assert any("Existing" in t for t in texts)
+        assert any("Appended" in t for t in texts)

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -57,53 +57,6 @@ Writing todos takes time and tokens, use it when it is helpful for managing comp
 - Don't be afraid to revise the To-Do list as you go. New information may reveal new tasks that need to be done, or old tasks that are irrelevant.
 
 
-
-
-## Skills System
-
-You have access to a skills library that provides specialized capabilities and domain knowledge.
-
-**User Skills**: `/skills/user/`
-**Project Skills**: `/skills/project/` (higher priority)
-
-**Available Skills:**
-
-- **web-research**: Structured approach to conducting thorough web research on any topic
-  -> Read `/skills/user/web-research/SKILL.md` for full instructions
-- **code-review**: Systematic code review process following best practices and style guides
-  -> Read `/skills/project/code-review/SKILL.md` for full instructions
-
-**How to Use Skills (Progressive Disclosure):**
-
-Skills follow a **progressive disclosure** pattern - you see their name and description above, but only read full instructions when needed:
-
-1. **Recognize when a skill applies**: Check if the user's task matches a skill's description
-2. **Read the skill's full instructions**: Use `read_file` on the path shown in the skill list above.
-   Pass `limit=1000` since the default of 100 lines is too small for most skill files.
-3. **Follow the skill's instructions**: SKILL.md contains step-by-step workflows, best practices, and examples
-4. **Access supporting files**: Skills may include helper scripts, configs, or reference docs - use absolute paths
-
-**When to Use Skills:**
-- User's request matches a skill's domain (e.g., "research X" -> web-research skill)
-- You need specialized knowledge or structured workflows
-- A skill provides proven patterns for complex tasks
-
-**Executing Skill Scripts:**
-Skills may contain Python scripts or other executable files. Always use absolute paths from the skill list.
-
-**Example Workflow:**
-
-User: "Can you research the latest developments in quantum computing?"
-
-1. Check available skills -> See "web-research" skill with its path
-2. Read the full skill file: `read_file(path, limit=1000)`
-3. Follow the skill's research workflow (search -> organize -> synthesize)
-4. Use any helper scripts with absolute paths
-
-Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!
-
-
-
 ## Following Conventions
 
 - Read files before editing — understand existing content before making changes
@@ -156,6 +109,53 @@ When NOT to use the task tool:
 
 Available subagent types:
 - general-purpose: General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. This agent has access to all tools as the main agent.
+
+
+
+
+## Skills System
+
+You have access to a skills library that provides specialized capabilities and domain knowledge.
+
+**User Skills**: `/skills/user/`
+**Project Skills**: `/skills/project/` (higher priority)
+
+**Available Skills:**
+
+- **web-research**: Structured approach to conducting thorough web research on any topic
+  -> Read `/skills/user/web-research/SKILL.md` for full instructions
+- **code-review**: Systematic code review process following best practices and style guides
+  -> Read `/skills/project/code-review/SKILL.md` for full instructions
+
+**How to Use Skills (Progressive Disclosure):**
+
+Skills follow a **progressive disclosure** pattern - you see their name and description above, but only read full instructions when needed:
+
+1. **Recognize when a skill applies**: Check if the user's task matches a skill's description
+2. **Read the skill's full instructions**: Use `read_file` on the path shown in the skill list above.
+   Pass `limit=1000` since the default of 100 lines is too small for most skill files.
+3. **Follow the skill's instructions**: SKILL.md contains step-by-step workflows, best practices, and examples
+4. **Access supporting files**: Skills may include helper scripts, configs, or reference docs - use absolute paths
+
+**When to Use Skills:**
+- User's request matches a skill's domain (e.g., "research X" -> web-research skill)
+- You need specialized knowledge or structured workflows
+- A skill provides proven patterns for complex tasks
+
+**Executing Skill Scripts:**
+Skills may contain Python scripts or other executable files. Always use absolute paths from the skill list.
+
+**Example Workflow:**
+
+User: "Can you research the latest developments in quantum computing?"
+
+1. Check available skills -> See "web-research" skill with its path
+2. Read the full skill file: `read_file(path, limit=1000)`
+3. Follow the skill's research workflow (search -> organize -> synthesize)
+4. Use any helper scripts with absolute paths
+
+Remember: Skills make you more capable and consistent. When in doubt, check if a skill exists for the task!
+
 
 
 <agent_memory>


### PR DESCRIPTION
## Summary

- Introduces `SystemSection` dataclass and `set_system_section(request, key, content)` API in `_utils.py` — middleware now declare named sections instead of appending to a shared buffer
- Adds `SystemPromptAssemblerMiddleware` (new innermost tail middleware in `graph.py`) that reads sections from `request.model_settings`, assembles them in deterministic priority order (`BUILTIN_SECTION_ORDER`), and strips the internal key before the model call
- Migrates all 7 call sites: `memory.py`, `skills.py`, `filesystem.py` (sync+async), `subagents.py` (sync+async), `async_subagents.py` (sync+async)
- Removes the fragile "patch the last content block" cache_control hack from `memory.py`; the assembler handles it centrally
- Backward-compatible: `set_system_section` also appends directly to `request.system_message` so middleware works with vanilla `create_agent` (without the assembler in the stack); `append_to_system_message` is deprecated but still functional
- Exports `SystemSection`, `set_system_section`, `get_system_section`, `BUILTIN_SECTION_ORDER` from `middleware/__init__.py`

## What this fixes

From the middleware design review: "Replace the system-prompt append-buffer with named, addressable sections" was identified as the highest-value single change. A surprising fraction of design limitations traced back to 'everyone scribbles into the same string in registration order':
- Section ordering was implicit (registration order), not declarative
- No section could replace another's content; only append
- `cache_control` placement was a manual hack — reached into "the last block", fragile under ordering changes
- No way for one middleware to read or modify another's section

## Test plan

- [ ] 26 new unit tests in `tests/unit_tests/middleware/test_system_prompt_sections.py` cover `set_system_section`, `get_system_section`, `assemble_system_message`, `SystemPromptAssemblerMiddleware` (sync + async), backward-compat deprecation warning
- [ ] Full unit test suite: 1521 passed, 84 skipped, 4 xfailed
- [ ] Smoke-test snapshots updated to reflect new canonical section ordering (filesystem → subagents → skills → memory)
- [ ] Existing memory middleware tests verify cache_control still applied correctly for Anthropic models

🤖 Generated with [Claude Code](https://claude.com/claude-code)