### PR TITLE
fix(ci): grant id-token: write to Benchmark (nightly) and skip forks

### DIFF
--- a/.github/workflows/_benchmark_nightly.yml
+++ b/.github/workflows/_benchmark_nightly.yml
@@ -12,10 +12,13 @@ on:
 
 permissions:
   contents: read
+  # Required for CodSpeed OIDC authentication in _benchmark.yml
+  id-token: write
 
 jobs:
   benchmark-deepagents:
     name: "⏱️ Benchmark deepagents"
+    if: github.repository_owner == 'langchain-ai'
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/deepagents"
@@ -23,6 +26,7 @@ jobs:
 
   benchmark-code:
     name: "⏱️ Benchmark code"
+    if: github.repository_owner == 'langchain-ai'
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/code"


### PR DESCRIPTION
## Summary
- The `Benchmark (nightly)` scheduled workflow has been failing with `startup_failure` (0s) on every run on `main` since it was added (15/15 since 2026-05-02). Grants `id-token: write` at the workflow level so the reusable `_benchmark.yml` can perform CodSpeed OIDC authentication, mirroring the same grant already present in `ci.yml`.
- Adds an `if: github.repository_owner == 'langchain-ai'` guard to both jobs so the scheduled nightly does not fire on forks, matching the pattern used in `integration_tests.yml`.

## Root cause
GitHub Actions requires a reusable workflow's permissions to be a subset of the caller's. `_benchmark.yml` declares `id-token: write` (required by `CodSpeedHQ/action` for OIDC), but `_benchmark_nightly.yml` only granted `contents: read` — so the workflow validator rejected every scheduled run before any job started. This produces the exact symptom observed: `startup_failure` with `run_started_at == updated_at`, no jobs, and no logs.

`ci.yml` already grants `id-token: write` with the explanatory comment `# Required for CodSpeed OIDC authentication in _benchmark.yml` (ci.yml:25-26), and its `_benchmark.yml` invocations succeed — this PR brings the nightly caller in line.

Fixes #3423

## Test plan
- [x] Workflow YAML parses (`yaml.safe_load`) and lints clean (`actionlint`)
- [x] Diff matches the `id-token: write` grant pattern from `ci.yml:25-26`
- [x] Fork-guard `if:` matches the pattern from `integration_tests.yml:48,81`
- [ ] Next scheduled run at 09:00 UTC succeeds (or maintainer triggers `workflow_dispatch` on `main` after merge to confirm)