### PR TITLE
fix(cli): show `Resuming...` banner immediately on thread resume

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1616,7 +1616,8 @@ class DeepAgentsApp(App):
                 connecting=self._connecting,
                 resuming=self._resume_thread_intent is not None,
                 local_server=self._server_kwargs is not None,
-                defer_connecting_display=self._connecting,
+                defer_connecting_display=self._connecting
+                and self._resume_thread_intent is None,
                 id="welcome-banner",
             )
             yield Container(id="messages")


### PR DESCRIPTION
Lifts the one-line `_resume_thread_intent` check from PR #3193 onto `main` so the fix can ship independently. Once #3193 merges `main` back in, this diff will collapse into the existing v0.6 change with no conflict.

`WelcomeBanner` was given `defer_connecting_display=self._connecting`, which suppresses the connecting footer entirely while `_connecting` is `True` — that path also runs for `deepagents -r` / `/thread` resumption, so the "Resuming..." footer never rendered until the connect finished. Gating the defer on `self._resume_thread_intent is None` lets the resume path show its banner immediately while leaving the cold-start connect behavior unchanged.

Co-authored-by: Sydney Runkle <sydneymarierunkle@gmail.com>