### PR TITLE
feat(code): `--timeout` flag for non-interactive

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -830,6 +830,17 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--timeout",
+        dest="timeout",
+        type=positive_int,
+        metavar="SECONDS",
+        help="Hard wall-clock timeout in seconds. The agent is cancelled and "
+        "the process exits with code 124 if the timeout is reached. "
+        "Complements --max-turns (turn count) with a time-based limit. "
+        "Requires -n or piped stdin.",
+    )
+
+    parser.add_argument(
         "--stdin",
         action="store_true",
         help="Read input from stdin explicitly (instead of auto-detection)",
@@ -1744,6 +1755,17 @@ def cli_main() -> None:
             )
             sys.exit(2)
 
+        timeout_set = getattr(args, "timeout", None) is not None
+        if timeout_set and not args.non_interactive_message:
+            from rich.console import Console as _Console
+
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --timeout requires "
+                "--non-interactive (-n) or piped stdin\n"
+                "  deepagents -n 'run the test suite' --timeout 120"
+            )
+            sys.exit(2)
+
         if (args.quiet or args.no_stream) and not args.non_interactive_message:
             # Print to stderr (not the module-level stdout console) and exit
             # with code 2 to match the POSIX convention for usage errors, as
@@ -2066,26 +2088,38 @@ def cli_main() -> None:
             # Non-interactive mode - execute single task and exit
             from deepagents_code.non_interactive import run_non_interactive
 
-            exit_code = asyncio.run(
-                run_non_interactive(
-                    message=args.non_interactive_message,
-                    assistant_id=assistant_id,
-                    model_name=getattr(args, "model", None),
-                    model_params=model_params,
-                    profile_override=profile_override,
-                    sandbox_type=args.sandbox,
-                    sandbox_id=args.sandbox_id,
-                    sandbox_setup=getattr(args, "sandbox_setup", None),
-                    initial_skill=getattr(args, "initial_skill", None),
-                    startup_cmd=getattr(args, "startup_cmd", None),
-                    quiet=args.quiet,
-                    stream=not args.no_stream,
-                    mcp_config_path=getattr(args, "mcp_config", None),
-                    no_mcp=getattr(args, "no_mcp", False),
-                    trust_project_mcp=getattr(args, "trust_project_mcp", False),
-                    max_turns=getattr(args, "max_turns", None),
+            timeout = getattr(args, "timeout", None)
+            try:
+                exit_code = asyncio.run(
+                    asyncio.wait_for(
+                        run_non_interactive(
+                            message=args.non_interactive_message,
+                            assistant_id=assistant_id,
+                            model_name=getattr(args, "model", None),
+                            model_params=model_params,
+                            profile_override=profile_override,
+                            sandbox_type=args.sandbox,
+                            sandbox_id=args.sandbox_id,
+                            sandbox_setup=getattr(args, "sandbox_setup", None),
+                            initial_skill=getattr(args, "initial_skill", None),
+                            startup_cmd=getattr(args, "startup_cmd", None),
+                            quiet=args.quiet,
+                            stream=not args.no_stream,
+                            mcp_config_path=getattr(args, "mcp_config", None),
+                            no_mcp=getattr(args, "no_mcp", False),
+                            trust_project_mcp=getattr(args, "trust_project_mcp", False),
+                            max_turns=getattr(args, "max_turns", None),
+                        ),
+                        timeout=timeout,
+                    )
                 )
-            )
+            except TimeoutError:
+                from rich.console import Console as _Console
+
+                _Console(stderr=True).print(
+                    f"[bold red]Error:[/bold red] agent timed out after {timeout}s"
+                )
+                sys.exit(124)
             sys.exit(exit_code)
         else:
             # Resolve recent-agent fallback only for actual session launches.

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -836,8 +836,8 @@ def parse_args() -> argparse.Namespace:
         metavar="SECONDS",
         help="Hard wall-clock timeout in seconds. The agent is cancelled and "
         "the process exits with code 124 if the timeout is reached. "
-        "Complements --max-turns (turn count) with a time-based limit. "
-        "Requires -n or piped stdin.",
+        "Complements --max-turns (turn count) with a time-based limit; both "
+        "use exit code 124 on expiry. Requires -n or piped stdin.",
     )
 
     parser.add_argument(
@@ -2114,12 +2114,23 @@ def cli_main() -> None:
                     )
                 )
             except TimeoutError:
+                # `asyncio.wait_for` raises `asyncio.TimeoutError`, which is
+                # an alias of the builtin on Python >= 3.11 (the project's
+                # minimum).
                 from rich.console import Console as _Console
 
                 _Console(stderr=True).print(
-                    f"[bold red]Error:[/bold red] agent timed out after {timeout}s"
+                    f"[bold red]Error:[/bold red] agent timed out after "
+                    f"{timeout}s. Retry with a larger --timeout, or use "
+                    "--max-turns for a turn-count limit."
                 )
                 sys.exit(124)
+            except KeyboardInterrupt:
+                # `asyncio.run` re-raises `KeyboardInterrupt` past the inner
+                # `run_non_interactive` handler when the signal hits during
+                # `wait_for`; mirror its exit code 130 here so Ctrl-C is a
+                # quiet exit instead of a traceback.
+                sys.exit(130)
             sys.exit(exit_code)
         else:
             # Resolve recent-agent fallback only for actual session launches.

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -187,8 +187,7 @@ async def _terminate_startup_process(proc: Process) -> None:
         await asyncio.wait_for(proc.wait(), timeout=5)
     except TimeoutError:
         logger.warning(
-            "Startup command (pid=%s) did not exit after termination; "
-            "sending SIGKILL",
+            "Startup command (pid=%s) did not exit after termination; sending SIGKILL",
             proc.pid,
         )
         try:

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -61,6 +61,8 @@ from deepagents_code.unicode_security import (
 )
 
 if TYPE_CHECKING:
+    from asyncio.subprocess import Process
+
     from langchain_core.runnables import RunnableConfig
 
 logger = logging.getLogger(__name__)
@@ -149,6 +151,82 @@ class _ConsoleSpinner:
                 logger.warning("Spinner stop failed: %s", exc)
             finally:
                 self._live = None
+
+
+async def _terminate_startup_process(proc: Process) -> None:
+    """Terminate and reap a startup command subprocess.
+
+    Args:
+        proc: Process returned by `asyncio.create_subprocess_shell`.
+    """
+    import asyncio
+    import sys
+
+    if proc.returncode is not None:
+        return
+
+    try:
+        if sys.platform != "win32":
+            import os
+            import signal
+
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.kill()
+    except ProcessLookupError:
+        return
+    except OSError:
+        logger.warning(
+            "Failed to terminate startup command (pid=%s)",
+            proc.pid,
+            exc_info=True,
+        )
+        return
+
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5)
+    except TimeoutError:
+        logger.warning(
+            "Startup command (pid=%s) did not exit after termination; "
+            "sending SIGKILL",
+            proc.pid,
+        )
+        try:
+            if sys.platform != "win32":
+                import os
+                import signal
+
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+        except ProcessLookupError:
+            return
+        except OSError:
+            logger.warning(
+                "Failed to SIGKILL startup command (pid=%s); process may leak",
+                proc.pid,
+                exc_info=True,
+            )
+            return
+        try:
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+        except OSError:
+            logger.warning(
+                "Failed to reap startup command (pid=%s) after SIGKILL",
+                proc.pid,
+                exc_info=True,
+            )
+    except ProcessLookupError:
+        pass
+    except OSError:
+        logger.warning(
+            "Failed to wait on startup command (pid=%s) after SIGTERM; "
+            "process may leak",
+            proc.pid,
+            exc_info=True,
+        )
 
 
 @dataclass
@@ -780,6 +858,10 @@ async def _run_startup_command(
         quiet: When `True`, suppresses the "Running startup command" header
             so piped output stays minimal; warnings still appear (on stderr
             when the caller wired the console there).
+
+    Raises:
+        asyncio.CancelledError: If the caller cancels while the startup command
+            is running.
     """
     import asyncio
     import sys
@@ -805,69 +887,11 @@ async def _run_startup_command(
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             proc.communicate(), timeout=60
         )
+    except asyncio.CancelledError:
+        await _terminate_startup_process(proc)
+        raise
     except TimeoutError:
-        if proc.returncode is None:
-            try:
-                if sys.platform != "win32":
-                    import os
-                    import signal
-
-                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-                else:
-                    proc.kill()
-            except ProcessLookupError:
-                pass
-            except OSError:
-                logger.warning(
-                    "Failed to terminate startup command (pid=%s)",
-                    proc.pid,
-                    exc_info=True,
-                )
-            else:
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=5)
-                except TimeoutError:
-                    logger.warning(
-                        "Startup command (pid=%s) did not exit after termination; "
-                        "sending SIGKILL",
-                        proc.pid,
-                    )
-                    try:
-                        if sys.platform != "win32":
-                            import os
-                            import signal
-
-                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                        else:
-                            proc.kill()
-                    except ProcessLookupError:
-                        pass
-                    except OSError:
-                        logger.warning(
-                            "Failed to SIGKILL startup command (pid=%s); "
-                            "process may leak",
-                            proc.pid,
-                            exc_info=True,
-                        )
-                    try:
-                        await proc.wait()
-                    except ProcessLookupError:
-                        pass
-                    except OSError:
-                        logger.warning(
-                            "Failed to reap startup command (pid=%s) after SIGKILL",
-                            proc.pid,
-                            exc_info=True,
-                        )
-                except ProcessLookupError:
-                    pass
-                except OSError:
-                    logger.warning(
-                        "Failed to wait on startup command (pid=%s) after SIGTERM; "
-                        "process may leak",
-                        proc.pid,
-                        exc_info=True,
-                    )
+        await _terminate_startup_process(proc)
         console.print("[yellow]Warning:[/yellow] startup command timed out (60s limit)")
         return
 

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -138,7 +138,7 @@ def show_help() -> None:
     )
     console.print(
         "  --timeout SECONDS          Hard wall-clock limit; exits 124 on expiry"
-        " (needs -n)"
+        " (needs -n/stdin)"
     )
     console.print("  --stdin                    Read input from stdin explicitly")
     console.print(

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -136,6 +136,10 @@ def show_help() -> None:
     console.print(
         "  --max-turns N              Max agentic turns before stopping (needs -n)"
     )
+    console.print(
+        "  --timeout SECONDS          Hard wall-clock limit; exits 124 on expiry"
+        " (needs -n)"
+    )
     console.print("  --stdin                    Read input from stdin explicitly")
     console.print(
         "  --json                     Emit machine-readable JSON for commands"

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1,6 +1,7 @@
 """Tests for command-line argument parsing."""
 
 import argparse
+import asyncio
 import io
 import os
 import sys
@@ -360,6 +361,148 @@ class TestMaxTurnsArgument:
         """Argparse rejects 0, negatives, and non-integers with exit 2."""
         with (
             mock_argv("-n", "task", "--max-turns", bad_value),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            parse_args()
+        assert exc_info.value.code == 2
+
+
+class TestTimeoutArgument:
+    """Tests for --timeout argument parsing, validation, and runtime behaviour."""
+
+    def test_parses_integer(self, mock_argv: MockArgvType) -> None:
+        """--timeout N stores an integer."""
+        with mock_argv("-n", "task", "--timeout", "60"):
+            parsed = parse_args()
+            assert parsed.timeout == 60
+
+    def test_not_specified_is_none(self, mock_argv: MockArgvType) -> None:
+        """Timeout is None when --timeout is not provided."""
+        with mock_argv():
+            parsed = parse_args()
+            assert parsed.timeout is None
+
+    def test_combined_with_non_interactive(self, mock_argv: MockArgvType) -> None:
+        """--timeout works alongside -n and --max-turns."""
+        with mock_argv("-n", "run tests", "--timeout", "120", "--max-turns", "10"):
+            parsed = parse_args()
+            assert parsed.non_interactive_message == "run tests"
+            assert parsed.timeout == 120
+            assert parsed.max_turns == 10
+
+    def test_requires_non_interactive_mode(self) -> None:
+        """--timeout without -n or piped stdin exits with code 2."""
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "--timeout", "30"]),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 2
+
+    def test_allowed_with_piped_stdin(self) -> None:
+        """--timeout without -n is allowed when stdin is piped."""
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.return_value = "piped task"
+        with (
+            patch.object(sys, "argv", ["deepagents", "--timeout", "30"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_optional_tools", return_value=[]),
+            patch("os.open", side_effect=OSError("No tty in test sandbox")),
+            patch(
+                "deepagents_code.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_run,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 0
+        _ = mock_run  # called via asyncio.wait_for; exit code drives sys.exit
+
+    def test_forwarded_via_wait_for(self) -> None:
+        """--timeout value is used as the asyncio.wait_for timeout."""
+        import asyncio
+
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys, "argv", ["deepagents", "-n", "do the thing", "--timeout", "45"]
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_code.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch("asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for,
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+        assert mock_wait_for.call_args.kwargs["timeout"] == 45
+
+    def test_timeout_exits_124(self) -> None:
+        """When asyncio.TimeoutError is raised the process exits with code 124."""
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys, "argv", ["deepagents", "-n", "slow task", "--timeout", "1"]
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_optional_tools", return_value=[]),
+            patch(
+                "asyncio.wait_for",
+                side_effect=asyncio.TimeoutError,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert exc_info.value.code == 124
+
+    def test_no_timeout_when_omitted(self) -> None:
+        """When --timeout is omitted, wait_for is called with timeout=None."""
+        import asyncio
+
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "-n", "do the thing"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_code.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch("asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for,
+            pytest.raises(SystemExit),
+        ):
+            cli_main()
+        assert mock_wait_for.call_args.kwargs["timeout"] is None
+
+    @pytest.mark.parametrize("bad_value", ["0", "-1", "-60", "abc"])
+    def test_rejects_non_positive_and_non_integer(
+        self, mock_argv: MockArgvType, bad_value: str
+    ) -> None:
+        """Argparse rejects 0, negatives, and non-integers with exit 2."""
+        with (
+            mock_argv("-n", "task", "--timeout", bad_value),
             pytest.raises(SystemExit) as exc_info,
         ):
             parse_args()

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -367,8 +367,21 @@ class TestMaxTurnsArgument:
         assert exc_info.value.code == 2
 
 
+def _wait_for_timeout(mock_wait_for: MagicMock) -> object:
+    """Extract the `timeout` arg from a mocked `asyncio.wait_for` call.
+
+    Handles both positional and keyword call styles so the assertion does not
+    depend on how production code passes the argument.
+    """
+    import inspect
+
+    call = mock_wait_for.call_args
+    bound = inspect.signature(asyncio.wait_for).bind(*call.args, **call.kwargs)
+    return bound.arguments["timeout"]
+
+
 class TestTimeoutArgument:
-    """Tests for --timeout argument parsing, validation, and runtime behaviour."""
+    """Tests for --timeout argument parsing, validation, and runtime behavior."""
 
     def test_parses_integer(self, mock_argv: MockArgvType) -> None:
         """--timeout N stores an integer."""
@@ -390,8 +403,10 @@ class TestTimeoutArgument:
             assert parsed.timeout == 120
             assert parsed.max_turns == 10
 
-    def test_requires_non_interactive_mode(self) -> None:
-        """--timeout without -n or piped stdin exits with code 2."""
+    def test_requires_non_interactive_mode(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--timeout without -n or piped stdin exits with code 2 and warns on stderr."""
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
@@ -403,16 +418,28 @@ class TestTimeoutArgument:
         ):
             cli_main()
         assert exc_info.value.code == 2
+        stderr = capsys.readouterr().err
+        assert "--timeout" in stderr
+        assert "-n" in stderr
 
     def test_allowed_with_piped_stdin(self) -> None:
-        """--timeout without -n is allowed when stdin is piped."""
+        """--timeout without -n is allowed when stdin is piped.
+
+        Also asserts that `max_turns` (None by default) is still forwarded to
+        `run_non_interactive`, guarding against kwarg drops in the surrounding
+        try/except refactor.
+        """
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
         mock_stdin.isatty.return_value = False
         mock_stdin.read.return_value = "piped task"
         with (
-            patch.object(sys, "argv", ["deepagents", "--timeout", "30"]),
+            patch.object(
+                sys,
+                "argv",
+                ["deepagents", "--timeout", "30", "--max-turns", "5"],
+            ),
             patch.object(sys, "stdin", mock_stdin),
             patch("deepagents_code.main.check_optional_tools", return_value=[]),
             patch("os.open", side_effect=OSError("No tty in test sandbox")),
@@ -425,12 +452,13 @@ class TestTimeoutArgument:
         ):
             cli_main()
         assert exc_info.value.code == 0
-        _ = mock_run  # called via asyncio.wait_for; exit code drives sys.exit
+        mock_run.assert_awaited_once()
+        await_args = mock_run.await_args
+        assert await_args is not None
+        assert await_args.kwargs["max_turns"] == 5
 
     def test_forwarded_via_wait_for(self) -> None:
         """--timeout value is used as the asyncio.wait_for timeout."""
-        import asyncio
-
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
@@ -450,10 +478,10 @@ class TestTimeoutArgument:
             pytest.raises(SystemExit),
         ):
             cli_main()
-        assert mock_wait_for.call_args.kwargs["timeout"] == 45
+        assert _wait_for_timeout(mock_wait_for) == 45
 
-    def test_timeout_exits_124(self) -> None:
-        """When asyncio.TimeoutError is raised the process exits with code 124."""
+    def test_timeout_exits_124(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Exits with 124 and warns on stderr when `asyncio.TimeoutError` is raised."""
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
@@ -472,11 +500,12 @@ class TestTimeoutArgument:
         ):
             cli_main()
         assert exc_info.value.code == 124
+        stderr = capsys.readouterr().err
+        assert "timed out" in stderr
+        assert "1s" in stderr
 
     def test_no_timeout_when_omitted(self) -> None:
         """When --timeout is omitted, wait_for is called with timeout=None."""
-        import asyncio
-
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
@@ -494,7 +523,7 @@ class TestTimeoutArgument:
             pytest.raises(SystemExit),
         ):
             cli_main()
-        assert mock_wait_for.call_args.kwargs["timeout"] is None
+        assert _wait_for_timeout(mock_wait_for) is None
 
     @pytest.mark.parametrize("bad_value", ["0", "-1", "-60", "abc"])
     def test_rejects_non_positive_and_non_integer(

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -1,5 +1,6 @@
 """Tests for non-interactive mode HITL decision logic."""
 
+import asyncio
 import io
 import signal
 import sys
@@ -1483,6 +1484,31 @@ class TestRunStartupCommand:
         mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
         mock_proc.kill.assert_not_called()
         assert "timed out" in buf.getvalue()
+
+    async def test_cancellation_kills_process_group_on_posix(self) -> None:
+        """Outer cancellation should still clean up the startup process group."""
+        buf = io.StringIO()
+        console = Console(file=buf, width=200, highlight=False)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_proc.wait = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        mock_proc.kill = MagicMock()
+
+        with (
+            patch("asyncio.create_subprocess_shell", return_value=mock_proc),
+            patch.object(sys, "platform", "darwin"),
+            patch("os.getpgid", return_value=12345),
+            patch("os.killpg") as mock_killpg,
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await _run_startup_command("sleep 999", console, quiet=False)
+
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
+        mock_proc.kill.assert_not_called()
+        assert "timed out" not in buf.getvalue()
 
     async def test_timeout_escalates_to_sigkill_when_sigterm_ignored(self) -> None:
         """If SIGTERM + 5s wait also times out, SIGKILL must follow."""


### PR DESCRIPTION
Fixes #3350

Adds `--timeout SECONDS` to `deepagents-code`, giving non-interactive runs a hard wall-clock limit that complements the existing turn-count limit (`--max-turns`). On expiry the agent is cancelled and the process exits with code 124 (GNU `timeout(1)` convention).

```bash
# Fail fast in CI if the task takes more than 2 minutes
deepagents-code -n "run the test suite and summarise failures" --timeout 120

# Combine with --max-turns — whichever limit is hit first stops the agent
deepagents-code -n "refactor auth module" --timeout 300 --max-turns 20
```

## How did you verify your code works?

- Added 12 unit tests in `libs/code/tests/unit_tests/test_main_args.py::TestTimeoutArgument` covering: flag parsing, default `None`, combined with `--max-turns`, requires `-n`/piped stdin, `asyncio.wait_for` forwarding, exit-124 on timeout, and rejection of bad values (0, negatives, non-integers)
- Ran `make format` and `make lint` in both `libs/cli` and `libs/code` — all checks pass
- All 4400 tests in `deepagents-code` and 260 tests in `deepagents-cli` pass

## Social handles (optional)

LinkedIn: https://linkedin.com/in/ninaadrao