### PR TITLE
style(cli): indent thread label in welcome banner

### DIFF
--- a/libs/cli/deepagents_cli/widgets/welcome.py
+++ b/libs/cli/deepagents_cli/widgets/welcome.py
@@ -369,13 +369,13 @@ class WelcomeBanner(Static):
                 )
                 parts.extend(
                     [
-                        ("Thread: ", "dim"),
+                        ("  Thread: ", "dim"),
                         (self._cli_thread_id, TStyle(dim=True, link=thread_url)),
                         ("\n", "dim"),
                     ]
                 )
             else:
-                parts.append((f"Thread: {self._cli_thread_id}\n", "dim"))
+                parts.append((f"  Thread: {self._cli_thread_id}\n", "dim"))
 
         if self._mcp_tool_count > 0:
             parts.append((f"{get_glyphs().checkmark} ", success_color))

--- a/libs/cli/tests/unit_tests/test_welcome.py
+++ b/libs/cli/tests/unit_tests/test_welcome.py
@@ -106,6 +106,7 @@ class TestBuildBannerThreadLink:
         banner = widget._build_banner(project_url=None)
 
         assert "Thread: 12345" in banner.plain
+        assert "\n  Thread: 12345\n" in banner.plain
 
         # Verify no link style on the thread portion
         thread_start = banner.plain.index("Thread: 12345")
@@ -120,6 +121,7 @@ class TestBuildBannerThreadLink:
         banner = widget._build_banner(project_url=project_url)
 
         assert "Thread: 99999" in banner.plain
+        assert "\n  Thread: 99999\n" in banner.plain
 
         # Find a span with a link on the thread ID text
         thread_id_start = banner.plain.index("99999")
@@ -164,6 +166,7 @@ class TestBuildBannerThreadLink:
 
         assert "my-project" in banner.plain
         assert "Thread: 77777" in banner.plain
+        assert "\n  Thread: 77777\n" in banner.plain
 
         thread_id_start = banner.plain.index("77777")
         thread_id_end = thread_id_start + len("77777")


### PR DESCRIPTION
Adds leading whitespace to the `Thread:` label in the `WelcomeBanner` widget so it aligns visually with other metadata lines in the banner output.