### PR TITLE
fix(ci): grant `id-token: write` to benchmark

### DIFF
--- a/.github/workflows/_benchmark_nightly.yml
+++ b/.github/workflows/_benchmark_nightly.yml
@@ -16,6 +16,11 @@ permissions:
 jobs:
   benchmark-deepagents:
     name: "⏱️ Benchmark deepagents"
+    if: github.repository_owner == 'langchain-ai'
+    permissions:
+      contents: read
+      # Required for CodSpeed OIDC authentication in _benchmark.yml
+      id-token: write
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/deepagents"
@@ -23,6 +28,11 @@ jobs:
 
   benchmark-code:
     name: "⏱️ Benchmark code"
+    if: github.repository_owner == 'langchain-ai'
+    permissions:
+      contents: read
+      # Required for CodSpeed OIDC authentication in _benchmark.yml
+      id-token: write
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/code"


### PR DESCRIPTION
Fixes #3423

Co-authored-by: Subham Kumar Das <35267544+lost-particles@users.noreply.github.com>