### PR TITLE
fix(ci,deps): harden manual releases and update `python-multipart`

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -207,14 +207,73 @@ For hotfixes or exceptional cases, you can trigger a release manually. Use the `
 1. Go to **Actions** > `⚠️ Manual Package Release`
 2. Click **Run workflow**
 3. Select the package to release
-4. **Provide `version`**: the version being released (e.g. `0.0.35`). This is required and used for the run name and a sanity-check warning against `pyproject.toml` — it does not control the released version.
-5. **Provide `release-sha`**: the SHA of the release-PR merge commit. Look it up with `gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid`. The workflow validates the commit's subject matches `release(<package>): <version>` and refuses to run otherwise.
-6. (Optionally enable `dangerous-nonmain-release` for hotfix branches AKA not `main` — when set, `release-sha` may be left empty and the dispatched HEAD is used instead. Validation is skipped.)
+4. **Provide `version`**: the version you want to publish (e.g. `0.0.35`). The workflow checks that the code you selected has the same version.
+5. **Provide `release-sha`**: the commit to publish. Usually this is the release-please PR's merge commit. Find it with `gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid`. If a release failed before anything reached PyPI, you can also use the hotfix commit you merged afterward. See [Hotfix Protocol > Case A](#case-a--release-failed-before-pypi-publish) for that recovery flow.
+6. (Optionally enable `dangerous-nonmain-release` for hotfix branches that are not `main`. When enabled, `release-sha` may be left empty and the workflow uses the branch's current commit.)
 
 > [!WARNING]
-> Manual releases should be rare. Prefer the standard release-please flow for managed packages. Manual dispatch bypasses the changelog detection in `release-please.yml` and skips the lockfile update job. Only use it for recovery scenarios (e.g., the release workflow failed after the release PR was already merged).
+> Manual releases should be rare. Prefer the normal release-please flow whenever possible. Use this workflow mainly for recovery, such as when the release workflow failed after the release PR was already merged!
 >
-> **Why `release-sha` is required:** when the auto-triggered release fails (e.g., at `pre-release-checks`) and you re-run via `workflow_dispatch`, `github.sha` resolves to whatever HEAD is at dispatch time — *not* the original release commit. Without `release-sha`, the GitHub release tag would land on an unrelated commit, which breaks release-please's tag-anchored changelog generation on the next run. release-please walks history back from the most recent tag for each package; if the tag sits on the wrong commit, the next run either includes commits that already shipped or treats the package as un-released and (incorrectly) regenerates the full changelog. The `setup` job's `Resolve and validate release SHA` step enforces this and refuses to run when the input is missing or doesn't match a `release(<package>): <version>` commit.
+> **Why `release-sha` matters:** it tells the workflow exactly which commit to build, test, publish, and tag. That keeps the PyPI package and the GitHub tag pointing at the same code. The workflow also checks that the selected commit declares the version you are releasing.
+
+## Hotfix Protocol
+
+Something went wrong with a release. This section tells you what to do.
+
+The right answer depends on a single question: **is the broken version already on PyPI?**
+
+- **No** → [Case A](#case-a--release-failed-before-pypi-publish): the release workflow failed partway through. Nothing public, you have options.
+- **Yes** → [Case B](#case-b--bug-found-after-pypi-publish): the bad version is out there. You'll ship a new patch version.
+
+> [!IMPORTANT]
+> **The rule we have to maintain:** a version should mean one exact thing. If `mypackage==1.2.3` is on PyPI, then the GitHub tag for `mypackage==1.2.3` must point at the same code.
+>
+> PyPI does its part automatically: once a version is uploaded, you cannot upload different files for that same version. GitHub tags are easier to move by accident, so we have to be careful. Do not move or recreate a tag for a version that is already on PyPI. If a shipped release needs a fix, ship a new version.
+>
+> Why it matters: if PyPI and GitHub disagree, different users can install different code for the same version without knowing it. See [Why one version = one artifact](#why-one-version--one-artifact) at the end of this section.
+
+### Case A — Release failed before PyPI publish
+
+The release-please PR was merged, but the release workflow failed before publishing anything. PyPI does not have the package yet, and no GitHub release was created.
+
+Because nothing was published, you still get to decide what eventually goes out as this version. The fix:
+
+1. **Figure out why the release failed.** Look at the workflow run logs.
+2. **Open a PR with the fix.** Use a `hotfix(<scope>): <description>` title so it doesn't trigger another release PR update. Merge it to `main`.
+   - Important: leave `pyproject.toml`'s version exactly as the release-please PR set it. The hotfix should only fix the problem that broke the release.
+3. **Manually re-dispatch the release workflow** ([Manual Release](#manual-release)). Pass `release-sha` = `main`'s HEAD (the hotfix commit). The workflow will build, publish, and tag that commit.
+4. **Confirm the label swap.** The `mark-release` job swaps the original release-please PR's `autorelease: pending` label to `autorelease: tagged` — it finds the right PR via a fallback label search, even though `release-sha` points at the hotfix commit, not the release-please commit. Double-check the original release-please PR in GitHub after the workflow succeeds. If the label didn't swap, fix it by hand — see [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label).
+
+> [!NOTE]
+> The git tag for the version ends up on the hotfix commit, not on the earlier release-please commit. That is okay: the hotfix commit is the code that actually shipped.
+
+### Case B — Bug found *after* PyPI publish
+
+The version is published.
+
+**Do not:**
+
+- Re-run the manual release workflow against the same version (PyPI will reject it anyway).
+- Delete and re-create the git tag.
+- Open a PR titled something like `hotfix(sdk): bump _version.py` and try to push out a "corrected" version with the same number.
+
+**Do this instead:**
+
+1. Open a normal `fix(<scope>): <description>` PR with the fix. Merge it to `main`.
+2. release-please will open (or update) the next release PR — something like `release(<package>): <next-patch>`. Merge it. The standard auto-release flow handles PyPI and the GitHub tag.
+3. If the broken release is actively harmful (security hole, won't install, corrupts data), also [yank it from PyPI](#yanking-a-release). Yanking hides a version from default installs but keeps it findable for anyone who pinned it explicitly. You don't need to delete the GitHub tag — leaving it preserves an audit trail.
+
+That's it. The new patch version has its own commit, tag, and wheel. The broken version stays exactly as it was when it shipped.
+
+#### Why one version = one artifact
+
+If the GitHub tag for `<version>` points at different code than the PyPI package for `<version>`, users get different software depending on how they install it:
+
+- `pip install <pkg>==<version>` → gets the PyPI wheel.
+- `pip install git+https://.../<repo>@<pkg>==<version>` → gets whatever's at the GitHub tag.
+- `git checkout <pkg>==<version>` (vendored copies, distro packagers, security tools pinning by SHA) → also gets the GitHub tag's code.
+
+When these disagree, the same version can behave differently for different users. The workflow pinning and the "never re-release a version" rule are there to prevent that.
 
 ## Alpha / Beta / Pre-release Versions
 
@@ -415,26 +474,27 @@ The label update is non-fatal in the workflow (`|| true`), so the release itself
 
 ### Release Failed: Pre-release Checks
 
-If the `pre-release-checks` job fails (unit tests, integration tests, or import verification), nothing has been published yet — neither Test PyPI nor PyPI have the package. The release PR is already merged, so the normal release-please flow won't re-trigger.
+The `pre-release-checks` job runs after the package is built but before anything is published. If it fails, nothing reached PyPI or GitHub Releases, but the release PR is already merged. release-please will not retry on its own. This is **Case A** in the [Hotfix Protocol](#case-a--release-failed-before-pypi-publish).
 
-**To fix:**
+**Steps:**
 
-1. **Inspect the failure** in the workflow run logs. Pre-release checks install the built wheel into a fresh venv (no cache) and run:
-   - Package import verification (`python -c "import <pkg>"`)
-   - Unit tests (`make test`)
-   - Integration tests (`make integration_test`, if the target exists)
+1. **Look at the workflow logs** to see why it failed. Pre-release checks install the built package in a clean environment and run:
+   - `python -c "import <pkg>"` — does the package even import?
+   - `make test` — do the unit tests pass against the built wheel?
+   - `make integration_test` (if defined) — do the integration tests pass?
 
-2. **Fix the issue on `main`** — open a PR titled `hotfix(<scope>): <description>`. This won't re-trigger the release because the commit doesn't modify the package's `CHANGELOG.md`.
+2. **Open a `hotfix(<scope>): <description>` PR with the fix.** Merge it to `main` on top of the release-please commit. **Leave `pyproject.toml`'s version exactly as the release-please PR set it.**
 
-3. **Manually trigger the release:**
-   - Go to **Actions** > `⚠️ Manual Package Release`
-   - Click **Run workflow**
-   - Select `main` branch and the affected package
+3. **Manually re-dispatch the release** ([Manual Release](#manual-release)). Pass:
+   - `version` = the same version you were originally trying to release.
+   - `release-sha` = `main` HEAD (the hotfix commit you just merged).
 
-4. **Verify the `autorelease: pending` label was swapped.** The `mark-release` job swaps this automatically (even on manual dispatch), but check the workflow logs to confirm. If it emitted a warning that the label swap failed, fix it manually — see [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label). **If this label isn't swapped, release-please will not create new release PRs.**
+   The workflow will build, test, publish, and tag that commit.
+
+4. **Confirm the label swap.** The `mark-release` job should change the original release-please PR from `autorelease: pending` to `autorelease: tagged`. If the swap didn't happen, fix it manually — see [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label).
 
 > [!TIP]
-> Because pre-release checks run against the built wheel (not the editable install), failures here sometimes indicate missing files in the package manifest or undeclared dependencies that happen to be present locally. Check `pyproject.toml` `[tool.setuptools.packages]` and dependency lists if the failure is an import error rather than a test assertion.
+> Pre-release checks run against the *built wheel*, not against your editable working copy. That means failures here often point at missing files in the wheel or undeclared dependencies — things that worked locally because they were sitting in your venv but didn't get packaged. If the failure is an import error rather than a test assertion, check the `packages` config in `pyproject.toml` and the declared dependencies first.
 
 ### Re-releasing a Version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ on:
         required: false
         type: string
         default: ""
-        description: "Merge commit SHA of the release PR. Find it with:
-          gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid.
-          Required unless you're running an alpha/hotfix release with
-          dangerous-nonmain-release=true. See .github/RELEASING.md > Manual Release."
+        description: "SHA on main whose pyproject.toml declares the input version.
+          Typically the release-please PR's squash-merge commit. May also be a
+          pre-publish hotfix commit on top of it. Look up the release-please
+          merge with: gh pr view <release-pr-number> --json mergeCommit --jq
+          .mergeCommit.oid. Required unless dangerous-nonmain-release=true. See
+          .github/RELEASING.md > Manual Release."
       dangerous-nonmain-release:
         required: false
         type: boolean
@@ -137,11 +139,10 @@ jobs:
               ;;
           esac
 
-      # Pin the GitHub release tag to the release-PR merge commit, not github.sha.
-      # github.sha is whatever commit triggered the workflow — fine for the auto path,
-      # but workflow_dispatch retries (e.g. after a pre-release-checks failure) point
-      # at later commits, leaving the tag on an unrelated commit. release-please then
-      # treats the package as un-released and rebuilds the changelog from scratch.
+      # fetch-depth: 0 so we can read pyproject.toml at an arbitrary historic
+      # SHA (resolve-sha validates that ${WORKING_DIR}/pyproject.toml at the
+      # input SHA declares the version being released). All downstream jobs
+      # check out the resolved SHA so wheel bytes and tag tree agree.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -150,8 +151,10 @@ jobs:
         id: resolve-sha
         env:
           INPUT_SHA: ${{ inputs.release-sha }}
+          INPUT_VERSION: ${{ inputs.version }}
           IS_DANGEROUS: ${{ inputs.dangerous-nonmain-release }}
           PACKAGE: ${{ steps.parse.outputs.package }}
+          WORKING_DIR: ${{ steps.parse.outputs.working-dir }}
           GITHUB_SHA_FALLBACK: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -176,6 +179,7 @@ jobs:
             else
               echo "::error::release-sha input is required for non-alpha releases."
               echo "::error::Look it up with: gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid"
+              echo "::error::For alpha or hotfix branch releases, set dangerous-nonmain-release=true to use the dispatched HEAD."
               exit 1
             fi
           else
@@ -187,21 +191,34 @@ jobs:
             exit 1
           fi
 
-          # Skip the message check on dangerous-nonmain-release: those branches use
-          # "hotfix(scope): alpha release ..." commits, not release-please commits.
+          # Validate that pyproject.toml at this SHA declares the requested version.
+          # This is what we actually care about: the wheel built from this SHA must
+          # claim to be `inputs.version`. It accommodates both the release-please
+          # commit AND a pre-publish hotfix commit on top of it (the hotfix retains
+          # the bumped version string). See RELEASING.md > Hotfix Protocol > Case A.
+          #
+          # Skipped in dangerous-nonmain-release: alpha branches may use throwaway
+          # version strings that don't need to round-trip with `inputs.version`.
           if [ "$IS_DANGEROUS" != "true" ]; then
-            if ! COMMIT_MSG=$(git log -1 --format=%s "$SHA" 2>&1); then
-              echo "::error::cannot read commit $SHA: $COMMIT_MSG"
+            if [ -z "$INPUT_VERSION" ]; then
+              echo "::error::version input is required for non-alpha releases."
               exit 1
             fi
-            EXPECTED="^release\(${PACKAGE}\): "
-            if ! printf '%s\n' "$COMMIT_MSG" | grep -qE "$EXPECTED"; then
-              echo "::error::Commit $SHA has subject: $COMMIT_MSG"
-              echo "::error::Expected subject matching: $EXPECTED"
-              echo "::error::Pass the SHA of the release PR's merge commit (gh pr view ... --json mergeCommit)."
+            PYPROJECT_PATH="${WORKING_DIR}/pyproject.toml"
+            if ! PYPROJECT_CONTENT=$(git show "${SHA}:${PYPROJECT_PATH}" 2>&1); then
+              echo "::error::cannot read ${PYPROJECT_PATH} at ${SHA}: ${PYPROJECT_CONTENT}"
               exit 1
             fi
-            echo "Validated release-sha $SHA -> $COMMIT_MSG"
+            if ! COMMIT_VERSION=$(printf '%s\n' "$PYPROJECT_CONTENT" | python -c 'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])' 2>&1); then
+              echo "::error::failed to extract [project].version from ${PYPROJECT_PATH} at ${SHA}: ${COMMIT_VERSION}"
+              exit 1
+            fi
+            if [ "$COMMIT_VERSION" != "$INPUT_VERSION" ]; then
+              echo "::error::Version mismatch at ${SHA}: ${PYPROJECT_PATH} declares '${COMMIT_VERSION}', release inputs say '${INPUT_VERSION}'."
+              echo "::error::Pass a SHA whose pyproject.toml version matches the release version — typically the release-please commit, or a hotfix on top of it that preserved the version string."
+              exit 1
+            fi
+            echo "Validated release-sha ${SHA}: ${PACKAGE}==${COMMIT_VERSION}"
           else
             echo "Using release-sha $SHA (validation skipped: dangerous-nonmain-release)"
           fi
@@ -225,7 +242,12 @@ jobs:
       is-prerelease: ${{ steps.check-version.outputs.is-prerelease }}
 
     steps:
+      # Build from the validated release commit (not dispatch HEAD) so the wheel
+      # bytes match the GitHub release tag's tree. See RELEASING.md > Hotfix
+      # Protocol for the integrity invariant this enforces.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.setup.outputs.release-sha }}
 
       - name: Set up Python + uv
         uses: "./.github/actions/uv_setup"
@@ -275,12 +297,13 @@ jobs:
               f.write(f"is-prerelease={'true' if is_pre else 'false'}\n")
 
       - name: Validate version consistency
-        if: inputs.version != ''
+        if: inputs.version != '' && inputs.dangerous-nonmain-release != true
         run: |
           BUILD_VERSION="${{ steps.check-version.outputs.version }}"
           INPUT_VERSION="${{ inputs.version }}"
           if [ "$BUILD_VERSION" != "$INPUT_VERSION" ]; then
-            echo "::warning::Version mismatch — run name says '$INPUT_VERSION' but pyproject.toml says '$BUILD_VERSION'"
+            echo "::error::Version mismatch — run name says '$INPUT_VERSION' but pyproject.toml says '$BUILD_VERSION'"
+            exit 1
           fi
 
   # Generate release notes from CHANGELOG.md (with git log fallback)
@@ -301,6 +324,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ needs.setup.outputs.release-sha }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -615,6 +639,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.setup.outputs.release-sha }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -648,6 +674,8 @@ jobs:
       WORKING_DIR: ${{ needs.setup.outputs.working-dir }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.setup.outputs.release-sha }}
 
       # We explicitly *don't* set up caching here. This ensures our tests are
       # maximally sensitive to catching breakage.
@@ -797,6 +825,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.setup.outputs.release-sha }}
 
       - name: Set up Python + uv
         uses: "./.github/actions/uv_setup"
@@ -845,6 +875,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.setup.outputs.release-sha }}
 
       - name: Set up Python + uv
         uses: "./.github/actions/uv_setup"
@@ -876,8 +908,10 @@ jobs:
       - name: Update release PR label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_DANGEROUS: ${{ inputs.dangerous-nonmain-release }}
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
           RELEASE_SHA: ${{ needs.setup.outputs.release-sha }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -931,11 +965,17 @@ jobs:
                 echo "::warning::gh pr edit #$PR_NUMBER failed: $EDIT_ERR"
                 echo "Falling through to label search."
               fi
+            elif printf '%s\n' "$LABELS" | grep -qFx "autorelease: tagged"; then
+              echo "::notice::Release PR #$PR_NUMBER is already tagged."
+              UPDATED=true
             else
-              # Idempotent re-run: the PR is already tagged, or RELEASE_SHA pointed
-              # at something other than a release-please merge. Either way, no-op
-              # here and let the label search confirm there's nothing pending.
-              echo "::notice::PR #$PR_NUMBER lacks 'autorelease: pending'. Either already tagged or RELEASE_SHA is not the release PR merge."
+              # Three legitimate paths land here:
+              #   1. Case A recovery: RELEASE_SHA is a hotfix commit on top of
+              #      the release-please commit, so this lookup found the hotfix
+              #      PR (no autorelease label). Try 2 will find the real one.
+              #   2. dangerous-nonmain-release: alpha/hotfix branches have no
+              #      release-please PR at all.
+              echo "::notice::PR #$PR_NUMBER lacks 'autorelease: pending'. Falling through to label search."
             fi
           else
             echo "No PR found via commit ${RELEASE_SHA}."
@@ -966,7 +1006,26 @@ jobs:
                 exit 1
               fi
             else
-              echo "::warning::No release PR with 'autorelease: pending' found for $PKG_NAME."
-              fail_summary ""
+              if ! TAGGED_PR=$(gh pr list --repo "${{ github.repository }}" \
+                --state merged \
+                --label "autorelease: tagged" \
+                --label "release" \
+                --search "\"release($PKG_NAME): $VERSION\" in:title" \
+                --json number --jq '.[0].number // empty' 2>&1); then
+                echo "::error::gh pr list failed while checking already-tagged releases: $TAGGED_PR"
+                fail_summary ""
+                exit 1
+              fi
+              if [ -n "$TAGGED_PR" ]; then
+                echo "::notice::Release PR #$TAGGED_PR is already tagged."
+                UPDATED=true
+              elif [ "$IS_DANGEROUS" = "true" ]; then
+                echo "::warning::No release PR with 'autorelease: pending' found for $PKG_NAME."
+                fail_summary ""
+              else
+                echo "::error::No release PR with 'autorelease: pending' found for $PKG_NAME."
+                fail_summary ""
+                exit 1
+              fi
             fi
           fi

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -4976,11 +4976,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -103,8 +103,8 @@ required-environments = [
 override-dependencies = [
     "openai>=1.109.1,<2.0.0",
     "e2b==2.4.3",
-    # CVE-2026-24486: path traversal vulnerability in < 0.0.22
-    "python-multipart>=0.0.22",
+    # CVE-2026-42561: DoS via unbounded multipart part headers in < 0.0.27
+    "python-multipart>=0.0.27",
     # CVE-2026-0994: JSON recursion depth bypass DoS in <= 6.33.4
     "protobuf>=6.33.5",
 ]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -19,7 +19,7 @@ overrides = [
     { name = "e2b", specifier = "==2.4.3" },
     { name = "openai", specifier = ">=1.109.1,<2.0.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
 ]
 
 [[package]]
@@ -2742,11 +2742,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Manual release recovery needs to publish and tag the exact commit selected by the maintainer. This updates the release workflow so `release-sha` is validated against the package version in `pyproject.toml`, then reused by downstream build, test, publish, release-note, and tagging jobs.

The label update step now treats already-tagged release PRs as an idempotent success, warns only for dangerous non-main releases, and fails normal releases when no matching release PR can be found. That makes release-please state drift visible instead of leaving maintainers with a stuck `autorelease: pending` label.

This also refreshes the release recovery docs with a clearer hotfix protocol and updates the evals `python-multipart` override for CVE-2026-42561.