### PR TITLE
fix(code): suppress interrupt-cleanup state writes from traces

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5514,6 +5514,8 @@ class DeepAgentsApp(App):
             if result.offload_warning:
                 await self._mount_message(ErrorMessage(result.offload_warning))
 
+            # Intentionally traced: the summarization event is a meaningful state
+            # transition that should surface in LangSmith alongside real agent turns.
             await self._agent.aupdate_state(
                 config, {"_summarization_event": result.new_event}
             )

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -1390,15 +1390,24 @@ async def _handle_interrupt_cleanup(
 
     # Save accumulated state before marking tools as rejected (best-effort).
     # State update failures shouldn't prevent cleanup.
-    try:
-        if interrupted_msg:
-            await agent.aupdate_state(config, {"messages": [interrupted_msg]})
+    from langsmith import tracing_context
 
-        cancellation_msg = HumanMessage(
-            content="[SYSTEM] Task interrupted by user. "
-            "Previous operation was cancelled."
-        )
-        await agent.aupdate_state(config, {"messages": [cancellation_msg]})
+    try:
+        # tracing_context(enabled=False) suppresses only the UpdateState traced
+        # run that each aupdate_state call would otherwise emit in LangSmith — it
+        # does not affect any other tracing in the surrounding turn. These writes
+        # are internal interrupt-recovery mechanics (partial AI message +
+        # cancellation notice), not user-driven agent activity; surfacing them as
+        # standalone peer runs alongside real agent turns clutters the trace view.
+        with tracing_context(enabled=False):
+            if interrupted_msg:
+                await agent.aupdate_state(config, {"messages": [interrupted_msg]})
+
+            cancellation_msg = HumanMessage(
+                content="[SYSTEM] Task interrupted by user. "
+                "Previous operation was cancelled."
+            )
+            await agent.aupdate_state(config, {"messages": [cancellation_msg]})
     except (httpx.TransportError, httpx.TimeoutException) as e:
         logger.warning("Could not save interrupted state (network): %s", e)
     except Exception:

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -225,7 +225,7 @@ class TestInterruptCleanup:
         assert interrupted_msg.tool_calls[0]["name"] == "read_file"
 
     async def test_disables_tracing_during_state_save(self) -> None:
-        """`aupdate_state` calls during interrupt cleanup must run with tracing disabled.
+        """Interrupt-cleanup `aupdate_state` calls must run with tracing disabled.
 
         Interrupt state writes (partial AI message + cancellation notice) are
         internal recovery mechanics. Surfacing them as standalone `UpdateState`
@@ -259,10 +259,12 @@ class TestInterruptCleanup:
         )
 
         assert captured, "aupdate_state was never called"
-        assert all(v is False for v in captured), f"tracing was not disabled: {captured}"
+        assert all(v is False for v in captured), (
+            f"tracing was not disabled: {captured}"
+        )
 
     async def test_disables_tracing_when_interrupted_msg_present(self) -> None:
-        """Both `aupdate_state` calls run with tracing disabled when interrupted_msg is set.
+        """Both `aupdate_state` calls disable tracing when interrupted_msg is set.
 
         When there is a partial AI message to save, both writes (interrupted AI
         message and cancellation notice) must be suppressed from LangSmith traces.
@@ -299,8 +301,12 @@ class TestInterruptCleanup:
             start_time=0.0,
         )
 
-        assert len(captured) == 2, f"expected 2 aupdate_state calls, got {len(captured)}"
-        assert all(v is False for v in captured), f"tracing was not disabled: {captured}"
+        assert len(captured) == 2, (
+            f"expected 2 aupdate_state calls, got {len(captured)}"
+        )
+        assert all(v is False for v in captured), (
+            f"tracing was not disabled: {captured}"
+        )
 
 
 class TestBuildStreamConfig:

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -224,6 +224,84 @@ class TestInterruptCleanup:
         assert interrupted_msg.tool_calls[0]["id"] == "call-1"
         assert interrupted_msg.tool_calls[0]["name"] == "read_file"
 
+    async def test_disables_tracing_during_state_save(self) -> None:
+        """`aupdate_state` calls during interrupt cleanup must run with tracing disabled.
+
+        Interrupt state writes (partial AI message + cancellation notice) are
+        internal recovery mechanics. Surfacing them as standalone `UpdateState`
+        runs in LangSmith would add noise unrelated to user-visible agent activity.
+        """
+        from langsmith import get_tracing_context
+
+        captured: list[object] = []
+
+        async def _capture(*_args: object, **_kwargs: object) -> None:  # noqa: RUF029
+            captured.append(get_tracing_context().get("enabled"))
+
+        agent = SimpleNamespace(aupdate_state=AsyncMock(side_effect=_capture))
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=AsyncMock(),
+            set_active_message=MagicMock(),
+        )
+
+        await _handle_interrupt_cleanup(
+            adapter=adapter,
+            agent=agent,
+            config={"configurable": {"thread_id": "t-1"}},  # type: ignore[arg-type]
+            pending_text_by_namespace={},
+            captured_input_tokens=0,
+            captured_output_tokens=0,
+            turn_stats=SessionStats(),
+            start_time=0.0,
+        )
+
+        assert captured, "aupdate_state was never called"
+        assert all(v is False for v in captured), f"tracing was not disabled: {captured}"
+
+    async def test_disables_tracing_when_interrupted_msg_present(self) -> None:
+        """Both `aupdate_state` calls run with tracing disabled when interrupted_msg is set.
+
+        When there is a partial AI message to save, both writes (interrupted AI
+        message and cancellation notice) must be suppressed from LangSmith traces.
+        """
+        from langsmith import get_tracing_context
+
+        captured: list[object] = []
+
+        async def _capture(*_args: object, **_kwargs: object) -> None:  # noqa: RUF029
+            captured.append(get_tracing_context().get("enabled"))
+
+        tool_widget = MagicMock()
+        tool_widget._tool_name = "read_file"
+        tool_widget._args = {"path": "notes.txt"}
+
+        agent = SimpleNamespace(aupdate_state=AsyncMock(side_effect=_capture))
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=AsyncMock(),
+            set_active_message=MagicMock(),
+        )
+        adapter._current_tool_messages = {"call-1": tool_widget}
+
+        await _handle_interrupt_cleanup(
+            adapter=adapter,
+            agent=agent,
+            config={"configurable": {"thread_id": "t-1"}},  # type: ignore[arg-type]
+            pending_text_by_namespace={},
+            captured_input_tokens=0,
+            captured_output_tokens=0,
+            turn_stats=SessionStats(),
+            start_time=0.0,
+        )
+
+        assert len(captured) == 2, f"expected 2 aupdate_state calls, got {len(captured)}"
+        assert all(v is False for v in captured), f"tracing was not disabled: {captured}"
+
 
 class TestBuildStreamConfig:
     """Tests for `build_stream_config` metadata construction."""


### PR DESCRIPTION
`aupdate_state` always emits its own traced `UpdateState` run in LangSmith, regardless of whether the values being written are marked `PrivateStateAttr`. The interrupt-cleanup path in `_handle_interrupt_cleanup` writes an internal partial-AI message and a system cancellation notice directly to graph state — neither represents user-visible agent activity, but both were surfacing as peer runs in LangSmith traces alongside real agent turns. The `_summarization_event` write (offload path) is left intentionally traced and annotated to make the asymmetry obvious.

## Changes

- Wrap the two `aupdate_state` calls in `_handle_interrupt_cleanup` with `tracing_context(enabled=False)` to suppress the resulting `UpdateState` LangSmith runs; the writes themselves and all exception-handling semantics are unchanged
- Add a comment to the offload-path `aupdate_state` call noting it is intentionally traced, since a summarization event is a meaningful state transition worth surfacing in traces

## Testing

Two new tests in `TestInterruptCleanup` verify tracing suppression by injecting a `get_tracing_context()` side-effect on `aupdate_state` and asserting the context reports `enabled=False` at call time — one exercises the cancellation-only path (`interrupted_msg is None`), the other populates `_current_tool_messages` to drive both writes and asserts both are suppressed.
