### PR TITLE
fix(sdk): import profile symbols directly from `harness_profiles`

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -48,8 +48,11 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
-from deepagents.profiles import GeneralPurposeSubagentProfile
-from deepagents.profiles.harness.harness_profiles import _apply_profile_prompt, _harness_profile_for_model
+from deepagents.profiles.harness.harness_profiles import (
+    GeneralPurposeSubagentProfile,
+    _apply_profile_prompt,
+    _harness_profile_for_model,
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
`graph.py` was importing `GeneralPurposeSubagentProfile` through the public `deepagents.profiles` re-export while pulling the private helpers `_apply_profile_prompt` and `_harness_profile_for_model` from the underlying module. Consolidating all three imports to the direct source removes a potential circular-import path and keeps internal imports consistent.

## Changes
- Import `GeneralPurposeSubagentProfile`, `_apply_profile_prompt`, and `_harness_profile_for_model` directly from `deepagents.profiles.harness.harness_profiles` instead of splitting between the public package re-export and the internal module
