### PR TITLE
chore(ci): rename `deepagents-code` PR label to `dcode`

### DIFF
--- a/.github/scripts/pr-labeler-config.json
+++ b/.github/scripts/pr-labeler-config.json
@@ -50,12 +50,12 @@
     "ci": "infra",
     "cli": "cli",
     "cli-gha": "github_actions",
-    "code": "deepagents-code",
+    "code": "dcode",
     "daytona": "daytona",
     "deepagents": "deepagents",
     "deepagents-acp": "acp",
     "deepagents-cli": "cli",
-    "deepagents-code": "deepagents-code",
+    "deepagents-code": "dcode",
     "deps": "dependencies",
     "docs": "documentation",
     "evals": "evals",
@@ -97,7 +97,7 @@
       "skipExcludedFiles": true
     },
     {
-      "label": "deepagents-code",
+      "label": "dcode",
       "prefix": "libs/code/",
       "skipExcludedFiles": true
     },

--- a/.github/workflows/auto-label-by-package.yml
+++ b/.github/workflows/auto-label-by-package.yml
@@ -37,7 +37,7 @@ jobs:
               "deepagents (SDK)": "deepagents",
               "cli": "cli",
               "acp": "acp",
-              "deepagents-code": "deepagents-code",
+              "deepagents-code": "dcode",
               "evals": "evals",
               "harbor": "harbor",
               "repl": "repl",


### PR DESCRIPTION
Synchronize the PR labeler and package auto-labeler configurations to assign the `dcode` label (instead of `deepagents-code`) to the `deepagents-code` package.