### PR TITLE
fix(sdk): surface FileNotFoundError and PermissionError in BaseSandbox.ls

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -407,7 +407,13 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         """
 
     def ls(self, path: str) -> LsResult:
-        """Structured listing with file metadata using os.scandir."""
+        """Structured listing with file metadata using os.scandir.
+
+        Returns ``LsResult`` with ``entries`` populated on success. On failure
+        (path missing or unreadable), ``error`` is set so callers can
+        distinguish an empty directory from a non-existent or unreadable path,
+        matching the behaviour of ``read``, ``grep`` and ``glob``.
+        """
         path_b64 = base64.b64encode(path.encode("utf-8")).decode("ascii")
         cmd = f"""python3 -c "
 import os
@@ -425,9 +431,11 @@ try:
             }}
             print(json.dumps(result))
 except FileNotFoundError:
-    pass
+    print(json.dumps({{'error': 'path_not_found'}}))
 except PermissionError:
-    pass
+    print(json.dumps({{'error': 'permission_denied'}}))
+except NotADirectoryError:
+    print(json.dumps({{'error': 'not_a_directory'}}))
 " 2>/dev/null"""
 
         result = self.execute(cmd)
@@ -438,9 +446,19 @@ except PermissionError:
                 continue
             try:
                 data = json.loads(line)
-                file_infos.append({"path": data["path"], "is_dir": data["is_dir"]})
             except json.JSONDecodeError:
                 continue
+            if isinstance(data, dict) and "error" in data:
+                code = data["error"]
+                if code == "path_not_found":
+                    return LsResult(error=f"Path '{path}': path_not_found")
+                if code == "permission_denied":
+                    return LsResult(error=f"Path '{path}': permission_denied")
+                if code == "not_a_directory":
+                    return LsResult(error=f"Path '{path}': not_a_directory")
+                return LsResult(error=f"Path '{path}': {code}")
+            if isinstance(data, dict) and "path" in data and "is_dir" in data:
+                file_infos.append({"path": data["path"], "is_dir": data["is_dir"]})
 
         return LsResult(entries=file_infos)
 

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -243,6 +243,90 @@ def test_read_handles_non_dict_json_output() -> None:
     assert "unexpected server response" in result.error
 
 
+def test_ls_returns_entries_on_success() -> None:
+    """ls() should return entries when the directory exists."""
+    sandbox = MockSandbox()
+    sandbox._next_output = "\n".join(
+        [
+            json.dumps({"path": "/a/foo.txt", "is_dir": False}),
+            json.dumps({"path": "/a/bar", "is_dir": True}),
+        ]
+    )
+
+    result = sandbox.ls("/a")
+
+    assert result.error is None
+    assert result.entries == [
+        {"path": "/a/foo.txt", "is_dir": False},
+        {"path": "/a/bar", "is_dir": True},
+    ]
+
+
+def test_ls_returns_error_for_missing_path() -> None:
+    """ls() must surface path_not_found, not silently return empty entries."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "path_not_found"})
+
+    result = sandbox.ls("/does/not/exist")
+
+    assert result.error is not None
+    assert "path_not_found" in result.error
+    assert "/does/not/exist" in result.error
+
+
+def test_ls_returns_error_for_permission_denied() -> None:
+    """ls() must surface permission_denied for unreadable directories."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "permission_denied"})
+
+    result = sandbox.ls("/locked")
+
+    assert result.error is not None
+    assert "permission_denied" in result.error
+
+
+def test_ls_returns_error_for_not_a_directory() -> None:
+    """ls() on a regular file path must surface not_a_directory."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "not_a_directory"})
+
+    result = sandbox.ls("/some/file.txt")
+
+    assert result.error is not None
+    assert "not_a_directory" in result.error
+
+
+def test_ls_empty_directory_has_no_error() -> None:
+    """A genuinely empty directory should not set an error."""
+    sandbox = MockSandbox()
+    sandbox._next_output = ""
+
+    result = sandbox.ls("/empty")
+
+    assert result.error is None
+    assert result.entries == []
+
+
+def test_ls_inline_script_emits_error_markers() -> None:
+    """End-to-end check: the inline ls script must emit error markers when run."""
+    sandbox = MockSandbox()
+    sandbox.ls("/definitely/does/not/exist/xyz_abc")
+    command = sandbox.last_command
+    assert command is not None
+    # Extract and exercise the inline python script via a real subprocess.
+    m = re.search(r"python3 -c \"(.+)\" 2>/dev/null", command, re.DOTALL)
+    assert m is not None, command
+    script = m.group(1)
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert payload == {"error": "path_not_found"}
+
+
 def test_read_allows_truncated_paginated_output() -> None:
     """Test that read() accepts truncated paginated content returned by the server."""
     sandbox = MockSandbox()


### PR DESCRIPTION
Fixes #3105

---

`BaseSandbox.ls` previously caught `FileNotFoundError` and `PermissionError` with bare `pass` in its inline script, making `LsResult` for a missing or unreadable path indistinguishable from a genuinely empty directory. The inline script now emits `path_not_found` / `permission_denied` / `not_a_directory` markers, which are mapped into `LsResult.error` so callers can distinguish these cases, matching the behaviour of `read`/`grep`/`glob`.

Disclaimer: AI assistance was used to draft this patch and tests; the change is small, scoped to `BaseSandbox.ls`, and covered by new unit tests including one that exercises the inline script via subprocess.