### PR TITLE
fix(sdk): import profile re-exports from leaf modules

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -11,12 +11,14 @@ from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMi
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
-from deepagents.profiles import (
+from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
     HarnessProfile,
     HarnessProfileConfig,
-    ProviderProfile,
     register_harness_profile,
+)
+from deepagents.profiles.provider.provider_profiles import (
+    ProviderProfile,
     register_provider_profile,
 )
 


### PR DESCRIPTION
The CLI's import prewarm worker (which runs `import deepagents.backends` in `asyncio.to_thread`) can race with the main event loop importing `deepagents.profiles.provider` during `create_model`. Both paths transit `deepagents/__init__.py`, and the `from deepagents.profiles import (...)` re-export there can't bind until `deepagents/profiles/__init__.py` has itself finished re-exporting from the harness and provider leaf modules — opening a window where the second importer sees a partially-initialized `deepagents.profiles` and crashes with `cannot import name 'GeneralPurposeSubagentProfile'`.

## Changes
- Pull `GeneralPurposeSubagentProfile`, `HarnessProfile`, `HarnessProfileConfig`, `register_harness_profile` directly from `deepagents.profiles.harness.harness_profiles`, and `ProviderProfile`/`register_provider_profile` from `deepagents.profiles.provider.provider_profiles`, so the SDK entry point no longer waits on `deepagents.profiles/__init__.py` re-exports to complete
- Same class of fix as #3291, which already untangled the equivalent path in `graph.py`; built-in profile registration is still lazy on first registry access, so import-graph behavior outside this entry point is unchanged
- Public surface (`__all__`) is identical — the six names remain importable from `deepagents`