### PR TITLE
fix(quickjs): auto-await final-expression Promise in eval REPL

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -52,12 +52,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Sentinel returned by the formatter when the underlying value was a
-# function/circular ref that couldn't be auto-marshaled. We format it as
-# a handle-shaped result so the model sees "you got back a function" rather
-# than nothing.
-_HANDLE_PLACEHOLDER = "[unmarshalable value]"
-
 
 def _clear_exception_references(exc: BaseException) -> None:
     """Drop traceback links to avoid cross-thread GC finalizing QJS handles.
@@ -696,6 +690,40 @@ class _ThreadREPL:
                 self._installed_skills.add(cache_key)
         return errors
 
+    async def _aeval_and_marshal(
+        self, ctx: Context, code: str
+    ) -> tuple[str, str | None]:
+        """Evaluate ``code`` and return ``(result_text, result_kind)``.
+
+        ``result_kind`` is ``"handle"`` when the value (or resolved
+        Promise value) could not be marshaled and was formatted as a
+        handle, and ``None`` otherwise.
+
+        Driving a final-expression Promise — e.g. a bare
+        ``(async () => { ... })();`` — avoids surfacing the Promise
+        object itself as ``[object]`` and lets the agent see the
+        awaited value instead. Issue #3424.
+        """
+        handle = await ctx.eval_handle_async(code, timeout=self._per_call_timeout)
+        try:
+            if handle.is_promise():
+                resolved = await handle.await_promise(timeout=self._per_call_timeout)
+            else:
+                resolved = handle
+            try:
+                try:
+                    value = resolved.to_python()
+                except MarshalError as me:
+                    text = format_handle(resolved)
+                    _clear_exception_references(me)
+                    return text, "handle"
+                return stringify(value), None
+            finally:
+                if resolved is not handle:
+                    resolved.dispose()
+        finally:
+            handle.dispose()
+
     async def _aeval_async(  # noqa: C901
         self,
         code: str,
@@ -739,19 +767,16 @@ class _ThreadREPL:
             outer_loop=outer_loop,
         )
         try:
-            value = await ctx.eval_async(code, timeout=self._per_call_timeout)
-            outcome.result = stringify(value)
+            outcome.result, outcome.result_kind = await self._aeval_and_marshal(
+                ctx, code
+            )
         except _PTCCallBudgetExceededError as e:
             # Raised from inside the PTC bridge; quickjs-rs propagates the
-            # original exception out of eval_async. Surface it as a
-            # distinct, model-recoverable error so the agent can shorten
-            # its script rather than crash.
+            # original exception out of eval_handle_async / await_promise.
+            # Surface it as a distinct, model-recoverable error so the
+            # agent can shorten its script rather than crash.
             outcome.error_type = "PTCCallBudgetExceeded"
             outcome.error_message = e.render_message()
-            _clear_exception_references(e)
-        except MarshalError as e:
-            outcome.result_kind = "handle"
-            outcome.result = await self._describe_via_handle_async(code)
             _clear_exception_references(e)
         except QJSTimeoutError as e:
             outcome.error_type = "Timeout"
@@ -791,17 +816,6 @@ class _ThreadREPL:
         outcome.error_type = e.name
         outcome.error_message = e.message
         outcome.error_stack = e.stack
-
-    async def _describe_via_handle_async(self, code: str) -> str:
-        ctx = self._require_ctx()
-        try:
-            handle = await ctx.eval_handle_async(code, timeout=self._per_call_timeout)
-        except Exception:  # noqa: BLE001 — describe-only path; swallow to placeholder
-            return _HANDLE_PLACEHOLDER
-        try:
-            return format_handle(handle)
-        finally:
-            handle.dispose()
 
     def close(self) -> None:
         self._worker.run_sync(self._aclose())

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -352,6 +352,55 @@ def test_function_return_falls_back_to_handle_description(repl: _ThreadREPL) -> 
 
 
 # ---------------------------------------------------------------------------
+# Final-expression Promise unwrapping (issue #3424)
+# ---------------------------------------------------------------------------
+
+
+def test_async_iife_returning_promise_is_unwrapped(repl: _ThreadREPL) -> None:
+    """Issue #3424: a final expression that is a Promise (e.g. a bare async
+    IIFE) must surface its resolved value instead of the Promise object.
+    """
+    outcome = repl.eval_sync(
+        "(async () => { const v = await Promise.resolve(456); return v; })();"
+    )
+    assert outcome.error_type is None, outcome.error_message
+    assert outcome.result_kind is None
+    assert outcome.result == "456"
+
+
+def test_top_level_promise_expression_is_unwrapped(repl: _ThreadREPL) -> None:
+    outcome = repl.eval_sync("Promise.resolve(7)")
+    assert outcome.error_type is None
+    assert outcome.result_kind is None
+    assert outcome.result == "7"
+
+
+def test_top_level_await_still_works(repl: _ThreadREPL) -> None:
+    """Regression guard: the existing top-level-await path is unaffected."""
+    outcome = repl.eval_sync("const v1 = await Promise.resolve(123); v1;")
+    assert outcome.error_type is None
+    assert outcome.result_kind is None
+    assert outcome.result == "123"
+
+
+def test_rejected_promise_surfaces_as_jserror(repl: _ThreadREPL) -> None:
+    outcome = repl.eval_sync("(async () => { throw new Error('iife-rejection'); })();")
+    assert outcome.result is None
+    assert outcome.error_type == "Error"
+    assert "iife-rejection" in (outcome.error_message or "")
+
+
+def test_unwrapping_does_not_double_user_side_effects(repl: _ThreadREPL) -> None:
+    """The user program (and its console.log side effects) must run exactly
+    once even when the final expression is a Promise that needs unwrapping.
+    """
+    outcome = repl.eval_sync("(async () => { console.log('hit'); return 1; })();")
+    assert outcome.error_type is None
+    assert outcome.result == "1"
+    assert outcome.stdout.count("hit") == 1
+
+
+# ---------------------------------------------------------------------------
 # Truncation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fixes #3424 properly at the engine layer: the QuickJS `eval` REPL now auto-awaits a final-expression Promise (e.g. a bare async IIFE) so the model sees the resolved value rather than `[object]`.
- Switches `_aeval_async` from `ctx.eval_async` to `ctx.eval_handle_async` + `Handle.await_promise` + `Handle.to_python`. `await_promise` is a no-op for non-Promise handles, so the existing fast paths are unchanged.
- Five new regression tests in `test_repl_middleware.py`.

## Root cause
`ctx.eval_async(code)` returns whatever the script's final expression evaluates to. When that expression is `(async () => { ... })()` the value is a Promise object; `quickjs_rs` cannot marshal a Promise to Python and raises `MarshalError`. The previous handler re-evaluated the code via `eval_handle_async` and formatted the handle as `"[" + handle.type_of + "]"` — which for a Promise is `"[object]"`.

Result: semantically equivalent code surfaces different values to the agent:

```js
const x = await Promise.resolve(123); x;
// → 123

(async () => { const x = await Promise.resolve(123); return x; })();
// → [object]    ← the headline bug
```

## Fix
Replace the eval path with handle-based evaluation:

1. `handle = await ctx.eval_handle_async(code, timeout=...)`
2. If `handle.is_promise()`, drive it via `await handle.await_promise(timeout=...)` to get a handle to the resolved value.
3. Marshal via `resolved.to_python()`; fall back to `format_handle(resolved)` on `MarshalError` (e.g. for genuinely unmarshalable values like functions).

The logic is extracted into a `_aeval_and_marshal` helper to keep `_aeval_async` under ruff's complexity thresholds. All other exception handlers (PTC budget, timeout, deadlock, JS error, etc.) are unchanged.

### Side benefit — no more side-effect doubling
The previous `MarshalError` handler called `_describe_via_handle_async(code)`, which re-evaluated the user's program to get a handle. That meant any user code that hit the marshal-fallback path (functions, Promises) ran twice — `console.log` was double-emitted, host-bridge tools were double-invoked, etc. With the new flow the program runs exactly once and the resulting handle is reused. The unused `_describe_via_handle_async` and `_HANDLE_PLACEHOLDER` sentinel are removed.

## Test plan
Added `tests/unit_tests/test_repl_middleware.py::test_async_iife_returning_promise_is_unwrapped` and four sibling tests covering:

- [x] **Headline bug** — async IIFE returning Promise unwraps to the resolved value
- [x] **Plain `Promise.resolve(...)`** as final expression unwraps
- [x] **Top-level await regression guard** — existing path unaffected
- [x] **Promise rejection** — surfaces as `JSError` with the JS error type preserved
- [x] **No side-effect doubling** — `console.log` count == 1 even when the final value is a Promise

Other verification:

- [x] `make test` — **170 tests pass** (165 existing + 5 new), 91% coverage
- [x] `make lint` — ruff check + format + ty all clean

## Supersedes / closes
Supersedes the prompt-only mitigation in #3429.

Fixes #3424