### PR TITLE
fix(ci): suppress empty failed section in release please step summary

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -484,9 +484,9 @@ jobs:
             else
               echo "_none_"
             fi
-            echo ""
-            echo "### Failed (${#FAILED[@]})"
             if [ "${#FAILED[@]}" -gt 0 ]; then
+              echo ""
+              echo "### Failed (${#FAILED[@]})"
               for p in "${FAILED[@]}"; do echo "- \`$p\`"; done
               echo ""
               echo "Recover with:"
@@ -496,8 +496,6 @@ jobs:
                 echo "gh workflow run release.yml -f package=$p -f version=$VERSION -f release-sha=$RELEASE_SHA"
               done
               echo '```'
-            else
-              echo "_none_"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Tightens the release-please post-dispatch step summary so the "### Failed" section only appears when there are actually failed dispatches. Previously the summary always rendered the failed header (and a redundant `_none_` fallback) even on clean releases.

## Changes
- Move the `### Failed` header and recovery instructions inside the `if [ "${#FAILED[@]}" -gt 0 ]` guard in the step summary builder
- Drop the `else` branch that printed `_none_` when no packages failed, eliminating visual noise from successful release runs