### PR TITLE
fix(examples): fallback to repos api when hub get omits source

### DIFF
--- a/examples/llm-wiki/init.py
+++ b/examples/llm-wiki/init.py
@@ -76,6 +76,22 @@ def _repo_api_path(owner: str | None, repo: str) -> str:
     return f"/api/v1/repos/{quote(owner_segment, safe='')}/{quote(repo, safe='')}"
 
 
+def _owner_repo_from_hub_identifier(hub_identifier: str) -> tuple[str | None, str]:
+    """Parse a hub identifier into owner/repo components."""
+    if hub_identifier.startswith("-/"):
+        repo = hub_identifier[2:]
+        if not repo:
+            msg = f"Invalid hub identifier {hub_identifier!r}; missing repo handle."
+            raise helpers.WikiError(msg)
+        return None, repo
+
+    owner, sep, repo = hub_identifier.partition("/")
+    if sep == "" or not owner or not repo:
+        msg = f"Invalid hub identifier {hub_identifier!r}; expected OWNER/REPO or -/REPO."
+        raise helpers.WikiError(msg)
+    return owner, repo
+
+
 def ensure_internal_repo_default(config: RunnerConfig, deps: CliDeps) -> None:
     """Ensure the hub repo exists with `source=internal` before first push."""
     repo_path = _repo_api_path(config.owner, config.repo)
@@ -145,11 +161,24 @@ def verify_internal_repo_source(hub_identifier: str, deps: CliDeps) -> None:
 
     source = extract_repo_source(payload)
     if source is None:
-        msg = (
-            "Unable to verify repo source from `hub get --format json` output. "
-            "Expected source metadata with value `internal`."
+        owner, repo = _owner_repo_from_hub_identifier(hub_identifier)
+        api_result = deps.run_langsmith_cli(
+            ["api", _repo_api_path(owner, repo), "--format", "json"]
         )
-        raise helpers.WikiError(msg)
+        api_payload = helpers._parse_cli_json_output(api_result)
+        if api_payload is None:
+            msg = (
+                "Unable to verify repo source from `hub get --format json` output. "
+                "Fallback `/api/v1/repos/{owner}/{repo}` response was not valid JSON."
+            )
+            raise helpers.WikiError(msg)
+        source = extract_repo_source(api_payload)
+        if source is None:
+            msg = (
+                "Unable to verify repo source from `hub get --format json` output. "
+                "Fallback `/api/v1/repos/{owner}/{repo}` output also lacked source metadata."
+            )
+            raise helpers.WikiError(msg)
 
     if source.lower() != "internal":
         msg = (

--- a/examples/llm-wiki/init.py
+++ b/examples/llm-wiki/init.py
@@ -130,7 +130,7 @@ def ensure_internal_repo_default(config: RunnerConfig, deps: CliDeps) -> None:
 
     payload = helpers._parse_cli_json_output(result)
     if payload is None:
-        msg = "Unable to verify repo source from `/api/v1/repos/{owner}/{repo}` output."
+        msg = "Unable to verify repo source from repos API response."
         raise helpers.WikiError(msg)
 
     source = extract_repo_source(payload)
@@ -169,14 +169,14 @@ def verify_internal_repo_source(hub_identifier: str, deps: CliDeps) -> None:
         if api_payload is None:
             msg = (
                 "Unable to verify repo source from `hub get --format json` output. "
-                "Fallback `/api/v1/repos/{owner}/{repo}` response was not valid JSON."
+                "Fallback repos API response was not valid JSON."
             )
             raise helpers.WikiError(msg)
         source = extract_repo_source(api_payload)
         if source is None:
             msg = (
                 "Unable to verify repo source from `hub get --format json` output. "
-                "Fallback `/api/v1/repos/{owner}/{repo}` output also lacked source metadata."
+                "Fallback repos API response also lacked source metadata."
             )
             raise helpers.WikiError(msg)
 

--- a/examples/llm-wiki/tests/unit_tests/test_helpers.py
+++ b/examples/llm-wiki/tests/unit_tests/test_helpers.py
@@ -303,10 +303,19 @@ def test_verify_internal_repo_source_fails_when_not_internal() -> None:
 
 
 def test_verify_internal_repo_source_fails_on_missing_source_field() -> None:
-    """Reject init flows when hub metadata omits source information."""
+    """Reject init flows when both hub and API metadata omit source information."""
+    calls: list[list[str]] = []
 
     def fake_run_langsmith_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
-        assert args[:2] == ["hub", "get"]
+        calls.append(args)
+        if args[:2] == ["hub", "get"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout='{"full_name": "langchain-ai/ada"}',
+                stderr="",
+            )
+        assert args[:2] == ["api", "/api/v1/repos/-/ada"]
         return subprocess.CompletedProcess(
             args=args,
             returncode=0,
@@ -316,8 +325,11 @@ def test_verify_internal_repo_source_fails_on_missing_source_field() -> None:
 
     deps = _make_deps(fake_run_langsmith_cli)
 
-    with pytest.raises(helpers.WikiError, match="Expected source metadata"):
+    with pytest.raises(helpers.WikiError, match="also lacked source metadata"):
         helpers._verify_internal_repo_source("-/ada", deps)
+
+    assert calls[0][:2] == ["hub", "get"]
+    assert calls[1][:2] == ["api", "/api/v1/repos/-/ada"]
 
 
 def test_run_init_ensures_internal_source_via_api(tmp_path: Path) -> None:


### PR DESCRIPTION
`examples/llm-wiki` `init` currently hard-fails when `langsmith hub get --format json` omits repo `source`, even when the repo is valid and internal.

This change preserves strict internal-source enforcement while making verification compatible with current Hub CLI output:
- Keep the existing `hub get` check first.
- If `source` is missing, fallback to `api /api/v1/repos/{owner}/{repo} --format json`.
- Fail only when source is explicitly non-`internal`, or both responses lack source metadata.

Tests were updated to cover the fallback path and the dual-missing-source failure path.

Notable review area:
- Hub identifier parsing in `init` (`OWNER/REPO` and `-/REPO`) used to build the fallback API path.

Validation:
- `uv run --project examples/llm-wiki python -m pytest examples/llm-wiki/tests/unit_tests/test_helpers.py`
- Live smoke check with updated credentials: `--mode init` succeeds for `langchain-ai/ada-lovelace-wiki-smoke-20260514-fix2-final`.
