### PR TITLE
style(cli): add hidden `/connect` alias for `/auth`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -4361,7 +4361,7 @@ class DeepAgentsApp(App):
             await self._handle_skill_command(rewritten)
         elif cmd == "/mcp":
             await self._show_mcp_viewer()
-        elif cmd == "/auth":
+        elif cmd in {"/auth", "/connect"}:
             await self._show_auth_manager()
         elif cmd == "/theme":
             await self._show_theme_selector()

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -83,6 +83,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         description="Manage stored API keys for model providers",
         bypass_tier=BypassTier.IMMEDIATE_UI,
         hidden_keywords="key keys credential credentials login token api",
+        aliases=("/connect",),
     ),
     SlashCommand(
         name="/clear",

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -2438,6 +2438,23 @@ class TestTraceCommand:
             await pilot.pause()
             assert isinstance(app.screen, AuthManagerScreen)
 
+    async def test_connect_alias_routed_from_handle_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'/connect' should push the AuthManagerScreen modal."""
+        from deepagents_cli.widgets.auth import AuthManagerScreen
+
+        monkeypatch.setattr(
+            "deepagents_cli.model_config.DEFAULT_STATE_DIR", tmp_path / ".state"
+        )
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await app._handle_command("/connect")
+            await pilot.pause()
+            assert isinstance(app.screen, AuthManagerScreen)
+
 
 class TestRunAgentTaskMediaTracker:
     """Tests image tracker wiring from app into textual execution."""

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -75,6 +75,7 @@ class TestBypassTiers:
     def test_aliases_in_correct_tier(self) -> None:
         assert "/q" in ALWAYS_IMMEDIATE
         assert "/compact" in QUEUE_BOUND
+        assert "/connect" in IMMEDIATE_UI
 
     def test_every_command_classified(self) -> None:
         for cmd in COMMANDS:


### PR DESCRIPTION
Adds `/connect` as a slash-command alias for `/auth` to improve discoverability. The new alias routes to the same provider API-key management screen and is classified with the same `IMMEDIATE_UI` bypass tier as the original command.