### PR TITLE
feat(ci): extend extras-sync check to all packages

### DIFF
--- a/.github/scripts/check_extras_sync.py
+++ b/.github/scripts/check_extras_sync.py
@@ -1,4 +1,4 @@
-"""Check that optional extras stay in sync with required dependencies (openai).
+"""Check that optional extras stay in sync with required dependencies.
 
 When a package appears in both [project.dependencies] and
 [project.optional-dependencies], we ensure their version constraints match.
@@ -12,12 +12,17 @@ from pathlib import Path
 from re import compile as re_compile
 
 # Matches the package name at the start of a PEP 508 dependency string.
-# Handles both hyphenated and underscored names (PEP 503 normalizes these).
+# Stops at the first non-name character; downstream code is responsible for
+# stripping extras (`[...]`) and env markers (`; ...`) from the remainder.
 _NAME_RE = re_compile(r"^([A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?)")
 
 
 def _normalize(name: str) -> str:
-    """PEP 503 normalize a package name for comparison.
+    """Normalize a package name for equality comparison.
+
+    Lowercases and maps `-` and `.` to `_`. Looser than PEP 503
+    (which uses `-` and collapses runs), but sufficient for matching the
+    same package across two PEP 508 strings.
 
     Returns:
         Lowercased, underscore-normalized package name.
@@ -26,42 +31,69 @@ def _normalize(name: str) -> str:
 
 
 def _parse_dep(dep: str) -> tuple[str, str]:
-    """Return (normalized_name, version_spec) from a PEP 508 string.
+    """Return `(normalized_name, version_spec)` from a PEP 508 string.
+
+    Strips extras (`pkg[async]`), environment markers (`; python_version ...`),
+    URL specifiers (`pkg @ git+...`), and whitespace so the returned
+    `version_spec` is directly comparable between a required and optional dep.
 
     Returns:
-        Tuple of normalized package name and version specifier.
+        Tuple of normalized package name and bare version specifier.
 
     Raises:
         ValueError: If the dependency string cannot be parsed.
     """
     match = _NAME_RE.match(dep)
     if not match:
-        msg = f"Cannot parse dependency: {dep}"
+        msg = f"Cannot parse dependency: {dep!r}"
         raise ValueError(msg)
     name = match.group(1)
-    version_spec = dep[match.end() :].strip()
-    return _normalize(name), version_spec
+    rest = dep[match.end() :].strip()
+
+    if rest.startswith("["):
+        close = rest.find("]")
+        if close == -1:
+            msg = f"Unclosed extras bracket in dependency: {dep!r}"
+            raise ValueError(msg)
+        rest = rest[close + 1 :].strip()
+
+    if ";" in rest:
+        rest = rest.split(";", 1)[0].strip()
+
+    # URL specifiers have no comparable version; treat as unconstrained.
+    if rest.startswith("@"):
+        rest = ""
+
+    rest = " ".join(rest.split())
+    return _normalize(name), rest
 
 
 def main(pyproject_path: Path) -> int:
-    """Check extras sync and return exit code (0 = pass, 1 = mismatch).
-
-    Returns:
-        0 if all extras match, 1 if there are mismatches.
-    """
+    """Check extras sync and return `0` on pass, `1` on mismatch or parse error."""
     with pyproject_path.open("rb") as f:
         data = tomllib.load(f)
 
     required: dict[str, str] = {}
     for dep in data.get("project", {}).get("dependencies", []):
-        name, spec = _parse_dep(dep)
+        try:
+            name, spec = _parse_dep(dep)
+        except ValueError as e:
+            print(f"::error file={pyproject_path}::{e}")
+            return 1
         required[name] = spec
 
-    mismatches: list[str] = []
     optional = data.get("project", {}).get("optional-dependencies", {})
+    if not optional:
+        return 0
+
+    mismatches: list[str] = []
     for group, deps in optional.items():
         for dep in deps:
-            name, spec = _parse_dep(dep)
+            try:
+                name, spec = _parse_dep(dep)
+            except ValueError as e:
+                print(f"::error file={pyproject_path}::{e}")
+                return 1
             if name in required and spec != required[name]:
                 mismatches.append(
                     f"  [{group}] {name}: extra has '{spec}' "
@@ -69,7 +101,7 @@ def main(pyproject_path: Path) -> int:
                 )
 
     if mismatches:
-        print("Extra / required dependency version mismatch:")
+        print(f"Extra / required dependency version mismatch in {pyproject_path}:")
         print("\n".join(mismatches))
         print(
             "\nUpdate the optional extras in [project.optional-dependencies] "
@@ -77,7 +109,7 @@ def main(pyproject_path: Path) -> int:
         )
         return 1
 
-    print("All extras are in sync with required dependencies.")
+    print(f"All extras in {pyproject_path} are in sync with required dependencies.")
     return 0
 
 

--- a/.github/workflows/block_fork_main_prs.yml
+++ b/.github/workflows/block_fork_main_prs.yml
@@ -5,6 +5,11 @@
 # directly on `main` as a 2-parent merge commit, bypassing the repo's
 # squash-only policy and polluting the changelog.
 #
+# `pull_request_target` is required so the job receives a token scoped to
+# write PR labels/comments on fork PRs (the standard `pull_request` token is
+# read-only for forks). This also means the job MUST NOT check out PR code —
+# see the inline warning in the trigger block below.
+#
 # Maintainer bypass: add the `bypass-fork-main-check` label to the PR.
 
 name: Block fork main PRs
@@ -42,14 +47,23 @@ jobs:
             try {
               await github.rest.issues.getLabel({ owner, repo, name: labelName });
             } catch (e) {
-              if (e.status !== 404) throw e;
+              if (e.status !== 404) {
+                throw new Error(`getLabel(${labelName}) failed: ${e.message}`);
+              }
               try {
                 await github.rest.issues.createLabel({
                   owner, repo, name: labelName, color: 'b76e79',
                 });
               } catch (createErr) {
-                // 422 = label already exists (race or pre-existing) — safe to ignore.
-                if (createErr.status !== 422) throw createErr;
+                // A 422 with code `already_exists` means a race created the
+                // label between getLabel and createLabel — safe to ignore.
+                // Any other 422 (bad color, name too long) indicates a real
+                // bug introduced by editing this step, so rethrow.
+                const alreadyExists =
+                  createErr.status === 422 &&
+                  Array.isArray(createErr.errors) &&
+                  createErr.errors.some(e => e.code === 'already_exists');
+                if (!alreadyExists) throw createErr;
               }
             }
             await github.rest.issues.addLabels({
@@ -99,7 +113,12 @@ jobs:
             // Best-effort: new runs may still queue after this loop (e.g., other
             // pull_request triggers fanning out). The PR is already closed above,
             // so leftover runs are wasted compute, not a correctness issue.
+            // We track the cancel ratio so a wholesale failure (token-scope
+            // regression making EVERY cancel return 403) is surfaced rather
+            // than silently producing N warnings + green job.
             const headSha = context.payload.pull_request.head.sha;
+            let attempted = 0;
+            let cancelled = 0;
             for (const status of ['in_progress', 'queued']) {
               const runs = await github.paginate(
                 github.rest.actions.listWorkflowRunsForRepo,
@@ -107,14 +126,19 @@ jobs:
               );
               for (const run of runs) {
                 if (run.id === context.runId) continue;
+                attempted++;
                 try {
                   await github.rest.actions.cancelWorkflowRun({
                     owner, repo, run_id: run.id,
                   });
+                  cancelled++;
                 } catch (err) {
                   core.warning(`Could not cancel run ${run.id}: ${err.message}`);
                 }
               }
+            }
+            if (attempted > 0 && cancelled === 0) {
+              core.warning(`Attempted to cancel ${attempted} run(s) on head ${headSha} but none succeeded — check token scope.`);
             }
 
             core.setFailed(`PR head ref is \`${headRef}\` on a fork — open from a feature branch instead.`);

--- a/.github/workflows/bump_uv_pin.yml
+++ b/.github/workflows/bump_uv_pin.yml
@@ -59,7 +59,10 @@ jobs:
           echo "Current pin: $current"
           echo "Latest uv:   $latest"
 
-      - name: Skip if already up to date
+      - name: Log if already up to date
+        # The actual skip is implemented by the `if:` guards on every
+        # subsequent step; this step only emits a log line so the run
+        # history shows why no PR was opened.
         if: steps.versions.outputs.current == steps.versions.outputs.latest
         run: echo "uv pin already at ${{ steps.versions.outputs.latest }}; nothing to do."
 
@@ -86,16 +89,40 @@ jobs:
           set -euo pipefail
           # The mirror can lag GitHub Releases. If it hasn't replicated yet,
           # defer the bump rather than landing a pin that races the mirror
-          # on every CI run. `|| echo "000"` keeps a connection failure
-          # (DNS, TCP refused) on the deferral path instead of aborting.
-          url="https://releases.astral.sh/github/uv/releases/download/${LATEST}/uv-x86_64-unknown-linux-gnu.tar.gz"
-          status=$(curl -sIo /dev/null -w '%{http_code}' --max-time 30 "$url" || echo "000")
-          echo "Mirror HEAD $url -> $status"
-          if [ "$status" = "200" ]; then
+          # on every CI run. We probe several arches because partial
+          # replication (linux ready, macOS/aarch64 not) would still race
+          # CI on other runners.
+          assets=(
+            "uv-x86_64-unknown-linux-gnu.tar.gz"
+            "uv-aarch64-unknown-linux-gnu.tar.gz"
+            "uv-x86_64-apple-darwin.tar.gz"
+            "uv-aarch64-apple-darwin.tar.gz"
+          )
+          ready=true
+          for asset in "${assets[@]}"; do
+            url="https://releases.astral.sh/github/uv/releases/download/${LATEST}/${asset}"
+            # `curl -sI` returns nothing on stderr at -s; capture exit code so a
+            # permanently broken DNS/TLS path is surfaced instead of collapsing
+            # to an opaque "000".
+            set +e
+            status=$(curl -sIo /dev/null -w '%{http_code}' --max-time 30 "$url" 2>/tmp/curl.err)
+            curl_rc=$?
+            set -e
+            echo "Mirror HEAD $url -> HTTP $status (curl exit=$curl_rc)"
+            if [ "$status" != "200" ]; then
+              ready=false
+              if [ "$curl_rc" -ne 0 ]; then
+                echo "::warning::curl failed for $asset (exit=$curl_rc): $(cat /tmp/curl.err 2>/dev/null || true)"
+              else
+                echo "::warning::astral mirror has not replicated $asset for uv $LATEST yet (HTTP $status)."
+              fi
+            fi
+          done
+          if [ "$ready" = "true" ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::astral mirror has not replicated uv $LATEST yet (HTTP $status); skipping bump."
+            echo "::warning::Deferring uv bump to $LATEST until all probed arches are mirrored."
           fi
 
       - name: Open bump PR
@@ -110,13 +137,31 @@ jobs:
           set -euo pipefail
           action_file=".github/actions/uv_setup/action.yml"
 
-          before=$(grep -cE "version: \"${CURRENT}\"" "$action_file" || true)
+          # `grep -c` returns 1 on no-match and 2 on read errors. We want
+          # "no match" surfaced as the explicit count-of-zero check below;
+          # read errors must abort. Capture the exit code separately so
+          # `set -e` doesn't swallow either case.
+          set +e
+          before=$(grep -cE "version: \"${CURRENT}\"" "$action_file")
+          before_rc=$?
+          set -e
+          if [ "$before_rc" -gt 1 ]; then
+            echo "::error::grep read error on $action_file (exit=$before_rc)"
+            exit 1
+          fi
           if [ "$before" -ne 1 ]; then
             echo "::error::Expected exactly 1 'version: \"$CURRENT\"' in $action_file, found $before"
             exit 1
           fi
           sed -i -E "s/version: \"${CURRENT}\"/version: \"${LATEST}\"/" "$action_file"
-          after=$(grep -cE "version: \"${LATEST}\"" "$action_file" || true)
+          set +e
+          after=$(grep -cE "version: \"${LATEST}\"" "$action_file")
+          after_rc=$?
+          set -e
+          if [ "$after_rc" -gt 1 ]; then
+            echo "::error::grep read error on $action_file (exit=$after_rc)"
+            exit 1
+          fi
           if [ "$after" -ne 1 ]; then
             echo "::error::Expected exactly 1 'version: \"$LATEST\"' after sed, found $after"
             exit 1
@@ -128,9 +173,15 @@ jobs:
 
           # Reuse-or-recreate orphan branch from a prior run that pushed
           # but failed before `gh pr create` (no open PR sits on it).
+          # The delete can race a concurrent run (manual workflow_dispatch
+          # firing while the cron is mid-flight, since concurrency group
+          # does not cancel-in-progress); fall through with a warning so a
+          # losing race does not kill an otherwise-clean job mid-state.
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             echo "::warning::Branch $BRANCH exists on origin without an open PR; deleting before recreating."
-            git push origin --delete "$BRANCH"
+            if ! git push origin --delete "$BRANCH"; then
+              echo "::warning::Delete of $BRANCH failed (concurrent run, or branch already gone); the subsequent push will surface any real conflict."
+            fi
           fi
 
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/check_extras_sync.yml
+++ b/.github/workflows/check_extras_sync.yml
@@ -1,21 +1,19 @@
-# Ensures optional extras stay in sync with required dependencies.
-#
-# When a package appears in both [project.dependencies] and
-# [project.optional-dependencies], the version constraints must match.
-# Only runs when pyproject.toml is modified.
+# See `.github/scripts/check_extras_sync.py` for the rationale.
 
 name: "🔍 Check Extras Sync"
 
 on:
   pull_request:
     paths:
-      - "libs/cli/pyproject.toml"
-      - "libs/code/pyproject.toml"
+      - "libs/**/pyproject.toml"
+      - ".github/scripts/check_extras_sync.py"
+      - ".github/workflows/check_extras_sync.yml"
   push:
     branches: [main]
     paths:
-      - "libs/cli/pyproject.toml"
-      - "libs/code/pyproject.toml"
+      - "libs/**/pyproject.toml"
+      - ".github/scripts/check_extras_sync.py"
+      - ".github/workflows/check_extras_sync.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,6 +24,7 @@ permissions:
 
 jobs:
   check-extras-sync:
+    if: github.repository_owner == 'langchain-ai'
     name: "Verify extras match required deps"
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -40,6 +39,35 @@ jobs:
           enable-cache: "false"
 
       - name: "🔍 Check extras sync"
+        # Iterate every package pyproject.toml under libs/. The script
+        # no-ops on packages without [project.optional-dependencies], so
+        # this is harmless on packages without extras and automatically
+        # picks up new partners as they're added. No `-maxdepth` cap so
+        # deeper future restructures (e.g. `libs/partners/<group>/<pkg>/`)
+        # are picked up automatically.
         run: |
-          python .github/scripts/check_extras_sync.py libs/cli/pyproject.toml
-          python .github/scripts/check_extras_sync.py libs/code/pyproject.toml
+          set -euo pipefail
+          mapfile -t files < <(
+            find libs -name pyproject.toml \
+              -not -path "*/.venv/*" \
+              -not -path "*/node_modules/*" \
+              -not -path "*/build/*" \
+              -not -path "*/dist/*" \
+              -not -path "*/.tox/*" \
+              | sort
+          )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No pyproject.toml files found under libs/"
+            exit 1
+          fi
+          failed=()
+          for f in "${files[@]}"; do
+            if ! python .github/scripts/check_extras_sync.py "$f"; then
+              failed+=("$f")
+            fi
+          done
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::Extras-sync check failed for ${#failed[@]} package(s):"
+            printf '::error::  %s\n' "${failed[@]}"
+            exit 1
+          fi

--- a/.github/workflows/pr_lint_trailer.yml
+++ b/.github/workflows/pr_lint_trailer.yml
@@ -16,10 +16,12 @@ jobs:
     # Serialize per-PR. Rapid `edited`/`synchronize` events on a PR open can
     # otherwise produce two concurrent runs that both observe "no existing
     # sticky" and both call `createComment`, leaving a duplicate failure
-    # comment that the find-first updater will never reconcile.
+    # comment that the find-first updater will never reconcile. We queue
+    # (cancel-in-progress: false) rather than cancel, so the in-flight run
+    # finishes its sticky write before the next event evaluates.
     concurrency:
       group: pr-trailer-lint-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - name: Check PR title and body for banned trailer
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -42,11 +44,11 @@ jobs:
 
             // Mirrors the org ruleset regex on `main`. Keep in lock-step:
             // the live source of truth is the ruleset's `commit_message_pattern.pattern`
-            // field at GitHub org settings → Rulesets → (the ruleset that targets
-            // `main`). The pattern below is informational; verify against the
-            // live ruleset when updating either side, or this check silently
-            // passes pushes that the ruleset will then reject (defeating the
-            // entire purpose).
+            // field at GitHub org settings → Rulesets → `block-anthropic-coauthor`
+            // (or whichever ruleset blocks this trailer on `main`).
+            // The pattern below is informational; verify against the live ruleset
+            // when updating either side, or this check silently passes pushes
+            // that the ruleset will then reject (defeating the entire purpose).
             //
             // Case-folding is intentionally narrow (`[Aa]`/`[Bb]`) because the
             // ruleset's pattern is narrow. Do NOT add the `i` flag — that would
@@ -75,9 +77,13 @@ jobs:
             // remediation manually. The check still fails — `setFailed` is
             // invoked before this function, so the failure signal is already
             // recorded by the time the comment write is attempted.
+            //
+            // The try/catch wraps ONLY the write call so that a bug in
+            // `findStickyComment` (e.g., pagination throwing) surfaces with
+            // its true cause instead of being misattributed to "fork PR token".
             async function postStickyOrSummary(commentBody, summaryHeading) {
+              const existing = await findStickyComment();
               try {
-                const existing = await findStickyComment();
                 if (existing) {
                   if (existing.body !== commentBody) {
                     await github.rest.issues.updateComment({
@@ -113,23 +119,29 @@ jobs:
 
             if (offendingIndices.length === 0) {
               core.info('No banned trailer in squash-merge message.');
-              // Clean up any prior failure comment. Wrapped in try/catch
-              // because a transient API failure during cleanup must NOT turn
-              // a green check into red.
+              // Mark any prior failure comment as resolved. We update rather
+              // than delete because `deleteComment` 403s under restricted
+              // fork-PR tokens, whereas `updateComment` on a bot-authored
+              // comment works in both modes. Wrapped in try/catch because a
+              // transient API failure during cleanup must NOT turn a green
+              // check into red.
               try {
                 const existing = await findStickyComment();
                 if (existing) {
-                  await github.rest.issues.deleteComment({
-                    ...context.repo,
-                    comment_id: existing.id,
-                  });
+                  const resolvedBody = [
+                    STICKY_MARKER,
+                    '✅ **Trailer fixed.** The previous warning is resolved.',
+                  ].join('\n');
+                  if (existing.body !== resolvedBody) {
+                    await github.rest.issues.updateComment({
+                      ...context.repo,
+                      comment_id: existing.id,
+                      body: resolvedBody,
+                    });
+                  }
                 }
               } catch (cleanupErr) {
-                // Fork PRs land here with a 403 — the restricted token cannot
-                // delete bot comments. The stale comment then misleads the
-                // author into thinking the PR is still broken; a maintainer
-                // must manually delete it.
-                core.warning(`Check passed but could not clean up prior failure comment (delete the stale sticky manually if this is a fork PR): ${cleanupErr.message}`);
+                core.warning(`Check passed but could not update prior failure comment to resolved: ${cleanupErr.message}`);
               }
               return;
             }


### PR DESCRIPTION
The extras-sync check previously ran against two hardcoded `pyproject.toml` paths (`libs/cli` and `libs/code`). This broadens it to auto-discover every `pyproject.toml` under `libs/` via a `find` loop, so new partner packages are covered automatically without editing the workflow. The script already no-ops on packages without `[project.optional-dependencies]`, so the wider sweep is safe.

The same PR opportunistically hardens several other CI workflows that were touched during investigation.