### PR TITLE
fix(sdk): clarify skill source labels in system prompt

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -786,6 +786,8 @@ You have access to a skills library that provides specialized capabilities and d
 
 {skills_locations}{skills_load_warnings}
 
+Sources labeled "Deepagents" are specific to this agent tool; sources labeled "Agents" are shared across all agent tools on this machine.
+
 **Available Skills:**
 
 {skills_list}

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -63,6 +63,8 @@ You have access to a skills library that provides specialized capabilities and d
 **User Skills**: `/skills/user/`
 **Project Skills**: `/skills/project/` (higher priority)
 
+Sources labeled "Deepagents" are specific to this agent tool; sources labeled "Agents" are shared across all agent tools on this machine.
+
 **Available Skills:**
 
 - **web-research**: Structured approach to conducting thorough web research on any topic


### PR DESCRIPTION
The skills section of the system prompt listed sources as `**User Deepagents Skills**` and `**User Agents Skills**` with no explanation of what that distinction means. Models reading the prompt had no basis for understanding that "Deepagents" sources are scoped to this agent tool while "Agents" sources are shared across all agent tools on the machine.

## Changes

- Adds a single explanatory sentence to `SKILLS_SYSTEM_PROMPT` in `SkillsMiddleware`, inserted between the locations list and `**Available Skills:**`, clarifying that "Deepagents" sources are agent-specific and "Agents" sources are cross-tool shared
