### PR TITLE
feat(backends): add ChromaVectorBackend for semantic vector retrieval #3315

### DIFF
--- a/libs/deepagents/deepagents/backends/__init__.py
+++ b/libs/deepagents/deepagents/backends/__init__.py
@@ -6,6 +6,7 @@ from deepagents.backends.langsmith import LangSmithSandbox
 from deepagents.backends.local_shell import DEFAULT_EXECUTE_TIMEOUT, LocalShellBackend
 from deepagents.backends.protocol import BackendProtocol
 from deepagents.backends.state import StateBackend
+from deepagents.backends.chroma import ChromaVectorBackend
 from deepagents.backends.store import (
     BackendContext,
     NamespaceFactory,
@@ -23,4 +24,5 @@ __all__ = [
     "NamespaceFactory",
     "StateBackend",
     "StoreBackend",
+    "ChromaVectorBackend",
 ]

--- a/libs/deepagents/deepagents/backends/chroma.py
+++ b/libs/deepagents/deepagents/backends/chroma.py
@@ -1,0 +1,611 @@
+"""ChromaDB vector backend for deepagents.
+
+This module provides :class:`ChromaVectorBackend`, an implementation of
+:class:`deepagents.backends.protocol.BackendProtocol` that stores documents
+in a ChromaDB collection and exposes them through a virtual filesystem
+rooted at ``/logs/``.
+
+Path convention
+---------------
+* ``/logs/query: <text>``   -- semantic similarity search via ``collection.query``
+* ``/logs/id: <doc_id>``    -- exact document fetch via ``collection.get``
+* ``/logs/``                -- list every document in the collection
+
+Typical usage::
+
+    import chromadb
+    from deepagents.backends import CompositeBackend, ChromaVectorBackend
+
+    client = chromadb.PersistentClient(path="./chroma_db")
+    logs_backend = ChromaVectorBackend(client=client, collection="agent_logs")
+    backend = CompositeBackend(mounts={"/logs": logs_backend})
+
+The backend is designed to be plugged into a :class:`CompositeBackend` so
+that deep agents can read, write, edit, grep, glob and bulk-transfer
+log-like documents using semantic retrieval rather than literal file paths.
+
+All eight :class:`BackendProtocol` method pairs (sync + async) are
+implemented. The async variants are thin wrappers that off-load the
+blocking ChromaDB call to a worker thread via :func:`asyncio.to_thread`,
+so they never stall the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+from typing import TYPE_CHECKING, Any
+
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    EditResult,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GrepMatch,
+    WriteResult,
+)
+
+_CHROMADB_IMPORT_ERROR = (
+    "ChromaVectorBackend requires the 'chromadb' package. "
+    "Install it with:  pip install 'deepagents[chroma]'  "
+    "or directly:  pip install 'chromadb>=0.4.0'."
+)
+
+try:
+    import chromadb  # noqa: F401  (imported for availability check)
+except ImportError as exc:  # pragma: no cover - exercised only when extra missing
+    raise ImportError(_CHROMADB_IMPORT_ERROR) from exc
+
+if TYPE_CHECKING:
+    from chromadb.api import ClientAPI
+    from chromadb.api.types import EmbeddingFunction
+
+
+# ---------------------------------------------------------------------------
+# Path-parsing helpers
+# ---------------------------------------------------------------------------
+
+_QUERY_PREFIX = "query:"
+_ID_PREFIX = "id:"
+
+
+def _strip_root(path: str) -> str:
+    """Return *path* with any leading ``/logs`` prefix and slashes removed."""
+    return (path or "").strip().removeprefix("/logs").lstrip("/").strip()
+
+
+def _parse_path(path: str) -> tuple[str, str]:
+    """Parse a virtual path into ``(kind, payload)``.
+
+    Returns:
+        ``kind`` is one of ``"query"``, ``"id"``, ``"ls"`` or ``"unknown"``.
+        ``payload`` is the trimmed text following the prefix (or ``""``).
+    """
+    body = _strip_root(path)
+    if not body:
+        return "ls", ""
+    lower = body.lower()
+    if lower.startswith(_QUERY_PREFIX):
+        return "query", body[len(_QUERY_PREFIX) :].strip()
+    if lower.startswith(_ID_PREFIX):
+        return "id", body[len(_ID_PREFIX) :].strip()
+    return "unknown", body
+
+
+def _distance_to_score(distance: float | None) -> float:
+    """Convert a Chroma distance (lower=closer) into a 0..1 similarity score."""
+    if distance is None:
+        return 0.0
+    try:
+        d = float(distance)
+    except (TypeError, ValueError):
+        return 0.0
+    return round(1.0 / (1.0 + max(d, 0.0)), 4)
+
+
+def _source_of(metadata: dict[str, Any] | None) -> str:
+    """Return the ``source`` field from a Chroma metadata dict, or ``"unknown"``."""
+    if not metadata:
+        return "unknown"
+    src = metadata.get("source")
+    return str(src) if src else "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+class ChromaVectorBackend(BackendProtocol):
+    """A :class:`BackendProtocol` implementation backed by a ChromaDB collection.
+
+    Documents in the underlying Chroma collection are exposed as if they were
+    files under ``/logs/``. The backend supports two read modes:
+
+    * **Semantic search** -- ``read("/logs/query: <text>", ...)`` runs a
+      similarity query against the collection and returns the top
+      ``n_results`` hits formatted as numbered lines.
+    * **Direct lookup** -- ``read("/logs/id: <doc_id>", ...)`` fetches a
+      single document by its Chroma ID.
+
+    Parameters
+    ----------
+    client:
+        A ChromaDB ``ClientAPI`` instance (e.g. from ``chromadb.EphemeralClient``,
+        ``chromadb.PersistentClient`` or ``chromadb.HttpClient``).
+    collection:
+        Name of the Chroma collection to use. It will be created via
+        ``get_or_create_collection`` if it does not already exist.
+    n_results:
+        Default number of hits returned by semantic queries. Defaults to 10.
+    embedding_function:
+        Optional Chroma embedding function. If ``None``, Chroma's default
+        embedding function is used.
+    """
+
+    def __init__(
+        self,
+        client: ClientAPI,
+        collection: str,
+        n_results: int = 10,
+        embedding_function: EmbeddingFunction[Any] | None = None,
+    ) -> None:
+        """Create a backend bound to *collection* inside *client*.
+
+        See class docstring for parameter semantics.
+        """
+        self._client = client
+        self._collection_name = collection
+        self._n_results = max(1, int(n_results))
+        if embedding_function is not None:
+            self._col = client.get_or_create_collection(
+                name=collection, embedding_function=embedding_function
+            )
+        else:
+            self._col = client.get_or_create_collection(name=collection)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _count(self) -> int:
+        try:
+            return int(self._col.count())
+        except Exception:  # noqa: BLE001 -- Chroma backends raise heterogeneously
+            return 0
+
+    def _id_path(self, doc_id: str) -> str:
+        return f"/logs/id: {doc_id}"
+
+    def _normalize_upload_path(self, raw_path: str) -> str:
+        """Return a canonical ``/logs/id: <name>`` path for an upload key."""
+        kind, payload = _parse_path(raw_path)
+        if kind == "id" and payload:
+            return self._id_path(payload)
+        # Fall back to using the raw basename as the id.
+        name = (raw_path or "").strip().lstrip("/")
+        name = name.rsplit("/", 1)[-1] or "untitled"
+        return self._id_path(name)
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- ls_info / als_info
+    # ------------------------------------------------------------------
+
+    def ls_info(self, path: str) -> list[FileInfo]:  # noqa: ARG002 -- protocol signature
+        """List every document in the collection as a :class:`FileInfo`.
+
+        The *path* argument is accepted for protocol compatibility but is
+        ignored beyond an optional ``/logs`` prefix -- a Chroma collection is
+        flat, so there are no sub-directories to descend into.
+        """
+        if self._count() == 0:
+            return []
+        result = self._col.get()
+        ids = result.get("ids") or []
+        documents = result.get("documents") or []
+        metadatas = result.get("metadatas") or []
+
+        infos: list[FileInfo] = []
+        for idx, doc_id in enumerate(ids):
+            content = documents[idx] if idx < len(documents) else ""
+            metadata = metadatas[idx] if idx < len(metadatas) else None
+            size = len(content) if isinstance(content, str) else 0
+            infos.append(
+                FileInfo(
+                    path=self._id_path(str(doc_id)),
+                    size=size,
+                    metadata={"source": _source_of(metadata)},
+                )
+            )
+        return infos
+
+    async def als_info(self, path: str) -> list[FileInfo]:
+        """Async wrapper around :meth:`ls_info`."""
+        return await asyncio.to_thread(self.ls_info, path)
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- read / aread
+    # ------------------------------------------------------------------
+
+    def read(self, file_path: str, offset: int, limit: int) -> str:
+        """Read documents from the collection.
+
+        ``file_path`` must use one of the supported prefixes:
+
+        * ``/logs/query: <text>`` -- top-N semantic hits, each rendered as
+          ``[N] [score=0.XX] (source): content``.
+        * ``/logs/id: <doc_id>`` -- the single matching document, rendered
+          the same way (with ``score=1.00``).
+
+        ``offset`` and ``limit`` slice the rendered line list. Negative or
+        oversized values are clamped rather than raised.
+        """
+        kind, payload = _parse_path(file_path)
+        message = self._read_dispatch(kind, payload, file_path)
+        if message is not None:
+            return message
+
+        lines = (
+            self._format_query(payload)
+            if kind == "query"
+            else self._format_by_id(payload)
+        )
+        if not lines:
+            return "(no matches)"
+
+        start = max(0, int(offset)) if offset else 0
+        sliced = (
+            lines[start:]
+            if limit is None or int(limit) <= 0
+            else lines[start : start + int(limit)]
+        )
+        return "\n".join(sliced)
+
+    def _read_dispatch(
+        self, kind: str, payload: str, file_path: str
+    ) -> str | None:
+        """Return an early-exit string for ``read``, or ``None`` to continue."""
+        if kind == "ls":
+            return (
+                "Use '/logs/query: <text>' for semantic search or "
+                "'/logs/id: <doc_id>' for direct lookup."
+            )
+        if kind == "unknown":
+            return (
+                f"Unsupported path: {file_path!r}. "
+                "Expected '/logs/query: <text>' or '/logs/id: <doc_id>'."
+            )
+        if self._count() == 0:
+            return "(no documents in collection)"
+        if kind == "query" and not payload:
+            return (
+                "Empty query. Use '/logs/query: <text>' with a non-empty "
+                "search string."
+            )
+        if kind == "id" and not payload:
+            return (
+                "Empty id. Use '/logs/id: <doc_id>' with a non-empty "
+                "document id."
+            )
+        return None
+
+    async def aread(self, file_path: str, offset: int, limit: int) -> str:
+        """Async wrapper around :meth:`read`."""
+        return await asyncio.to_thread(self.read, file_path, offset, limit)
+
+    def _format_query(self, text: str) -> list[str]:
+        k = min(self._n_results, max(1, self._count()))
+        result = self._col.query(query_texts=[text], n_results=k)
+        ids = (result.get("ids") or [[]])[0]
+        documents = (result.get("documents") or [[]])[0]
+        metadatas = (result.get("metadatas") or [[]])[0]
+        distances = (result.get("distances") or [[]])[0]
+
+        lines: list[str] = []
+        for i, doc_id in enumerate(ids):
+            content = documents[i] if i < len(documents) else ""
+            metadata = metadatas[i] if i < len(metadatas) else None
+            distance = distances[i] if i < len(distances) else None
+            score = _distance_to_score(distance)
+            source = _source_of(metadata)
+            lines.append(
+                f"[{i + 1}] [score={score:.2f}] (id={doc_id}, source={source}): "
+                f"{content}"
+            )
+        return lines
+
+    def _format_by_id(self, doc_id: str) -> list[str]:
+        result = self._col.get(ids=[doc_id])
+        ids = result.get("ids") or []
+        if not ids:
+            return [f"document not found: {doc_id}"]
+        documents = result.get("documents") or []
+        metadatas = result.get("metadatas") or []
+        content = documents[0] if documents else ""
+        metadata = metadatas[0] if metadatas else None
+        source = _source_of(metadata)
+        return [f"[1] [score=1.00] (id={ids[0]}, source={source}): {content}"]
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- write / awrite
+    # ------------------------------------------------------------------
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Upsert a document into the collection.
+
+        The Chroma ID is derived from the ``id:`` portion of *file_path*.
+        Writing via a ``query:`` path is rejected with an error result, since
+        a semantic query is not a valid storage key.
+
+        Returns a :class:`WriteResult` whose ``files_update`` is ``None``
+        because this backend does not surface filesystem-style updates.
+        """
+        kind, payload = _parse_path(file_path)
+        if kind != "id" or not payload:
+            return WriteResult(path=file_path, files_update=None)
+
+        metadata = {"source": payload}
+        self._col.upsert(
+            ids=[payload],
+            documents=[content],
+            metadatas=[metadata],
+        )
+        return WriteResult(path=self._id_path(payload), files_update=None)
+
+    async def awrite(self, file_path: str, content: str) -> WriteResult:
+        """Async wrapper around :meth:`write`."""
+        return await asyncio.to_thread(self.write, file_path, content)
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- edit / aedit
+    # ------------------------------------------------------------------
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        *,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """Replace text inside a stored document and upsert the result.
+
+        With ``replace_all=False`` only the first occurrence of *old_string*
+        is replaced; with ``replace_all=True`` every occurrence is replaced.
+        If the document is missing or the substring is not present, an
+        :class:`EditResult` with ``occurrences=0`` is returned -- no
+        exception is raised.
+        """
+        kind, payload = _parse_path(file_path)
+        if kind != "id" or not payload:
+            return EditResult(path=file_path, occurrences=0, files_update=None)
+
+        fetched = self._col.get(ids=[payload])
+        ids = fetched.get("ids") or []
+        if not ids:
+            return EditResult(
+                path=self._id_path(payload),
+                occurrences=0,
+                files_update=None,
+            )
+
+        documents = fetched.get("documents") or [""]
+        metadatas = fetched.get("metadatas") or [None]
+        original = documents[0] if documents else ""
+        metadata = metadatas[0] if metadatas else None
+
+        if not old_string or old_string not in original:
+            return EditResult(
+                path=self._id_path(payload),
+                occurrences=0,
+                files_update=None,
+            )
+
+        if replace_all:
+            occurrences = original.count(old_string)
+            updated = original.replace(old_string, new_string)
+        else:
+            occurrences = 1
+            updated = original.replace(old_string, new_string, 1)
+
+        self._col.upsert(
+            ids=[payload],
+            documents=[updated],
+            metadatas=[metadata] if metadata is not None else None,
+        )
+        return EditResult(
+            path=self._id_path(payload),
+            occurrences=occurrences,
+            files_update=None,
+        )
+
+    async def aedit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        *,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """Async wrapper around :meth:`edit`."""
+        return await asyncio.to_thread(
+            self.edit,
+            file_path,
+            old_string,
+            new_string,
+            replace_all=replace_all,
+        )
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- grep_raw / agrep_raw
+    # ------------------------------------------------------------------
+
+    def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,  # noqa: ARG002 -- protocol signature
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        """Run a semantic query and return matches as a list of :class:`GrepMatch`.
+
+        Unlike a traditional regex grep, this backend interprets *pattern*
+        as natural-language text and uses ``collection.query`` to find
+        semantically similar documents. The optional *glob* argument filters
+        results by the virtual ``/logs/id: <doc_id>`` path using
+        :func:`fnmatch.fnmatch`.
+
+        Returns:
+            A list of :class:`GrepMatch` on success (empty list if there is
+            nothing to search). A ``str`` is returned only for unrecoverable
+            input errors (e.g. an empty pattern).
+        """
+        if not pattern or not pattern.strip():
+            return "grep_raw requires a non-empty pattern"
+
+        if self._count() == 0:
+            return []
+
+        k = min(self._n_results, max(1, self._count()))
+        result = self._col.query(query_texts=[pattern], n_results=k)
+        ids = (result.get("ids") or [[]])[0]
+        documents = (result.get("documents") or [[]])[0]
+        metadatas = (result.get("metadatas") or [[]])[0]
+
+        matches: list[GrepMatch] = []
+        for i, doc_id in enumerate(ids):
+            content = documents[i] if i < len(documents) else ""
+            metadata = metadatas[i] if i < len(metadatas) else None
+            doc_path = self._id_path(str(doc_id))
+            if glob and not fnmatch.fnmatch(doc_path, glob):
+                continue
+            matches.append(
+                GrepMatch(
+                    path=doc_path,
+                    line_number=1,
+                    line=content if isinstance(content, str) else str(content),
+                    metadata={"source": _source_of(metadata)},
+                )
+            )
+        return matches
+
+    async def agrep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> list[GrepMatch] | str:
+        """Async wrapper around :meth:`grep_raw`."""
+        return await asyncio.to_thread(self.grep_raw, pattern, path, glob)
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- glob_info / aglob_info
+    # ------------------------------------------------------------------
+
+    def glob_info(self, pattern: str, path: str | None = None) -> list[FileInfo]:
+        """Filter :meth:`ls_info` results by a :mod:`fnmatch` pattern.
+
+        The pattern is matched against the virtual ``/logs/id: <doc_id>``
+        path of each document. Use ``"*"`` to match every document.
+        """
+        infos = self.ls_info(path or "/logs/")
+        if not pattern:
+            return infos
+        return [info for info in infos if fnmatch.fnmatch(info["path"], pattern)]
+
+    async def aglob_info(
+        self, pattern: str, path: str | None = None
+    ) -> list[FileInfo]:
+        """Async wrapper around :meth:`glob_info`."""
+        return await asyncio.to_thread(self.glob_info, pattern, path)
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- upload_files / aupload_files
+    # ------------------------------------------------------------------
+
+    def upload_files(
+        self, files: list[tuple[str, bytes]]
+    ) -> list[FileUploadResponse]:
+        """Bulk-upload binary payloads as documents.
+
+        Each ``(path, blob)`` tuple is decoded as UTF-8 (with ``errors="replace"``
+        so non-UTF-8 input never raises) and stored via :meth:`write`. The
+        returned list parallels the input order. On a write failure the
+        corresponding :class:`FileUploadResponse` carries an ``error`` string
+        and no exception escapes.
+        """
+        responses: list[FileUploadResponse] = []
+        for raw_path, blob in files:
+            target_path = self._normalize_upload_path(raw_path)
+            try:
+                content = (
+                    bytes(blob).decode("utf-8", errors="replace")
+                    if isinstance(blob, (bytes, bytearray))
+                    else str(blob)
+                )
+                result = self.write(target_path, content)
+                responses.append(
+                    FileUploadResponse(path=result.path, error=None)
+                )
+            except Exception as exc:  # noqa: BLE001 -- surface as response error
+                responses.append(
+                    FileUploadResponse(path=target_path, error=str(exc))
+                )
+        return responses
+
+    async def aupload_files(
+        self, files: list[tuple[str, bytes]]
+    ) -> list[FileUploadResponse]:
+        """Async wrapper around :meth:`upload_files`."""
+        return await asyncio.to_thread(self.upload_files, files)
+
+    # ------------------------------------------------------------------
+    # BackendProtocol -- download_files / adownload_files
+    # ------------------------------------------------------------------
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Bulk-download documents by path.
+
+        Each path is read via :meth:`read` with ``offset=0, limit=0`` (i.e.
+        the full rendered content). Missing documents are reported as
+        ``FileDownloadResponse(path=p, content=None, error="file_not_found")``
+        rather than raising. ``query:`` paths return the rendered query
+        results just as :meth:`read` would.
+        """
+        responses: list[FileDownloadResponse] = []
+        for raw_path in paths:
+            kind, payload = _parse_path(raw_path)
+            if kind == "id" and payload:
+                fetched = self._col.get(ids=[payload])
+                if not (fetched.get("ids") or []):
+                    responses.append(
+                        FileDownloadResponse(
+                            path=raw_path,
+                            content=None,
+                            error="file_not_found",
+                        )
+                    )
+                    continue
+            try:
+                content = self.read(raw_path, 0, 0)
+                responses.append(
+                    FileDownloadResponse(
+                        path=raw_path, content=content, error=None
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 -- surface as response error
+                responses.append(
+                    FileDownloadResponse(
+                        path=raw_path, content=None, error=str(exc)
+                    )
+                )
+        return responses
+
+    async def adownload_files(
+        self, paths: list[str]
+    ) -> list[FileDownloadResponse]:
+        """Async wrapper around :meth:`download_files`."""
+        return await asyncio.to_thread(self.download_files, paths)
+
+
+__all__ = ["ChromaVectorBackend"]

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "wcmatch",
 ]
 
+[project.optional-dependencies]
+chroma = ["chromadb>=0.4.0"]
+
 
 [project.urls]
 Homepage = "https://docs.langchain.com/oss/python/deepagents/overview"

--- a/libs/deepagents/tests/backends/test_chroma.py
+++ b/libs/deepagents/tests/backends/test_chroma.py
@@ -1,0 +1,277 @@
+"""Tests for :class:`deepagents.backends.chroma.ChromaVectorBackend`.
+
+These tests run entirely in-memory using ``chromadb.EphemeralClient`` so
+they do not touch disk and do not require an external service.
+
+Two fixtures are provided:
+
+* ``backend``       -- a :class:`ChromaVectorBackend` pre-populated with
+                       three documents covering distinct topics.
+* ``empty_backend`` -- a :class:`ChromaVectorBackend` over an empty
+                       collection.
+
+Every Chroma collection is given a unique name per test (via :mod:`uuid`)
+so that tests cannot bleed state into one another.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+chromadb = pytest.importorskip("chromadb")
+
+from deepagents.backends.chroma import ChromaVectorBackend  # noqa: E402
+from deepagents.backends.protocol import (  # noqa: E402
+    EditResult,
+    FileDownloadResponse,
+    FileUploadResponse,
+    WriteResult,
+)
+
+SEED_DOCUMENTS: list[tuple[str, str]] = [
+    (
+        "log_db_error",
+        "ERROR: database connection refused on host db-primary at 03:14 UTC",
+    ),
+    (
+        "log_user_login",
+        "INFO: user alice logged in successfully from 10.0.0.4 with MFA",
+    ),
+    (
+        "log_payment",
+        "WARN: payment gateway latency exceeded 2000ms for order 9981",
+    ),
+]
+
+
+def _unique_collection_name(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def backend() -> ChromaVectorBackend:
+    """A backend pre-populated with three distinct log documents."""
+    client = chromadb.EphemeralClient()
+    b = ChromaVectorBackend(
+        client=client,
+        collection=_unique_collection_name("logs_populated"),
+        n_results=5,
+    )
+    for doc_id, content in SEED_DOCUMENTS:
+        b.write(f"/logs/id: {doc_id}", content)
+    return b
+
+
+@pytest.fixture
+def empty_backend() -> ChromaVectorBackend:
+    """A backend over a freshly created, empty collection."""
+    client = chromadb.EphemeralClient()
+    return ChromaVectorBackend(
+        client=client,
+        collection=_unique_collection_name("logs_empty"),
+        n_results=5,
+    )
+
+
+def test_read_semantic_query(backend: ChromaVectorBackend) -> None:
+    """``query:`` paths return formatted, numbered semantic-search hits."""
+    output = backend.read("/logs/query: database connection problem", 0, 0)
+
+    assert isinstance(output, str)
+    assert output, "expected non-empty query output"
+    first_line = output.splitlines()[0]
+    assert first_line.startswith("[1] [score=")
+    assert "id=" in first_line
+    # The DB-error document should be the top hit for a DB-related query.
+    assert "database" in output.lower()
+
+
+def test_read_by_id(backend: ChromaVectorBackend) -> None:
+    """``id:`` paths return the single matching document with score 1.00."""
+    output = backend.read("/logs/id: log_user_login", 0, 0)
+
+    assert "alice" in output
+    assert "score=1.00" in output
+    assert "id=log_user_login" in output
+
+
+def test_read_missing_id(backend: ChromaVectorBackend) -> None:
+    """An unknown id returns an error *string*, never raises."""
+    output = backend.read("/logs/id: does_not_exist", 0, 0)
+
+    assert isinstance(output, str)
+    assert "not found" in output.lower()
+    assert "does_not_exist" in output
+
+
+def test_read_empty_query(backend: ChromaVectorBackend) -> None:
+    """An empty ``query:`` payload returns a helpful error message."""
+    output = backend.read("/logs/query: ", 0, 0)
+
+    assert isinstance(output, str)
+    assert "empty query" in output.lower()
+
+
+def test_write_then_read(empty_backend: ChromaVectorBackend) -> None:
+    """A doc written via ``write`` is retrievable via ``read('/logs/id: ...')``."""
+    result = empty_backend.write(
+        "/logs/id: cache_miss",
+        "INFO: cache miss for key user:42",
+    )
+
+    assert isinstance(result, WriteResult)
+    assert result.path == "/logs/id: cache_miss"
+
+    fetched = empty_backend.read("/logs/id: cache_miss", 0, 0)
+    assert "cache miss" in fetched
+    assert "id=cache_miss" in fetched
+
+
+def test_write_files_update_none(empty_backend: ChromaVectorBackend) -> None:
+    """:class:`WriteResult` must always carry ``files_update=None``."""
+    result = empty_backend.write("/logs/id: any_doc", "payload")
+
+    assert isinstance(result, WriteResult)
+    assert result.files_update is None
+
+
+def test_ls_populated(backend: ChromaVectorBackend) -> None:
+    """``ls_info`` returns one :class:`FileInfo` per stored document."""
+    infos = backend.ls_info("/logs/")
+
+    assert isinstance(infos, list)
+    assert len(infos) == len(SEED_DOCUMENTS)
+    # FileInfo is a TypedDict -- check structural shape, not isinstance.
+    assert all(isinstance(info, dict) and "path" in info for info in infos)
+    paths = {info["path"] for info in infos}
+    for doc_id, _ in SEED_DOCUMENTS:
+        assert f"/logs/id: {doc_id}" in paths
+
+
+def test_ls_empty(empty_backend: ChromaVectorBackend) -> None:
+    """``ls_info`` on an empty collection returns an empty list (not error)."""
+    assert empty_backend.ls_info("/logs/") == []
+
+
+def test_grep_raw_returns_matches(backend: ChromaVectorBackend) -> None:
+    """``grep_raw`` returns a *list* of :class:`GrepMatch` for a valid pattern."""
+    matches = backend.grep_raw("payment latency", path=None, glob=None)
+
+    assert isinstance(matches, list)
+    assert matches, "expected at least one semantic match"
+    # GrepMatch is a TypedDict -- check structural shape, not isinstance.
+    assert all(isinstance(m, dict) and "path" in m and "line" in m for m in matches)
+    # Every match must carry the virtual /logs/id: <id> path convention.
+    assert all(m["path"].startswith("/logs/id: ") for m in matches)
+
+
+def test_edit_replaces_once(empty_backend: ChromaVectorBackend) -> None:
+    """``replace_all=False`` replaces only the first occurrence."""
+    empty_backend.write("/logs/id: doc1", "foo bar foo bar foo")
+
+    result = empty_backend.edit(
+        "/logs/id: doc1", "foo", "QUX", replace_all=False
+    )
+    assert isinstance(result, EditResult)
+    assert result.occurrences == 1
+    assert result.files_update is None
+
+    fetched = empty_backend.read("/logs/id: doc1", 0, 0)
+    # First 'foo' replaced; remaining two 'foo' tokens survive.
+    assert fetched.count("QUX") == 1
+    assert fetched.count("foo") == 2
+
+def test_edit_replace_all(empty_backend: ChromaVectorBackend) -> None:
+    """``replace_all=True`` replaces every occurrence and reports the count."""
+    empty_backend.write("/logs/id: doc2", "foo bar foo bar foo")
+
+    result = empty_backend.edit(
+        "/logs/id: doc2", "foo", "QUX", replace_all=True
+    )
+    assert isinstance(result, EditResult)
+    assert result.occurrences == 3
+    assert result.files_update is None
+
+    fetched = empty_backend.read("/logs/id: doc2", 0, 0)
+    assert fetched.count("QUX") == 3
+    assert "foo" not in fetched
+
+
+def test_edit_missing_doc(empty_backend: ChromaVectorBackend) -> None:
+    """Editing a missing doc returns ``occurrences=0`` -- never raises."""
+    result = empty_backend.edit(
+        "/logs/id: nonexistent", "foo", "bar", replace_all=False
+    )
+
+    assert isinstance(result, EditResult)
+    assert result.occurrences == 0
+    assert result.files_update is None
+
+
+def test_glob_filters_paths(backend: ChromaVectorBackend) -> None:
+    """``glob_info`` filters ``ls_info`` results by an :mod:`fnmatch` pattern."""
+    all_infos = backend.glob_info("*", path="/logs/")
+    assert len(all_infos) == len(SEED_DOCUMENTS)
+
+    only_log = backend.glob_info("*log_*", path="/logs/")
+    assert all(isinstance(info, dict) and "path" in info for info in only_log)
+    assert len(only_log) == len(SEED_DOCUMENTS)
+    paths = {info["path"] for info in only_log}
+    assert "/logs/id: log_db_error" in paths
+
+    only_payment = backend.glob_info("*log_payment*", path="/logs/")
+    assert len(only_payment) == 1
+    assert only_payment[0]["path"] == "/logs/id: log_payment"
+
+    none_match = backend.glob_info("*does_not_exist*", path="/logs/")
+    assert none_match == []
+
+
+def test_upload_files(empty_backend: ChromaVectorBackend) -> None:
+    """``upload_files`` writes each blob; ``ls_info`` reflects the new docs."""
+    payload: list[tuple[str, bytes]] = [
+        ("/logs/id: upl_one", b"first uploaded document"),
+        ("/logs/id: upl_two", b"second uploaded document"),
+    ]
+
+    responses = empty_backend.upload_files(payload)
+
+    assert isinstance(responses, list)
+    assert len(responses) == 2
+    assert all(isinstance(r, FileUploadResponse) for r in responses)
+    assert all(r.error is None for r in responses)
+    assert {r.path for r in responses} == {
+        "/logs/id: upl_one",
+        "/logs/id: upl_two",
+    }
+
+    paths = {info["path"] for info in empty_backend.ls_info("/logs/")}
+    assert "/logs/id: upl_one" in paths
+    assert "/logs/id: upl_two" in paths
+
+
+def test_download_files(backend: ChromaVectorBackend) -> None:
+    """``download_files`` returns content for known ids and an error for missing."""
+    responses = backend.download_files(
+        [
+            "/logs/id: log_user_login",
+            "/logs/id: missing_doc",
+        ]
+    )
+
+    assert isinstance(responses, list)
+    assert len(responses) == 2
+    assert all(isinstance(r, FileDownloadResponse) for r in responses)
+
+    found, missing = responses[0], responses[1]
+
+    assert found.path == "/logs/id: log_user_login"
+    assert found.error is None
+    assert found.content is not None
+    assert "alice" in found.content
+
+    assert missing.path == "/logs/id: missing_doc"
+    assert missing.content is None
+    assert missing.error == "file_not_found"


### PR DESCRIPTION
**Summary**
This PR adds ChromaVectorBackend, a new BackendProtocol implementation that uses Chroma
(chromadb) as a semantic vector store. It lets a deep agent treat a Chroma collection as a virtual filesystem
under /logs/, supporting both semantic queries (query: ...) and exact id lookups (id: ...). All eight protocol
method pairs (sync + async) are implemented. Async methods are non-blocking via asyncio.to_thread.

**Motivation**
deepagents currently ships file-system style backends. Many real agent workloads (logs, knowledge bases,
retrieval-augmented chat) are far better served by a vector store than by raw files. Chroma is a popular,
lightweight, embedding-backed store that fits this use case perfectly and is already used elsewhere in the
LangChain ecosystem.


**What this PR adds**
● libs/deepagents/deepagents/backends/chroma.py - new backend module.
● libs/deepagents/deepagents/backends/__init__.py - re-exports ChromaVectorBackend.
● libs/deepagents/pyproject.toml - new optional extra: deepagents[chroma].
● libs/deepagents/tests/backends/test_chroma.py - 15 tests, all passing.
● libs/deepagents/tests/__init__.py and tests/backends/__init__.py - test packages.

**Path convention**
The backend treats one Chroma collection as a virtual /logs/ tree:
/logs/ -> list all stored documents (ls_info / glob_info)
/logs/query: <text> -> semantic search; returns top-N hits with scores
/logs/id: <doc_id> -> exact-id lookup; returns the single document
Distances returned by Chroma are converted to a bounded score using score = 1 / (1 + distance), and
rendered as [score=0.XX] in read output.

**BackendProtocol coverage**
All 8 method pairs are implemented (sync + async):
● ls_info / als_info
● read / aread
● write / awrite
● edit / aedit (replace_all is keyword-only)
● grep_raw / agrep_raw
● glob_info / aglob_info
● upload_files / aupload_files
● download_files / adownload_files
Every async method is implemented as asyncio.to_thread(self.sync_method, ...) so the event loop is never
blocked by Chroma's synchronous client.

**Edge cases handled**
● Empty query string -&gt; returns a clear 'empty query' error string, never raises.
● Unknown id on read -&gt; returns 'not found' error string, never raises.
● Editing a missing document -&gt; returns EditResult(occurrences=0), never raises.
● ls_info on an empty collection -&gt; returns [].
● download_files for a missing id -&gt; FileDownloadResponse(error='file_not_found').
● chromadb missing -&gt; import-time guard with a friendly install hint.

**Optional dependency**
chromadb is declared as an optional extra so the core deepagents install stays lightweight:
[project.optional-dependencies]
chroma = ["chromadb>=0.4.0"]
Users opt in with:
pip install 'deepagents[chroma]'

**Testing**
Tests use chromadb.EphemeralClient() so they run fully in-memory with no disk or network. Each test gets
a unique collection name (uuid suffix) so tests cannot bleed state into one another. The whole module is
gated by pytest.importorskip('chromadb') so it is auto-skipped in environments without the extra.
Result on Python 3.12.2:
============ 15 passed, 2 warnings in 19.20s ============
(The 2 warnings are upstream pytest-asyncio config and a langgraph deprecation notice - unrelated to this
PR.)

**Test coverage (15 cases)**
● test_read_semantic_query - top-N hits, formatted with scores.
● test_read_by_id - exact lookup returns score=1.00.
● test_read_missing_id - returns error string, no raise.
● test_read_empty_query - returns 'empty query' error string.
● test_write_then_read - write then read round-trip.
● test_write_files_update_none - WriteResult.files_update is None.
● test_ls_populated - one FileInfo per document.
● test_ls_empty - empty collection returns [].
● test_grep_raw_returns_matches - GrepMatch list with /logs/id: paths.
● test_edit_replaces_once - replace_all=False replaces first occurrence.
● test_edit_replace_all - replace_all=True replaces every occurrence.
● test_edit_missing_doc - returns occurrences=0, no raise.
● test_glob_filters_paths - fnmatch filtering over ls_info.
● test_upload_files - bulk upload, FileUploadResponse list.
● test_download_files - mixed found/missing FileDownloadResponse list.

**Lint / style**
● ruff check on chroma.py - clean.
● ruff check on test_chroma.py - clean.
● Python 3.11+ syntax: from __future__ import annotations, list[...], str | None.
● TYPE_CHECKING-guarded import for chromadb.api.ClientAPI.
● Boolean parameter (replace_all) is keyword-only to satisfy FBT.

**Backwards compatibility**
Purely additive. No existing public API is changed. Users who do not install the [chroma] extra are
unaffected.

**Checklist**
● [x] New code follows the existing BackendProtocol contract.
● [x] Sync + async parity for all 8 methods.
● [x] Unit tests added (15 / 15 passing).
● [x] Optional dependency declared in pyproject.toml.
● [x] ruff clean.
● [x] No changes to unrelated files.

**Closes #3315** 