### PR TITLE
style(cli): make post-upgrade changelog URL clickable in terminal

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -807,6 +807,26 @@ def _build_model_switch_error_body(exc: BaseException) -> str | Content:
     return f"Failed to switch model: {exc}"
 
 
+def _build_whats_new_message(heading: str) -> Content:
+    """Build the post-upgrade banner with a clickable changelog URL.
+
+    Args:
+        heading: First line of the post-upgrade banner.
+
+    Returns:
+        Styled banner content with the changelog URL embedded as a link.
+    """
+    return Content.assemble(
+        (heading, TStyle(dim=True, italic=True)),
+        "\n",
+        ("See what's new: ", TStyle(dim=True, italic=True)),
+        (
+            CHANGELOG_URL,
+            TStyle(dim=True, italic=True, underline=True, link=CHANGELOG_URL),
+        ),
+    )
+
+
 def _format_startup_error(error: BaseException) -> str:
     """Format a server-startup exception for the welcome banner.
 
@@ -2820,9 +2840,7 @@ class DeepAgentsApp(App):
             else:
                 heading = f"Updated to v{cli_version}"
 
-            await self._mount_message(
-                AppMessage(f"{heading}\nSee what's new: {CHANGELOG_URL}")
-            )
+            await self._mount_message(AppMessage(_build_whats_new_message(heading)))
         except Exception:
             logger.debug("What's new banner display failed", exc_info=True)
             return

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -30,6 +30,7 @@ from textual.screen import ModalScreen
 from textual.widget import Widget
 from textual.widgets import Checkbox, Input, Static
 
+from deepagents_cli._version import CHANGELOG_URL
 from deepagents_cli.app import (
     _TYPING_IDLE_THRESHOLD_SECONDS,
     DeepAgentsApp,
@@ -37,6 +38,7 @@ from deepagents_cli.app import (
     ExternalInput,
     QueuedMessage,
     TextualSessionState,
+    _build_whats_new_message,
 )
 from deepagents_cli.event_bus import ExternalEvent
 from deepagents_cli.widgets.chat_input import ChatInput
@@ -57,6 +59,22 @@ async def _wait_for_branch(app: DeepAgentsApp, branch: str) -> None:
         await asyncio.sleep(0.01)
     msg = f"Timed out waiting for branch {branch!r}"
     raise AssertionError(msg)
+
+
+class TestWhatsNewMessage:
+    """Tests for the post-upgrade banner content."""
+
+    def test_changelog_url_is_clickable(self) -> None:
+        """The changelog URL should be carried as a Textual link span."""
+        content = _build_whats_new_message("Updated to v1.2.3")
+
+        assert content.plain == f"Updated to v1.2.3\nSee what's new: {CHANGELOG_URL}"
+        links = [
+            link
+            for span in content.spans
+            if (link := getattr(span.style, "link", None))
+        ]
+        assert links == [CHANGELOG_URL]
 
 
 class TestInitialPromptOnMount:


### PR DESCRIPTION
The post-upgrade banner now renders the changelog URL as a proper clickable hyperlink in supported terminals. Previously the URL was plain text, forcing users to copy-paste it manually.