### PR TITLE
feat(quickjs): rename middleware

### DIFF
--- a/examples/repl_swarm/README.md
+++ b/examples/repl_swarm/README.md
@@ -30,12 +30,12 @@ repl_swarm/
 
 1. `swarm_agent.py` creates a `create_deep_agent` with
    `skills=[".../skills"]` and
-   `REPLMiddleware(ptc=["task"], skills_backend=backend)`.
+   `CodeInterpreterMiddleware(ptc=["task"], skills_backend=backend)`.
 2. `SkillsMiddleware` parses `SKILL.md` frontmatter, including the new
    `module` key, and writes a `SkillMetadata` entry into state.
 3. When the model writes
    `await import("@/skills/swarm")` inside an `eval` call,
-   `REPLMiddleware` scans the source, loads the skill dir via the
+   `CodeInterpreterMiddleware` scans the source, loads the skill dir via the
    backend, builds a `ModuleScope` with `index.ts` (oxidase strips
    TypeScript types at install time), and calls `ctx.install`.
 4. Guest code imports `runSwarm`, which calls `tools.task(...)`

--- a/examples/repl_swarm/swarm_agent.py
+++ b/examples/repl_swarm/swarm_agent.py
@@ -25,7 +25,7 @@ from deepagents import create_deep_agent
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.state import StateBackend
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 SKILLS_DIR = str(Path(__file__).parent / "skills")
 DEFAULT_MODEL = "claude-sonnet-4-6"
@@ -53,7 +53,7 @@ def _build_agent(model: str) -> object:
         backend=backend,
         skills=["/skills/"],
         middleware=[
-            REPLMiddleware(
+            CodeInterpreterMiddleware(
                 ptc=["task"],
                 skills_backend=backend,
                 timeout=None,

--- a/examples/rlm_agent/README.md
+++ b/examples/rlm_agent/README.md
@@ -1,7 +1,7 @@
 # Recursive REPL Mode (RLM)
 
 `create_rlm_agent` is a wrapper over `create_deep_agent` that adds
-[`REPLMiddleware`](../../libs/partners/quickjs) to the agent and — for
+[`CodeInterpreterMiddleware`](../../libs/partners/quickjs) to the agent and — for
 `max_depth > 0` — replaces the default `general-purpose` subagent
 with a `CompiledSubAgent` whose runnable is a depth-(N-1) RLM agent.
 
@@ -16,7 +16,7 @@ at depth 0, where `general-purpose` is the plain built-in.
 A plain Deep Agent can delegate to a subagent via the `task` tool.
 That's one call per subtask, serialized across model turns.
 
-With `REPLMiddleware(ptc=["task", ...])` on the agent, the model can write:
+With `CodeInterpreterMiddleware(ptc=["task", ...])` on the agent, the model can write:
 
 ```javascript
 // inside one `eval` tool call
@@ -34,9 +34,9 @@ can fan out again.
 ## Structure
 
 ```
-root (depth=2, has REPLMiddleware)
-└── general-purpose → compiled depth-1 graph (has REPLMiddleware)
-    └── general-purpose → compiled depth-0 graph (has REPLMiddleware)
+root (depth=2, has CodeInterpreterMiddleware)
+└── general-purpose → compiled depth-1 graph (has CodeInterpreterMiddleware)
+    └── general-purpose → compiled depth-0 graph (has CodeInterpreterMiddleware)
         └── general-purpose → built-in default (no REPL, no recursion)
 ```
 
@@ -103,5 +103,5 @@ uv run python rlm_agent.py --max-depth 2
   the `task` tool's `description` argument or let results flow back
   through tool return values.
 - **Only the root agent has REPL at each level.** If you want REPL
-  on a non-`general-purpose` subagent too, add `REPLMiddleware` to
+  on a non-`general-purpose` subagent too, add `CodeInterpreterMiddleware` to
   its `middleware` list yourself when you define it.

--- a/examples/rlm_agent/rlm_agent.py
+++ b/examples/rlm_agent/rlm_agent.py
@@ -3,7 +3,7 @@
 `create_deep_agent` with a compiled general-purpose chain.
 
 `create_rlm_agent` builds a Deep Agent whose own middleware stack
-includes `REPLMiddleware(ptc=[...])`, and — for `max_depth > 0` —
+includes `CodeInterpreterMiddleware(ptc=[...])`, and — for `max_depth > 0` —
 replaces the default `general-purpose` subagent with a
 `CompiledSubAgent` whose runnable is itself a depth-(N-1) RLM agent.
 The model delegates via `tools.task({subagent_type: "general-purpose",
@@ -44,7 +44,7 @@ from deepagents.middleware.subagents import (
     SubAgent,
 )
 from langchain_core.tools import BaseTool, tool
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 _MAX_DEPTH_LIMIT = 8  # guard against typos that would build thousands of agents
 
@@ -135,7 +135,7 @@ def _build(
             model=model,
             tools=tools,
             subagents=extra_subagents,
-            middleware=[REPLMiddleware(ptc=ptc_tool_names)],
+            middleware=[CodeInterpreterMiddleware(ptc=ptc_tool_names)],
             **kwargs,
         )
 
@@ -156,7 +156,7 @@ def _build(
         model=model,
         tools=tools,
         subagents=[compiled_gp, *extra_subagents],
-        middleware=[REPLMiddleware(ptc=ptc_tool_names)],
+        middleware=[CodeInterpreterMiddleware(ptc=ptc_tool_names)],
         **kwargs,
     )
 

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -293,7 +293,7 @@ class SkillMetadata(TypedDict):
     Warning: this is experimental.
 
     When present, consumers of this metadata (notably `langchain-quickjs`'s
-    `REPLMiddleware`) may install the skill as a dynamic-importable ES
+    `CodeInterpreterMiddleware`) may install the skill as a dynamic-importable ES
     module. The string is a POSIX path like `./index.ts` pointing at a
     file inside the skill dir. This middleware only parses and validates
     the field — it does not load or execute any JavaScript.

--- a/libs/evals/tests/evals/test_tool_usage_incident_graph.py
+++ b/libs/evals/tests/evals/test_tool_usage_incident_graph.py
@@ -14,7 +14,7 @@ from deepagents import create_deep_agent
 from langchain.agents.middleware.types import ToolCallRequest, wrap_tool_call
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import ToolException, tool
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from langchain_repl.middleware import ReplMiddleware
 
 if TYPE_CHECKING:
@@ -770,7 +770,7 @@ def _create_agent(model: BaseChatModel, repl_name: str | None):
     if repl_name == "langchain":
         middleware.append(ReplMiddleware(ptc=INCIDENT_GRAPH_TOOLS, add_ptc_docs=True))
     elif repl_name == "quickjs":
-        middleware.append(REPLMiddleware(ptc=INCIDENT_GRAPH_TOOLS))
+        middleware.append(CodeInterpreterMiddleware(ptc=INCIDENT_GRAPH_TOOLS))
     elif repl_name is None:
         tools = INCIDENT_GRAPH_TOOLS
     else:

--- a/libs/evals/tests/evals/test_tool_usage_relational.py
+++ b/libs/evals/tests/evals/test_tool_usage_relational.py
@@ -17,7 +17,7 @@ from typing_extensions import TypedDict
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from langchain_repl.middleware import ReplMiddleware
 
 from tests.evals.utils import (
@@ -442,7 +442,7 @@ def _create_agent(model: BaseChatModel, repl_name: str | None):
     if repl_name == "langchain":
         middleware = [ReplMiddleware(ptc=RELATIONAL_TOOLS, add_ptc_docs=True)]
     elif repl_name == "quickjs":
-        middleware = [REPLMiddleware(ptc=RELATIONAL_TOOLS)]
+        middleware = [CodeInterpreterMiddleware(ptc=RELATIONAL_TOOLS)]
     elif repl_name is None:
         tools = RELATIONAL_TOOLS
     else:

--- a/libs/partners/quickjs/README.md
+++ b/libs/partners/quickjs/README.md
@@ -6,11 +6,11 @@ Instead of issuing N serial tool calls, the model can write one block of JavaScr
 
 ```python
 from deepagents import create_deep_agent
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 agent = create_deep_agent(
     model="claude-sonnet-4-6",
-    middleware=[REPLMiddleware()],
+    middleware=[CodeInterpreterMiddleware()],
 )
 ```
 
@@ -52,11 +52,11 @@ uv add langchain-quickjs
 
 ```python
 from deepagents import create_deep_agent
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 agent = create_deep_agent(
     model="claude-sonnet-4-6",
-    middleware=[REPLMiddleware()],
+    middleware=[CodeInterpreterMiddleware()],
 )
 
 # Use `ainvoke` — PTC bridges register as async QuickJS host functions,
@@ -178,9 +178,9 @@ await tools.summarize({ text: results.join("\n\n") })
 ### Enabling it
 
 ```python
-REPLMiddleware()                              # disabled (default)
-REPLMiddleware(ptc=["search_web"])            # explicit allowlist
-REPLMiddleware(ptc=[search_tool])             # explicit tool object allowlist
+CodeInterpreterMiddleware()                              # disabled (default)
+CodeInterpreterMiddleware(ptc=["search_web"])            # explicit allowlist
+CodeInterpreterMiddleware(ptc=[search_tool])             # explicit tool object allowlist
 ```
 
 The REPL's own tool is always excluded from PTC; `tools.eval("tools.eval(...)")` would be pointless recursion, and if the model wants nested code it can just write nested code in one call.
@@ -228,7 +228,7 @@ Under the hood:
 Enable it by passing the same `BackendProtocol` your `SkillsMiddleware` uses:
 
 ```python
-REPLMiddleware(skills_backend=my_backend)
+CodeInterpreterMiddleware(skills_backend=my_backend)
 ```
 
 There's a hard cap of 1 MiB per skill bundle. If you hit it, split the skill or prune generated code.
@@ -236,7 +236,7 @@ There's a hard cap of 1 MiB per skill bundle. If you hit it, split the skill or 
 ## Configuration reference
 
 ```python
-REPLMiddleware(
+CodeInterpreterMiddleware(
     memory_limit=64 * 1024 * 1024,  # bytes, shared across contexts
     timeout=5.0,                     # per-call seconds
     max_ptc_calls=256,     # per-eval `tools.*` bridge calls, None disables (DoS risk)

--- a/libs/partners/quickjs/langchain_quickjs/__init__.py
+++ b/libs/partners/quickjs/langchain_quickjs/__init__.py
@@ -1,6 +1,6 @@
 """langchain-quickjs: persistent JS REPL middleware for agents."""
 
 from langchain_quickjs._ptc import PTCOption
-from langchain_quickjs.middleware import REPLMiddleware
+from langchain_quickjs.middleware import CodeInterpreterMiddleware
 
-__all__ = ["PTCOption", "REPLMiddleware"]
+__all__ = ["CodeInterpreterMiddleware", "PTCOption"]

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -37,7 +37,7 @@ def render_repl_system_prompt(
     memory_limit_mb: int,
     snapshot_between_turns: bool,
 ) -> str:
-    """Render the base REPL system prompt text for ``REPLMiddleware``."""
+    """Render the base REPL system prompt text for ``CodeInterpreterMiddleware``."""
     state_persistence_line = (
         "- State (variables, functions) persists across tool calls and across "
         "multiple turns for this conversation thread."

--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -1,4 +1,4 @@
-"""Programmatic tool calling (PTC) support for ``REPLMiddleware``.
+"""Programmatic tool calling (PTC) support for ``CodeInterpreterMiddleware``.
 
 PTC exposes the agent's LangChain tools inside the JavaScript REPL as
 ``tools.<camelCaseName>(input)`` async functions. Instead of issuing

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -1,4 +1,4 @@
-"""``REPLMiddleware``: exposes a persistent JavaScript REPL as an agent tool.
+"""``CodeInterpreterMiddleware``: exposes a persistent JavaScript REPL as an agent tool.
 
 State persists across tool calls within a LangGraph thread (each thread
 gets its own QuickJS context).
@@ -52,7 +52,7 @@ _DEFAULT_TOOL_NAME = "eval"
 
 
 class REPLState(AgentState):
-    """State schema for ``REPLMiddleware``."""
+    """State schema for ``CodeInterpreterMiddleware``."""
 
     _quickjs_snapshot_payload: NotRequired[Annotated[bytes | None, PrivateStateAttr]]
 
@@ -74,7 +74,7 @@ def _resolve_thread_id(fallback: str) -> str:
     The fallback is a middleware-instance-scoped id: when the caller
     didn't configure a ``thread_id`` (common for ad-hoc
     ``agent.invoke(...)`` in tests or single-shot scripts), we still need
-    all resolver calls within one REPLMiddleware lifetime to return the
+    all resolver calls within one CodeInterpreterMiddleware lifetime to return the
     same id — otherwise ``wrap_model_call`` installs tools on one REPL
     and the eval tool looks up a different one, and the model sees
     ``ReferenceError: tools is not defined``.
@@ -91,7 +91,7 @@ def _resolve_thread_id(fallback: str) -> str:
 
 
 @beta()
-class REPLMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
+class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
     """Middleware exposing a persistent JS REPL to the agent.
 
     Each LangGraph thread gets its own QuickJS slot (worker + runtime +
@@ -165,11 +165,11 @@ class REPLMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
     Example:
         ```python
         from deepagents import create_deep_agent
-        from langchain_quickjs import REPLMiddleware
+        from langchain_quickjs import CodeInterpreterMiddleware
 
         agent = create_deep_agent(
             model="claude-sonnet-4-6",
-            middleware=[REPLMiddleware()],
+            middleware=[CodeInterpreterMiddleware()],
         )
         ```
     """
@@ -521,3 +521,6 @@ class REPLMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT]):
         # half-unloaded.
         with contextlib.suppress(Exception):
             self._registry.close()
+
+
+REPLMiddleware = CodeInterpreterMiddleware

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -521,6 +521,3 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         # half-unloaded.
         with contextlib.suppress(Exception):
             self._registry.close()
-
-
-REPLMiddleware = CodeInterpreterMiddleware

--- a/libs/partners/quickjs/tests/benchmarks/_common.py
+++ b/libs/partners/quickjs/tests/benchmarks/_common.py
@@ -11,7 +11,7 @@ from deepagents import create_deep_agent
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from tests._common import FakeChatModel
 
 if TYPE_CHECKING:
@@ -74,7 +74,7 @@ def finite_script(code: str, *, repeats: int) -> Iterator[AIMessage]:
 def make_agent(
     *,
     code: str,
-    middleware: REPLMiddleware,
+    middleware: CodeInterpreterMiddleware,
     repeats: int,
 ) -> Any:
     """Create a deep agent with a scripted fake chat model."""
@@ -113,7 +113,9 @@ def run_counter_turns(
     snapshot_between_turns: bool,
 ) -> list[str]:
     """Run `turn_count` REPL turns and return counter values per turn."""
-    middleware = REPLMiddleware(snapshot_between_turns=snapshot_between_turns)
+    middleware = CodeInterpreterMiddleware(
+        snapshot_between_turns=snapshot_between_turns
+    )
     state: REPLState = {}
     runtime: Any = None  # hooks ignore runtime; `None` keeps this path lightweight
     values: list[str] = []

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from tests.benchmarks._common import (
     CONSOLE_LOG_CODE,
     PTC_ONLY_CODE,
@@ -42,7 +42,7 @@ class TestQuickJSMemoryBenchmarks:
         use_ptc: bool,
     ) -> None:
         def _worker(index: int) -> None:
-            middleware = REPLMiddleware(
+            middleware = CodeInterpreterMiddleware(
                 timeout=45.0,
                 capture_console=True,
                 ptc=[echo_payload] if use_ptc else None,

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from tests.benchmarks._common import (
     PTC_AND_CONSOLE_CODE,
     THROUGHPUT_ITERATIONS,
@@ -53,7 +53,7 @@ class TestQuickJSThroughputBenchmarks:
         benchmark: BenchmarkFixture,
     ) -> None:
         """Measure throughput for many eval calls in one thread and process."""
-        middleware = REPLMiddleware(capture_console=True, ptc=[echo_payload])
+        middleware = CodeInterpreterMiddleware(capture_console=True, ptc=[echo_payload])
 
         @benchmark
         def _() -> None:

--- a/libs/partners/quickjs/tests/integration_tests/test_postgres.py
+++ b/libs/partners/quickjs/tests/integration_tests/test_postgres.py
@@ -13,7 +13,7 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from pydantic import Field
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 try:
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
@@ -139,7 +139,7 @@ async def test_ptc_task_with_postgres_checkpointer_keeps_loop_affinity(
                         }
                     ],
                 ),
-                REPLMiddleware(ptc=["task"]),
+                CodeInterpreterMiddleware(ptc=["task"]),
             ],
             checkpointer=checkpointer,
         )

--- a/libs/partners/quickjs/tests/integration_tests/test_rlm.py
+++ b/libs/partners/quickjs/tests/integration_tests/test_rlm.py
@@ -11,7 +11,7 @@ Both invocation paths are exercised:
 - ``agent.invoke`` (sync path)
 - ``agent.ainvoke`` (async path)
 
-``REPLMiddleware`` routes both paths through async QuickJS eval under
+``CodeInterpreterMiddleware`` routes both paths through async QuickJS eval under
 the hood so PTC host-function bridges work consistently in either mode.
 
 Requires ``ANTHROPIC_API_KEY`` in the environment. Run with
@@ -29,7 +29,7 @@ from langchain.agents import create_agent
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage, ToolMessage
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("ANTHROPIC_API_KEY"),
@@ -96,7 +96,7 @@ async def test_ptc_spawns_subagent_through_eval(invoke_mode: InvokeMode) -> None
                 backend=None,  # not used by this trivial subagent
                 subagents=[_researcher_subagent()],
             ),
-            REPLMiddleware(ptc=["task"]),
+            CodeInterpreterMiddleware(ptc=["task"]),
         ],
     )
 
@@ -147,7 +147,7 @@ async def test_ptc_respects_allowlist_config(invoke_mode: InvokeMode) -> None:
                 backend=None,
                 subagents=[_researcher_subagent()],
             ),
-            REPLMiddleware(ptc=[]),
+            CodeInterpreterMiddleware(ptc=[]),
         ],
     )
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -12,7 +12,7 @@ from langchain_core.tools import tool
 from pydantic import Field
 from typing_extensions import TypedDict
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -154,7 +154,7 @@ def test_system_prompt_snapshot_no_tools(
     model = _smoke_model()
     agent = create_deep_agent(
         model=model,
-        middleware=[REPLMiddleware()],
+        middleware=[CodeInterpreterMiddleware()],
     )
     _invoke_for_snapshot(agent, {"messages": [HumanMessage(content="hi")]})
     prompt = _capture_system_prompt(model)
@@ -176,7 +176,7 @@ def test_system_prompt_snapshot_with_mixed_foreign_functions(
     model = _smoke_model()
     agent = create_deep_agent(
         model=model,
-        middleware=[REPLMiddleware(ptc=mixed_tools)],
+        middleware=[CodeInterpreterMiddleware(ptc=mixed_tools)],
         tools=mixed_tools,
     )
     _invoke_for_snapshot(agent, {"messages": [HumanMessage(content="hi")]})

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for ``REPLMiddleware`` with a fake LLM.
+"""End-to-end tests for ``CodeInterpreterMiddleware`` with a fake LLM.
 
 Regression gate for the sync tool handler: before the worker-thread
 refactor, sync ``invoke`` ran ``ctx.eval``, which cannot dispatch async
@@ -31,7 +31,7 @@ from langchain.tools import (
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import InjectedToolCallId, tool
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from tests._common import FakeChatModel
 
 # The exact snippet a model produced in production when this regressed.
@@ -137,7 +137,7 @@ def _script(code: str, *, final_message: str = "Done.") -> Iterator[AIMessage]:
 
 def _make_agent(
     code: str,
-    middleware: REPLMiddleware,
+    middleware: CodeInterpreterMiddleware,
     *,
     final_message: str = "Done.",
 ) -> Any:
@@ -170,7 +170,7 @@ def test_deepagent_with_quickjs_interpreter_sync() -> None:
     """Basic sync test with QuickJS interpreter."""
     result = _make_agent(
         "6 * 7",
-        REPLMiddleware(),
+        CodeInterpreterMiddleware(),
         final_message="The answer is 42.",
     ).invoke(
         {"messages": [HumanMessage(content="Use the eval tool to calculate 6 * 7")]}
@@ -184,7 +184,7 @@ def test_deepagent_with_quickjs_interpreter_sync() -> None:
 def test_deepagent_with_quickjs_list_returning_foreign_function_sync() -> None:
     """A PTC tool returning a Python ``list`` surfaces as a native JS Array."""
     code = "const ids = await tools.listUserIds({});\nids.join(',');"
-    result = _make_agent(code, REPLMiddleware(ptc=[list_user_ids])).invoke(
+    result = _make_agent(code, CodeInterpreterMiddleware(ptc=[list_user_ids])).invoke(
         {
             "messages": [
                 HumanMessage(
@@ -201,7 +201,7 @@ def test_deepagent_with_quickjs_list_returning_foreign_function_sync() -> None:
 def test_ptc_int_return_is_native_js_number() -> None:
     """A PTC tool returning a Python ``int`` surfaces as a JS ``number``."""
     code = "const n = await tools.getUserCount({});\n`${typeof n}:${n + 1}`;"
-    result = _make_agent(code, REPLMiddleware(ptc=[get_user_count])).invoke(
+    result = _make_agent(code, CodeInterpreterMiddleware(ptc=[get_user_count])).invoke(
         {"messages": [HumanMessage(content="go")]}
     )
     _assert_result_contains(_eval_tool_message(result).content, "number:8")
@@ -213,9 +213,9 @@ def test_ptc_dict_return_is_native_js_object() -> None:
         "const u = await tools.getUserProfile({});\n"
         "`${u.id}:${u.name}:${u.tags.join(',')}`;"
     )
-    result = _make_agent(code, REPLMiddleware(ptc=[get_user_profile])).invoke(
-        {"messages": [HumanMessage(content="go")]}
-    )
+    result = _make_agent(
+        code, CodeInterpreterMiddleware(ptc=[get_user_profile])
+    ).invoke({"messages": [HumanMessage(content="go")]})
     _assert_result_contains(_eval_tool_message(result).content, "21:Bob:admin,ops")
 
 
@@ -227,7 +227,7 @@ def test_ptc_dict_with_nested_non_native_values_does_not_break_eval() -> None:
     )
     result = _make_agent(
         code,
-        REPLMiddleware(ptc=[get_user_profile_with_dates]),
+        CodeInterpreterMiddleware(ptc=[get_user_profile_with_dates]),
     ).invoke({"messages": [HumanMessage(content="go")]})
 
     _assert_result_contains(
@@ -239,9 +239,9 @@ def test_ptc_dict_with_nested_non_native_values_does_not_break_eval() -> None:
 def test_ptc_none_return_is_js_null() -> None:
     """A PTC tool returning ``None`` surfaces as JS ``null``."""
     code = "const r = await tools.getUserEmailOrNone({user_id: -1});\n`${r === null}`;"
-    result = _make_agent(code, REPLMiddleware(ptc=[get_user_email_or_none])).invoke(
-        {"messages": [HumanMessage(content="go")]}
-    )
+    result = _make_agent(
+        code, CodeInterpreterMiddleware(ptc=[get_user_email_or_none])
+    ).invoke({"messages": [HumanMessage(content="go")]})
     _assert_result_contains(_eval_tool_message(result).content, "true")
 
 
@@ -252,7 +252,7 @@ def test_ptc_injects_tool_call_id_per_call() -> None:
         "const b = await tools.echoCallId({value: 'b'});\n"
         "`${a !== b}:${a.startsWith('a|')}:${b.startsWith('b|')}`;"
     )
-    result = _make_agent(code, REPLMiddleware(ptc=[echo_call_id])).invoke(
+    result = _make_agent(code, CodeInterpreterMiddleware(ptc=[echo_call_id])).invoke(
         {"messages": [HumanMessage(content="go")]}
     )
     _assert_result_contains(_eval_tool_message(result).content, "true:true:true")
@@ -269,7 +269,7 @@ def test_deepagent_with_quickjs_mixed_foreign_function_sync() -> None:
     )
     result = _make_agent(
         code,
-        REPLMiddleware(ptc=[sync_label_tool, async_label_tool]),
+        CodeInterpreterMiddleware(ptc=[sync_label_tool, async_label_tool]),
     ).invoke(
         {
             "messages": [
@@ -286,7 +286,7 @@ def test_quickjs_sync_timeout_error() -> None:
     """Verify sync eval path surfaces QuickJS eval timeouts."""
     result = _make_agent(
         "while (true) {}",
-        REPLMiddleware(timeout=1),
+        CodeInterpreterMiddleware(timeout=1),
         final_message="timeout hit",
     ).invoke(
         {
@@ -307,7 +307,7 @@ def test_quickjs_sync_tool_exception_propagates() -> None:
     semantics as a non-quickjs tool that raises."""
     agent = _make_agent(
         "await tools.alwaysFails({value: 'x'})",
-        REPLMiddleware(ptc=[always_fails]),
+        CodeInterpreterMiddleware(ptc=[always_fails]),
     )
     with pytest.raises(RuntimeError, match="boom:x"):
         agent.invoke(
@@ -327,7 +327,7 @@ def test_quickjs_sync_host_call_budget_exceeded() -> None:
         "await tools.syncLabel({value: 'a'});\n"
         "await tools.syncLabel({value: 'b'});\n"
         "'done'",
-        REPLMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
+        CodeInterpreterMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
     ).invoke(
         {"messages": [HumanMessage(content="Use eval and call sync_label twice.")]}
     )
@@ -340,7 +340,7 @@ def test_quickjs_sync_toolruntime_configurable_foreign_function() -> None:
     """Verify sync PTC tool calls see configurable runtime data."""
     result = _make_agent(
         "await tools.runtimeConfigurable({value: 'value'})",
-        REPLMiddleware(ptc=[runtime_configurable]),
+        CodeInterpreterMiddleware(ptc=[runtime_configurable]),
     ).invoke(
         {
             "messages": [
@@ -362,7 +362,7 @@ def test_quickjs_sync_parallel_agents_across_threads() -> None:
     def _run_agent(index: int) -> tuple[int, dict[str, object]]:
         result = _make_agent(
             f"{index} * 10",
-            REPLMiddleware(),
+            CodeInterpreterMiddleware(),
             final_message=f"done-{index}",
         ).invoke(
             {
@@ -385,9 +385,9 @@ def test_quickjs_sync_parallel_agents_across_threads() -> None:
 
 def test_sync_ptc_eval_through_repl() -> None:
     """``invoke`` path: the observed production snippet must not error."""
-    result = _make_agent(_EVAL_CODE, REPLMiddleware(ptc=[list_user_ids])).invoke(
-        {"messages": [HumanMessage(content="go")]}
-    )
+    result = _make_agent(
+        _EVAL_CODE, CodeInterpreterMiddleware(ptc=[list_user_ids])
+    ).invoke({"messages": [HumanMessage(content="go")]})
     _assert_no_error(_eval_tool_message(result).content)
 
 
@@ -395,7 +395,7 @@ async def test_async_ptc_eval_through_repl() -> None:
     """``ainvoke`` path: same guard on the async handler."""
     result = await _make_agent(
         _EVAL_CODE,
-        REPLMiddleware(ptc=[list_user_ids]),
+        CodeInterpreterMiddleware(ptc=[list_user_ids]),
     ).ainvoke({"messages": [HumanMessage(content="go")]})
     _assert_no_error(_eval_tool_message(result).content)
 
@@ -423,7 +423,7 @@ def test_wrong_arg_name_surfaces_to_model() -> None:
                 ]
             )
         ),
-        middleware=[REPLMiddleware(ptc=[echo_foo])],
+        middleware=[CodeInterpreterMiddleware(ptc=[echo_foo])],
     )
     result = agent.invoke({"messages": [HumanMessage(content="go")]})
     message_types = [message.type for message in result["messages"]]

--- a/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_end_to_end_async.py
@@ -1,4 +1,4 @@
-"""Async end-to-end tests for ``REPLMiddleware`` with a fake LLM.
+"""Async end-to-end tests for ``CodeInterpreterMiddleware`` with a fake LLM.
 
 Covers the same integration surfaces as the prior quickjs e2e suite:
 agent wiring, REPL execution, PTC tool calls, runtime propagation,
@@ -21,7 +21,7 @@ from langchain.tools import (
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from tests._common import FakeChatModel
 
 
@@ -79,7 +79,7 @@ def _script(code: str, *, final_message: str = "done") -> Iterator[AIMessage]:
 
 def _make_agent(
     code: str,
-    middleware: REPLMiddleware,
+    middleware: CodeInterpreterMiddleware,
     *,
     final_message: str = "done",
 ) -> Any:
@@ -107,7 +107,7 @@ async def test_deepagent_with_quickjs_interpreter() -> None:
     """Basic async test with QuickJS interpreter."""
     result = await _make_agent(
         "6 * 7",
-        REPLMiddleware(),
+        CodeInterpreterMiddleware(),
         final_message="The answer is 42.",
     ).ainvoke(
         {"messages": [HumanMessage(content="Use the eval tool to calculate 6 * 7")]}
@@ -121,7 +121,9 @@ async def test_deepagent_with_quickjs_interpreter() -> None:
 async def test_deepagent_with_quickjs_list_returning_foreign_function() -> None:
     """A PTC tool returning a Python ``list`` surfaces as a native JS Array."""
     code = "const ids = await tools.listUserIds({});\nids.join(',');"
-    result = await _make_agent(code, REPLMiddleware(ptc=[list_user_ids])).ainvoke(
+    result = await _make_agent(
+        code, CodeInterpreterMiddleware(ptc=[list_user_ids])
+    ).ainvoke(
         {
             "messages": [
                 HumanMessage(
@@ -146,7 +148,7 @@ async def test_deepagent_with_quickjs_async_foreign_function() -> None:
     )
     result = await _make_agent(
         code,
-        REPLMiddleware(ptc=[sync_label_tool, async_label_tool]),
+        CodeInterpreterMiddleware(ptc=[sync_label_tool, async_label_tool]),
     ).ainvoke(
         {
             "messages": [
@@ -163,7 +165,7 @@ async def test_quickjs_async_timeout_error() -> None:
     """Verify the async eval path surfaces QuickJS eval timeouts."""
     result = await _make_agent(
         "while (true) {}",
-        REPLMiddleware(timeout=1),
+        CodeInterpreterMiddleware(timeout=1),
         final_message="timeout hit",
     ).ainvoke(
         {
@@ -184,7 +186,7 @@ async def test_quickjs_async_tool_exception_propagates() -> None:
     semantics as a non-quickjs tool that raises."""
     agent = _make_agent(
         "await tools.alwaysFails({value: 'x'})",
-        REPLMiddleware(ptc=[always_fails]),
+        CodeInterpreterMiddleware(ptc=[always_fails]),
     )
     with pytest.raises(RuntimeError, match="boom:x"):
         await agent.ainvoke(
@@ -204,7 +206,7 @@ async def test_quickjs_async_host_call_budget_exceeded() -> None:
         "await tools.syncLabel({value: 'a'});\n"
         "await tools.syncLabel({value: 'b'});\n"
         "'done'",
-        REPLMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
+        CodeInterpreterMiddleware(ptc=[sync_label_tool], max_ptc_calls=1),
     ).ainvoke(
         {"messages": [HumanMessage(content="Use eval and call sync_label twice.")]}
     )
@@ -217,7 +219,7 @@ async def test_quickjs_async_toolruntime_configurable_foreign_function() -> None
     """Verify async PTC tool calls see configurable runtime data."""
     result = await _make_agent(
         "await tools.runtimeConfigurable({value: 'value'})",
-        REPLMiddleware(ptc=[runtime_configurable]),
+        CodeInterpreterMiddleware(ptc=[runtime_configurable]),
     ).ainvoke(
         {
             "messages": [
@@ -239,7 +241,7 @@ async def test_quickjs_async_parallel_agents() -> None:
     async def _run_agent(index: int) -> tuple[int, dict[str, object]]:
         result = await _make_agent(
             f"{index} * 10",
-            REPLMiddleware(),
+            CodeInterpreterMiddleware(),
             final_message=f"done-{index}",
         ).ainvoke(
             {

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from quickjs_rs import Runtime, ThreadWorker
 from typing_extensions import TypedDict
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from langchain_quickjs._ptc import (
     filter_tools_for_ptc,
     render_ptc_prompt,
@@ -566,7 +566,7 @@ async def test_ptc_host_call_budget_none_disables_limit(
 
 
 def test_middleware_ptc_default_off_omits_prompt_block() -> None:
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     # Calling _prepare_for_call directly is fine — pass a minimal request
     # stand-in. We don't need a full ModelRequest for this check.
     from types import SimpleNamespace
@@ -579,7 +579,7 @@ def test_middleware_ptc_default_off_omits_prompt_block() -> None:
 def test_middleware_ptc_list_includes_prompt_block() -> None:
     from types import SimpleNamespace
 
-    mw = REPLMiddleware(ptc=["greet", "eval"])
+    mw = CodeInterpreterMiddleware(ptc=["greet", "eval"])
     req = SimpleNamespace(tools=[_greet_tool(), _echo_tool("eval")])
     prompt = mw._prepare_for_call(req)
     # Greet included
@@ -592,7 +592,7 @@ def test_middleware_ptc_list_of_tools_exposes_without_agent_tools() -> None:
     """`ptc=[tool]` installs the tool in the REPL even when the agent has none."""
     from types import SimpleNamespace
 
-    mw = REPLMiddleware(ptc=[_greet_tool()])
+    mw = CodeInterpreterMiddleware(ptc=[_greet_tool()])
     req = SimpleNamespace(tools=[])
     prompt = mw._prepare_for_call(req)
     assert "async function greet(" in prompt
@@ -608,7 +608,7 @@ async def test_ptc_install_and_eval_resolve_to_same_repl() -> None:
     """
     from types import SimpleNamespace
 
-    mw = REPLMiddleware(ptc=["greet", "eval"])
+    mw = CodeInterpreterMiddleware(ptc=["greet", "eval"])
     # Simulate a model-call turn without any langgraph config present.
     req = SimpleNamespace(tools=[_greet_tool(), _echo_tool("eval")])
     mw._prepare_for_call(req)
@@ -626,7 +626,7 @@ async def test_middleware_eval_tool_returns_tool_message_only() -> None:
     from langchain.tools import ToolRuntime
 
     command_tool = _command_tool()
-    mw = REPLMiddleware(ptc=[command_tool])
+    mw = CodeInterpreterMiddleware(ptc=[command_tool])
     tool = mw.tools[0]
     mw._prepare_for_call(SimpleNamespace(tools=[command_tool, tool]))
     runtime = ToolRuntime(
@@ -651,10 +651,10 @@ async def test_middleware_eval_tool_returns_tool_message_only() -> None:
 def test_middleware_rejects_boolean_ptc_config_during_prepare() -> None:
     from types import SimpleNamespace
 
-    mw = REPLMiddleware(ptc=True)  # type: ignore[arg-type]
+    mw = CodeInterpreterMiddleware(ptc=True)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
         mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))
-    mw = REPLMiddleware(ptc=False)  # type: ignore[arg-type]
+    mw = CodeInterpreterMiddleware(ptc=False)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
         mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))
 
@@ -662,7 +662,7 @@ def test_middleware_rejects_boolean_ptc_config_during_prepare() -> None:
 def test_middleware_rejects_dict_ptc_config_during_prepare() -> None:
     from types import SimpleNamespace
 
-    mw = REPLMiddleware(ptc={"include": ["greet"]})  # type: ignore[arg-type]
+    mw = CodeInterpreterMiddleware(ptc={"include": ["greet"]})  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="Unsupported `ptc` config type"):
         mw._prepare_for_call(SimpleNamespace(tools=[_greet_tool()]))
 

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -1,4 +1,4 @@
-"""Unit tests for REPLMiddleware and its backing REPL wrapper."""
+"""Unit tests for CodeInterpreterMiddleware and its backing REPL wrapper."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from langchain_core.tools import StructuredTool
 from pydantic import BaseModel
 from quickjs_rs import Runtime, ThreadWorker
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from langchain_quickjs._format import format_outcome
 from langchain_quickjs._repl import _clear_exception_references, _Registry, _ThreadREPL
 
@@ -84,7 +84,7 @@ class _StubModel:
 
 
 def test_tool_registered_with_default_name() -> None:
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     # langchain's create_agent accepts a model string; we use a cheap local
     # fake to avoid any provider import. Any string maps through init_chat_model,
     # but we want to avoid network/config; go direct via tools=[] + our middleware.
@@ -101,7 +101,7 @@ def test_tool_registered_with_default_name() -> None:
 
 
 def test_tool_registered_with_custom_name() -> None:
-    mw = REPLMiddleware(tool_name="js")
+    mw = CodeInterpreterMiddleware(tool_name="js")
     from langchain_core.language_models.fake_chat_models import FakeListChatModel
 
     agent = create_agent(
@@ -115,23 +115,23 @@ def test_tool_registered_with_custom_name() -> None:
 
 
 def test_legacy_system_prompt_alias_removed() -> None:
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     assert not hasattr(mw, "system_prompt")
 
 
 def test_rejects_invalid_max_ptc_calls() -> None:
     with pytest.raises(ValueError, match="must be >= 1 or None"):
-        REPLMiddleware(max_ptc_calls=0)
+        CodeInterpreterMiddleware(max_ptc_calls=0)
 
 
 def test_rejects_invalid_max_snapshot_bytes() -> None:
     with pytest.raises(ValueError, match="must be >= 1 or None"):
-        REPLMiddleware(max_snapshot_bytes=0)
+        CodeInterpreterMiddleware(max_snapshot_bytes=0)
 
 
 def test_system_prompt_injected_once() -> None:
     """wrap_model_call appends exactly one snippet per call, idempotent in content."""
-    mw = REPLMiddleware(timeout=7.0, memory_limit=32 * 1024 * 1024)
+    mw = CodeInterpreterMiddleware(timeout=7.0, memory_limit=32 * 1024 * 1024)
     seen: list[ModelRequest] = []
 
     def handler(req: ModelRequest):
@@ -167,7 +167,7 @@ def test_system_prompt_injected_once() -> None:
 
 
 def test_system_prompt_mentions_single_turn_when_snapshots_disabled() -> None:
-    mw = REPLMiddleware(snapshot_between_turns=False)
+    mw = CodeInterpreterMiddleware(snapshot_between_turns=False)
     assert "DO NOT persist across multiple turns" in mw._base_system_prompt
 
 
@@ -403,7 +403,7 @@ def test_registry_get_if_exists_does_not_create_slot() -> None:
 
 
 def test_middleware_del_closes_runtime() -> None:
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     # Force a slot to exist
     _ = mw._registry.get("t")
     slots = list(mw._registry._slots.values())
@@ -546,7 +546,7 @@ async def test_aevict_closes_and_removes_slot() -> None:
 
 def test_after_agent_evicts_current_thread_slot() -> None:
     """``after_agent`` snapshots state and evicts the resolved thread slot."""
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     try:
         # Force a slot to exist for the middleware's fallback thread id.
         repl = mw._registry.get(mw._fallback_thread_id)
@@ -562,7 +562,7 @@ def test_after_agent_evicts_current_thread_slot() -> None:
 
 async def test_aafter_agent_evicts_current_thread_slot() -> None:
     """``aafter_agent`` snapshots state and evicts the resolved thread slot."""
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         repl.eval_sync("globalThis.counter = 10")
@@ -577,7 +577,7 @@ async def test_aafter_agent_evicts_current_thread_slot() -> None:
 
 def test_after_agent_snapshot_roundtrip_with_before_agent() -> None:
     """Snapshots from ``after_agent`` restore into fresh slots in ``before_agent``."""
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         repl.eval_sync("const answer = 42")
@@ -595,7 +595,7 @@ def test_after_agent_snapshot_roundtrip_with_before_agent() -> None:
 
 async def test_aafter_agent_snapshot_roundtrip_with_abefore_agent() -> None:
     """Async snapshot roundtrip restores state in a fresh slot."""
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         await repl.eval_async("const answer = 42")
@@ -612,7 +612,7 @@ async def test_aafter_agent_snapshot_roundtrip_with_abefore_agent() -> None:
 
 
 def test_before_agent_clears_payload_on_restore_failure() -> None:
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     try:
         update = mw.before_agent(
             state={"_quickjs_snapshot_payload": b"not-a-snapshot"},
@@ -624,7 +624,7 @@ def test_before_agent_clears_payload_on_restore_failure() -> None:
 
 
 def test_after_agent_clears_payload_on_snapshot_failure() -> None:
-    mw = REPLMiddleware()
+    mw = CodeInterpreterMiddleware()
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         with patch.object(repl, "create_snapshot", side_effect=RuntimeError("boom")):
@@ -636,7 +636,7 @@ def test_after_agent_clears_payload_on_snapshot_failure() -> None:
 
 
 def test_after_agent_drops_payload_above_snapshot_size_cap() -> None:
-    mw = REPLMiddleware(max_snapshot_bytes=4)
+    mw = CodeInterpreterMiddleware(max_snapshot_bytes=4)
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         with patch.object(repl, "create_snapshot", return_value=b"12345"):
@@ -648,7 +648,7 @@ def test_after_agent_drops_payload_above_snapshot_size_cap() -> None:
 
 
 async def test_aafter_agent_drops_payload_above_snapshot_size_cap() -> None:
-    mw = REPLMiddleware(max_snapshot_bytes=4)
+    mw = CodeInterpreterMiddleware(max_snapshot_bytes=4)
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         with patch.object(
@@ -664,7 +664,7 @@ async def test_aafter_agent_drops_payload_above_snapshot_size_cap() -> None:
 
 
 def test_snapshot_between_turns_disabled_keeps_reset_behavior() -> None:
-    mw = REPLMiddleware(snapshot_between_turns=False)
+    mw = CodeInterpreterMiddleware(snapshot_between_turns=False)
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         repl.eval_sync("globalThis.answer = 42")

--- a/libs/partners/quickjs/tests/unit_tests/test_snapshot_persistence.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_snapshot_persistence.py
@@ -11,7 +11,7 @@ from deepagents.backends.state import StateBackend
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.memory import InMemorySaver
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 from tests._common import FakeChatModel
 
 InvokeMode = Literal["invoke", "ainvoke"]
@@ -138,7 +138,7 @@ async def test_repl_snapshot_persists_state_between_turns(
     """REPL state survives across turns on the same thread_id."""
     agent = create_deep_agent(
         model=FakeChatModel(messages=iter(_script_two_turns())),
-        middleware=[REPLMiddleware()],
+        middleware=[CodeInterpreterMiddleware()],
         checkpointer=InMemorySaver(),
     )
     config = {"configurable": {"thread_id": "quickjs-snapshot-thread"}}
@@ -174,7 +174,7 @@ async def test_repl_without_snapshots_resets_state_between_turns(
     """When snapshots are disabled, turn-2 eval starts with a fresh context."""
     agent = create_deep_agent(
         model=FakeChatModel(messages=iter(_script_two_turns_without_snapshots())),
-        middleware=[REPLMiddleware(snapshot_between_turns=False)],
+        middleware=[CodeInterpreterMiddleware(snapshot_between_turns=False)],
         checkpointer=InMemorySaver(),
     )
     config = {"configurable": {"thread_id": "quickjs-no-snapshot-thread"}}
@@ -235,7 +235,7 @@ async def test_repl_snapshot_persists_skill_usage_between_turns(
         model=FakeChatModel(messages=iter(_script_two_turns_with_skill())),
         backend=backend,
         skills=["/skills"],
-        middleware=[REPLMiddleware(skills_backend=backend)],
+        middleware=[CodeInterpreterMiddleware(skills_backend=backend)],
         checkpointer=InMemorySaver(),
     )
     config = {"configurable": {"thread_id": "quickjs-snapshot-skill-thread"}}
@@ -310,7 +310,7 @@ async def test_repl_snapshot_persists_top_level_await_binding_between_turns(
     ]
     agent = create_deep_agent(
         model=FakeChatModel(messages=iter(script)),
-        middleware=[REPLMiddleware()],
+        middleware=[CodeInterpreterMiddleware()],
         checkpointer=InMemorySaver(),
     )
     config = {"configurable": {"thread_id": "quickjs-top-level-await-thread"}}

--- a/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
@@ -17,7 +17,7 @@ from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 from pydantic import Field
 
-from langchain_quickjs import REPLMiddleware
+from langchain_quickjs import CodeInterpreterMiddleware
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -68,7 +68,7 @@ def _assert_result_contains(content: str, expected: str) -> None:
 
 def _make_agent(
     code: str,
-    middleware: REPLMiddleware,
+    middleware: CodeInterpreterMiddleware,
     *,
     final_message: str = "done",
 ) -> Any:
@@ -90,7 +90,7 @@ async def test_quickjs_async_ptc_runs_tools_on_outer_loop() -> None:
     outer_loop_id = str(id(asyncio.get_running_loop()))
     result = await _make_agent(
         "await tools.currentLoopId({})",
-        REPLMiddleware(ptc=[current_loop_id]),
+        CodeInterpreterMiddleware(ptc=[current_loop_id]),
     ).ainvoke(
         {
             "messages": [
@@ -146,7 +146,7 @@ async def test_quickjs_async_ptc_task_subagent_loop_affinity_e2e() -> None:
                     }
                 ],
             ),
-            REPLMiddleware(ptc=["task"]),
+            CodeInterpreterMiddleware(ptc=["task"]),
         ],
     )
 


### PR DESCRIPTION
REPLMiddleware -> CodeInterpreterMiddleware

Middleware is marked as beta and undocumented / unannounced, so we do not implement backward-compatibility.