### PR TITLE
style(cli): sync terminal background color to active Textual theme

### DIFF
--- a/libs/cli/deepagents_cli/app.py
+++ b/libs/cli/deepagents_cli/app.py
@@ -1151,6 +1151,7 @@ class DeepAgentsApp(App):
         Loaded from the user's saved preference (or the default) so the app
         boots with consistent colors before `/theme` runs.
         """
+        self.sync_terminal_background()
 
         # Injected session config
         self._agent = agent
@@ -3289,6 +3290,27 @@ class DeepAgentsApp(App):
             )
 
         return children[-1] == self._loading_widget
+
+    def sync_terminal_background(self) -> None:
+        """Best-effort sync of terminal default background to the active theme.
+
+        Custom themes use their stored registry colors; built-in Textual themes
+        resolve colors from the active app theme. Terminal write failures are
+        logged and swallowed because the OSC background sync is cosmetic.
+        """
+        from deepagents_cli.terminal_escape import set_terminal_background
+
+        entry = theme.get_registry().get(self.theme)
+        colors = (
+            entry.colors
+            if entry is not None and entry.custom
+            else theme.get_theme_colors(self)
+        )
+        try:
+            set_terminal_background(colors.background)
+        except Exception:
+            # Cosmetic only: must never break app startup or theme changes.
+            logger.warning("set_terminal_background raised unexpectedly", exc_info=True)
 
     async def _set_spinner(self, status: SpinnerStatus) -> None:
         """Show, update, or hide the loading spinner.
@@ -6603,6 +6625,15 @@ class DeepAgentsApp(App):
             ).encode()
             _dispatch_hook_sync("session.end", payload, hooks)
 
+        from deepagents_cli.terminal_escape import reset_terminal_background
+
+        try:
+            reset_terminal_background()
+        except Exception:
+            # Cosmetic only: must never raise during shutdown.
+            logger.warning(
+                "reset_terminal_background raised unexpectedly", exc_info=True
+            )
         restore_iterm_cursor_guide()
         super().exit(result=result, return_code=return_code, message=message)
 
@@ -7007,6 +7038,7 @@ class DeepAgentsApp(App):
             """Handle the theme selector result."""
             if result is not None:
                 self.theme = result
+                self.sync_terminal_background()
                 self.refresh_css(animate=False)
 
                 async def _persist() -> None:

--- a/libs/cli/deepagents_cli/terminal_escape.py
+++ b/libs/cli/deepagents_cli/terminal_escape.py
@@ -140,8 +140,19 @@ def write_osc(command: str, payload: str = "", *, st: bool = False) -> bool:
 
 
 _progress_active = False
+_terminal_background_active = False
 _atexit_registered = False
 _atexit_lock = threading.Lock()
+
+
+def _ensure_atexit_registered() -> None:
+    """Register terminal-state cleanup exactly once."""
+    global _atexit_registered  # noqa: PLW0603
+
+    with _atexit_lock:
+        if not _atexit_registered:
+            atexit.register(_atexit_clear)
+            _atexit_registered = True
 
 
 def _validate_progress(progress: int | None, state: TerminalProgressState) -> int:
@@ -199,16 +210,13 @@ def set_terminal_progress(
     Returns:
         `True` if the sequence was written.
     """
-    global _atexit_registered, _progress_active  # noqa: PLW0603
+    global _progress_active  # noqa: PLW0603
 
     value = _validate_progress(progress, state)
     payload = f"{state.value};{value}"
     written = write_osc("9;4", payload)
     if written and state is not TerminalProgressState.CLEAR:
-        with _atexit_lock:
-            if not _atexit_registered:
-                atexit.register(_atexit_clear)
-                _atexit_registered = True
+        _ensure_atexit_registered()
         _progress_active = True
     elif state is TerminalProgressState.CLEAR:
         _progress_active = False
@@ -226,7 +234,54 @@ def clear_terminal_progress() -> bool:
     return set_terminal_progress(state=TerminalProgressState.CLEAR)
 
 
+def set_terminal_background(color: str) -> bool:
+    """Set the terminal's dynamic default background color with `OSC 11`.
+
+    This is cosmetic and intentionally best-effort. Terminals that don't
+    support `OSC 11` ignore it; `OSC 111` is emitted from `atexit` to restore
+    the default background when this call succeeds.
+
+    Args:
+        color: Terminal color payload, usually a CSS-style hex color such as
+            `#11121D`.
+
+    Returns:
+        `True` if the sequence was written.
+    """
+    global _terminal_background_active  # noqa: PLW0603
+
+    if not color:
+        return False
+    written = write_osc("11", color, st=True)
+    if written:
+        _ensure_atexit_registered()
+        _terminal_background_active = True
+    return written
+
+
+def reset_terminal_background() -> bool:
+    """Reset the terminal's dynamic default background color with `OSC 111`.
+
+    Returns:
+        `True` if the sequence was written.
+    """
+    global _terminal_background_active  # noqa: PLW0603
+
+    written = write_osc("111", st=True)
+    if written:
+        _terminal_background_active = False
+    return written
+
+
 def _atexit_clear() -> None:
-    """`atexit` hook that clears any leftover progress indicator."""
+    """`atexit` hook that clears any leftover terminal state."""
     if _progress_active:
-        clear_terminal_progress()
+        try:
+            clear_terminal_progress()
+        except Exception:
+            logger.warning("Failed to clear terminal progress at exit", exc_info=True)
+    if _terminal_background_active:
+        try:
+            reset_terminal_background()
+        except Exception:
+            logger.warning("Failed to reset terminal background at exit", exc_info=True)

--- a/libs/cli/deepagents_cli/widgets/theme_selector.py
+++ b/libs/cli/deepagents_cli/widgets/theme_selector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
 
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
@@ -20,6 +20,14 @@ from deepagents_cli import theme
 from deepagents_cli.config import get_glyphs, is_ascii_mode
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class _TerminalBackgroundSyncApp(Protocol):
+    """App protocol for terminal background sync after theme preview changes."""
+
+    def sync_terminal_background(self) -> None:
+        """Sync the terminal background to the active theme."""
 
 
 class ThemeSelectorScreen(ModalScreen[str | None]):
@@ -103,6 +111,11 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         self._terminal_default = terminal_default
         self._show_keys = False
 
+    def _sync_terminal_background(self) -> None:
+        """Ask the app to sync terminal background after preview changes."""
+        if isinstance(self.app, _TerminalBackgroundSyncApp):
+            self.app.sync_terminal_background()
+
     def _format_option(self, name: str, entry: theme.ThemeEntry) -> str:
         """Render the option text for a theme entry.
 
@@ -172,6 +185,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         if name is not None and name in theme.get_registry():
             try:
                 self.app.theme = name
+                self._sync_terminal_background()
                 # refresh_css only repaints the active (modal) screen's layout;
                 # force the screen beneath us to repaint so the user sees the
                 # preview through the transparent scrim.
@@ -182,6 +196,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 logger.warning("Failed to preview theme '%s'", name, exc_info=True)
                 try:
                     self.app.theme = self._original_theme
+                    self._sync_terminal_background()
                 except Exception:
                     logger.warning(
                         "Failed to restore original theme '%s'",
@@ -205,6 +220,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     def action_cancel(self) -> None:
         """Restore the original theme and dismiss."""
         self.app.theme = self._original_theme
+        self._sync_terminal_background()
         self.dismiss(None)
 
     def action_cursor_down(self) -> None:

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
+import logging
 import os
 import signal
 import time
@@ -4446,6 +4447,132 @@ class TestRemoteAgent:
         app = DeepAgentsApp()
         app._agent = MagicMock(spec=[])
         assert app._remote_agent() is None
+
+
+class TestTerminalBackgroundSync:
+    """Tests for syncing Textual theme background to terminal background."""
+
+    def test_initial_theme_sync_sets_terminal_background(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli import terminal_escape, theme
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            terminal_escape,
+            "set_terminal_background",
+            lambda color: calls.append(color) or True,
+        )
+
+        app = DeepAgentsApp()
+        entry = theme.get_registry()[app.theme]
+
+        assert calls[-1] == entry.colors.background
+
+    def test_sync_terminal_background_uses_active_theme(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli import terminal_escape, theme
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            terminal_escape,
+            "set_terminal_background",
+            lambda color: calls.append(color) or True,
+        )
+        app = DeepAgentsApp()
+        calls.clear()
+
+        app.theme = "langchain-light"
+        app.sync_terminal_background()
+
+        assert calls == [theme.LIGHT_COLORS.background]
+
+    def test_sync_terminal_background_uses_custom_theme_entry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from textual.theme import Theme as TextualTheme
+
+        from deepagents_cli import terminal_escape, theme
+
+        app = DeepAgentsApp()
+        calls: list[str] = []
+        entry = theme.ThemeEntry(
+            label="Custom Test",
+            dark=True,
+            colors=theme.DARK_COLORS,
+            custom=True,
+        )
+        c = entry.colors
+        app.register_theme(
+            TextualTheme(
+                name="custom-test",
+                primary=c.primary,
+                secondary=c.secondary,
+                accent=c.accent,
+                foreground=c.foreground,
+                background=c.background,
+                surface=c.surface,
+                panel=c.panel,
+                warning=c.warning,
+                error=c.error,
+                success=c.success,
+                dark=entry.dark,
+            )
+        )
+        monkeypatch.setattr(theme, "get_registry", lambda: {"custom-test": entry})
+        monkeypatch.setattr(
+            theme,
+            "get_theme_colors",
+            MagicMock(side_effect=AssertionError("custom themes use entry colors")),
+        )
+        monkeypatch.setattr(
+            terminal_escape,
+            "set_terminal_background",
+            lambda color: calls.append(color) or True,
+        )
+
+        app.theme = "custom-test"
+        app.sync_terminal_background()
+
+        assert calls == [theme.DARK_COLORS.background]
+
+    def test_sync_terminal_background_swallows_terminal_errors(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from deepagents_cli import terminal_escape
+
+        app = DeepAgentsApp()
+
+        def _raise(_color: str) -> bool:
+            msg = "terminal unavailable"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(terminal_escape, "set_terminal_background", _raise)
+
+        with caplog.at_level(logging.WARNING, logger="deepagents_cli.app"):
+            app.sync_terminal_background()
+
+        assert "set_terminal_background raised unexpectedly" in caplog.text
+
+    def test_exit_resets_terminal_background(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_cli import terminal_escape
+
+        calls: list[bool] = []
+        monkeypatch.setattr(
+            terminal_escape,
+            "reset_terminal_background",
+            lambda: calls.append(True) or True,
+        )
+        app = DeepAgentsApp()
+
+        with patch.object(App, "exit") as app_exit:
+            app.exit()
+
+        assert calls == [True]
+        app_exit.assert_called_once()
 
 
 class TestSlashCommandBypass:

--- a/libs/cli/tests/unit_tests/test_terminal_escape.py
+++ b/libs/cli/tests/unit_tests/test_terminal_escape.py
@@ -13,6 +13,8 @@ from deepagents_cli.terminal_escape import (
     TerminalProgressState,
     _validate_progress,
     clear_terminal_progress,
+    reset_terminal_background,
+    set_terminal_background,
     set_terminal_progress,
     write_osc,
     write_terminal_escape,
@@ -21,8 +23,9 @@ from deepagents_cli.terminal_escape import (
 
 @pytest.fixture(autouse=True)
 def _reset_active_state(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Reset the module-level progress sentinel between tests."""
+    """Reset module-level terminal state sentinels between tests."""
     monkeypatch.setattr(terminal_escape, "_progress_active", False)
+    monkeypatch.setattr(terminal_escape, "_terminal_background_active", False)
     monkeypatch.setattr(terminal_escape, "_atexit_registered", False)
     monkeypatch.delenv(terminal_escape.NO_TERMINAL_ESCAPE, raising=False)
 
@@ -262,8 +265,59 @@ class TestSetTerminalProgress:
         assert terminal_escape._progress_active is False
 
 
+class TestTerminalBackground:
+    """Tests for `OSC 11` / `OSC 111` terminal background helpers."""
+
+    def test_set_background_writes_osc_11_with_st(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        assert set_terminal_background("#11121D") is True
+        assert fake.getvalue() == "\x1b]11;#11121D\x1b\\"
+        assert terminal_escape._terminal_background_active is True
+
+    def test_reset_background_writes_osc_111_with_st(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        monkeypatch.setattr(terminal_escape, "_terminal_background_active", True)
+        assert reset_terminal_background() is True
+        assert fake.getvalue() == "\x1b]111\x1b\\"
+        assert terminal_escape._terminal_background_active is False
+
+    def test_empty_background_is_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        assert set_terminal_background("") is False
+        assert fake.getvalue() == ""
+        assert terminal_escape._terminal_background_active is False
+
+    def test_set_background_registers_atexit_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        registered: list[object] = []
+        monkeypatch.setattr("atexit.register", lambda fn: registered.append(fn) or fn)
+        set_terminal_background("#11121D")
+        set_terminal_background("#F5F5F7")
+        assert registered == [terminal_escape._atexit_clear]
+
+    def test_background_respects_terminal_escape_opt_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(terminal_escape.NO_TERMINAL_ESCAPE, "1")
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        assert set_terminal_background("#11121D") is False
+        assert fake.getvalue() == ""
+        assert terminal_escape._terminal_background_active is False
+
+
 class TestAtexitClear:
-    """`_atexit_clear` should only emit a clear when progress was set."""
+    """`_atexit_clear` should only emit clears for active terminal state."""
 
     def test_emits_clear_when_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake = _FakeTTY()
@@ -282,3 +336,42 @@ class TestAtexitClear:
         monkeypatch.setattr(terminal_escape, "_progress_active", False)
         terminal_escape._atexit_clear()
         assert called == []
+
+    def test_emits_background_reset_when_active(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        monkeypatch.setattr(terminal_escape, "_terminal_background_active", True)
+        terminal_escape._atexit_clear()
+        assert fake.getvalue() == "\x1b]111\x1b\\"
+
+    def test_emits_progress_and_background_clear_when_both_active(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeTTY()
+        monkeypatch.setattr(terminal_escape, "_open_tty", lambda: fake)
+        monkeypatch.setattr(terminal_escape, "_progress_active", True)
+        monkeypatch.setattr(terminal_escape, "_terminal_background_active", True)
+        terminal_escape._atexit_clear()
+        assert fake.getvalue() == "\x1b]9;4;0;0\a\x1b]111\x1b\\"
+
+    def test_background_reset_runs_even_when_progress_clear_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called: list[bool] = []
+
+        def _raise() -> bool:
+            msg = "progress clear failed"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(terminal_escape, "clear_terminal_progress", _raise)
+        monkeypatch.setattr(
+            terminal_escape,
+            "reset_terminal_background",
+            lambda: called.append(True) or True,
+        )
+        monkeypatch.setattr(terminal_escape, "_progress_active", True)
+        monkeypatch.setattr(terminal_escape, "_terminal_background_active", True)
+        terminal_escape._atexit_clear()
+        assert called == [True]

--- a/libs/cli/tests/unit_tests/test_theme.py
+++ b/libs/cli/tests/unit_tests/test_theme.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import fields
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -1915,6 +1916,150 @@ class TestThemeSelectorScreen:
             await pilot.pause()
             assert app.theme == "langchain"
             assert results == [None]
+
+    async def test_highlight_syncs_terminal_background_preview(self) -> None:
+        from textual.app import App
+        from textual.theme import Theme as TextualTheme
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        class SyncApp(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.synced: list[str] = []
+
+            def sync_terminal_background(self) -> None:
+                self.synced.append(self.theme)
+
+        app = SyncApp()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            c = theme.LIGHT_COLORS
+            app.register_theme(
+                TextualTheme(
+                    name="langchain-light",
+                    primary=c.primary,
+                    secondary=c.secondary,
+                    accent=c.accent,
+                    foreground=c.foreground,
+                    background=c.background,
+                    surface=c.surface,
+                    panel=c.panel,
+                    warning=c.warning,
+                    error=c.error,
+                    success=c.success,
+                    dark=False,
+                )
+            )
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await pilot.press("down")
+            await pilot.pause()
+
+            target = next(key for key in theme.get_registry() if key != "langchain")
+            assert app.synced[-1] == target
+
+    async def test_escape_syncs_terminal_background_after_restore(self) -> None:
+        from textual.app import App
+        from textual.theme import Theme as TextualTheme
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        class SyncApp(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.synced: list[str] = []
+
+            def sync_terminal_background(self) -> None:
+                self.synced.append(self.theme)
+
+        app = SyncApp()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            c = theme.LIGHT_COLORS
+            app.register_theme(
+                TextualTheme(
+                    name="langchain-light",
+                    primary=c.primary,
+                    secondary=c.secondary,
+                    accent=c.accent,
+                    foreground=c.foreground,
+                    background=c.background,
+                    surface=c.surface,
+                    panel=c.panel,
+                    warning=c.warning,
+                    error=c.error,
+                    success=c.success,
+                    dark=False,
+                )
+            )
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await pilot.press("down")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert app.theme == "langchain"
+            assert app.synced[-1] == "langchain"
+
+    async def test_preview_failure_syncs_terminal_background_after_rollback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from textual.app import App
+        from textual.theme import Theme as TextualTheme
+
+        from deepagents_cli.widgets.theme_selector import ThemeSelectorScreen
+
+        class SyncApp(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.synced: list[str] = []
+
+            def sync_terminal_background(self) -> None:
+                self.synced.append(self.theme)
+                if self.theme != "langchain":
+                    msg = "preview sync failed"
+                    raise RuntimeError(msg)
+
+        app = SyncApp()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            c = theme.LIGHT_COLORS
+            app.register_theme(
+                TextualTheme(
+                    name="langchain-light",
+                    primary=c.primary,
+                    secondary=c.secondary,
+                    accent=c.accent,
+                    foreground=c.foreground,
+                    background=c.background,
+                    surface=c.surface,
+                    panel=c.panel,
+                    warning=c.warning,
+                    error=c.error,
+                    success=c.success,
+                    dark=False,
+                )
+            )
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            with caplog.at_level(
+                logging.WARNING, logger="deepagents_cli.widgets.theme_selector"
+            ):
+                await pilot.press("down")
+                await pilot.pause()
+
+            target = next(key for key in theme.get_registry() if key != "langchain")
+            assert app.synced[-2:] == [target, "langchain"]
+            assert app.theme == "langchain"
+            assert "Failed to preview theme" in caplog.text
 
     async def test_enter_selects_theme(self) -> None:
         from textual.app import App


### PR DESCRIPTION
Adds `OSC 11` / `OSC 111` support so the terminal dynamically adopts the background color of the active Textual theme, and resets it cleanly on exit. This makes the CLI feel more visually cohesive, especially with transparent terminal windows or terminal-native UI chrome.