### PR TITLE
feat(cli): surface Perplexity as a first-class provider

### DIFF
--- a/libs/cli/deepagents_cli/config.py
+++ b/libs/cli/deepagents_cli/config.py
@@ -1935,9 +1935,14 @@ def _get_provider_kwargs(
     base_url = config.get_base_url(provider)
     if base_url:
         result["base_url"] = base_url
-    from deepagents_cli.model_config import PROVIDER_API_KEY_ENV, resolve_env_var
+    from deepagents_cli.model_config import (
+        PROVIDER_API_KEY_ENV,
+        PROVIDER_API_KEY_ENV_FALLBACKS,
+        resolve_env_var,
+    )
 
     api_key_env = config.get_api_key_env(provider)
+    fallback_envs: tuple[str, ...] = ()
     if not api_key_env:
         api_key_env = PROVIDER_API_KEY_ENV.get(provider)
         if api_key_env:
@@ -1946,8 +1951,19 @@ def _get_provider_kwargs(
                 " using hardcoded provider env var",
                 provider,
             )
+            fallback_envs = PROVIDER_API_KEY_ENV_FALLBACKS.get(provider, ())
     if api_key_env:
         api_key = resolve_env_var(api_key_env)
+        if not api_key:
+            for fallback in fallback_envs:
+                api_key = resolve_env_var(fallback)
+                if api_key:
+                    logger.debug(
+                        "Using fallback env var %s for provider '%s'",
+                        fallback,
+                        provider,
+                    )
+                    break
         if api_key:
             result["api_key"] = api_key
 

--- a/libs/cli/deepagents_cli/model_config.py
+++ b/libs/cli/deepagents_cli/model_config.py
@@ -279,7 +279,7 @@ PROVIDER_API_KEY_ENV: dict[str, str] = {
     "nvidia": "NVIDIA_API_KEY",
     "openai": "OPENAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
-    "perplexity": "PPLX_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
     "together": "TOGETHER_API_KEY",
     "xai": "XAI_API_KEY",
 }
@@ -292,6 +292,18 @@ time.
 
 Providers not listed here fall through to the config-file check or the langchain
 registry fallback.
+"""
+
+PROVIDER_API_KEY_ENV_FALLBACKS: dict[str, tuple[str, ...]] = {
+    "perplexity": ("PPLX_API_KEY",),
+}
+"""Legacy env-var names checked when the primary `PROVIDER_API_KEY_ENV` value is unset.
+
+Some providers ship under a canonical env var (e.g. `PERPLEXITY_API_KEY`) but
+also support an older name (`PPLX_API_KEY`) for backwards compatibility with
+the upstream SDK. Listing the legacy names here lets the credential pre-check
+and the api_key kwarg resolution recognise either, while keeping the canonical
+name visible in error messages.
 """
 
 IMPLICIT_AUTH_PROVIDERS: frozenset[str] = frozenset({"google_vertexai"})
@@ -801,7 +813,14 @@ def has_provider_credentials(provider: str) -> bool | None:
     # Fall back to hardcoded well-known providers.
     env_var = PROVIDER_API_KEY_ENV.get(provider)
     if env_var:
-        return bool(resolve_env_var(env_var))
+        if resolve_env_var(env_var):
+            return True
+        # Some providers accept legacy env-var names (e.g. PPLX_API_KEY for
+        # Perplexity). Treat the credential as available when any fallback is set.
+        for fallback in PROVIDER_API_KEY_ENV_FALLBACKS.get(provider, ()):
+            if resolve_env_var(fallback):
+                return True
+        return False
 
     # Provider not found in config or hardcoded map — credential status is
     # unknown. The provider itself will report auth failures at
@@ -817,7 +836,10 @@ def get_credential_env_var(provider: str) -> str | None:
     """Return the env var name that holds credentials for a provider.
 
     Checks the config file first (user override), then falls back to the
-    hardcoded `PROVIDER_API_KEY_ENV` map.
+    hardcoded `PROVIDER_API_KEY_ENV` map. Always returns the canonical primary
+    env var; legacy fallbacks (see `PROVIDER_API_KEY_ENV_FALLBACKS`) are not
+    surfaced here so that credential-missing messages prompt for the
+    user-facing canonical name.
 
     Args:
         provider: Provider name.

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -138,9 +138,7 @@ class TestHasProviderCredentials:
 
     def test_perplexity_resolves_via_canonical_env_var(self):
         """Perplexity recognises `PERPLEXITY_API_KEY` as the primary env var."""
-        with patch.dict(
-            "os.environ", {"PERPLEXITY_API_KEY": "pplx-test"}, clear=True
-        ):
+        with patch.dict("os.environ", {"PERPLEXITY_API_KEY": "pplx-test"}, clear=True):
             assert has_provider_credentials("perplexity") is True
 
     def test_perplexity_resolves_via_legacy_env_var(self):

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -11,6 +11,7 @@ import pytest
 from deepagents_cli import model_config
 from deepagents_cli.model_config import (
     PROVIDER_API_KEY_ENV,
+    PROVIDER_API_KEY_ENV_FALLBACKS,
     THREAD_COLUMN_DEFAULTS,
     ModelConfig,
     ModelConfigError,
@@ -134,6 +135,23 @@ class TestHasProviderCredentials:
             clear=True,
         ):
             assert has_provider_credentials("anthropic") is True
+
+    def test_perplexity_resolves_via_canonical_env_var(self):
+        """Perplexity recognises `PERPLEXITY_API_KEY` as the primary env var."""
+        with patch.dict(
+            "os.environ", {"PERPLEXITY_API_KEY": "pplx-test"}, clear=True
+        ):
+            assert has_provider_credentials("perplexity") is True
+
+    def test_perplexity_resolves_via_legacy_env_var(self):
+        """Perplexity falls back to `PPLX_API_KEY` when canonical name is unset."""
+        with patch.dict("os.environ", {"PPLX_API_KEY": "pplx-legacy"}, clear=True):
+            assert has_provider_credentials("perplexity") is True
+
+    def test_perplexity_returns_false_when_neither_env_var_set(self):
+        """Perplexity reports missing credentials when neither var is set."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert has_provider_credentials("perplexity") is False
 
 
 class TestThreadColumnPersistence:
@@ -498,9 +516,13 @@ class TestProviderApiKeyEnv:
         assert PROVIDER_API_KEY_ENV["nvidia"] == "NVIDIA_API_KEY"
         assert PROVIDER_API_KEY_ENV["openai"] == "OPENAI_API_KEY"
         assert PROVIDER_API_KEY_ENV["openrouter"] == "OPENROUTER_API_KEY"
-        assert PROVIDER_API_KEY_ENV["perplexity"] == "PPLX_API_KEY"
+        assert PROVIDER_API_KEY_ENV["perplexity"] == "PERPLEXITY_API_KEY"
         assert PROVIDER_API_KEY_ENV["together"] == "TOGETHER_API_KEY"
         assert PROVIDER_API_KEY_ENV["xai"] == "XAI_API_KEY"
+
+    def test_perplexity_legacy_fallback_registered(self):
+        """`PPLX_API_KEY` remains a recognised legacy fallback for Perplexity."""
+        assert "PPLX_API_KEY" in PROVIDER_API_KEY_ENV_FALLBACKS["perplexity"]
 
 
 class TestModelConfigLoad:


### PR DESCRIPTION
Closes #3438

## Summary

Aligns the CLI's well-known provider env-var registry for Perplexity with the canonical, user-facing name (`PERPLEXITY_API_KEY`) used across the Perplexity API docs, while keeping backwards compatibility with the legacy `PPLX_API_KEY` env var that the upstream `langchain-perplexity` SDK ships with by default.

The `langchain-perplexity` package itself reads the legacy variable as its default. This PR only changes how the CLI surfaces credentials in the `/model` switcher and the `api_key=` resolution.

## Changes

- `libs/cli/deepagents_cli/config.py`
  - Switches `PROVIDER_API_KEY_ENV["perplexity"]` to canonical `PERPLEXITY_API_KEY`.
  - Adds `PROVIDER_API_KEY_ENV_FALLBACKS` so `PPLX_API_KEY` still works.
- `libs/cli/deepagents_cli/model_config.py`
  - Wires fallback lookup into both the credential pre-check and the `api_key=` kwarg resolution.
- `libs/cli/tests/unit_tests/test_model_config.py`
  - Adds unit coverage for canonical-only, legacy-only, missing credentials, and fallback registry behavior.

## Re-submission note

This re-submits #3061, which was closed by `require-issue-link` automation because the linked issue was not assigned to the external contributor. The original linked issue, #3059, was also closed by automation, so #3438 was opened as the replacement issue.

External contributors cannot self-assign issues in this repo; attempting to assign #3438 returned `403 Must have admin rights to Repository`. Could a maintainer please assign #3438 to the PR author (@jliounis) so the linked-issue bot does not auto-close this PR again?

## Tests

From the original local validation on #3061:

- `uv run pytest tests/unit_tests/test_model_config.py` — 197 passed.
- `uv run pytest tests/unit_tests/test_config.py` — 181 passed.
- `make lint` clean.

Signed-off-by: james-pplx <james@perplexity.ai>

---
🤖 _Generated by [PSI](https://www.notion.so/perplexity-ai/HowTo-PSI-Perplexity-Super-Intelligence-29c6172b229b80d3a8ece89a6cfb6ae6)_
🧠 _Agent used: `codex`_
