### PR TITLE
fix(cli): only restore iTerm2 cursor guide when it was enabled at startup

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -58,6 +58,7 @@ from deepagents_cli._session_stats import (
 # after user interaction begins.
 from deepagents_cli._version import CHANGELOG_URL, DOCS_URL
 from deepagents_cli.config import is_ascii_mode
+from deepagents_cli.iterm_cursor_guide import restore_iterm_cursor_guide
 from deepagents_cli.notifications import (
     ActionId,
     MissingDepPayload,
@@ -115,73 +116,12 @@ if TYPE_CHECKING:
     from deepagents_cli.widgets.ask_user import AskUserMenu
     from deepagents_cli.widgets.notification_center import NotificationSuppressRequested
 
-# iTerm2 Cursor Guide Workaround
-# ===============================
-# iTerm2's cursor guide (highlight cursor line) causes visual artifacts when
-# Textual takes over the terminal in alternate screen mode. We disable it at
-# module load and restore on exit. Both atexit and exit() override are used
-# for defense-in-depth: atexit catches abnormal termination (SIGTERM, unhandled
-# exceptions), while exit() ensures restoration before Textual's cleanup.
-
-# Detection: check env vars AND that stderr is a TTY (avoids false positives
-# when env vars are inherited but running in non-TTY context like CI)
-_IS_ITERM = (
-    (
-        os.environ.get("LC_TERMINAL", "") == "iTerm2"
-        or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
-    )
-    and hasattr(os, "isatty")
-    and os.isatty(2)
-)
-
-# iTerm2 cursor guide escape sequences (OSC 1337)
-# Format: OSC 1337 ; HighlightCursorLine=<yes|no> ST
-# Where OSC = ESC ] (0x1b 0x5d) and ST = ESC \ (0x1b 0x5c)
-_ITERM_CURSOR_GUIDE_OFF = "\x1b]1337;HighlightCursorLine=no\x1b\\"
-_ITERM_CURSOR_GUIDE_ON = "\x1b]1337;HighlightCursorLine=yes\x1b\\"
-
 _LAUNCH_INIT_CONNECTION_TIMEOUT_SECONDS = 60.0
 """Upper bound on waiting for server readiness during onboarding model switch.
 
 Server startup is normally seconds; this ceiling exists only so a stuck
 backend cannot trap the user inside a finished onboarding modal forever.
 """
-
-
-def _write_iterm_escape(sequence: str) -> None:
-    """Write an iTerm2 escape sequence to stderr.
-
-    Silently fails if the terminal is unavailable (redirected, closed, broken
-    pipe). This is a cosmetic feature, so failures should never crash the app.
-    """
-    if not _IS_ITERM:
-        return
-    try:
-        import sys
-
-        if sys.__stderr__ is not None:
-            sys.__stderr__.write(sequence)
-            sys.__stderr__.flush()
-    except OSError:
-        # Terminal may be unavailable (redirected, closed, broken pipe)
-        pass
-
-
-# Disable cursor guide at module load (before Textual takes over)
-_write_iterm_escape(_ITERM_CURSOR_GUIDE_OFF)
-
-if _IS_ITERM:
-    import atexit
-
-    def _restore_cursor_guide() -> None:
-        """Restore iTerm2 cursor guide on exit.
-
-        Registered with atexit to ensure the cursor guide is re-enabled
-        when the CLI exits, regardless of how the exit occurs.
-        """
-        _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-
-    atexit.register(_restore_cursor_guide)
 
 
 def _load_theme_preference() -> str:
@@ -5972,11 +5912,7 @@ class DeepAgentsApp(App):
         return_code: int = 0,
         message: Any = None,  # noqa: ANN401  # Dynamic LangGraph message type
     ) -> None:
-        """Exit the app, restoring iTerm2 cursor guide if applicable.
-
-        Overrides parent to restore iTerm2's cursor guide before Textual's
-        cleanup. The atexit handler serves as a fallback for abnormal
-        termination.
+        """Exit the app after shutting down background resources.
 
         Args:
             result: Return value passed to the app runner.
@@ -6032,7 +5968,7 @@ class DeepAgentsApp(App):
             ).encode()
             _dispatch_hook_sync("session.end", payload, hooks)
 
-        _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+        restore_iterm_cursor_guide()
         super().exit(result=result, return_code=return_code, message=message)
 
     def action_toggle_auto_approve(self) -> None:

--- a/libs/cli/deepagents_cli/iterm_cursor_guide.py
+++ b/libs/cli/deepagents_cli/iterm_cursor_guide.py
@@ -1,0 +1,176 @@
+"""iTerm2 cursor guide workaround for Textual alternate-screen rendering."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# iTerm2's cursor guide (highlight cursor line) causes visual artifacts when
+# Textual takes over the terminal in alternate screen mode. We disable it at
+# module load and restore it on exit only if the active/default iTerm2 profile
+# had cursor guide enabled before launch.
+
+# Detection: check env vars AND that stderr is a TTY (avoids false positives
+# when env vars are inherited but running in non-TTY context like CI).
+_IS_ITERM = (
+    (
+        os.environ.get("LC_TERMINAL", "") == "iTerm2"
+        or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+    )
+    and hasattr(os, "isatty")
+    and os.isatty(2)
+)
+
+# iTerm2 cursor guide escape sequences (OSC 1337)
+# Format: OSC 1337 ; HighlightCursorLine=<yes|no> ST
+# Where OSC = ESC ] (0x1b 0x5d) and ST = ESC \ (0x1b 0x5c)
+_ITERM_CURSOR_GUIDE_OFF = "\x1b]1337;HighlightCursorLine=no\x1b\\"
+_ITERM_CURSOR_GUIDE_ON = "\x1b]1337;HighlightCursorLine=yes\x1b\\"
+_ITERM_PREFS_PATH = Path("~/Library/Preferences/com.googlecode.iterm2.plist")
+
+
+def _write_iterm_escape(sequence: str) -> None:
+    """Write an iTerm2 escape sequence to stderr.
+
+    Silently fails if the terminal is unavailable (redirected, closed, broken
+    pipe). This is a cosmetic feature, so failures should never crash the app.
+    """
+    if not _IS_ITERM:
+        return
+    try:
+        import sys
+
+        if sys.__stderr__ is not None:
+            sys.__stderr__.write(sequence)
+            sys.__stderr__.flush()
+    except OSError:
+        # Terminal may be unavailable (redirected, closed, broken pipe).
+        pass
+
+
+def _plist_bool(value: object) -> bool | None:
+    """Return a plist boolean/int value as `bool`, or `None` if not boolean-like."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    return None
+
+
+def _profile_uses_cursor_guide(profile: dict[str, object]) -> bool:
+    """Return whether an iTerm2 profile has cursor guide enabled."""
+    enabled = _plist_bool(profile.get("Use Cursor Guide"))
+    if enabled is not None:
+        return enabled
+
+    # Newer iTerm2 profiles may carry separate light/dark values. If the shared
+    # value is absent, restoring when either variant is enabled preserves the
+    # user's visible default better than losing the guide for both appearances.
+    return any(
+        _plist_bool(profile.get(key)) is True
+        for key in ("Use Cursor Guide (Dark)", "Use Cursor Guide (Light)")
+    )
+
+
+def _coerce_profile(raw: object) -> dict[str, object] | None:
+    """Return a string-keyed profile dictionary from raw plist data."""
+    if not isinstance(raw, dict):
+        return None
+    return {key: value for key, value in raw.items() if isinstance(key, str)}
+
+
+def _find_iterm_profile(
+    profiles: list[object], *, name: str, guid: str
+) -> dict[str, object] | None:
+    """Find the current iTerm2 profile by name, then by default profile GUID.
+
+    Args:
+        profiles: Profile entries from iTerm2 preferences.
+        name: Active profile name from `ITERM_PROFILE`.
+        guid: Default profile GUID from iTerm2 preferences.
+
+    Returns:
+        The matching profile dictionary, or `None` when no match is found.
+    """
+    for raw in profiles:
+        profile = _coerce_profile(raw)
+        if profile is None:
+            continue
+        if profile.get("Name") == name:
+            return profile
+    for raw in profiles:
+        profile = _coerce_profile(raw)
+        if profile is None:
+            continue
+        if profile.get("Guid") == guid:
+            return profile
+    return None
+
+
+def _iterm_profile_cursor_guide_enabled() -> bool:
+    """Infer whether iTerm2 cursor guide was enabled before CLI startup.
+
+    iTerm2's OSC 1337 `HighlightCursorLine` command can set the guide to yes/no
+    but does not report the current state. The best cheap signal available at
+    startup is the active profile preference, exposed in the iTerm2 plist. The
+    `ITERM_PROFILE` environment variable is set by iTerm2; when it is missing,
+    fall back to the default profile GUID in preferences.
+
+    Returns:
+        `True` if the matched iTerm2 profile has cursor guide enabled.
+    """
+    if not _IS_ITERM:
+        return False
+
+    import plistlib
+
+    try:
+        with _ITERM_PREFS_PATH.expanduser().open("rb") as f:
+            prefs = plistlib.load(f)
+    except (OSError, plistlib.InvalidFileException, ValueError):
+        return False
+
+    if not isinstance(prefs, dict):
+        return False
+
+    profiles = prefs.get("New Bookmarks")
+    if not isinstance(profiles, list):
+        return False
+
+    name = os.environ.get("ITERM_PROFILE", "").strip()
+    guid = str(prefs.get("Default Bookmark Guid", ""))
+    profile = _find_iterm_profile(profiles, name=name, guid=guid)
+    if profile is None:
+        return False
+    return _profile_uses_cursor_guide(profile)
+
+
+_RESTORE_ITERM_CURSOR_GUIDE = _iterm_profile_cursor_guide_enabled()
+_ITERM_CURSOR_GUIDE_RESTORED = False
+
+
+def restore_iterm_cursor_guide() -> None:
+    """Restore iTerm2 cursor guide when launch-time profile state required it."""
+    global _ITERM_CURSOR_GUIDE_RESTORED  # noqa: PLW0603  # atexit/exit idempotence
+
+    if not _RESTORE_ITERM_CURSOR_GUIDE or _ITERM_CURSOR_GUIDE_RESTORED:
+        return
+    _ITERM_CURSOR_GUIDE_RESTORED = True
+    _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+
+
+def _disable_iterm_cursor_guide() -> None:
+    """Disable iTerm2 cursor guide only when the module has a restore path."""
+    if not _RESTORE_ITERM_CURSOR_GUIDE:
+        return
+    _write_iterm_escape(_ITERM_CURSOR_GUIDE_OFF)
+
+
+# Disable cursor guide at module load (before Textual takes over), but only
+# when launch-time state detection confirmed that exit cleanup will restore it.
+_disable_iterm_cursor_guide()
+
+if _RESTORE_ITERM_CURSOR_GUIDE:
+    import atexit
+
+    atexit.register(restore_iterm_cursor_guide)

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
-import io
 import os
 import signal
 import time
@@ -32,15 +31,12 @@ from textual.widget import Widget
 from textual.widgets import Checkbox, Input, Static
 
 from deepagents_cli.app import (
-    _ITERM_CURSOR_GUIDE_OFF,
-    _ITERM_CURSOR_GUIDE_ON,
     _TYPING_IDLE_THRESHOLD_SECONDS,
     DeepAgentsApp,
     DeferredAction,
     ExternalInput,
     QueuedMessage,
     TextualSessionState,
-    _write_iterm_escape,
 )
 from deepagents_cli.event_bus import ExternalEvent
 from deepagents_cli.widgets.chat_input import ChatInput
@@ -1009,119 +1005,6 @@ class TestAppBindings:
         bindings = [b for b in DeepAgentsApp.BINDINGS if isinstance(b, Binding)]
         bindings_by_key = {b.key: b for b in bindings}
         assert "ctrl+e" not in bindings_by_key
-
-
-class TestITerm2CursorGuide:
-    """Test iTerm2 cursor guide handling."""
-
-    def test_escape_sequences_are_valid(self) -> None:
-        """Escape sequences should be properly formatted OSC 1337 commands.
-
-        Format: OSC (ESC ]) + "1337;" + command + ST (ESC backslash)
-        """
-        assert _ITERM_CURSOR_GUIDE_OFF.startswith("\x1b]1337;")
-        assert _ITERM_CURSOR_GUIDE_OFF.endswith("\x1b\\")
-        assert "HighlightCursorLine=no" in _ITERM_CURSOR_GUIDE_OFF
-
-        assert _ITERM_CURSOR_GUIDE_ON.startswith("\x1b]1337;")
-        assert _ITERM_CURSOR_GUIDE_ON.endswith("\x1b\\")
-        assert "HighlightCursorLine=yes" in _ITERM_CURSOR_GUIDE_ON
-
-    def test_write_iterm_escape_does_nothing_when_not_iterm(self) -> None:
-        """_write_iterm_escape should no-op when _IS_ITERM is False."""
-        mock_stderr = MagicMock()
-        with (
-            patch("deepagents_cli.app._IS_ITERM", False),
-            patch("sys.__stderr__", mock_stderr),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-            mock_stderr.write.assert_not_called()
-
-    def test_write_iterm_escape_writes_sequence_when_iterm(self) -> None:
-        """_write_iterm_escape should write sequence when in iTerm2."""
-        mock_stderr = io.StringIO()
-        with (
-            patch("deepagents_cli.app._IS_ITERM", True),
-            patch("sys.__stderr__", mock_stderr),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-            assert mock_stderr.getvalue() == _ITERM_CURSOR_GUIDE_ON
-
-    def test_write_iterm_escape_handles_oserror_gracefully(self) -> None:
-        """_write_iterm_escape should not raise on OSError."""
-        mock_stderr = MagicMock()
-        mock_stderr.write.side_effect = OSError("Broken pipe")
-        with (
-            patch("deepagents_cli.app._IS_ITERM", True),
-            patch("sys.__stderr__", mock_stderr),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-
-    def test_write_iterm_escape_handles_none_stderr(self) -> None:
-        """_write_iterm_escape should handle None __stderr__ gracefully."""
-        with (
-            patch("deepagents_cli.app._IS_ITERM", True),
-            patch("sys.__stderr__", None),
-        ):
-            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-
-
-class TestITerm2Detection:
-    """Test iTerm2 detection logic."""
-
-    def test_detection_requires_tty(self) -> None:
-        """_IS_ITERM should check that stderr is a TTY.
-
-        Detection happens at module load, so we test the logic pattern directly.
-        """
-        with (
-            patch.dict(os.environ, {"LC_TERMINAL": "iTerm2"}, clear=False),
-            patch("os.isatty", return_value=False),
-        ):
-            result = (
-                (
-                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
-                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
-                )
-                and hasattr(os, "isatty")
-                and os.isatty(2)
-            )
-            assert result is False
-
-    def test_detection_via_lc_terminal(self) -> None:
-        """Detection should match LC_TERMINAL=iTerm2."""
-        with (
-            patch.dict(
-                os.environ, {"LC_TERMINAL": "iTerm2", "TERM_PROGRAM": ""}, clear=False
-            ),
-            patch("os.isatty", return_value=True),
-        ):
-            result = (
-                (
-                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
-                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
-                )
-                and hasattr(os, "isatty")
-                and os.isatty(2)
-            )
-            assert result is True
-
-    def test_detection_via_term_program(self) -> None:
-        """Detection should match TERM_PROGRAM=iTerm.app."""
-        env = {"LC_TERMINAL": "", "TERM_PROGRAM": "iTerm.app"}
-        with (
-            patch.dict(os.environ, env, clear=False),
-            patch("os.isatty", return_value=True),
-        ):
-            result = (
-                (
-                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
-                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
-                )
-                and hasattr(os, "isatty")
-                and os.isatty(2)
-            )
-            assert result is True
 
 
 class TestModalScreenEscapeDismissal:

--- a/libs/cli/tests/unit_tests/test_iterm_cursor_guide.py
+++ b/libs/cli/tests/unit_tests/test_iterm_cursor_guide.py
@@ -1,0 +1,256 @@
+"""Tests for the iTerm2 cursor guide workaround."""
+
+from __future__ import annotations
+
+import io
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from textual.app import App
+
+from deepagents_cli import iterm_cursor_guide
+from deepagents_cli.app import DeepAgentsApp
+from deepagents_cli.iterm_cursor_guide import (
+    _ITERM_CURSOR_GUIDE_OFF,
+    _ITERM_CURSOR_GUIDE_ON,
+    _disable_iterm_cursor_guide,
+    _iterm_profile_cursor_guide_enabled,
+    _write_iterm_escape,
+    restore_iterm_cursor_guide,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestITerm2CursorGuide:
+    """Test iTerm2 cursor guide handling."""
+
+    def test_escape_sequences_are_valid(self) -> None:
+        """Escape sequences should be properly formatted OSC 1337 commands.
+
+        Format: OSC (ESC ]) + "1337;" + command + ST (ESC backslash)
+        """
+        assert _ITERM_CURSOR_GUIDE_OFF.startswith("\x1b]1337;")
+        assert _ITERM_CURSOR_GUIDE_OFF.endswith("\x1b\\")
+        assert "HighlightCursorLine=no" in _ITERM_CURSOR_GUIDE_OFF
+
+        assert _ITERM_CURSOR_GUIDE_ON.startswith("\x1b]1337;")
+        assert _ITERM_CURSOR_GUIDE_ON.endswith("\x1b\\")
+        assert "HighlightCursorLine=yes" in _ITERM_CURSOR_GUIDE_ON
+
+    def test_write_iterm_escape_does_nothing_when_not_iterm(self) -> None:
+        """_write_iterm_escape should no-op when `_IS_ITERM` is `False`."""
+        mock_stderr = MagicMock()
+        with (
+            patch.object(iterm_cursor_guide, "_IS_ITERM", False),
+            patch("sys.__stderr__", mock_stderr),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+            mock_stderr.write.assert_not_called()
+
+    def test_write_iterm_escape_writes_sequence_when_iterm(self) -> None:
+        """_write_iterm_escape should write sequence when in iTerm2."""
+        mock_stderr = io.StringIO()
+        with (
+            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
+            patch("sys.__stderr__", mock_stderr),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+            assert mock_stderr.getvalue() == _ITERM_CURSOR_GUIDE_ON
+
+    def test_write_iterm_escape_handles_oserror_gracefully(self) -> None:
+        """_write_iterm_escape should not raise on `OSError`."""
+        mock_stderr = MagicMock()
+        mock_stderr.write.side_effect = OSError("Broken pipe")
+        with (
+            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
+            patch("sys.__stderr__", mock_stderr),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+
+    def test_write_iterm_escape_handles_none_stderr(self) -> None:
+        """_write_iterm_escape should handle `None` `__stderr__` gracefully."""
+        with (
+            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
+            patch("sys.__stderr__", None),
+        ):
+            _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
+
+    def test_disable_cursor_guide_noops_without_restore_path(self) -> None:
+        """Cursor guide should not be disabled when startup state is unknown."""
+        with (
+            patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", False),
+            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+        ):
+            _disable_iterm_cursor_guide()
+
+        write_escape.assert_not_called()
+
+    def test_disable_cursor_guide_writes_off_when_restore_path_exists(self) -> None:
+        """Cursor guide may be disabled only when cleanup will restore it."""
+        with (
+            patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", True),
+            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+        ):
+            _disable_iterm_cursor_guide()
+
+        write_escape.assert_called_once_with(_ITERM_CURSOR_GUIDE_OFF)
+
+    def test_app_exit_does_not_reenable_cursor_guide(self) -> None:
+        """App exit should not restore when cursor guide was off before launch."""
+        app = DeepAgentsApp()
+        with (
+            patch("deepagents_cli.app.restore_iterm_cursor_guide") as restore,
+            patch("deepagents_cli.hooks._load_hooks", return_value=[]),
+            patch.object(App, "exit") as app_exit,
+        ):
+            app.exit()
+
+        restore.assert_called_once_with()
+        app_exit.assert_called_once_with(result=None, return_code=0, message=None)
+
+    def test_restore_cursor_guide_reenables_when_profile_had_it(self) -> None:
+        """Restore should write the iTerm2 escape when launch state requires it."""
+        with (
+            patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", True),
+            patch.object(iterm_cursor_guide, "_ITERM_CURSOR_GUIDE_RESTORED", False),
+            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+        ):
+            restore_iterm_cursor_guide()
+
+        write_escape.assert_called_once_with(_ITERM_CURSOR_GUIDE_ON)
+
+    def test_restore_cursor_guide_is_idempotent(self) -> None:
+        """The direct exit path and atexit fallback should not double-restore."""
+        with (
+            patch.object(iterm_cursor_guide, "_RESTORE_ITERM_CURSOR_GUIDE", True),
+            patch.object(iterm_cursor_guide, "_ITERM_CURSOR_GUIDE_RESTORED", False),
+            patch.object(iterm_cursor_guide, "_write_iterm_escape") as write_escape,
+        ):
+            restore_iterm_cursor_guide()
+            restore_iterm_cursor_guide()
+
+        write_escape.assert_called_once_with(_ITERM_CURSOR_GUIDE_ON)
+
+    def test_profile_cursor_guide_enabled_from_iterm_profile(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The active `ITERM_PROFILE` controls whether cursor guide is restored."""
+        import plistlib
+
+        prefs_path = tmp_path / "com.googlecode.iterm2.plist"
+        with prefs_path.open("wb") as f:
+            plistlib.dump(
+                {
+                    "Default Bookmark Guid": "disabled-guid",
+                    "New Bookmarks": [
+                        {
+                            "Guid": "disabled-guid",
+                            "Name": "Disabled",
+                            "Use Cursor Guide": 0,
+                        },
+                        {
+                            "Guid": "enabled-guid",
+                            "Name": "Enabled",
+                            "Use Cursor Guide": 1,
+                        },
+                    ],
+                },
+                f,
+            )
+
+        monkeypatch.setenv("ITERM_PROFILE", "Enabled")
+        with (
+            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
+            patch.object(iterm_cursor_guide, "_ITERM_PREFS_PATH", prefs_path),
+        ):
+            assert _iterm_profile_cursor_guide_enabled() is True
+
+    def test_profile_cursor_guide_disabled_from_default_guid(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The default profile GUID is used when `ITERM_PROFILE` is unavailable."""
+        import plistlib
+
+        prefs_path = tmp_path / "com.googlecode.iterm2.plist"
+        with prefs_path.open("wb") as f:
+            plistlib.dump(
+                {
+                    "Default Bookmark Guid": "disabled-guid",
+                    "New Bookmarks": [
+                        {
+                            "Guid": "disabled-guid",
+                            "Name": "Disabled",
+                            "Use Cursor Guide": 0,
+                        }
+                    ],
+                },
+                f,
+            )
+
+        monkeypatch.delenv("ITERM_PROFILE", raising=False)
+        with (
+            patch.object(iterm_cursor_guide, "_IS_ITERM", True),
+            patch.object(iterm_cursor_guide, "_ITERM_PREFS_PATH", prefs_path),
+        ):
+            assert _iterm_profile_cursor_guide_enabled() is False
+
+
+class TestITerm2Detection:
+    """Test iTerm2 detection logic."""
+
+    def test_detection_requires_tty(self) -> None:
+        """_IS_ITERM should check that stderr is a TTY.
+
+        Detection happens at module load, so we test the logic pattern directly.
+        """
+        with (
+            patch.dict(os.environ, {"LC_TERMINAL": "iTerm2"}, clear=False),
+            patch("os.isatty", return_value=False),
+        ):
+            result = (
+                (
+                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
+                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+                )
+                and hasattr(os, "isatty")
+                and os.isatty(2)
+            )
+            assert result is False
+
+    def test_detection_via_lc_terminal(self) -> None:
+        """Detection should match `LC_TERMINAL=iTerm2`."""
+        with (
+            patch.dict(
+                os.environ, {"LC_TERMINAL": "iTerm2", "TERM_PROGRAM": ""}, clear=False
+            ),
+            patch("os.isatty", return_value=True),
+        ):
+            result = (
+                (
+                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
+                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+                )
+                and hasattr(os, "isatty")
+                and os.isatty(2)
+            )
+            assert result is True
+
+    def test_detection_via_term_program(self) -> None:
+        """Detection should match `TERM_PROGRAM=iTerm.app`."""
+        env = {"LC_TERMINAL": "", "TERM_PROGRAM": "iTerm.app"}
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("os.isatty", return_value=True),
+        ):
+            result = (
+                (
+                    os.environ.get("LC_TERMINAL", "") == "iTerm2"
+                    or os.environ.get("TERM_PROGRAM", "") == "iTerm.app"
+                )
+                and hasattr(os, "isatty")
+                and os.isatty(2)
+            )
+            assert result is True


### PR DESCRIPTION
Previously the CLI unconditionally re-enabled iTerm2's cursor guide on exit, which left the feature on for users who had it disabled before launch. Now it reads the active profile from iTerm2 preferences and restores the guide only when the profile had it enabled at startup.