### PR TITLE
docs(sdk): document `excluded_tools` mechanism for hiding built-in tools

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -272,6 +272,11 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             These are merged with the built-in tool suite listed above
             (`write_todos`, filesystem tools, `execute`, and `task`).
+
+            Passing tools here is additive — it never removes a built-in.
+            To drop a built-in tool, register a
+            [`HarnessProfile`][deepagents.HarnessProfile] with
+            `excluded_tools`.
         system_prompt: Custom system instructions placed at the front of
             the system prompt sent to the model.
 

--- a/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
@@ -670,7 +670,10 @@ class HarnessProfile:
             cannot be excluded as class or as their `.name` string. The check
             fires at `HarnessProfile` construction,
             so register-site typos fail fast rather than waiting until
-            `create_deep_agent` resolves the profile.
+            `create_deep_agent` resolves the profile. To hide their tools
+            from the model without removing the middleware, use
+            `excluded_tools` instead — the runtime rejection message points
+            at the same workaround.
         - Entries that match no middleware in the assembled stack are
             rejected as likely typos or stale profiles.
 


### PR DESCRIPTION
Clarifies in docstrings how to hide built-in tools from the model without fully removing their middleware. The existing `excluded_tools` field on `HarnessProfile` already supports this, but it wasn't mentioned alongside the `tools` parameter in `create_deep_agent` or in the `HarnessProfile` docs for `excluded_middleware`.