### PR TITLE
feat(cli): add incognito shell mode

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -396,7 +396,7 @@ def _format_model_params(extra_kwargs: dict[str, Any] | None) -> str:
     return f" with model params {json.dumps(extra_kwargs, sort_keys=True)}"
 
 
-InputMode = Literal["normal", "shell", "command"]
+InputMode = Literal["normal", "shell", "shell_incognito", "command"]
 
 _TYPING_IDLE_THRESHOLD_SECONDS: float = 2.0
 """Seconds since the last keystroke after which the user is considered idle and
@@ -3287,7 +3287,9 @@ class DeepAgentsApp(App):
             value: The message text to process.
             mode: The input mode that determines message routing.
         """
-        if mode == "shell":
+        if mode == "shell_incognito":
+            await self._handle_shell_command(value.removeprefix("!!"), incognito=True)
+        elif mode == "shell":
             await self._handle_shell_command(value.removeprefix("!"))
         elif mode == "command":
             await self._handle_command(value)
@@ -3962,7 +3964,12 @@ class DeepAgentsApp(App):
         if self._chat_input:
             self.call_after_refresh(self._chat_input.focus_input)
 
-    async def _handle_shell_command(self, command: str) -> None:
+    async def _handle_shell_command(
+        self,
+        command: str,
+        *,
+        incognito: bool = False,
+    ) -> None:
         """Handle a shell command (! prefix).
 
         Thin dispatcher that mounts the user message and spawns a worker
@@ -3970,19 +3977,30 @@ class DeepAgentsApp(App):
 
         Args:
             command: The shell command to execute.
+            incognito: Whether the command/output should remain local-only.
         """
-        await self._mount_message(UserMessage(f"!{command}"))
+        if incognito:
+            await self._mount_message(
+                AppMessage(
+                    Content.from_markup(
+                        "Running incognito shell command: $cmd",
+                        cmd=command,
+                    )
+                )
+            )
+        else:
+            await self._mount_message(UserMessage(f"!{command}"))
         self._shell_running = True
 
         if self._chat_input:
             self._chat_input.set_cursor_active(active=False)
 
         self._shell_worker = self.run_worker(
-            self._run_shell_task(command),
+            self._run_shell_task(command, incognito=incognito),
             exclusive=False,
         )
 
-    async def _run_shell_task(self, command: str) -> None:
+    async def _run_shell_task(self, command: str, *, incognito: bool = False) -> None:
         """Run a shell command in a background worker.
 
         This mirrors `_run_agent_task`: running in a worker keeps the event
@@ -3991,6 +4009,7 @@ class DeepAgentsApp(App):
 
         Args:
             command: The shell command to execute.
+            incognito: Whether the command/output should remain local-only.
 
         Raises:
             CancelledError: If the command is interrupted by the user.
@@ -4029,9 +4048,14 @@ class DeepAgentsApp(App):
                 output += f"\n[stderr]\n{stderr_text}"
 
             if output:
-                msg = AssistantMessage(f"```\n{output}\n```")
-                await self._mount_message(msg)
-                await msg.write_initial_content()
+                if incognito:
+                    await self._mount_message(
+                        AppMessage(f"```\n{output}\n```", markdown=True)
+                    )
+                else:
+                    msg = AssistantMessage(f"```\n{output}\n```")
+                    await self._mount_message(msg)
+                    await msg.write_initial_content()
             else:
                 await self._mount_message(AppMessage("Command completed (no output)"))
 
@@ -4300,7 +4324,9 @@ class DeepAgentsApp(App):
                 "  Shift+Tab       Toggle auto-approve mode\n"
                 "  @filename       Auto-complete files and inject content\n"
                 "  /command        Slash commands (/help, /clear, /quit)\n"
-                "  !command        Run shell commands directly\n\n"
+                "  !command        Run shell commands directly\n"
+                "  !!command       Run shell commands locally without adding "
+                "command/output to model context\n\n"
                 "Docs: "
             )
             help_text = Content.assemble(

--- a/libs/cli/deepagents_cli/app.tcss
+++ b/libs/cli/deepagents_cli/app.tcss
@@ -152,6 +152,10 @@ UserMessage.-mode-shell {
     border-left: wide $mode-bash;
 }
 
+UserMessage.-mode-shell-incognito {
+    border-left: wide $warning;
+}
+
 UserMessage.-mode-command {
     border-left: wide $mode-command;
 }
@@ -163,6 +167,10 @@ UserMessage.-ascii {
 
 UserMessage.-ascii.-mode-shell {
     border-left: ascii $mode-bash;
+}
+
+UserMessage.-ascii.-mode-shell-incognito {
+    border-left: ascii $warning;
 }
 
 UserMessage.-ascii.-mode-command {

--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -245,12 +245,14 @@ if TYPE_CHECKING:
     console: Console
 
 MODE_PREFIXES: dict[str, str] = {
+    "shell_incognito": "!!",
     "shell": "!",
     "command": "/",
 }
 """Maps each non-normal mode to its trigger character."""
 
 MODE_DISPLAY_GLYPHS: dict[str, str] = {
+    "shell_incognito": "$",
     "shell": "$",
     "command": "/",
 }
@@ -267,6 +269,26 @@ if MODE_PREFIXES.keys() != MODE_DISPLAY_GLYPHS.keys():
 
 PREFIX_TO_MODE: dict[str, str] = {v: k for k, v in MODE_PREFIXES.items()}
 """Reverse lookup: trigger character -> mode name."""
+
+
+def detect_mode_prefix(text: str) -> tuple[str, str] | None:
+    """Return the longest mode prefix and mode for `text`, if any.
+
+    Args:
+        text: Input text that may start with a mode trigger.
+
+    Returns:
+        Tuple of `(prefix, mode)` for the longest matching trigger, otherwise
+        `None`.
+    """
+    for mode, prefix in sorted(
+        MODE_PREFIXES.items(),
+        key=lambda item: len(item[1]),
+        reverse=True,
+    ):
+        if text.startswith(prefix):
+            return prefix, mode
+    return None
 
 
 class CharsetMode(StrEnum):

--- a/libs/cli/deepagents_cli/widgets/chat_input.py
+++ b/libs/cli/deepagents_cli/widgets/chat_input.py
@@ -26,7 +26,7 @@ from deepagents_cli.command_registry import SLASH_COMMANDS, CommandEntry
 from deepagents_cli.config import (
     MODE_DISPLAY_GLYPHS,
     MODE_PREFIXES,
-    PREFIX_TO_MODE,
+    detect_mode_prefix,
     is_ascii_mode,
 )
 from deepagents_cli.input import IMAGE_PLACEHOLDER_PATTERN, VIDEO_PLACEHOLDER_PATTERN
@@ -1003,6 +1003,10 @@ class ChatInput(Vertical):
         border: solid $mode-command;
     }
 
+    ChatInput.mode-shell-incognito {
+        border: solid $warning;
+    }
+
     ChatInput .input-row {
         height: auto;
         width: 100%;
@@ -1022,6 +1026,23 @@ class ChatInput(Vertical):
 
     ChatInput.mode-command .input-prompt {
         color: $mode-command;
+    }
+
+    ChatInput.mode-shell-incognito .input-prompt {
+        color: $warning;
+    }
+
+    ChatInput .input-mode-label {
+        display: none;
+        height: 1;
+        width: auto;
+        padding: 0 1;
+        color: $warning;
+        text-style: bold;
+    }
+
+    ChatInput.mode-shell-incognito .input-mode-label {
+        display: block;
     }
 
     ChatInput ChatTextArea {
@@ -1134,6 +1155,7 @@ class ChatInput(Vertical):
         """
         with Horizontal(classes="input-row"):
             yield Static(">", classes="input-prompt", id="prompt")
+            yield Static("", classes="input-mode-label", id="mode-label")
             yield ChatTextArea(id="chat-input")
 
         yield CompletionPopup(id="completion-popup")
@@ -1257,8 +1279,9 @@ class ChatInput(Vertical):
         # a prefix character.
         if self._stripping_prefix:
             self._stripping_prefix = False
-        elif text and text[0] in PREFIX_TO_MODE:
-            if text[0] == "/" and is_path_payload:
+        elif detected_prefix := detect_mode_prefix(text):
+            prefix, detected = detected_prefix
+            if prefix == "/" and is_path_payload:
                 # Absolute dropped paths stay normal input, not slash-command mode.
                 if self.mode != "normal":
                     self.mode = "normal"
@@ -1269,10 +1292,9 @@ class ChatInput(Vertical):
                 # text that re-includes the trigger character.  The
                 # _stripping_prefix guard prevents the resulting change event
                 # from looping back here.
-                detected = PREFIX_TO_MODE[text[0]]
                 if self.mode != detected:
                     self.mode = detected
-                self._strip_mode_prefix()
+                self._strip_mode_prefix(len(prefix))
                 # Fall through to update completion suggestions in the same
                 # refresh cycle as the mode/glyph change rather than waiting
                 # for the next text-change event caused by the prefix strip.
@@ -1397,11 +1419,14 @@ class ChatInput(Vertical):
             return self._is_existing_path_payload(candidate)
         return False
 
-    def _strip_mode_prefix(self) -> None:
-        """Remove the first character (mode trigger) from the text area.
+    def _strip_mode_prefix(self, length: int = 1) -> None:
+        """Remove the mode trigger from the text area.
 
         Sets the `_stripping_prefix` guard so the resulting text-change event is
         not misinterpreted as new input.
+
+        Args:
+            length: Number of leading trigger characters to remove.
         """
         if not self._text_area:
             return
@@ -1415,9 +1440,9 @@ class ChatInput(Vertical):
             return
         row, col = self._text_area.cursor_location
         self._stripping_prefix = True
-        self._text_area.text = text[1:]
+        self._text_area.text = text[length:]
         if row == 0 and col > 0:
-            col -= 1
+            col = max(0, col - length)
         self._text_area.move_cursor((row, col))
 
     def _completion_text_and_cursor(self) -> tuple[str, int]:
@@ -1783,10 +1808,9 @@ class ChatInput(Vertical):
             Tuple of `(mode, display_text)` where mode-trigger prefixes are
                 removed from `display_text`.
         """
-        for prefix, mode in PREFIX_TO_MODE.items():
-            # Small dict; loop is fine. No need to over-engineer right now
-            if entry.startswith(prefix):
-                return mode, entry[len(prefix) :]
+        if mode_match := detect_mode_prefix(entry):
+            prefix, mode = mode_match
+            return mode, entry[len(prefix) :]
         return "normal", entry
 
     async def on_key(self, event: events.Key) -> None:
@@ -1881,15 +1905,25 @@ class ChatInput(Vertical):
             )
 
         def _apply() -> None:
-            self.remove_class("mode-shell", "mode-command")
+            self.remove_class("mode-shell", "mode-command", "mode-shell-incognito")
             if glyph:
-                self.add_class(f"mode-{mode}")
+                class_name = (
+                    "mode-shell-incognito"
+                    if mode == "shell_incognito"
+                    else f"mode-{mode}"
+                )
+                self.add_class(class_name)
             try:
                 prompt = self.query_one("#prompt", Static)
+                mode_label = self.query_one("#mode-label", Static)
             except NoMatches:
-                logger.warning("watch_mode._apply: #prompt widget not found")
+                logger.warning("watch_mode._apply: prompt widgets not found")
                 return
             prompt.update(glyph or ">")
+            if mode == "shell_incognito":
+                mode_label.update("Shell (incognito)")
+            else:
+                mode_label.update("")
 
         self.call_after_refresh(_apply)
         self.post_message(self.ModeChanged(mode))

--- a/libs/cli/deepagents_cli/widgets/messages.py
+++ b/libs/cli/deepagents_cli/widgets/messages.py
@@ -21,7 +21,7 @@ from textual.widgets import Static
 from deepagents_cli import theme
 from deepagents_cli.config import (
     MODE_DISPLAY_GLYPHS,
-    PREFIX_TO_MODE,
+    detect_mode_prefix,
     get_glyphs,
     is_ascii_mode,
 )
@@ -96,6 +96,8 @@ def _mode_color(mode: str | None, widget_or_app: object | None = None) -> str:
     colors = theme.get_theme_colors(widget_or_app)
     if not mode:
         return colors.primary
+    if mode == "shell_incognito":
+        return colors.warning
     if mode == "shell":
         return colors.mode_bash
     if mode == "command":
@@ -188,9 +190,10 @@ class UserMessage(_TimestampClickMixin, Static):
 
     def on_mount(self) -> None:
         """Add CSS classes for mode-specific border and ASCII border type."""
-        mode = PREFIX_TO_MODE.get(self._content[:1]) if self._content else None
-        if mode:
-            self.add_class(f"-mode-{mode}")
+        mode_match = detect_mode_prefix(self._content)
+        if mode_match:
+            _prefix, mode = mode_match
+            self.add_class(f"-mode-{mode.replace('_', '-')}")
         if is_ascii_mode():
             self.add_class("-ascii")
 
@@ -207,11 +210,12 @@ class UserMessage(_TimestampClickMixin, Static):
         # Use mode-specific prefix indicator when content starts with a
         # mode trigger character (e.g. "!" for shell, "/" for commands).
         # The display glyph may differ from the trigger (e.g. "$" for shell).
-        mode = PREFIX_TO_MODE.get(content[:1]) if content else None
-        if mode:
-            glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
+        mode_match = detect_mode_prefix(content)
+        if mode_match:
+            prefix_text, mode = mode_match
+            glyph = MODE_DISPLAY_GLYPHS.get(mode, prefix_text[0])
             parts.append((f"{glyph} ", f"bold {_mode_color(mode, self)}"))
-            content = content[1:]
+            content = content[len(prefix_text) :]
         else:
             parts.append(("> ", f"bold {colors.primary}"))
 
@@ -288,11 +292,12 @@ class QueuedUserMessage(Static):
         """
         colors = theme.get_theme_colors(self)
         content = self._content
-        mode = PREFIX_TO_MODE.get(content[:1]) if content else None
-        if mode:
-            glyph = MODE_DISPLAY_GLYPHS.get(mode, content[0])
+        mode_match = detect_mode_prefix(content)
+        if mode_match:
+            prefix_text, mode = mode_match
+            glyph = MODE_DISPLAY_GLYPHS.get(mode, prefix_text[0])
             prefix = (f"{glyph} ", f"bold {colors.muted}")
-            content = content[1:]
+            content = content[len(prefix_text) :]
         else:
             prefix = ("> ", f"bold {colors.muted}")
         return Content.assemble(prefix, (content, colors.muted))

--- a/libs/cli/deepagents_cli/widgets/status.py
+++ b/libs/cli/deepagents_cli/widgets/status.py
@@ -124,6 +124,12 @@ class StatusBar(Horizontal):
         color: white;
     }
 
+    StatusBar .status-mode.shell-incognito {
+        background: $warning;
+        color: $background;
+        text-style: bold;
+    }
+
     StatusBar .status-auto-approve {
         width: auto;
         padding: 0 1;
@@ -270,11 +276,14 @@ class StatusBar(Horizontal):
             indicator = self.query_one("#mode-indicator", Static)
         except NoMatches:
             return
-        indicator.remove_class("normal", "shell", "command")
+        indicator.remove_class("normal", "shell", "command", "shell-incognito")
 
         if mode == "shell":
             indicator.update("SHELL")
             indicator.add_class("shell")
+        elif mode == "shell_incognito":
+            indicator.update("INCOG")
+            indicator.add_class("shell-incognito")
         elif mode == "command":
             indicator.update("CMD")
             indicator.add_class("command")

--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -53,6 +53,7 @@ _TIPS: dict[str, int] = {
     "Use /agents to browse and switch between your available agents": 2,
     "In /agents, press Ctrl+S to set the highlighted agent as your default": 1,
     "Use --startup-cmd to run a shell command before the first prompt": 1,
+    "Use !! for incognito shell commands that stay out of model context": 1,
     "Run `deepagents mcp login <server>` to authorize a remote MCP server": 1,
     "Deep Agents can explain its own features and look up its docs. Ask it how to use.": 3,  # noqa: E501
 }

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -1838,6 +1838,28 @@ class TestMessageQueue:
             assert len(widgets) == 1
             assert len(app._queued_widgets) == 1
 
+    async def test_queued_incognito_shell_preserves_mode_on_drain(self) -> None:
+        """Queued incognito shell commands should drain as incognito shell."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            app.post_message(ChatInput.Submitted("!!echo hidden", "shell_incognito"))
+            await pilot.pause()
+
+            assert len(app._pending_messages) == 1
+            assert app._pending_messages[0].text == "!!echo hidden"
+            assert app._pending_messages[0].mode == "shell_incognito"
+
+            handler = AsyncMock()
+            app._handle_shell_command = handler  # type: ignore[method-assign]
+            app._agent_running = False
+
+            await app._process_next_from_queue()
+
+            handler.assert_awaited_once_with("echo hidden", incognito=True)
+
     async def test_immediate_processing_when_agent_idle(self) -> None:
         """Messages should process immediately when agent is not running."""
         app = DeepAgentsApp()
@@ -3101,6 +3123,40 @@ class TestShellCommandInterrupt:
             error_msgs = app.query(ErrorMessage)
             assert any("timed out" in w._content for w in error_msgs)
 
+    async def test_incognito_timeout_feedback_is_not_model_visible(self) -> None:
+        """Incognito timeout feedback should stay out of user/assistant records."""
+        from deepagents_cli.widgets.message_store import MessageType
+
+        app = DeepAgentsApp()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        mock_proc.wait = AsyncMock()
+        mock_proc.terminate = MagicMock()
+        mock_proc.kill = MagicMock()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with patch(
+                "asyncio.create_subprocess_shell",
+                return_value=mock_proc,
+            ):
+                await app._run_shell_task("echo secret", incognito=True)
+                await pilot.pause()
+
+            messages = app._message_store.get_all_messages()
+            assert any(
+                msg.type == MessageType.ERROR and "timed out" in msg.content
+                for msg in messages
+            )
+            assert not any(
+                msg.type in {MessageType.USER, MessageType.ASSISTANT}
+                and "secret" in msg.content
+                for msg in messages
+            )
+
     async def test_posix_killpg_called(self) -> None:
         """On POSIX, _kill_shell_process should use os.killpg with SIGTERM."""
         app = DeepAgentsApp()
@@ -3194,6 +3250,85 @@ class TestShellCommandInterrupt:
             # Close the unawaited coroutine to suppress RuntimeWarning
             coro = mock_rw.call_args[0][0]
             coro.close()
+
+    async def test_process_message_routes_incognito_shell_command(self) -> None:
+        """`shell_incognito` mode should strip `!!` and mark the shell run."""
+        app = DeepAgentsApp()
+        handler = AsyncMock()
+        app._handle_shell_command = handler  # type: ignore[method-assign]
+
+        await app._process_message("!!echo secret", "shell_incognito")
+
+        handler.assert_awaited_once_with("echo secret", incognito=True)
+
+    async def test_incognito_shell_command_header_is_app_message(self) -> None:
+        """Incognito shell commands should not be stored as user messages."""
+        from deepagents_cli.widgets.message_store import MessageType
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with patch.object(app, "run_worker") as mock_rw:
+                mock_rw.return_value = MagicMock()
+                await app._handle_shell_command("echo secret", incognito=True)
+
+            messages = app._message_store.get_all_messages()
+            assert any(
+                msg.type == MessageType.APP
+                and "incognito shell command" in msg.content
+                and "echo secret" in msg.content
+                for msg in messages
+            )
+            assert not any(
+                msg.type == MessageType.USER and "echo secret" in msg.content
+                for msg in messages
+            )
+
+            # Close the unawaited coroutine to suppress RuntimeWarning.
+            coro = mock_rw.call_args[0][0]
+            coro.close()
+
+    async def test_incognito_shell_output_is_app_message(self) -> None:
+        """Incognito shell output should avoid assistant transcript records."""
+        from deepagents_cli.widgets.message_store import MessageType
+
+        app = DeepAgentsApp()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"secret\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._schedule_git_branch_refresh = MagicMock()  # type: ignore[assignment]
+            app._maybe_drain_deferred = AsyncMock()  # type: ignore[assignment]
+            app._process_next_from_queue = AsyncMock()  # type: ignore[assignment]
+
+            with (
+                patch(
+                    "asyncio.create_subprocess_shell",
+                    return_value=mock_proc,
+                ),
+                patch(
+                    "deepagents_cli.app.AssistantMessage.write_initial_content",
+                    new=AsyncMock(),
+                ) as write_mock,
+            ):
+                await app._run_shell_task("echo secret", incognito=True)
+                await pilot.pause()
+
+        messages = app._message_store.get_all_messages()
+        assert any(
+            msg.type == MessageType.APP and "secret" in msg.content for msg in messages
+        )
+        assert not any(
+            msg.type in {MessageType.USER, MessageType.ASSISTANT}
+            and "secret" in msg.content
+            for msg in messages
+        )
+        write_mock.assert_not_awaited()
 
     async def test_kill_noop_when_already_exited(self) -> None:
         """_kill_shell_process should no-op if process already exited."""

--- a/libs/cli/tests/unit_tests/test_chat_input.py
+++ b/libs/cli/tests/unit_tests/test_chat_input.py
@@ -312,6 +312,21 @@ class TestPromptIndicator:
             assert _prompt_text(prompt) == "$"
             assert chat_input.has_class("mode-shell")
 
+    async def test_prompt_shows_shell_style_in_incognito_shell_mode(self) -> None:
+        """Mode 'shell_incognito' should show an explicit incognito cue."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            prompt = chat_input.query_one("#prompt", Static)
+            mode_label = chat_input.query_one("#mode-label", Static)
+
+            chat_input.mode = "shell_incognito"
+            await pilot.pause()
+
+            assert _prompt_text(prompt) == "$"
+            assert _prompt_text(mode_label) == "Shell (incognito)"
+            assert chat_input.has_class("mode-shell-incognito")
+
     async def test_prompt_shows_slash_in_command_mode(self) -> None:
         """Setting mode to 'command' should change prompt and styling."""
         app = _ChatInputTestApp()
@@ -1015,6 +1030,25 @@ class TestModePrefixStripping:
             assert app.submitted[0].value == "!ls"
             assert app.submitted[0].mode == "shell"
 
+    async def test_submission_prepends_incognito_shell_prefix(self) -> None:
+        """Submitting in incognito shell mode should preserve the `'!!'` prefix."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.text = "!!pwd"
+            await _pause_for_strip(pilot)
+            assert chat.mode == "shell_incognito"
+            assert chat._text_area.text == "pwd"
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "!!pwd"
+            assert app.submitted[0].mode == "shell_incognito"
+
     async def test_submission_prepends_command_prefix(self) -> None:
         """Submitting in command mode should prepend `'/'` to the value."""
         app = _RecordingApp()
@@ -1381,6 +1415,28 @@ class TestHistorySlashPrefixRecall:
             assert len(app.submitted) == 1
             assert app.submitted[0].value == "/help"
             assert app.submitted[0].mode == "command"
+
+    async def test_history_incognito_shell_entry_enters_incognito_mode(self) -> None:
+        """Recalling a `!!` history entry should enter incognito shell mode."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("!!pwd")
+
+            await pilot.press("up")
+            await _pause_for_strip(pilot)
+
+            assert chat.mode == "shell_incognito"
+            assert chat._text_area.text == "pwd"
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(app.submitted) == 1
+            assert app.submitted[0].value == "!!pwd"
+            assert app.submitted[0].mode == "shell_incognito"
 
 
 class TestCompletionIndexToTextIndex:

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -179,3 +179,13 @@ class TestHelpBodyDrift:
             f"Commands in /help body but missing from COMMANDS: {extra}\n"
             "Remove them from help_body or add to COMMANDS in command_registry.py."
         )
+
+    def test_help_body_describes_incognito_shell_prefix(self) -> None:
+        """The `/help` body should document local-only incognito shell mode."""
+        app_src = (
+            Path(__file__).resolve().parents[2] / "deepagents_cli" / "app.py"
+        ).read_text()
+
+        assert "!!command" in app_src
+        assert "command/output" in app_src
+        assert "model context" in app_src

--- a/libs/cli/tests/unit_tests/test_messages.py
+++ b/libs/cli/tests/unit_tests/test_messages.py
@@ -636,6 +636,13 @@ class TestUserMessageModeRendering:
         first_span = content._spans[0]
         assert theme.DARK_COLORS.mode_bash in str(first_span.style)
 
+    def test_incognito_shell_prefix_renders_dollar_indicator(self) -> None:
+        """`UserMessage('!!ls')` should strip the full incognito prefix."""
+        content = _render_content(UserMessage("!!ls"))
+        assert content.plain == "$ ls"
+        first_span = content._spans[0]
+        assert theme.DARK_COLORS.warning in str(first_span.style)
+
     def test_command_prefix_renders_slash_indicator(self) -> None:
         """`UserMessage('/help')` should render with `'/ '` prefix and body."""
         content = _render_content(UserMessage("/help"))
@@ -677,6 +684,11 @@ class TestQueuedUserMessageModeRendering:
     def test_shell_prefix_renders_dimmed_dollar(self) -> None:
         """`QueuedUserMessage('!ls')` should render dimmed `'$ '` prefix."""
         content = _render_content(QueuedUserMessage("!ls"))
+        assert content.plain == "$ ls"
+
+    def test_incognito_shell_prefix_renders_dimmed_dollar(self) -> None:
+        """`QueuedUserMessage('!!ls')` should strip the full incognito prefix."""
+        content = _render_content(QueuedUserMessage("!!ls"))
         assert content.plain == "$ ls"
 
     def test_command_prefix_renders_dimmed_slash(self) -> None:

--- a/libs/cli/tests/unit_tests/test_status.py
+++ b/libs/cli/tests/unit_tests/test_status.py
@@ -261,6 +261,22 @@ class TestTokenDisplay:
             assert "+" not in rendered
 
 
+class TestModeIndicator:
+    """Tests for the input-mode indicator in the status bar."""
+
+    async def test_incognito_shell_mode_shows_indicator(self) -> None:
+        """Incognito shell mode should not look like normal input mode."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            indicator = pilot.app.query_one("#mode-indicator")
+
+            bar.set_mode("shell_incognito")
+            await pilot.pause()
+
+            assert str(indicator.render()) == "INCOG"
+            assert indicator.has_class("shell-incognito")
+
+
 class TestModelLabelPrefixStripping:
     """Tests for provider-specific model prefix stripping in ModelLabel."""
 

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -426,6 +426,10 @@ class TestBuildWelcomeFooter:
         """New `--startup-cmd` flag must have a discoverability tip."""
         assert any("--startup-cmd" in tip for tip in _TIPS)
 
+    def test_incognito_shell_tip_registered(self) -> None:
+        """New `!!` shell mode must have a discoverability tip."""
+        assert any("!!" in tip and "incognito" in tip.lower() for tip in _TIPS)
+
     def test_tip_varies_across_calls(self) -> None:
         """Tips should rotate (not always the same)."""
         seen = {build_welcome_footer().plain for _ in range(50)}


### PR DESCRIPTION
Closes #2091

---

Adds an incognito shell mode behind `!!`.

This leaves the existing `!` shell behavior alone. Runs started with `!!` still show in the CLI, but the input and output stay out of the model-visible transcript.

The input and status UI now make the incognito mode clear, and help text mentions the new prefix.