### PR TITLE
Support .deepagentsignore in the code CLI

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -62,6 +62,11 @@ from deepagents_code.config import (
     settings,
 )
 from deepagents_code.configurable_model import ConfigurableModelMiddleware
+from deepagents_code.deepagentsignore import (
+    DeepagentsIgnore,
+    IgnoringBackend,
+    IgnoringSandboxBackend,
+)
 from deepagents_code.integrations.sandbox_factory import get_default_working_dir
 from deepagents_code.local_context import (
     LocalContextMiddleware,
@@ -1192,9 +1197,17 @@ def create_cli_agent(
                 inherit_env=True,
                 env=shell_env,
             )
+            backend = IgnoringSandboxBackend(
+                backend,
+                DeepagentsIgnore.from_project(root_dir),
+            )
         else:
             # No shell access - use plain FilesystemBackend
             backend = FilesystemBackend(root_dir=root_dir)
+            backend = IgnoringBackend(
+                backend,
+                DeepagentsIgnore.from_project(root_dir),
+            )
     else:
         # ========== REMOTE SANDBOX MODE ==========
         backend = sandbox  # Remote sandbox (ModalSandbox, etc.)

--- a/libs/code/deepagents_code/deepagentsignore.py
+++ b/libs/code/deepagents_code/deepagentsignore.py
@@ -1,0 +1,411 @@
+"""Project ignore support for Deep Agents Code file context."""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    EditResult,
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GlobResult,
+    GrepMatch,
+    GrepResult,
+    LsResult,
+    ReadResult,
+    SandboxBackendProtocol,
+    WriteResult,
+)
+
+from deepagents_code.project_utils import find_project_root
+
+logger = logging.getLogger(__name__)
+
+DEEPAGENTSIGNORE_FILENAME = ".deepagentsignore"
+DEFAULT_IGNORE_PATTERNS = (
+    ".git/",
+    "node_modules/",
+    "dist/",
+    "build/",
+    ".venv/",
+    "venv/",
+    "__pycache__/",
+)
+IGNORED_READ_ERROR = "Access denied by .deepagentsignore"
+
+
+@dataclass(frozen=True)
+class IgnoreRule:
+    """One parsed `.deepagentsignore` rule."""
+
+    pattern: str
+    negated: bool = False
+    directory_only: bool = False
+    anchored: bool = False
+
+
+@dataclass(frozen=True)
+class DeepagentsIgnore:
+    """Compiled ignore rules for one project root."""
+
+    root: Path
+    rules: tuple[IgnoreRule, ...]
+
+    @classmethod
+    def from_project(cls, cwd: str | Path | None = None) -> DeepagentsIgnore:
+        """Load default, global, and project `.deepagentsignore` rules.
+
+        Returns:
+            Compiled ignore rules for the detected project root.
+        """
+        start = _resolve_lenient(Path(cwd or Path.cwd()).expanduser())
+
+        try:
+            root = find_project_root(start) or start
+        except (OSError, RuntimeError):
+            root = start
+
+        rules: list[IgnoreRule] = []
+        for pattern in DEFAULT_IGNORE_PATTERNS:
+            rule = _parse_ignore_line(pattern)
+            if rule is not None:
+                rules.append(rule)
+
+        global_file = Path.home() / ".deepagents" / DEEPAGENTSIGNORE_FILENAME
+        rules.extend(_load_rules_from_file(global_file))
+        rules.extend(_load_rules_from_file(root / DEEPAGENTSIGNORE_FILENAME))
+        root = _resolve_lenient(root)
+        return cls(root=root, rules=tuple(rules))
+
+    def is_ignored_relative(self, path: str, *, is_dir: bool = False) -> bool:
+        """Return whether a project-relative path is ignored."""
+        rel_path = _normalize_relative_path(path)
+        if not rel_path:
+            return False
+
+        ignored = False
+        for rule in self.rules:
+            if _rule_matches(rule, rel_path, is_dir=is_dir):
+                ignored = not rule.negated
+        return ignored
+
+    def is_ignored_path(self, path: str | Path, *, is_dir: bool = False) -> bool:
+        """Return whether an absolute or relative filesystem path is ignored."""
+        rel_path = self.relative_path(path)
+        if rel_path is None:
+            return False
+        return self.is_ignored_relative(rel_path, is_dir=is_dir)
+
+    def relative_path(self, path: str | Path) -> str | None:
+        """Map a filesystem path to the configured project-relative path.
+
+        Returns:
+            Project-relative path, or `None` when the path is outside the root.
+        """
+        try:
+            raw = str(path)
+            trailing_slash = raw.endswith(("/", "\\"))
+            candidate = Path(raw.rstrip("/\\")).expanduser()
+            if not candidate.is_absolute():
+                candidate = self.root / candidate
+            resolved = candidate.resolve(strict=False)
+            rel = resolved.relative_to(self.root)
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+        rel_path = rel.as_posix()
+        if trailing_slash and rel_path != ".":
+            rel_path += "/"
+        return rel_path
+
+    def filter_project_files(self, paths: list[str]) -> list[str]:
+        """Filter project-relative file paths through the ignore rules.
+
+        Returns:
+            Paths that are not ignored.
+        """
+        return [
+            path for path in paths if not self.is_ignored_relative(path, is_dir=False)
+        ]
+
+
+class IgnoringBackend(BackendProtocol):
+    """Backend wrapper that hides ignored files from CLI file context."""
+
+    def __init__(self, backend: BackendProtocol, ignore: DeepagentsIgnore) -> None:
+        """Wrap a backend with project ignore filtering."""
+        self._backend = backend
+        self._ignore = ignore
+
+    def ls(self, path: str) -> LsResult:
+        """List directory entries, excluding ignored paths.
+
+        Returns:
+            Directory listing with ignored entries removed.
+        """
+        result = self._backend.ls(path)
+        if result.error or result.entries is None:
+            return result
+        return LsResult(
+            error=result.error,
+            entries=[
+                entry
+                for entry in result.entries
+                if not self._is_ignored_file_info(entry)
+            ],
+        )
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        """Read a file unless it is ignored.
+
+        Returns:
+            Read result, or a permission-style error for ignored paths.
+        """
+        if self._ignore.is_ignored_path(file_path):
+            return ReadResult(error=f"{IGNORED_READ_ERROR}: {file_path}")
+        return self._backend.read(file_path, offset, limit)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """Edit a file unless it is ignored.
+
+        Returns:
+            Edit result, or a permission-style error for ignored paths.
+        """
+        if self._ignore.is_ignored_path(file_path):
+            return EditResult(error=f"{IGNORED_READ_ERROR}: {file_path}")
+        return self._backend.edit(file_path, old_string, new_string, replace_all)
+
+    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        """Find files, excluding ignored matches.
+
+        Returns:
+            Glob result with ignored matches removed.
+        """
+        result = self._backend.glob(pattern, path)
+        if result.error or result.matches is None:
+            return result
+        return GlobResult(
+            error=result.error,
+            matches=[
+                match
+                for match in result.matches
+                if not self._is_ignored_file_info(match)
+            ],
+        )
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> GrepResult:
+        """Search files, excluding ignored matches from the result.
+
+        Returns:
+            Grep result with ignored matches removed.
+        """
+        result = self._backend.grep(pattern, path, glob)
+        if result.error or result.matches is None:
+            return result
+        return GrepResult(
+            error=result.error,
+            matches=[
+                match for match in result.matches if not self._is_ignored_grep(match)
+            ],
+        )
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Download files, returning permission errors for ignored paths.
+
+        Returns:
+            One download response per requested path.
+        """
+        blocked_indexes = {
+            index
+            for index, path in enumerate(paths)
+            if self._ignore.is_ignored_path(path)
+        }
+        allowed_paths = [
+            path for index, path in enumerate(paths) if index not in blocked_indexes
+        ]
+        allowed_results = iter(self._backend.download_files(allowed_paths))
+
+        results: list[FileDownloadResponse] = []
+        for index, path in enumerate(paths):
+            if index in blocked_indexes:
+                results.append(
+                    FileDownloadResponse(
+                        path=path,
+                        error="permission_denied",
+                    )
+                )
+            else:
+                results.append(next(allowed_results))
+        return results
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Write a file through to the wrapped backend.
+
+        Returns:
+            Wrapped backend write result.
+        """
+        return self._backend.write(file_path, content)
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload files through to the wrapped backend.
+
+        Returns:
+            Wrapped backend upload results.
+        """
+        return self._backend.upload_files(files)
+
+    def _is_ignored_file_info(self, info: FileInfo) -> bool:
+        path = info.get("path", "")
+        is_dir = bool(info.get("is_dir")) or path.endswith("/")
+        return self._ignore.is_ignored_path(path, is_dir=is_dir)
+
+    def _is_ignored_grep(self, match: GrepMatch) -> bool:
+        return self._ignore.is_ignored_path(match["path"])
+
+
+class IgnoringSandboxBackend(IgnoringBackend, SandboxBackendProtocol):
+    """Ignore-filtering wrapper for backends that can execute shell commands."""
+
+    def __init__(
+        self,
+        backend: SandboxBackendProtocol,
+        ignore: DeepagentsIgnore,
+    ) -> None:
+        """Wrap a shell-capable backend with project ignore filtering."""
+        super().__init__(backend, ignore)
+        self._sandbox_backend = backend
+
+    @property
+    def id(self) -> str:
+        """Return the wrapped backend id.
+
+        Returns:
+            Backend identifier.
+        """
+        return self._sandbox_backend.id
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        """Delegate shell execution to the wrapped backend.
+
+        Returns:
+            Wrapped backend execution response.
+        """
+        if timeout is None:
+            return self._sandbox_backend.execute(command)
+        return self._sandbox_backend.execute(command, timeout=timeout)
+
+    async def aexecute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,  # noqa: ASYNC109
+    ) -> ExecuteResponse:
+        """Delegate async shell execution to the wrapped backend.
+
+        Returns:
+            Wrapped backend execution response.
+        """
+        if timeout is None:
+            return await self._sandbox_backend.aexecute(command)
+        return await self._sandbox_backend.aexecute(command, timeout=timeout)
+
+
+def _load_rules_from_file(path: Path) -> list[IgnoreRule]:
+    if not path.exists():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        logger.warning("Could not read %s", path, exc_info=True)
+        return []
+    return [rule for line in lines if (rule := _parse_ignore_line(line)) is not None]
+
+
+def _resolve_lenient(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _parse_ignore_line(line: str) -> IgnoreRule | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("#"):
+        return None
+
+    negated = stripped.startswith("!")
+    if negated or stripped.startswith(("\\!", "\\#")):
+        stripped = stripped[1:]
+
+    stripped = stripped.strip()
+    if not stripped:
+        return None
+
+    anchored = stripped.startswith("/")
+    if anchored:
+        stripped = stripped.lstrip("/")
+
+    directory_only = stripped.endswith("/")
+    stripped = stripped.rstrip("/")
+    if not stripped:
+        return None
+
+    return IgnoreRule(
+        pattern=stripped,
+        negated=negated,
+        directory_only=directory_only,
+        anchored=anchored,
+    )
+
+
+def _normalize_relative_path(path: str) -> str:
+    normalized = path.replace("\\", "/").strip("/")
+    if normalized == ".":
+        return ""
+    return normalized
+
+
+def _rule_matches(rule: IgnoreRule, rel_path: str, *, is_dir: bool) -> bool:
+    if rule.directory_only:
+        return _directory_rule_matches(rule, rel_path, is_dir=is_dir)
+    if rule.anchored or "/" in rule.pattern:
+        return _path_matches(rule.pattern, rel_path)
+    return any(_path_matches(rule.pattern, part) for part in rel_path.split("/"))
+
+
+def _directory_rule_matches(
+    rule: IgnoreRule,
+    rel_path: str,
+    *,
+    is_dir: bool,
+) -> bool:
+    if rule.anchored or "/" in rule.pattern:
+        pattern = rule.pattern.rstrip("/")
+        return rel_path == pattern or rel_path.startswith(f"{pattern}/")
+
+    parts = rel_path.split("/")
+    directory_parts = parts if is_dir else parts[:-1]
+    return any(_path_matches(rule.pattern, part) for part in directory_parts)
+
+
+def _path_matches(pattern: str, rel_path: str) -> bool:
+    return fnmatch.fnmatchcase(rel_path, pattern)

--- a/libs/code/deepagents_code/input.py
+++ b/libs/code/deepagents_code/input.py
@@ -11,6 +11,7 @@ from urllib.parse import unquote, urlparse
 from rich.markup import escape as escape_markup
 
 from deepagents_code.config import console
+from deepagents_code.deepagentsignore import DeepagentsIgnore
 from deepagents_code.media_utils import ImageData, VideoData
 
 logger = logging.getLogger(__name__)
@@ -297,6 +298,7 @@ def parse_file_mentions(text: str) -> tuple[str, list[Path]]:
     """
     matches = FILE_MENTION_PATTERN.finditer(text)
 
+    ignore = DeepagentsIgnore.from_project(Path.cwd())
     files = []
     for match in matches:
         # Skip if this looks like an email address
@@ -314,6 +316,12 @@ def parse_file_mentions(text: str) -> tuple[str, list[Path]]:
                 path = Path.cwd() / path
 
             resolved = path.resolve()
+            if ignore.is_ignored_path(resolved):
+                console.print(
+                    f"[yellow]Warning: File ignored by .deepagentsignore: "
+                    f"{escape_markup(raw_path)}[/yellow]"
+                )
+                continue
             if resolved.exists() and resolved.is_file():
                 files.append(resolved)
             else:

--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -17,6 +17,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
+from deepagents_code.deepagentsignore import DeepagentsIgnore
 from deepagents_code.project_utils import find_project_root
 
 
@@ -323,6 +324,7 @@ def _get_project_files(root: Path) -> list[str]:
     Returns:
         List of relative file paths from project root.
     """
+    ignore = DeepagentsIgnore.from_project(root)
     git_path = _get_git_executable()
     if git_path:
         try:
@@ -337,7 +339,7 @@ def _get_project_files(root: Path) -> list[str]:
             )
             if result.returncode == 0:
                 files = result.stdout.strip().split("\n")
-                return [f for f in files if f]  # Filter empty strings
+                return ignore.filter_project_files([f for f in files if f])
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
 
@@ -354,7 +356,7 @@ def _get_project_files(root: Path) -> list[str]:
                 break
     except OSError:
         pass
-    return files
+    return ignore.filter_project_files(files)
 
 
 def _fuzzy_score(query: str, candidate: str) -> float:

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -15,6 +15,7 @@ from deepagents_code.widgets.autocomplete import (
     SlashCommandController,
     _fuzzy_score,
     _fuzzy_search,
+    _get_project_files,
     _is_dotpath,
     _path_depth,
 )
@@ -132,6 +133,25 @@ class TestFuzzySearch:
         results = _fuzzy_search("utils", sample_files, limit=10)
         assert len(results) >= 2
         assert any("utils.py" in r for r in results)
+
+
+def test_get_project_files_respects_deepagentsignore(tmp_path):
+    """Project file collection should omit `.deepagentsignore` matches."""
+    (tmp_path / ".deepagentsignore").write_text(
+        "secret.txt\nnode_modules/\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "visible.txt").write_text("visible", encoding="utf-8")
+    (tmp_path / "secret.txt").write_text("secret", encoding="utf-8")
+    vendor = tmp_path / "node_modules"
+    vendor.mkdir()
+    (vendor / "pkg.js").write_text("pkg", encoding="utf-8")
+
+    files = _get_project_files(tmp_path)
+
+    assert "visible.txt" in files
+    assert "secret.txt" not in files
+    assert "node_modules/pkg.js" not in files
 
 
 class TestHelperFunctions:

--- a/libs/code/tests/unit_tests/test_deepagentsignore.py
+++ b/libs/code/tests/unit_tests/test_deepagentsignore.py
@@ -1,0 +1,69 @@
+"""Tests for `.deepagentsignore` parsing and backend filtering."""
+
+from pathlib import Path
+
+from deepagents.backends.filesystem import FilesystemBackend
+
+from deepagents_code.deepagentsignore import (
+    IGNORED_READ_ERROR,
+    DeepagentsIgnore,
+    IgnoringBackend,
+)
+
+
+def test_deepagentsignore_matches_defaults_and_project_rules(tmp_path: Path) -> None:
+    (tmp_path / ".deepagentsignore").write_text(
+        ".env\nsecrets/\n!secrets/public.txt\n/root-only.txt\n",
+        encoding="utf-8",
+    )
+
+    ignore = DeepagentsIgnore.from_project(tmp_path)
+
+    assert ignore.is_ignored_relative("node_modules/pkg/index.js")
+    assert ignore.is_ignored_relative("nested/node_modules", is_dir=True)
+    assert ignore.is_ignored_relative("dist/app.js")
+    assert ignore.is_ignored_relative(".env")
+    assert ignore.is_ignored_relative("nested/.env")
+    assert ignore.is_ignored_relative("secrets/token.txt")
+    assert not ignore.is_ignored_relative("secrets/public.txt")
+    assert ignore.is_ignored_relative("root-only.txt")
+    assert not ignore.is_ignored_relative("nested/root-only.txt")
+
+
+def test_ignoring_backend_filters_read_list_glob_and_grep(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".deepagentsignore").write_text(
+        "secret.txt\nnode_modules/\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "visible.txt").write_text("hello visible\n", encoding="utf-8")
+    (tmp_path / "secret.txt").write_text("hello secret\n", encoding="utf-8")
+    vendor = tmp_path / "node_modules"
+    vendor.mkdir()
+    (vendor / "pkg.js").write_text("hello package\n", encoding="utf-8")
+
+    backend = IgnoringBackend(
+        FilesystemBackend(root_dir=tmp_path, virtual_mode=False),
+        DeepagentsIgnore.from_project(tmp_path),
+    )
+
+    read_result = backend.read(str(tmp_path / "secret.txt"))
+    assert read_result.error is not None
+    assert IGNORED_READ_ERROR in read_result.error
+
+    listed = backend.ls(str(tmp_path))
+    listed_paths = {Path(entry["path"]).name for entry in listed.entries or []}
+    assert "visible.txt" in listed_paths
+    assert "secret.txt" not in listed_paths
+    assert "node_modules" not in listed_paths
+
+    globbed = backend.glob("**/*", str(tmp_path))
+    globbed_names = {Path(entry["path"]).name for entry in globbed.matches or []}
+    assert "visible.txt" in globbed_names
+    assert "secret.txt" not in globbed_names
+    assert "pkg.js" not in globbed_names
+
+    grep = backend.grep("hello", str(tmp_path))
+    grep_names = {Path(match["path"]).name for match in grep.matches or []}
+    assert grep_names == {"visible.txt"}

--- a/libs/code/tests/unit_tests/test_input_parsing.py
+++ b/libs/code/tests/unit_tests/test_input_parsing.py
@@ -75,6 +75,23 @@ def test_parse_file_mentions_warns_for_nonexistent_file(
     assert "nonexistent.py" in mock_console.print.call_args[0][0]
 
 
+def test_parse_file_mentions_skips_deepagentsignored_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    """Ensure ignored files are not attached through `@` mentions."""
+    (tmp_path / ".deepagentsignore").write_text("secret.txt\n", encoding="utf-8")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("token", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    mock_console = mocker.patch("deepagents_code.input.console")
+
+    _, files = parse_file_mentions("@secret.txt")
+
+    assert files == []
+    mock_console.print.assert_called_once()
+    assert "ignored by .deepagentsignore" in mock_console.print.call_args[0][0]
+
+
 def test_parse_file_mentions_ignores_directories(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
 ) -> None:


### PR DESCRIPTION
## Summary

- add `.deepagentsignore` support for Deep Agents Code local file operations
- load default ignores plus global `~/.deepagents/.deepagentsignore` and project `.deepagentsignore`
- filter ignored paths from `read_file`, `edit_file`, `download_files`, `ls`, `glob`, `grep`, `@` mentions, and file autocomplete

Fixes #2143.

## Validation

- `.venv/bin/ruff check deepagents_code/deepagentsignore.py deepagents_code/input.py deepagents_code/widgets/autocomplete.py deepagents_code/agent.py tests/unit_tests/test_deepagentsignore.py tests/unit_tests/test_input_parsing.py tests/unit_tests/test_autocomplete.py`
- `.venv/bin/ruff format --check deepagents_code/deepagentsignore.py deepagents_code/input.py deepagents_code/widgets/autocomplete.py deepagents_code/agent.py tests/unit_tests/test_deepagentsignore.py tests/unit_tests/test_input_parsing.py tests/unit_tests/test_autocomplete.py`
- `.venv/bin/python -m pytest tests/unit_tests/test_deepagentsignore.py tests/unit_tests/test_input_parsing.py tests/unit_tests/test_autocomplete.py tests/unit_tests/test_agent.py -q`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact`

## Notes

The issue discussion asked to keep this behavior out of the SDK filesystem middleware. The interactive terminal CLI implementation currently lives under `libs/code`, so this PR wraps the CLI-created local backends and filters the CLI mention/autocomplete paths there.

The shell command tool is unchanged; existing HITL/allow-list behavior still applies there.
