### PR TITLE
style(code): remove excess vertical spacing between chat and footer

### DIFF
--- a/libs/code/deepagents_code/app.tcss
+++ b/libs/code/deepagents_code/app.tcss
@@ -24,7 +24,7 @@ Screen {
 /* Chat area - main scrollable messages area */
 #chat {
     height: 1fr;
-    padding: 1 2;
+    padding: 1 2 0 2;
     background: $background;
 }
 
@@ -44,7 +44,7 @@ Screen {
 /* Bottom app container - holds ChatInput (now inside scroll) */
 #bottom-app-container {
     height: auto;
-    margin-top: 1;
+    margin-top: 0;
 }
 
 /* Input area */


### PR DESCRIPTION
Tighten the layout of the code agent TUI by removing the 1-cell gap between the chat scroll area and the bottom input container. The `#chat` area no longer has bottom padding, and the `#bottom-app-container` no longer has a top margin, making the two sections flush.