### PR TITLE
fix(cli): halt turn immediately when `ask_user` is cancelled

### DIFF
--- a/libs/cli/deepagents_cli/textual_adapter.py
+++ b/libs/cli/deepagents_cli/textual_adapter.py
@@ -983,6 +983,7 @@ async def execute_task_textual(
             # Handle HITL after stream completes
             if interrupt_occurred:
                 any_rejected = False
+                ask_user_cancelled = False
                 resume_payload: dict[str, Any] = {}
 
                 for interrupt_id, ask_req in list(pending_ask_user.items()):
@@ -1076,6 +1077,9 @@ async def execute_task_textual(
                                 "answers": ["" for _ in questions],
                             }
                             any_rejected = True
+                            # Halt the turn on cancel; error branches still
+                            # resume so the agent can react to the failure.
+                            ask_user_cancelled = True
                             tool_msg = adapter._current_tool_messages.pop(tool_id, None)
                             if tool_msg is not None:
                                 tool_msg.set_rejected()
@@ -1238,12 +1242,15 @@ async def execute_task_textual(
                 suppress_resumed_output = any_rejected
 
             if interrupt_occurred and resume_payload:
-                if suppress_resumed_output and not pending_ask_user:
-                    await adapter._mount_message(
-                        AppMessage(
-                            "Command rejected. Tell the agent what you'd like instead."
-                        )
+                if suppress_resumed_output and (
+                    ask_user_cancelled or not pending_ask_user
+                ):
+                    message = (
+                        "Question cancelled. Tell the agent what you'd like instead."
+                        if ask_user_cancelled
+                        else "Command rejected. Tell the agent what you'd like instead."
                     )
+                    await adapter._mount_message(AppMessage(message))
                     turn_stats.wall_time_seconds = time.monotonic() - start_time
                     return turn_stats
 

--- a/libs/cli/tests/unit_tests/test_textual_adapter.py
+++ b/libs/cli/tests/unit_tests/test_textual_adapter.py
@@ -29,7 +29,11 @@ from deepagents_cli.textual_adapter import (
     format_token_count,
     print_usage_table,
 )
-from deepagents_cli.widgets.messages import SummarizationMessage, ToolCallMessage
+from deepagents_cli.widgets.messages import (
+    AppMessage,
+    SummarizationMessage,
+    ToolCallMessage,
+)
 
 
 async def _mock_mount(widget: object) -> None:
@@ -1232,10 +1236,15 @@ class TestExecuteTaskTextualAskUser:
         tool_rows = [w for w in mounted if isinstance(w, ToolCallMessage)]
         assert len(tool_rows) == 1
 
-    async def test_ask_user_cancelled_marks_row_rejected(self) -> None:
-        """Cancelled result should call `set_rejected` and pop the tool row."""
+    async def test_ask_user_cancelled_marks_row_rejected_and_halts(self) -> None:
+        """Cancelled result should reject the row and not resume generation."""
+        mounted: list[object] = []
         future: asyncio.Future[object] = asyncio.Future()
         future.set_result({"type": "cancelled"})
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            mounted.append(widget)
 
         async def request_ask_user(
             _questions: list[Any],
@@ -1258,7 +1267,7 @@ class TestExecuteTaskTextualAskUser:
             ]
         )
         adapter = TextualUIAdapter(
-            mount_message=_mock_mount,
+            mount_message=mount_message,
             update_status=_noop_status,
             request_approval=_mock_approval,
             request_ask_user=request_ask_user,
@@ -1272,11 +1281,11 @@ class TestExecuteTaskTextualAskUser:
             adapter=adapter,
         )
 
-        resume_cmd = agent.stream_inputs[1]
-        assert isinstance(resume_cmd, Command)
-        resume_payload = cast("dict[str, dict[str, Any]]", resume_cmd.resume)
-        assert resume_payload["interrupt-1"]["status"] == "cancelled"
+        assert len(agent.stream_inputs) == 1
         assert "tool-1" not in adapter._current_tool_messages
+        app_messages = [widget for widget in mounted if isinstance(widget, AppMessage)]
+        assert len(app_messages) == 1
+        assert "Question cancelled" in str(app_messages[0]._content)
 
     async def test_ask_user_invalid_answers_payload_marks_row_error(self) -> None:
         """Non-list answers should mark row as error and pop it."""


### PR DESCRIPTION
Closes #2165

---

When a user cancels an `ask_user` interrupt, the agent now halts the current turn instead of resuming with a cancelled-status payload and continuing generation. This prevents the model from attempting to proceed with an empty-answer placeholder that the user explicitly rejected.