### PR TITLE
feat(sdk): add shell_executable parameter to LocalShellBackend  

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -110,6 +110,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         max_output_bytes: int = 100_000,
         env: dict[str, str] | None = None,
         inherit_env: bool = False,
+        shell_executable: str | None = None,
     ) -> None:
         """Initialize local shell backend with filesystem access.
 
@@ -157,6 +158,10 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             inherit_env: Whether to inherit the parent process's environment variables.
                 When False (default), only variables in `env` dict are available.
                 When True, inherits all `os.environ` variables and applies `env` overrides.
+
+            shell_executable: Path to the shell executable to use for command execution.
+                When None (default), uses the system default (`/bin/sh` on most systems).
+                Set to `"zsh"` to use zsh, `"bash"` for bash, etc.
 
         Raises:
             ValueError: If timeout is not positive.
@@ -208,6 +213,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
 
         # Generate unique sandbox ID
         self._sandbox_id = f"local-{uuid.uuid4().hex[:8]}"
+        self._shell_executable = shell_executable
 
     @property
     def id(self) -> str:
@@ -223,6 +229,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         command: str,
         *,
         timeout: int | None = None,
+        shell_executable: str | None = None,
     ) -> ExecuteResponse:
         r"""Execute a shell command directly on the host system.
 
@@ -252,6 +259,12 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 **Security:** This string is passed directly to the shell. Agents can
                 execute arbitrary commands including pipes, redirects, command
                 substitution, etc.
+            shell_executable: Maximum time in seconds to wait for this command.
+
+                Overrides the default timeout set at init and the instance-level
+                `shell_executable` setting.
+
+                If None, uses the instance-level setting.
             timeout: Maximum time in seconds to wait for this command.
 
                 Overrides the default timeout set at init.
@@ -287,6 +300,10 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             # Override timeout for long-running commands
             result = backend.execute("make build", timeout=300)
 
+            # Use zsh instead of the default shell
+            result = backend.execute("ls -la", shell_executable="zsh")
+
+
             # Commands run in root_dir, but can access any path
             result = backend.execute("cat /etc/passwd")  # Can read system files!
             ```
@@ -304,17 +321,34 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             raise ValueError(msg)
 
         try:
-            result = subprocess.run(  # noqa: S602
-                command,
-                check=False,
-                shell=True,  # Intentional: designed for LLM-controlled shell execution
-                capture_output=True,
-                stdin=subprocess.DEVNULL,  # Prevent hanging on commands that read stdin (e.g. python, cat)
-                text=True,
-                timeout=effective_timeout,
-                env=self._env,
-                cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
-            )
+            effective_shell = shell_executable if shell_executable is not None else self._shell_executable
+
+            if effective_shell:
+                # Use specified shell executable with -c flag
+                result = subprocess.run(  # noqa: S603
+                    [effective_shell, "-c", command],
+                    check=False,
+                    shell=False,
+                    capture_output=True,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                    timeout=effective_timeout,
+                    env=self._env,
+                    cwd=str(self.cwd),
+                )
+            else:
+                # Use system shell (shell=True)
+                result = subprocess.run(  # noqa: S602
+                    command,
+                    check=False,
+                    shell=True,  # Intentional: designed for LLM-controlled shell execution
+                    capture_output=True,
+                    stdin=subprocess.DEVNULL,  # Prevent hanging on commands that read stdin (e.g. python, cat)
+                    text=True,
+                    timeout=effective_timeout,
+                    env=self._env,
+                    cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
+                )
 
             # Combine stdout and stderr
             # Prefix each stderr line with [stderr] for clear attribution.

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -275,6 +275,34 @@ def test_local_shell_backend_stderr_formatting() -> None:
         assert "error message" in result.output
 
 
+def test_local_shell_backend_custom_shell_executable() -> None:
+    """Test that custom shell executable can be specified."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir, inherit_env=True, shell_executable="sh")
+
+
+        # Execute command using the specified shell
+        result = backend.execute("echo $0")
+
+
+        assert result.exit_code == 0
+        # When using explicit [shell, -c, cmd], $0 should be empty or the shell name
+        assert "sh" in result.output or result.output.strip() == ""
+
+
+
+def test_local_shell_backend_execute_with_shell_executable_override() -> None:
+    """Test that shell_executable can be overridden per-command."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir, inherit_env=True, shell_executable="sh")
+
+        # Override shell executable for this specific command
+        result = backend.execute("echo test", shell_executable="sh")
+
+        assert result.exit_code == 0
+        assert "test" in result.output
+
+
 async def test_local_shell_backend_async_execute() -> None:
     """Test async execute method."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
 Adds a `shell_executable` parameter to `LocalShellBackend` that allows users to specify which shell to use when executing commands (e.g., `"zsh"`, `"bash"`). The parameter can be set at initialization or overridden per-command via `execute()`.        
