### PR TITLE
feat(cli): add `--host` to `deepagents dev`

### DIFF
--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -84,6 +84,15 @@ def setup_deploy_parsers(
         default=True,
         help="Pass --allow-blocking to langgraph dev (default: enabled)",
     )
+    dev_parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Network interface to bind the dev server "
+            "(default: 127.0.0.1; use 0.0.0.0 for all interfaces)"
+        ),
+    )
 
     # deepagents deploy
     deploy_parser = subparsers.add_parser(
@@ -138,6 +147,7 @@ def execute_dev_command(args: argparse.Namespace) -> None:
     _dev(
         config_path=args.config,
         port=args.port,
+        host=args.host,
         allow_blocking=args.allow_blocking,
     )
 
@@ -343,6 +353,7 @@ def _dev(
     *,
     config_path: str | None,
     port: int,
+    host: str = "127.0.0.1",
     allow_blocking: bool,
 ) -> None:
     """Bundle the project and run a local `langgraph dev` server.
@@ -356,6 +367,7 @@ def _dev(
     Args:
         config_path: Path to `deepagents.toml`, or `None` for default.
         port: Local port for the dev server.
+        host: Network interface to bind (default: 127.0.0.1).
         allow_blocking: Pass `--allow-blocking` to `langgraph dev` so
             sync HTTP calls inside the graph (e.g. the LangSmith sandbox
             client) don't trigger blockbuster errors.
@@ -413,13 +425,15 @@ def _dev(
             "langgraph",
             "dev",
             "--no-browser",
+            "--host",
+            host,
             "--port",
             str(port),
         ]
         if allow_blocking:
             cmd.append("--allow-blocking")
 
-        print(f"\nStarting langgraph dev on http://localhost:{port}")
+        print(f"\nStarting langgraph dev on http://{host}:{port}")
         print(f"Build directory: {build_dir}")
         print(f"Running: {' '.join(cmd)}\n")
 

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -433,7 +433,13 @@ def _dev(
         if allow_blocking:
             cmd.append("--allow-blocking")
 
-        print(f"\nStarting langgraph dev on http://{host}:{port}")
+        if host == "0.0.0.0":
+            print(
+                f"\nStarting langgraph dev on http://localhost:{port} "
+                "(bound to 0.0.0.0)"
+            )
+        else:
+            print(f"\nStarting langgraph dev on http://{host}:{port}")
         print(f"Build directory: {build_dir}")
         print(f"Running: {' '.join(cmd)}\n")
 

--- a/libs/cli/tests/unit_tests/deploy/test_commands.py
+++ b/libs/cli/tests/unit_tests/deploy/test_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
@@ -197,3 +198,30 @@ class TestAutoWireIssuesBoard:
         _auto_wire_issues_board_if_hub(cast("DeployConfig", cfg))
 
         assert observed["context_hub_repo_handle"] == "custom-agent"
+
+
+class TestDevParserHost:
+    """Test argparse wiring for the `deepagents dev --host` flag."""
+
+    def _build_parser(self) -> argparse.ArgumentParser:
+        from deepagents_cli.deploy.commands import setup_deploy_parsers
+
+        class _NoopAction(argparse.Action):
+            def __call__(self, *_args: object, **_kwargs: object) -> None:
+                return
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        setup_deploy_parsers(
+            subparsers,
+            make_help_action=lambda _printer: _NoopAction,
+        )
+        return parser
+
+    def test_host_defaults_to_loopback(self) -> None:
+        args = self._build_parser().parse_args(["dev"])
+        assert args.host == "127.0.0.1"
+
+    def test_host_accepts_all_interfaces(self) -> None:
+        args = self._build_parser().parse_args(["dev", "--host", "0.0.0.0"])
+        assert args.host == "0.0.0.0"


### PR DESCRIPTION
Fixes #3431

---

Adds a `--host` argument to `deepagents dev` (default `127.0.0.1`) that is forwarded to `langgraph dev --host`. When running the dev server inside a container, binding to `0.0.0.0` is required so the server is reachable from outside the container.

Supersedes #3432 — that PR was accidentally merged and then force-undone from `main`. GitHub does not allow reopening merged PRs, so this revival lives on a maintainer branch with original authorship preserved as `Kevin Pedretti`.