### PR TITLE
fix(code): correct LangSmith sandbox working directory

### DIFF
--- a/libs/code/deepagents_code/_version.py
+++ b/libs/code/deepagents_code/_version.py
@@ -4,7 +4,7 @@
 # bump `__version__` in sync with `pyproject.toml` on every release PR.
 __version__ = "0.1.0"  # x-release-please-version
 
-DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/cli"
+DOCS_URL = "https://docs.langchain.com/oss/python/deepagents/code"
 """URL for `deepagents-code` documentation."""
 
 PYPI_URL = "https://pypi.org/pypi/deepagents-code/json"

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -73,7 +73,7 @@ def _run_sandbox_setup(backend: SandboxBackendProtocol, setup_script_path: str) 
 _PROVIDER_TO_WORKING_DIR = {
     "agentcore": "/tmp",  # noqa: S108 # AgentCore Code Interpreter working directory
     "daytona": "/home/daytona",
-    "langsmith": "/tmp",  # noqa: S108  # LangSmith sandbox working directory
+    "langsmith": "/root",  # `$HOME` in the LangSmith sandbox
     "modal": "/workspace",
     "runloop": "/home/user",
 }

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1521,7 +1521,7 @@ def _check_mcp_project_trust(*, trust_flag: bool = False) -> bool | None:
     from rich.console import Console as _Console
 
     docs_url = (
-        "https://docs.langchain.com/oss/python/deepagents/cli/"
+        "https://docs.langchain.com/oss/python/deepagents/code/"
         "mcp-tools#project-level-trust"
     )
     prompt_console = _Console(stderr=True)

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -94,7 +94,7 @@ def resolve_env_var(name: str) -> str | None:
 
 
 PROVIDERS_DOCS_URL = (
-    "https://docs.langchain.com/oss/python/deepagents/cli/providers#provider-reference"
+    "https://docs.langchain.com/oss/python/deepagents/code/providers#provider-reference"
 )
 """Public docs page for configuring model providers.
 

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -45,7 +45,7 @@ cleanup() {
   if [ $exit_code -ne 0 ]; then
     echo "" >&2
     log_error "Installation failed (exit code ${exit_code}). See errors above."
-    log_error "For help, visit: https://docs.langchain.com/oss/python/deepagents/cli/overview"
+    log_error "For help, visit: https://docs.langchain.com/oss/python/deepagents/code/overview"
   fi
 }
 trap cleanup EXIT
@@ -436,4 +436,4 @@ echo ""
 printf "${GREEN}✔${NC} Setup complete. Run: ${BOLD}deepagents${NC}\n"
 echo ""
 echo "For help and support, see the Deep Agents Code docs:"
-echo "  https://docs.langchain.com/oss/python/deepagents/cli/overview"
+echo "  https://docs.langchain.com/oss/python/deepagents/code/overview"

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1034,7 +1034,7 @@ class TestCheckMcpProjectTrustPrompt:
         captured = capsys.readouterr()
         flattened = captured.err.replace("\n", "")
         assert (
-            "https://docs.langchain.com/oss/python/deepagents/cli/"
+            "https://docs.langchain.com/oss/python/deepagents/code/"
             "mcp-tools#project-level-trust" in flattened
         )
         assert "Learn more:" in captured.err

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -79,7 +79,7 @@ class TestErrorMessageMarkupSafety:
         """Pre-built `Content` with `link` spans passes through to render output."""
         from textual.style import Style as TStyle
 
-        url = "https://docs.langchain.com/oss/python/deepagents/cli/providers"
+        url = "https://docs.langchain.com/oss/python/deepagents/code/providers"
         body = Content.assemble(
             "see ",
             (url, TStyle(underline=True, link=url)),

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -241,7 +241,7 @@ def test_agentcore_delete_untracked_session() -> None:
     [
         ("agentcore", "/tmp"),
         ("daytona", "/home/daytona"),
-        ("langsmith", "/tmp"),
+        ("langsmith", "/root"),
         ("modal", "/workspace"),
         ("runloop", "/home/user"),
     ],


### PR DESCRIPTION
The `deepagents-code` package still referenced `deepagents/cli` in its documentation URLs and had an incorrect working directory for the `langsmith` sandbox backend. Both issues are corrected across the package and its tests.