### PR TITLE
feat(cli): wire configurable model middleware into subagents without explicit models

### DIFF
--- a/libs/cli/deepagents_cli/agent.py
+++ b/libs/cli/deepagents_cli/agent.py
@@ -1062,40 +1062,50 @@ def create_cli_agent(
         else settings.get_project_agents_dir()
     )
 
+    def _subagent_cli_middleware(*, has_explicit_model: bool) -> list[AgentMiddleware]:
+        middleware: list[AgentMiddleware] = []
+        if not has_explicit_model:
+            middleware.append(ConfigurableModelMiddleware())
+        if restrictive_shell_allow_list is not None:
+            middleware.append(ShellAllowListMiddleware(restrictive_shell_allow_list))
+        return middleware
+
     for subagent_meta in list_subagents(
         user_agents_dir=user_agents_dir,
         project_agents_dir=project_agents_dir,
     ):
+        model_spec = subagent_meta["model"]
+        has_explicit_model = model_spec is not None
         subagent: SubAgent = {
             "name": subagent_meta["name"],
             "description": subagent_meta["description"],
             "system_prompt": subagent_meta["system_prompt"],
         }
-        if subagent_meta["model"]:
-            subagent["model"] = subagent_meta["model"]
-        if restrictive_shell_allow_list is not None:
-            subagent["middleware"] = [
-                ShellAllowListMiddleware(restrictive_shell_allow_list)
-            ]
+        if model_spec is not None:
+            subagent["model"] = model_spec
+        subagent_middleware = _subagent_cli_middleware(
+            has_explicit_model=has_explicit_model
+        )
+        if subagent_middleware:
+            subagent["middleware"] = subagent_middleware
         custom_subagents.append(subagent)
 
-    if restrictive_shell_allow_list is not None:
-        from deepagents.middleware.subagents import (
-            GENERAL_PURPOSE_SUBAGENT,
-            SubAgent as RuntimeSubAgent,
-        )
+    from deepagents.middleware.subagents import (
+        GENERAL_PURPOSE_SUBAGENT,
+        SubAgent as RuntimeSubAgent,
+    )
 
-        if not any(
-            subagent["name"] == GENERAL_PURPOSE_SUBAGENT["name"]
-            for subagent in custom_subagents
-        ):
-            general_purpose_subagent: RuntimeSubAgent = {
-                "name": GENERAL_PURPOSE_SUBAGENT["name"],
-                "description": GENERAL_PURPOSE_SUBAGENT["description"],
-                "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
-                "middleware": [ShellAllowListMiddleware(restrictive_shell_allow_list)],
-            }
-            custom_subagents.append(general_purpose_subagent)
+    if not any(
+        subagent["name"] == GENERAL_PURPOSE_SUBAGENT["name"]
+        for subagent in custom_subagents
+    ):
+        general_purpose_subagent: RuntimeSubAgent = {
+            "name": GENERAL_PURPOSE_SUBAGENT["name"],
+            "description": GENERAL_PURPOSE_SUBAGENT["description"],
+            "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
+            "middleware": _subagent_cli_middleware(has_explicit_model=False),
+        }
+        custom_subagents.append(general_purpose_subagent)
 
     # Build middleware stack based on enabled features
     agent_middleware = []

--- a/libs/cli/tests/unit_tests/test_agent.py
+++ b/libs/cli/tests/unit_tests/test_agent.py
@@ -2234,6 +2234,114 @@ class TestCreateCliAgentShellMiddlewareWiring:
                 f"Expected shell middleware on subagent {name!r}"
             )
 
+    def test_model_switch_middleware_added_to_inherited_model_subagents(
+        self, tmp_path: Path
+    ) -> None:
+        """Subagents without a model should inherit runtime model switches."""
+        from deepagents_cli.configurable_model import ConfigurableModelMiddleware
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+
+        subagent_meta = {
+            "name": "researcher",
+            "description": "Researches things",
+            "system_prompt": "Investigate the task thoroughly.",
+            "model": None,
+        }
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware"),
+            patch(
+                "deepagents_cli.agent.list_subagents",
+                return_value=[subagent_meta],
+            ),
+            patch(
+                "deepagents_cli.agent.create_deep_agent",
+                return_value=mock_agent,
+            ) as mock_create,
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=True,
+            )
+
+        _, kwargs = mock_create.call_args
+        subagents = kwargs["subagents"]
+        assert subagents is not None
+
+        subagents_by_name = {subagent["name"]: subagent for subagent in subagents}
+        assert "researcher" in subagents_by_name
+        assert "general-purpose" in subagents_by_name
+
+        for name in ("researcher", "general-purpose"):
+            middleware = subagents_by_name[name]["middleware"]
+            assert any(
+                isinstance(mw, ConfigurableModelMiddleware) for mw in middleware
+            ), f"Expected configurable model middleware on subagent {name!r}"
+
+    def test_model_switch_middleware_skipped_for_explicit_subagent_model(
+        self, tmp_path: Path
+    ) -> None:
+        """Subagent-specific models should not be overridden by runtime switches."""
+        from deepagents_cli.configurable_model import ConfigurableModelMiddleware
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+
+        subagent_meta = {
+            "name": "researcher",
+            "description": "Researches things",
+            "system_prompt": "Investigate the task thoroughly.",
+            "model": "openai:gpt-5",
+        }
+
+        with (
+            patch("deepagents_cli.agent.settings", mock_settings),
+            patch("deepagents_cli.agent.SkillsMiddleware"),
+            patch("deepagents_cli.agent.MemoryMiddleware"),
+            patch(
+                "deepagents_cli.agent.list_subagents",
+                return_value=[subagent_meta],
+            ),
+            patch(
+                "deepagents_cli.agent.create_deep_agent",
+                return_value=mock_agent,
+            ) as mock_create,
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=True,
+            )
+
+        _, kwargs = mock_create.call_args
+        subagents = kwargs["subagents"]
+        researcher = next(
+            subagent for subagent in subagents if subagent["name"] == "researcher"
+        )
+        middleware = researcher.get("middleware", [])
+        assert not any(isinstance(mw, ConfigurableModelMiddleware) for mw in middleware)
+
     def test_no_duplicate_general_purpose_when_user_defined(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Subagents and the fallback `general-purpose` subagent now respect the user's runtime model switch when they don't define their own model. Subagents with an explicit model spec continue to use it without interference.