### PR TITLE
style(cli): show installed version age in update notices

### DIFF
--- a/examples/async-subagent-server/uv.lock
+++ b/examples/async-subagent-server/uv.lock
@@ -365,7 +365,7 @@ dependencies = [
 requires-dist = [
     { name = "langchain", specifier = ">=1.2.17,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.3,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.2,<5.0.0" },
     { name = "langsmith", specifier = ">=0.8.0" },
     { name = "wcmatch" },

--- a/examples/repl_swarm/uv.lock
+++ b/examples/repl_swarm/uv.lock
@@ -296,7 +296,7 @@ dependencies = [
 requires-dist = [
     { name = "langchain", specifier = ">=1.2.17,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.3,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.2,<5.0.0" },
     { name = "langsmith", specifier = ">=0.8.0" },
     { name = "wcmatch" },
@@ -635,7 +635,7 @@ dependencies = [
 requires-dist = [
     { name = "deepagents", editable = "../../libs/deepagents" },
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
     { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
     { name = "quickjs-rs", specifier = ">=0.1.2,<0.2.0" },
 ]

--- a/examples/rlm_agent/uv.lock
+++ b/examples/rlm_agent/uv.lock
@@ -296,7 +296,7 @@ dependencies = [
 requires-dist = [
     { name = "langchain", specifier = ">=1.2.17,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.3,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.2,<5.0.0" },
     { name = "langsmith", specifier = ">=0.8.0" },
     { name = "wcmatch" },
@@ -635,7 +635,7 @@ dependencies = [
 requires-dist = [
     { name = "deepagents", editable = "../../libs/deepagents" },
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
     { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
     { name = "quickjs-rs", specifier = ">=0.1.2,<0.2.0" },
 ]

--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -2343,7 +2343,8 @@ class DeepAgentsApp(App):
                     )
             else:
                 from deepagents_cli.update_check import (
-                    format_age_suffix,
+                    format_installed_age_suffix,
+                    format_release_age_parenthetical,
                     mark_update_notified,
                     should_notify_update,
                 )
@@ -2352,11 +2353,17 @@ class DeepAgentsApp(App):
                     return
 
                 cmd = upgrade_command()
-                age_suffix = await asyncio.to_thread(format_age_suffix, latest)
+                release_age = await asyncio.to_thread(
+                    format_release_age_parenthetical, latest
+                )
+                installed_age = await asyncio.to_thread(
+                    format_installed_age_suffix, cli_version
+                )
                 notification = self._build_update_notification(
                     latest=latest,
                     cli_version=cli_version,
-                    age_suffix=age_suffix,
+                    release_age=release_age,
+                    installed_age=installed_age,
                     upgrade_cmd=cmd,
                 )
                 # Register without a toast: the dedicated modal is
@@ -2384,7 +2391,8 @@ class DeepAgentsApp(App):
         *,
         latest: str,
         cli_version: str,
-        age_suffix: str,
+        release_age: str,
+        installed_age: str,
         upgrade_cmd: str,
     ) -> PendingNotification:
         """Build the update-available registry entry.
@@ -2392,16 +2400,20 @@ class DeepAgentsApp(App):
         Args:
             latest: New version advertised by PyPI.
             cli_version: Currently installed version string.
-            age_suffix: Pre-formatted "(released N days ago)" fragment.
+            release_age: Pre-formatted " (released N days ago)" fragment.
+            installed_age: Pre-formatted " (N days old)" fragment.
             upgrade_cmd: Shell command to install the update.
 
         Returns:
             Registry entry ready to pass to `_notify_actionable`.
         """
-        body = f"v{latest} is available (current: v{cli_version}{age_suffix})."
+        body = (
+            f"v{latest} is available{release_age}.\n"
+            f"Currently installed: {cli_version}{installed_age}."
+        )
         return PendingNotification(
             key="update:available",
-            title=f"Update available: v{latest}",
+            title="Update available",
             body=body,
             actions=(
                 NotificationAction(ActionId.INSTALL, "Install now", primary=True),
@@ -2454,6 +2466,8 @@ class DeepAgentsApp(App):
             from deepagents_cli.config import _is_editable_install
             from deepagents_cli.update_check import (
                 format_age_suffix,
+                format_installed_age_suffix,
+                format_release_age_parenthetical,
                 is_update_available,
                 perform_upgrade,
                 upgrade_command,
@@ -2490,11 +2504,17 @@ class DeepAgentsApp(App):
                 )
                 return
 
-            age_suffix = await asyncio.to_thread(format_age_suffix, latest)
+            release_age = await asyncio.to_thread(
+                format_release_age_parenthetical, latest
+            )
+            installed_age = await asyncio.to_thread(
+                format_installed_age_suffix, cli_version
+            )
             await self._mount_message(
                 AppMessage(
-                    f"Update available: v{latest} "
-                    f"(current: v{cli_version}{age_suffix}). Upgrading..."
+                    f"Update available: v{latest}{release_age}. "
+                    f"Currently installed: {cli_version}{installed_age}. "
+                    "Upgrading..."
                 )
             )
             success, output = await perform_upgrade()
@@ -6919,7 +6939,8 @@ class DeepAgentsApp(App):
         update_notification = self._build_update_notification(
             latest="9.9.9",
             cli_version="0.0.1",
-            age_suffix=", released 2 days ago",
+            release_age=" (released 2 days ago)",
+            installed_age="",
             upgrade_cmd="uv tool upgrade deepagents-cli",
         )
         self._notice_registry.add(update_notification)
@@ -7239,6 +7260,18 @@ class DeepAgentsApp(App):
         )
 
         if action_id == ActionId.INSTALL:
+            from deepagents_cli._env_vars import DEBUG_UPDATE
+
+            if os.environ.get(DEBUG_UPDATE):
+                self._notice_registry.remove(entry.key)
+                self.notify(
+                    "Skipped update install (debug mode).",
+                    severity="information",
+                    timeout=4,
+                    markup=False,
+                )
+                return
+
             self.notify(
                 f"Updating to v{payload.latest}...",
                 severity="information",

--- a/libs/cli/deepagents_cli/main.py
+++ b/libs/cli/deepagents_cli/main.py
@@ -1686,6 +1686,8 @@ def cli_main() -> None:
                 from deepagents_cli.config import _is_editable_install
                 from deepagents_cli.update_check import (
                     format_age_suffix,
+                    format_installed_age_suffix,
+                    format_release_age_parenthetical,
                     is_update_available,
                     perform_upgrade,
                     upgrade_command,
@@ -1716,10 +1718,12 @@ def cli_main() -> None:
                     )
                     sys.exit(0)
 
-                age_suffix = format_age_suffix(latest)
+                release_age = format_release_age_parenthetical(latest)
+                installed_age = format_installed_age_suffix(cli_version)
                 console.print(
-                    f"Update available: v{latest} "
-                    f"(current: v{cli_version}{age_suffix}). Upgrading..."
+                    f"Update available: v{latest}{release_age}. "
+                    f"Currently installed: {cli_version}{installed_age}. "
+                    "Upgrading..."
                 )
                 success, output = asyncio.run(perform_upgrade())
                 if success:
@@ -2085,7 +2089,8 @@ def cli_main() -> None:
                 if result.update_available[0]:
                     from deepagents_cli._version import __version__ as cli_version
                     from deepagents_cli.update_check import (
-                        format_age_suffix,
+                        format_installed_age_suffix,
+                        format_release_age_parenthetical,
                         is_auto_update_enabled,
                         mark_update_notified,
                         should_notify_update,
@@ -2095,11 +2100,14 @@ def cli_main() -> None:
                     latest = result.update_available[1]
                     if latest and should_notify_update(latest):
                         console.print()
-                        age_suffix = format_age_suffix(latest)
+                        release_age = format_release_age_parenthetical(latest)
+                        installed_age = format_installed_age_suffix(cli_version)
                         update_msg = Text("Update available: ", style="yellow bold")
                         update_msg.append(f"v{latest}", style="yellow")
+                        update_msg.append(release_age, style="dim")
                         update_msg.append(
-                            f" (current: v{cli_version}{age_suffix})", style="dim"
+                            f". Currently installed: {cli_version}{installed_age}.",
+                            style="dim",
                         )
                         console.print(update_msg)
                         cmd_hint = Text("Run: ", style="dim")

--- a/libs/cli/deepagents_cli/update_check.py
+++ b/libs/cli/deepagents_cli/update_check.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import time
 import tomllib
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from packaging.version import InvalidVersion, Version
@@ -57,6 +58,9 @@ A cached `latest_version.json` younger than this is reused without an HTTP
 call to PyPI; older payloads trigger a fresh fetch. Set conservatively at
 24h since release cadence is on the order of days, not minutes.
 """
+
+INSTALLED_AGE_NOTICE_DAYS = 7
+"""Minimum installed-version age before update notices call it out explicitly."""
 
 _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 """`CACHE_FILE` key for cached SDK upload timestamps, keyed by version string."""
@@ -154,13 +158,21 @@ def get_latest_version(
         The latest version string, or `None` on any failure.
     """
     cache_key = "version_prerelease" if include_prereleases else "version"
+    cached_version: str | None = None
 
     try:
         if not bypass_cache and CACHE_FILE.exists():
             data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
             fresh = time.time() - data.get("checked_at", 0) < CACHE_TTL
             if fresh and cache_key in data:
-                return data[cache_key]
+                value = data[cache_key]
+                cached_version = value if isinstance(value, str) else None
+            release_times = data.get("release_times")
+            has_installed_release_time = (
+                isinstance(release_times, dict) and __version__ in release_times
+            )
+            if fresh and cache_key in data and has_installed_release_time:
+                return cached_version
     except (OSError, json.JSONDecodeError, TypeError):
         logger.debug("Failed to read update-check cache", exc_info=True)
 
@@ -171,7 +183,7 @@ def get_latest_version(
             "requests package not installed — update checks disabled. "
             "Install with: pip install requests"
         )
-        return None
+        return cached_version
 
     try:
         resp = requests.get(
@@ -188,10 +200,10 @@ def get_latest_version(
         prerelease = _latest_from_releases(releases, include_prereleases=True)
     except (requests.RequestException, OSError, KeyError, json.JSONDecodeError):
         logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
-        return None
+        return cached_version
 
     release_times = _extract_release_times(
-        payload, stable=stable, prerelease=prerelease
+        payload, stable=stable, prerelease=prerelease, installed=__version__
     )
 
     try:
@@ -214,7 +226,11 @@ def get_latest_version(
 
 
 def _extract_release_times(
-    payload: dict[str, Any], *, stable: str, prerelease: str | None
+    payload: dict[str, Any],
+    *,
+    stable: str,
+    prerelease: str | None,
+    installed: str | None = None,
 ) -> dict[str, str]:
     """Pull `upload_time_iso_8601` for the given versions out of a PyPI payload.
 
@@ -229,6 +245,7 @@ def _extract_release_times(
         payload: Parsed PyPI JSON response.
         stable: Latest stable version string.
         prerelease: Latest pre-release version string, if any.
+        installed: Currently installed version string, if it should be cached.
 
     Returns:
         Mapping of version string to ISO-8601 upload time. Silently drops
@@ -238,7 +255,7 @@ def _extract_release_times(
     releases = payload.get("releases")
     if not isinstance(releases, dict):
         return times
-    for ver in (stable, prerelease):
+    for ver in (stable, prerelease, installed):
         if not ver:
             continue
         files = releases.get(ver)
@@ -312,6 +329,39 @@ def format_age_suffix(version: str | None) -> str:
     """
     age = format_release_age(version)
     return f", {age}" if age else ""
+
+
+def format_release_age_parenthetical(version: str | None) -> str:
+    """Return `" (released Nd ago)"` for `version`, or `""` when unknown."""
+    age = format_release_age(version)
+    return f" ({age})" if age else ""
+
+
+def _days_old_from_iso(iso: str | None) -> int | None:
+    """Return whole elapsed days for an ISO-8601 timestamp, or `None` on failure."""
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso).astimezone()
+    except (ValueError, TypeError):
+        logger.debug(
+            "Failed to parse release timestamp %r for installed age",
+            iso,
+            exc_info=True,
+        )
+        return None
+
+    days = (datetime.now(tz=dt.tzinfo) - dt).days
+    return max(days, 0)
+
+
+def format_installed_age_suffix(version: str | None) -> str:
+    """Return `" (N days old)"` for installed versions at least a week old."""
+    days = _days_old_from_iso(get_release_time(version))
+    if days is None or days < INSTALLED_AGE_NOTICE_DAYS:
+        return ""
+    unit = "day" if days == 1 else "days"
+    return f" ({days} {unit} old)"
 
 
 def get_sdk_release_time(

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -5334,6 +5334,25 @@ def _update_entry(latest: str = "2.0.0") -> PendingNotification:
     )
 
 
+def test_build_update_notification_uses_release_and_installed_age_copy() -> None:
+    """Update notices separate latest-release age from installed-version age."""
+    from deepagents_cli.app import DeepAgentsApp
+
+    notification = DeepAgentsApp._build_update_notification(
+        latest="2.0.0",
+        cli_version="1.0.0",
+        release_age=" (released 3d ago)",
+        installed_age=" (8 days old)",
+        upgrade_cmd="pip install",
+    )
+
+    assert notification.body == (
+        "v2.0.0 is available (released 3d ago).\n"
+        "Currently installed: 1.0.0 (8 days old)."
+    )
+    assert notification.title == "Update available"
+
+
 class TestNotificationCenterIntegration:
     """App-level wiring between the notifications registry and the modal."""
 
@@ -5817,6 +5836,40 @@ class TestNotificationCenterIntegration:
 
         assert app._notice_registry.get("update:available") is None
 
+    async def test_debug_update_install_does_not_run_upgrade(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Debug update modal can exercise Install now without changing packages."""
+        from deepagents_cli._env_vars import DEBUG_UPDATE
+        from deepagents_cli.notifications import ActionId
+
+        monkeypatch.setenv(DEBUG_UPDATE, "1")
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _update_entry()
+        app._notice_registry.add(entry)
+
+        notified: list[str] = []
+        original_notify = app.notify
+
+        def capture_notify(message: str, **kwargs: Any) -> None:
+            notified.append(message)
+            original_notify(message, **kwargs)
+
+        app.notify = capture_notify  # type: ignore[method-assign]
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with patch(
+                "deepagents_cli.update_check.perform_upgrade",
+                new=AsyncMock(return_value=(True, "Updated deepagents-cli")),
+            ) as mock_upgrade:
+                await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
+                await pilot.pause()
+
+        mock_upgrade.assert_not_called()
+        assert app._notice_registry.get("update:available") is None
+        assert any("debug mode" in m for m in notified)
+
     async def test_install_failure_removes_entry_and_toasts_manual(self) -> None:
         """Failed install removes the stale entry and surfaces the manual command."""
         from deepagents_cli.notifications import ActionId
@@ -6101,7 +6154,11 @@ class TestNotificationCenterIntegration:
                 "deepagents_cli.update_check.mark_update_notified",
             ),
             patch(
-                "deepagents_cli.update_check.format_age_suffix",
+                "deepagents_cli.update_check.format_release_age_parenthetical",
+                return_value="",
+            ),
+            patch(
+                "deepagents_cli.update_check.format_installed_age_suffix",
                 return_value="",
             ),
             patch(

--- a/libs/cli/tests/unit_tests/test_notification_center.py
+++ b/libs/cli/tests/unit_tests/test_notification_center.py
@@ -42,8 +42,8 @@ def _dep_entry(key: str = "dep:ripgrep") -> PendingNotification:
 def _update_entry() -> PendingNotification:
     return PendingNotification(
         key="update:available",
-        title="Update available: v2.0.0",
-        body="v2.0.0 is available (current: v1.0.0).",
+        title="Update available",
+        body="v2.0.0 is available.\nCurrently installed: 1.0.0.",
         actions=(
             NotificationAction(ActionId.INSTALL, "Install now", primary=True),
             NotificationAction(ActionId.SKIP_ONCE, "Remind me next launch"),

--- a/libs/cli/tests/unit_tests/test_update_available.py
+++ b/libs/cli/tests/unit_tests/test_update_available.py
@@ -22,8 +22,8 @@ from deepagents_cli.widgets.update_available import (
 def _update_entry() -> PendingNotification:
     return PendingNotification(
         key="update:available",
-        title="Update available: v2.0.0",
-        body="v2.0.0 is available (current: v1.0.0).",
+        title="Update available",
+        body="v2.0.0 is available.\nCurrently installed: 1.0.0.",
         actions=(
             NotificationAction(ActionId.INSTALL, "Install now", primary=True),
             NotificationAction(ActionId.SKIP_ONCE, "Remind me next launch"),

--- a/libs/cli/tests/unit_tests/test_update_check.py
+++ b/libs/cli/tests/unit_tests/test_update_check.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from packaging.version import InvalidVersion, Version
 
+from deepagents_cli._version import __version__
 from deepagents_cli.update_check import (
     CACHE_TTL,
     _extract_release_times,
@@ -17,7 +18,9 @@ from deepagents_cli.update_check import (
     _parse_version,
     clear_update_notified,
     format_age_suffix,
+    format_installed_age_suffix,
     format_release_age,
+    format_release_age_parenthetical,
     format_sdk_age_suffix,
     format_sdk_release_age,
     get_latest_version,
@@ -169,13 +172,58 @@ class TestGetLatestVersion:
     def test_cached_hit(self, cache_file) -> None:
         """Fresh cache returns version without HTTP call."""
         cache_file.write_text(
-            json.dumps({"version": "1.5.0", "checked_at": time.time()})
+            json.dumps(
+                {
+                    "version": "1.5.0",
+                    "release_times": {__version__: "2026-04-01T12:00:00Z"},
+                    "checked_at": time.time(),
+                }
+            )
         )
         with patch("requests.get") as mock_get:
             result = get_latest_version()
 
         assert result == "1.5.0"
         mock_get.assert_not_called()
+
+    def test_cached_hit_missing_installed_release_time_triggers_fetch(
+        self, cache_file
+    ) -> None:
+        """Old cache files are refreshed so installed age notices have data."""
+        cache_file.write_text(
+            json.dumps({"version": "1.5.0", "checked_at": time.time()})
+        )
+        releases = {
+            "2.0.0": [{"filename": "a.tar.gz"}],
+            __version__: [{"filename": "installed.tar.gz"}],
+        }
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "2.0.0",
+                releases=releases,
+                release_times={__version__: "2026-04-01T12:00:00Z"},
+            ),
+        ) as mock_get:
+            result = get_latest_version()
+
+        assert result == "2.0.0"
+        mock_get.assert_called_once()
+        data = json.loads(cache_file.read_text())
+        assert data["release_times"][__version__] == "2026-04-01T12:00:00Z"
+
+    def test_cached_hit_missing_installed_release_time_falls_back_on_fetch_error(
+        self, cache_file
+    ) -> None:
+        """Age metadata refresh failures must not discard a fresh cached version."""
+        cache_file.write_text(
+            json.dumps({"version": "1.5.0", "checked_at": time.time()})
+        )
+        with patch("requests.get", side_effect=OSError("offline")) as mock_get:
+            result = get_latest_version()
+
+        assert result == "1.5.0"
+        mock_get.assert_called_once()
 
     def test_cached_hit_prerelease(self, cache_file) -> None:
         """Fresh cache returns pre-release version without HTTP call."""
@@ -184,6 +232,7 @@ class TestGetLatestVersion:
                 {
                     "version": "1.5.0",
                     "version_prerelease": "1.6.0a1",
+                    "release_times": {__version__: "2026-04-01T12:00:00Z"},
                     "checked_at": time.time(),
                 }
             )
@@ -201,6 +250,7 @@ class TestGetLatestVersion:
                 {
                     "version": "1.5.0",
                     "version_prerelease": None,
+                    "release_times": {__version__: "2026-04-01T12:00:00Z"},
                     "checked_at": time.time(),
                 }
             )
@@ -467,6 +517,21 @@ class TestExtractReleaseTimes:
             "1.1.0a1": "2026-04-18T09:30:00Z",
         }
 
+    def test_includes_installed_version_when_provided(self) -> None:
+        payload = {
+            "releases": {
+                "1.0.0": [{"upload_time_iso_8601": "2026-04-15T12:00:00Z"}],
+                "0.9.0": [{"upload_time_iso_8601": "2026-04-01T12:00:00Z"}],
+            },
+        }
+        times = _extract_release_times(
+            payload, stable="1.0.0", prerelease=None, installed="0.9.0"
+        )
+        assert times == {
+            "1.0.0": "2026-04-15T12:00:00Z",
+            "0.9.0": "2026-04-01T12:00:00Z",
+        }
+
     def test_releases_key_absent(self) -> None:
         """Payload with no `releases` key yields an empty result."""
         payload: dict[str, object] = {}
@@ -651,6 +716,62 @@ class TestFormatAgeSuffix:
         assert format_age_suffix(None) == ""
 
 
+class TestFormatReleaseAgeParenthetical:
+    def test_returns_parenthesized_release_age(self, cache_file) -> None:
+        """Known age is formatted for update-available lead sentences."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": "2026-04-15T12:00:00Z"},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        with patch(
+            "deepagents_cli.sessions.format_relative_timestamp", return_value="3d ago"
+        ):
+            assert format_release_age_parenthetical("1.0.0") == " (released 3d ago)"
+
+    def test_unknown_age_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        assert format_release_age_parenthetical("1.0.0") == ""
+
+
+class TestFormatInstalledAgeSuffix:
+    def test_returns_days_old_for_versions_at_least_one_week_old(
+        self, cache_file
+    ) -> None:
+        """Installed version age is shown only after it crosses the threshold."""
+        from datetime import UTC, datetime, timedelta
+
+        iso = (datetime.now(tz=UTC) - timedelta(days=8)).isoformat()
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": iso},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        assert format_installed_age_suffix("1.0.0") == " (8 days old)"
+
+    def test_omits_versions_newer_than_one_week(self, cache_file) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        iso = (datetime.now(tz=UTC) - timedelta(days=6)).isoformat()
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_times": {"1.0.0": iso},
+                    "checked_at": time.time(),
+                }
+            )
+        )
+        assert format_installed_age_suffix("1.0.0") == ""
+
+    def test_unknown_age_returns_empty(self, cache_file) -> None:  # noqa: ARG002
+        assert format_installed_age_suffix("1.0.0") == ""
+
+
 def _mock_sdk_pypi_response(
     releases: dict[str, list[dict[str, object]]] | None = None,
 ) -> MagicMock:
@@ -823,6 +944,28 @@ class TestGetLatestVersionReleaseTimes:
 
         data = json.loads(cache_file.read_text())
         assert data["release_times"] == {"2.0.0": "2026-04-15T12:00:00Z"}
+
+    def test_installed_release_time_cached_on_fresh_fetch(self, cache_file) -> None:
+        """The current install's release timestamp is cached for age notices."""
+        releases = {
+            "2.0.0": [{"filename": "a.tar.gz"}],
+            __version__: [{"filename": "installed.tar.gz"}],
+        }
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "2.0.0",
+                releases=releases,
+                release_times={
+                    "2.0.0": "2026-04-15T12:00:00Z",
+                    __version__: "2026-04-01T12:00:00Z",
+                },
+            ),
+        ):
+            get_latest_version()
+
+        data = json.loads(cache_file.read_text())
+        assert data["release_times"][__version__] == "2026-04-01T12:00:00Z"
 
     def test_release_times_cached_for_prerelease(self, cache_file) -> None:
         """Prerelease fetch captures both stable and prerelease timestamps."""

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -437,7 +437,7 @@ dependencies = [
 requires-dist = [
     { name = "langchain", specifier = ">=1.2.17,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.3,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.2,<5.0.0" },
     { name = "langsmith", specifier = ">=0.8.0" },
     { name = "wcmatch" },
@@ -1548,7 +1548,7 @@ dependencies = [
 requires-dist = [
     { name = "deepagents", editable = "../deepagents" },
     { name = "langchain", specifier = ">=1.2.15,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.3.1,<2.0.0" },
     { name = "langgraph", specifier = ">=1.1.10,<2.0.0" },
     { name = "quickjs-rs", specifier = ">=0.1.2,<0.2.0" },
 ]


### PR DESCRIPTION
Update-available messages now distinguish between how recently the latest release was published and how old the currently installed version is. This gives users better context when deciding whether to upgrade.