### PR TITLE
style(cli): hidden `/about` alias for `/version`

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -4324,7 +4324,7 @@ class DeepAgentsApp(App):
 
         elif cmd in {"/changelog", "/docs", "/feedback"}:
             await self._open_url_command(command, cmd)
-        elif cmd == "/version":
+        elif cmd in {"/version", "/about"}:
             await self._mount_message(UserMessage(command))
             await self._handle_version_command()
         elif cmd == "/agents":

--- a/libs/cli/deepagents_cli/command_registry.py
+++ b/libs/cli/deepagents_cli/command_registry.py
@@ -192,6 +192,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/version",
         description="Show version",
         bypass_tier=BypassTier.CONNECTING,
+        aliases=("/about",),
     ),
     SlashCommand(
         name="/feedback",

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -4256,6 +4256,20 @@ class TestSlashCommandBypass:
             pm.assert_called_once_with("/version", "command")
             assert len(app._pending_messages) == 0
 
+    async def test_about_alias_executes_during_connecting(self) -> None:
+        """/about should process like the hidden alias for /version."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._connecting = True
+
+            with patch.object(app, "_process_message", new_callable=AsyncMock) as pm:
+                app.post_message(ChatInput.Submitted("/about", "command"))
+                await pilot.pause()
+
+            pm.assert_called_once_with("/about", "command")
+            assert len(app._pending_messages) == 0
+
     async def test_version_queues_during_agent_running(self) -> None:
         """/version should still queue when agent is actively running."""
         app = DeepAgentsApp()
@@ -4697,6 +4711,18 @@ class TestDeferredActions:
             app._connecting = False
             app._shell_running = False
             assert app._can_bypass_queue("/version") is False
+
+    async def test_can_bypass_queue_about_matches_version(self) -> None:
+        """/about follows the same connection-only bypass policy as /version."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._connecting = True
+            assert app._can_bypass_queue("/about") is True
+
+            app._agent_running = True
+            assert app._can_bypass_queue("/about") is False
 
     async def test_can_bypass_queue_bare_model_bypasses(self) -> None:
         """Bare /model should bypass the queue."""

--- a/libs/cli/tests/unit_tests/test_command_registry.py
+++ b/libs/cli/tests/unit_tests/test_command_registry.py
@@ -74,6 +74,7 @@ class TestBypassTiers:
 
     def test_aliases_in_correct_tier(self) -> None:
         assert "/q" in ALWAYS_IMMEDIATE
+        assert "/about" in BYPASS_WHEN_CONNECTING
         assert "/compact" in QUEUE_BOUND
         assert "/connect" in IMMEDIATE_UI
 


### PR DESCRIPTION
Adds `/about` as a hidden alias for the `/version` slash command, routing it to the same handler and queue-bypass behavior (`BYPASS_WHEN_CONNECTING`) as the original command.