### PR TITLE
feat(ci): add automated cleanup for stale open-swe PRs

### DIFF
--- a/.github/scripts/close-open-swe-prs.js
+++ b/.github/scripts/close-open-swe-prs.js
@@ -1,0 +1,317 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const DEFAULT_AUTHOR = 'app/open-swe';
+const DEFAULT_BYPASS_LABEL = 'do-not-close';
+const DEFAULT_REMINDER_DAYS = 7;
+const DEFAULT_CLOSE_DAYS = 14;
+const DEFAULT_MAX_ITEMS = 1000;
+const COMMENT_MARKER = '<!-- open-swe-auto-close -->';
+
+function parsePositiveInt(value, fallback, name) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function ageInDays(createdAt, now) {
+  return Math.floor((now.getTime() - new Date(createdAt).getTime()) / MS_PER_DAY);
+}
+
+function labelNames(labels) {
+  return labels.map(label => typeof label === 'string' ? label : label.name);
+}
+
+async function ensureLabel({ github, owner, repo, name }) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name });
+  } catch (error) {
+    if (error.status !== 404) throw error;
+    try {
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name,
+        color: '0e8a16',
+        description: 'Bypass automatic open-swe PR closure',
+      });
+    } catch (createError) {
+      if (createError.status !== 422) throw createError;
+      await github.rest.issues.getLabel({ owner, repo, name });
+    }
+  }
+}
+
+async function findMarkerComment({ github, owner, repo, issueNumber }) {
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: issueNumber, per_page: 100 },
+  );
+  return comments.find(comment => comment.body?.includes(COMMENT_MARKER));
+}
+
+async function upsertComment({ github, owner, repo, issueNumber, body }) {
+  const existing = await findMarkerComment({ github, owner, repo, issueNumber });
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    return 'updated';
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+  return 'created';
+}
+
+async function createCommentIfMissing({ github, owner, repo, issueNumber, body }) {
+  const existing = await findMarkerComment({ github, owner, repo, issueNumber });
+  if (existing) return 'existing';
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+  return 'created';
+}
+
+function reminderBody({ reminderDays, closeDays, bypassLabel }) {
+  return [
+    COMMENT_MARKER,
+    `This PR was opened by \`app/open-swe\` and has had no activity for at least ${reminderDays} day(s).`,
+    '',
+    `It will be automatically closed after ${closeDays} days unless a maintainer adds the \`${bypassLabel}\` label.`,
+  ].join('\n');
+}
+
+function closeBody({ closeDays, bypassLabel }) {
+  return [
+    COMMENT_MARKER,
+    `This PR was opened by \`app/open-swe\` and has had no maintainer activity since the cleanup reminder.`,
+    '',
+    `Closing automatically. Add the \`${bypassLabel}\` label before the ${closeDays}-day mark to bypass this cleanup.`,
+  ].join('\n');
+}
+
+async function getLivePrState({ github, owner, repo, number }) {
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: number,
+  });
+  return {
+    draft: pr.draft === true,
+    state: pr.state,
+    updatedAt: pr.updated_at,
+    labels: labelNames(pr.labels ?? []),
+  };
+}
+
+async function searchOpenSwePrs({ github, owner, repo, author, maxItems, core }) {
+  const query = [
+    `repo:${owner}/${repo}`,
+    'is:pr',
+    'is:open',
+    'draft:false',
+    `author:${author}`,
+  ].join(' ');
+
+  const items = [];
+  try {
+    for await (const response of github.paginate.iterator(
+      github.rest.search.issuesAndPullRequests,
+      { q: query, per_page: 100 },
+    )) {
+      const pageItems = response.data.items ?? [];
+      for (const item of pageItems) {
+        items.push(item);
+        if (items.length >= maxItems) return items;
+      }
+    }
+  } catch (error) {
+    core.warning(
+      `Search failed after collecting ${items.length} PR(s) ` +
+      `(HTTP ${error.status ?? 'unknown'}): ${error.message}`,
+    );
+  }
+  return items;
+}
+
+function hasActivityAfterReminder(live, reminder) {
+  const liveUpdatedAt = new Date(live.updatedAt).getTime();
+  const reminderUpdatedAt = new Date(reminder.updated_at ?? reminder.created_at).getTime();
+  return liveUpdatedAt > reminderUpdatedAt;
+}
+
+async function processPr({
+  github,
+  core,
+  owner,
+  repo,
+  item,
+  now,
+  bypassLabel,
+  reminderDays,
+  closeDays,
+}) {
+  const number = item.number;
+  const live = await getLivePrState({ github, owner, repo, number });
+
+  if (live.state !== 'open') {
+    core.info(`PR #${number} is no longer open; skipping`);
+    return 'skipped';
+  }
+  if (live.draft) {
+    core.info(`PR #${number} is a draft; skipping`);
+    return 'skipped';
+  }
+  if (live.labels.includes(bypassLabel)) {
+    core.info(`PR #${number} has ${bypassLabel}; skipping`);
+    return 'skipped';
+  }
+
+  const reminder = await findMarkerComment({ github, owner, repo, issueNumber: number });
+  const activityAt = live.updatedAt ?? item.updated_at ?? item.created_at;
+  const inactiveDays = ageInDays(activityAt, now);
+
+  if (reminder) {
+    if (hasActivityAfterReminder(live, reminder)) {
+      if (inactiveDays >= reminderDays) {
+        await github.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: reminder.id,
+          body: reminderBody({ reminderDays, closeDays, bypassLabel }),
+        });
+        core.info(`Refreshed reminder on PR #${number} after ${inactiveDays} inactive day(s)`);
+        return 'reminded';
+      }
+      core.info(`PR #${number} had activity after the reminder; skipping`);
+      return 'skipped';
+    }
+
+    const reminderAge = ageInDays(reminder.updated_at ?? reminder.created_at, now);
+    const warningDays = closeDays - reminderDays;
+    if (reminderAge >= warningDays) {
+      await upsertComment({
+        github,
+        owner,
+        repo,
+        issueNumber: number,
+        body: closeBody({ closeDays, bypassLabel }),
+      });
+      await github.rest.pulls.update({
+        owner,
+        repo,
+        pull_number: number,
+        state: 'closed',
+      });
+      core.info(`Closed PR #${number} after ${reminderAge} day(s) with cleanup reminder`);
+      return 'closed';
+    }
+
+    core.info(`PR #${number} already has a reminder; no action`);
+    return 'skipped';
+  }
+
+  if (inactiveDays >= reminderDays) {
+    await createCommentIfMissing({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      body: reminderBody({ reminderDays, closeDays, bypassLabel }),
+    });
+    core.info(`Posted reminder on PR #${number}`);
+    return 'reminded';
+  }
+
+  core.info(`PR #${number} has been inactive for ${inactiveDays} day(s); no action`);
+  return 'skipped';
+}
+
+async function run({ github, context, core, options = {} }) {
+  const { owner, repo } = context.repo;
+  const author = options.author ?? process.env.OPEN_SWE_AUTHOR ?? DEFAULT_AUTHOR;
+  const bypassLabel = options.bypassLabel ?? process.env.BYPASS_LABEL ?? DEFAULT_BYPASS_LABEL;
+  const reminderDays = parsePositiveInt(
+    options.reminderDays ?? process.env.REMINDER_DAYS,
+    DEFAULT_REMINDER_DAYS,
+    'reminderDays',
+  );
+  const closeDays = parsePositiveInt(
+    options.closeDays ?? process.env.CLOSE_DAYS,
+    DEFAULT_CLOSE_DAYS,
+    'closeDays',
+  );
+  const maxItems = parsePositiveInt(
+    options.maxItems ?? process.env.MAX_ITEMS,
+    DEFAULT_MAX_ITEMS,
+    'maxItems',
+  );
+  const now = options.now ?? new Date();
+
+  if (reminderDays >= closeDays) {
+    throw new Error(`reminderDays (${reminderDays}) must be less than closeDays (${closeDays})`);
+  }
+
+  await ensureLabel({ github, owner, repo, name: bypassLabel });
+
+  const prs = await searchOpenSwePrs({ github, owner, repo, author, maxItems, core });
+  core.info(`Found ${prs.length} open PR(s) from ${author}`);
+
+  const summary = { checked: 0, reminded: 0, closed: 0, skipped: 0, errors: [] };
+  for (const item of prs) {
+    summary.checked += 1;
+    const number = item.number;
+    try {
+      const result = await processPr({
+        github,
+        core,
+        owner,
+        repo,
+        item,
+        now,
+        bypassLabel,
+        reminderDays,
+        closeDays,
+      });
+      summary[result] += 1;
+    } catch (error) {
+      const message = `PR #${number} failed: ${error.message}`;
+      core.warning(message);
+      summary.errors.push({ number, message: error.message });
+    }
+  }
+
+  core.info(
+    `Checked ${summary.checked}; reminded ${summary.reminded}; ` +
+    `closed ${summary.closed}; skipped ${summary.skipped}; errors ${summary.errors.length}`,
+  );
+  if (summary.errors.length > 0) {
+    core.setFailed(
+      `Failed to process ${summary.errors.length} open-swe PR(s): ` +
+      summary.errors.map(error => `#${error.number}`).join(', '),
+    );
+  }
+  return summary;
+}
+
+module.exports = {
+  COMMENT_MARKER,
+  ageInDays,
+  closeBody,
+  reminderBody,
+  run,
+};

--- a/.github/scripts/close-open-swe-prs.test.js
+++ b/.github/scripts/close-open-swe-prs.test.js
@@ -1,0 +1,310 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { run } = require('./close-open-swe-prs.js');
+
+function httpError(message, status) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function makeCore() {
+  return {
+    failed: null,
+    infos: [],
+    warnings: [],
+    info(message) {
+      this.infos.push(message);
+    },
+    warning(message) {
+      this.warnings.push(message);
+    },
+    setFailed(message) {
+      this.failed = message;
+    },
+  };
+}
+
+function makeGithub({
+  items,
+  comments = new Map(),
+  live = new Map(),
+  labelExists = true,
+  createLabelError = null,
+  iteratorError = null,
+  getErrors = new Map(),
+  maxPagesBeforeError = null,
+} = {}) {
+  const calls = {
+    createLabel: [],
+    createComment: [],
+    updateComment: [],
+    close: [],
+    searchQueries: [],
+  };
+
+  let getLabelCalls = 0;
+  const github = {
+    rest: {
+      issues: {
+        getLabel: async () => {
+          getLabelCalls += 1;
+          if (!labelExists) throw httpError('missing label', 404);
+          return { data: { name: 'do-not-close' } };
+        },
+        createLabel: async params => {
+          calls.createLabel.push(params);
+          if (createLabelError) throw createLabelError;
+          labelExists = true;
+        },
+        listComments: async params => ({
+          data: comments.get(params.issue_number) ?? [],
+        }),
+        createComment: async params => {
+          calls.createComment.push(params);
+          return { data: { id: 1000 + params.issue_number } };
+        },
+        updateComment: async params => {
+          calls.updateComment.push(params);
+          return { data: { id: params.comment_id } };
+        },
+      },
+      pulls: {
+        get: async params => {
+          const error = getErrors.get(params.pull_number);
+          if (error) throw error;
+
+          const state = live.get(params.pull_number) ?? {};
+          return {
+            data: {
+              draft: state.draft ?? false,
+              state: state.state ?? 'open',
+              updated_at: state.updated_at ?? '2026-04-30T00:00:00Z',
+              labels: (state.labels ?? []).map(name => ({ name })),
+            },
+          };
+        },
+        update: async params => {
+          calls.close.push(params.pull_number);
+          return { data: { number: params.pull_number, state: params.state } };
+        },
+      },
+      search: {
+        issuesAndPullRequests: async () => {},
+      },
+    },
+    paginate: async (method, params) => {
+      const result = await method(params);
+      return result.data;
+    },
+  };
+
+  github.paginate.iterator = async function* iterator(_method, params) {
+    calls.searchQueries.push(params.q);
+    const pages = [];
+    for (let index = 0; index < (items ?? []).length; index += 100) {
+      pages.push((items ?? []).slice(index, index + 100));
+    }
+
+    for (const [index, page] of pages.entries()) {
+      if (maxPagesBeforeError !== null && index >= maxPagesBeforeError) {
+        throw iteratorError;
+      }
+      yield { data: { items: page } };
+    }
+    if (iteratorError) throw iteratorError;
+  };
+
+  return { github, calls, getLabelCalls: () => getLabelCalls };
+}
+
+const context = { repo: { owner: 'langchain-ai', repo: 'deepagents' } };
+const now = new Date('2026-05-08T00:00:00Z');
+
+test('reminds inactive PRs, closes aged reminders, and skips bypass/draft/closed PRs', async () => {
+  const comments = new Map([
+    [
+      102,
+      [{
+        id: 77,
+        body: '<!-- open-swe-auto-close -->\nold',
+        created_at: '2026-04-30T00:00:00Z',
+        updated_at: '2026-04-30T00:00:00Z',
+      }],
+    ],
+  ]);
+  const live = new Map([
+    [101, { updated_at: '2026-04-30T00:00:00Z' }],
+    [102, { updated_at: '2026-04-30T00:00:00Z' }],
+    [103, { labels: ['do-not-close'], updated_at: '2026-04-10T00:00:00Z' }],
+    [104, { draft: true, updated_at: '2026-04-10T00:00:00Z' }],
+    [105, { state: 'closed', updated_at: '2026-04-10T00:00:00Z' }],
+  ]);
+  const { github, calls } = makeGithub({
+    items: [
+      { number: 101, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-30T00:00:00Z' },
+      { number: 102, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-30T00:00:00Z' },
+      { number: 103, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-10T00:00:00Z' },
+      { number: 104, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-10T00:00:00Z' },
+      { number: 105, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-10T00:00:00Z' },
+    ],
+    comments,
+    live,
+  });
+  const core = makeCore();
+
+  const summary = await run({ github, context, core, options: { now } });
+
+  assert.deepEqual(summary, { checked: 5, reminded: 1, closed: 1, skipped: 3, errors: [] });
+  assert.match(calls.searchQueries[0], /draft:false/);
+  assert.equal(calls.createComment.length, 1);
+  assert.equal(calls.createComment[0].issue_number, 101);
+  assert.match(calls.createComment[0].body, /at least 7 day\(s\)/);
+  assert.equal(calls.updateComment.length, 1);
+  assert.equal(calls.updateComment[0].comment_id, 77);
+  assert.match(calls.updateComment[0].body, /Closing automatically/);
+  assert.deepEqual(calls.close, [102]);
+  assert.equal(core.failed, null);
+});
+
+test('refreshes reminder instead of closing when PR had activity after prior reminder', async () => {
+  const comments = new Map([
+    [
+      201,
+      [{
+        id: 88,
+        body: '<!-- open-swe-auto-close -->\nold',
+        created_at: '2026-04-20T00:00:00Z',
+        updated_at: '2026-04-20T00:00:00Z',
+      }],
+    ],
+  ]);
+  const live = new Map([
+    [201, { updated_at: '2026-05-01T00:00:00Z' }],
+  ]);
+  const { github, calls } = makeGithub({
+    items: [{ number: 201, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-05-01T00:00:00Z' }],
+    comments,
+    live,
+  });
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(summary.reminded, 1);
+  assert.equal(summary.closed, 0);
+  assert.equal(calls.updateComment.length, 1);
+  assert.match(calls.updateComment[0].body, /at least 7 day\(s\)/);
+  assert.deepEqual(calls.close, []);
+});
+
+test('continues after a single PR failure and fails the workflow at the end', async () => {
+  const getErrors = new Map([[301, httpError('temporary outage', 503)]]);
+  const { github, calls } = makeGithub({
+    items: [
+      { number: 301, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-30T00:00:00Z' },
+      { number: 302, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-30T00:00:00Z' },
+    ],
+    getErrors,
+  });
+  const core = makeCore();
+
+  const summary = await run({ github, context, core, options: { now } });
+
+  assert.equal(summary.checked, 2);
+  assert.equal(summary.reminded, 1);
+  assert.equal(summary.errors.length, 1);
+  assert.equal(summary.errors[0].number, 301);
+  assert.match(core.warnings[0], /PR #301 failed/);
+  assert.match(core.failed, /#301/);
+  assert.equal(calls.createComment[0].issue_number, 302);
+});
+
+test('confirms label exists after create-label 422', async () => {
+  const { github, calls, getLabelCalls } = makeGithub({
+    items: [],
+    labelExists: false,
+    createLabelError: httpError('already exists', 422),
+  });
+  let confirmed = false;
+  github.rest.issues.getLabel = async () => {
+    getLabelCalls();
+    if (!confirmed) {
+      confirmed = true;
+      throw httpError('missing label', 404);
+    }
+    return { data: { name: 'do-not-close' } };
+  };
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(calls.createLabel.length, 1);
+  assert.equal(summary.checked, 0);
+});
+
+test('throws when create-label 422 cannot be confirmed', async () => {
+  const { github } = makeGithub({
+    items: [],
+    labelExists: false,
+    createLabelError: httpError('invalid label', 422),
+  });
+
+  await assert.rejects(
+    run({ github, context, core: makeCore(), options: { now } }),
+    /missing label/,
+  );
+});
+
+test('rejects invalid reminder and close day configuration', async () => {
+  const { github } = makeGithub({ items: [] });
+
+  await assert.rejects(
+    run({
+      github,
+      context,
+      core: makeCore(),
+      options: { now, reminderDays: 14, closeDays: 14 },
+    }),
+    /reminderDays \(14\) must be less than closeDays \(14\)/,
+  );
+});
+
+test('keeps collected search pages when later pagination fails', async () => {
+  const { github } = makeGithub({
+    items: [
+      { number: 501, created_at: '2026-04-01T00:00:00Z', updated_at: '2026-04-30T00:00:00Z' },
+      ...Array.from({ length: 100 }, (_, index) => ({
+        number: 600 + index,
+        created_at: '2026-05-07T00:00:00Z',
+        updated_at: '2026-05-07T00:00:00Z',
+      })),
+    ],
+    iteratorError: httpError('search timeout', 503),
+    maxPagesBeforeError: 1,
+  });
+  const core = makeCore();
+
+  const summary = await run({ github, context, core, options: { now } });
+
+  assert.equal(summary.checked, 100);
+  assert.match(core.warnings[0], /Search failed after collecting 100 PR\(s\)/);
+});
+
+test('honors maxItems truncation', async () => {
+  const { github } = makeGithub({
+    items: Array.from({ length: 3 }, (_, index) => ({
+      number: 701 + index,
+      created_at: '2026-05-07T00:00:00Z',
+      updated_at: '2026-05-07T00:00:00Z',
+    })),
+  });
+
+  const summary = await run({
+    github,
+    context,
+    core: makeCore(),
+    options: { now, maxItems: 2 },
+  });
+
+  assert.equal(summary.checked, 2);
+});

--- a/.github/scripts/test_close_open_swe_prs.py
+++ b/.github/scripts/test_close_open_swe_prs.py
@@ -1,0 +1,17 @@
+"""Pytest shim for the open-swe PR cleanup Node.js tests."""
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_close_open_swe_prs_node_tests() -> None:
+    """Run native Node.js tests for the GitHub workflow helper."""
+    subprocess.run(
+        ["node", "--test", ".github/scripts/close-open-swe-prs.test.js"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+    )

--- a/.github/workflows/close_open_swe_prs.yml
+++ b/.github/workflows/close_open_swe_prs.yml
@@ -1,0 +1,42 @@
+# Remind on open-swe PRs after one week and close them after two weeks.
+# Maintainers can bypass cleanup by adding the "do-not-close" label.
+
+name: Close Open SWE PRs
+
+on:
+  schedule:
+    - cron: "17 14 * * *"
+  workflow_dispatch:
+    inputs:
+      max_items:
+        description: "Maximum open-swe PRs to process"
+        default: "1000"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  close-open-swe-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Remind or close stale open-swe PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          MAX_ITEMS: ${{ inputs.max_items || '1000' }}
+        with:
+          script: |
+            const { run } = require('./.github/scripts/close-open-swe-prs.js');
+            await run({ github, context, core });


### PR DESCRIPTION
Adds a scheduled workflow that reminds on and eventually closes stale PRs opened by `app/open-swe`. Maintainers can opt a PR out of cleanup by adding the `do-not-close` label.

## Changes

- **Scheduled workflow** (`close_open_swe_prs.yml`) runs daily, posting a reminder comment after 7 days of inactivity and closing the PR after 14 days total
- **Cleanup script** (`close-open-swe-prs.js`) with idempotent comment handling: detects existing marker comments and updates them rather than creating duplicates, and refreshes the reminder timer when new maintainer activity occurs after the initial warning
- **Bypass mechanism** via a configurable `do-not-close` label that is auto-created if missing; drafts and already-closed PRs are skipped automatically
- **Resilient error handling**: individual PR failures are logged and the workflow fails at the end so one bad PR doesn't block cleanup of the rest; search pagination timeouts are handled gracefully