### PR TITLE
style(cli): add scroll and overflow hint to thread selector controls

### DIFF
--- a/libs/cli/deepagents_cli/widgets/thread_selector.py
+++ b/libs/cli/deepagents_cli/widgets/thread_selector.py
@@ -106,6 +106,8 @@ _RIGHT_ALIGNED_COLUMNS: set[str] = set()
 _SWITCH_ID_PREFIX = "thread-column-"
 _SORT_SWITCH_ID = "thread-sort-toggle"
 _RELATIVE_TIME_SWITCH_ID = "thread-relative-time"
+_CONTROLS_SCROLL_ID = "thread-controls-scroll"
+_CONTROLS_OVERFLOW_ID = "thread-controls-overflow"
 _CELL_PADDING_RIGHT = 1
 
 _FormatFns = tuple[
@@ -385,6 +387,19 @@ class ThreadOption(Horizontal):
         self.post_message(self.Clicked(self.thread_id, self.index))
 
 
+class ThreadControlsScroll(VerticalScroll):
+    """Emit scroll changes so the parent can refresh the overflow indicator."""
+
+    class Scrolled(Message):
+        """Message sent when the controls pane scroll position changes."""
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        """Notify the selector so it can update the overflow indicator."""
+        super().watch_scroll_y(old_value, new_value)
+        if self.is_attached:
+            self.post_message(self.Scrolled())
+
+
 class DeleteThreadConfirmScreen(ModalScreen[bool]):
     """Confirmation modal shown before deleting a thread."""
 
@@ -548,6 +563,12 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         border-left: solid $primary-lighten-2;
     }
 
+    ThreadSelectorScreen .thread-controls-scroll {
+        height: 1fr;
+        min-height: 1;
+        scrollbar-gutter: stable;
+    }
+
     ThreadSelectorScreen .thread-controls-title {
         text-style: bold;
         color: $primary;
@@ -562,6 +583,12 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
     ThreadSelectorScreen .thread-column-toggle {
         width: 1fr;
         height: auto;
+    }
+
+    ThreadSelectorScreen .thread-controls-overflow {
+        height: 1;
+        color: $text-muted;
+        text-align: center;
     }
 
     ThreadSelectorScreen .thread-list-header {
@@ -893,28 +920,36 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                         classes="thread-controls-help",
                         markup=False,
                     )
-                    yield Checkbox(
-                        self._format_sort_toggle_label(),
-                        self._sort_by_updated,
-                        id=_SORT_SWITCH_ID,
-                        classes="thread-column-toggle",
-                        compact=True,
-                    )
-                    yield Checkbox(
-                        "Relative Timestamps",
-                        self._relative_time,
-                        id=_RELATIVE_TIME_SWITCH_ID,
-                        classes="thread-column-toggle",
-                        compact=True,
-                    )
-                    for key in _COLUMN_ORDER:
+                    with ThreadControlsScroll(
+                        id=_CONTROLS_SCROLL_ID, classes="thread-controls-scroll"
+                    ):
                         yield Checkbox(
-                            _COLUMN_TOGGLE_LABELS[key],
-                            self._columns.get(key, False),
-                            id=self._switch_id(key),
+                            self._format_sort_toggle_label(),
+                            self._sort_by_updated,
+                            id=_SORT_SWITCH_ID,
                             classes="thread-column-toggle",
                             compact=True,
                         )
+                        yield Checkbox(
+                            "Relative Timestamps",
+                            self._relative_time,
+                            id=_RELATIVE_TIME_SWITCH_ID,
+                            classes="thread-column-toggle",
+                            compact=True,
+                        )
+                        for key in _COLUMN_ORDER:
+                            yield Checkbox(
+                                _COLUMN_TOGGLE_LABELS[key],
+                                self._columns.get(key, False),
+                                id=self._switch_id(key),
+                                classes="thread-column-toggle",
+                                compact=True,
+                            )
+                    yield Static(
+                        get_glyphs().ellipsis,
+                        id=_CONTROLS_OVERFLOW_ID,
+                        classes="thread-controls-overflow",
+                    )
 
             yield Static(
                 self._build_help_text(),
@@ -932,6 +967,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         filter_input = self._get_filter_input()
         self._filter_focus_order()
         filter_input.focus()
+        self.call_after_refresh(self._update_controls_overflow_hint)
 
         if self._has_initial_threads:
             self.call_after_refresh(self._scroll_selected_into_view)
@@ -950,6 +986,17 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             self.run_worker(
                 self._load_threads, exclusive=True, group="thread-selector-load"
             )
+
+    def on_resize(self) -> None:
+        """Refresh the overflow indicator when the modal is resized."""
+        self.call_after_refresh(self._update_controls_overflow_hint)
+
+    def on_thread_controls_scroll_scrolled(
+        self, event: ThreadControlsScroll.Scrolled
+    ) -> None:
+        """Refresh the overflow indicator after the options pane scrolls."""
+        event.stop()
+        self.call_after_refresh(self._update_controls_overflow_hint)
 
     def _start_thread_load(self) -> None:
         """Launch the thread-load worker after the initial layout pass."""
@@ -1627,6 +1674,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
     def _update_help_widgets(self) -> None:
         """Update visible header and help text after state changes."""
         self._schedule_header_rebuild()
+        self.call_after_refresh(self._update_controls_overflow_hint)
 
         try:
             help_widget = self.query_one("#thread-help", Static)
@@ -1639,6 +1687,16 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             sort_checkbox.label = self._format_sort_toggle_label()
             if sort_checkbox.value != self._sort_by_updated:
                 sort_checkbox.value = self._sort_by_updated
+
+    def _update_controls_overflow_hint(self) -> None:
+        """Show an ellipsis when the options pane has hidden rows below."""
+        try:
+            scroll = self.query_one(f"#{_CONTROLS_SCROLL_ID}", VerticalScroll)
+            hint = self.query_one(f"#{_CONTROLS_OVERFLOW_ID}", Static)
+        except NoMatches:
+            return
+
+        hint.display = scroll.scroll_y < scroll.max_scroll_y
 
     def _schedule_header_rebuild(self) -> None:
         """Queue a header rebuild to reflect column/sort changes."""

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -9,7 +9,7 @@ from rich.cells import cell_len
 from rich.style import Style
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.screen import ModalScreen
 from textual.widgets import Checkbox, Input, Static
@@ -2038,6 +2038,46 @@ class TestThreadSelectorColumnConfig:
 
                 mock_populate.assert_awaited_once()
                 assert screen._threads[0]["initial_prompt"] == "loaded prompt"
+
+
+class TestThreadSelectorControlsOverflow:
+    """Tests for short-window overflow handling in the options pane."""
+
+    async def test_options_overflow_shows_ellipsis(self) -> None:
+        """A short options pane should show an ellipsis when controls are hidden."""
+        with _patch_list_threads(), _patch_columns():
+            app = ThreadSelectorTestApp()
+            async with app.run_test(size=(100, 12)) as pilot:
+                app.show_selector()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+
+                scroll = screen.query_one("#thread-controls-scroll", VerticalScroll)
+                hint = screen.query_one("#thread-controls-overflow", Static)
+
+                assert scroll.max_scroll_y > 0
+                assert hint.display is True
+
+    async def test_options_overflow_ellipsis_hides_at_end(self) -> None:
+        """The options ellipsis should disappear after scrolling to the end."""
+        with _patch_list_threads(), _patch_columns():
+            app = ThreadSelectorTestApp()
+            async with app.run_test(size=(100, 12)) as pilot:
+                app.show_selector()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+
+                scroll = screen.query_one("#thread-controls-scroll", VerticalScroll)
+                hint = screen.query_one("#thread-controls-overflow", Static)
+                scroll.scroll_end(animate=False)
+                await pilot.pause()
+
+                assert scroll.scroll_y == scroll.max_scroll_y
+                assert hint.display is False
 
 
 def _get_widget_text(widget: Static) -> str:


### PR DESCRIPTION
The thread selector's right-hand controls pane could become inaccessible when the terminal window was too short to fit all column toggles. Wrapping the pane in a scrollable container and showing an ellipsis when content is clipped keeps the UI usable on small screens.