### PR TITLE
fix(sdk): return error from `SandboxBackend.grep` when exec fails

### DIFF
--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -792,6 +792,18 @@ except PermissionError:
         result = self.execute(cmd)
 
         output = result.output.rstrip()
+        # ``|| true`` in the command above masks shell-level grep failures
+        # (e.g. exit code 1 when there are no matches), so a non-zero
+        # ``exit_code`` reaching this point indicates a runtime-layer failure
+        # — the shell never started (chdir error, missing binary, container
+        # died mid-exec). In that case ``output`` is the runtime's error
+        # message; surface it via ``GrepResult.error`` instead of trying to
+        # parse it as ``path:line:text`` rows.
+        if result.exit_code is not None and result.exit_code != 0:
+            return GrepResult(
+                matches=None,
+                error=output or f"grep exec failed with exit code {result.exit_code}",
+            )
         if not output:
             return GrepResult(matches=[])
 

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -772,6 +772,35 @@ def test_sandbox_grep_quotes_include_glob() -> None:
     assert "--include='x'\"'\"' ; echo injected ; #' -e needle /test" in sandbox.last_command
 
 
+def test_sandbox_grep_returns_error_when_exec_fails() -> None:
+    """Test that grep returns ``GrepResult(error=...)`` when ``execute`` fails.
+
+    When the sandbox runtime fails to start the command (e.g. Docker exec
+    chdir error, missing binary, container died mid-exec) the runtime
+    returns an error message via ``ExecuteResponse.output`` and a non-zero
+    ``exit_code``. That message commonly contains ``:`` characters, which
+    the parser previously mistook for ``path:line:text`` rows and crashed
+    on ``int(parts[1])``. See issue #3441.
+    """
+    sandbox = MockSandbox()
+    oci_error = (
+        "OCI runtime exec failed: exec failed: unable to start container "
+        'process: chdir to cwd ("/does-not-exist"): no such file or '
+        "directory: unknown"
+    )
+
+    def failing_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
+        return ExecuteResponse(output=oci_error, exit_code=126, truncated=False)
+
+    sandbox.execute = failing_execute
+
+    result = sandbox.grep("needle", path="/test")
+
+    assert result.matches is None
+    assert result.error is not None
+    assert oci_error in result.error
+
+
 # -- upload/download failure tests --------------------------------------------
 
 


### PR DESCRIPTION
Fixes #3441

When `container.exec_run` fails at the OCI runtime layer (chdir error, missing binary, container died mid-exec) the runtime returns its error message via `ExecuteResponse.output` and a non-zero `exit_code`. That message contains `:` characters which pass the existing `len(parts) >= 3` guard, and `int(parts[1])` then raises `ValueError` — crashing the tool node.

Add an exit-code short-circuit before parsing: when `result.exit_code` is non-zero (and not `None`), return `GrepResult(matches=None, error=output)` — mirroring how `glob` and other backend methods surface unreachable-path failures. `|| true` in the constructed grep command still masks shell-level grep exit codes (e.g. exit 1 when there are no matches), so the new branch only triggers on runtime-layer failures.

Includes a regression test pinning the behavior with the actual OCI runtime error string from the production crash.

## Social handles
LinkedIn: https://www.linkedin.com/in/pierre-larochelle/
